### PR TITLE
use prototype instead of 'this' before super

### DIFF
--- a/src/observable/observable.js
+++ b/src/observable/observable.js
@@ -75,7 +75,7 @@ Observable.return = function(value) {
 
 export class ScheduledObservable extends Observable {
   constructor(source, observationScheduler) {
-    super(this._observer);
+    super(ScheduledObservable.prototype._observer);
     this._observationScheduler = observationScheduler;
     this._source = source;
   }
@@ -89,7 +89,7 @@ export class ScheduledObservable extends Observable {
 
 export class MergeAllObservable extends Observable {
   constructor(source) {
-    super(this._observer);
+    super(MergeAllObservable.prototype._observer);
     this._source = source;
   }
 
@@ -102,7 +102,7 @@ export class MergeAllObservable extends Observable {
 
 export class MapObservable extends Observable {
   constructor(source, projection) {
-    super(this._observer);
+    super(MapObservable.prototype._observer);
     this._projection = projection;
     this._source = source;
   }


### PR DESCRIPTION
'this' in subclass constructor before call to super exits is undefined
according to spec. Use prototype object to pass in method instead to
comply with spec. 
See https://github.com/babel/babel/issues/1284 for more details