### PR TITLE
fix(bufferCount): set default value for skip argument, do not emit em…

### DIFF
--- a/spec/operators/bufferCount-spec.js
+++ b/spec/operators/bufferCount-spec.js
@@ -17,4 +17,17 @@ describe('Observable.prototype.bufferCount', function () {
         expect(w).toEqual(expected.shift())
       }, null, done);
   }, 2000);
+  
+  it('should emit buffers at buffersize of intervals if not specified', function (done) {
+    var expected = [
+      [0, 1],
+      [2, 3],
+      [4, 5]
+    ];
+    Observable.range(0, 6)
+      .bufferCount(2)
+      .subscribe(function (w) {
+        expect(w).toEqual(expected.shift())
+      }, null, done);
+  }, 2000);
 });

--- a/src/operators/bufferCount.ts
+++ b/src/operators/bufferCount.ts
@@ -33,7 +33,7 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
     const count = (this.count += 1);
     const destination = this.destination;
     const bufferSize = this.bufferSize;
-    const startBufferEvery = this.startBufferEvery;
+    const startBufferEvery = (this.startBufferEvery == null) ? bufferSize : this.startBufferEvery;
     const buffers = this.buffers;
     const len = buffers.length;
     let remove = -1;
@@ -64,7 +64,10 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
     const destination = this.destination;
     const buffers = this.buffers;
     while (buffers.length > 0) {
-      destination.next(buffers.shift());
+      var buffer = buffers.shift();
+      if (buffer.length > 0) {
+        destination.next(buffer);
+      }
     }
     destination.complete();
   }


### PR DESCRIPTION
…pty buffer at the end.

Found while try to write micro perf test for bufferCount, when bufferCount does not have explicit skip argument (startBufferEvery parameter) it only emits very first buffer element then completes observable. This PR aligns bufferCount behaves as same as current bufferWithCount (https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/bufferwithcount.md) by set default skip argument to size of buffer if it's not specified.