### PR TITLE
chore(test): add macro performance tests for merge

### DIFF
--- a/perf/macro/index.html
+++ b/perf/macro/index.html
@@ -7,9 +7,11 @@
 <body>
 	<h2>Tests</h2>
 	<ul>
-		<li><a href="map">map</a></li>
+		<li><a href="map">map</a></li> 
+		<li><a href="merge">merge</a></li>
 		<li><a href="flatMap">flatMap</a></li>
-    <li><a href="flatMap-scalar">flatMap-scalar</a></li>
+    	<li><a href="flatMap-scalar">flatMap-scalar</a></li>
+		<li><a href="zip">zip</a></li>
 	</ul>
 </body>
 </html>

--- a/perf/macro/merge/index.html
+++ b/perf/macro/merge/index.html
@@ -1,0 +1,24 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>RxJS 3 Perf Tests</title>
+  <script src="../../../dist/global/Rx.js"></script>
+  <script type="text/javascript">
+    window.RxNext = window.Rx;
+    window.Rx = void 0;
+  </script>
+  <script src="../../../node_modules/rx/dist/rx.all.js"></script>
+
+</head>
+<body>
+	<a href="../">perf index</a>
+  <label>
+    Number of Iterations
+    <input type="number" name="iteration">
+  </label>
+  <button id="rx-2-merge">Rx2 merge Test</button>
+  <button id="rx-3-merge">RxNext merge Test</button>
+  <script src="perf.js"></script>
+</body>
+</html>

--- a/perf/macro/merge/merge.spec.js
+++ b/perf/macro/merge/merge.spec.js
@@ -1,0 +1,47 @@
+var benchpress = require('benchpress');
+var runner = new benchpress.Runner([
+  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
+  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
+  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
+  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
+  benchpress.bind(benchpress.Options.FORCE_GC).toValue(false)
+]);
+
+describe('merge comparison', function () {
+  [
+    1000,
+    10000
+  ].forEach(function (val) {
+    it('should be fast in Rx2', function (done) {
+      browser.ignoreSynchronization = true;
+      browser.get('http://localhost:8080/perf/macro/merge/index.html?iterations=' + val);
+      runner.sample({
+        id: 'merge Rx2',
+        execute: function () {
+          $('#rx-2-merge').click();
+        },
+        bindings: [
+          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
+            iterations: val
+          })
+        ]
+      }).then(done, done.fail);
+    });
+
+    it('should be fast in RxNext', function (done) {
+      browser.ignoreSynchronization = true;
+      browser.get('http://localhost:8080/perf/macro/merge/index.html?iterations=' + val);
+      runner.sample({
+        id: 'merge RxNext',
+        execute: function () {
+          $('#rx-3-merge').click();
+        },
+        bindings: [
+          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
+            iterations: val
+          })
+        ]
+      }).then(done, done.fail);
+    });
+  });
+});

--- a/perf/macro/merge/perf.js
+++ b/perf/macro/merge/perf.js
@@ -1,0 +1,33 @@
+var iterationInput = document.querySelector('input[name=iteration]');
+var match = /iterations=(\w+)/.exec(decodeURIComponent(location.search));
+
+if (match) {
+  iterationInput.value = match[1];
+}
+
+var numIterations = iterationInput.valueAsNumber || 1000;
+
+var Rx2Merge = document.querySelector('#rx-2-merge');
+var RxNextMerge = document.querySelector('#rx-3-merge');
+
+var Rx2TestObservable = Rx.Observable.create(generator);
+var RxNextTestObservable = new RxNext.Observable(generator);
+
+var Rx2TestArgObservable = Rx.Observable.create(generator);
+var RxNextTestArgObservable = new RxNext.Observable(generator);
+
+Rx2Merge.addEventListener('click', function() {
+  Rx2TestObservable.merge(Rx2TestArgObservable).subscribe();
+});
+
+RxNextMerge.addEventListener('click', function() {
+  RxNextTestObservable.merge(RxNextTestArgObservable).subscribe();
+});
+
+function generator(observer) {
+  var index = -1;
+  while(++index < numIterations) {
+    observer.onNext(index);
+  }
+  observer.onCompleted();
+}


### PR DESCRIPTION
Try to close https://github.com/ReactiveX/RxJS/issues/257.

After adding this test case I'm observing failures on my machine at the end of perf test using **Windows 10, Chrome 45.0.2454.85 m (64-bit)**. To verify it's occurring on other configuration created clean machine runnning **Ubuntu 12.02 LTS 45.0.2454.85 (64-bit) and test was exited without error**. Since test case itself ran successfully I suspect this is somewhat related with protractor issue (maybe this? https://github.com/angular/protractor/issues/2001) but do not have concrete clue. While trying to troubleshoot issue, creating PR to ask if anyone experiences similar cases.

>github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\webdriver.js:377
>      throw new Error('This driver instance does not have a valid session ID ' +
>            ^
>Error: This driver instance does not have a valid session ID (did you call WebDriver.quit()?) and may no longer be used.
>    at checkHasNotQuit (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\webdriver.js:377:13)
>    at Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\webdriver.js:350:5
>    at [object Object].webdriver.promise.ControlFlow.runInNewFrame_ (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\promise.js:1654:20)
>    at [object Object].webdriver.promise.ControlFlow.runEventLoop_ (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\promise.js:1518:8)
>    at [object Object].wrapper [as _onTimeout] (timers.js:265:14)
>    at Timer.listOnTimeout (timers.js:110:15)
>==== async task ====
>WebDriver.quit()
>    at [object Object].webdriver.WebDriver.schedule (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\webdriver.js:345:15)
>    at [object Object].webdriver.WebDriver.quit (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\webdriver.js:418:21)
>    at Z:\github\RxJS\node_modules\protractor\lib\driverProviders\driverProvider.js:59:14
>    at Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\goog\base.js:1582:15
>    at [object Object].webdriver.promise.ControlFlow.runInNewFrame_ (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\promise.js:1654:20)
>    at notify (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\promise.js:465:12)
>    at [object Object].then (Z:\github\RxJS\node_modules\protractor\node_modules\selenium-webdriver\lib\webdriver\promise.js:522:7)
>    at [object Object].DriverProvider.quitDriver (Z:\github\RxJS\node_modules\protractor\lib\driverProviders\driverProvider.js:57:23)
>    at Array.map (native)
>[launcher] Process exited with error code 1