### PR TITLE
refactor(operator): ensure parameter type safety for each subscriber …

### DIFF
--- a/src/observables/ForkJoinObservable.ts
+++ b/src/observables/ForkJoinObservable.ts
@@ -11,7 +11,7 @@ export default class ForkJoinObservable<T> extends Observable<T> {
     return new ForkJoinObservable(observables);
   }
   
-  _subscribe(subscriber: Observer<any>) {
+  _subscribe(subscriber: Subscriber<any>) {
     const observables = this.observables;
     const len = observables.length;
     let context = { complete: 0, total: len, values: emptyArray(len) };
@@ -24,7 +24,7 @@ export default class ForkJoinObservable<T> extends Observable<T> {
 class AllSubscriber<T> extends Subscriber<T> {
   private _value: T;
   
-  constructor(destination: Observer<T>, private parent: ForkJoinObservable<T>, private index: number,
+  constructor(destination: Subscriber<T>, private parent: ForkJoinObservable<T>, private index: number,
     private context: { complete: number, total: number, values: any[] }) {
     super(destination);
   }

--- a/src/operators/buffer.ts
+++ b/src/operators/buffer.ts
@@ -32,7 +32,7 @@ class BufferOperator<T, R> implements Operator<T, R> {
 class BufferSubscriber<T> extends Subscriber<T> {
   buffer: T[] = [];
   
-  constructor(destination: Observer<T>, closingNotifier: Observable<any>) {
+  constructor(destination: Subscriber<T>, closingNotifier: Observable<any>) {
     super(destination);
     this.add(closingNotifier._subscribe(new BufferClosingNotifierSubscriber(this)));
   }

--- a/src/operators/bufferCount.ts
+++ b/src/operators/bufferCount.ts
@@ -25,7 +25,7 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
   buffers: Array<T[]> = [[]];
   count: number = 0;
   
-  constructor(destination: Observer<T>, private bufferSize: number, private startBufferEvery: number) {
+  constructor(destination: Subscriber<T>, private bufferSize: number, private startBufferEvery: number) {
     super(destination);
   }
   

--- a/src/operators/bufferTime.ts
+++ b/src/operators/bufferTime.ts
@@ -28,7 +28,7 @@ class BufferTimeOperator<T, R> implements Operator<T, R> {
 class BufferTimeSubscriber<T> extends Subscriber<T> {
   private buffers: Array<T[]> = [];
   
-  constructor(destination: Observer<T>, private bufferTimeSpan: number, private bufferCreationInterval: number, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<T>, private bufferTimeSpan: number, private bufferCreationInterval: number, private scheduler: Scheduler) {
     super(destination);
     let buffer = this.openBuffer();
     if (bufferCreationInterval !== null && bufferCreationInterval >= 0) {

--- a/src/operators/bufferToggle.ts
+++ b/src/operators/bufferToggle.ts
@@ -27,7 +27,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
   private buffers: Array<T[]> = [];
   private closingNotification: Subscription<any>;
   
-  constructor(destination: Observer<T>, private openings: Observable<O>, private closingSelector: (openValue: O) => Observable<any>) {
+  constructor(destination: Subscriber<T>, private openings: Observable<O>, private closingSelector: (openValue: O) => Observable<any>) {
     super(destination);
     this.add(this.openings._subscribe(new BufferToggleOpeningsSubscriber(this)));
   }

--- a/src/operators/bufferWhen.ts
+++ b/src/operators/bufferWhen.ts
@@ -27,7 +27,7 @@ class BufferWhenSubscriber<T> extends Subscriber<T> {
   private buffer: T[];
   private closingNotification: Subscription<any>;
   
-  constructor(destination: Observer<T>, private closingSelector: () => Observable<any>) {
+  constructor(destination: Subscriber<T>, private closingSelector: () => Observable<any>) {
     super(destination);
     this.openBuffer();
   }

--- a/src/operators/catch.ts
+++ b/src/operators/catch.ts
@@ -31,7 +31,7 @@ class CatchSubscriber<T> extends Subscriber<T> {
   selector: (err:any, caught:Observable<any>) => Observable<any>;
   caught: Observable<any>;
 
-  constructor(destination: Observer<T>, selector: (err:any, caught:Observable<any>) => Observable<any>, caught: Observable<any>) {
+  constructor(destination: Subscriber<T>, selector: (err:any, caught:Observable<any>) => Observable<any>, caught: Observable<any>) {
     super(destination);
     this.selector = selector;
     this.caught = caught;

--- a/src/operators/combineLatest-support.ts
+++ b/src/operators/combineLatest-support.ts
@@ -45,7 +45,7 @@ export class CombineLatestSubscriber<T, R> extends ZipSubscriber<T, R> {
   project: (...values: Array<any>) => R;
   limit: number = 0;
 
-  constructor(destination: Observer<R>, project?: (...values: Array<any>) => R) {
+  constructor(destination: Subscriber<R>, project?: (...values: Array<any>) => R) {
     super(destination, project, []);
   }
 

--- a/src/operators/count.ts
+++ b/src/operators/count.ts
@@ -16,7 +16,7 @@ class CountSubscriber<T> extends Subscriber<T> {
 
   count: number = 0;
 
-  constructor(destination: Observer<number>) {
+  constructor(destination: Subscriber<number>) {
     super(destination);
   }
 

--- a/src/operators/debounce.ts
+++ b/src/operators/debounce.ts
@@ -27,7 +27,7 @@ class DebounceOperator<T, R> implements Operator<T, R> {
 class DebounceSubscriber<T> extends Subscriber<T> {
   private debounced: Subscription<any>;
 
-  constructor(destination: Observer < T >, private dueTime: number, private scheduler: Scheduler) {
+  constructor(destination: Subscriber < T >, private dueTime: number, private scheduler: Scheduler) {
     super(destination);
   }
 

--- a/src/operators/defaultIfEmpty.ts
+++ b/src/operators/defaultIfEmpty.ts
@@ -25,7 +25,7 @@ class DefaultIfEmptySubscriber<T, R> extends Subscriber<T> {
 
   isEmpty: boolean = true;
 
-  constructor(destination: Observer<T>, private defaultValue: R) {
+  constructor(destination: Subscriber<T>, private defaultValue: R) {
     super(destination);
   }
 

--- a/src/operators/delay.ts
+++ b/src/operators/delay.ts
@@ -48,7 +48,7 @@ class DelaySubscriber<T> extends Subscriber<T> {
     }
   }
 
-  constructor(destination: Observer<T>, delay: number, scheduler: Scheduler) {
+  constructor(destination: Subscriber<T>, delay: number, scheduler: Scheduler) {
     super(destination);
     this.delay = delay;
     this.scheduler = scheduler;

--- a/src/operators/distinctUntilChanged.ts
+++ b/src/operators/distinctUntilChanged.ts
@@ -30,7 +30,7 @@ class DistinctUntilChangedSubscriber<T> extends Subscriber<T> {
   value: T;
   hasValue: boolean = false;
 
-  constructor(destination: Observer<T>, compare?: (x: T, y: T) => boolean) {
+  constructor(destination: Subscriber<T>, compare?: (x: T, y: T) => boolean) {
     super(destination);
     if (typeof compare === "function") {
       this.compare = compare;

--- a/src/operators/do.ts
+++ b/src/operators/do.ts
@@ -35,7 +35,7 @@ class DoSubscriber<T> extends Subscriber<T> {
   __complete: () => void;
 
 
-  constructor(destination: Observer<T>, next: (x: T) => void, error: (e: any) => void, complete: () => void) {
+  constructor(destination: Subscriber<T>, next: (x: T) => void, error: (e: any) => void, complete: () => void) {
     super(destination);
     this.__next = next;
     this.__error = error;

--- a/src/operators/expand.ts
+++ b/src/operators/expand.ts
@@ -31,7 +31,7 @@ class ExpandSubscriber<T, R> extends MergeSubscriber<T, R> {
 
   project: (x: T, ix: number) => Observable<any>;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Subscriber<R>,
               project: (x: T, ix: number) => Observable<any>) {
     super(destination, Number.POSITIVE_INFINITY);
     this.project = project;

--- a/src/operators/filter.ts
+++ b/src/operators/filter.ts
@@ -37,7 +37,7 @@ class FilterSubscriber<T> extends Subscriber<T> {
   count: number = 0;
   select: (x: T, ix?: number) => boolean;
 
-  constructor(destination: Observer<T>, select: (x: T, ix?: number) => boolean) {
+  constructor(destination: Subscriber<T>, select: (x: T, ix?: number) => boolean) {
     super(destination);
     this.select = select;
   }

--- a/src/operators/finally.ts
+++ b/src/operators/finally.ts
@@ -27,7 +27,7 @@ class FinallyOperator<T, R> implements Operator<T, R> {
 }
 
 class FinallySubscriber<T> extends Subscriber<T> {
-  constructor(destination: Observer<T>, finallySelector: () => void) {
+  constructor(destination: Subscriber<T>, finallySelector: () => void) {
     super(destination);
     this.add(new Subscription(finallySelector));
   }

--- a/src/operators/flatMap-support.ts
+++ b/src/operators/flatMap-support.ts
@@ -33,7 +33,7 @@ export class FlatMapSubscriber<T, R> extends MergeSubscriber<T, R> {
   project: (x: T, ix: number) => Observable<any>;
   projectResult: (x: T, y: any, ix: number, iy: number) => R;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Subscriber<R>,
               concurrent: number,
               project: (x: T, ix: number) => Observable<any>,
               projectResult?: (x: T, y: any, ix: number, iy: number) => R) {

--- a/src/operators/flatMapTo-support.ts
+++ b/src/operators/flatMapTo-support.ts
@@ -28,7 +28,7 @@ export class FlatMapToSubscriber<T, R> extends FlatMapSubscriber<T, R> {
 
   observable: Observable<T>;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Subscriber<R>,
               concurrent: number,
               observable: Observable<T>,
               projectResult?: (x: T, y: any, ix: number, iy: number) => R) {

--- a/src/operators/groupBy.ts
+++ b/src/operators/groupBy.ts
@@ -32,7 +32,7 @@ class GroupByOperator<T, R> implements Operator<T, R> {
 class GroupBySubscriber<T, R> extends Subscriber<T> {
   private groups = null;
 
-  constructor(destination: Observer<R>, private keySelector: (value: T) => string,
+  constructor(destination: Subscriber<R>, private keySelector: (value: T) => string,
     private durationSelector?: (grouped: GroupSubject<R>) => Observable<any>,
     private elementSelector?: (value: T) => R) {
     super(destination);

--- a/src/operators/map.ts
+++ b/src/operators/map.ts
@@ -36,7 +36,7 @@ class MapSubscriber<T, R> extends Subscriber<T> {
   count: number = 0;
   project: (x: T, ix?: number) => R;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Subscriber<R>,
               project: (x: T, ix?: number) => R) {
     super(destination);
     this.project = project;

--- a/src/operators/mapTo.ts
+++ b/src/operators/mapTo.ts
@@ -28,7 +28,7 @@ class MapToSubscriber<T, R> extends Subscriber<T> {
 
   value: R;
 
-  constructor(destination: Observer<R>, value: R) {
+  constructor(destination: Subscriber<R>, value: R) {
     super(destination);
     this.value = value;
   }

--- a/src/operators/materialize.ts
+++ b/src/operators/materialize.ts
@@ -14,7 +14,7 @@ class MaterializeOperator<T, R> implements Operator<T, R> {
 }
 
 class MaterializeSubscriber<T> extends Subscriber<T> {
-  constructor(destination: Observer<T>) {
+  constructor(destination: Subscriber<T>) {
     super(destination);
   }
 

--- a/src/operators/merge-support.ts
+++ b/src/operators/merge-support.ts
@@ -26,7 +26,7 @@ export class MergeSubscriber<T, R> extends Subscriber<T> {
   buffer: Observable<any>[] = [];
   concurrent: number;
 
-  constructor(destination: Observer<R>, concurrent: number) {
+  constructor(destination: Subscriber<R>, concurrent: number) {
     super(destination);
     this.concurrent = concurrent;
   }

--- a/src/operators/observeOn-support.ts
+++ b/src/operators/observeOn-support.ts
@@ -28,7 +28,7 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
   delay: number;
   scheduler: Scheduler;
 
-  constructor(destination: Observer<T>, scheduler: Scheduler, delay: number = 0) {
+  constructor(destination: Subscriber<T>, scheduler: Scheduler, delay: number = 0) {
     super(destination);
     this.delay = delay;
     this.scheduler = scheduler;

--- a/src/operators/reduce.ts
+++ b/src/operators/reduce.ts
@@ -31,7 +31,7 @@ class ReduceSubscriber<T, R> extends Subscriber<T> {
   hasValue: boolean = false;
   project: (acc: R, x: T) => R;
 
-  constructor(destination: Observer<T>, project: (acc: R, x: T) => R, acc?: R) {
+  constructor(destination: Subscriber<T>, project: (acc: R, x: T) => R, acc?: R) {
     super(destination);
     this.acc = acc;
     this.project = project;

--- a/src/operators/repeat.ts
+++ b/src/operators/repeat.ts
@@ -23,7 +23,7 @@ class RepeatOperator<T, R> implements Operator<T, R> {
 
 class RepeatSubscriber<T> extends Subscriber<T> {
   private repeated: number = 0;
-  constructor(destination: Observer<T>, public count: number, public original: Observable<T>) {
+  constructor(destination: Subscriber<T>, public count: number, public original: Observable<T>) {
     super(destination);
   }
 

--- a/src/operators/retry.ts
+++ b/src/operators/retry.ts
@@ -18,7 +18,7 @@ class RetryOperator<T, R> implements Operator<T, R> {
 
 class RetrySubscriber<T> extends Subscriber<T> {
   private retries: number = 0;
-  constructor(destination: Observer<T>, private count: number, private original: Observable<T>) {
+  constructor(destination: Subscriber<T>, private count: number, private original: Observable<T>) {
     super(destination);
   }
   

--- a/src/operators/retryWhen.ts
+++ b/src/operators/retryWhen.ts
@@ -25,7 +25,7 @@ class RetryWhenSubscriber<T> extends Subscriber<T> {
   errors: Subject<any>;
   retryNotifications: Observable<any>;
 
-  constructor(destination: Observer<T>, public notifier: (errors: Observable<any>) => Observable<any>, public original: Observable<T>) {
+  constructor(destination: Subscriber<T>, public notifier: (errors: Observable<any>) => Observable<any>, public original: Observable<T>) {
     super(destination);
   }
 

--- a/src/operators/sample.ts
+++ b/src/operators/sample.ts
@@ -21,7 +21,7 @@ class SampleSubscriber<T> extends Subscriber<T> {
   private lastValue: T;
   private hasValue: boolean = false;
   
-  constructor(destination: Observer<T>, private notifier: Observable<any>) {
+  constructor(destination: Subscriber<T>, private notifier: Observable<any>) {
     super(destination);
     this.add(notifier._subscribe(new SampleNoficationSubscriber(this)));
   }

--- a/src/operators/sampleTime.ts
+++ b/src/operators/sampleTime.ts
@@ -23,7 +23,7 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
   lastValue: T;
   hasValue: boolean = false;
   
-  constructor(destination: Observer<T>, private delay: number, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<T>, private delay: number, private scheduler: Scheduler) {
     super(destination);
     this.add(scheduler.schedule(dispatchNotification, delay, { subscriber: this, delay }));
   }

--- a/src/operators/scan.ts
+++ b/src/operators/scan.ts
@@ -31,7 +31,7 @@ class ScanSubscriber<T, R> extends Subscriber<T> {
   hasValue: boolean = false;
   project: (acc: R, x: T) => R;
 
-  constructor(destination: Observer<T>, project: (acc: R, x: T) => R, acc?: R) {
+  constructor(destination: Subscriber<T>, project: (acc: R, x: T) => R, acc?: R) {
     super(destination);
     this.acc = acc;
     this.project = project;

--- a/src/operators/skip.ts
+++ b/src/operators/skip.ts
@@ -24,7 +24,7 @@ class SkipSubscriber<T> extends Subscriber<T> {
   total: number;
   count: number = 0;
 
-  constructor(destination: Observer<T>, total: number) {
+  constructor(destination: Subscriber<T>, total: number) {
     super(destination);
     this.total = total;
   }

--- a/src/operators/skipUntil.ts
+++ b/src/operators/skipUntil.ts
@@ -19,7 +19,7 @@ class SkipUntilOperator<T, R> implements Operator<T, R> {
 class SkipUntilSubscriber<T> extends Subscriber<T> {
   private notificationSubscriber: NotificationSubscriber<any> = new NotificationSubscriber();
 
-  constructor(destination: Observer<T>, private notifier: Observable<any>) {
+  constructor(destination: Subscriber<T>, private notifier: Observable<any>) {
     super(destination);
     this.add(this.notifier.subscribe(this.notificationSubscriber))
   }

--- a/src/operators/switchAll.ts
+++ b/src/operators/switchAll.ts
@@ -23,7 +23,7 @@ class SwitchSubscriber<T, R> extends MergeSubscriber<T, R> {
 
   innerSubscription: Subscription<T>;
 
-  constructor(destination: Observer<R>) {
+  constructor(destination: Subscriber<R>) {
     super(destination, 1);
   }
 

--- a/src/operators/switchLatest.ts
+++ b/src/operators/switchLatest.ts
@@ -27,7 +27,7 @@ class SwitchLatestSubscriber<T, R> extends FlatMapSubscriber<T, R> {
 
   innerSubscription: Subscription<T>;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Subscriber<R>,
               project: (x: T, ix: number) => Observable<any>,
               projectResult?: (x: T, y: any, ix: number, iy: number) => R) {
     super(destination, 1, project, projectResult);

--- a/src/operators/switchLatestTo.ts
+++ b/src/operators/switchLatestTo.ts
@@ -27,7 +27,7 @@ class SwitchLatestToSubscriber<T, R> extends FlatMapToSubscriber<T, R> {
 
   innerSubscription: Subscription<T>;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Subscriber<R>,
               observable: Observable<any>,
               projectResult?: (x: T, y: any, ix: number, iy: number) => R) {
     super(destination, 1, observable, projectResult);

--- a/src/operators/take.ts
+++ b/src/operators/take.ts
@@ -24,7 +24,7 @@ class TakeSubscriber<T> extends Subscriber<T> {
   total: number;
   count: number = 0;
 
-  constructor(destination: Observer<T>, total: number) {
+  constructor(destination: Subscriber<T>, total: number) {
     super(destination);
     this.total = total;
   }

--- a/src/operators/takeUntil.ts
+++ b/src/operators/takeUntil.ts
@@ -21,7 +21,7 @@ class TakeUntilOperator<T, R> implements Operator<T, R> {
 }
 
 class TakeUntilSubscriber<T> extends Subscriber<T> {
-  constructor(destination: Observer<T>,
+  constructor(destination: Subscriber<T>,
               observable: Observable<any>) {
     super(destination);
     this.add(observable._subscribe(new TakeUntilInnerSubscriber(destination)));
@@ -29,7 +29,7 @@ class TakeUntilSubscriber<T> extends Subscriber<T> {
 }
 
 class TakeUntilInnerSubscriber<T> extends Subscriber<T> {
-  constructor(destination: Observer<T>) {
+  constructor(destination: Subscriber<T>) {
     super(destination);
   }
   _next() {

--- a/src/operators/timeout.ts
+++ b/src/operators/timeout.ts
@@ -23,7 +23,7 @@ class TimeoutOperator<T, R> implements Operator<T, R> {
 class TimeoutSubscriber<T> extends Subscriber<T> {
   timeoutSubscription: Subscription<any>;
   
-  constructor(destination: Observer<T>, private waitFor: number, private errorToSend: any, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<T>, private waitFor: number, private errorToSend: any, private scheduler: Scheduler) {
     super(destination);
     let delay = waitFor;
     scheduler.schedule(dispatchTimeout, delay, { subscriber: this });

--- a/src/operators/timeoutWith.ts
+++ b/src/operators/timeoutWith.ts
@@ -24,7 +24,7 @@ class TimeoutWithOperator<T, R> implements Operator<T, R> {
 class TimeoutWithSubscriber<T> extends Subscriber<T> {
   timeoutSubscription: Subscription<any>;
   
-  constructor(destination: Observer<T>, private waitFor: number, private withObservable: Observable<any>, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<T>, private waitFor: number, private withObservable: Observable<any>, private scheduler: Scheduler) {
     super(destination);
     let delay = waitFor;
     scheduler.schedule(dispatchTimeout, delay, { subscriber: this });

--- a/src/operators/toArray.ts
+++ b/src/operators/toArray.ts
@@ -16,7 +16,7 @@ class ToArraySubscriber<T> extends Subscriber<T> {
 
   array: T [] = [];
 
-  constructor(destination: Observer<T[]>) {
+  constructor(destination: Subscriber<T[]>) {
     super(destination);
   }
 

--- a/src/operators/window.ts
+++ b/src/operators/window.ts
@@ -25,7 +25,7 @@ class WindowOperator<T, R> implements Operator<T, R> {
 class WindowSubscriber<T> extends Subscriber<T> {
   private window: Subject<T> = new Subject<T>();
   
-  constructor(destination: Observer<T>, private closingNotifier: Observable<any>) {
+  constructor(destination: Subscriber<T>, private closingNotifier: Observable<any>) {
     super(destination);
     this.add(closingNotifier._subscribe(new WindowClosingNotifierSubscriber(this)));
     this.openWindow();

--- a/src/operators/windowCount.ts
+++ b/src/operators/windowCount.ts
@@ -28,7 +28,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
   private windows: { count: number, notified : boolean, window: Subject<T> } [] = [{ count: 0, notified : false, window : new Subject<T>() }];
   private count: number = 0;
   
-  constructor(destination: Observer<T>, private windowSize: number, private startWindowEvery: number) {
+  constructor(destination: Subscriber<T>, private windowSize: number, private startWindowEvery: number) {
     super(destination);
   }
   

--- a/src/operators/windowTime.ts
+++ b/src/operators/windowTime.ts
@@ -29,7 +29,7 @@ class WindowTimeOperator<T, R> implements Operator<T, R> {
 class WindowTimeSubscriber<T> extends Subscriber<T> {
   private windows: Subject<T>[] = [];
   
-  constructor(destination: Observer<T>, private windowTimeSpan: number, private windowCreationInterval: number, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<T>, private windowTimeSpan: number, private windowCreationInterval: number, private scheduler: Scheduler) {
     super(destination);
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
       let window = this.openWindow();

--- a/src/operators/windowToggle.ts
+++ b/src/operators/windowToggle.ts
@@ -27,7 +27,7 @@ class WindowToggleSubscriber<T, O> extends Subscriber<T> {
   private windows: Subject<T>[] = [];
   private closingNotification: Subscription<any>;
   
-  constructor(destination: Observer<T>, private openings: Observable<O>, private closingSelector: (openValue: O) => Observable<any>) {
+  constructor(destination: Subscriber<T>, private openings: Observable<O>, private closingSelector: (openValue: O) => Observable<any>) {
     super(destination);
     this.add(this.openings._subscribe(new WindowToggleOpeningsSubscriber(this)));
   }

--- a/src/operators/windowWhen.ts
+++ b/src/operators/windowWhen.ts
@@ -27,7 +27,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
   private window: Subject<T> = new Subject<T>();
   private closingNotification: Subscription<any>;
   
-  constructor(destination: Observer<T>, private closingSelector: () => Observable<any>) {
+  constructor(destination: Subscriber<T>, private closingSelector: () => Observable<any>) {
     super(destination);
     this.openWindow();
   }

--- a/src/operators/withLatestFrom.ts
+++ b/src/operators/withLatestFrom.ts
@@ -25,7 +25,7 @@ class WithLatestFromSubscriber<T, R> extends Subscriber<T> {
   private values: any[];
   private toSet: number;
   
-  constructor(destination: Observer<T>, private observables: Observable<any>[], private project: (...values: any[]) => Observable<R>) {
+  constructor(destination: Subscriber<T>, private observables: Observable<any>[], private project: (...values: any[]) => Observable<R>) {
     super(destination);
     const len = observables.length;
     this.values = new Array(len);

--- a/src/operators/zip-support.ts
+++ b/src/operators/zip-support.ts
@@ -30,7 +30,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   project: (...values: Array<any>) => R;
   limit: number = Number.POSITIVE_INFINITY;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Subscriber<R>,
               project?: (...values: Array<any>) => R,
               values: any = Object.create(null)) {
     super(destination);


### PR DESCRIPTION
…ctor

This PR is aligning changes followed by https://github.com/ReactiveX/RxJS/pull/296 for each subscriber construction. Previous PR ensures parameter type of `call` to `Subscriber<>` and each subscriber constructor still able to accept `Observer<>`. This isn't big issue since `call` already guards type so subscriber constructor won't be able to accept other than `Subscriber<>` but better to have build type safety. 