### PR TITLE
Add multicast/publish/refCount .. fix issue with clean up

### DIFF
--- a/dist/amd/BehaviorSubject.js
+++ b/dist/amd/BehaviorSubject.js
@@ -17,7 +17,7 @@ define(['exports', 'module', './util/Symbol_observer', './Subscription', './Subj
         function BehaviorSubject(value) {
             _classCallCheck(this, BehaviorSubject);
 
-            _Subject.call(this, null);
+            _Subject.call(this);
             this.value = value;
         }
 

--- a/dist/amd/ConnectableObservable.js
+++ b/dist/amd/ConnectableObservable.js
@@ -30,6 +30,10 @@ define(['exports', 'module', './Observable', './Observer', './util/Symbol_observ
             return _nextTick['default'].schedule(0, this, dispatchConnection);
         };
 
+        ConnectableObservable.prototype.connectSync = function connectSync() {
+            return dispatchConnection(this);
+        };
+
         ConnectableObservable.prototype[_$$observer['default']] = function (observer) {
             if (!(observer instanceof _Observer2['default'])) {
                 observer = new _Observer2['default'](observer);

--- a/dist/amd/ConnectableObservable.js
+++ b/dist/amd/ConnectableObservable.js
@@ -1,0 +1,40 @@
+define(['exports', 'module', './Observable', './util/Symbol_observer'], function (exports, module, _Observable2, _utilSymbol_observer) {
+    'use strict';
+
+    function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+    function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+    function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+
+    var _Observable3 = _interopRequireDefault(_Observable2);
+
+    var _$$observer = _interopRequireDefault(_utilSymbol_observer);
+
+    var ConnectableObservable = (function (_Observable) {
+        function ConnectableObservable(source, subject) {
+            _classCallCheck(this, ConnectableObservable);
+
+            _Observable.call(this, null);
+            this.source = source;
+            this.subject = subject;
+        }
+
+        _inherits(ConnectableObservable, _Observable);
+
+        ConnectableObservable.prototype.connect = function connect() {
+            if (!this.subscription) {
+                this.subscription = this.source.subscribe(this.subject);
+            }
+            return this.subscription;
+        };
+
+        ConnectableObservable.prototype[_$$observer['default']] = function (observer) {
+            return this.subject[_$$observer['default']](observer);
+        };
+
+        return ConnectableObservable;
+    })(_Observable3['default']);
+
+    module.exports = ConnectableObservable;
+});

--- a/dist/amd/ConnectableObservable.js
+++ b/dist/amd/ConnectableObservable.js
@@ -1,4 +1,4 @@
-define(['exports', 'module', './Observable', './Observer', './util/Symbol_observer', './scheduler/nextTick'], function (exports, module, _Observable2, _Observer, _utilSymbol_observer, _schedulerNextTick) {
+define(['exports', 'module', './Observable', './Observer', './util/Symbol_observer', './scheduler/nextTick'], function (exports, module, _Observable3, _Observer, _utilSymbol_observer, _schedulerNextTick) {
     'use strict';
 
     function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -7,7 +7,7 @@ define(['exports', 'module', './Observable', './Observer', './util/Symbol_observ
 
     function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-    var _Observable3 = _interopRequireDefault(_Observable2);
+    var _Observable4 = _interopRequireDefault(_Observable3);
 
     var _Observer2 = _interopRequireDefault(_Observer);
 
@@ -47,10 +47,45 @@ define(['exports', 'module', './Observable', './Observer', './util/Symbol_observ
             return this.subject[_$$observer['default']](observer);
         };
 
+        ConnectableObservable.prototype.refCount = function refCount() {
+            return new RefCountObservable(this);
+        };
+
         return ConnectableObservable;
-    })(_Observable3['default']);
+    })(_Observable4['default']);
 
     module.exports = ConnectableObservable;
+
+    var RefCountObservable = (function (_Observable2) {
+        function RefCountObservable(source) {
+            _classCallCheck(this, RefCountObservable);
+
+            _Observable2.call(this, null);
+            this.refCount = 0;
+            this.source = source;
+        }
+
+        _inherits(RefCountObservable, _Observable2);
+
+        RefCountObservable.prototype.subscriber = function subscriber(observer) {
+            var _this = this;
+
+            this.refCount++;
+            this.source[_$$observer['default']](observer);
+            var shouldConnect = this.refCount === 1;
+            if (shouldConnect) {
+                this.connectionSubscription = this.source.connectSync();
+            }
+            return function () {
+                var refCount = _this.refCount--;
+                if (refCount === 0) {
+                    _this.connectionSubscription.unsubscribe();
+                }
+            };
+        };
+
+        return RefCountObservable;
+    })(_Observable4['default']);
 
     function dispatchConnection(connectable) {
         if (!connectable.subscription) {

--- a/dist/amd/Observable.js
+++ b/dist/amd/Observable.js
@@ -33,6 +33,9 @@ define(['exports', 'module', './Observer', './Subscription', './SerialSubscripti
         };
 
         Observable.prototype[_$$observer['default']] = function (observer) {
+            if (!(observer instanceof _Observer2['default'])) {
+                observer = new _Observer2['default'](observer);
+            }
             return _Subscription2['default'].from(this.subscriber(observer), observer);
         };
 

--- a/dist/amd/Observer.js
+++ b/dist/amd/Observer.js
@@ -95,6 +95,16 @@ define(["exports", "module"], function (exports, module) {
 
         Observer.prototype.unsubscribe = function unsubscribe() {
             this.unsubscribed = true;
+            if (this.subscription && this.subscription._unsubscribe) {
+                this.subscription._unsubscribe();
+            }
+        };
+
+        Observer.prototype.setSubscription = function setSubscription(subscription) {
+            this.subscription = subscription;
+            if (this.unsubscribed && subscription._unsubscribe) {
+                subscription._unsubscribe();
+            }
         };
 
         Observer.prototype.dispose = function dispose() {

--- a/dist/amd/RxNext.js
+++ b/dist/amd/RxNext.js
@@ -1,4 +1,4 @@
-define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick', './scheduler/immediate', './Subscription', './CompositeSubscription', './SerialSubscription', './Subject', './BehaviorSubject', './ConnectableObservable', './observable/value', './observable/return', './observable/fromEventPattern', './observable/fromEvent', './observable/throw', './observable/empty', './observable/range', './observable/fromArray', './observable/zip', './observable/fromPromise', './observable/of', './observable/timer', './observable/interval', './operator/map', './operator/mapTo', './operator/mergeAll', './operator/flatMap', './operator/concatAll', './operator/skip', './operator/take', './operator/subscribeOn', './operator/observeOn', './operator/zipAll', './operator/zip', './operator/merge', './operator/toArray', './operator/multicast'], function (exports, module, _Observable, _Observer, _schedulerNextTick, _schedulerImmediate, _Subscription, _CompositeSubscription, _SerialSubscription, _Subject, _BehaviorSubject, _ConnectableObservable, _observableValue, _observableReturn, _observableFromEventPattern, _observableFromEvent, _observableThrow, _observableEmpty, _observableRange, _observableFromArray, _observableZip, _observableFromPromise, _observableOf, _observableTimer, _observableInterval, _operatorMap, _operatorMapTo, _operatorMergeAll, _operatorFlatMap, _operatorConcatAll, _operatorSkip, _operatorTake, _operatorSubscribeOn, _operatorObserveOn, _operatorZipAll, _operatorZip, _operatorMerge, _operatorToArray, _operatorMulticast) {
+define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick', './scheduler/immediate', './Subscription', './CompositeSubscription', './SerialSubscription', './Subject', './BehaviorSubject', './ConnectableObservable', './observable/value', './observable/return', './observable/fromEventPattern', './observable/fromEvent', './observable/throw', './observable/empty', './observable/range', './observable/fromArray', './observable/zip', './observable/fromPromise', './observable/of', './observable/timer', './observable/interval', './operator/map', './operator/mapTo', './operator/mergeAll', './operator/flatMap', './operator/concatAll', './operator/skip', './operator/take', './operator/subscribeOn', './operator/observeOn', './operator/zipAll', './operator/zip', './operator/merge', './operator/toArray', './operator/multicast', './operator/publish'], function (exports, module, _Observable, _Observer, _schedulerNextTick, _schedulerImmediate, _Subscription, _CompositeSubscription, _SerialSubscription, _Subject, _BehaviorSubject, _ConnectableObservable, _observableValue, _observableReturn, _observableFromEventPattern, _observableFromEvent, _observableThrow, _observableEmpty, _observableRange, _observableFromArray, _observableZip, _observableFromPromise, _observableOf, _observableTimer, _observableInterval, _operatorMap, _operatorMapTo, _operatorMergeAll, _operatorFlatMap, _operatorConcatAll, _operatorSkip, _operatorTake, _operatorSubscribeOn, _operatorObserveOn, _operatorZipAll, _operatorZip, _operatorMerge, _operatorToArray, _operatorMulticast, _operatorPublish) {
     'use strict';
 
     function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -77,6 +77,8 @@ define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick
 
     var _multicast = _interopRequireDefault(_operatorMulticast);
 
+    var _publish = _interopRequireDefault(_operatorPublish);
+
     _Observable2['default'].value = _value['default'];
     _Observable2['default']['return'] = _return2['default'];
     _Observable2['default'].fromEventPattern = _fromEventPattern['default'];
@@ -104,6 +106,7 @@ define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick
     _Observable2['default'].prototype.merge = _mergeProto['default'];
     _Observable2['default'].prototype.toArray = _toArray['default'];
     _Observable2['default'].prototype.multicast = _multicast['default'];
+    _Observable2['default'].prototype.publish = _publish['default'];
     var RxNext = {
         Scheduler: {
             nextTick: _nextTick['default'],

--- a/dist/amd/RxNext.js
+++ b/dist/amd/RxNext.js
@@ -1,4 +1,4 @@
-define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick', './scheduler/immediate', './Subscription', './CompositeSubscription', './SerialSubscription', './Subject', './BehaviorSubject', './observable/value', './observable/return', './observable/fromEventPattern', './observable/fromEvent', './observable/throw', './observable/empty', './observable/range', './observable/fromArray', './observable/zip', './observable/fromPromise', './observable/of', './observable/timer', './observable/interval', './operator/map', './operator/mapTo', './operator/mergeAll', './operator/flatMap', './operator/concatAll', './operator/skip', './operator/take', './operator/subscribeOn', './operator/observeOn', './operator/zipAll', './operator/zip', './operator/merge', './operator/toArray'], function (exports, module, _Observable, _Observer, _schedulerNextTick, _schedulerImmediate, _Subscription, _CompositeSubscription, _SerialSubscription, _Subject, _BehaviorSubject, _observableValue, _observableReturn, _observableFromEventPattern, _observableFromEvent, _observableThrow, _observableEmpty, _observableRange, _observableFromArray, _observableZip, _observableFromPromise, _observableOf, _observableTimer, _observableInterval, _operatorMap, _operatorMapTo, _operatorMergeAll, _operatorFlatMap, _operatorConcatAll, _operatorSkip, _operatorTake, _operatorSubscribeOn, _operatorObserveOn, _operatorZipAll, _operatorZip, _operatorMerge, _operatorToArray) {
+define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick', './scheduler/immediate', './Subscription', './CompositeSubscription', './SerialSubscription', './Subject', './BehaviorSubject', './ConnectableObservable', './observable/value', './observable/return', './observable/fromEventPattern', './observable/fromEvent', './observable/throw', './observable/empty', './observable/range', './observable/fromArray', './observable/zip', './observable/fromPromise', './observable/of', './observable/timer', './observable/interval', './operator/map', './operator/mapTo', './operator/mergeAll', './operator/flatMap', './operator/concatAll', './operator/skip', './operator/take', './operator/subscribeOn', './operator/observeOn', './operator/zipAll', './operator/zip', './operator/merge', './operator/toArray', './operator/multicast'], function (exports, module, _Observable, _Observer, _schedulerNextTick, _schedulerImmediate, _Subscription, _CompositeSubscription, _SerialSubscription, _Subject, _BehaviorSubject, _ConnectableObservable, _observableValue, _observableReturn, _observableFromEventPattern, _observableFromEvent, _observableThrow, _observableEmpty, _observableRange, _observableFromArray, _observableZip, _observableFromPromise, _observableOf, _observableTimer, _observableInterval, _operatorMap, _operatorMapTo, _operatorMergeAll, _operatorFlatMap, _operatorConcatAll, _operatorSkip, _operatorTake, _operatorSubscribeOn, _operatorObserveOn, _operatorZipAll, _operatorZip, _operatorMerge, _operatorToArray, _operatorMulticast) {
     'use strict';
 
     function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -20,6 +20,8 @@ define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick
     var _Subject2 = _interopRequireDefault(_Subject);
 
     var _BehaviorSubject2 = _interopRequireDefault(_BehaviorSubject);
+
+    var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
 
     var _value = _interopRequireDefault(_observableValue);
 
@@ -73,6 +75,8 @@ define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick
 
     var _toArray = _interopRequireDefault(_operatorToArray);
 
+    var _multicast = _interopRequireDefault(_operatorMulticast);
+
     _Observable2['default'].value = _value['default'];
     _Observable2['default']['return'] = _return2['default'];
     _Observable2['default'].fromEventPattern = _fromEventPattern['default'];
@@ -99,6 +103,7 @@ define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick
     _Observable2['default'].prototype.zip = _zipProto['default'];
     _Observable2['default'].prototype.merge = _mergeProto['default'];
     _Observable2['default'].prototype.toArray = _toArray['default'];
+    _Observable2['default'].prototype.multicast = _multicast['default'];
     var RxNext = {
         Scheduler: {
             nextTick: _nextTick['default'],
@@ -110,7 +115,8 @@ define(['exports', 'module', './Observable', './Observer', './scheduler/nextTick
         CompositeSubscription: _CompositeSubscription2['default'],
         SerialSubscription: _SerialSubscription2['default'],
         Subject: _Subject2['default'],
-        BehaviorSubject: _BehaviorSubject2['default']
+        BehaviorSubject: _BehaviorSubject2['default'],
+        ConnectableObservable: _ConnectableObservable2['default']
     };
     module.exports = RxNext;
 });

--- a/dist/amd/Subject.js
+++ b/dist/amd/Subject.js
@@ -24,13 +24,13 @@ define(['exports', 'module', './Observable', './util/Symbol_observer', './Subscr
             _Observable.call.apply(_Observable, [this].concat(args));
             this.disposed = false;
             this.observers = [];
+            this.unsubscribed = false;
         }
 
         _inherits(Subject, _Observable);
 
         Subject.prototype.dispose = function dispose() {
             this.disposed = true;
-            this.observers.length = 0;
             if (this._dispose) {
                 this._dispose();
             }
@@ -43,7 +43,7 @@ define(['exports', 'module', './Observable', './util/Symbol_observer', './Subscr
         };
 
         Subject.prototype.next = function next(value) {
-            if (this.disposed) {
+            if (this.unsubscribed) {
                 return { done: true };
             }
             this.observers.forEach(function (o) {
@@ -53,25 +53,30 @@ define(['exports', 'module', './Observable', './util/Symbol_observer', './Subscr
         };
 
         Subject.prototype['throw'] = function _throw(err) {
-            if (this.disposed) {
+            if (this.unsubscribed) {
                 return { done: true };
             }
             this.observers.forEach(function (o) {
                 return o['throw'](err);
             });
-            this.dispose();
+            this.unsubscribe();
             return { done: true };
         };
 
         Subject.prototype['return'] = function _return(value) {
-            if (this.disposed) {
+            if (this.unsubscribed) {
                 return { done: true };
             }
             this.observers.forEach(function (o) {
                 return o['return'](value);
             });
-            this.dispose();
+            this.unsubscribe();
             return { done: true };
+        };
+
+        Subject.prototype.unsubscribe = function unsubscribe() {
+            this.observers.length = 0;
+            this.unsubscribed = true;
         };
 
         return Subject;

--- a/dist/amd/Subject.js
+++ b/dist/amd/Subject.js
@@ -49,6 +49,7 @@ define(['exports', 'module', './Observable', './util/Symbol_observer', './Subscr
             this.observers.forEach(function (o) {
                 return o.next(value);
             });
+            this._cleanUnsubbedObservers();
             return { done: false };
         };
 
@@ -60,6 +61,7 @@ define(['exports', 'module', './Observable', './util/Symbol_observer', './Subscr
                 return o['throw'](err);
             });
             this.unsubscribe();
+            this._cleanUnsubbedObservers();
             return { done: true };
         };
 
@@ -71,7 +73,21 @@ define(['exports', 'module', './Observable', './util/Symbol_observer', './Subscr
                 return o['return'](value);
             });
             this.unsubscribe();
+            this._cleanUnsubbedObservers();
             return { done: true };
+        };
+
+        Subject.prototype._cleanUnsubbedObservers = function _cleanUnsubbedObservers() {
+            var i;
+            var observers = this.observers;
+            for (i = observers.length; i--;) {
+                if (observers[i].unsubscribed) {
+                    observers.splice(i, 1);
+                }
+            }
+            if (observers.length === 0) {
+                this.unsubscribe();
+            }
         };
 
         Subject.prototype.unsubscribe = function unsubscribe() {

--- a/dist/amd/Subject.js
+++ b/dist/amd/Subject.js
@@ -15,13 +15,9 @@ define(['exports', 'module', './Observable', './util/Symbol_observer', './Subscr
 
     var Subject = (function (_Observable) {
         function Subject() {
-            for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-                args[_key] = arguments[_key];
-            }
-
             _classCallCheck(this, Subject);
 
-            _Observable.call.apply(_Observable, [this].concat(args));
+            _Observable.call(this, null);
             this.disposed = false;
             this.observers = [];
             this.unsubscribed = false;

--- a/dist/amd/Subscription.js
+++ b/dist/amd/Subscription.js
@@ -11,6 +11,9 @@ define(['exports', 'module'], function (exports, module) {
             this.unsubscribed = false;
             this._unsubscribe = _unsubscribe;
             this.observer = observer;
+            if (observer) {
+                observer.setSubscription(this);
+            }
         }
 
         Subscription.prototype.unsubscribe = function unsubscribe() {

--- a/dist/amd/operator/multicast.js
+++ b/dist/amd/operator/multicast.js
@@ -1,0 +1,15 @@
+define(['exports', 'module', '../ConnectableObservable'], function (exports, module, _ConnectableObservable) {
+    'use strict';
+
+    module.exports = multicast;
+
+    function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+    var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
+
+    function multicast(subject) {
+        return new _ConnectableObservable2['default'](this, subject);
+    }
+
+    ;
+});

--- a/dist/amd/operator/multicast.js
+++ b/dist/amd/operator/multicast.js
@@ -7,8 +7,8 @@ define(['exports', 'module', '../ConnectableObservable'], function (exports, mod
 
     var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
 
-    function multicast(subject) {
-        return new _ConnectableObservable2['default'](this, subject);
+    function multicast(subjectFactory) {
+        return new _ConnectableObservable2['default'](this, subjectFactory);
     }
 
     ;

--- a/dist/amd/operator/publish.js
+++ b/dist/amd/operator/publish.js
@@ -1,0 +1,17 @@
+define(['exports', 'module', '../Subject'], function (exports, module, _Subject) {
+    'use strict';
+
+    module.exports = publish;
+
+    function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+    var _Subject2 = _interopRequireDefault(_Subject);
+
+    function subjectFactory() {
+        return new _Subject2['default']();
+    }
+
+    function publish() {
+        return this.multicast(subjectFactory);
+    }
+});

--- a/dist/cjs/BehaviorSubject.js
+++ b/dist/cjs/BehaviorSubject.js
@@ -24,7 +24,7 @@ var BehaviorSubject = (function (_Subject) {
     function BehaviorSubject(value) {
         _classCallCheck(this, BehaviorSubject);
 
-        _Subject.call(this, null);
+        _Subject.call(this);
         this.value = value;
     }
 

--- a/dist/cjs/ConnectableObservable.js
+++ b/dist/cjs/ConnectableObservable.js
@@ -1,0 +1,45 @@
+'use strict';
+
+exports.__esModule = true;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+
+var _Observable2 = require('./Observable');
+
+var _Observable3 = _interopRequireDefault(_Observable2);
+
+var _utilSymbol_observer = require('./util/Symbol_observer');
+
+var _utilSymbol_observer2 = _interopRequireDefault(_utilSymbol_observer);
+
+var ConnectableObservable = (function (_Observable) {
+    function ConnectableObservable(source, subject) {
+        _classCallCheck(this, ConnectableObservable);
+
+        _Observable.call(this, null);
+        this.source = source;
+        this.subject = subject;
+    }
+
+    _inherits(ConnectableObservable, _Observable);
+
+    ConnectableObservable.prototype.connect = function connect() {
+        if (!this.subscription) {
+            this.subscription = this.source.subscribe(this.subject);
+        }
+        return this.subscription;
+    };
+
+    ConnectableObservable.prototype[_utilSymbol_observer2['default']] = function (observer) {
+        return this.subject[_utilSymbol_observer2['default']](observer);
+    };
+
+    return ConnectableObservable;
+})(_Observable3['default']);
+
+exports['default'] = ConnectableObservable;
+module.exports = exports['default'];

--- a/dist/cjs/ConnectableObservable.js
+++ b/dist/cjs/ConnectableObservable.js
@@ -8,9 +8,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _Observable2 = require('./Observable');
+var _Observable3 = require('./Observable');
 
-var _Observable3 = _interopRequireDefault(_Observable2);
+var _Observable4 = _interopRequireDefault(_Observable3);
 
 var _Observer = require('./Observer');
 
@@ -56,10 +56,45 @@ var ConnectableObservable = (function (_Observable) {
         return this.subject[_utilSymbol_observer2['default']](observer);
     };
 
+    ConnectableObservable.prototype.refCount = function refCount() {
+        return new RefCountObservable(this);
+    };
+
     return ConnectableObservable;
-})(_Observable3['default']);
+})(_Observable4['default']);
 
 exports['default'] = ConnectableObservable;
+
+var RefCountObservable = (function (_Observable2) {
+    function RefCountObservable(source) {
+        _classCallCheck(this, RefCountObservable);
+
+        _Observable2.call(this, null);
+        this.refCount = 0;
+        this.source = source;
+    }
+
+    _inherits(RefCountObservable, _Observable2);
+
+    RefCountObservable.prototype.subscriber = function subscriber(observer) {
+        var _this = this;
+
+        this.refCount++;
+        this.source[_utilSymbol_observer2['default']](observer);
+        var shouldConnect = this.refCount === 1;
+        if (shouldConnect) {
+            this.connectionSubscription = this.source.connectSync();
+        }
+        return function () {
+            var refCount = _this.refCount--;
+            if (refCount === 0) {
+                _this.connectionSubscription.unsubscribe();
+            }
+        };
+    };
+
+    return RefCountObservable;
+})(_Observable4['default']);
 
 function dispatchConnection(connectable) {
     if (!connectable.subscription) {

--- a/dist/cjs/ConnectableObservable.js
+++ b/dist/cjs/ConnectableObservable.js
@@ -39,6 +39,10 @@ var ConnectableObservable = (function (_Observable) {
         return _schedulerNextTick2['default'].schedule(0, this, dispatchConnection);
     };
 
+    ConnectableObservable.prototype.connectSync = function connectSync() {
+        return dispatchConnection(this);
+    };
+
     ConnectableObservable.prototype[_utilSymbol_observer2['default']] = function (observer) {
         if (!(observer instanceof _Observer2['default'])) {
             observer = new _Observer2['default'](observer);

--- a/dist/cjs/ConnectableObservable.js
+++ b/dist/cjs/ConnectableObservable.js
@@ -12,29 +12,43 @@ var _Observable2 = require('./Observable');
 
 var _Observable3 = _interopRequireDefault(_Observable2);
 
+var _Observer = require('./Observer');
+
+var _Observer2 = _interopRequireDefault(_Observer);
+
 var _utilSymbol_observer = require('./util/Symbol_observer');
 
 var _utilSymbol_observer2 = _interopRequireDefault(_utilSymbol_observer);
 
+var _schedulerNextTick = require('./scheduler/nextTick');
+
+var _schedulerNextTick2 = _interopRequireDefault(_schedulerNextTick);
+
 var ConnectableObservable = (function (_Observable) {
-    function ConnectableObservable(source, subject) {
+    function ConnectableObservable(source, subjectFactory) {
         _classCallCheck(this, ConnectableObservable);
 
         _Observable.call(this, null);
         this.source = source;
-        this.subject = subject;
+        this.subjectFactory = subjectFactory;
     }
 
     _inherits(ConnectableObservable, _Observable);
 
     ConnectableObservable.prototype.connect = function connect() {
-        if (!this.subscription) {
-            this.subscription = this.source.subscribe(this.subject);
-        }
-        return this.subscription;
+        return _schedulerNextTick2['default'].schedule(0, this, dispatchConnection);
     };
 
     ConnectableObservable.prototype[_utilSymbol_observer2['default']] = function (observer) {
+        if (!(observer instanceof _Observer2['default'])) {
+            observer = new _Observer2['default'](observer);
+        }
+        if (!this.subject || this.subject.unsubscribed) {
+            if (this.subscription) {
+                this.subscription = undefined;
+            }
+            this.subject = this.subjectFactory();
+        }
         return this.subject[_utilSymbol_observer2['default']](observer);
     };
 
@@ -42,4 +56,14 @@ var ConnectableObservable = (function (_Observable) {
 })(_Observable3['default']);
 
 exports['default'] = ConnectableObservable;
+
+function dispatchConnection(connectable) {
+    if (!connectable.subscription) {
+        if (!connectable.subject) {
+            connectable.subject = connectable.subjectFactory();
+        }
+        connectable.subscription = connectable.source.subscribe(connectable.subject);
+    }
+    return connectable.subscription;
+}
 module.exports = exports['default'];

--- a/dist/cjs/Observable.js
+++ b/dist/cjs/Observable.js
@@ -44,6 +44,9 @@ var Observable = (function () {
     };
 
     Observable.prototype[_utilSymbol_observer2['default']] = function (observer) {
+        if (!(observer instanceof _Observer2['default'])) {
+            observer = new _Observer2['default'](observer);
+        }
         return _Subscription2['default'].from(this.subscriber(observer), observer);
     };
 

--- a/dist/cjs/Observer.js
+++ b/dist/cjs/Observer.js
@@ -96,6 +96,16 @@ var Observer = (function () {
 
     Observer.prototype.unsubscribe = function unsubscribe() {
         this.unsubscribed = true;
+        if (this.subscription && this.subscription._unsubscribe) {
+            this.subscription._unsubscribe();
+        }
+    };
+
+    Observer.prototype.setSubscription = function setSubscription(subscription) {
+        this.subscription = subscription;
+        if (this.unsubscribed && subscription._unsubscribe) {
+            subscription._unsubscribe();
+        }
     };
 
     Observer.prototype.dispose = function dispose() {

--- a/dist/cjs/RxNext.js
+++ b/dist/cjs/RxNext.js
@@ -40,6 +40,10 @@ var _BehaviorSubject = require('./BehaviorSubject');
 
 var _BehaviorSubject2 = _interopRequireDefault(_BehaviorSubject);
 
+var _ConnectableObservable = require('./ConnectableObservable');
+
+var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
+
 var _observableValue = require('./observable/value');
 
 var _observableValue2 = _interopRequireDefault(_observableValue);
@@ -144,6 +148,10 @@ var _operatorToArray = require('./operator/toArray');
 
 var _operatorToArray2 = _interopRequireDefault(_operatorToArray);
 
+var _operatorMulticast = require('./operator/multicast');
+
+var _operatorMulticast2 = _interopRequireDefault(_operatorMulticast);
+
 _Observable2['default'].value = _observableValue2['default'];
 _Observable2['default']['return'] = _observableReturn2['default'];
 _Observable2['default'].fromEventPattern = _observableFromEventPattern2['default'];
@@ -170,6 +178,7 @@ _Observable2['default'].prototype.zipAll = _operatorZipAll2['default'];
 _Observable2['default'].prototype.zip = _operatorZip2['default'];
 _Observable2['default'].prototype.merge = _operatorMerge2['default'];
 _Observable2['default'].prototype.toArray = _operatorToArray2['default'];
+_Observable2['default'].prototype.multicast = _operatorMulticast2['default'];
 var RxNext = {
     Scheduler: {
         nextTick: _schedulerNextTick2['default'],
@@ -181,7 +190,8 @@ var RxNext = {
     CompositeSubscription: _CompositeSubscription2['default'],
     SerialSubscription: _SerialSubscription2['default'],
     Subject: _Subject2['default'],
-    BehaviorSubject: _BehaviorSubject2['default']
+    BehaviorSubject: _BehaviorSubject2['default'],
+    ConnectableObservable: _ConnectableObservable2['default']
 };
 exports['default'] = RxNext;
 module.exports = exports['default'];

--- a/dist/cjs/RxNext.js
+++ b/dist/cjs/RxNext.js
@@ -152,6 +152,10 @@ var _operatorMulticast = require('./operator/multicast');
 
 var _operatorMulticast2 = _interopRequireDefault(_operatorMulticast);
 
+var _operatorPublish = require('./operator/publish');
+
+var _operatorPublish2 = _interopRequireDefault(_operatorPublish);
+
 _Observable2['default'].value = _observableValue2['default'];
 _Observable2['default']['return'] = _observableReturn2['default'];
 _Observable2['default'].fromEventPattern = _observableFromEventPattern2['default'];
@@ -179,6 +183,7 @@ _Observable2['default'].prototype.zip = _operatorZip2['default'];
 _Observable2['default'].prototype.merge = _operatorMerge2['default'];
 _Observable2['default'].prototype.toArray = _operatorToArray2['default'];
 _Observable2['default'].prototype.multicast = _operatorMulticast2['default'];
+_Observable2['default'].prototype.publish = _operatorPublish2['default'];
 var RxNext = {
     Scheduler: {
         nextTick: _schedulerNextTick2['default'],

--- a/dist/cjs/Subject.js
+++ b/dist/cjs/Subject.js
@@ -56,6 +56,7 @@ var Subject = (function (_Observable) {
         this.observers.forEach(function (o) {
             return o.next(value);
         });
+        this._cleanUnsubbedObservers();
         return { done: false };
     };
 
@@ -67,6 +68,7 @@ var Subject = (function (_Observable) {
             return o['throw'](err);
         });
         this.unsubscribe();
+        this._cleanUnsubbedObservers();
         return { done: true };
     };
 
@@ -78,7 +80,21 @@ var Subject = (function (_Observable) {
             return o['return'](value);
         });
         this.unsubscribe();
+        this._cleanUnsubbedObservers();
         return { done: true };
+    };
+
+    Subject.prototype._cleanUnsubbedObservers = function _cleanUnsubbedObservers() {
+        var i;
+        var observers = this.observers;
+        for (i = observers.length; i--;) {
+            if (observers[i].unsubscribed) {
+                observers.splice(i, 1);
+            }
+        }
+        if (observers.length === 0) {
+            this.unsubscribe();
+        }
     };
 
     Subject.prototype.unsubscribe = function unsubscribe() {

--- a/dist/cjs/Subject.js
+++ b/dist/cjs/Subject.js
@@ -22,13 +22,9 @@ var _Subscription3 = _interopRequireDefault(_Subscription2);
 
 var Subject = (function (_Observable) {
     function Subject() {
-        for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-            args[_key] = arguments[_key];
-        }
-
         _classCallCheck(this, Subject);
 
-        _Observable.call.apply(_Observable, [this].concat(args));
+        _Observable.call(this, null);
         this.disposed = false;
         this.observers = [];
         this.unsubscribed = false;

--- a/dist/cjs/Subject.js
+++ b/dist/cjs/Subject.js
@@ -31,13 +31,13 @@ var Subject = (function (_Observable) {
         _Observable.call.apply(_Observable, [this].concat(args));
         this.disposed = false;
         this.observers = [];
+        this.unsubscribed = false;
     }
 
     _inherits(Subject, _Observable);
 
     Subject.prototype.dispose = function dispose() {
         this.disposed = true;
-        this.observers.length = 0;
         if (this._dispose) {
             this._dispose();
         }
@@ -50,7 +50,7 @@ var Subject = (function (_Observable) {
     };
 
     Subject.prototype.next = function next(value) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(function (o) {
@@ -60,25 +60,30 @@ var Subject = (function (_Observable) {
     };
 
     Subject.prototype['throw'] = function _throw(err) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(function (o) {
             return o['throw'](err);
         });
-        this.dispose();
+        this.unsubscribe();
         return { done: true };
     };
 
     Subject.prototype['return'] = function _return(value) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(function (o) {
             return o['return'](value);
         });
-        this.dispose();
+        this.unsubscribe();
         return { done: true };
+    };
+
+    Subject.prototype.unsubscribe = function unsubscribe() {
+        this.observers.length = 0;
+        this.unsubscribed = true;
     };
 
     return Subject;

--- a/dist/cjs/Subscription.js
+++ b/dist/cjs/Subscription.js
@@ -12,6 +12,9 @@ var Subscription = (function () {
         this.unsubscribed = false;
         this._unsubscribe = _unsubscribe;
         this.observer = observer;
+        if (observer) {
+            observer.setSubscription(this);
+        }
     }
 
     Subscription.prototype.unsubscribe = function unsubscribe() {

--- a/dist/cjs/operator/multicast.js
+++ b/dist/cjs/operator/multicast.js
@@ -9,8 +9,8 @@ var _ConnectableObservable = require('../ConnectableObservable');
 
 var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
 
-function multicast(subject) {
-    return new _ConnectableObservable2['default'](this, subject);
+function multicast(subjectFactory) {
+    return new _ConnectableObservable2['default'](this, subjectFactory);
 }
 
 ;

--- a/dist/cjs/operator/multicast.js
+++ b/dist/cjs/operator/multicast.js
@@ -1,0 +1,17 @@
+'use strict';
+
+exports.__esModule = true;
+exports['default'] = multicast;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _ConnectableObservable = require('../ConnectableObservable');
+
+var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
+
+function multicast(subject) {
+    return new _ConnectableObservable2['default'](this, subject);
+}
+
+;
+module.exports = exports['default'];

--- a/dist/cjs/operator/publish.js
+++ b/dist/cjs/operator/publish.js
@@ -1,0 +1,20 @@
+'use strict';
+
+exports.__esModule = true;
+exports['default'] = publish;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _Subject = require('../Subject');
+
+var _Subject2 = _interopRequireDefault(_Subject);
+
+function subjectFactory() {
+    return new _Subject2['default']();
+}
+
+function publish() {
+    return this.multicast(subjectFactory);
+}
+
+module.exports = exports['default'];

--- a/dist/es6/BehaviorSubject.js
+++ b/dist/es6/BehaviorSubject.js
@@ -3,7 +3,7 @@ import Subscription from './Subscription';
 import Subject from './Subject';
 export default class BehaviorSubject extends Subject {
     constructor(value) {
-        super(null);
+        super();
         this.value = value;
     }
     [$$observer](observer) {

--- a/dist/es6/ConnectableObservable.d.ts
+++ b/dist/es6/ConnectableObservable.d.ts
@@ -1,0 +1,10 @@
+import Observable from './Observable';
+import Subscription from './Subscription';
+import Subject from './Subject';
+export default class ConnectableObservable extends Observable {
+    source: Observable;
+    subject: Subject;
+    subscription: Subscription;
+    constructor(source: Observable, subject: Subject);
+    connect(): Subscription;
+}

--- a/dist/es6/ConnectableObservable.d.ts
+++ b/dist/es6/ConnectableObservable.d.ts
@@ -8,4 +8,5 @@ export default class ConnectableObservable extends Observable {
     subject: Subject;
     constructor(source: Observable, subjectFactory: () => Subject);
     connect(): Subscription;
+    connectSync(): Subscription;
 }

--- a/dist/es6/ConnectableObservable.d.ts
+++ b/dist/es6/ConnectableObservable.d.ts
@@ -9,4 +9,5 @@ export default class ConnectableObservable extends Observable {
     constructor(source: Observable, subjectFactory: () => Subject);
     connect(): Subscription;
     connectSync(): Subscription;
+    refCount(): Observable;
 }

--- a/dist/es6/ConnectableObservable.d.ts
+++ b/dist/es6/ConnectableObservable.d.ts
@@ -3,8 +3,9 @@ import Subscription from './Subscription';
 import Subject from './Subject';
 export default class ConnectableObservable extends Observable {
     source: Observable;
-    subject: Subject;
+    subjectFactory: () => Subject;
     subscription: Subscription;
-    constructor(source: Observable, subject: Subject);
+    subject: Subject;
+    constructor(source: Observable, subjectFactory: () => Subject);
     connect(): Subscription;
 }

--- a/dist/es6/ConnectableObservable.js
+++ b/dist/es6/ConnectableObservable.js
@@ -1,0 +1,18 @@
+import Observable from './Observable';
+import $$observer from './util/Symbol_observer';
+export default class ConnectableObservable extends Observable {
+    constructor(source, subject) {
+        super(null);
+        this.source = source;
+        this.subject = subject;
+    }
+    connect() {
+        if (!this.subscription) {
+            this.subscription = this.source.subscribe(this.subject);
+        }
+        return this.subscription;
+    }
+    [$$observer](observer) {
+        return this.subject[$$observer](observer);
+    }
+}

--- a/dist/es6/ConnectableObservable.js
+++ b/dist/es6/ConnectableObservable.js
@@ -11,6 +11,9 @@ export default class ConnectableObservable extends Observable {
     connect() {
         return nextTick.schedule(0, this, dispatchConnection);
     }
+    connectSync() {
+        return dispatchConnection(this);
+    }
     [$$observer](observer) {
         if (!(observer instanceof Observer)) {
             observer = new Observer(observer);

--- a/dist/es6/ConnectableObservable.js
+++ b/dist/es6/ConnectableObservable.js
@@ -1,18 +1,35 @@
 import Observable from './Observable';
+import Observer from './Observer';
 import $$observer from './util/Symbol_observer';
+import nextTick from './scheduler/nextTick';
 export default class ConnectableObservable extends Observable {
-    constructor(source, subject) {
+    constructor(source, subjectFactory) {
         super(null);
         this.source = source;
-        this.subject = subject;
+        this.subjectFactory = subjectFactory;
     }
     connect() {
-        if (!this.subscription) {
-            this.subscription = this.source.subscribe(this.subject);
-        }
-        return this.subscription;
+        return nextTick.schedule(0, this, dispatchConnection);
     }
     [$$observer](observer) {
+        if (!(observer instanceof Observer)) {
+            observer = new Observer(observer);
+        }
+        if (!this.subject || this.subject.unsubscribed) {
+            if (this.subscription) {
+                this.subscription = undefined;
+            }
+            this.subject = this.subjectFactory();
+        }
         return this.subject[$$observer](observer);
     }
+}
+function dispatchConnection(connectable) {
+    if (!connectable.subscription) {
+        if (!connectable.subject) {
+            connectable.subject = connectable.subjectFactory();
+        }
+        connectable.subscription = connectable.source.subscribe(connectable.subject);
+    }
+    return connectable.subscription;
 }

--- a/dist/es6/Observable.d.ts
+++ b/dist/es6/Observable.d.ts
@@ -3,6 +3,8 @@ import Subscription from './Subscription';
 import SerialSubscription from './SerialSubscription';
 import Scheduler from './scheduler/Scheduler';
 import { IteratorResult } from './IteratorResult';
+import Subject from './Subject';
+import ConnectableObservable from './ConnectableObservable';
 export default class Observable {
     static value: (value: any) => Observable;
     static return: (returnValue: any) => Observable;
@@ -31,6 +33,7 @@ export default class Observable {
     zip: (observables: Array<Observable>, project: (...observables: Array<Observable>) => Observable) => Observable;
     merge: (observables: Array<Observable>) => Observable;
     toArray: () => Observable;
+    multicast: (subject: Subject) => ConnectableObservable;
     constructor(subscriber: (observer: Observer) => Function | void);
     static create(subscriber: (observer: Observer) => any): Observable;
     subscriber(observer: Observer): Function | Subscription | void;

--- a/dist/es6/Observable.d.ts
+++ b/dist/es6/Observable.d.ts
@@ -33,7 +33,7 @@ export default class Observable {
     zip: (observables: Array<Observable>, project: (...observables: Array<Observable>) => Observable) => Observable;
     merge: (observables: Array<Observable>) => Observable;
     toArray: () => Observable;
-    multicast: (subject: Subject) => ConnectableObservable;
+    multicast: (subjectFactory: () => Subject) => ConnectableObservable;
     constructor(subscriber: (observer: Observer) => Function | void);
     static create(subscriber: (observer: Observer) => any): Observable;
     subscriber(observer: Observer): Function | Subscription | void;

--- a/dist/es6/Observable.d.ts
+++ b/dist/es6/Observable.d.ts
@@ -34,6 +34,7 @@ export default class Observable {
     merge: (observables: Array<Observable>) => Observable;
     toArray: () => Observable;
     multicast: (subjectFactory: () => Subject) => ConnectableObservable;
+    publish: () => ConnectableObservable;
     constructor(subscriber: (observer: Observer) => Function | void);
     static create(subscriber: (observer: Observer) => any): Observable;
     subscriber(observer: Observer): Function | Subscription | void;

--- a/dist/es6/Observable.js
+++ b/dist/es6/Observable.js
@@ -16,6 +16,9 @@ export default class Observable {
         return void 0;
     }
     [$$observer](observer) {
+        if (!(observer instanceof Observer)) {
+            observer = new Observer(observer);
+        }
         return Subscription.from(this.subscriber(observer), observer);
     }
     subscribe(observerOrNextHandler, throwHandler = null, returnHandler = null, disposeHandler = null) {

--- a/dist/es6/Observer.d.ts
+++ b/dist/es6/Observer.d.ts
@@ -1,7 +1,9 @@
+import Subscription from './Subscription';
 import { IteratorResult } from './IteratorResult';
 export default class Observer {
     destination: Observer;
     unsubscribed: boolean;
+    subscription: Subscription;
     static create(_next: (value: any) => IteratorResult<any>, _throw?: ((value: any) => IteratorResult<any>), _return?: ((value: any) => IteratorResult<any>), _dispose?: (() => void)): Observer;
     _dispose(): void;
     _next(value: any): IteratorResult<any>;
@@ -12,5 +14,6 @@ export default class Observer {
     throw(error: any): IteratorResult<any>;
     return(value?: any): IteratorResult<any>;
     unsubscribe(): void;
+    setSubscription(subscription: Subscription): void;
     dispose(): void;
 }

--- a/dist/es6/Observer.js
+++ b/dist/es6/Observer.js
@@ -73,6 +73,15 @@ export default class Observer {
     }
     unsubscribe() {
         this.unsubscribed = true;
+        if (this.subscription && this.subscription._unsubscribe) {
+            this.subscription._unsubscribe();
+        }
+    }
+    setSubscription(subscription) {
+        this.subscription = subscription;
+        if (this.unsubscribed && subscription._unsubscribe) {
+            subscription._unsubscribe();
+        }
     }
     dispose() {
         if (!this.unsubscribed) {

--- a/dist/es6/RxNext.d.ts
+++ b/dist/es6/RxNext.d.ts
@@ -7,6 +7,7 @@ import CompositeSubscription from './CompositeSubscription';
 import SerialSubscription from './SerialSubscription';
 import Subject from './Subject';
 import BehaviorSubject from './BehaviorSubject';
+import ConnectableObservable from './ConnectableObservable';
 declare var RxNext: {
     Scheduler: {
         nextTick: NextTickScheduler;
@@ -19,5 +20,6 @@ declare var RxNext: {
     SerialSubscription: typeof SerialSubscription;
     Subject: typeof Subject;
     BehaviorSubject: typeof BehaviorSubject;
+    ConnectableObservable: typeof ConnectableObservable;
 };
 export default RxNext;

--- a/dist/es6/RxNext.js
+++ b/dist/es6/RxNext.js
@@ -35,6 +35,7 @@ import zipProto from './operator/zip';
 import mergeProto from './operator/merge';
 import toArray from './operator/toArray';
 import multicast from './operator/multicast';
+import publish from './operator/publish';
 Observable.value = value;
 Observable.return = _return;
 Observable.fromEventPattern = fromEventPattern;
@@ -62,6 +63,7 @@ Observable.prototype.zip = zipProto;
 Observable.prototype.merge = mergeProto;
 Observable.prototype.toArray = toArray;
 Observable.prototype.multicast = multicast;
+Observable.prototype.publish = publish;
 var RxNext = {
     Scheduler: {
         nextTick,

--- a/dist/es6/RxNext.js
+++ b/dist/es6/RxNext.js
@@ -7,6 +7,7 @@ import CompositeSubscription from './CompositeSubscription';
 import SerialSubscription from './SerialSubscription';
 import Subject from './Subject';
 import BehaviorSubject from './BehaviorSubject';
+import ConnectableObservable from './ConnectableObservable';
 import value from './observable/value';
 import _return from './observable/return';
 import fromEventPattern from './observable/fromEventPattern';
@@ -33,6 +34,7 @@ import zipAll from './operator/zipAll';
 import zipProto from './operator/zip';
 import mergeProto from './operator/merge';
 import toArray from './operator/toArray';
+import multicast from './operator/multicast';
 Observable.value = value;
 Observable.return = _return;
 Observable.fromEventPattern = fromEventPattern;
@@ -59,6 +61,7 @@ Observable.prototype.zipAll = zipAll;
 Observable.prototype.zip = zipProto;
 Observable.prototype.merge = mergeProto;
 Observable.prototype.toArray = toArray;
+Observable.prototype.multicast = multicast;
 var RxNext = {
     Scheduler: {
         nextTick,
@@ -70,6 +73,7 @@ var RxNext = {
     CompositeSubscription,
     SerialSubscription,
     Subject,
-    BehaviorSubject
+    BehaviorSubject,
+    ConnectableObservable
 };
 export default RxNext;

--- a/dist/es6/Subject.d.ts
+++ b/dist/es6/Subject.d.ts
@@ -17,5 +17,6 @@ export default class Subject extends Observable {
     next(value: any): IteratorResult<any>;
     throw(err: any): IteratorResult<any>;
     return(value: any): IteratorResult<any>;
+    _cleanUnsubbedObservers(): void;
     unsubscribe(): void;
 }

--- a/dist/es6/Subject.d.ts
+++ b/dist/es6/Subject.d.ts
@@ -13,6 +13,7 @@ export default class Subject extends Observable {
     _next: (value: any) => IteratorResult<any>;
     _throw: (err: any) => IteratorResult<any>;
     _return: (value: any) => IteratorResult<any>;
+    constructor();
     dispose(): void;
     next(value: any): IteratorResult<any>;
     throw(err: any): IteratorResult<any>;

--- a/dist/es6/Subject.d.ts
+++ b/dist/es6/Subject.d.ts
@@ -8,9 +8,14 @@ export default class Subject extends Observable {
     destination: Observer;
     disposed: boolean;
     observers: Array<Observer>;
-    _dispose: Function;
+    _dispose: () => void;
+    unsubscribed: boolean;
+    _next: (value: any) => IteratorResult<any>;
+    _throw: (err: any) => IteratorResult<any>;
+    _return: (value: any) => IteratorResult<any>;
     dispose(): void;
     next(value: any): IteratorResult<any>;
     throw(err: any): IteratorResult<any>;
     return(value: any): IteratorResult<any>;
+    unsubscribe(): void;
 }

--- a/dist/es6/Subject.js
+++ b/dist/es6/Subject.js
@@ -2,8 +2,8 @@ import Observable from './Observable';
 import $$observer from './util/Symbol_observer';
 import Subscription from './Subscription';
 export default class Subject extends Observable {
-    constructor(...args) {
-        super(...args);
+    constructor() {
+        super(null);
         this.disposed = false;
         this.observers = [];
         this.unsubscribed = false;

--- a/dist/es6/Subject.js
+++ b/dist/es6/Subject.js
@@ -6,10 +6,10 @@ export default class Subject extends Observable {
         super(...args);
         this.disposed = false;
         this.observers = [];
+        this.unsubscribed = false;
     }
     dispose() {
         this.disposed = true;
-        this.observers.length = 0;
         if (this._dispose) {
             this._dispose();
         }
@@ -20,27 +20,31 @@ export default class Subject extends Observable {
         return subscription;
     }
     next(value) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(o => o.next(value));
         return { done: false };
     }
     throw(err) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(o => o.throw(err));
-        this.dispose();
+        this.unsubscribe();
         return { done: true };
     }
     return(value) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(o => o.return(value));
-        this.dispose();
+        this.unsubscribe();
         return { done: true };
+    }
+    unsubscribe() {
+        this.observers.length = 0;
+        this.unsubscribed = true;
     }
 }
 class SubjectSubscription extends Subscription {

--- a/dist/es6/Subject.js
+++ b/dist/es6/Subject.js
@@ -24,6 +24,7 @@ export default class Subject extends Observable {
             return { done: true };
         }
         this.observers.forEach(o => o.next(value));
+        this._cleanUnsubbedObservers();
         return { done: false };
     }
     throw(err) {
@@ -32,6 +33,7 @@ export default class Subject extends Observable {
         }
         this.observers.forEach(o => o.throw(err));
         this.unsubscribe();
+        this._cleanUnsubbedObservers();
         return { done: true };
     }
     return(value) {
@@ -40,7 +42,20 @@ export default class Subject extends Observable {
         }
         this.observers.forEach(o => o.return(value));
         this.unsubscribe();
+        this._cleanUnsubbedObservers();
         return { done: true };
+    }
+    _cleanUnsubbedObservers() {
+        var i;
+        var observers = this.observers;
+        for (i = observers.length; i--;) {
+            if (observers[i].unsubscribed) {
+                observers.splice(i, 1);
+            }
+        }
+        if (observers.length === 0) {
+            this.unsubscribe();
+        }
     }
     unsubscribe() {
         this.observers.length = 0;

--- a/dist/es6/Subscription.js
+++ b/dist/es6/Subscription.js
@@ -4,6 +4,9 @@ export default class Subscription {
         this.unsubscribed = false;
         this._unsubscribe = _unsubscribe;
         this.observer = observer;
+        if (observer) {
+            observer.setSubscription(this);
+        }
     }
     unsubscribe() {
         if (this.unsubscribed) {

--- a/dist/es6/operator/multicast.d.ts
+++ b/dist/es6/operator/multicast.d.ts
@@ -1,0 +1,3 @@
+import Subject from '../Subject';
+import ConnectableObservable from '../ConnectableObservable';
+export default function multicast(subject: Subject): ConnectableObservable;

--- a/dist/es6/operator/multicast.d.ts
+++ b/dist/es6/operator/multicast.d.ts
@@ -1,3 +1,3 @@
 import Subject from '../Subject';
 import ConnectableObservable from '../ConnectableObservable';
-export default function multicast(subject: Subject): ConnectableObservable;
+export default function multicast(subjectFactory: () => Subject): ConnectableObservable;

--- a/dist/es6/operator/multicast.js
+++ b/dist/es6/operator/multicast.js
@@ -1,5 +1,5 @@
 import ConnectableObservable from '../ConnectableObservable';
-export default function multicast(subject) {
-    return new ConnectableObservable(this, subject);
+export default function multicast(subjectFactory) {
+    return new ConnectableObservable(this, subjectFactory);
 }
 ;

--- a/dist/es6/operator/multicast.js
+++ b/dist/es6/operator/multicast.js
@@ -1,0 +1,5 @@
+import ConnectableObservable from '../ConnectableObservable';
+export default function multicast(subject) {
+    return new ConnectableObservable(this, subject);
+}
+;

--- a/dist/es6/operator/publish.d.ts
+++ b/dist/es6/operator/publish.d.ts
@@ -1,0 +1,2 @@
+import ConnectableObservable from '../ConnectableObservable';
+export default function publish(): ConnectableObservable;

--- a/dist/es6/operator/publish.js
+++ b/dist/es6/operator/publish.js
@@ -1,0 +1,7 @@
+import Subject from '../Subject';
+function subjectFactory() {
+    return new Subject();
+}
+export default function publish() {
+    return this.multicast(subjectFactory);
+}

--- a/dist/global/RxNext.js
+++ b/dist/global/RxNext.js
@@ -25,7 +25,7 @@ var BehaviorSubject = (function (_Subject) {
     function BehaviorSubject(value) {
         _classCallCheck(this, BehaviorSubject);
 
-        _Subject.call(this, null);
+        _Subject.call(this);
         this.value = value;
     }
 
@@ -48,7 +48,7 @@ var BehaviorSubject = (function (_Subject) {
 
 exports['default'] = BehaviorSubject;
 module.exports = exports['default'];
-},{"./Subject":8,"./Subscription":9,"./util/Symbol_observer":44}],2:[function(require,module,exports){
+},{"./Subject":8,"./Subscription":9,"./util/Symbol_observer":45}],2:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -138,7 +138,7 @@ var CompositeSubscription = (function (_Subscription) {
 
 exports['default'] = CompositeSubscription;
 module.exports = exports['default'];
-},{"./Subscription":9,"./util/arraySlice":45}],3:[function(require,module,exports){
+},{"./Subscription":9,"./util/arraySlice":46}],3:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -212,7 +212,7 @@ function dispatchConnection(connectable) {
     return connectable.subscription;
 }
 module.exports = exports['default'];
-},{"./Observable":4,"./Observer":5,"./scheduler/nextTick":42,"./util/Symbol_observer":44}],4:[function(require,module,exports){
+},{"./Observable":4,"./Observer":5,"./scheduler/nextTick":43,"./util/Symbol_observer":45}],4:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -312,7 +312,7 @@ function dispatchSubscription(_ref) {
     return observable[_utilSymbol_observer2['default']](observer);
 }
 module.exports = exports['default'];
-},{"./Observer":5,"./SerialSubscription":7,"./Subscription":9,"./scheduler/nextTick":42,"./util/Symbol_observer":44}],5:[function(require,module,exports){
+},{"./Observer":5,"./SerialSubscription":7,"./Subscription":9,"./scheduler/nextTick":43,"./util/Symbol_observer":45}],5:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -582,6 +582,10 @@ var _operatorMulticast = require('./operator/multicast');
 
 var _operatorMulticast2 = _interopRequireDefault(_operatorMulticast);
 
+var _operatorPublish = require('./operator/publish');
+
+var _operatorPublish2 = _interopRequireDefault(_operatorPublish);
+
 _Observable2['default'].value = _observableValue2['default'];
 _Observable2['default']['return'] = _observableReturn2['default'];
 _Observable2['default'].fromEventPattern = _observableFromEventPattern2['default'];
@@ -609,6 +613,7 @@ _Observable2['default'].prototype.zip = _operatorZip2['default'];
 _Observable2['default'].prototype.merge = _operatorMerge2['default'];
 _Observable2['default'].prototype.toArray = _operatorToArray2['default'];
 _Observable2['default'].prototype.multicast = _operatorMulticast2['default'];
+_Observable2['default'].prototype.publish = _operatorPublish2['default'];
 var RxNext = {
     Scheduler: {
         nextTick: _schedulerNextTick2['default'],
@@ -625,7 +630,7 @@ var RxNext = {
 };
 exports['default'] = RxNext;
 module.exports = exports['default'];
-},{"./BehaviorSubject":1,"./CompositeSubscription":2,"./ConnectableObservable":3,"./Observable":4,"./Observer":5,"./SerialSubscription":7,"./Subject":8,"./Subscription":9,"./observable/empty":11,"./observable/fromArray":12,"./observable/fromEvent":13,"./observable/fromEventPattern":14,"./observable/fromPromise":15,"./observable/interval":16,"./observable/of":17,"./observable/range":18,"./observable/return":19,"./observable/throw":20,"./observable/timer":21,"./observable/value":22,"./observable/zip":23,"./operator/concatAll":24,"./operator/flatMap":25,"./operator/map":26,"./operator/mapTo":27,"./operator/merge":28,"./operator/mergeAll":29,"./operator/multicast":30,"./operator/observeOn":31,"./operator/skip":32,"./operator/subscribeOn":33,"./operator/take":34,"./operator/toArray":35,"./operator/zip":36,"./operator/zipAll":37,"./scheduler/immediate":41,"./scheduler/nextTick":42}],7:[function(require,module,exports){
+},{"./BehaviorSubject":1,"./CompositeSubscription":2,"./ConnectableObservable":3,"./Observable":4,"./Observer":5,"./SerialSubscription":7,"./Subject":8,"./Subscription":9,"./observable/empty":11,"./observable/fromArray":12,"./observable/fromEvent":13,"./observable/fromEventPattern":14,"./observable/fromPromise":15,"./observable/interval":16,"./observable/of":17,"./observable/range":18,"./observable/return":19,"./observable/throw":20,"./observable/timer":21,"./observable/value":22,"./observable/zip":23,"./operator/concatAll":24,"./operator/flatMap":25,"./operator/map":26,"./operator/mapTo":27,"./operator/merge":28,"./operator/mergeAll":29,"./operator/multicast":30,"./operator/observeOn":31,"./operator/publish":32,"./operator/skip":33,"./operator/subscribeOn":34,"./operator/take":35,"./operator/toArray":36,"./operator/zip":37,"./operator/zipAll":38,"./scheduler/immediate":42,"./scheduler/nextTick":43}],7:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -715,13 +720,9 @@ var _Subscription3 = _interopRequireDefault(_Subscription2);
 
 var Subject = (function (_Observable) {
     function Subject() {
-        for (var _len = arguments.length, args = Array(_len), _key = 0; _key < _len; _key++) {
-            args[_key] = arguments[_key];
-        }
-
         _classCallCheck(this, Subject);
 
-        _Observable.call.apply(_Observable, [this].concat(args));
+        _Observable.call(this, null);
         this.disposed = false;
         this.observers = [];
         this.unsubscribed = false;
@@ -823,7 +824,7 @@ var SubjectSubscription = (function (_Subscription) {
 })(_Subscription3['default']);
 
 module.exports = exports['default'];
-},{"./Observable":4,"./Subscription":9,"./util/Symbol_observer":44}],9:[function(require,module,exports){
+},{"./Observable":4,"./Subscription":9,"./util/Symbol_observer":45}],9:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1097,7 +1098,7 @@ function fromEvent(element, eventName) {
 
 ;
 module.exports = exports['default'];
-},{"../CompositeSubscription":2,"../Observable":4,"../Subscription":9,"../util/errorObject":46,"../util/tryCatch":48,"./fromEventPattern":14}],14:[function(require,module,exports){
+},{"../CompositeSubscription":2,"../Observable":4,"../Subscription":9,"../util/errorObject":47,"../util/tryCatch":49,"./fromEventPattern":14}],14:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1181,7 +1182,7 @@ function fromEventPattern(addHandler) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":4,"../util/errorObject":46,"../util/tryCatch":48}],15:[function(require,module,exports){
+},{"../Observable":4,"../util/errorObject":47,"../util/tryCatch":49}],15:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1304,7 +1305,7 @@ function timer() {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":4,"../Observer":5,"../scheduler/nextTick":42}],17:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../scheduler/nextTick":43}],17:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1512,7 +1513,7 @@ function timer() {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":4,"../scheduler/nextTick":42}],22:[function(require,module,exports){
+},{"../Observable":4,"../scheduler/nextTick":43}],22:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1675,7 +1676,7 @@ function zip(observables, project) {
 }
 
 module.exports = exports['default'];
-},{"../CompositeSubscription":2,"../Observable":4,"../Observer":5,"../Subscription":9,"../util/Symbol_observer":44,"../util/errorObject":46,"../util/tryCatch":48}],24:[function(require,module,exports){
+},{"../CompositeSubscription":2,"../Observable":4,"../Observer":5,"../Subscription":9,"../util/Symbol_observer":45,"../util/errorObject":47,"../util/tryCatch":49}],24:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1794,7 +1795,7 @@ function select(project) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":4,"../Observer":5,"../Subscription":9,"../util/errorObject":46,"../util/tryCatch":48}],27:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9,"../util/errorObject":47,"../util/tryCatch":49}],27:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2016,7 +2017,7 @@ function mergeAll() {
 
 ;
 module.exports = exports['default'];
-},{"../CompositeSubscription":2,"../Observable":4,"../Observer":5,"../SerialSubscription":7,"../Subscription":9,"../util/Symbol_observer":44}],30:[function(require,module,exports){
+},{"../CompositeSubscription":2,"../Observable":4,"../Observer":5,"../SerialSubscription":7,"../Subscription":9,"../util/Symbol_observer":45}],30:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2138,6 +2139,27 @@ module.exports = exports['default'];
 'use strict';
 
 exports.__esModule = true;
+exports['default'] = publish;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _Subject = require('../Subject');
+
+var _Subject2 = _interopRequireDefault(_Subject);
+
+function subjectFactory() {
+    return new _Subject2['default']();
+}
+
+function publish() {
+    return this.multicast(subjectFactory);
+}
+
+module.exports = exports['default'];
+},{"../Subject":8}],33:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
 exports['default'] = skip;
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
@@ -2204,7 +2226,7 @@ function skip(count) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":4,"../Observer":5,"../Subscription":9}],33:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],34:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2264,7 +2286,7 @@ function subscribeOn(scheduler) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":4,"../SerialSubscription":7,"../util/Symbol_observer":44}],34:[function(require,module,exports){
+},{"../Observable":4,"../SerialSubscription":7,"../util/Symbol_observer":45}],35:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2335,7 +2357,7 @@ function take(count) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":4,"../Observer":5,"../Subscription":9}],35:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],36:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2405,7 +2427,7 @@ function toArray() {
 }
 
 module.exports = exports['default'];
-},{"../Observable":4,"../Observer":5,"../Subscription":9}],36:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],37:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2422,7 +2444,7 @@ function zip(observables, project) {
 }
 
 module.exports = exports['default'];
-},{"../Observable":4}],37:[function(require,module,exports){
+},{"../Observable":4}],38:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2441,7 +2463,7 @@ function zipAll(project) {
 }
 
 module.exports = exports['default'];
-},{"../Observable":4}],38:[function(require,module,exports){
+},{"../Observable":4}],39:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2480,7 +2502,7 @@ var NextTickScheduler = (function (_Scheduler) {
 
 exports['default'] = NextTickScheduler;
 module.exports = exports['default'];
-},{"./Scheduler":39,"./SchedulerActions":40}],39:[function(require,module,exports){
+},{"./Scheduler":40,"./SchedulerActions":41}],40:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2531,7 +2553,7 @@ var Scheduler = (function () {
 
 exports['default'] = Scheduler;
 module.exports = exports['default'];
-},{"./SchedulerActions":40}],40:[function(require,module,exports){
+},{"./SchedulerActions":41}],41:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2684,7 +2706,7 @@ var FutureScheduledAction = (function (_ScheduledAction2) {
 })(ScheduledAction);
 
 exports.FutureScheduledAction = FutureScheduledAction;
-},{"../SerialSubscription":7,"../Subscription":9,"../util/Immediate":43}],41:[function(require,module,exports){
+},{"../SerialSubscription":7,"../Subscription":9,"../util/Immediate":44}],42:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2698,7 +2720,7 @@ var _Scheduler2 = _interopRequireDefault(_Scheduler);
 var immediate = new _Scheduler2['default']();
 exports['default'] = immediate;
 module.exports = exports['default'];
-},{"./Scheduler":39}],42:[function(require,module,exports){
+},{"./Scheduler":40}],43:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2712,7 +2734,7 @@ var _NextTickScheduler2 = _interopRequireDefault(_NextTickScheduler);
 var nextTick = new _NextTickScheduler2['default']();
 exports['default'] = nextTick;
 module.exports = exports['default'];
-},{"./NextTickScheduler":38}],43:[function(require,module,exports){
+},{"./NextTickScheduler":39}],44:[function(require,module,exports){
 /**
 All credit for this helper goes to http://github.com/YuzuJS/setImmediate
 */
@@ -2881,7 +2903,7 @@ if (_root2["default"] && _root2["default"].setImmediate) {
 }
 exports["default"] = Immediate;
 module.exports = exports["default"];
-},{"./root":47}],44:[function(require,module,exports){
+},{"./root":48}],45:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2903,7 +2925,7 @@ if (!_root2['default'].Symbol.observer) {
 }
 exports['default'] = _root2['default'].Symbol.observer;
 module.exports = exports['default'];
-},{"./root":47}],45:[function(require,module,exports){
+},{"./root":48}],46:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -2927,14 +2949,14 @@ function arraySlice(array) {
 
 ;
 module.exports = exports["default"];
-},{}],46:[function(require,module,exports){
+},{}],47:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
 var errorObject = { e: {} };
 exports["default"] = errorObject;
 module.exports = exports["default"];
-},{}],47:[function(require,module,exports){
+},{}],48:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -2958,7 +2980,7 @@ if (freeGlobal && (freeGlobal.global === freeGlobal || freeGlobal.window === fre
 exports['default'] = root;
 module.exports = exports['default'];
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],48:[function(require,module,exports){
+},{}],49:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2987,7 +3009,7 @@ function tryCatch(fn) {
 
 ;
 module.exports = exports['default'];
-},{"./errorObject":46}],49:[function(require,module,exports){
+},{"./errorObject":47}],50:[function(require,module,exports){
 (function (global){
 (function (root, factory) {
   root.RxNext = factory();
@@ -2995,4 +3017,4 @@ module.exports = exports['default'];
   return require('../dist/cjs/RxNext');	
 }));
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../dist/cjs/RxNext":6}]},{},[49]);
+},{"../dist/cjs/RxNext":6}]},{},[50]);

--- a/dist/global/RxNext.js
+++ b/dist/global/RxNext.js
@@ -48,7 +48,7 @@ var BehaviorSubject = (function (_Subject) {
 
 exports['default'] = BehaviorSubject;
 module.exports = exports['default'];
-},{"./Subject":7,"./Subscription":8,"./util/Symbol_observer":42}],2:[function(require,module,exports){
+},{"./Subject":8,"./Subscription":9,"./util/Symbol_observer":44}],2:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -138,7 +138,53 @@ var CompositeSubscription = (function (_Subscription) {
 
 exports['default'] = CompositeSubscription;
 module.exports = exports['default'];
-},{"./Subscription":8,"./util/arraySlice":43}],3:[function(require,module,exports){
+},{"./Subscription":9,"./util/arraySlice":45}],3:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+function _classCallCheck(instance, Constructor) { if (!(instance instanceof Constructor)) { throw new TypeError('Cannot call a class as a function'); } }
+
+function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
+
+var _Observable2 = require('./Observable');
+
+var _Observable3 = _interopRequireDefault(_Observable2);
+
+var _utilSymbol_observer = require('./util/Symbol_observer');
+
+var _utilSymbol_observer2 = _interopRequireDefault(_utilSymbol_observer);
+
+var ConnectableObservable = (function (_Observable) {
+    function ConnectableObservable(source, subject) {
+        _classCallCheck(this, ConnectableObservable);
+
+        _Observable.call(this, null);
+        this.source = source;
+        this.subject = subject;
+    }
+
+    _inherits(ConnectableObservable, _Observable);
+
+    ConnectableObservable.prototype.connect = function connect() {
+        if (!this.subscription) {
+            this.subscription = this.source.subscribe(this.subject);
+        }
+        return this.subscription;
+    };
+
+    ConnectableObservable.prototype[_utilSymbol_observer2['default']] = function (observer) {
+        return this.subject[_utilSymbol_observer2['default']](observer);
+    };
+
+    return ConnectableObservable;
+})(_Observable3['default']);
+
+exports['default'] = ConnectableObservable;
+module.exports = exports['default'];
+},{"./Observable":4,"./util/Symbol_observer":44}],4:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -235,7 +281,7 @@ function dispatchSubscription(_ref) {
     return observable[_utilSymbol_observer2['default']](observer);
 }
 module.exports = exports['default'];
-},{"./Observer":4,"./SerialSubscription":6,"./Subscription":8,"./scheduler/nextTick":40,"./util/Symbol_observer":42}],4:[function(require,module,exports){
+},{"./Observer":5,"./SerialSubscription":7,"./Subscription":9,"./scheduler/nextTick":42,"./util/Symbol_observer":44}],5:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -350,7 +396,7 @@ var Observer = (function () {
 
 exports["default"] = Observer;
 module.exports = exports["default"];
-},{}],5:[function(require,module,exports){
+},{}],6:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -392,6 +438,10 @@ var _Subject2 = _interopRequireDefault(_Subject);
 var _BehaviorSubject = require('./BehaviorSubject');
 
 var _BehaviorSubject2 = _interopRequireDefault(_BehaviorSubject);
+
+var _ConnectableObservable = require('./ConnectableObservable');
+
+var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
 
 var _observableValue = require('./observable/value');
 
@@ -497,6 +547,10 @@ var _operatorToArray = require('./operator/toArray');
 
 var _operatorToArray2 = _interopRequireDefault(_operatorToArray);
 
+var _operatorMulticast = require('./operator/multicast');
+
+var _operatorMulticast2 = _interopRequireDefault(_operatorMulticast);
+
 _Observable2['default'].value = _observableValue2['default'];
 _Observable2['default']['return'] = _observableReturn2['default'];
 _Observable2['default'].fromEventPattern = _observableFromEventPattern2['default'];
@@ -523,6 +577,7 @@ _Observable2['default'].prototype.zipAll = _operatorZipAll2['default'];
 _Observable2['default'].prototype.zip = _operatorZip2['default'];
 _Observable2['default'].prototype.merge = _operatorMerge2['default'];
 _Observable2['default'].prototype.toArray = _operatorToArray2['default'];
+_Observable2['default'].prototype.multicast = _operatorMulticast2['default'];
 var RxNext = {
     Scheduler: {
         nextTick: _schedulerNextTick2['default'],
@@ -534,11 +589,12 @@ var RxNext = {
     CompositeSubscription: _CompositeSubscription2['default'],
     SerialSubscription: _SerialSubscription2['default'],
     Subject: _Subject2['default'],
-    BehaviorSubject: _BehaviorSubject2['default']
+    BehaviorSubject: _BehaviorSubject2['default'],
+    ConnectableObservable: _ConnectableObservable2['default']
 };
 exports['default'] = RxNext;
 module.exports = exports['default'];
-},{"./BehaviorSubject":1,"./CompositeSubscription":2,"./Observable":3,"./Observer":4,"./SerialSubscription":6,"./Subject":7,"./Subscription":8,"./observable/empty":10,"./observable/fromArray":11,"./observable/fromEvent":12,"./observable/fromEventPattern":13,"./observable/fromPromise":14,"./observable/interval":15,"./observable/of":16,"./observable/range":17,"./observable/return":18,"./observable/throw":19,"./observable/timer":20,"./observable/value":21,"./observable/zip":22,"./operator/concatAll":23,"./operator/flatMap":24,"./operator/map":25,"./operator/mapTo":26,"./operator/merge":27,"./operator/mergeAll":28,"./operator/observeOn":29,"./operator/skip":30,"./operator/subscribeOn":31,"./operator/take":32,"./operator/toArray":33,"./operator/zip":34,"./operator/zipAll":35,"./scheduler/immediate":39,"./scheduler/nextTick":40}],6:[function(require,module,exports){
+},{"./BehaviorSubject":1,"./CompositeSubscription":2,"./ConnectableObservable":3,"./Observable":4,"./Observer":5,"./SerialSubscription":7,"./Subject":8,"./Subscription":9,"./observable/empty":11,"./observable/fromArray":12,"./observable/fromEvent":13,"./observable/fromEventPattern":14,"./observable/fromPromise":15,"./observable/interval":16,"./observable/of":17,"./observable/range":18,"./observable/return":19,"./observable/throw":20,"./observable/timer":21,"./observable/value":22,"./observable/zip":23,"./operator/concatAll":24,"./operator/flatMap":25,"./operator/map":26,"./operator/mapTo":27,"./operator/merge":28,"./operator/mergeAll":29,"./operator/multicast":30,"./operator/observeOn":31,"./operator/skip":32,"./operator/subscribeOn":33,"./operator/take":34,"./operator/toArray":35,"./operator/zip":36,"./operator/zipAll":37,"./scheduler/immediate":41,"./scheduler/nextTick":42}],7:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -603,7 +659,7 @@ var SerialSubscription = (function (_Subscription) {
 
 exports['default'] = SerialSubscription;
 module.exports = exports['default'];
-},{"./Subscription":8}],7:[function(require,module,exports){
+},{"./Subscription":9}],8:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -637,13 +693,13 @@ var Subject = (function (_Observable) {
         _Observable.call.apply(_Observable, [this].concat(args));
         this.disposed = false;
         this.observers = [];
+        this.unsubscribed = false;
     }
 
     _inherits(Subject, _Observable);
 
     Subject.prototype.dispose = function dispose() {
         this.disposed = true;
-        this.observers.length = 0;
         if (this._dispose) {
             this._dispose();
         }
@@ -656,7 +712,7 @@ var Subject = (function (_Observable) {
     };
 
     Subject.prototype.next = function next(value) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(function (o) {
@@ -666,25 +722,30 @@ var Subject = (function (_Observable) {
     };
 
     Subject.prototype['throw'] = function _throw(err) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(function (o) {
             return o['throw'](err);
         });
-        this.dispose();
+        this.unsubscribe();
         return { done: true };
     };
 
     Subject.prototype['return'] = function _return(value) {
-        if (this.disposed) {
+        if (this.unsubscribed) {
             return { done: true };
         }
         this.observers.forEach(function (o) {
             return o['return'](value);
         });
-        this.dispose();
+        this.unsubscribe();
         return { done: true };
+    };
+
+    Subject.prototype.unsubscribe = function unsubscribe() {
+        this.observers.length = 0;
+        this.unsubscribed = true;
     };
 
     return Subject;
@@ -715,7 +776,7 @@ var SubjectSubscription = (function (_Subscription) {
 })(_Subscription3['default']);
 
 module.exports = exports['default'];
-},{"./Observable":3,"./Subscription":8,"./util/Symbol_observer":42}],8:[function(require,module,exports){
+},{"./Observable":4,"./Subscription":9,"./util/Symbol_observer":44}],9:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -776,7 +837,7 @@ var Subscription = (function () {
 
 exports['default'] = Subscription;
 module.exports = exports['default'];
-},{}],9:[function(require,module,exports){
+},{}],10:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -817,7 +878,7 @@ var ArrayObservable = (function (_Observable) {
 
 exports['default'] = ArrayObservable;
 module.exports = exports['default'];
-},{"../Observable":3}],10:[function(require,module,exports){
+},{"../Observable":4}],11:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -839,7 +900,7 @@ function empty() {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3}],11:[function(require,module,exports){
+},{"../Observable":4}],12:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -856,7 +917,7 @@ function fromArray(array) {
 }
 
 module.exports = exports['default'];
-},{"./ArrayObservable":9}],12:[function(require,module,exports){
+},{"./ArrayObservable":10}],13:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -989,7 +1050,7 @@ function fromEvent(element, eventName) {
 
 ;
 module.exports = exports['default'];
-},{"../CompositeSubscription":2,"../Observable":3,"../Subscription":8,"../util/errorObject":44,"../util/tryCatch":46,"./fromEventPattern":13}],13:[function(require,module,exports){
+},{"../CompositeSubscription":2,"../Observable":4,"../Subscription":9,"../util/errorObject":46,"../util/tryCatch":48,"./fromEventPattern":14}],14:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1073,7 +1134,7 @@ function fromEventPattern(addHandler) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../util/errorObject":44,"../util/tryCatch":46}],14:[function(require,module,exports){
+},{"../Observable":4,"../util/errorObject":46,"../util/tryCatch":48}],15:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1119,7 +1180,7 @@ function fromPromise(promise) {
 }
 
 module.exports = exports['default'];
-},{"../Observable":3}],15:[function(require,module,exports){
+},{"../Observable":4}],16:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1196,7 +1257,7 @@ function timer() {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../Observer":4,"../scheduler/nextTick":40}],16:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../scheduler/nextTick":42}],17:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1218,7 +1279,7 @@ function of() {
 
 ;
 module.exports = exports['default'];
-},{"./ArrayObservable":9}],17:[function(require,module,exports){
+},{"./ArrayObservable":10}],18:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1267,7 +1328,7 @@ function range() {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3}],18:[function(require,module,exports){
+},{"../Observable":4}],19:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1307,7 +1368,7 @@ function _return() {
 }
 
 module.exports = exports['default'];
-},{"../Observable":3}],19:[function(require,module,exports){
+},{"../Observable":4}],20:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1350,7 +1411,7 @@ function _throw() {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3}],20:[function(require,module,exports){
+},{"../Observable":4}],21:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1404,7 +1465,7 @@ function timer() {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../scheduler/nextTick":40}],21:[function(require,module,exports){
+},{"../Observable":4,"../scheduler/nextTick":42}],22:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1444,7 +1505,7 @@ function value(value) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3}],22:[function(require,module,exports){
+},{"../Observable":4}],23:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1567,7 +1628,7 @@ function zip(observables, project) {
 }
 
 module.exports = exports['default'];
-},{"../CompositeSubscription":2,"../Observable":3,"../Observer":4,"../Subscription":8,"../util/Symbol_observer":42,"../util/errorObject":44,"../util/tryCatch":46}],23:[function(require,module,exports){
+},{"../CompositeSubscription":2,"../Observable":4,"../Observer":5,"../Subscription":9,"../util/Symbol_observer":44,"../util/errorObject":46,"../util/tryCatch":48}],24:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1584,7 +1645,7 @@ function concatAll() {
 }
 
 module.exports = exports['default'];
-},{"./mergeAll":28}],24:[function(require,module,exports){
+},{"./mergeAll":29}],25:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1607,7 +1668,7 @@ function flatMap(project) {
 }
 
 module.exports = exports['default'];
-},{"./map":25,"./mergeAll":28}],25:[function(require,module,exports){
+},{"./map":26,"./mergeAll":29}],26:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1686,7 +1747,7 @@ function select(project) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../Observer":4,"../Subscription":8,"../util/errorObject":44,"../util/tryCatch":46}],26:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9,"../util/errorObject":46,"../util/tryCatch":48}],27:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1752,7 +1813,7 @@ function mapTo(value) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../Observer":4,"../Subscription":8}],27:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],28:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1769,7 +1830,7 @@ function merge(observables) {
 }
 
 module.exports = exports['default'];
-},{"../Observable":3}],28:[function(require,module,exports){
+},{"../Observable":4}],29:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -1908,7 +1969,25 @@ function mergeAll() {
 
 ;
 module.exports = exports['default'];
-},{"../CompositeSubscription":2,"../Observable":3,"../Observer":4,"../SerialSubscription":6,"../Subscription":8,"../util/Symbol_observer":42}],29:[function(require,module,exports){
+},{"../CompositeSubscription":2,"../Observable":4,"../Observer":5,"../SerialSubscription":7,"../Subscription":9,"../util/Symbol_observer":44}],30:[function(require,module,exports){
+'use strict';
+
+exports.__esModule = true;
+exports['default'] = multicast;
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { 'default': obj }; }
+
+var _ConnectableObservable = require('../ConnectableObservable');
+
+var _ConnectableObservable2 = _interopRequireDefault(_ConnectableObservable);
+
+function multicast(subject) {
+    return new _ConnectableObservable2['default'](this, subject);
+}
+
+;
+module.exports = exports['default'];
+},{"../ConnectableObservable":3}],31:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2008,7 +2087,7 @@ function observeOn(scheduler) {
 }
 
 module.exports = exports['default'];
-},{"../Observable":3,"../Observer":4,"../Subscription":8}],30:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],32:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2078,7 +2157,7 @@ function skip(count) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../Observer":4,"../Subscription":8}],31:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],33:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2138,7 +2217,7 @@ function subscribeOn(scheduler) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../SerialSubscription":6,"../util/Symbol_observer":42}],32:[function(require,module,exports){
+},{"../Observable":4,"../SerialSubscription":7,"../util/Symbol_observer":44}],34:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2209,7 +2288,7 @@ function take(count) {
 
 ;
 module.exports = exports['default'];
-},{"../Observable":3,"../Observer":4,"../Subscription":8}],33:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],35:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2279,7 +2358,7 @@ function toArray() {
 }
 
 module.exports = exports['default'];
-},{"../Observable":3,"../Observer":4,"../Subscription":8}],34:[function(require,module,exports){
+},{"../Observable":4,"../Observer":5,"../Subscription":9}],36:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2296,7 +2375,7 @@ function zip(observables, project) {
 }
 
 module.exports = exports['default'];
-},{"../Observable":3}],35:[function(require,module,exports){
+},{"../Observable":4}],37:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2315,7 +2394,7 @@ function zipAll(project) {
 }
 
 module.exports = exports['default'];
-},{"../Observable":3}],36:[function(require,module,exports){
+},{"../Observable":4}],38:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2354,7 +2433,7 @@ var NextTickScheduler = (function (_Scheduler) {
 
 exports['default'] = NextTickScheduler;
 module.exports = exports['default'];
-},{"./Scheduler":37,"./SchedulerActions":38}],37:[function(require,module,exports){
+},{"./Scheduler":39,"./SchedulerActions":40}],39:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2405,7 +2484,7 @@ var Scheduler = (function () {
 
 exports['default'] = Scheduler;
 module.exports = exports['default'];
-},{"./SchedulerActions":38}],38:[function(require,module,exports){
+},{"./SchedulerActions":40}],40:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2558,7 +2637,7 @@ var FutureScheduledAction = (function (_ScheduledAction2) {
 })(ScheduledAction);
 
 exports.FutureScheduledAction = FutureScheduledAction;
-},{"../SerialSubscription":6,"../Subscription":8,"../util/Immediate":41}],39:[function(require,module,exports){
+},{"../SerialSubscription":7,"../Subscription":9,"../util/Immediate":43}],41:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2572,7 +2651,7 @@ var _Scheduler2 = _interopRequireDefault(_Scheduler);
 var immediate = new _Scheduler2['default']();
 exports['default'] = immediate;
 module.exports = exports['default'];
-},{"./Scheduler":37}],40:[function(require,module,exports){
+},{"./Scheduler":39}],42:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2586,7 +2665,7 @@ var _NextTickScheduler2 = _interopRequireDefault(_NextTickScheduler);
 var nextTick = new _NextTickScheduler2['default']();
 exports['default'] = nextTick;
 module.exports = exports['default'];
-},{"./NextTickScheduler":36}],41:[function(require,module,exports){
+},{"./NextTickScheduler":38}],43:[function(require,module,exports){
 /**
 All credit for this helper goes to http://github.com/YuzuJS/setImmediate
 */
@@ -2755,7 +2834,7 @@ if (_root2["default"] && _root2["default"].setImmediate) {
 }
 exports["default"] = Immediate;
 module.exports = exports["default"];
-},{"./root":45}],42:[function(require,module,exports){
+},{"./root":47}],44:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2777,7 +2856,7 @@ if (!_root2['default'].Symbol.observer) {
 }
 exports['default'] = _root2['default'].Symbol.observer;
 module.exports = exports['default'];
-},{"./root":45}],43:[function(require,module,exports){
+},{"./root":47}],45:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
@@ -2801,14 +2880,14 @@ function arraySlice(array) {
 
 ;
 module.exports = exports["default"];
-},{}],44:[function(require,module,exports){
+},{}],46:[function(require,module,exports){
 "use strict";
 
 exports.__esModule = true;
 var errorObject = { e: {} };
 exports["default"] = errorObject;
 module.exports = exports["default"];
-},{}],45:[function(require,module,exports){
+},{}],47:[function(require,module,exports){
 (function (global){
 'use strict';
 
@@ -2832,7 +2911,7 @@ if (freeGlobal && (freeGlobal.global === freeGlobal || freeGlobal.window === fre
 exports['default'] = root;
 module.exports = exports['default'];
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{}],46:[function(require,module,exports){
+},{}],48:[function(require,module,exports){
 'use strict';
 
 exports.__esModule = true;
@@ -2861,7 +2940,7 @@ function tryCatch(fn) {
 
 ;
 module.exports = exports['default'];
-},{"./errorObject":44}],47:[function(require,module,exports){
+},{"./errorObject":46}],49:[function(require,module,exports){
 (function (global){
 (function (root, factory) {
   root.RxNext = factory();
@@ -2869,4 +2948,4 @@ module.exports = exports['default'];
   return require('../dist/cjs/RxNext');	
 }));
 }).call(this,typeof global !== "undefined" ? global : typeof self !== "undefined" ? self : typeof window !== "undefined" ? window : {})
-},{"../dist/cjs/RxNext":5}]},{},[47]);
+},{"../dist/cjs/RxNext":6}]},{},[49]);

