### PR TITLE
refactor(Scheduler): change order of arguments to schedule method

### DIFF
--- a/spec/scheduler-spec.js
+++ b/spec/scheduler-spec.js
@@ -8,9 +8,9 @@ describe('Scheduler.immediate', function() {
     var call1 = false;
     var call2 = false;
     Scheduler.immediate.active = false;
-    Scheduler.immediate.schedule(0, null, function(){
+    Scheduler.immediate.schedule(function () {
       call1 = true;
-      Scheduler.immediate.schedule(0, null, function(){
+      Scheduler.immediate.schedule(function(){
         call2 = true;
       });
     });   
@@ -20,9 +20,9 @@ describe('Scheduler.immediate', function() {
   
   it('should schedule things in the future too', function (done) {
     var called = false;
-    Scheduler.immediate.schedule(500, null, function () {
+    Scheduler.immediate.schedule(function () {
       called = true;
-    });
+    }, 500);
     
     setTimeout(function () {
       expect(called).toBe(false);

--- a/spec/subject-spec.js
+++ b/spec/subject-spec.js
@@ -8,14 +8,10 @@ describe('Subject', function () {
   it('should pump values right on through itself', function (done) {
     var subject = new Subject();
     var expected = ['foo', 'bar'];
-    var i = 0;
 
     subject.subscribe(function (x) {
-      expect(x).toBe(expected[i++]);
-    }, null,
-      function () {
-        done();
-      });
+      expect(x).toBe(expected.shift());
+    }, null, done);
     
     subject.next('foo');
     subject.next('bar');
@@ -34,39 +30,25 @@ describe('Subject', function () {
 
     subject.subscribe(function (x) {
       expect(x).toBe(expected[j++]);
-    }, null,
-      function () {
-        done();
-      });
+    }, null, done);
     
-    // HACK
-    nextTick.schedule(0, null, function () {
-      expect(subject.observers.length).toBe(2);
-      subject.next('foo');
-      subject.next('bar');
-      subject.complete();
-    });
+    expect(subject.observers.length).toBe(2);
+    subject.next('foo');
+    subject.next('bar');
+    subject.complete();
   });
 
   it('should not allow values to be nexted after a return', function (done) {
     var subject = new Subject();
     var expected = ['foo'];
-    var i = 0;
 
     subject.subscribe(function (x) {
-      expect(x).toBe(expected[i++]);
-    }, null,
-      function () {
-        //HACK
-        nextTick.schedule(0, null, done);
-      });
-    
-    // HACK
-    nextTick.schedule(0, null, function () {
-      subject.next('foo');
-      subject.complete();
-      subject.next('bar');
-    });
+      expect(x).toBe(expected.shift());
+    }, null, done);
+  
+    subject.next('foo');
+    subject.complete();
+    subject.next('bar');
   });
 
   it('should clean out unsubscribed subscribers', function (done) {

--- a/spec/subjects/behavior-subject-spec.js
+++ b/spec/subjects/behavior-subject-spec.js
@@ -18,15 +18,9 @@ describe('BehaviorSubject', function() {
     
     subject.subscribe(function(x) {
       expect(x).toBe(expected[i++]);
-    }, null,
-    function(){
-      done();
-    });
-    
-    // HACK
-    Rx.Scheduler.nextTick.schedule(0, null, function(){
-      subject.next('bar');
-      subject.complete();
-    });
+    }, null, done);
+
+    subject.next('bar');
+    subject.complete();
   });
 });

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -3,7 +3,7 @@ import Subscription from './Subscription';
 interface Scheduler {
   now(): number;
   
-  schedule<T>(delay: number, state: any, work: (state?: any) => Subscription<T>|void): Subscription<T>;
+  schedule<T>(work: (state?: any) => Subscription<T>|void, delay?: number, state?: any): Subscription<T>;
 }
 
 export default Scheduler;

--- a/src/observables/ArrayObservable.ts
+++ b/src/observables/ArrayObservable.ts
@@ -59,9 +59,9 @@ export default class ArrayObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(0, {
+      subscriber.add(scheduler.schedule(ArrayObservable.dispatch, 0, {
         array, index, count, subscriber
-      }, ArrayObservable.dispatch));
+      }));
     } else {
       do {
         if (index >= count) {

--- a/src/observables/EmptyObservable.ts
+++ b/src/observables/EmptyObservable.ts
@@ -20,7 +20,7 @@ export default class EmptyObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(0, { subscriber }, EmptyObservable.dispatch));
+      subscriber.add(scheduler.schedule(EmptyObservable.dispatch, 0, { subscriber }));
     } else {
       subscriber.complete();
     }

--- a/src/observables/ErrorObservable.ts
+++ b/src/observables/ErrorObservable.ts
@@ -21,9 +21,9 @@ export default class ErrorObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(0, {
+      subscriber.add(scheduler.schedule(ErrorObservable.dispatch, 0, {
         error, subscriber
-      }, ErrorObservable.dispatch));
+      }));
     } else {
       subscriber.error(error);
     }

--- a/src/observables/IntervalObservable.ts
+++ b/src/observables/IntervalObservable.ts
@@ -40,8 +40,8 @@ export default class IntervalObservable<T> extends Observable<T> {
     const period = this.period;
     const scheduler = this.scheduler;
 
-    subscriber.add(scheduler.schedule(period, {
+    subscriber.add(scheduler.schedule(IntervalObservable.dispatch, period, {
       index, subscriber
-    }, IntervalObservable.dispatch));
+    }));
   }
 }

--- a/src/observables/IteratorObservable.ts
+++ b/src/observables/IteratorObservable.ts
@@ -74,9 +74,9 @@ export default class IteratorObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(0, {
+      subscriber.add(scheduler.schedule(IteratorObservable.dispatch, 0, {
         index, thisArg, project, iterator, subscriber
-      }, IteratorObservable.dispatch));
+      }));
     } else {
       do {
         let result = iterator.next();

--- a/src/observables/PromiseObservable.ts
+++ b/src/observables/PromiseObservable.ts
@@ -26,8 +26,8 @@ export default class PromiseObservable<T> extends Observable<T> {
         err => subscriber.error(err));
     } else {
       let subscription = new Subscription();
-      promise.then(value => subscription.add(scheduler.schedule(0, { value, subscriber }, dispatchNext)),
-      err => subscription.add(scheduler.schedule(0, { err, subscriber }, dispatchError)));
+      promise.then(value => subscription.add(scheduler.schedule(dispatchNext, 0, { value, subscriber })),
+      err => subscription.add(scheduler.schedule(dispatchError, 0, { err, subscriber })));
       return subscription;
     }
   }

--- a/src/observables/RangeObservable.ts
+++ b/src/observables/RangeObservable.ts
@@ -47,9 +47,9 @@ export default class RangeObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(0, {
+      subscriber.add(scheduler.schedule(RangeObservable.dispatch, 0, {
         index, end, start, subscriber
-      }, RangeObservable.dispatch));
+      }));
     } else {
       do {
         if (index++ >= end) {

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -37,9 +37,9 @@ export default class ScalarObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(0, {
+      subscriber.add(scheduler.schedule(ScalarObservable.dispatch, 0, {
         done: false, value, subscriber
-      }, ScalarObservable.dispatch));
+      }));
     } else {
       subscriber.next(value);
       if (!subscriber.isUnsubscribed) {

--- a/src/observables/SubscribeOnObservable.ts
+++ b/src/observables/SubscribeOnObservable.ts
@@ -28,8 +28,8 @@ export default class SubscribeOnObservable<T> extends Observable<T> {
     const source = this.source;
     const scheduler = this.scheduler;
 
-    subscriber.add(scheduler.schedule(delay, {
+    subscriber.add(scheduler.schedule(SubscribeOnObservable.dispatch, delay, {
       source, subscriber
-    }, SubscribeOnObservable.dispatch));
+    }));
   }
 }

--- a/src/observables/TimerObservable.ts
+++ b/src/observables/TimerObservable.ts
@@ -24,9 +24,9 @@ export default class TimerObservable<T> extends Observable<T> {
     }
 
     if (typeof action.delay === 'undefined') {
-      action.add(action.scheduler.schedule(period, {
+      action.add(action.scheduler.schedule(TimerObservable.dispatch, period, {
         index: index + 1, period, subscriber
-      }, TimerObservable.dispatch));
+      }));
     } else {
       state.index = index + 1;
       action.schedule(state);
@@ -55,8 +55,6 @@ export default class TimerObservable<T> extends Observable<T> {
     const dueTime = this.dueTime;
     const scheduler = this.scheduler;
 
-    subscriber.add(scheduler.schedule(dueTime, {
-      index, period, subscriber
-    }, TimerObservable.dispatch));
+    subscriber.add(scheduler.schedule(TimerObservable.dispatch, dueTime, { index, period, subscriber }));
   }
 }

--- a/src/operators/bufferTime.ts
+++ b/src/operators/bufferTime.ts
@@ -32,10 +32,10 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     super(destination);
     let buffer = this.openBuffer();
     if (bufferCreationInterval !== null && bufferCreationInterval >= 0) {
-      this.add(scheduler.schedule(bufferTimeSpan, { subscriber: this, buffer }, dispatchBufferClose));
-      this.add(scheduler.schedule(bufferCreationInterval, { bufferTimeSpan, bufferCreationInterval, subscriber: this, scheduler }, dispatchBufferCreation));
+      this.add(scheduler.schedule(dispatchBufferClose, bufferTimeSpan, { subscriber: this, buffer }));
+      this.add(scheduler.schedule(dispatchBufferCreation, bufferCreationInterval, { bufferTimeSpan, bufferCreationInterval, subscriber: this, scheduler }));
     } else {
-      this.add(scheduler.schedule(bufferTimeSpan, { subscriber: this, buffer }, dispatchBufferTimeSpanOnly));
+      this.add(scheduler.schedule(dispatchBufferTimeSpanOnly, bufferTimeSpan, { subscriber: this, buffer }));
     }
   }
   
@@ -89,7 +89,7 @@ function dispatchBufferCreation(state) {
   let { bufferTimeSpan, subscriber, scheduler } = state;
   let buffer = subscriber.openBuffer();
   var action = <Action<any>>this;
-  action.add(scheduler.schedule(bufferTimeSpan, { subscriber, buffer }, dispatchBufferClose));
+  action.add(scheduler.schedule(dispatchBufferClose, bufferTimeSpan, { subscriber, buffer }));
   action.schedule(state);
 }
 

--- a/src/operators/debounce.ts
+++ b/src/operators/debounce.ts
@@ -33,7 +33,7 @@ class DebounceSubscriber<T> extends Subscriber<T> {
 
   _next(value: T) {
     if (!this.debounced) {
-      this.add(this.debounced = this.scheduler.schedule(this.dueTime, { value, subscriber: this }, dispatchNext));
+      this.add(this.debounced = this.scheduler.schedule(dispatchNext, this.dueTime, { value, subscriber: this }));
     }
   }
 

--- a/src/operators/delay.ts
+++ b/src/operators/delay.ts
@@ -87,9 +87,9 @@ class DelaySubscriber<T> extends Subscriber<T> {
 
   _schedule(scheduler) {
     this.active = true;
-    this.add(scheduler.schedule(this.delay, {
+    this.add(scheduler.schedule(DelaySubscriber.dispatch, this.delay, {
       source: this, destination: this.destination, scheduler: scheduler
-    }, DelaySubscriber.dispatch));
+    }));
   }
 }
 

--- a/src/operators/observeOn-support.ts
+++ b/src/operators/observeOn-support.ts
@@ -35,22 +35,18 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
   }
 
   _next(x) {
-    this.add(this.scheduler.schedule(this.delay,
-      new ObserveOnMessage(Notification.createNext(x), this.destination),
-      ObserveOnSubscriber.dispatch)
-    );
+    this.add(this.scheduler.schedule(ObserveOnSubscriber.dispatch, this.delay,
+      new ObserveOnMessage(Notification.createNext(x), this.destination)));
   }
 
   _error(e) {
-    this.add(this.scheduler.schedule(this.delay,
-      new ObserveOnMessage(Notification.createError(e), this.destination),
-      ObserveOnSubscriber.dispatch));
+    this.add(this.scheduler.schedule(ObserveOnSubscriber.dispatch, this.delay,
+      new ObserveOnMessage(Notification.createError(e), this.destination)));
   }
 
   _complete() {
-    this.add(this.scheduler.schedule(this.delay,
-      new ObserveOnMessage(Notification.createComplete(), this.destination),
-      ObserveOnSubscriber.dispatch));
+    this.add(this.scheduler.schedule(ObserveOnSubscriber.dispatch, this.delay,
+      new ObserveOnMessage(Notification.createComplete(), this.destination)));
   }
 }
 

