### PR TITLE
test(combineLatest): add tests with empty or never sources

### DIFF
--- a/spec/observables/combineLatest-spec.js
+++ b/spec/observables/combineLatest-spec.js
@@ -3,15 +3,69 @@ var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
 describe('Observable.combineLatest', function () {
+  function concat(x, y) { return '' + x + y; }
+
+  it('should be never when sources are never and never', function () {
+    var e1 = Observable.never();
+    var e2 = Observable.never();
+    var expected = '-';
+    var combined = Observable.combineLatest(e1, e2, concat);
+    expectObservable(combined).toBe(expected);
+  });
+
+  it('should be never when one of the sources is never', function () {
+    var e1 = Observable.never();
+    var e2 = Observable.empty();
+    var expected = '-';
+    var combined = Observable.combineLatest(e1, e2, concat);
+    expectObservable(combined).toBe(expected);
+  });
+
+  it('should be never when one of the sources is never and the other has values', function () {
+    var e1 = cold('---a--b--c--');
+    var e2 = Observable.never();
+    var expected = '-';
+    var combined = Observable.combineLatest(e1, e2, concat);
+    expectObservable(combined).toBe(expected);
+  });
+
+  it('should be never when one of the sources is never and the other complete', function () {
+    var e1 = cold('---a--b--c--|');
+    var e2 = Observable.never();
+    var expected = '-';
+    var combined = Observable.combineLatest(e1, e2, concat);
+    expectObservable(combined).toBe(expected);
+  });
+
+  it('should be never when sources are empty and empty', function () {
+    var e1 = Observable.empty();
+    var e2 = Observable.empty();
+    var expected = '-';
+    var combined = Observable.combineLatest(e1, e2, concat);
+    expectObservable(combined).toBe(expected);
+  });
+
+  it('should be never when one of the sources is empty', function () {
+    var e1 = Observable.empty();
+    var e2 = cold('---a---');
+    var expected = '-';
+    var combined = Observable.combineLatest(e1, e2, concat);
+    expectObservable(combined).toBe(expected);
+  });
+
+  it('should be never when one of the sources is empty and the other complete', function () {
+    var e1 = hot('--^--a--b--c--|');
+    var e2 = Observable.empty();
+    var expected = '-';
+    var combined = Observable.combineLatest(e1, e2, concat);
+    expectObservable(combined).toBe(expected);
+  });
+
   it('should combineLatest the provided observables', function () {
-    var firstSource =  hot('----a----b----c----|');
-    var secondSource = hot('--d--e--f--g--|');
-    var expected =         '----uv--wx-y--z----|';
-    
-    var combined = Observable.combineLatest(firstSource, secondSource, function (a, b) {
-        return '' + a + b;
-      })
-      
+    var e1 =   hot('----a----b----c----|');
+    var e2 =   hot('--d--e--f--g--|');
+    var expected = '----uv--wx-y--z----|';
+    var combined = Observable.combineLatest(e1, e2, concat);
     expectObservable(combined).toBe(expected, {u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg'});
   });
 });


### PR DESCRIPTION
Observable.combileLatest should be never when:
 - sources are never and never
 - one of the sources is never
 - one of the sources is never and the other has values
 - one of the sources is never and the other complete
 - sources are empty and empty
 - one of the sources is empty
 - one of the sources is empty and the other complete

with two failing tests:
 - Observable.combineLatest should be never when sources are empty and empty
 - Observable.combineLatest should be never when one of the sources is empty and the other complete