### PR TITLE
chore(test): add micro-benchmark performance test for catch operator

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/catch.js
+++ b/perf/micro/current-thread-scheduler/operators/catch.js
@@ -1,0 +1,20 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+
+  var oldCatchWithCurrentThreadScheduler = RxOld.Observable.throw(new Error('error'), RxOld.Scheduler.currentThread).catch(RxOld.Observable.of(25, RxOld.Scheduler.currentThread));
+  var newCatchWithCurrentThreadScheduler = RxNew.Observable.throw(new Error('error'), RxNew.Scheduler.immediate).catch(RxNew.Observable.of(25, RxNew.Scheduler.immediate));
+
+  return suite
+    .add('old catch with current thread scheduler', function () {
+      oldCatchWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new catch with current thread scheduler', function () {
+      newCatchWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+    
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};

--- a/perf/micro/immediate-scheduler/operators/catch.js
+++ b/perf/micro/immediate-scheduler/operators/catch.js
@@ -1,0 +1,20 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+
+  var oldCatchWithImmediateScheduler = RxOld.Observable.throw(new Error('error'), RxOld.Scheduler.immediate).catch(RxOld.Observable.of(25, RxOld.Scheduler.immediate));
+  var newCatchWithImmediateScheduler = RxNew.Observable.throw(new Error('error')).catch(RxNew.Observable.of(25));
+
+  return suite
+    .add('old catch with immediate scheduler', function () {
+      oldCatchWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new catch with immediate scheduler', function () {
+      newCatchWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};

--- a/perf/micro/index.js
+++ b/perf/micro/index.js
@@ -14,6 +14,7 @@ Observable.from([
         require("./immediate-scheduler/observable/throw"),
 
         require("./immediate-scheduler/operators/buffer-count"),
+        require("./immediate-scheduler/operators/catch"),
         require("./immediate-scheduler/operators/combine-latest"),
         require("./immediate-scheduler/operators/concat"),
         require("./immediate-scheduler/operators/concat-all"),
@@ -47,6 +48,7 @@ Observable.from([
         require("./current-thread-scheduler/observable/throw"),
 
         require("./current-thread-scheduler/operators/buffer-count"),
+        require("./current-thread-scheduler/operators/catch"),
         require("./current-thread-scheduler/operators/combine-latest"),
         require("./current-thread-scheduler/operators/concat"),
         require("./current-thread-scheduler/operators/concat-all"),


### PR DESCRIPTION
Continue to cover #100.

Able to see noticeable slowness on new operator.

>old catch with immediate scheduler x 87,736 ops/sec ±3.78% (83 runs sampled)
>new catch with immediate scheduler x 61,858 ops/sec ±2.73% (79 runs sampled)
>       -29.5% slower than Rx2

>old catch with current thread scheduler x 73,027 ops/sec ±2.87% (78 runs sampled)
>new catch with current thread scheduler x 58,123 ops/sec ±2.95% (82 runs sampled)
>        -20.41% slower than Rx2

(number varies by system running tests, but shows same trend)