### PR TITLE
Adding thisArg and bindCallback

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -116,13 +116,13 @@ export default class Observable<T> {
   zip: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R)) []) => Observable<R>;
   zipAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
 
-  map: <T, R>(project: (x: T, ix?: number) => R) => Observable<R>;
+  map: <T, R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
   mapTo: <R>(value: R) => Observable<R>;
   toArray: () => Observable<T[]>;
   scan: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
   reduce: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
 
-  filter: (predicate: (x: T) => boolean) => Observable<T>;
+  filter: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
   skip: (count: number) => Observable<T>;
   take: (count: number) => Observable<T>;
   takeUntil: (observable: Observable<any>) => Observable<T>;

--- a/src/operators/filter.ts
+++ b/src/operators/filter.ts
@@ -4,18 +4,19 @@ import Subscriber from '../Subscriber';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
+import bindCallback from '../util/bindCallback';
 
-export default function filter<T>(select: (x: T) => boolean) {
-  return this.lift(new FilterOperator(select));
+export default function filter<T>(select: (x: T, ix?: number) => boolean, thisArg?: any) {
+  return this.lift(new FilterOperator(select, thisArg));
 }
 
 export class FilterOperator<T, R> extends Operator<T, R> {
 
-  select: (x: T) => boolean;
+  select: (x: T, ix?: number) => boolean;
 
-  constructor(select: (x: T) => boolean) {
+  constructor(select: (x: T, ix?: number) => boolean, thisArg?: any) {
     super();
-    this.select = select;
+    this.select = <(x: T, ix?: number) => boolean>bindCallback(select, thisArg, 2);
   }
 
   call(observer: Observer<T>): Observer<T> {
@@ -25,15 +26,16 @@ export class FilterOperator<T, R> extends Operator<T, R> {
 
 export class FilterSubscriber<T> extends Subscriber<T> {
 
-  select: (x: T) => boolean;
+  count: number = 0;
+  select: (x: T, ix?: number) => boolean;
 
-  constructor(destination: Observer<T>, select: (x: T) => boolean) {
+  constructor(destination: Observer<T>, select: (x: T, ix?: number) => boolean) {
     super(destination);
     this.select = select;
   }
 
   _next(x) {
-    const result = tryCatch(this.select).call(this, x);
+    const result = tryCatch(this.select)(x, this.count++);
     if (result === errorObject) {
       this.destination.error(errorObject.e);
     } else if (Boolean(result)) {

--- a/src/util/bindCallback.ts
+++ b/src/util/bindCallback.ts
@@ -1,0 +1,25 @@
+export default function bindCallback (func: Function, thisArg, argCount) : Function {
+  if (typeof thisArg === 'undefined') { return func; }
+  switch(argCount) {
+    case 0:
+      return function() {
+        return func.call(thisArg)
+      };
+    case 1:
+      return function(arg) {
+        return func.call(thisArg, arg);
+      }
+    case 2:
+      return function(value, index) {
+        return func.call(thisArg, value, index);
+      };
+    case 3:
+      return function(value, index, collection) {
+        return func.call(thisArg, value, index, collection);
+      };
+  }
+
+  return function() {
+    return func.apply(thisArg, arguments);
+  };
+};


### PR DESCRIPTION
This should optimize the `.call` attempts on `map` and `filter` so that if the `thisArg` is not supplied, there is no perf hit.