### PR TITLE
refactor(build): make build_global runs on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "build_amd": "rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5",
     "build_cjs": "rm -rf dist/cjs && babel dist/es6 --out-dir dist/cjs --modules common --sourceMaps --loose all",
     "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts --outDir dist/es6 --target ES6 -d",
-    "build_global": "rm -rf dist/global && mkdir dist/global && browserify src/Rx.global.js --outfile dist/global/Rx.js; ./node_modules/.bin/uglifyjs ./dist/global/Rx.js --source-map ./dist/global/Rx.min.js.map --screw-ie8 -o ./dist/global/Rx.min.js",
+    "build_global": "rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && \"./node_modules/.bin/uglifyjs\" ./dist/global/Rx.js --source-map ./dist/global/Rx.min.js.map --screw-ie8 -o ./dist/global/Rx.min.js",
     "build_perf": "npm run build_es6 && npm run build_cjs && npm run build_global && npm run perf",
     "build_test": "rm -rf dist/ && npm run build_es6 && npm run build_cjs && jasmine",
     "build_docs": "./docgen.sh",


### PR DESCRIPTION
Small modification to path parameters of `build_global` script to allow it runs on windows platform too. Regression verification was done using linux machine (ubuntu) as well as travis, unfortunately was not able to verify on Mac.