### PR TITLE
bugfix(combinelatest): No upper bound limit

### DIFF
--- a/spec/operators/combineLatest-spec.js
+++ b/spec/operators/combineLatest-spec.js
@@ -12,7 +12,10 @@ describe('combineLatest', function () {
     var i = 0;
     Observable.of(a, b).combineAll().subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);
-    }, null, done);
+    }, null, function() {
+      expect(i).toEqual(r.length);
+      done();
+    });
   });
   it("should combine a source with a second", function (done) {
     var a = Observable.of(1, 2, 3);
@@ -21,7 +24,10 @@ describe('combineLatest', function () {
     var i = 0;
     a.combineLatest(b).subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);
-    }, null, done);
+    }, null, function() {
+      expect(i).toEqual(r.length);
+      done();
+    });
   });
   it("should combine two immediately-scheduled observables", function (done) {
     var a = Observable.of(1, 2, 3, immediateScheduler);
@@ -30,7 +36,10 @@ describe('combineLatest', function () {
     var i = 0;
     Observable.of(a, b, immediateScheduler).combineAll().subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);
-    }, null, done);
+    }, null, function() {
+      expect(i).toEqual(r.length);
+      done();
+    });
   });
   it("should combine an immediately-scheduled source with an immediately-scheduled second", function (done) {
     var a = Observable.of(1, 2, 3, immediateScheduler);
@@ -39,7 +48,10 @@ describe('combineLatest', function () {
     var i = 0;
     a.combineLatest(b).subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);
-    }, null, done);
+    }, null, function() {
+      expect(i).toEqual(r.length);
+      done();
+    });
   });
   it('should combineLatest the source with the provided observables', function (done) {
     var expected = ['00', '01', '11', '12', '22', '23'];
@@ -50,6 +62,9 @@ describe('combineLatest', function () {
       })
       .subscribe(function (x) {
         expect(x).toBe(expected[i++]);
-      }, null, done);
+      }, null, function() {
+        expect(i).toEqual(expected.length);
+        done();
+      });
   }, 300);
 });

--- a/src/operators/combineLatest.ts
+++ b/src/operators/combineLatest.ts
@@ -5,7 +5,7 @@ import Subscriber from '../Subscriber';
 
 import ArrayObservable from '../observables/ArrayObservable';
 import EmptyObservable from '../observables/EmptyObservable';
-import {ZipSubscriber, ZipInnerSubscriber, hasValue, mapValue} from './zip';
+import {ZipSubscriber, ZipInnerSubscriber} from './zip';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
@@ -43,6 +43,7 @@ export class CombineLatestOperator<T, R> implements Operator<T, R> {
 export class CombineLatestSubscriber<T, R> extends ZipSubscriber<T, R> {
 
   project: (...values: Array<any>) => R;
+  limit: number = 0;
 
   constructor(destination: Observer<R>, project?: (...values: Array<any>) => R) {
     super(destination, project, []);
@@ -82,7 +83,7 @@ export class CombineLatestInnerSubscriber<T, R> extends ZipInnerSubscriber<T, R>
       values[index] = [x];
     }
 
-    if(limit === total) {
+    if(limit >= total) {
       this._projectNext(values, parent.project);
     }
   }


### PR DESCRIPTION
The `combineLatest` operator was basically operating like `ignoreElements`, and the tests did not test anything except for the completion of the returned observable. This PR should fix the issue.