### PR TITLE
chore(perf): fix catch micro perf test

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/catch.js
+++ b/perf/micro/current-thread-scheduler/operators/catch.js
@@ -3,8 +3,10 @@ var RxNew = require("../../../../index");
 
 module.exports = function (suite) {
 
-  var oldCatchWithCurrentThreadScheduler = RxOld.Observable.throw(new Error('error'), RxOld.Scheduler.currentThread).catch(RxOld.Observable.of(25, RxOld.Scheduler.currentThread));
-  var newCatchWithCurrentThreadScheduler = RxNew.Observable.throw(new Error('error'), RxNew.Scheduler.immediate).catch(RxNew.Observable.of(25, RxNew.Scheduler.immediate));
+  var oldCatchWithCurrentThreadScheduler = RxOld.Observable.throw(new Error('error'), RxOld.Scheduler.currentThread)
+    .catch(function() { return RxOld.Observable.of(25, RxOld.Scheduler.currentThread); });
+  var newCatchWithCurrentThreadScheduler = RxNew.Observable.throw(new Error('error'), RxNew.Scheduler.immediate)
+    .catch(function() { return RxNew.Observable.of(25, RxNew.Scheduler.immediate); });
 
   return suite
     .add('old catch with current thread scheduler', function () {

--- a/perf/micro/immediate-scheduler/operators/catch.js
+++ b/perf/micro/immediate-scheduler/operators/catch.js
@@ -3,8 +3,10 @@ var RxNew = require("../../../../index");
 
 module.exports = function (suite) {
 
-  var oldCatchWithImmediateScheduler = RxOld.Observable.throw(new Error('error'), RxOld.Scheduler.immediate).catch(RxOld.Observable.of(25, RxOld.Scheduler.immediate));
-  var newCatchWithImmediateScheduler = RxNew.Observable.throw(new Error('error')).catch(RxNew.Observable.of(25));
+  var oldCatchWithImmediateScheduler = RxOld.Observable.throw(new Error('error'), RxOld.Scheduler.immediate)
+    .catch(function(){ return RxOld.Observable.of(25, RxOld.Scheduler.immediate); });
+  var newCatchWithImmediateScheduler = RxNew.Observable.throw(new Error('error'))
+    .catch(function() { return RxNew.Observable.of(25); });
 
   return suite
     .add('old catch with immediate scheduler', function () {


### PR DESCRIPTION
The new method isn't polymorphic, and can only be called with a function

```sh
old catch with immediate scheduler x 235,384 ops/sec ±0.64% (94 runs sampled)
new catch with immediate scheduler x 1,621,709 ops/sec ±0.56% (96 runs sampled)
	588.96% faster than Rx2

old catch with current thread scheduler x 217,551 ops/sec ±1.02% (94 runs sampled)
new catch with current thread scheduler x 637,311 ops/sec ±0.54% (93 runs sampled)
	192.95% faster than Rx2
```

closes #283