--- a/src/operators/sampleTime.ts
+++ b/src/operators/sampleTime.ts
@@ -25,7 +25,7 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
   
   constructor(destination: Observer<T>, private delay: number, private scheduler: Scheduler) {
     super(destination);
-    this.add(scheduler.schedule(delay, { subscriber: this }, dispatchNotification));
+    this.add(scheduler.schedule(dispatchNotification, delay, { subscriber: this }));
   }
   
   _next(value: T) {

--- a/src/operators/throttle.ts
+++ b/src/operators/throttle.ts
@@ -32,7 +32,7 @@ class ThrottleSubscriber<T, R> extends Subscriber<T> {
 
   _next(x) {
     this.clearThrottle();
-    this.add(this.throttled = this.scheduler.schedule(this.delay, { value: x, subscriber: this }, dispatchNext));
+    this.add(this.throttled = this.scheduler.schedule(dispatchNext, this.delay, { value: x, subscriber: this }));
   }
 
   throttledNext(x) {

--- a/src/operators/timeout.ts
+++ b/src/operators/timeout.ts
@@ -26,7 +26,7 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
   constructor(destination: Observer<T>, private waitFor: number, private errorToSend: any, private scheduler: Scheduler) {
     super(destination);
     let delay = waitFor;
-    scheduler.schedule(delay, { subscriber: this }, dispatchTimeout);
+    scheduler.schedule(dispatchTimeout, delay, { subscriber: this });
   }
   
   sendTimeoutError() {

--- a/src/operators/timeoutWith.ts
+++ b/src/operators/timeoutWith.ts
@@ -27,7 +27,7 @@ class TimeoutWithSubscriber<T> extends Subscriber<T> {
   constructor(destination: Observer<T>, private waitFor: number, private withObservable: Observable<any>, private scheduler: Scheduler) {
     super(destination);
     let delay = waitFor;
-    scheduler.schedule(delay, { subscriber: this }, dispatchTimeout);
+    scheduler.schedule(dispatchTimeout, delay, { subscriber: this });
   }
   
   handleTimeout() {

--- a/src/operators/windowTime.ts
+++ b/src/operators/windowTime.ts
@@ -33,11 +33,11 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     super(destination);
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
       let window = this.openWindow();
-      this.add(scheduler.schedule(windowTimeSpan, { subscriber: this, window, context: null }, dispatchWindowClose))
-      this.add(scheduler.schedule(windowCreationInterval, { windowTimeSpan, windowCreationInterval, subscriber: this, scheduler }, dispatchWindowCreation))
+      this.add(scheduler.schedule(dispatchWindowClose, windowTimeSpan, { subscriber: this, window, context: null }))
+      this.add(scheduler.schedule(dispatchWindowCreation, windowCreationInterval, { windowTimeSpan, windowCreationInterval, subscriber: this, scheduler }))
     } else {
       let window = this.openWindow();
-      this.add(scheduler.schedule(windowTimeSpan, { subscriber: this, window }, dispatchWindowTimeSpanOnly));
+      this.add(scheduler.schedule(dispatchWindowTimeSpanOnly, windowTimeSpan, { subscriber: this, window }));
     }
   }
   
@@ -96,7 +96,7 @@ function dispatchWindowCreation(state) {
   let window = subscriber.openWindow();
   let action = <Action<any>>this;
   let context = { action, subscription: null };
-  action.add(context.subscription = scheduler.schedule(windowTimeSpan, { subscriber, window, context }, dispatchWindowClose));
+  action.add(context.subscription = scheduler.schedule(dispatchWindowClose, windowTimeSpan, { subscriber, window, context }));
   action.schedule(state);
 }
 

--- a/src/schedulers/ImmediateScheduler.ts
+++ b/src/schedulers/ImmediateScheduler.ts
@@ -25,17 +25,17 @@ export default class ImmediateScheduler implements Scheduler {
     this.active = false;
   }
 
-  schedule<T>(delay: number, state: any, work: (x?: any) => Subscription<T> | void): Subscription<T> {
+  schedule<T>(work: (x?: any) => Subscription<T> | void, delay: number = 0, state?: any): Subscription<T> {
     return (delay <= 0) ?
-      this.scheduleNow(state, work) :
-      this.scheduleLater(state, work, delay);
+      this.scheduleNow(work, state) :
+      this.scheduleLater(work, delay, state);
   }
 
-  scheduleNow<T>(state: any, work: (x?: any) => Subscription<T> | void): Action<T> {
+  scheduleNow<T>(work: (x?: any) => Subscription<T> | void, state?: any): Action<T> {
     return new Action(this, work).schedule(state);
   }
 
-  scheduleLater<T>(state: any, work: (x?: any) => Subscription<T> | void, delay: number): Action<T> {
+  scheduleLater<T>(work: (x?: any) => Subscription<T> | void, delay: number, state?: any): Action<T> {
     return new FutureAction(this, work, delay).schedule(state);
   }
 }

--- a/src/schedulers/NextTickScheduler.ts
+++ b/src/schedulers/NextTickScheduler.ts
@@ -5,7 +5,7 @@ import Action from './Action';
 import NextTickAction from './NextTickAction';
 
 export default class NextTickScheduler extends ImmediateScheduler {
-  scheduleNow<T>(state: any, work: (x?: any) => Subscription<T> | void): Action<T> {
+  scheduleNow<T>(work: (x?: any) => Subscription<T>, state?: any): Action<T> {
     return (this.scheduled ?
       new Action(this, work) :
       new NextTickAction(this, work)).schedule(state);


### PR DESCRIPTION
schedule is now: schedule(work, delay?, state?)
also cleaned up some tests that still used scheduling from the early days when subscription was still async

closes #265