### PR TITLE
refactor(from): fromArray, fromPromise removed

### DIFF
--- a/perf/micro/current-thread-scheduler/observable/from-array.js
+++ b/perf/micro/current-thread-scheduler/observable/from-array.js
@@ -8,7 +8,7 @@ module.exports = function fromArray(suite) {
     }
 
     var oldFromArrayWithCurrentThreadScheduler = RxOld.Observable.fromArray(args, RxOld.Scheduler.currentThread);
-    var newFromArrayWithCurrentThreadScheduler = RxNew.Observable.fromArray(args, RxNew.Scheduler.immediate);
+    var newFromArrayWithCurrentThreadScheduler = RxNew.Observable.from(args, RxNew.Scheduler.immediate);
 
     // add tests
     return suite

--- a/perf/micro/immediate-scheduler/observable/from-array.js
+++ b/perf/micro/immediate-scheduler/observable/from-array.js
@@ -8,7 +8,7 @@ module.exports = function fromArray(suite) {
     }
 
     var oldFromArrayWithImmediateScheduler = RxOld.Observable.fromArray(args, RxOld.Scheduler.immediate);
-    var newFromArrayWithImmediateScheduler = RxNew.Observable.fromArray(args);
+    var newFromArrayWithImmediateScheduler = RxNew.Observable.from(args);
 
     // add tests
     return suite

