### PR TITLE
refactor(Scalar): move to _isScalar from instanceof ScalarObservable

### DIFF
--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -27,6 +27,8 @@ export default class ScalarObservable<T> extends Observable<T> {
     (<any> this).schedule(state);
   }
 
+  _isScalar: boolean = true;
+  
   constructor(public value: T, private scheduler?: Scheduler) {
     super();
   }

--- a/src/operators/expand.ts
+++ b/src/operators/expand.ts
@@ -47,10 +47,10 @@ class ExpandSubscriber<T, R> extends MergeSubscriber<T, R> {
   }
 
   _subscribeInner(observable, value, index) {
-    if(observable instanceof ScalarObservable) {
+    if(observable._isScalar) {
       this.destination.next((<ScalarObservable<T>> observable).value);
       this._innerComplete();
-      this._next((<ScalarObservable<T>> observable).value);
+      this._next((<any>observable).value);
     } else if(observable instanceof EmptyObservable) {
       this._innerComplete();
     } else {

--- a/src/operators/flatMap-support.ts
+++ b/src/operators/flatMap-support.ts
@@ -55,8 +55,8 @@ export class FlatMapSubscriber<T, R> extends MergeSubscriber<T, R> {
     const projectResult = this.projectResult;
     if(projectResult) {
       return observable.subscribe(new FlatMapInnerSubscriber(this.destination, this, value, index, projectResult));
-    } else if(observable instanceof ScalarObservable) {
-      this.destination.next((<ScalarObservable<T>> observable).value);
+    } else if(observable._isScalar) {
+      this.destination.next((<any> observable).value);
       this._innerComplete();
     } else {
       return observable.subscribe(new MergeInnerSubscriber(this.destination, this));

--- a/src/operators/merge-support.ts
+++ b/src/operators/merge-support.ts
@@ -67,8 +67,8 @@ export class MergeSubscriber<T, R> extends Subscriber<T> {
   }
 
   _subscribeInner(observable, value, index) {
-    if(observable instanceof ScalarObservable) {
-      this.destination.next((<ScalarObservable<T>> observable).value);
+    if(observable._isScalar) {
+      this.destination.next((<any>observable).value);
       this._innerComplete();
     } else {
       return observable.subscribe(new MergeInnerSubscriber(this.destination, this));


### PR DESCRIPTION
- add _isScalar property to Observables that could be scalar
- check for _isScalar rather than instanceof ScalarObservable
- add _isScalar property to PromiseObservable that defaults to false
- set _isScalar property to true when PromiseObservable's promise resolves
- also set the value property of the PromiseObservable

closes #276