### PR TITLE
refactor(test): let macro test share common test spec initializer

### DIFF
--- a/perf/macro/flatMap-scalar/flatmap-scalar.spec.js
+++ b/perf/macro/flatMap-scalar/flatmap-scalar.spec.js
@@ -1,47 +1,24 @@
-var benchpress = require('benchpress');
-var runner = new benchpress.Runner([
-  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
-  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
-  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
-  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
-  benchpress.bind(benchpress.Options.FORCE_GC).toValue(false)
-]);
+var builder = require('../specbuilder');
+
+var preset = new builder.Preset();
+var runner = preset.runner;
 
 describe('flatMap comparison', function () {
-  [
-    1000,
-    10000
-  ].forEach(function (val) {
+  var testUrlIdentifier = 'flatMap-scalar';
+  
+  preset.iteration.forEach(function (val) {
+    
     it('should be fast in Rx2', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/flatMap-scalar/index.html?iterations=' + val);
-      runner.sample({
-        id: 'flatMap-range-to-scalar Rx2',
-        execute: function () {
-          $('#rx-2-flatmap-range-to-scalar').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier, val);
+      var param = preset.sampleParameter('flatMap-range-to-scalar Rx2', '#rx-2-flatmap-range-to-scalar', val);
+      runner.sample(param).then(done, done.fail);
     });
-
+    
     it('should be fast in RxNext', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/flatMap-scalar/index.html?iterations=' + val);
-      runner.sample({
-        id: 'flatMap-range-to-scalar RxNext',
-        execute: function () {
-          $('#rx-3-flatmap-range-to-scalar').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier , val);
+      var param = preset.sampleParameter('flatMap-range-to-scalar RxNext', '#rx-3-flatmap-range-to-scalar', val);
+      runner.sample(param).then(done, done.fail);
     });
+    
   });
 });

--- a/perf/macro/flatMap/flatmap.spec.js
+++ b/perf/macro/flatMap/flatmap.spec.js
@@ -1,48 +1,24 @@
-var benchpress = require('benchpress');
-var runner = new benchpress.Runner([
-  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
-  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
-  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
-  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
-  benchpress.bind(benchpress.Options.FORCE_GC).toValue(false)
-]);
+var builder = require('../specbuilder');
 
-describe('flatMap comparison', function() {
-  [
-    1000,
-    10000
-  ].forEach(function (val) {
+var preset = new builder.Preset();
+var runner = preset.runner;
 
+describe('flatMap comparison', function () {
+  var testUrlIdentifier = 'flatMap';
+  
+  preset.iteration.forEach(function (val) {
+    
     it('should be fast in Rx2', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/flatMap/index.html?iterations=' + val);
-      runner.sample({
-        id: 'flatMap Rx2',
-        execute: function () {
-          $('#rx-2-flatmap').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier, val);
+      var param = preset.sampleParameter('flatMap Rx2', '#rx-2-flatmap', val);
+      runner.sample(param).then(done, done.fail);
     });
-
+    
     it('should be fast in RxNext', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/flatMap/index.html?iterations=' + val);
-      runner.sample({
-        id: 'flatMap RxNext',
-        execute: function () {
-          $('#rx-3-flatmap').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier , val);
+      var param = preset.sampleParameter('flatMap RxNext', '#rx-3-flatmap', val);
+      runner.sample(param).then(done, done.fail);
     });
+    
   });
 });

--- a/perf/macro/groupBy/groupby.spec.js
+++ b/perf/macro/groupBy/groupby.spec.js
@@ -1,47 +1,24 @@
-var benchpress = require('benchpress');
-var runner = new benchpress.Runner([
-  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
-  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
-  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
-  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
-  benchpress.bind(benchpress.Options.FORCE_GC).toValue(false)
-]);
+var builder = require('../specbuilder');
 
-describe('groupBy comparison', function () {
-  [
-    1000,
-    10000
-  ].forEach(function (val) {
+var preset = new builder.Preset();
+var runner = preset.runner;
+
+describe('zip comparison', function () {
+  var testUrlIdentifier = 'groupBy';
+  
+  preset.iteration.forEach(function (val) {
+    
     it('should be fast in Rx2', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/groupBy/index.html?iterations=' + val);
-      runner.sample({
-        id: 'groupBy Rx2',
-        execute: function () {
-          $('#rx-2-groupBy').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier, val);
+      var param = preset.sampleParameter('groupBy Rx2', '#rx-2-groupBy', val);
+      runner.sample(param).then(done, done.fail);
     });
-
+    
     it('should be fast in RxNext', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/groupBy/index.html?iterations=' + val);
-      runner.sample({
-        id: 'groupBy RxNext',
-        execute: function () {
-          $('#rx-3-groupBy').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier , val);
+      var param = preset.sampleParameter('groupBy RxNext', '#rx-3-groupBy', val);
+      runner.sample(param).then(done, done.fail);
     });
+    
   });
 });

--- a/perf/macro/merge/merge.spec.js
+++ b/perf/macro/merge/merge.spec.js
@@ -1,47 +1,24 @@
-var benchpress = require('benchpress');
-var runner = new benchpress.Runner([
-  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
-  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
-  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
-  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
-  benchpress.bind(benchpress.Options.FORCE_GC).toValue(false)
-]);
+var builder = require('../specbuilder');
 
-describe('merge comparison', function () {
-  [
-    1000,
-    10000
-  ].forEach(function (val) {
+var preset = new builder.Preset();
+var runner = preset.runner;
+
+describe('zip comparison', function () {
+  var testUrlIdentifier = 'merge';
+  
+  preset.iteration.forEach(function (val) {
+    
     it('should be fast in Rx2', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/merge/index.html?iterations=' + val);
-      runner.sample({
-        id: 'merge Rx2',
-        execute: function () {
-          $('#rx-2-merge').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier, val);
+      var param = preset.sampleParameter('merge Rx2', '#rx-2-merge', val);
+      runner.sample(param).then(done, done.fail);
     });
-
+    
     it('should be fast in RxNext', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/merge/index.html?iterations=' + val);
-      runner.sample({
-        id: 'merge RxNext',
-        execute: function () {
-          $('#rx-3-merge').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier , val);
+      var param = preset.sampleParameter('merge RxNext', '#rx-3-merge', val);
+      runner.sample(param).then(done, done.fail);
     });
+    
   });
 });

--- a/perf/macro/specbuilder.js
+++ b/perf/macro/specbuilder.js
@@ -1,0 +1,36 @@
+var benchpress = require('benchpress');
+
+var Preset = (function() {
+  function Preset() {
+    this.iteration = arguments.length ? Array.prototype.slice.call(arguments) : [1000, 10000];
+    this.runner = new benchpress.Runner([
+	    benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
+	    benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
+	    benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
+	    benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
+	    benchpress.bind(benchpress.Options.FORCE_GC).toValue(false)
+	  ]);
+  };
+	
+  Preset.prototype.initBrowser = function(browser, url, value) {
+    browser.ignoreSynchronization = true;
+    browser.get('http://localhost:8080/perf/macro/'+ url + '/index.html?iterations=' + value);
+  };
+  
+  Preset.prototype.sampleParameter = function(sampleId, documentId, value) {
+    return {
+      id: sampleId,
+      execute: function () {
+        $(documentId).click();
+      },
+      bindings: [
+        benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
+          iterations: value
+        })
+      ]};
+  };
+    
+  return Preset;
+})();
+
+exports.Preset = Preset;

--- a/perf/macro/zip/zip.spec.js
+++ b/perf/macro/zip/zip.spec.js
@@ -1,47 +1,24 @@
-var benchpress = require('benchpress');
-var runner = new benchpress.Runner([
-  benchpress.SeleniumWebDriverAdapter.PROTRACTOR_BINDINGS,
-  benchpress.Validator.bindTo(benchpress.RegressionSlopeValidator),
-  benchpress.bind(benchpress.RegressionSlopeValidator.SAMPLE_SIZE).toValue(20),
-  benchpress.bind(benchpress.RegressionSlopeValidator.METRIC).toValue('scriptTime'),
-  benchpress.bind(benchpress.Options.FORCE_GC).toValue(false)
-]);
+var builder = require('../specbuilder');
+
+var preset = new builder.Preset();
+var runner = preset.runner;
 
 describe('zip comparison', function () {
-  [
-    1000,
-    10000
-  ].forEach(function (val) {
+  var testUrlIdentifier = 'zip';
+  
+  preset.iteration.forEach(function (val) {
+    
     it('should be fast in Rx2', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/zip/index.html?iterations=' + val);
-      runner.sample({
-        id: 'zip Rx2',
-        execute: function () {
-          $('#rx-2-zip').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier, val);
+      var param = preset.sampleParameter('zip Rx2', '#rx-2-zip', val);
+      runner.sample(param).then(done, done.fail);
     });
-
+    
     it('should be fast in RxNext', function (done) {
-      browser.ignoreSynchronization = true;
-      browser.get('http://localhost:8080/perf/macro/zip/index.html?iterations=' + val);
-      runner.sample({
-        id: 'zip RxNext',
-        execute: function () {
-          $('#rx-3-zip').click();
-        },
-        bindings: [
-          benchpress.bind(benchpress.Options.SAMPLE_DESCRIPTION).toValue({
-            iterations: val
-          })
-        ]
-      }).then(done, done.fail);
+      preset.initBrowser(browser, testUrlIdentifier , val);
+      var param = preset.sampleParameter('zip RxNext', '#rx-3-zip', val);
+      runner.sample(param).then(done, done.fail);
     });
+    
   });
 });


### PR DESCRIPTION
While most macro test specs can be created by simple copy-paste which wouldn't need much effort, one thing tickled me was if macro test configuration change is needed, each individual case need to be updated. This PR tries to create small initializer to centralize setups allows easier modification in further if required. (Though not sure if it'll be required frequently enough..)