### PR TITLE
chore(test): add micro-benchmark performance test for Observable.from…

### DIFF
--- a/perf/micro/immediate-scheduler/observable/fromPromise.js
+++ b/perf/micro/immediate-scheduler/observable/fromPromise.js
@@ -1,0 +1,25 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function fromPromise(suite) {
+    
+  var promise = new Promise(function (resolve, reject) {
+      resolve(25);
+  });
+
+  var oldFromPromiseWithImmediateScheduler = RxOld.Observable.fromPromise(promise);
+  var newFromPromiseWithImmediateScheduler = RxNew.Observable.fromPromise(promise);
+
+  // add tests
+  return suite
+      .add('old fromPromise with immediate scheduler', function () {
+          oldFromPromiseWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new fromPromise with immediate scheduler', function () {
+          newFromPromiseWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};


### PR DESCRIPTION
…Promise

Single specs created for default scheduler due to `RxOld.fromPromise()` doesn't accept scheduler for creation. 