### PR TITLE
fix(last): emit value matches with predicate instead of result of pre…

### DIFF
--- a/spec/operators/last-spec.js
+++ b/spec/operators/last-spec.js
@@ -19,4 +19,15 @@ describe('Observable.prototype.last()', function(){
     var expected = '----';
     expectObservable(e2.last()).toBe(expected);
   });
+  
+  it('Should return last element matches with predicate', function() {
+    var e1 =    hot('--a--b--a--b--|');
+    var expected =  '--------------(b|)';
+    
+    var predicate = function (value) { 
+      return value === 'b'; 
+    }
+    
+    expectObservable(e1.last(predicate)).toBe(expected);
+  });
 });

--- a/src/operators/last.ts
+++ b/src/operators/last.ts
@@ -47,7 +47,7 @@ class LastSubscriber<T> extends Subscriber<T> {
       if(result === errorObject) {
         this.destination.error(result.e);
       } else if (result) {
-        this.lastValue = result;
+        this.lastValue = value;
         this.hasValue = true;
       }
     } else {


### PR DESCRIPTION
…dicate

Minor correction to `last` operator to emit actual values instead of emitting result of predicate if predicate matches. Also added small test case to verify behavior.