### PR TITLE
proposal: Change `Operator` from class to interface.

### DIFF
--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -1,8 +1,12 @@
 import Observer from './Observer';
 import Subscriber from './Subscriber';
 
-export default class Operator<T, R> {
-  call<T, R>(observer: Observer<R>): Observer<T> {
-    return new Subscriber<T>(observer);
-  }
+interface Operator<T, R> {
+  call<T, R>(observer: Observer<R>): Observer<T>;
+}
+
+export default Operator;
+
+export function defaultCallFn<T, R>(observer: Observer<R>): Observer<T> {
+  return new Subscriber<T>(observer);
 }

--- a/src/observables/ConnectableObservable.ts
+++ b/src/observables/ConnectableObservable.ts
@@ -1,5 +1,4 @@
 import Subject from '../Subject';
-import Operator from '../Operator';
 import Scheduler from '../Scheduler';
 import Observable from '../Observable';
 import Subscription from '../Subscription';

--- a/src/operators/catch.ts
+++ b/src/operators/catch.ts
@@ -13,13 +13,12 @@ export default function _catch<T>(selector: (err:any, caught:Observable<any>) =>
   return caught;
 }
 
-export class CatchOperator<T, R> extends Operator<T, R> {
+export class CatchOperator<T, R> implements Operator<T, R> {
   selector: (err:any, caught:Observable<any>) => Observable<any>;
   caught: Observable<any>;
   source: Observable<T>;
-  
+
   constructor(selector: (err:any, caught:Observable<any>) => Observable<any>) {
-    super();
     this.selector = selector;
   }
 
@@ -31,7 +30,7 @@ export class CatchOperator<T, R> extends Operator<T, R> {
 export class CatchSubscriber<T> extends Subscriber<T> {
   selector: (err:any, caught:Observable<any>) => Observable<any>;
   caught: Observable<any>;
-  
+
   constructor(destination: Observer<T>, selector: (err:any, caught:Observable<any>) => Observable<any>, caught: Observable<any>) {
     super(destination);
     this.selector = selector;

--- a/src/operators/combineLatest.ts
+++ b/src/operators/combineLatest.ts
@@ -27,12 +27,11 @@ export function combineLatestProto<R>(...observables: (Observable<any>|((...valu
   return new ArrayObservable(observables).lift(new CombineLatestOperator(project));
 }
 
-export class CombineLatestOperator<T, R> extends Operator<T, R> {
+export class CombineLatestOperator<T, R> implements Operator<T, R> {
 
   project: (...values: Array<any>) => R;
 
   constructor(project?: (...values: Array<any>) => R) {
-    super();
     this.project = project;
   }
 

--- a/src/operators/count.ts
+++ b/src/operators/count.ts
@@ -6,7 +6,7 @@ export default function count() {
   return this.lift(new CountOperator());
 }
 
-export class CountOperator<T, R> extends Operator<T, R> {
+export class CountOperator<T, R> implements Operator<T, R> {
   call(observer: Observer<number>): Observer<T> {
     return new CountSubscriber<T>(observer);
   }

--- a/src/operators/debounce.ts
+++ b/src/operators/debounce.ts
@@ -13,10 +13,9 @@ export default function debounce<T>(dueTime: number, scheduler: Scheduler = Sche
   return this.lift(new DebounceOperator(dueTime, scheduler));
 }
 
-export class DebounceOperator<T, R> extends Operator<T, R> {
+export class DebounceOperator<T, R> implements Operator<T, R> {
 
   constructor(private dueTime: number, private scheduler: Scheduler) {
-    super();
   }
 
   call(observer: Observer<T>): Observer<T> {
@@ -36,7 +35,7 @@ export class DebounceSubscriber<T> extends Subscriber<T> {
       this.add(this.debounced = this.scheduler.schedule(this.dueTime, { value, subscriber: this }, dispatchNext));
     }
   }
-  
+
   clearDebounce() {
     const debounced = this.debounced;
     if (debounced) {
@@ -44,7 +43,7 @@ export class DebounceSubscriber<T> extends Subscriber<T> {
       this.remove(debounced);
     }
   }
-  
+
   debouncedNext(value: T) {
     this.clearDebounce();
     this.destination.next(value);

--- a/src/operators/defaultIfEmpty.ts
+++ b/src/operators/defaultIfEmpty.ts
@@ -11,10 +11,9 @@ export default function defaultIfEmpty<T,R>(defaultValue: R = null) : Observable
   return this.lift(new DefaultIfEmptyOperator(defaultValue));
 }
 
-export class DefaultIfEmptyOperator<T, R> extends Operator<T, R> {
+export class DefaultIfEmptyOperator<T, R> implements Operator<T, R> {
 
   constructor(private defaultValue: R) {
-    super();
   }
 
   call(observer: Observer<T>): Observer<T> {

--- a/src/operators/delay.ts
+++ b/src/operators/delay.ts
@@ -8,13 +8,12 @@ export default function delay<T>(delay: number, scheduler: Scheduler = Scheduler
   return this.lift(new DelayOperator(delay, scheduler));
 }
 
-export class DelayOperator<T, R> extends Operator<T, R> {
+export class DelayOperator<T, R> implements Operator<T, R> {
 
   delay: number;
   scheduler: Scheduler;
 
   constructor(delay: number, scheduler: Scheduler) {
-    super();
     this.delay = delay;
     this.scheduler = scheduler;
   }

--- a/src/operators/distinctUntilChanged.ts
+++ b/src/operators/distinctUntilChanged.ts
@@ -12,12 +12,11 @@ export default function distinctUntilChanged<T>(compare?: (x: T, y: T) => boolea
     compare));
 }
 
-export class DistinctUntilChangedOperator<T, R> extends Operator<T, R> {
+export class DistinctUntilChangedOperator<T, R> implements Operator<T, R> {
 
   compare: (x: T, y: T) => boolean;
 
   constructor(compare?: (x: T, y: T) => boolean) {
-    super();
     this.compare = compare;
   }
 

--- a/src/operators/do.ts
+++ b/src/operators/do.ts
@@ -11,14 +11,13 @@ export default function _do<T>(next?: (x: T) => void, error?: (e: any) => void, 
   return this.lift(new DoOperator(next || noop, error || noop, complete || noop));
 }
 
-export class DoOperator<T, R> extends Operator<T, R> {
+export class DoOperator<T, R> implements Operator<T, R> {
 
   next: (x: T) => void;
   error: (e: any) => void;
   complete: () => void;
 
   constructor(next: (x: T) => void, error: (e: any) => void, complete: () => void) {
-    super();
     this.next = next;
     this.error = error;
     this.complete = complete;

--- a/src/operators/expand.ts
+++ b/src/operators/expand.ts
@@ -14,12 +14,11 @@ export default function expand<T>(project: (x: T, ix: number) => Observable<any>
   return this.lift(new ExpandOperator(project));
 }
 
-export class ExpandOperator<T, R> extends Operator<T, R> {
+export class ExpandOperator<T, R> implements Operator<T, R> {
 
   project: (x: T, ix: number) => Observable<any>;
 
   constructor(project: (x: T, ix: number) => Observable<any>) {
-    super();
     this.project = project;
   }
 

--- a/src/operators/filter.ts
+++ b/src/operators/filter.ts
@@ -10,12 +10,11 @@ export default function filter<T>(select: (x: T, ix?: number) => boolean, thisAr
   return this.lift(new FilterOperator(select, thisArg));
 }
 
-export class FilterOperator<T, R> extends Operator<T, R> {
+export class FilterOperator<T, R> implements Operator<T, R> {
 
   select: (x: T, ix?: number) => boolean;
 
   constructor(select: (x: T, ix?: number) => boolean, thisArg?: any) {
-    super();
     this.select = <(x: T, ix?: number) => boolean>bindCallback(select, thisArg, 2);
   }
 

--- a/src/operators/finally.ts
+++ b/src/operators/finally.ts
@@ -13,12 +13,11 @@ export default function _finally<T>(finallySelector: () => void, thisArg?: any) 
     finallySelector));
 }
 
-export class FinallyOperator<T, R> extends Operator<T, R> {
+export class FinallyOperator<T, R> implements Operator<T, R> {
 
   finallySelector: () => void;
 
   constructor(finallySelector: () => void) {
-    super();
     this.finallySelector = finallySelector;
   }
 

--- a/src/operators/flatMap.ts
+++ b/src/operators/flatMap.ts
@@ -15,7 +15,7 @@ export default function flatMap<T, R>(project: (x: T, ix: number) => Observable<
   return this.lift(new FlatMapOperator(project, projectResult, concurrent));
 }
 
-export class FlatMapOperator<T, R> extends Operator<T, R> {
+export class FlatMapOperator<T, R> implements Operator<T, R> {
 
   project: (x: T, ix: number) => Observable<any>;
   projectResult: (x: T, y: any, ix: number, iy: number) => R;
@@ -24,7 +24,6 @@ export class FlatMapOperator<T, R> extends Operator<T, R> {
   constructor(project: (x: T, ix: number) => Observable<any>,
               projectResult?: (x: T, y: any, ix: number, iy: number) => R,
               concurrent: number = Number.POSITIVE_INFINITY) {
-    super();
     this.project = project;
     this.projectResult = projectResult;
     this.concurrent = concurrent;

--- a/src/operators/flatMapTo.ts
+++ b/src/operators/flatMapTo.ts
@@ -11,7 +11,7 @@ export default function flatMapTo<T, R>(observable: Observable<any>,
   return this.lift(new FlatMapToOperator(observable, projectResult, concurrent));
 }
 
-export class FlatMapToOperator<T, R> extends Operator<T, R> {
+export class FlatMapToOperator<T, R> implements Operator<T, R> {
 
   observable: Observable<any>;
   projectResult: (x: T, y: any, ix: number, iy: number) => R
@@ -20,7 +20,6 @@ export class FlatMapToOperator<T, R> extends Operator<T, R> {
   constructor(observable: Observable<any>,
               projectResult?: (x: T, y: any, ix: number, iy: number) => R,
               concurrent: number = Number.POSITIVE_INFINITY) {
-    super();
     this.observable = observable;
     this.projectResult = projectResult;
     this.concurrent = concurrent;

--- a/src/operators/map.ts
+++ b/src/operators/map.ts
@@ -10,12 +10,11 @@ export default function map<T, R>(project: (x: T, ix?: number) => R, thisArg?: a
   return this.lift(new MapOperator(project, thisArg));
 }
 
-export class MapOperator<T, R> extends Operator<T, R> {
+export class MapOperator<T, R> implements Operator<T, R> {
 
   project: (x: T, ix?: number) => R;
 
   constructor(project: (x: T, ix?: number) => R, thisArg?: any) {
-    super();
     this.project = <(x: T, ix?: number) => R>bindCallback(project, thisArg, 2);
   }
   call(observer: Observer<R>): Observer<T> {

--- a/src/operators/mapTo.ts
+++ b/src/operators/mapTo.ts
@@ -6,12 +6,11 @@ export default function mapTo<T, R>(value: R) {
   return this.lift(new MapToOperator(value));
 }
 
-export class MapToOperator<T, R> extends Operator<T, R> {
+export class MapToOperator<T, R> implements Operator<T, R> {
 
   value: R;
 
   constructor(value: R) {
-    super();
     this.value = value;
   }
 

--- a/src/operators/materialize.ts
+++ b/src/operators/materialize.ts
@@ -7,7 +7,7 @@ export default function materialize<T>() {
   return this.lift(new MaterializeOperator());
 }
 
-export class MaterializeOperator<T, R> extends Operator<T, R> {
+export class MaterializeOperator<T, R> implements Operator<T, R> {
   call(observer: Observer<T>): Observer<T> {
     return new MaterializeSubscriber(observer);
   }
@@ -21,13 +21,13 @@ export class MaterializeSubscriber<T> extends Subscriber<T> {
   _next(value:T) {
     this.destination.next(Notification.createNext(value));
   }
-  
+
   _error(err: any) {
     const destination = this.destination;
     destination.next(Notification.createError(err));
     destination.complete();
   }
-  
+
   _complete() {
     const destination = this.destination;
     destination.next(Notification.createComplete());

--- a/src/operators/merge.ts
+++ b/src/operators/merge.ts
@@ -22,11 +22,11 @@ export function merge<R>(...observables: (Observable<any>|Scheduler|number)[]): 
   } else if (typeof last === 'number') {
     concurrent = <number>observables.pop();
   }
-  
+
   if(observables.length === 1) {
     return <Observable<R>>observables[0];
   }
-  
+
   return new ArrayObservable(observables, scheduler).lift(new MergeOperator(concurrent));
 }
 
@@ -35,12 +35,11 @@ export function mergeProto<R>(...observables: (Observable<any>|number)[]): Obser
   return merge.apply(this, observables);
 }
 
-export class MergeOperator<T, R> extends Operator<T, R> {
+export class MergeOperator<T, R> implements Operator<T, R> {
 
   concurrent: number;
 
   constructor(concurrent: number = Number.POSITIVE_INFINITY) {
-    super();
     this.concurrent = concurrent;
   }
 

--- a/src/operators/observeOn.ts
+++ b/src/operators/observeOn.ts
@@ -8,13 +8,12 @@ export default function observeOn<T>(scheduler: Scheduler, delay: number = 0): O
   return this.lift(new ObserveOnOperator(scheduler, delay));
 }
 
-export class ObserveOnOperator<T, R> extends Operator<T, R> {
+export class ObserveOnOperator<T, R> implements Operator<T, R> {
 
   delay: number;
   scheduler: Scheduler;
 
   constructor(scheduler: Scheduler, delay: number = 0) {
-    super();
     this.delay = delay;
     this.scheduler = scheduler;
   }
@@ -47,13 +46,13 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
   }
 
   _error(e) {
-    this.add(this.scheduler.schedule(this.delay, 
+    this.add(this.scheduler.schedule(this.delay,
       new ScheduledNotification("error", e, this.destination),
       ObserveOnSubscriber.dispatch));
   }
 
   _complete() {
-    this.add(this.scheduler.schedule(this.delay, 
+    this.add(this.scheduler.schedule(this.delay,
       new ScheduledNotification("complete", void 0, this.destination),
       ObserveOnSubscriber.dispatch));
   }

--- a/src/operators/reduce.ts
+++ b/src/operators/reduce.ts
@@ -9,13 +9,12 @@ export default function reduce<T, R>(project: (acc: R, x: T) => R, acc?: R) {
   return this.lift(new ReduceOperator(project, acc));
 }
 
-export class ReduceOperator<T, R> extends Operator<T, R> {
+export class ReduceOperator<T, R> implements Operator<T, R> {
 
   acc: R;
   project: (acc: R, x: T) => R;
 
   constructor(project: (acc: R, x: T) => R, acc?: R) {
-    super();
     this.acc = acc;
     this.project = project;
   }

--- a/src/operators/repeat.ts
+++ b/src/operators/repeat.ts
@@ -12,9 +12,8 @@ export default function repeat<T>(count: number): Observable<T> {
   return this.lift(new RepeatOperator(count, this));
 }
 
-export class RepeatOperator<T, R> extends Operator<T, R> {
+export class RepeatOperator<T, R> implements Operator<T, R> {
   constructor(protected count: number, protected original:Observable<T>) {
-    super();
   }
 
   call(observer: Observer<T>): Observer<T> {
@@ -27,16 +26,16 @@ export class RepeatSubscriber<T> extends Subscriber<T> {
   constructor(destination: Observer<T>, public count: number, public original: Observable<T>) {
     super(destination);
   }
-  
+
   _complete(){
     if (this.count === (this.repeated+=1)){
       this.destination.complete();
     }else{
-      this.resubscribe();  
-    }             
+      this.resubscribe();
+    }
   }
 
-  resubscribe() {    
+  resubscribe() {
     this.original.subscribe(this);
   }
 }

--- a/src/operators/retryWhen.ts
+++ b/src/operators/retryWhen.ts
@@ -12,9 +12,8 @@ export default function retryWhen<T>(notifier: (errors:Observable<any>) => Obser
   return this.lift(new RetryWhenOperator(notifier, this));
 }
 
-export class RetryWhenOperator<T, R> extends Operator<T, R> {
+export class RetryWhenOperator<T, R> implements Operator<T, R> {
   constructor(protected notifier: (errors: Observable<any>) => Observable<any>, protected original:Observable<T>) {
-    super();
   }
 
   call(observer: Observer<T>): Observer<T> {
@@ -26,11 +25,11 @@ export class RetryWhenSubscriber<T> extends Subscriber<T> {
   errors: Subject<any>;
   retryNotifications: Observable<any>;
   retryNotificationSubscription: Subscription<any>;
-  
+
   constructor(destination: Observer<T>, public notifier: (errors: Observable<any>) => Observable<any>, public original: Observable<T>) {
     super(destination);
   }
-  
+
   _error(err: any) {
     if (!this.retryNotifications) {
       this.errors = new Subject();
@@ -45,11 +44,11 @@ export class RetryWhenSubscriber<T> extends Subscriber<T> {
     }
     this.errors.next(err);
   }
-  
+
   finalError(err: any) {
     this.destination.error(err);
   }
-  
+
   resubscribe() {
     this.original.subscribe(this);
   }
@@ -57,17 +56,17 @@ export class RetryWhenSubscriber<T> extends Subscriber<T> {
 
 export class RetryNotificationSubscriber<T> extends Subscriber<T> {
   constructor(public parent: RetryWhenSubscriber<any>) {
-    super(null);  
+    super(null);
   }
-  
+
   _next(value: T) {
     this.parent.resubscribe();
   }
-  
+
   _error(err: any) {
     this.parent.finalError(err);
   }
-  
+
   _complete() {
     this.parent.complete();
   }

--- a/src/operators/scan.ts
+++ b/src/operators/scan.ts
@@ -9,13 +9,12 @@ export default function scan<T, R>(project: (acc: R, x: T) => R, acc?: R) {
   return this.lift(new ScanOperator(project));
 }
 
-export class ScanOperator<T, R> extends Operator<T, R> {
+export class ScanOperator<T, R> implements Operator<T, R> {
 
   acc: R;
   project: (acc: R, x: T) => R;
 
   constructor(project: (acc: R, x: T) => R, acc?: R) {
-    super();
     this.acc = acc;
     this.project = project;
   }

--- a/src/operators/skip.ts
+++ b/src/operators/skip.ts
@@ -6,12 +6,11 @@ export default function skip(total) {
   return this.lift(new SkipOperator(total));
 }
 
-export class SkipOperator<T, R> extends Operator<T, R> {
+export class SkipOperator<T, R> implements Operator<T, R> {
 
   total: number;
 
   constructor(total: number) {
-    super();
     this.total = total;
   }
 

--- a/src/operators/skipUntil.ts
+++ b/src/operators/skipUntil.ts
@@ -7,9 +7,8 @@ export default function skipUntil(total) {
   return this.lift(new SkipUntilOperator(total));
 }
 
-export class SkipUntilOperator<T, R> extends Operator<T, R> {
+export class SkipUntilOperator<T, R> implements Operator<T, R> {
   constructor(private notifier: Observable<any>) {
-    super();
   }
 
   call(observer: Observer<R>): Observer<T> {
@@ -19,7 +18,7 @@ export class SkipUntilOperator<T, R> extends Operator<T, R> {
 
 export class SkipUntilSubscriber<T> extends Subscriber<T> {
   private notificationSubscriber: NotificationSubscriber<any> = new NotificationSubscriber();
-  
+
   constructor(destination: Observer<T>, private notifier: Observable<any>) {
     super(destination);
     this.add(this.notifier.subscribe(this.notificationSubscriber))
@@ -34,11 +33,11 @@ export class SkipUntilSubscriber<T> extends Subscriber<T> {
 
 export class NotificationSubscriber<T> extends Subscriber<T> {
   hasNotified: boolean = false;
-  
+
   constructor() {
     super(null);
   }
-  
+
   _next() {
     this.hasNotified = true;
     this.unsubscribe();

--- a/src/operators/switchAll.ts
+++ b/src/operators/switchAll.ts
@@ -10,10 +10,9 @@ export default function switchAll() {
   return this.lift(new SwitchOperator());
 }
 
-export class SwitchOperator<T, R> extends Operator<T, R> {
+export class SwitchOperator<T, R> implements Operator<T, R> {
 
   constructor() {
-    super();
   }
 
   call(observer: Observer<R>): Observer<T> {

--- a/src/operators/take.ts
+++ b/src/operators/take.ts
@@ -6,12 +6,11 @@ export default function take(total) {
   return this.lift(new TakeOperator(total));
 }
 
-export class TakeOperator<T, R> extends Operator<T, R> {
+export class TakeOperator<T, R> implements Operator<T, R> {
 
   total: number;
 
   constructor(total: number) {
-    super();
     this.total = total;
   }
 

--- a/src/operators/takeUntil.ts
+++ b/src/operators/takeUntil.ts
@@ -7,12 +7,11 @@ export default function takeUntil<T>(observable: Observable<any>) {
   return this.lift(new TakeUntilOperator(observable));
 }
 
-export class TakeUntilOperator<T, R> extends Operator<T, R> {
+export class TakeUntilOperator<T, R> implements Operator<T, R> {
 
   observable: Observable<any>;
 
   constructor(observable: Observable<any>) {
-    super();
     this.observable = observable;
   }
 

--- a/src/operators/throttle.ts
+++ b/src/operators/throttle.ts
@@ -13,11 +13,10 @@ export default function throttle<T>(delay: number, scheduler: Scheduler = Schedu
   return this.lift(new ThrottleOperator(delay, scheduler));
 }
 
-export class ThrottleOperator<T, R> extends Operator<T, R> {
+export class ThrottleOperator<T, R> implements Operator<T, R> {
   constructor(private delay:number, private scheduler:Scheduler) {
-    super();
   }
-  
+
   call(observer: Observer<R>): Observer<T> {
     return new ThrottleSubscriber(observer, this.delay, this.scheduler);
   }
@@ -25,7 +24,7 @@ export class ThrottleOperator<T, R> extends Operator<T, R> {
 
 export class ThrottleSubscriber<T, R> extends Subscriber<T> {
   private throttled: Subscription<any>;
-  
+
   constructor(destination:Observer<T>, private delay:number, private scheduler:Scheduler) {
     super(destination);
   }
@@ -34,18 +33,18 @@ export class ThrottleSubscriber<T, R> extends Subscriber<T> {
     this.clearThrottle();
     this.add(this.throttled = this.scheduler.schedule(this.delay, { value: x, subscriber: this }, dispatchNext));
   }
-  
+
   throttledNext(x) {
-    this.clearThrottle();  
+    this.clearThrottle();
     this.destination.next(x);
   }
-  
+
   clearThrottle() {
     const throttled = this.throttled;
     if (throttled) {
       this.remove(throttled);
       throttled.unsubscribe();
-      this.throttled = null;  
+      this.throttled = null;
     }
   }
 }

--- a/src/operators/toArray.ts
+++ b/src/operators/toArray.ts
@@ -6,7 +6,7 @@ export default function toArray() {
   return this.lift(new ToArrayOperator());
 }
 
-export class ToArrayOperator<T, R> extends Operator<T, R> {
+export class ToArrayOperator<T, R> implements Operator<T, R> {
   call(observer: Observer<T[]>): Observer<T> {
     return new ToArraySubscriber<T>(observer);
   }

--- a/src/operators/zip.ts
+++ b/src/operators/zip.ts
@@ -21,12 +21,11 @@ export function zipProto<R>(...observables: (Observable<any> | ((...values: Arra
   return zip.apply(this, [this, ...observables]);
 }
 
-export class ZipOperator<T, R> extends Operator<T, R> {
-  
+export class ZipOperator<T, R> implements Operator<T, R> {
+
   project: (...values: Array<any>) => R
 
   constructor(project?: (...values: Array<any>) => R) {
-    super();
     this.project = project;
   }
 


### PR DESCRIPTION
The motivation of this pull request is here:

A deriving class is unclear to understand "what we should need to implement this derived classs?". Thus, I think we should define interface and implement it for each implementations in these case:

- There is no default behavior, or a few default behavior.
- No need to create a base class instance.

`Operator` base class define only `call()` method, I think it will not be high cost for us to implement `call` method for each `Operator` implementations.

How do you think about this?