### PR TITLE
fix(windowCount): set default value for skip argument, do not emit em…

### DIFF
--- a/spec/operators/windowCount-spec.js
+++ b/spec/operators/windowCount-spec.js
@@ -18,4 +18,18 @@ describe('Observable.prototype.windowCount', function () {
         expect(w).toEqual(expected.shift())
       }, null, done);
   }, 2000);
+  
+  it('should emit buffers at buffersize of intervals if not specified', function (done) {
+    var expected = [
+      [0, 1],
+      [2, 3],
+      [4, 5]
+    ];
+    Observable.range(0, 6)
+      .windowCount(2)
+      .flatMap(function (x) { return x.toArray(); })
+      .subscribe(function (w) {
+        expect(w).toEqual(expected.shift())
+      }, null, done);
+  }, 2000);
 });


### PR DESCRIPTION
…pty buffer at the end.

As same as `bufferCount` implementation fixed in https://github.com/ReactiveX/RxJS/pull/271, windowCount also does not sets default skip argument if it's not specified. This PR `windowCount` to set default skip argument to size of window.