### PR TITLE
refactor(Subscriber): make Observer an interface, inherit from Subscr…

### DIFF
--- a/perf/macro/flatMap-scalar/perf.js
+++ b/perf/macro/flatMap-scalar/perf.js
@@ -18,7 +18,7 @@ var RxNextTestObservable = new RxNext.Observable(function(observer) {
   while(++index < numIterations) {
     observer.next(index);
   }
-  observer.completed();
+  observer.complete();
 });
 
 var Rx2TestObservable = Rx.Observable.create(function(observer) {

--- a/perf/macro/flatMap/perf.js
+++ b/perf/macro/flatMap/perf.js
@@ -15,7 +15,7 @@ var RxNextTestObservable = new RxNext.Observable(function(observer) {
   while(++index < numIterations) {
     observer.next(index);
   }
-  observer.completed();
+  observer.complete();
 });
 
 var Rx2TestObservable = Rx.Observable.create(function(observer) {

--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -2,41 +2,11 @@ import noop from './util/noop';
 import throwError from './util/throwError';
 import tryOrOnError from './util/tryOrOnError';
 
-export default class Observer<T> {
-
-  destination: Observer<any>;
-
-  constructor(destination?: Observer<any>) {
-    if (!destination) {
-      return;
-    }
-    (typeof destination.next === "function") || (destination.next = noop);
-    (typeof destination.error === "function") || (destination.error = throwError);
-    (typeof destination.complete === "function") || (destination.complete = noop);
-    this.destination = destination;
-  }
-
-  next(value?): void {
-    this._next(value);
-  }
-
-  error(error?): void {
-    this._error(error);
-  }
-
-  complete(): void {
-    this._complete();
-  }
-
-  _next(value?) {
-    this.destination.next(value);
-  }
-
-  _error(error?) {
-    this.destination.error(error);
-  }
-
-  _complete() {
-    this.destination.complete();
-  }
+interface Observer<T> {
+  next(value: T): void;
+  error(err?: any): void;
+  complete(): void;
+  isUnsubscribed: boolean;
 }
+
+export default Observer;

--- a/src/observables/ConnectableObservable.ts
+++ b/src/observables/ConnectableObservable.ts
@@ -74,7 +74,7 @@ export class RefCountObservable<T> extends Observable<T> {
 
 export class RefCountSubscription<T> extends Subscription<T> {
 
-  constructor(protected refCountObservable: RefCountObservable<T>) {
+  constructor(private refCountObservable: RefCountObservable<T>) {
     super();
   }
 

--- a/src/operators/combineLatest.ts
+++ b/src/operators/combineLatest.ts
@@ -49,7 +49,7 @@ export class CombineLatestSubscriber<T, R> extends ZipSubscriber<T, R> {
   }
 
   _subscribeInner(observable, values, index, total) {
-    return observable.subscribe(new CombineLatestInnerSubscriber(this, values, index, total));
+    return observable.subscribe(new CombineLatestInnerSubscriber(this.destination, this, values, index, total));
   }
 
   _innerComplete(innerSubscriber) {
@@ -61,8 +61,8 @@ export class CombineLatestSubscriber<T, R> extends ZipSubscriber<T, R> {
 
 export class CombineLatestInnerSubscriber<T, R> extends ZipInnerSubscriber<T, R> {
 
-  constructor(parent: ZipSubscriber<T, R>, values: any, index : number, total : number) {
-    super(parent, values, index, total);
+  constructor(destination: Observer<T>, parent: ZipSubscriber<T, R>, values: any, index : number, total : number) {
+    super(destination, parent, values, index, total);
   }
 
   _next(x) {

--- a/src/operators/expand.ts
+++ b/src/operators/expand.ts
@@ -54,14 +54,14 @@ export class ExpandSubscriber<T, R> extends MergeSubscriber<T, R> {
     } else if(observable instanceof EmptyObservable) {
       this._innerComplete();
     } else {
-      return observable.subscribe(new ExpandInnerSubscriber(this));
+      return observable.subscribe(new ExpandInnerSubscriber(this.destination, this));
     }
   }
 }
 
 export class ExpandInnerSubscriber<T, R> extends MergeInnerSubscriber<T, R> {
-  constructor(parent: ExpandSubscriber<T, R>) {
-    super(parent);
+  constructor(destination: Observer<T>, parent: ExpandSubscriber<T, R>) {
+    super(destination, parent);
   }
   _next(value) {
     this.destination.next(value);

--- a/src/operators/flatMap.ts
+++ b/src/operators/flatMap.ts
@@ -60,12 +60,12 @@ export class FlatMapSubscriber<T, R> extends MergeSubscriber<T, R> {
   _subscribeInner(observable, value, index) {
     const projectResult = this.projectResult;
     if(projectResult) {
-      return observable.subscribe(new FlatMapInnerSubscriber(this, value, index, projectResult));
+      return observable.subscribe(new FlatMapInnerSubscriber(this.destination, this, value, index, projectResult));
     } else if(observable instanceof ScalarObservable) {
       this.destination.next((<ScalarObservable<T>> observable).value);
       this._innerComplete();
     } else {
-      return observable.subscribe(new MergeInnerSubscriber(this));
+      return observable.subscribe(new MergeInnerSubscriber(this.destination, this));
     }
   }
 }
@@ -77,11 +77,12 @@ export class FlatMapInnerSubscriber<T, R> extends MergeInnerSubscriber<T, R> {
   project: (x: T, y: any, ix: number, iy: number) => R;
   count: number = 0;
 
-  constructor(parent: FlatMapSubscriber<T, R>,
+  constructor(destination: Observer<T>,
+              parent: FlatMapSubscriber<T, R>,
               value: any,
               index: number,
               project?: (x: T, y: any, ix: number, iy: number) => R) {
-    super(parent);
+    super(destination, parent);
     this.value = value;
     this.index = index;
     this.project = project;

--- a/src/operators/merge.ts
+++ b/src/operators/merge.ts
@@ -102,7 +102,7 @@ export class MergeSubscriber<T, R> extends Subscriber<T> {
       this.destination.next((<ScalarObservable<T>> observable).value);
       this._innerComplete();
     } else {
-      return observable.subscribe(new MergeInnerSubscriber(this));
+      return observable.subscribe(new MergeInnerSubscriber(this.destination, this));
     }
   }
 
@@ -125,8 +125,8 @@ export class MergeInnerSubscriber<T, R> extends Subscriber<T> {
 
   parent: MergeSubscriber<T, R>;
 
-  constructor(parent: MergeSubscriber<T, R>) {
-    super(parent.destination);
+  constructor(destination: Observer<T>, parent: MergeSubscriber<T, R>) {
+    super(destination);
     this.parent = parent;
   }
 

--- a/src/operators/skip.ts
+++ b/src/operators/skip.ts
@@ -15,7 +15,7 @@ export class SkipOperator<T, R> implements Operator<T, R> {
   }
 
   call(observer: Observer<R>): Observer<T> {
-    return new SkipSubscriber<T>(observer, this.total);
+    return new SkipSubscriber(observer, this.total);
   }
 }
 

--- a/src/operators/skipUntil.ts
+++ b/src/operators/skipUntil.ts
@@ -12,7 +12,7 @@ export class SkipUntilOperator<T, R> implements Operator<T, R> {
   }
 
   call(observer: Observer<R>): Observer<T> {
-    return new SkipUntilSubscriber<T>(observer, this.notifier);
+    return new SkipUntilSubscriber(observer, this.notifier);
   }
 }
 

--- a/src/operators/take.ts
+++ b/src/operators/take.ts
@@ -15,7 +15,7 @@ export class TakeOperator<T, R> implements Operator<T, R> {
   }
 
   call(observer: Observer<R>): Observer<T> {
-    return new TakeSubscriber<T>(observer, this.total);
+    return new TakeSubscriber(observer, this.total);
   }
 }
 

--- a/src/operators/withLatestFrom.ts
+++ b/src/operators/withLatestFrom.ts
@@ -16,7 +16,7 @@ export class WithLatestFromOperator<T, R> implements Operator<T, R> {
   constructor(private observables: Observable<any>[], private project: (...values: any[]) => Observable<R>) {
   }
 
-  call(observer: Observer<R>): Observer<T> {
+  call(observer: Observer<T>): Observer<T> {
     return new WithLatestFromSubscriber<T, R>(observer, this.observables, this.project);
   }
 }

--- a/src/operators/zip.ts
+++ b/src/operators/zip.ts
@@ -70,7 +70,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   }
 
   _subscribeInner(observable, values, index, total) {
-    return observable.subscribe(new ZipInnerSubscriber(this, values, index, total));
+    return observable.subscribe(new ZipInnerSubscriber(this.destination, this, values, index, total));
   }
 
   _innerComplete(innerSubscriber) {
@@ -98,8 +98,8 @@ export class ZipInnerSubscriber<T, R> extends Subscriber<T> {
   total: number;
   events: number = 0;
 
-  constructor(parent: ZipSubscriber<T, R>, values: any, index : number, total : number) {
-    super(parent.destination);
+  constructor(destination: Observer<T>, parent: ZipSubscriber<T, R>, values: any, index : number, total : number) {
+    super(destination);
     this.parent = parent;
     this.values = values;
     this.index = index;


### PR DESCRIPTION
…iption

Changed Observer to an interface throughout the app since we were not using it directly as a class anywhere
Fixed macro perf tests that were calling  rather than  for some reason

closes #224