--- a/dist/global/RxNext.js
+++ b/dist/global/RxNext.js
@@ -180,6 +180,10 @@ var ConnectableObservable = (function (_Observable) {
         return _schedulerNextTick2['default'].schedule(0, this, dispatchConnection);
     };
 
+    ConnectableObservable.prototype.connectSync = function connectSync() {
+        return dispatchConnection(this);
+    };
+
     ConnectableObservable.prototype[_utilSymbol_observer2['default']] = function (observer) {
         if (!(observer instanceof _Observer2['default'])) {
             observer = new _Observer2['default'](observer);

--- a/dist/global/RxNext.js
+++ b/dist/global/RxNext.js
@@ -149,9 +149,9 @@ function _classCallCheck(instance, Constructor) { if (!(instance instanceof Cons
 
 function _inherits(subClass, superClass) { if (typeof superClass !== 'function' && superClass !== null) { throw new TypeError('Super expression must either be null or a function, not ' + typeof superClass); } subClass.prototype = Object.create(superClass && superClass.prototype, { constructor: { value: subClass, enumerable: false, writable: true, configurable: true } }); if (superClass) subClass.__proto__ = superClass; }
 
-var _Observable2 = require('./Observable');
+var _Observable3 = require('./Observable');
 
-var _Observable3 = _interopRequireDefault(_Observable2);
+var _Observable4 = _interopRequireDefault(_Observable3);
 
 var _Observer = require('./Observer');
 
@@ -197,10 +197,45 @@ var ConnectableObservable = (function (_Observable) {
         return this.subject[_utilSymbol_observer2['default']](observer);
     };
 
+    ConnectableObservable.prototype.refCount = function refCount() {
+        return new RefCountObservable(this);
+    };
+
     return ConnectableObservable;
-})(_Observable3['default']);
+})(_Observable4['default']);
 
 exports['default'] = ConnectableObservable;
+
+var RefCountObservable = (function (_Observable2) {
+    function RefCountObservable(source) {
+        _classCallCheck(this, RefCountObservable);
+
+        _Observable2.call(this, null);
+        this.refCount = 0;
+        this.source = source;
+    }
+
+    _inherits(RefCountObservable, _Observable2);
+
+    RefCountObservable.prototype.subscriber = function subscriber(observer) {
+        var _this = this;
+
+        this.refCount++;
+        this.source[_utilSymbol_observer2['default']](observer);
+        var shouldConnect = this.refCount === 1;
+        if (shouldConnect) {
+            this.connectionSubscription = this.source.connectSync();
+        }
+        return function () {
+            var refCount = _this.refCount--;
+            if (refCount === 0) {
+                _this.connectionSubscription.unsubscribe();
+            }
+        };
+    };
+
+    return RefCountObservable;
+})(_Observable4['default']);
 
 function dispatchConnection(connectable) {
     if (!connectable.subscription) {
@@ -411,6 +446,16 @@ var Observer = (function () {
 
     Observer.prototype.unsubscribe = function unsubscribe() {
         this.unsubscribed = true;
+        if (this.subscription && this.subscription._unsubscribe) {
+            this.subscription._unsubscribe();
+        }
+    };
+
+    Observer.prototype.setSubscription = function setSubscription(subscription) {
+        this.subscription = subscription;
+        if (this.unsubscribed && subscription._unsubscribe) {
+            subscription._unsubscribe();
+        }
     };
 
     Observer.prototype.dispose = function dispose() {
@@ -839,6 +884,9 @@ var Subscription = (function () {
         this.unsubscribed = false;
         this._unsubscribe = _unsubscribe;
         this.observer = observer;
+        if (observer) {
+            observer.setSubscription(this);
+        }
     }
 
     Subscription.prototype.unsubscribe = function unsubscribe() {

--- a/spec/observable-spec.js
+++ b/spec/observable-spec.js
@@ -1,0 +1,18 @@
+/* globals describe, it, expect */
+var RxNext = require('../dist/cjs/RxNext');
+
+var Observable = RxNext.Observable;
+
+describe('Observable', function () { 
+  it('should be constructed with a subscriber function', function (done) {
+    var source = new Observable(function (observer) {
+      observer.next(1);
+      observer.return();
+      return function () {
+        done();
+      };
+    });
+    
+    source.subscribe(function (x) { expect(x).toBe(1); });
+  });
+});

--- a/spec/operator/multicast-spec.js
+++ b/spec/operator/multicast-spec.js
@@ -16,9 +16,11 @@ describe('Observable.prototype.multicast()', function () {
       observer.next(3);
       observer.next(4);
       observer.return();
-    })
-    var subject = new Subject();
-    var connectable = source.multicast(subject);
+    });
+    
+    var connectable = source.multicast(function () {
+      return new Subject();
+    });
     
     connectable.subscribe(function (x) {
       results1.push(x);
@@ -34,12 +36,63 @@ describe('Observable.prototype.multicast()', function () {
     
       connectable.connect();
       
-      RxNext.Scheduler.nextTick.schedule(0, null, function () {
+      RxNext.Scheduler.nextTick.schedule(10, null, function () {
         expect(results1).toEqual([1, 2, 3, 4]);
         expect(results1).toEqual([1, 2, 3, 4]);
         expect(subscriptions).toBe(1);
         done();
       });
     });
+  });
+  
+  it('should remove all observers from the subject when disconnected', function (done) {
+    var subject = new Subject();
+    var expected = [1, 2, 3, 4];
+    var i = 0;
+    
+    var source = Observable.fromArray([1, 2, 3, 4]).multicast(function () {
+      //NOTE: This is done for testing only, NEVER do this in prod code, LOL
+      return subject;
+    });
+    
+    debugger;
+    source.subscribe(function (x) {
+      expect(x).toBe(expected[i++]);
+    }, null, function () {
+      setTimeout(function () {
+        //HACK: everything is good and done now...
+        expect(subject.observers.length).toBe(0);
+        done();
+      }, 10);
+    });
+    
+    source.connect();
+  });
+  
+  it('should allow you to reconnect by subscribing again', function (done) {
+    var expected = [1, 2, 3, 4];
+    var i = 0;
+    
+    var source = Observable.of(1, 2, 3, 4).multicast(function () {
+      return new Subject();
+    });
+    
+    source.subscribe(function (x) {
+      expect(x).toBe(expected[i++]);
+    }, null,
+    function () {
+      i = 0;
+      source.subscribe(function (x) {
+        expect(x).toBe(expected[i++]);
+      }, null, done);
+      
+      setTimeout(function () {
+        source.connect();
+      }, 10);
+    });
+    
+    setTimeout(function () {
+      source.connect();
+    }, 10)
   });
 });

--- a/spec/operator/multicast-spec.js
+++ b/spec/operator/multicast-spec.js
@@ -55,7 +55,6 @@ describe('Observable.prototype.multicast()', function () {
       return subject;
     });
     
-    debugger;
     source.subscribe(function (x) {
       expect(x).toBe(expected[i++]);
     }, null, function () {

--- a/spec/operator/multicast-spec.js
+++ b/spec/operator/multicast-spec.js
@@ -1,0 +1,45 @@
+/* globals describe, it, expect */
+var RxNext = require('../../dist/cjs/RxNext');
+var Observable = RxNext.Observable;
+var Subject = RxNext.Subject;
+
+describe('Observable.prototype.multicast()', function () {
+  it('should multicast one observable to multiple observers', function (done) {
+    var results1 = [];
+    var results2 = [];
+    var subscriptions = 0;
+    
+    var source = Observable.create(function (observer) {
+      subscriptions++;
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.next(4);
+      observer.return();
+    })
+    var subject = new Subject();
+    var connectable = source.multicast(subject);
+    
+    connectable.subscribe(function (x) {
+      results1.push(x);
+    });
+    
+    connectable.subscribe(function (x) {
+      results2.push(x);
+    });
+    
+    RxNext.Scheduler.nextTick.schedule(0, null, function () {
+      expect(results1).toEqual([]);
+      expect(results2).toEqual([]);
+    
+      connectable.connect();
+      
+      RxNext.Scheduler.nextTick.schedule(0, null, function () {
+        expect(results1).toEqual([1, 2, 3, 4]);
+        expect(results1).toEqual([1, 2, 3, 4]);
+        expect(subscriptions).toBe(1);
+        done();
+      });
+    });
+  });
+});

--- a/spec/operator/publish-spec.js
+++ b/spec/operator/publish-spec.js
@@ -1,0 +1,75 @@
+/* globals describe, it, expect */
+var RxNext = require('../../dist/cjs/RxNext');
+var Observable = RxNext.Observable;
+var Subject = RxNext.Subject;
+
+describe('Observable.prototype.publish()', function () {
+  it('should return a ConnectableObservable', function () {
+    var source = Observable.value(1).publish();
+    expect(source instanceof RxNext.ConnectableObservable).toBe(true);
+  });
+  
+  it('should multicast one observable to multiple observers', function (done) {
+    var results1 = [];
+    var results2 = [];
+    var subscriptions = 0;
+    
+    var source = Observable.create(function (observer) {
+      subscriptions++;
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.next(4);
+      observer.return();
+    });
+    
+    var connectable = source.publish();
+    
+    connectable.subscribe(function (x) {
+      results1.push(x);
+    });
+    
+    connectable.subscribe(function (x) {
+      results2.push(x);
+    });
+    
+    RxNext.Scheduler.nextTick.schedule(0, null, function () {
+      expect(results1).toEqual([]);
+      expect(results2).toEqual([]);
+    
+      connectable.connect();
+      
+      RxNext.Scheduler.nextTick.schedule(10, null, function () {
+        expect(results1).toEqual([1, 2, 3, 4]);
+        expect(results1).toEqual([1, 2, 3, 4]);
+        expect(subscriptions).toBe(1);
+        done();
+      });
+    });
+  });
+  
+  it('should allow you to reconnect by subscribing again', function (done) {
+    var expected = [1, 2, 3, 4];
+    var i = 0;
+    
+    var source = Observable.of(1, 2, 3, 4).publish();
+    
+    source.subscribe(function (x) {
+      expect(x).toBe(expected[i++]);
+    }, null,
+    function () {
+      i = 0;
+      source.subscribe(function (x) {
+        expect(x).toBe(expected[i++]);
+      }, null, done);
+      
+      setTimeout(function () {
+        source.connect();
+      }, 10);
+    });
+    
+    setTimeout(function () {
+      source.connect();
+    }, 10)
+  });
+});

--- a/spec/operator/refCount-spec.js
+++ b/spec/operator/refCount-spec.js
@@ -1,0 +1,48 @@
+/* globals describe, it, expect, Symbol */
+var RxNext = require('../../dist/cjs/RxNext');
+var Observable = RxNext.Observable;
+var Subject = RxNext.Subject;
+var Observer = RxNext.Observer;
+
+describe('Observable.prototype.publish().refCount()', function () {
+  it('should count references', function () {
+    var source = Observable.value(1).publish().refCount();
+       
+    source[Symbol.observer](Observer.create(function () { }));
+    source[Symbol.observer](Observer.create(function () { }));
+    source[Symbol.observer](Observer.create(function () { }));
+    
+    expect(source.refCount).toBe(3);
+  });
+  
+  it('should unsub from the source when all other subscriptions are unsubbed', function (done) {
+    var unsubscribeCalled = false;
+    var source = Observable.create(function (observer) {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.next(4);
+      observer.next(5);
+      observer.next(6);
+      observer.return();
+      
+      return function () {
+        unsubscribeCalled = true;
+      }
+    }).publish().refCount();
+    
+    source.take(1).subscribe(function () {});
+    source.take(3).subscribe(function () {});
+    source.take(5).subscribe(function (x) {
+      if (x > 3) {
+        expect(source.refCount).toBe(1);
+      }
+    }, null, function () {
+      setTimeout(function () {
+        expect(source.refCount).toBe(0);
+        expect(unsubscribeCalled).toBe(true);
+        done();
+      })
+    });
+  });
+});

--- a/spec/subject-spec.js
+++ b/spec/subject-spec.js
@@ -4,73 +4,98 @@ var RxNext = require('../dist/cjs/RxNext');
 var Subject = RxNext.Subject;
 var nextTick = RxNext.Scheduler.nextTick;
 
-describe('Subject', function() {
-	it('should pump values right on through itself', function(done) {
-		var subject = new Subject();
-		var expected = ['foo', 'bar'];
-		var i = 0;
+describe('Subject', function () {
+  it('should pump values right on through itself', function (done) {
+    var subject = new Subject();
+    var expected = ['foo', 'bar'];
+    var i = 0;
+
+    subject.subscribe(function (x) {
+      expect(x).toBe(expected[i++]);
+    }, null,
+      function () {
+        done();
+      });
 		
-		subject.subscribe(function(x) {
-			expect(x).toBe(expected[i++]);
-		}, null,
-		function(){
-			done();
-		});
+    // HACK
+    RxNext.Scheduler.nextTick.schedule(0, null, function () {
+      subject.next('foo');
+      subject.next('bar');
+      subject.return();
+    });
+  });
+
+
+  it('should pump values to multiple observers', function (done) {
+    var subject = new Subject();
+    var expected = ['foo', 'bar'];
+    var i = 0;
+    var j = 0;
+
+    subject.subscribe(function (x) {
+      expect(x).toBe(expected[i++]);
+    });
+
+    subject.subscribe(function (x) {
+      expect(x).toBe(expected[j++]);
+    }, null,
+      function () {
+        done();
+      });
 		
-		// HACK
-		RxNext.Scheduler.nextTick.schedule(0, null, function(){
-			subject.next('foo');
-			subject.next('bar');
-			subject.return();
-		});
-	});
-	
-	
-	it('should pump values to multiple observers', function(done) {
-		var subject = new Subject();
-		var expected = ['foo', 'bar'];
-		var i = 0;
-		var j = 0;
+    // HACK
+    nextTick.schedule(0, null, function () {
+      expect(subject.observers.length).toBe(2);
+      subject.next('foo');
+      subject.next('bar');
+      subject.return();
+    });
+  });
+
+
+  it('should not allow values to be nexted after a return', function (done) {
+    var subject = new Subject();
+    var expected = ['foo'];
+    var i = 0;
+
+    subject.subscribe(function (x) {
+      expect(x).toBe(expected[i++]);
+    }, null,
+      function () {
+        //HACK
+        nextTick.schedule(0, null, done);
+      });
 		
-		subject.subscribe(function(x) {
-			expect(x).toBe(expected[i++]);
-		});
-		
-		subject.subscribe(function(x) {
-			expect(x).toBe(expected[j++]);
-		}, null,
-		function(){
-			done();
-		});
-		
-		// HACK
-		nextTick.schedule(0, null, function(){
-			expect(subject.observers.length).toBe(2);
-			subject.next('foo');
-			subject.next('bar');
-			subject.return();
-		});
-	});
-	
-	
-	it('should not allow values to be nexted after a return', function(done) {
-		var subject = new Subject();
-		var expected = ['foo'];
-		var i = 0;
-		
-		subject.subscribe(function(x) {
-			expect(x).toBe(expected[i++]);
-		}, null,
-		function(){
-			//HACK
-			nextTick.schedule(0, null, done);
-		});
-		
-		// HACK
-		nextTick.schedule(0, null, function(){
-			subject.next('foo');
-			subject.return();
-			subject.next('bar');
-		});
-	});
+    // HACK
+    nextTick.schedule(0, null, function () {
+      subject.next('foo');
+      subject.return();
+      subject.next('bar');
+    });
+  });
+
+  it('should clean out unsubscribed observers after a next', function (done) {
+    var subject = new Subject();
+    var expected1 = ['foo', 'bar'];
+    var expected2 = ['foo', 'bar'];
+    var i1 = 0;
+    var i2 = 0;
+    
+    var sub1 = subject.subscribe(function (x) {
+      expect(x).toBe(expected1[i1++]);
+      sub1.unsubscribe();
+    });
+    
+    subject.subscribe(function (x) {
+      expect(x).toBe(expected2[i2++]);
+    });
+    
+    nextTick.schedule(0, null, function () {
+      expect(subject.observers.length).toBe(2);
+      subject.next('foo');
+      expect(subject.observers.length).toBe(1);
+      subject.next('bar');
+      done();
+    });
+  });
 });

--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -10,7 +10,7 @@ export default class BehaviorSubject extends Subject {
   value:any;
   
   constructor(value:any) {
-    super(null);
+    super();
     this.value = value;
   }
   

--- a/src/ConnectableObservable.ts
+++ b/src/ConnectableObservable.ts
@@ -21,6 +21,10 @@ export default class ConnectableObservable extends Observable {
     return nextTick.schedule(0, this, dispatchConnection);
   }
   
+  connectSync() : Subscription {
+    return dispatchConnection(this);
+  }
+  
   [$$observer](observer: Observer) {
     if (!(observer instanceof Observer)) {
       observer = new Observer(observer);

--- a/src/ConnectableObservable.ts
+++ b/src/ConnectableObservable.ts
@@ -1,0 +1,28 @@
+import Observable from './Observable';
+import Observer from './Observer';
+import $$observer from './util/Symbol_observer';
+import Subscription from './Subscription';
+import Subject from './Subject';
+
+export default class ConnectableObservable extends Observable {
+  source: Observable;
+  subject: Subject;
+  subscription: Subscription;
+  
+  constructor(source:Observable, subject:Subject) {
+    super(null);
+    this.source = source;
+    this.subject = subject;
+  }
+  
+  connect() : Subscription {
+    if (!this.subscription) {
+      this.subscription = this.source.subscribe(this.subject);
+    }
+    return this.subscription;
+  }
+  
+  [$$observer](observer: Observer) {
+    return this.subject[$$observer](observer);
+  }
+}

--- a/src/ConnectableObservable.ts
+++ b/src/ConnectableObservable.ts
@@ -3,26 +3,44 @@ import Observer from './Observer';
 import $$observer from './util/Symbol_observer';
 import Subscription from './Subscription';
 import Subject from './Subject';
+import nextTick from './scheduler/nextTick';
 
 export default class ConnectableObservable extends Observable {
   source: Observable;
-  subject: Subject;
+  subjectFactory: ()=>Subject;
   subscription: Subscription;
+  subject: Subject;
   
-  constructor(source:Observable, subject:Subject) {
+  constructor(source:Observable, subjectFactory:()=>Subject) {
     super(null);
     this.source = source;
-    this.subject = subject;
+    this.subjectFactory = subjectFactory;
   }
   
-  connect() : Subscription {
-    if (!this.subscription) {
-      this.subscription = this.source.subscribe(this.subject);
-    }
-    return this.subscription;
+  connect(): Subscription {
+    return nextTick.schedule(0, this, dispatchConnection);
   }
   
   [$$observer](observer: Observer) {
+    if (!(observer instanceof Observer)) {
+      observer = new Observer(observer);
+    }
+    if (!this.subject || this.subject.unsubscribed) {
+      if (this.subscription) {
+        this.subscription = undefined;
+      }
+      this.subject = this.subjectFactory();
+    }
     return this.subject[$$observer](observer);
   }
+}
+
+function dispatchConnection(connectable) {
+  if (!connectable.subscription) {
+    if (!connectable.subject) {
+      connectable.subject = connectable.subjectFactory();
+    }
+    connectable.subscription = connectable.source.subscribe(connectable.subject);
+  }
+  return connectable.subscription;
 }

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -37,7 +37,7 @@ export default class Observable {
   zip:(observables:Array<Observable>, project:(...observables:Array<Observable>)=>Observable)=>Observable;
   merge:(observables:Array<Observable>)=>Observable;
   toArray:()=>Observable;
-  multicast: (subject: Subject) => ConnectableObservable;
+  multicast: (subjectFactory: ()=>Subject) => ConnectableObservable;
   
   constructor(subscriber:(observer:Observer)=>Function|void) {
     if(subscriber) {
@@ -53,7 +53,10 @@ export default class Observable {
     return void 0;
   }
   
-  [$$observer](observer:Observer) {
+  [$$observer](observer: Observer) {
+    if (!(observer instanceof Observer)) {
+      observer = new Observer(observer);
+    }
     return Subscription.from(this.subscriber(observer), observer);
   }
   

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -36,8 +36,9 @@ export default class Observable {
   zipAll:(project:(...observables:Array<Observable>)=>Observable)=>Observable;
   zip:(observables:Array<Observable>, project:(...observables:Array<Observable>)=>Observable)=>Observable;
   merge:(observables:Array<Observable>)=>Observable;
-  toArray:()=>Observable;
+  toArray: () => Observable;
   multicast: (subjectFactory: ()=>Subject) => ConnectableObservable;
+  publish: () => ConnectableObservable;
   
   constructor(subscriber:(observer:Observer)=>Function|void) {
     if(subscriber) {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -5,6 +5,8 @@ import nextTick from './scheduler/nextTick';
 import $$observer from './util/Symbol_observer';
 import Scheduler from './scheduler/Scheduler';
 import { IteratorResult } from './IteratorResult';
+import Subject from './Subject';
+import ConnectableObservable from './ConnectableObservable';
 
 export default class Observable {  
   static value:(value:any)=>Observable;
@@ -35,6 +37,7 @@ export default class Observable {
   zip:(observables:Array<Observable>, project:(...observables:Array<Observable>)=>Observable)=>Observable;
   merge:(observables:Array<Observable>)=>Observable;
   toArray:()=>Observable;
+  multicast: (subject: Subject) => ConnectableObservable;
   
   constructor(subscriber:(observer:Observer)=>Function|void) {
     if(subscriber) {

--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -5,6 +5,7 @@ import { IteratorResult } from './IteratorResult';
 export default class Observer {
   destination:Observer;
   unsubscribed:boolean = false;
+  subscription: Subscription;
   
   static create(_next:(value:any)=>IteratorResult<any>, 
                 _throw:((value:any)=>IteratorResult<any>)=null, 
@@ -89,6 +90,16 @@ export default class Observer {
   
   unsubscribe() {
     this.unsubscribed = true;
+    if(this.subscription && this.subscription._unsubscribe) {
+      this.subscription._unsubscribe();
+    }
+  }
+  
+  setSubscription(subscription: Subscription) {
+    this.subscription = subscription;
+    if(this.unsubscribed && subscription._unsubscribe) {
+      subscription._unsubscribe();
+    }
   }
   
   dispose() {

--- a/src/RxNext.ts
+++ b/src/RxNext.ts
@@ -9,6 +9,7 @@ import CompositeSubscription from './CompositeSubscription';
 import SerialSubscription from './SerialSubscription';
 import Subject from './Subject';
 import BehaviorSubject from './BehaviorSubject';
+import ConnectableObservable from './ConnectableObservable';
 
 import value from './observable/value';
 import _return from './observable/return';
@@ -37,6 +38,7 @@ import zipAll from './operator/zipAll';
 import zipProto from './operator/zip';
 import mergeProto from './operator/merge';
 import toArray from './operator/toArray';
+import multicast from './operator/multicast';
 
 Observable.value = value;
 Observable.return = _return;
@@ -65,6 +67,7 @@ Observable.prototype.zipAll = zipAll;
 Observable.prototype.zip = zipProto;
 Observable.prototype.merge = mergeProto;
 Observable.prototype.toArray = toArray;
+Observable.prototype.multicast = multicast;
 
 var RxNext = {
   Scheduler: {
@@ -77,7 +80,8 @@ var RxNext = {
   CompositeSubscription,
   SerialSubscription, 
   Subject,
-  BehaviorSubject
+  BehaviorSubject,
+  ConnectableObservable
 };
 
 export default RxNext;

--- a/src/RxNext.ts
+++ b/src/RxNext.ts
@@ -39,6 +39,7 @@ import zipProto from './operator/zip';
 import mergeProto from './operator/merge';
 import toArray from './operator/toArray';
 import multicast from './operator/multicast';
+import publish from './operator/publish';
 
 Observable.value = value;
 Observable.return = _return;
@@ -68,6 +69,7 @@ Observable.prototype.zip = zipProto;
 Observable.prototype.merge = mergeProto;
 Observable.prototype.toArray = toArray;
 Observable.prototype.multicast = multicast;
+Observable.prototype.publish = publish;
 
 var RxNext = {
   Scheduler: {

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -19,6 +19,9 @@ export default class Subject extends Observable {
   _throw: (err: any) => IteratorResult<any>;
   _return: (value: any) => IteratorResult<any>;
   
+  constructor() {
+    super(null);
+  }
   
   dispose() {
     this.disposed = true;

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -38,6 +38,7 @@ export default class Subject extends Observable {
       return { done: true };
     }
     this.observers.forEach(o => o.next(value));
+    this._cleanUnsubbedObservers();
     return { done: false };
   }
   
@@ -47,6 +48,7 @@ export default class Subject extends Observable {
     }
     this.observers.forEach(o => o.throw(err));
     this.unsubscribe();
+    this._cleanUnsubbedObservers();
     return { done: true };
   }
 
@@ -56,8 +58,22 @@ export default class Subject extends Observable {
     }
     this.observers.forEach(o => o.return(value));
     this.unsubscribe();
+    this._cleanUnsubbedObservers();
     return { done: true };
   } 
+  
+  _cleanUnsubbedObservers() {
+    var i;
+    var observers = this.observers;
+    for (i = observers.length; i--;) {
+      if (observers[i].unsubscribed) {
+        observers.splice(i, 1);
+      }
+    }
+    if (observers.length === 0) {
+      this.unsubscribe();
+    }
+  }
   
   unsubscribe() {
     this.observers.length = 0;

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -13,11 +13,15 @@ export default class Subject extends Observable {
   destination:Observer;
   disposed:boolean=false;
   observers:Array<Observer> = [];
-  _dispose:Function;
+  _dispose:()=>void;
+  unsubscribed: boolean = false;
+  _next: (value: any) => IteratorResult<any>;
+  _throw: (err: any) => IteratorResult<any>;
+  _return: (value: any) => IteratorResult<any>;
+  
   
   dispose() {
     this.disposed = true;
-    this.observers.length = 0;
     if(this._dispose) {
       this._dispose();
     }
@@ -30,7 +34,7 @@ export default class Subject extends Observable {
   }
   
   next(value:any) : IteratorResult<any> {
-    if(this.disposed) {
+    if(this.unsubscribed) {
       return { done: true };
     }
     this.observers.forEach(o => o.next(value));
@@ -38,22 +42,27 @@ export default class Subject extends Observable {
   }
   
   throw(err:any) : IteratorResult<any> {
-    if(this.disposed) {
+    if(this.unsubscribed) {
       return { done: true };
     }
     this.observers.forEach(o => o.throw(err));
-    this.dispose();
+    this.unsubscribe();
     return { done: true };
   }
 
   return(value:any) : IteratorResult<any> {
-    if(this.disposed) {
+    if(this.unsubscribed) {
       return { done: true };
     }
     this.observers.forEach(o => o.return(value));
-    this.dispose();
+    this.unsubscribe();
     return { done: true };
   } 
+  
+  unsubscribe() {
+    this.observers.length = 0;
+    this.unsubscribed = true;
+  }
 }
 
 class SubjectSubscription extends Subscription {

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -9,6 +9,9 @@ export default class Subscription {
   constructor(_unsubscribe:Function, observer:Observer) {
     this._unsubscribe = _unsubscribe;
     this.observer = observer;
+    if (observer) {
+      observer.setSubscription(this);
+    }
   }
   
   unsubscribe():void {

--- a/src/operator/multicast.ts
+++ b/src/operator/multicast.ts
@@ -2,6 +2,6 @@ import Observable from '../Observable';
 import Subject from '../Subject';
 import ConnectableObservable from '../ConnectableObservable';
 
-export default function multicast(subject:Subject) : ConnectableObservable {
-  return new ConnectableObservable(this, subject);
+export default function multicast(subjectFactory:()=>Subject) : ConnectableObservable {
+  return new ConnectableObservable(this, subjectFactory);
 };

--- a/src/operator/multicast.ts
+++ b/src/operator/multicast.ts
@@ -1,0 +1,7 @@
+import Observable from '../Observable';
+import Subject from '../Subject';
+import ConnectableObservable from '../ConnectableObservable';
+
+export default function multicast(subject:Subject) : ConnectableObservable {
+  return new ConnectableObservable(this, subject);
+};

--- a/src/operator/publish.ts
+++ b/src/operator/publish.ts
@@ -1,0 +1,10 @@
+import ConnectableObservable from '../ConnectableObservable';
+import Subject from '../Subject';
+
+function subjectFactory() {
+  return new Subject();
+}
+
+export default function publish(): ConnectableObservable {
+  return this.multicast(subjectFactory);
+}


### PR DESCRIPTION
### Bug Fixes

- Observables were not cleaning up subscriptions after `Observer.dispose()` change. Now Subscription registers itself with accompanying Observer so clean up can be called. (ATTN @jhusain)

### Features

- multicast : now creates "reconnectable" ConnectableObservables
- publish: simple, reusable multicast shortcut
- refCount: method on ConnectableObservable ... does what it used to do.