### PR TITLE
Typescriptify simplification of operators

### DIFF
--- a/spec/observable/value-spec.js
+++ b/spec/observable/value-spec.js
@@ -1,0 +1,14 @@
+/* globals describe, it, expect */
+var RxNext = require('../../dist/cjs/RxNext');
+var Observable = RxNext.Observable;
+var Scheduler = RxNext.Scheduler;
+
+describe('Observable.value or Observable.return', function(){
+	it('should emit one value', function() {
+		var calls = 0;
+		Observable.value(42, Scheduler.immediate).subscribe(function(x) {
+			expect(++calls).toBe(1);
+			expect(x).toBe(42);
+		});
+	});
+});

--- a/spec/scheduler-spec.js
+++ b/spec/scheduler-spec.js
@@ -1,0 +1,20 @@
+/* globals describe, it, expect */
+var RxNext = require('../dist/cjs/RxNext');
+
+var Scheduler = RxNext.Scheduler;
+
+describe('Scheduler.immediate', function() {
+	it('should schedule things recursively', function() {
+		var call1 = false;
+		var call2 = false;
+		Scheduler.immediate.active = false;
+		Scheduler.immediate.schedule(0, null, function(){
+			call1 = true;
+			Scheduler.immediate.schedule(0, null, function(){
+				call2 = true;
+			});
+		});		
+		expect(call1).toBe(true);
+		expect(call2).toBe(true);
+	});
+});

--- a/src/NextTickScheduler.ts
+++ b/src/NextTickScheduler.ts
@@ -1,0 +1,11 @@
+import Scheduler from './Scheduler';
+import {
+	NextScheduledAction,
+	ScheduledAction
+} from './SchedulerActions';
+
+export default class NextTickScheduler extends Scheduler {
+  scheduleNow(state:any, work:Function):ScheduledAction {
+    return this.scheduled ? new ScheduledAction(this, state, work) : new NextScheduledAction(this, state, work);
+  }
+}

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,10 +1,8 @@
 import Observer from './Observer';
-import Scheduler from './Scheduler';
 import Subscription from './Subscription';
 import SerialSubscription from './SerialSubscription';
+import nextTick from './scheduler/nextTick';
 import $$observer from './util/Symbol_observer';
