### PR TITLE
refactor(operators): ensure _subscribe is being called where possible

### DIFF
--- a/spec/operators/switchAll-spec.js
+++ b/spec/operators/switchAll-spec.js
@@ -1,0 +1,29 @@
+/* expect, it, describe */
+var Rx = require('../../dist/cjs/Rx');
+
+var Observable = Rx.Observable;
+var immediateScheduler = Rx.Scheduler.immediate;
+
+describe('Observable.prototype.switchAll()', function(){
+  it("should switch to each immediately-scheduled inner Observable", function (done) {
+    var a = Observable.of(1, 2, 3, immediateScheduler);
+    var b = Observable.of(4, 5, 6, immediateScheduler);
+    var r = [1, 4, 5, 6];
+    var i = 0;
+    Observable.of(a, b, immediateScheduler)
+      .switchAll()
+      .subscribe(function (x) {
+        expect(x).toBe(r[i++]);
+      }, null, done);
+  });
+  
+  it("should switch to each inner Observable", function (done) {
+    var a = Observable.of(1, 2, 3);
+    var b = Observable.of(4, 5, 6);
+    var r = [1, 2, 3, 4, 5, 6];
+    var i = 0;
+    Observable.of(a, b).switchAll().subscribe(function (x) {
+      expect(x).toBe(r[i++]);
+    }, null, done);
+  });
+});

