### PR TITLE
Fix TS compiler errors related to SwitchLatestSubscriber

### DIFF
--- a/src/operators/switchLatest.ts
+++ b/src/operators/switchLatest.ts
@@ -26,9 +26,9 @@ export class SwitchLatestSubscriber<T, R> extends FlatMapSubscriber<T, R> {
 
   innerSubscription: Subscription<T>;
 
-  constructor(public    destination: Observer<R>,
-              protected project: (x: T, ix: number) => Observable<any>,
-              protected projectResult?: (x: T, y: any, ix: number, iy: number) => R) {
+  constructor(public destination: Observer<R>,
+              public project: (x: T, ix: number) => Observable<any>,
+              public projectResult?: (x: T, y: any, ix: number, iy: number) => R) {
     super(destination, 1, project, projectResult);
   }
 

--- a/src/operators/switchLatestTo.ts
+++ b/src/operators/switchLatestTo.ts
@@ -26,9 +26,9 @@ export class SwitchLatestToSubscriber<T, R> extends FlatMapToSubscriber<T, R> {
 
   innerSubscription: Subscription<T>;
 
-  constructor(public    destination: Observer<R>,
-              protected observable: Observable<any>,
-              protected projectResult?: (x: T, y: any, ix: number, iy: number) => R) {
+  constructor(public destination: Observer<R>,
+              public observable: Observable<any>,
+              public projectResult?: (x: T, y: any, ix: number, iy: number) => R) {
     super(destination, 1, observable, projectResult);
   }
 


### PR DESCRIPTION
I checkout'd the master branch, removed my old `node_modules`, and ran `npm install`, which after installing packages started running `prepublish`, which ran `npm run build_all`:

```
> RxJS-Next@0.0.0-prealpha.1 prepublish /Users/amed/RxJSNext
> npm run build_all

> RxJS-Next@0.0.0-prealpha.1 build_all /Users/amed/RxJSNext
> npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global

> RxJS-Next@0.0.0-prealpha.1 build_es6 /Users/amed/RxJSNext
> rm -rf dist/es6 && tsc src/Rx.ts --outDir dist/es6 --target ES6 -d

src/operators/switchLatest.ts(25,14): error TS2415: Class 'SwitchLatestSubscriber<T, R>' incorrectly extends base class 'FlatMapSubscriber<T, R>'.
  Property 'project' is protected in type 'SwitchLatestSubscriber<T, R>' but public in type 'FlatMapSubscriber<T, R>'.
src/operators/switchLatestTo.ts(25,14): error TS2415: Class 'SwitchLatestToSubscriber<T, R>' incorrectly extends base class 'FlatMapToSubscriber<T, R>'.
  Property 'observable' is protected in type 'SwitchLatestToSubscriber<T, R>' but public in type 'FlatMapToSubscriber<T, R>'.
```

This PR fixes that error.