### PR TITLE
chore(test): add micro-benchmark performance test for Observable.just

### DIFF
--- a/perf/micro/current-thread-scheduler/observable/just.js
+++ b/perf/micro/current-thread-scheduler/observable/just.js
@@ -1,0 +1,20 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function just(suite) {
+
+    var oldJustWithCurrentThreadScheduler = RxOld.Observable.just(25, RxOld.Scheduler.currentThread);
+    var newJustWithCurrentThreadScheduler = RxNew.Observable.just(25, RxNew.Scheduler.immediate);
+
+    // add tests
+    return suite
+        .add('old just with current thread scheduler', function () {
+            oldJustWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+        })
+        .add('new just with current thread scheduler', function () {
+            newJustWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+        });
+    function _next(x) { }
+    function _error(e){ }
+    function _complete(){ }
+};

--- a/perf/micro/immediate-scheduler/observable/just.js
+++ b/perf/micro/immediate-scheduler/observable/just.js
@@ -1,0 +1,20 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function just(suite) {
+
+    var oldJustWithImmediateScheduler = RxOld.Observable.just(25, RxOld.Scheduler.immediate);
+    var newJustWithImmediateScheduler = RxNew.Observable.just(25);
+
+    // add tests
+    return suite
+        .add('old just with immediate scheduler', function () {
+            oldJustWithImmediateScheduler.subscribe(_next, _error, _complete);
+        })
+        .add('new just with immediate scheduler', function () {
+            newJustWithImmediateScheduler.subscribe(_next, _error, _complete);
+        });
+    function _next(x) { }
+    function _error(e){ }
+    function _complete(){ }
+};

--- a/perf/micro/index.js
+++ b/perf/micro/index.js
@@ -9,6 +9,7 @@ Observable.from([
         require("./immediate-scheduler/observable/from-array"),
         require("./immediate-scheduler/observable/from-with-array"),
         require("./immediate-scheduler/observable/from-with-string"),
+        require("./immediate-scheduler/observable/just"),
         require("./immediate-scheduler/observable/of"),
         require("./immediate-scheduler/observable/range"),
 
@@ -38,6 +39,7 @@ Observable.from([
         require("./current-thread-scheduler/observable/from-array"),
         require("./current-thread-scheduler/observable/from-with-array"),
         require("./current-thread-scheduler/observable/from-with-string"),
+        require("./current-thread-scheduler/observable/just"),
         require("./current-thread-scheduler/observable/of"),
         require("./current-thread-scheduler/observable/range"),
 


### PR DESCRIPTION
Not sure how does alias being treated per coverage i.e, 'just' and 'return', one test considered covers all alias or not - any suggestions?