### PR TITLE
bugfix(take): Complete on limit reached

### DIFF
--- a/src/operators/take.ts
+++ b/src/operators/take.ts
@@ -30,10 +30,12 @@ export class TakeSubscriber<T> extends Subscriber<T> {
   }
 
   _next(x) {
-    if (++this.count <= this.total) {
+    const total = this.total;
+    if (++this.count <= total) {
       this.destination.next(x);
-    } else {
-      this.destination.complete();
+      if (this.count === total) {
+        this.destination.complete();
+      }
     }
   }
 }


### PR DESCRIPTION
`take` should complete when the limit is reached, not waiting for another event and then complete.