-
-const immediateScheduler = Scheduler.immediate;
 
 export default class Observable {  
   static value:(value:any)=>Observable;
@@ -53,7 +51,7 @@ export default class Observable {
         observer = Observer.create(<(any)=>IteratorResult<any>>observerOrNextHandler, throwHandler, returnHandler);
       }
       
-      return Scheduler.nextTick.schedule(0, [observer, this], dispatchSubscription);
+      return nextTick.schedule(0, [observer, this], dispatchSubscription);
     }
   
   forEach(nextHandler) {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -2,25 +2,28 @@ import Observer from './Observer';
 import Scheduler from './Scheduler';
 import Subscription from './Subscription';
 import SerialSubscription from './SerialSubscription';
+import $$observer from './util/Symbol_observer';
 
 const immediateScheduler = Scheduler.immediate;
 
 export default class Observable {  
-  static value:(value:any,scheduler:Scheduler)=>Observable;
-  static return:(value:any,scheduler:Scheduler)=>Observable;
+  static value:(value:any)=>Observable;
+  static return:(returnValue:any)=>Observable;
   static fromEvent:(element:any, eventName:string, selector:Function)=>Observable;
   static fromEventPattern:(addHandler:Function, removeHandler:Function, selector:Function)=>Observable;
-  static throw:(err:any, scheduler:Scheduler)=>Observable;
-  static empty:(scheduler:Scheduler)=>Observable;
-  static range:(start:number,end:number,scheduler:Scheduler)=>Observable;
+  static throw:(err:any)=>Observable;
+  static empty:()=>Observable;
+  static never:()=>Observable;
+  static range:(start:number,end:number)=>Observable;
+  static fromArray:(array:Array<any>)=>Observable;
   
-  select:(project:any)=>Observable;
-  map:(project:any)=>Observable;
+  map:(project:(any)=>any)=>Observable;
+  mapTo:(value:any)=>Observable;
   mergeAll:(concurrent?:number)=>Observable;
-  selectMany:(project:any, concurrent?:number)=>Observable;
   flatMap:(project:any, concurrent?:number)=>Observable;
+  concatAll:()=>Observable;
   
-  constructor(subscriber:(observer:Observer)=>Function) {
+  constructor(subscriber:(observer:Observer)=>Function|void) {
     if(subscriber) {
       this.subscriber = subscriber;
     }
@@ -34,13 +37,40 @@ export default class Observable {
     return void 0;
   }
   
-  subscribe(a, b=null, c=null) {
-    if(!a || typeof a !== "object") {
-        a = Observer.create(a, b, c);
-    }
-    if (!immediateScheduler.active) {
-        return immediateScheduler.schedule(0, null, () => this.subscriber(a));
-    }
-    return Subscription.from(this.subscriber(a));
+  [$$observer](observer:Observer) {
+    return Subscription.from(this.subscriber(observer));
   }
+  
+  subscribe(observerOrNextHandler:Observer|((any)=>IteratorResult<any>),
+    throwHandler:(any)=>IteratorResult<any>=null,
+    returnHandler:(any)=>IteratorResult<any>=null) {
+      var observer;
+      if(typeof observerOrNextHandler === 'object') {
+        observer = observerOrNextHandler;
+      } else {
+        observer = Observer.create(<(any)=>IteratorResult<any>>observerOrNextHandler, throwHandler, returnHandler);
+      }
+      
+      return Scheduler.nextTick.schedule(0, [observer, this], dispatchSubscription);
+    }
+  
+  forEach(nextHandler) {
+    return new Promise((resolve, reject) => {
+      var observer = Observer.create((value) => {
+       nextHandler(value);
+       return { done: false }; 
+      }, (err) => {
+        reject(err); 
+        return { done: true };
+      }, (value) => {
+        resolve(value);
+        return { done: true };
+      });
+      this[$$observer](observer);
+    });
+  }
+}
+
+function dispatchSubscription([observer, observable]) {
+  return observable[$$observer](observer);
 }

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -22,6 +22,8 @@ export default class Observable {
   mergeAll:(concurrent?:number)=>Observable;
   flatMap:(project:any, concurrent?:number)=>Observable;
   concatAll:()=>Observable;
+  skip:(count:number)=>Observable;
+  take:(count:number)=>Observable;
   
   constructor(subscriber:(observer:Observer)=>Function|void) {
     if(subscriber) {

--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -14,7 +14,7 @@ export default class Observer {
   
   static create(_next:(value:any)=>IteratorResult<any>, 
                 _throw:((value:any)=>IteratorResult<any>)=null, 
-                _return:(()=>IteratorResult<any>)=null) : Observer {
+                _return:((value:any)=>IteratorResult<any>)=null) : Observer {
     var observer = new Observer(null, null);
     observer._next = _next;
     observer._throw = _throw;
@@ -23,15 +23,15 @@ export default class Observer {
   }
   
   _next(value:any):IteratorResult<any> {
-    return this.destination["next"](value);
+    return this.destination.next(value);
   }
 
   _throw(error:any):IteratorResult<any> {
-    return this.destination["throw"](error);
+    return this.destination.throw(error);
   }
 
-  _return():IteratorResult<any> {
-    return this.destination["return"]();
+  _return(value:any):IteratorResult<any> {
+    return this.destination.return(value);
   }
   
   constructor(destination:Observer, subscription:Subscription) {
@@ -89,13 +89,13 @@ export default class Observer {
     return result;
   }
   
-  return():IteratorResult<any> {
+  return(value:any=undefined):IteratorResult<any> {
     var result = this.result;
     if (this.unsubscribed || Boolean(result.done)) {
         return result;
     }
 
-    var result2 = this._return() || result;
+    var result2 = this._return(value) || result;
     if (result !== result2) {
         result.value = result2.value;
     }

--- a/src/RxNext.ts
+++ b/src/RxNext.ts
@@ -20,6 +20,8 @@ import mapTo from './operator/mapTo';
 import mergeAll from './operator/mergeAll';
 import flatMap from './operator/flatMap';
 import concatAll from './operator/concatAll';
+import skip from './operator/skip';
+import take from './operator/take';
 
 Observable.value = value;
 Observable.return = _return;
@@ -35,6 +37,8 @@ Observable.prototype.mapTo = mapTo;
 Observable.prototype.mergeAll = mergeAll;
 Observable.prototype.flatMap = flatMap;
 Observable.prototype.concatAll = concatAll;
+Observable.prototype.skip = skip;
+Observable.prototype.take = take;
 
 var RxNext = {
   Scheduler,

--- a/src/RxNext.ts
+++ b/src/RxNext.ts
@@ -1,6 +1,9 @@
 import Observable from './Observable';
 import Observer from './Observer';
-import Scheduler from './Scheduler';
+import nextTick from './scheduler/nextTick';
+import immediate from './scheduler/immediate';
+import NextTickScheduler from './scheduler/NextTickScheduler';
+import Scheduler from './scheduler/Scheduler';
 import Subscription from './Subscription';
 import CompositeSubscription from './CompositeSubscription';
 import SerialSubscription from './SerialSubscription';
@@ -41,7 +44,10 @@ Observable.prototype.skip = skip;
 Observable.prototype.take = take;
 
 var RxNext = {
-  Scheduler,
+  Scheduler: {
+    nextTick,
+    immediate
+  },
   Observer,
   Observable,
   Subscription,

--- a/src/RxNext.ts
+++ b/src/RxNext.ts
@@ -7,29 +7,34 @@ import SerialSubscription from './SerialSubscription';
 
 
 import value from './observable/value';
+import _return from './observable/return';
 import fromEventPattern from './observable/fromEventPattern';
 import fromEvent from './observable/fromEvent';
 import _throw from './observable/throw';
 import empty from './observable/empty';
 import range from './observable/range';
+import fromArray from './observable/fromArray';
 
-import select from './operator/select';
+import map from './operator/map';
+import mapTo from './operator/mapTo';
 import mergeAll from './operator/mergeAll';
-import selectMany from './operator/selectMany';
+import flatMap from './operator/flatMap';
+import concatAll from './operator/concatAll';
 
 Observable.value = value;
-Observable.return = value;
+Observable.return = _return;
 Observable.fromEventPattern = fromEventPattern;
 Observable.fromEvent = fromEvent;
 Observable.throw = _throw;
 Observable.empty = empty;
 Observable.range = range;
+Observable.fromArray = fromArray;
 
-Observable.prototype.select = select;
-Observable.prototype.map = select;
+Observable.prototype.map = map;
+Observable.prototype.mapTo = mapTo;
 Observable.prototype.mergeAll = mergeAll;
-Observable.prototype.selectMany = selectMany;
-Observable.prototype.flatMap = selectMany;
+Observable.prototype.flatMap = flatMap;
+Observable.prototype.concatAll = concatAll;
 
 var RxNext = {
   Scheduler,

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -3,6 +3,8 @@ import Observer from './Observer';
 import Immediate from './util/Immediate';
 import SerialSubscription from './SerialSubscription';
 import Subscription from './Subscription';
+import NextTickScheduler from './NextTickScheduler';
+
 import {
   ScheduledAction,
   NextScheduledAction,
@@ -16,35 +18,36 @@ export default class Scheduler {
   scheduled:boolean = false;  
   
   static immediate:Scheduler = new Scheduler(false);
-  static nextTick:Scheduler = new Scheduler(true);
+  static nextTick:Scheduler = new NextTickScheduler(true);
   
   constructor(async:boolean=false) {
     this.async = async;
   }
   
   schedule(delay:number, state:any, work:Function):Subscription {
-   if (delay <= 0) {
-        if (Boolean(this.async)) {
-          return scheduleNext(this, state, work);
-        } else {
-          return scheduleNow(this, state, work);
-        }
+    if (delay <= 0) {
+      return this.scheduleNow(state, work);
     } else {
-        return scheduleLater(this, state, work, delay);
+      return this.scheduleLater(state, work, delay);
     }
   }
-}
-
-function scheduleNow(scheduler:Scheduler, state:any, work:Function):ScheduledAction {
-    return new ScheduledAction(scheduler, state, work);
-}
-
-function scheduleNext(scheduler:Scheduler, state:any, work:Function):ScheduledAction {
-    return Boolean(scheduler.scheduled) ?
-        new ScheduledAction(scheduler, state, work)    :
-        new NextScheduledAction(scheduler, state, work);
-}
-
-function scheduleLater(scheduler:Scheduler, state:any, work:Function, delay:number):FutureScheduledAction {
-    return new FutureScheduledAction(scheduler, state, work, delay);
+  
+  flush() {
+    if (!this.active) {
+        this.active = true;
+        var action;
+        while(action = this.actions.shift()) {
+            action.execute();
+        };
+        this.active = false;
+    } 
+  }
+  
+  scheduleNow(state:any, work:Function):ScheduledAction {
+    return new ScheduledAction(this, state, work);
+  }
+  
+  scheduleLater(state:any, work:Function, delay:number) {
+    return new FutureScheduledAction(this, state, work, delay);
+  }
 }

--- a/src/SchedulerActions.ts
+++ b/src/SchedulerActions.ts
@@ -21,7 +21,7 @@ export class ScheduledAction extends SerialSubscription {
     var actions = scheduler.actions;
     this.state = state;
     actions.push(this);
-    flush(scheduler, actions);
+    scheduler.flush();
     return this;
   }
  
@@ -56,14 +56,14 @@ export class NextScheduledAction extends ScheduledAction {
     var scheduler = this.scheduler;
     this.state = state;
     scheduler.actions.push(this);
-    if (!Boolean(scheduler.scheduled)) {
+    if (!scheduler.scheduled) {
         scheduler.active = true;
         scheduler.scheduled = true;
         this.id = Immediate.setImmediate(function () {
             self.id = void 0;
             scheduler.active = false;
             scheduler.scheduled = false;
-            flush(scheduler, scheduler.actions);
+            scheduler.flush();
         });
     }
     return this;
@@ -117,17 +117,4 @@ export class FutureScheduledAction extends ScheduledAction {
         clearTimeout(id);
     }
   }
-}
-
-
-
-function flush(scheduler, actions) {
-    if (!Boolean(scheduler.active)) {
-        scheduler.active = true;
-        var action;
-        while(action = actions.shift()) {
-            action.execute();
-        };
-        scheduler.active = false;
-    }
 }

--- a/src/observable/empty.ts
+++ b/src/observable/empty.ts
@@ -1,29 +1,9 @@
 import Observable from '../Observable';
-import Scheduler from '../Scheduler';
 
-class EmptyObservable extends Observable {
-  scheduler:Scheduler;
-  
-  constructor(scheduler:Scheduler) {
-    super(null);
-    this.scheduler = scheduler;
-  }
-  
-  subscriber(observer) {
-    var scheduler = this.scheduler;
-    if(scheduler) {
-        return scheduler.schedule(0, observer, dispatch);
-    }
-    observer["return"]();
-  }
-}
+const EMPTY = new Observable(observer => {
+  observer.return();
+});
 
-function dispatch(observer) {
-    observer["return"]();
-}
-
-const staticEmpty = new EmptyObservable(Scheduler.immediate);
-
-export default function empty(scheduler:Scheduler=Scheduler.immediate):Observable {
-    return scheduler && new EmptyObservable(scheduler) || staticEmpty;
+export default function empty():Observable {
+  return EMPTY;
 };

--- a/src/observable/fromArray.ts
+++ b/src/observable/fromArray.ts
@@ -1,0 +1,26 @@
+import Observable from '../Observable';
+import Observer from '../Observer';
+
+class ArrayObservable extends Observable {
+	array:Array<any>;
+	
+	constructor(array:Array<any>) {
+		super(null);
+		this.array = array;
+	}
+	
+	subscriber(observer:Observer) {
+		var i, len;
+		var array = this.array;
+		if(Array.isArray(array)) {
+			for(i = 0, len = array.length; i < len && !observer.unsubscribed; i++) {
+				observer.next(array[i]);
+			}
+		}
+		observer.return();
+	}
+}
+
+export default function fromArray(array:Array<any>) : Observable {
+	return new ArrayObservable(array);
+}

--- a/src/observable/fromPromise.ts
+++ b/src/observable/fromPromise.ts
@@ -1,0 +1,25 @@
+import Observable from '../Observable';
+
+class PromiseObservable extends Observable {
+	promise:Promise<any>;
+	
+	constructor(promise:Promise<any>) {
+		super(null);
+		this.promise = promise;	
+	}
+	
+	subscriber(observer:Observer) {
+		if(promise) {
+			promise.then(x => {
+				if(!observer.unsubscribed) {
+					observer.next(x);
+				}
+				observer.return();
+			});
+		}
+	}
+}
+
+export default function fromPromise(promise:Promise<any>) : Observable {
+	return new PromiseObservable(promise);
+}

--- a/src/observable/never.ts
+++ b/src/observable/never.ts
@@ -1,0 +1,7 @@
+import Observable from '../Observable';
+
+const NEVER = new Observable((observer) => {});
+
+export default function never() {
+	return NEVER; // NEVER!!!!
+}

--- a/src/observable/range.ts
+++ b/src/observable/range.ts
@@ -1,59 +1,30 @@
 import Observable from '../Observable';
-import Scheduler from '../Scheduler';
 import Observer from '../Observer';
 
 class RangeObservable extends Observable {
-	scheduler:Scheduler;
 	end:number;
 	start:number;
 	
-	constructor(start:number, end:number, scheduler:Scheduler) {
+	constructor(start:number, end:number) {
 		super(null);
     this.end = end;
     this.start = start;
-    this.scheduler = scheduler;
 	}
 	
 	subscriber(observer:Observer) {
     var end = this.end;
-    var start = this.start - 1;
-    var scheduler = this.scheduler;
-
-    if (scheduler) {
-        return scheduler.schedule(0, [{ done: false }, observer, start, end], dispatch);
+    var start = this.start;
+    var i;
+    for(i = start; i < end && !observer.unsubscribed; i++) {
+      observer.next(i);
     }
-
-    while (++start < end) {
-        var result = observer.next(start);
-        if (result.done) {
-            return;
-        }
-    }
-    observer["return"]();	
+    observer.return();
 	}
 }
 
-function dispatch(state) {
-    var result = state[0];
-    var observer = state[1];
-    var end = state[3];
-    var start = state[2];
-    if (++start < end) {
-        result = observer.next(start);
-        if (!result.done) {
-            state[0] = result;
-            state[2] = start;
-            this.reschedule(state);
-        }
-    } else if (!result.done) {
-        observer["return"]();
-    }
-}
-
-export default function range(start:number, end:number, scheduler:Scheduler=Scheduler.immediate):Observable {
+export default function range(start:number=0, end:number=0):Observable {
     return new RangeObservable(
-        Math.min(start || (start = 0), end || (end = 0)),
-        Math.max(start, end),
-        scheduler
+        Math.min(start, end),
+        Math.max(start, end)
     );
 };

--- a/src/observable/return.ts
+++ b/src/observable/return.ts
@@ -1,0 +1,19 @@
+import Observable from '../Observable';
+import Observer from '../Observer';
+
+class ReturnObservable extends Observable {
+	returnValue:any;
+	
+	constructor(returnValue:any) {
+		super(null);
+		this.returnValue = returnValue;	
+	}
+	
+	subscriber(observer:Observer) {
+		observer.return(this.returnValue);
+	}
+}
+
+export default function _return(returnValue:any=undefined) : Observable {
+	return new ReturnObservable(returnValue);
+}

--- a/src/observable/throw.ts
+++ b/src/observable/throw.ts
@@ -1,32 +1,21 @@
 import Observable from '../Observable';
-import Scheduler from '../Scheduler';
+import Observer from '../Observer';
 
 class ThrowObservable extends Observable {
-  scheduler:Scheduler;
   err:any;
   
-  constructor(err:any, scheduler:Scheduler) {
+  constructor(err:any) {
     super(null);
     this.err = err;
-    this.scheduler = scheduler;
   }
   
-  subscriber(observer) {
-    var scheduler = this.scheduler;
-    var err = this.err;
-    if(scheduler) {
-        return scheduler.schedule(0, { observer, err }, dispatch);
-    }
-    observer["throw"](this.err);
+  subscriber(observer:Observer) {
+    observer.throw(this.err);
   }
 }
 
-function dispatch({ observer, err }) {
-    observer["throw"](err);
-}
+const EMPTY_THROW = new ThrowObservable(undefined);
 
-var staticEmpty = new ThrowObservable(undefined, undefined);
-
-export default function _throw(err:any=undefined, scheduler:Scheduler=Scheduler.immediate):Observable {
-    return new ThrowObservable(err, scheduler);
+export default function _throw(err:any=undefined):Observable {
+    return err ? new ThrowObservable(err) : EMPTY_THROW;
 };

--- a/src/observable/value.ts
+++ b/src/observable/value.ts
@@ -1,49 +1,20 @@
 import Observable from '../Observable';
-import Scheduler from '../Scheduler';
 import Observer from '../Observer';
 
 class ValueObservable extends Observable {
   value:any;
-  scheduler:Scheduler;
   
-  constructor(value:any, scheduler:Scheduler) {
+  constructor(value:any) {
     super(null);
     this.value = value;
-    this.scheduler = scheduler;  
   }
   
   subscriber(observer:Observer) {
-    var value = this.value;
-    var scheduler = this.scheduler;
-
-    if(scheduler) {
-        return scheduler.schedule(0, ["N", observer, value], dispatch);
-    }
-
-    var result = observer.next(value);
-
-    if(result.done) {
-        return;
-    }
-
-    observer["return"]();
+    observer.next(this.value);
+    observer.return();
   }
 }
 
-function dispatch(state) {
-    var phase = state[0];
-    var observer = state[1];
-    if(phase === "N") {
-        var result = observer.next(state[2]);
-        if(!result.done) {
-            state[0] = "C";
-            this.reschedule(state);
-        }
-    } else {
-        observer["return"]();
-    }
-}
-
-export default function value(value:any, scheduler:Scheduler=undefined) : Observable {
-    return new ValueObservable(value, scheduler);
+export default function value(value:any) : Observable {
+    return new ValueObservable(value);
 };

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -1,0 +1,5 @@
+import mergeAll from './mergeAll';
+
+export default function concatAll() {
+	return mergeAll.call(this, 1);
+}

--- a/src/operator/flatMap.ts
+++ b/src/operator/flatMap.ts
@@ -1,0 +1,7 @@
+import map from './map';
+import mergeAll from './mergeAll';
+import Observable from '../Observable';
+
+export default function flatMap(project:any, concurrent:number=Number.POSITIVE_INFINITY) : Observable {
+    return mergeAll.call(map.call(this, project), concurrent);
+}

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -10,18 +10,12 @@ interface IteratorResult<T> {
 	value?:T
 }
 
-class SelectObserver extends Observer {
-  value:any;
-  
+class MapObserver extends Observer {
   project:(any)=>any;
   
   constructor(destination:Observer, subscription:Subscription, project:(any)=>any) {
     super(destination, subscription);
-    if(typeof project !== "function") {
-        this.value = project;
-    } else {
-        this.project = project;
-    }
+    this.project = project;
   }
   
   _next(value:any):IteratorResult<any> {
@@ -34,11 +28,7 @@ class SelectObserver extends Observer {
   }
 }
 
-SelectObserver.prototype.project = function projectValue():any {
-    return this.value;
-};
-
-class SelectObservable extends Observable {
+class MapObservable extends Observable {
   source:Observable;
   project:(any)=>any;
   
@@ -50,10 +40,10 @@ class SelectObservable extends Observable {
   
   subscriber(observer:Observer):Subscription {
     var subscription = new SerialSubscription(null);
-    return Subscription.from(this.source.subscriber(new SelectObserver(observer, subscription, this.project)));
+    return Subscription.from(this.source.subscriber(new MapObserver(observer, subscription, this.project)));
   }
 }
 
 export default function select(project:(any)=>any) : Observable {
-  return new SelectObservable(this, project);
+  return new MapObservable(this, project);
 };

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -1,0 +1,43 @@
+import Observer from '../Observer';
+import error_obj from '../util/errorObject';
+import Observable from '../Observable';
+import Subscription from '../Subscription';
+import SerialSubscription from '../SerialSubscription';
+
+interface IteratorResult<T> {
+	done:boolean;
+	value?:T
+}
+
+class MapToObserver extends Observer {
+  value:any;
+  
+  constructor(destination:Observer, subscription:Subscription, value:any) {
+    super(destination, subscription);
+    this.value = value;
+  }
+  
+  _next(_:any):IteratorResult<any> {
+    return this.destination.next(this.value);
+  }
+}
+
+class MapToObservable extends Observable {
+  source:Observable;
+	value:any;
+  
+  constructor(source:Observable, value:any) {
+    super(null);
+    this.source = source;
+    this.value = value;
+  }
+  
+  subscriber(observer:Observer):Subscription {
+    var subscription = new SerialSubscription(null);
+    return Subscription.from(this.source.subscriber(new MapToObserver(observer, subscription, this.value)));
+  }
+}
+
+export default function mapTo(value:any) : Observable {
+  return new MapToObservable(this, value);
+};

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -3,6 +3,7 @@ import Subscription from '../Subscription';
 import SerialSubscription from '../SerialSubscription';
 import CompositeSubscription from '../CompositeSubscription';
 import Observable from '../Observable';
+import $$observer from '../util/Symbol_observer';
 
 interface IteratorResult<T> {
   value?:T;
@@ -33,7 +34,7 @@ class MergeAllObserver extends Observer {
     if (subscriptions.length < concurrent) {
         var innerSubscription = new SerialSubscription(null);
         subscriptions.add(innerSubscription);
-        innerSubscription.add(observable.subscribe(new MergeInnerObserver(this, innerSubscription)));
+        innerSubscription.add(observable[$$observer](new MergeInnerObserver(this, innerSubscription)));
     } else if (buffer) {
         buffer.push(observable);
     }

--- a/src/operator/selectMany.ts
+++ b/src/operator/selectMany.ts
@@ -1,7 +1,0 @@
-import select from './select';
-import mergeAll from './mergeAll';
-import Observable from '../Observable';
-
-export default function selectMany(project:any, concurrent:number=Number.POSITIVE_INFINITY) : Observable {
-    return mergeAll.call(select.call(this, project), concurrent);
-}

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -1,0 +1,46 @@
+import Observer from '../Observer';
+import Observable from '../Observable';
+import Subscription from '../Subscription';
+import SerialSubscription from '../SerialSubscription';
+
+interface IteratorResult<T> {
+	done:boolean;
+	value?:T
+}
+
+class SkipObserver extends Observer {
+  count:number;
+	counter:number=0;
+  
+  constructor(destination:Observer, subscription:Subscription, count:number) {
+    super(destination, subscription);
+    this.count = count;
+  }
+  
+  _next(value:any):IteratorResult<any> {
+		if(this.counter++ >= this.count) {
+			return this.destination.next(value);
+		}
+		return { done: false };
+  }
+}
+
+class SkipObservable extends Observable {
+  source:Observable;
+	count:number;
+  
+  constructor(source:Observable, count:number) {
+    super(null);
+    this.source = source;
+    this.count = count;
+  }
+  
+  subscriber(observer:Observer):Subscription {
+    var subscription = new SerialSubscription(null);
+    return Subscription.from(this.source.subscriber(new SkipObserver(observer, subscription, this.count)));
+  }
+}
+
+export default function skip(count:number) : Observable {
+  return new SkipObservable(this, count);
+};

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -1,0 +1,47 @@
+import Observer from '../Observer';
+import Observable from '../Observable';
+import Subscription from '../Subscription';
+import SerialSubscription from '../SerialSubscription';
+
+interface IteratorResult<T> {
+	done:boolean;
+	value?:T
+}
+
+class TakeObserver extends Observer {
+  count:number;
+	counter:number=0;
+  
+  constructor(destination:Observer, subscription:Subscription, count:number) {
+    super(destination, subscription);
+    this.count = count;
+  }
+  
+  _next(value:any):IteratorResult<any> {
+		if(this.counter++ < this.count) {
+			return this.destination.next(value);
+		} else {
+      return this.destination.return();
+    }
+  }
+}
+
+class TakeObservable extends Observable {
+  source:Observable;
+	count:number;
+  
+  constructor(source:Observable, count:number) {
+    super(null);
+    this.source = source;
+    this.count = count;
+  }
+  
+  subscriber(observer:Observer):Subscription {
+    var subscription = new SerialSubscription(null);
+    return Subscription.from(this.source.subscriber(new TakeObserver(observer, subscription, this.count)));
+  }
+}
+
+export default function take(count:number) : Observable {
+  return new TakeObservable(this, count);
+};

--- a/src/scheduler/NextTickScheduler.ts
+++ b/src/scheduler/NextTickScheduler.ts
@@ -1,4 +1,5 @@
 import Scheduler from './Scheduler';
+
 import {
 	NextScheduledAction,
 	ScheduledAction

--- a/src/scheduler/Scheduler.ts
+++ b/src/scheduler/Scheduler.ts
@@ -1,8 +1,6 @@
-import isNumeric from './util/isNumeric';
-import Observer from './Observer';
-import Immediate from './util/Immediate';
-import SerialSubscription from './SerialSubscription';
-import Subscription from './Subscription';
+import Immediate from '../util/Immediate';
+import SerialSubscription from '../SerialSubscription';
+import Subscription from '../Subscription';
 import NextTickScheduler from './NextTickScheduler';
 
 import {
@@ -13,15 +11,10 @@ import {
 
 export default class Scheduler {
   actions:Array<ScheduledAction> = [];
-  async:boolean = false;
   active:boolean = false;
   scheduled:boolean = false;  
   
-  static immediate:Scheduler = new Scheduler(false);
-  static nextTick:Scheduler = new NextTickScheduler(true);
-  
-  constructor(async:boolean=false) {
-    this.async = async;
+  constructor() {
   }
   
   schedule(delay:number, state:any, work:Function):Subscription {

--- a/src/scheduler/SchedulerActions.ts
+++ b/src/scheduler/SchedulerActions.ts
@@ -1,7 +1,7 @@
 import Scheduler from './Scheduler';
-import SerialSubscription from './SerialSubscription';
-import Immediate from './util/Immediate';
-import Subscription from './Subscription';
+import SerialSubscription from '../SerialSubscription';
+import Immediate from '../util/Immediate';
+import Subscription from '../Subscription';
 
 export class ScheduledAction extends SerialSubscription {
   scheduler:Scheduler;

--- a/src/scheduler/immediate.ts
+++ b/src/scheduler/immediate.ts
@@ -1,0 +1,5 @@
+import Scheduler from './Scheduler';
+
+const immediate:Scheduler = new Scheduler();
+
+export default immediate;

--- a/src/scheduler/nextTick.ts
+++ b/src/scheduler/nextTick.ts
@@ -1,0 +1,5 @@
+import NextTickScheduler from './NextTickScheduler';
+
+const nextTick:NextTickScheduler = new NextTickScheduler();
+
+export default nextTick;

--- a/src/util/Symbol_observer.ts
+++ b/src/util/Symbol_observer.ts
@@ -1,0 +1,14 @@
+import root from './root';
+
+if(!root.Symbol) {
+	root.Symbol = {};
+}
+
+if(!root.Symbol.observer) {
+	if(typeof root.Symbol.for === 'function') {
+		root.Symbol.observer = root.Symbol.for('observer');
+	}
+	root.Symbol.observer = '@@observer';
+}
+
+export default root.Symbol.observer;


### PR DESCRIPTION
Simplified many operators after discussing RxJava's approach with @benjchristensen 

Moved Schedulers around a bit, better modularization.

Split `map` into `map` and `mapTo`

Got rid of clunky names like `selectMany` in favor of `flatMap`

Added `Observable.return` which is *different* than `Observable.value`, because return actually carries a value now.

Added really, really simple `Symbol.observer` polyfill. (this could be improved, I'm sure)

Added `forEach` method per the spec.

`subscribe` is now "zalgo safe"

Everything needs tests.