--- a/spec/observables/from-promise-spec.js
+++ b/spec/observables/from-promise-spec.js
@@ -6,7 +6,7 @@ var Promise = require('promise');
 describe('Observable.fromPromise', function(){
   it('should emit one value from that promise', function(done) {
     var promise = Promise.resolve(42);
-    Observable.fromPromise(promise)
+    Observable.from(promise)
       .subscribe(function(x) {
         expect(x).toBe(42);
       }, null,
@@ -21,7 +21,7 @@ describe('Observable.fromPromise', function(){
     var throwSpy = jasmine.createSpy('throw');
     var completeSpy = jasmine.createSpy('complete');
     var promise = Promise.resolve(42);
-    var subscription = Observable.fromPromise(promise)
+    var subscription = Observable.from(promise)
       .subscribe(nextSpy, throwSpy, completeSpy);
     subscription.unsubscribe();
 

--- a/spec/observables/zip-spec.js
+++ b/spec/observables/zip-spec.js
@@ -8,8 +8,8 @@ describe('Observable.zip', function(){
     var i = 0;
 
     Observable.zip(
-      Observable.fromArray(['a','b','c']),
-      Observable.fromArray([1,2,3]),
+      Observable.from(['a','b','c']),
+      Observable.from([1,2,3]),
       function(a, b) {
         return a + b;
       }

--- a/spec/operators/count-spec.js
+++ b/spec/operators/count-spec.js
@@ -4,7 +4,7 @@ var Observable = Rx.Observable;
 
 describe('count', function () {
   it('should count the values of an observable', function (done) {
-    Observable.fromArray([1, 2, 3])
+    Observable.from([1, 2, 3])
       .count()
       .subscribe(function (total) {
           expect(total).toEqual(3);

--- a/spec/operators/filter-spec.js
+++ b/spec/operators/filter-spec.js
@@ -6,7 +6,7 @@ describe('Observable.prototype.filter()', function () {
   it('should filter out values', function (done) {
     var expected = [1, 3];
     var i = 0;
-    Observable.fromArray([1, 2, 3]).filter(function (x) {
+    Observable.from([1, 2, 3]).filter(function (x) {
       return x % 2 === 1;
     })
     .subscribe(function (x) {

--- a/spec/operators/map-spec.js
+++ b/spec/operators/map-spec.js
@@ -15,7 +15,7 @@ describe('Observable.prototype.map()', function () {
   it('should map multiple values', function (done) {
     var expected = ['1!', '2!', '3!'];
     var i = 0;
-    Observable.fromArray([1, 2, 3]).map(function (x) {
+    Observable.from([1, 2, 3]).map(function (x) {
       return x + '!';
     })
     .subscribe(function (x) {

--- a/spec/operators/merge-all-spec.js
+++ b/spec/operators/merge-all-spec.js
@@ -6,7 +6,7 @@ describe('mergeAll', function () {
   it('should merge all obsevables in an obsevable', function (done) {
     var expected = [1, 2, 3];
     var i = 0;
-    Observable.fromArray([
+    Observable.from([
       Observable.of(1),
       Observable.of(2),
       Observable.of(3)
@@ -20,7 +20,7 @@ describe('mergeAll', function () {
   });
 
   it('should throw if any child observable throws', function (done) {
-    Observable.fromArray([
+    Observable.from([
       Observable.of(1),
       Observable.throw('bad'),
       Observable.of(3)

--- a/spec/operators/multicast-spec.js
+++ b/spec/operators/multicast-spec.js
@@ -46,7 +46,7 @@ describe('Observable.prototype.multicast()', function () {
     var expected = [1, 2, 3, 4];
     var i = 0;
 
-    var source = Observable.fromArray([1, 2, 3, 4]).multicast(function () {
+    var source = Observable.from([1, 2, 3, 4]).multicast(function () {
       //NOTE: This is done for testing only, NEVER do this in prod code, LOL
       return subject;
     });

--- a/spec/operators/partition-spec.js
+++ b/spec/operators/partition-spec.js
@@ -22,7 +22,7 @@ describe('Observable.prototype.partition()', function () {
 
     var values = [-3, -2, -1, 0, 1, 2];
 
-    var numberStream = Rx.Observable.fromArray(values);
+    var numberStream = Rx.Observable.from(values);
 
     var streams = numberStream.partition(function (value) {
       return value >= 0;
@@ -47,7 +47,7 @@ describe('Observable.prototype.partition()', function () {
   it('should pass errors to both returned observables', function (done) {
 
     var values = [-3, -2, -1, 0, 1, 2];
-    var numberStream = Rx.Observable.fromArray(values);
+    var numberStream = Rx.Observable.from(values);
     var errored = false;
 
     function rejecter() {

--- a/spec/operators/to-array-spec.js
+++ b/spec/operators/to-array-spec.js
@@ -4,7 +4,7 @@ var Observable = Rx.Observable;
 
 describe('toArray', function () {
   it('should reduce the values of an observable into an array', function (done) {
-    Observable.fromArray([1, 2, 3])
+    Observable.from([1, 2, 3])
       .toArray()
       .subscribe(function (arr) {
           expect(arr).toEqual([1, 2, 3]);

--- a/spec/operators/zip-all-spec.js
+++ b/spec/operators/zip-all-spec.js
@@ -6,9 +6,9 @@ describe('zipAll', function () {
   it('should take all observables from the source and zip them', function (done) {
     var expected = ['a1', 'b2', 'c3'];
     var i = 0;
-    Observable.fromArray([
-      Observable.fromArray(['a', 'b', 'c']),
-      Observable.fromArray([1, 2, 3])
+    Observable.from([
+      Observable.from(['a', 'b', 'c']),
+      Observable.from([1, 2, 3])
     ])
     .zipAll(function (a, b) {
       return a + b;
@@ -21,9 +21,9 @@ describe('zipAll', function () {
   it('should zip until one child terminates', function (done) {
     var expected = ['a1', 'b2'];
     var i = 0;
-    Observable.fromArray([
-      Observable.fromArray(['a', 'b']),
-      Observable.fromArray([1, 2, 3])
+    Observable.from([
+      Observable.from(['a', 'b']),
+      Observable.from([1, 2, 3])
     ])
     .zipAll(function (a, b) {
       return a + b;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -75,7 +75,6 @@ export default class Observable<T> {
 
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
   static from: <T>(iterable: any, scheduler?: Scheduler) => Observable<T>;
-  static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;
   static fromEvent: <T>(element: any, eventName: string, selector: (...args:Array<any>) => T) => Observable<T>;
   static fromEventPattern: <T>(addHandler: (handler:Function)=>void, removeHandler: (handler:Function) => void, selector?: (...args:Array<any>) => T) => Observable<T>;
   static throw: <T>(error: T) => Observable<T>;
@@ -83,7 +82,6 @@ export default class Observable<T> {
   static never: <T>() => Observable<T>;
   static of: <T>(...values: (T | Scheduler)[]) => Observable<T>;
   static range: <T>(start: number, end: number, scheduler?: Scheduler) => Observable<number>;
-  static fromPromise: <T>(promise: Promise<T>) => Observable<T>;
   static timer: (delay: number) => Observable<number>;
   static interval: (interval: number) => Observable<number>;
   static forkJoin: (...observables: Observable<any>[]) => Observable<any[]>;

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -15,7 +15,6 @@ import EmptyObservable from './observables/EmptyObservable';
 import ErrorObservable from './observables/ErrorObservable';
 import InfiniteObservable from './observables/InfiniteObservable';
 import IntervalObservable from './observables/IntervalObservable';
-import PromiseObservable from './observables/PromiseObservable';
 import RangeObservable from './observables/RangeObservable';
 import TimerObservable from './observables/TimerObservable';
 import FromEventPatternObservable from './observables/FromEventPatternObservable';
@@ -25,8 +24,6 @@ import FromObservable from './observables/FromObservable';
 
 Observable.defer = DeferObservable.create;
 Observable.from = FromObservable.create;
-Observable.fromArray = ArrayObservable.create;
-Observable.fromPromise = PromiseObservable.create;
 Observable.of = ArrayObservable.of;
 Observable.range = RangeObservable.create;
 Observable.fromEventPattern = FromEventPatternObservable.create;


### PR DESCRIPTION
- removes fromArray and fromPromise to reduce API surface
- updates tests that utilized the above methods

covers issue https://github.com/ReactiveX/RxJS/issues/239 .