### PR TITLE
chore(docs): add documentation for marble test syntax

### DIFF
--- a/CONTRIBUTION.md
+++ b/CONTRIBUTION.md
@@ -7,6 +7,8 @@ Contents
 - [Pull Requests](#pull-requests)
   - [Coding Style](#code)
   - [Commit Messages](#commit)
+- [Unit Tests](#unit-tests)
+  - [Writing Marble Tests](doc/writing-marble-tests.md)
 - [Performance Tests](#performance-tests)
   - [Macro](#macro)
   - [Micro](#micro)
@@ -94,6 +96,30 @@ from the main (upstream) repository:
 - favor readability over terseness
 
 (TBD): For now try to follow the style that exists elsewhere in the source, and use your best judgment.
+
+
+### <a id="unit-tests"></a>Unit Tests
+
+Unit tests are located under the [specs directory](/specs). Unit tests over synchronous operators and operations 
+can be written in a standard [jasmine](http://jasmine.github.io/) style. Unit tests written against any 
+asynchronous operator should be written in [Marble Test Style outlined in detail here](docs/writing-marble-tests.md). 
+
+Each operator under test must be in its own file to cover the following cases:
+
+- Never
+- Empty
+- Single/Multiple Values
+- Error in the sequence
+- Never ending sequences
+- Early disposal in sequences
+
+If the operator accepts a function as an argument from the user/developer (for example `filter(fn)` or `zip(a, fn)`), 
+then it must cover the following cases:
+
+- Success with all values in the callback
+- Success with the context, if any allowed in the operator signature
+- If an error is thrown
+
 
 ### <a id="performance-tests"></a>Performance Tests
 

--- a/doc/writing-marble-tests.md
+++ b/doc/writing-marble-tests.md
@@ -1,0 +1,119 @@
+# Writing Marble Tests
+
+"Marble Tests" are tests that use a specialized VirtualScheduler called the `TestScheduler`. They enable us to test
+asynchronous operations in a synchronous and dependable manner. The "marble notation" is something that's been adapted
+from many teachings and documents by people such as @jhusain, @headinthebox, @mattpodwysocki and @staltz. In fact,
+@staltz first recommended this as a DSL for creating unit tests, and it has since been altered and adopted.
+
+#### links
+
+- [Contribution](../CONTRIBUTION.md)
+- [Code of Conduct](../CODE_OF_CONDUNCT.md)
+
+## Basic methods
+
+The unit tests have helper methods that have been added to make creating tests easier.
+
+- `hot(marbles: string, values?: object, error?: any)` - creates a "hot" observable (a subject) that will behave 
+  as though it's already "running" when the test begins. An interesting difference is that `hot` marbles allow a 
+  `^` character to signal where the "zero frame" is. That is the point at which the subscription to observables 
+  being tested begins.
+- `cold(marbles: string, values?: object, error?: any)` - creates a "cold" observable whose subscription starts when 
+  the test begins.
+- `expectObservable(actual: Observable<T>).toBe(marbles: string, values?: object, error?: any)` - schedules an assertion
+  for when the TestScheduler flushes. The TestScheduler will automatically flush at the end of your jasmine `it` block.
+
+### Ergonomic defaults for `hot` and `cold`
+
+In both `hot` and `cold` methods, value charecters specified in marble diagrams are emitted as strings unless a `values`
+argument is passed to the method. Therefor:
+
+`hot('--a--b')` will emit `"a"` and `"b"` whereas
+
+`hot('--a--b', { a: 1, b: 2 })` will emit `1` and `2`.
+
+Likewise, unspecified errors will just default to the string `"error"`, so:
+
+`hot('---#')` will emit error `"error"` whereas
+
+`hot('---#', null, new SpecialError('test'))` will emit `new SpecialError('test')`
+
+
+## Marble Syntax
+
+Marble syntax is a string represents events happening over "time". The first character of any marble string
+always represents the "zero frame". A "frame" is somewhat analogous to a virtual millisecond.
+
+- `"-"` time: 10 "frames" of time passage.
+- `"|"` complete: The successful completion of an observable. This is the observable producer signaling `complete()`
+- `"#"` error: An error terminating the observable. This is the observable producer signaling `error()`
+- `"a"` any character: All other characters represent a value being emitted by the producure signaling `next()`
+- `"()"` sync groupings: When multiple events need to single in the same frame synchronously, parenthesis are used
+  to group those events. You can group nexted values, a completion or an error in this manner. The position of the 
+  initial `(` determines the time at which its values are emitted.
+- `"^"` subscription point: (hot observables only) shows the point at which the tested observables will be subscribed
+  to the hot observable. This is the "zero frame" for that observable, every frame before the `^` will be negative.
+  
+### examples
+
+`'-'` or `'------'`: Equivalent to `Observable.never()`, or an observable that never emits or completes
+
+`|`: Equivalent to `Observable.empty()`
+
+`#`: Equivalent to `Observable.throw()`
+
+`'--a--'`: An observable that waits 20 "frames", emits value `a` and then never completes.
+
+`'--a--b--|`: On frame 20 emit `a`, on frame 50 emit `b`, and on frame 80, `complete`
+
+`'--a--b--#`: On frame 20 emit `a`, on frame 50 emit `b`, and on frame 80, `error`
+
+`'-a-^-b--|`: In a hot observable, on frame -20 emit `a`, then on frame 20 emit `b`, and on frame 50, `complete`.
+
+`'--(abc)-|'`: on frame 20, emit `a`, `b`, and `c`, then on frame 80 `complete`
+
+`'-----(a|)'`: on frame 50, emit `a` and `complete`.
+
+
+## Anatomy of a Test
+
+A basic test might look as follows:
+
+```js
+
+var e1 = hot('----a--^--b-------c--|');
+var e2 = hot(  '---d-^--e---------f-----|');
+var expected =      '---(be)----c-f-----|';
+
+expectObservable(e1.merge(e2)).toBe(expected);
+```
+
+- The `^` characters of `hot` observables should **always** be aligned.
+- The **first charactor** of `cold` observables or expected observables should **always** be aligned
+  with each other, and with the `^` of hot observables.
+- Use default emission values when you can. Specify `values` when you have to.
+
+A test example with specified values:
+
+```js
+var values = {
+  a: 1,
+  b: 2,
+  c: 3,
+  d: 4
+  x: 1 + 3, // a + c
+  y: 2 + 4, // b + d
+}
+var e1 =    hot('---a---b---|', values);
+var e2 =    hot('-----c---d---|', values);
+var expected =  '-----x---y---|';
+
+expectObservable(e1.zip(e2, function(x, y) { return x + y; }))
+  .toBe(expected, values);
+```
+
+- Use the same hash to look up all values, this ensures that multiple uses of the same character have the
+  same value.
+- Make the result values as obvious as possible as to what they represent, these are *tests* afterall, we want
+  clarity more than efficiency, so `x: 1 + 3, // a + c` is better than just `x: 4`. The former conveys *why* it's 4,
+  the latter does not.


### PR DESCRIPTION
Adds information about "marble tests" as well as porting over some guidelines for testing from RxJS 2/3