### PR TITLE
bugfix(zip): Remove usage of sparse array

### DIFF
--- a/spec/operators/zip-spec.js
+++ b/spec/operators/zip-spec.js
@@ -40,4 +40,13 @@ describe("zip", function () {
       expect(vals).toDeepEqual(r[i++]);
     }, null, done);
   });
+  it("should combine a source with an immediately-scheduled source", function (done) {
+    var a = Observable.of(1, 2, 3, immediateScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8);
+    var r = [[1, 4], [2, 5], [3, 6]];
+    var i = 0;
+    Observable.of(a, b, immediateScheduler).zipAll().subscribe(function (vals) {
+      expect(vals).toDeepEqual(r[i++]);
+    }, null, done);
+  });
 });

--- a/src/operators/zip.ts
+++ b/src/operators/zip.ts
@@ -82,6 +82,14 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   }
 }
 
+function arrayInitialize(length) {
+  var arr = Array(length);
+  for (let i = 0; i < length; i++) {
+    arr[i] = null;
+  }
+  return arr;
+}
+
 export class ZipInnerSubscriber<T, R> extends Subscriber<T> {
 
   parent: ZipSubscriber<T, R>;
@@ -102,6 +110,7 @@ export class ZipInnerSubscriber<T, R> extends Subscriber<T> {
 
     const parent = this.parent;
     const events = this.events;
+    const total = this.total;
     const limit = parent.limit;
 
     if (events >= limit) {
@@ -111,11 +120,11 @@ export class ZipInnerSubscriber<T, R> extends Subscriber<T> {
 
     const index = this.index;
     const values = this.values;
-    const zipped = values[events] || (values[events] = []);
+    const zipped = values[events] || (values[events] = arrayInitialize(total));
 
     zipped[index] = [x];
 
-    if (zipped.length === this.total && zipped.every(hasValue)) {
+    if (zipped.every(hasValue)) {
       this._projectNext(zipped, parent.project);
       values[events] = undefined;
     }


### PR DESCRIPTION
ES5 `every` has a weird behavior on sparse arrays which broke `zip` operator.

```js
var foo = []; foo[1] = "a";
foo.every(hasValue); // === true;
```