### PR TITLE
Fix devDependencies and mention of global packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,14 +36,6 @@ The build and test structure is fairly primitive at the moment. There are variou
 npm run build_all
 ```
 
-### Prerequisites
-
-Currently, you need `typescript`, `jasmine`, `babel`, and `browserify` globally installed to build and test.
-This will change as the build process matures. You can install all of these with the following:
-```sh
-npm i -g typescript jasmine babel browserify
-```
-
 ## Performance Tests
 
 First you'll need to host the root directory under a web server, the simplest way to do that is to install `http-server` with `npm i -g http-server`,

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "babelify": "^6.1.2",
     "benchmark": "^1.0.0",
     "benchpress": "^2.0.0-alpha.25",
+    "browserify": "^11.0.0",
     "glob": "^5.0.10",
     "http-server": "^0.8.0",
     "jasmine": "^2.3.1",


### PR DESCRIPTION
It is not necessary to have those prerequisite packages installed globally. When running npm scripts, the bin (e.g. browserify) is found automatically in /node_modules/.bin/, before it tries to find it globally. This commit also includes browserify as a devDependency, since it was the only one missing in order for
`build_all` to run.