### PR TITLE
feat(config): add global configuration of Promise capability

### DIFF
--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -78,3 +78,29 @@ afterEach(function () {
 function assertDeepEqual(actual, expected) {
   expect(actual).toDeepEqual(expected);
 }
+
+
+(function (){
+  var objectTypes = {
+      'boolean': false,
+      'function': true,
+      'object': true,
+      'number': false,
+      'string': false,
+      'undefined': false
+  };
+  
+  var _root = (objectTypes[typeof self] && self) || (objectTypes[typeof window] && window);
+  
+  var freeExports = objectTypes[typeof exports] && exports && !exports.nodeType && exports;
+  var freeModule = objectTypes[typeof module] && module && !module.nodeType && module;
+  var freeGlobal = objectTypes[typeof global] && global;
+  
+  if (freeGlobal && (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal)) {
+      _root = freeGlobal;
+  }
+  
+  
+  
+  global.__root__ = _root;
+}());

--- a/spec/operators/toPromise-spec.js
+++ b/spec/operators/toPromise-spec.js
@@ -1,21 +1,37 @@
 /* globals describe, it, expect */
 var Rx = require('../../dist/cjs/Rx');
-var promise = require('promise');
+var Promise = require('promise');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.toPromise()', function () {
   it('should convert an Observable to a promise of its last value', function (done) {
-    Observable.of(1, 2, 3).toPromise(promise).then(function (x) {
+    Observable.of(1, 2, 3).toPromise(Promise).then(function (x) {
       expect(x).toBe(3);
       done();
     });
   });
   
   it('should handle errors properly', function (done) {
-    Observable.throw('bad').toPromise(promise).then(function () {
+    Observable.throw('bad').toPromise(Promise).then(function () {
       throw 'should not be called';
     }, function (err) {
       expect(err).toBe('bad');
+      done();
+    });
+  });
+  
+  it('should allow for global config via Rx.config.Promise', function(done){
+    var wasCalled = false;
+    __root__.Rx = {};
+    __root__.Rx.config = {};
+    __root__.Rx.config.Promise = function MyPromise(callback) {
+      wasCalled = true;
+      return new Promise(callback);
+    };
+    
+    Observable.of(42).toPromise().then(function(x) {
+      expect(wasCalled).toBe(true);
+      expect(x).toBe(42);
       done();
     });
   });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -6,7 +6,7 @@ import Subscriber from './Subscriber';
 import Subscription from './Subscription';
 import ConnectableObservable from './observables/ConnectableObservable';
 import GroupSubject from './subjects/GroupSubject';
-
+import {root} from './util/root';
 
 import $$observable from './util/Symbol_observable';
 
@@ -112,8 +112,20 @@ export default class Observable<T>  {
    * @returns {Promise} a promise that either resolves on observable completion or
    *  rejects with the handled error
    */
-  forEach(next:(value:T) => void) {
-    return new Promise((resolve, reject) => {
+  forEach(next:(value:T) => void, PromiseCtor?: PromiseConstructor): Promise<void> {
+    if(!PromiseCtor) {
+      if(root.Rx && root.Rx.config && root.Rx.config.Promise) {
+        PromiseCtor = root.Rx.config.Promise;
+      } else if (root.Promise) {
+        PromiseCtor = root.Promise;
+      }
+    }
+    
+    if(!PromiseCtor) {
+      throw new Error('no Promise impl found');
+    }
+    
+    return new PromiseCtor<void>((resolve, reject) => {
       this.subscribe(next, reject, resolve);
     });
   }

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -241,5 +241,5 @@ export {
     VirtualTimeScheduler,
     TestScheduler,
     EmptyError,
-    ArgumentOutOfRangeError
+    ArgumentOutOfRangeError,
 };

--- a/src/operators/toPromise.ts
+++ b/src/operators/toPromise.ts
@@ -1,6 +1,19 @@
 import Subscriber from '../Subscriber';
+import { root } from '../util/root';
 
-export default function toPromise<T>(PromiseCtor: PromiseConstructor = Promise): Promise<T> {
+export default function toPromise<T>(PromiseCtor?: PromiseConstructor): Promise<T> {
+  if(!PromiseCtor) {
+    if(root.Rx && root.Rx.config && root.Rx.config.Promise) {
+      PromiseCtor = root.Rx.config.Promise;
+    } else if (root.Promise) {
+      PromiseCtor = root.Promise;
+    }
+  }
+  
+  if(!PromiseCtor) {
+    throw new Error('no Promise impl found');
+  }
+  
   return new PromiseCtor((resolve, reject) => {
     let value: any;
     this.subscribe(x => value = x, err => reject(err), () => resolve(value));


### PR DESCRIPTION
- Adds a minimal global configuration for Promises
- Adds a PromiseCtor optional parameter to `Observable.prototype.forEach`
- Adds some basic tests for `Observable.prototype.forEach`

closes #115