### PR TITLE
add jspm meta config

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,5 +50,9 @@
     "protractor": "^1.7.0",
     "rx": "^2.4.3",
     "typescript": "^1.5.0-beta"
+  },
+  "format": "es6",
+  "directories": {
+    "lib": "src"
   }
 }


### PR DESCRIPTION
This adds a couple of meta hints to the package config to enable easy usage via jspm, which is set up for a primarily ES6/TypeScript source use case (where consumers are doing their own ES6 transpiliation)

JSPM leverages npm and github, and for sanity reasons modules installed from npm are treated as commonJS by default - the `format: "es6" ` override instructs jspm to use ES6 module semantics.

The ` directories: { lib: "src" } ` hint tells JSPM to treat src/ as the root of the package and ignores other files when installed by consumers. This should be updated to the appropriate dist directory once the npm publishing pipeline is set up - in angular2 for example, its `lib: "es6/prod"`

In pre-alpha states this allows us to `jspm install github:reactivex/rxjs` to install directly from github. Once npm and versioning are up and running, I'll add a registry entry like https://github.com/jspm/registry/blob/master/registry.json#L315 - which allows `jspm install rxjs` (or whatever) - it'll grab the npm published files and only download the directory configured. 