### PR TITLE
refactor(test): let macro perf test use common generator function

### DIFF
--- a/perf/macro/flatMap-scalar/perf.js
+++ b/perf/macro/flatMap-scalar/perf.js
@@ -13,21 +13,8 @@ var RxNextFlatMapRange = document.querySelector('#rx-3-flatmap-range-to-scalar')
 var Rx2ObservableReturn = Rx.Observable.return;
 var RxNextObservableReturn = RxNext.Observable.of;
 
-var RxNextTestObservable = new RxNext.Observable(function(observer) {
-  var index = -1;
-  while(++index < numIterations) {
-    observer.next(index);
-  }
-  observer.complete();
-});
-
-var Rx2TestObservable = Rx.Observable.create(function(observer) {
-  var index = -1;
-  while(++index < numIterations) {
-    observer.onNext(index);
-  }
-  observer.onCompleted();
-});
+var RxNextTestObservable = RxNext.Observable.range(0, numIterations);
+var Rx2TestObservable = Rx.Observable.range(0, numIterations);
 
 Rx2FlatMapRange.addEventListener('click', function() {
   Rx2TestObservable.flatMap(projectionRx2).subscribe();

--- a/perf/macro/flatMap/perf.js
+++ b/perf/macro/flatMap/perf.js
@@ -10,21 +10,8 @@ var numIterations = iterationInput.valueAsNumber || 1000;
 var RxNextFlatMap = document.querySelector('#rx-3-flatmap');
 var Rx2FlatMap = document.querySelector('#rx-2-flatmap');
 
-var RxNextTestObservable = new RxNext.Observable(function(observer) {
-  var index = -1;
-  while(++index < numIterations) {
-    observer.next(index);
-  }
-  observer.complete();
-});
-
-var Rx2TestObservable = Rx.Observable.create(function(observer) {
-  var index = -1;
-  while(++index < numIterations) {
-    observer.onNext(index);
-  }
-  observer.onCompleted();
-});
+var RxNextTestObservable = RxNext.Observable.range(0, numIterations);
+var Rx2TestObservable = Rx.Observable.range(0, numIterations);
 
 RxNextFlatMap.addEventListener('click', function() {
   RxNextTestObservable.flatMap(projectionRxNext).subscribe();

--- a/perf/macro/merge/perf.js
+++ b/perf/macro/merge/perf.js
@@ -10,11 +10,11 @@ var numIterations = iterationInput.valueAsNumber || 1000;
 var Rx2Merge = document.querySelector('#rx-2-merge');
 var RxNextMerge = document.querySelector('#rx-3-merge');
 
-var Rx2TestObservable = Rx.Observable.create(generator);
-var RxNextTestObservable = new RxNext.Observable(generator);
+var Rx2TestObservable = Rx.Observable.range(0, numIterations);
+var RxNextTestObservable = RxNext.Observablerange(0, numIterations);
 
-var Rx2TestArgObservable = Rx.Observable.create(generator);
-var RxNextTestArgObservable = new RxNext.Observable(generator);
+var Rx2TestArgObservable = Rx.Observable.range(0, numIterations);
+var RxNextTestArgObservable = RxNext.Observable.range(0, numIterations);
 
 Rx2Merge.addEventListener('click', function() {
   Rx2TestObservable.merge(Rx2TestArgObservable).subscribe();
@@ -23,11 +23,3 @@ Rx2Merge.addEventListener('click', function() {
 RxNextMerge.addEventListener('click', function() {
   RxNextTestObservable.merge(RxNextTestArgObservable).subscribe();
 });
-
-function generator(observer) {
-  var index = -1;
-  while(++index < numIterations) {
-    observer.onNext(index);
-  }
-  observer.onCompleted();
-}

--- a/perf/macro/zip/perf.js
+++ b/perf/macro/zip/perf.js
@@ -10,11 +10,11 @@ var numIterations = iterationInput.valueAsNumber || 1000;
 var Rx2Zip = document.querySelector('#rx-2-zip');
 var RxNextZip = document.querySelector('#rx-3-zip');
 
-var Rx2TestObservable = Rx.Observable.create(generator);
-var RxNextTestObservable = new RxNext.Observable(generator);
+var Rx2TestObservable = Rx.Observable.range(0, numIterations);
+var RxNextTestObservable = RxNext.Observable.range(0, numIterations);
 
-var Rx2TestArgObservable = Rx.Observable.create(generator);
-var RxNextTestArgObservable = new RxNext.Observable(generator);
+var Rx2TestArgObservable = Rx.Observable.range(0, numIterations);
+var RxNextTestArgObservable = RxNext.Observable.range(0, numIterations);
 
 Rx2Zip.addEventListener('click', function() {
   Rx2TestObservable.zip(Rx2TestArgObservable).subscribe();
@@ -23,11 +23,3 @@ Rx2Zip.addEventListener('click', function() {
 RxNextZip.addEventListener('click', function() {
   RxNextTestObservable.zip(RxNextTestArgObservable).subscribe();
 });
-
-function generator(observer) {
-  var index = -1;
-  while(++index < numIterations) {
-    observer.onNext(index);
-  }
-  observer.onCompleted();
-}


### PR DESCRIPTION
In macro perf test, I could see same generator function to create test observable is used by several test cases. This PR aims to have common generator function using existing perf-helper module can be used current & further test cases. PR does not include any functional changes or test coverage expansion.