--- a/spec/operators/switchLatest-spec.js
+++ b/spec/operators/switchLatest-spec.js
@@ -4,16 +4,6 @@ var Observable = Rx.Observable;
 var immediateScheduler = Rx.Scheduler.immediate;
 
 describe('Observable.prototype.switchLatest()', function () {
-  it("should switch to each inner Observable", function (done) {
-    var a = Observable.of(1, 2, 3);
-    var b = Observable.of(4, 5, 6);
-    var r = [1, 2, 3, 4, 5, 6];
-    var i = 0;
-    Observable.of(a, b).switchAll().subscribe(function (x) {
-      expect(x).toBe(r[i++]);
-    }, null, done);
-  });
-  
   it("should switch with a selector function", function (done) {
     var a = Observable.of(1, 2, 3);
     var r = [11, 12, 13, 12, 13, 14, 13, 14, 15];
@@ -21,16 +11,6 @@ describe('Observable.prototype.switchLatest()', function () {
     a.switchLatest(function(x) {
       return Observable.range(x + 10, 3);
     }).subscribe(function (x) {
-      expect(x).toBe(r[i++]);
-    }, null, done);
-  });
-  
-  it("should switch to each immediately-scheduled inner Observable", function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, immediateScheduler);
-    var r = [1, 4, 5, 6];
-    var i = 0;
-    Observable.of(a, b, immediateScheduler).switchAll().subscribe(function (x) {
       expect(x).toBe(r[i++]);
     }, null, done);
   });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -21,7 +21,8 @@ export default class Observable<T>  {
 
   source: Observable<any>;
   operator: Operator<any, T>;
-
+  _isScalar: boolean = false;
+  
   /**
    * @constructor
    * @param {Function} subscribe the function that is

--- a/src/operators/buffer.ts
+++ b/src/operators/buffer.ts
@@ -26,7 +26,7 @@ class BufferSubscriber<T> extends Subscriber<T> {
   
   constructor(destination: Observer<T>, closingNotifier: Observable<any>) {
     super(destination);
-    this.add(closingNotifier.subscribe(new BufferClosingNotifierSubscriber(this)));
+    this.add(closingNotifier._subscribe(new BufferClosingNotifierSubscriber(this)));
   }
   
   _next(value: T) {

--- a/src/operators/bufferToggle.ts
+++ b/src/operators/bufferToggle.ts
@@ -29,7 +29,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
   
   constructor(destination: Observer<T>, private openings: Observable<O>, private closingSelector: (openValue: O) => Observable<any>) {
     super(destination);
-    this.add(this.openings.subscribe(new BufferToggleOpeningsSubscriber(this)));
+    this.add(this.openings._subscribe(new BufferToggleOpeningsSubscriber(this)));
   }
 
   _next(value: T) {
@@ -66,10 +66,10 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
       let buffer = [];
       let context = {
         buffer,
-        subscription: null
+        subscription: new Subscription()
       };
       buffers.push(buffer);
-      this.add(context.subscription = closingNotifier.subscribe(new BufferClosingNotifierSubscriber(this, context)));
+      this.add(context.subscription.add(closingNotifier._subscribe(new BufferClosingNotifierSubscriber(this, context))));
     }
   }
   

--- a/src/operators/bufferWhen.ts
+++ b/src/operators/bufferWhen.ts
@@ -67,7 +67,7 @@ class BufferWhenSubscriber<T> extends Subscriber<T> {
       this.buffer = null;
       this.destination.error(err);
     } else {
-      this.add(this.closingNotification = closingNotifier.subscribe(new BufferClosingNotifierSubscriber(this))); 
+      this.add(this.closingNotification = closingNotifier._subscribe(new BufferClosingNotifierSubscriber(this))); 
     }
   }
 }

--- a/src/operators/combineLatest-support.ts
+++ b/src/operators/combineLatest-support.ts
@@ -50,7 +50,7 @@ export class CombineLatestSubscriber<T, R> extends ZipSubscriber<T, R> {
   }
 
   _subscribeInner(observable, values, index, total) {
-    return observable.subscribe(new CombineLatestInnerSubscriber(this.destination, this, values, index, total));
+    return observable._subscribe(new CombineLatestInnerSubscriber(this.destination, this, values, index, total));
   }
 
   _innerComplete(innerSubscriber) {

--- a/src/operators/expand.ts
+++ b/src/operators/expand.ts
@@ -54,7 +54,7 @@ class ExpandSubscriber<T, R> extends MergeSubscriber<T, R> {
     } else if(observable instanceof EmptyObservable) {
       this._innerComplete();
     } else {
-      return observable.subscribe(new ExpandInnerSubscriber(this.destination, this));
+      return observable._subscribe(new ExpandInnerSubscriber(this.destination, this));
     }
   }
 }

--- a/src/operators/flatMap-support.ts
+++ b/src/operators/flatMap-support.ts
@@ -51,15 +51,15 @@ export class FlatMapSubscriber<T, R> extends MergeSubscriber<T, R> {
     return observable;
   }
 
-  _subscribeInner(observable, value, index) {
+  _subscribeInner(observable:Observable<T>, value, index) {
     const projectResult = this.projectResult;
     if(projectResult) {
-      return observable.subscribe(new FlatMapInnerSubscriber(this.destination, this, value, index, projectResult));
+      return observable._subscribe(new FlatMapInnerSubscriber(this.destination, this, value, index, projectResult));
     } else if(observable._isScalar) {
       this.destination.next((<any> observable).value);
       this._innerComplete();
     } else {
-      return observable.subscribe(new MergeInnerSubscriber(this.destination, this));
+      return observable._subscribe(new MergeInnerSubscriber(this.destination, this));
     }
   }
 }

--- a/src/operators/groupBy.ts
+++ b/src/operators/groupBy.ts
@@ -61,7 +61,7 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
           if (duration === errorObject) {
             this.error(duration.e);
           } else {
-            this.add(duration.subscribe(new GroupDurationSubscriber(group, this)));
+            this.add(duration._subscribe(new GroupDurationSubscriber(group, this)));
           }
         }
 

--- a/src/operators/merge-support.ts
+++ b/src/operators/merge-support.ts
@@ -3,6 +3,7 @@ import Subscriber from '../Subscriber';
 import Observer from '../Observer';
 import Observable from '../Observable';
 import ScalarObservable from '../observables/ScalarObservable';
+import Subscription from '../Subscription';
 
 export class MergeOperator<T, R> implements Operator<T, R> {
 
@@ -66,12 +67,15 @@ export class MergeSubscriber<T, R> extends Subscriber<T> {
     this.buffer.push(value);
   }
 
-  _subscribeInner(observable, value, index) {
+  _subscribeInner(observable:Observable<any>, value, index): Subscription<any> {
+    const destination = this.destination;
     if(observable._isScalar) {
-      this.destination.next((<any>observable).value);
+      destination.next((<any>observable).value);
       this._innerComplete();
     } else {
-      return observable.subscribe(new MergeInnerSubscriber(this.destination, this));
+      const subscriber = new MergeInnerSubscriber(destination, this);
+      observable._subscribe(subscriber);
+      return subscriber;
     }
   }
 

--- a/src/operators/retryWhen.ts
+++ b/src/operators/retryWhen.ts
@@ -24,7 +24,6 @@ class RetryWhenOperator<T, R> implements Operator<T, R> {
 class RetryWhenSubscriber<T> extends Subscriber<T> {
   errors: Subject<any>;
   retryNotifications: Observable<any>;
-  retryNotificationSubscription: Subscription<any>;
 
   constructor(destination: Observer<T>, public notifier: (errors: Observable<any>) => Observable<any>, public original: Observable<T>) {
     super(destination);
@@ -38,8 +37,7 @@ class RetryWhenSubscriber<T> extends Subscriber<T> {
         this.destination.error(errorObject.e);
       } else {
         this.retryNotifications = notifications;
-        this.retryNotificationSubscription = notifications.subscribe(new RetryNotificationSubscriber(this));
-        this.add(this.retryNotificationSubscription);
+        this.add(notifications._subscribe(new RetryNotificationSubscriber(this)));
       }
     }
     this.errors.next(err);

--- a/src/operators/sample.ts
+++ b/src/operators/sample.ts
@@ -20,11 +20,10 @@ class SampleOperator<T, R> implements Operator<T, R> {
 class SampleSubscriber<T> extends Subscriber<T> {
   private lastValue: T;
   private hasValue: boolean = false;
-  private innerSubscription: Subscription<T>;
   
   constructor(destination: Observer<T>, private notifier: Observable<any>) {
     super(destination);
-    this.add(this.innerSubscription = notifier.subscribe(new SampleNoficationSubscriber(this)));
+    this.add(notifier._subscribe(new SampleNoficationSubscriber(this)));
   }
   
   _next(value: T) {
@@ -36,11 +35,6 @@ class SampleSubscriber<T> extends Subscriber<T> {
     if (this.hasValue) {
       this.destination.next(this.lastValue);
     }  
-  }
-  
-  notifyComplete() {
-    this.remove(this.innerSubscription);
-    this.innerSubscription.unsubscribe();
   }
 }
 
@@ -59,6 +53,6 @@ class SampleNoficationSubscriber<T> extends Subscriber<T> {
   }
   
   _complete() {
-    this.parent.notifyComplete();
+    //noop
   }
 }

--- a/src/operators/switchAll.ts
+++ b/src/operators/switchAll.ts
@@ -34,13 +34,16 @@ class SwitchSubscriber<T, R> extends MergeSubscriber<T, R> {
       const inner = this.innerSubscription;
       if(inner) {
         inner.unsubscribe()
+        this.innerSubscription = null;
       }
     }
     this._next(value);
   }
 
   _subscribeInner(observable, value, index) {
-    return (this.innerSubscription = super._subscribeInner(observable, value, index));
+    this.innerSubscription = new Subscription();
+    this.innerSubscription.add(super._subscribeInner(observable, value, index));
+    return this.innerSubscription;
   }
 }
 

--- a/src/operators/switchLatest.ts
+++ b/src/operators/switchLatest.ts
@@ -45,6 +45,8 @@ class SwitchLatestSubscriber<T, R> extends FlatMapSubscriber<T, R> {
   }
 
   _subscribeInner(observable, value, index) {
-    return (this.innerSubscription = super._subscribeInner(observable, value, index));
+    this.innerSubscription = new Subscription();
+    this.innerSubscription.add(super._subscribeInner(observable, value, index));
+    return this.innerSubscription;
   }
 }

--- a/src/operators/takeUntil.ts
+++ b/src/operators/takeUntil.ts
@@ -24,7 +24,7 @@ class TakeUntilSubscriber<T> extends Subscriber<T> {
   constructor(destination: Observer<T>,
               observable: Observable<any>) {
     super(destination);
-    this.add(observable.subscribe(new TakeUntilInnerSubscriber(destination)));
+    this.add(observable._subscribe(new TakeUntilInnerSubscriber(destination)));
   }
 }
 

--- a/src/operators/window.ts
+++ b/src/operators/window.ts
@@ -27,7 +27,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
   
   constructor(destination: Observer<T>, private closingNotifier: Observable<any>) {
     super(destination);
-    this.add(closingNotifier.subscribe(new WindowClosingNotifierSubscriber(this)));
+    this.add(closingNotifier._subscribe(new WindowClosingNotifierSubscriber(this)));
     this.openWindow();
   }
 

--- a/src/operators/windowToggle.ts
+++ b/src/operators/windowToggle.ts
@@ -29,7 +29,7 @@ class WindowToggleSubscriber<T, O> extends Subscriber<T> {
   
   constructor(destination: Observer<T>, private openings: Observable<O>, private closingSelector: (openValue: O) => Observable<any>) {
     super(destination);
-    this.add(this.openings.subscribe(new WindowToggleOpeningsSubscriber(this)));
+    this.add(this.openings._subscribe(new WindowToggleOpeningsSubscriber(this)));
   }
 
   _next(value: T) {
@@ -62,7 +62,7 @@ class WindowToggleSubscriber<T, O> extends Subscriber<T> {
     this.destination.next(window);
     let windowContext = {
       window,
-      subscription: null
+      subscription: new Subscription()
     };
 
     const closingSelector = this.closingSelector;
@@ -70,7 +70,7 @@ class WindowToggleSubscriber<T, O> extends Subscriber<T> {
     if (closingNotifier === errorObject) {
       this.error(closingNotifier.e);
     } else {
-      this.add(windowContext.subscription = closingNotifier.subscribe(new WindowClosingNotifierSubscriber<T, O>(this, windowContext)));
+      this.add(windowContext.subscription.add(closingNotifier._subscribe(new WindowClosingNotifierSubscriber<T, O>(this, windowContext))));
     }
   }
   

--- a/src/operators/windowWhen.ts
+++ b/src/operators/windowWhen.ts
@@ -66,7 +66,8 @@ class WindowSubscriber<T> extends Subscriber<T> {
       this.destination.error(err);
       this.window.error(err);
     } else {
-      this.add(this.closingNotification = closingNotifier.subscribe(new WindowClosingNotifierSubscriber(this))); 
+      let closingNotification = this.closingNotification = new Subscription();
+      this.add(closingNotification.add(closingNotifier._subscribe(new WindowClosingNotifierSubscriber(this)))); 
     }
   }
 }

--- a/src/operators/withLatestFrom.ts
+++ b/src/operators/withLatestFrom.ts
@@ -31,7 +31,7 @@ class WithLatestFromSubscriber<T, R> extends Subscriber<T> {
     this.values = new Array(len);
     this.toSet = len;
     for (let i = 0; i < len; i++) {
-      this.add(observables[i].subscribe(new WithLatestInnerSubscriber(this, i)))
+      this.add(observables[i]._subscribe(new WithLatestInnerSubscriber(this, i)))
     }
   }
   

--- a/src/operators/zip-support.ts
+++ b/src/operators/zip-support.ts
@@ -58,7 +58,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   }
 
   _subscribeInner(observable, values, index, total) {
-    return observable.subscribe(new ZipInnerSubscriber(this.destination, this, values, index, total));
+    return observable._subscribe(new ZipInnerSubscriber(this.destination, this, values, index, total));
   }
 
   _innerComplete(innerSubscriber) {


### PR DESCRIPTION
Many operators with inner subscriptions were calling `subscribe` when they could
have been calling `_subscribe`, thus avoiding an `instanceof Subscriber` check.

- makes sure `_subscribe` is being called where possible
- cleans up inner subscription handling in a few places
- seperates `switchAll` tests from `switchLatest` tests

closes #290