### PR TITLE
chore(test): use test marbles for delay operator spec

### DIFF
--- a/spec/operators/delay-spec.js
+++ b/spec/operators/delay-spec.js
@@ -1,18 +1,12 @@
-/* globals describe, it, expect */
+/* globals describe, it, expect, expectObservable, hot, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.delay()', function () {
-  it('should delay by 100ms', function (done) {
-    var time = Date.now();
-    Observable
-      .of(42)
-      .delay(100)
-      .subscribe(function (x) {
-        expect(Date.now() - time >= 100).toBe(true);
-      }, null, function() {
-        expect(Date.now() - time >= 100).toBe(true);
-        done();
-      });
+  it('should delay by specified timeframe', function () {
+    var source = hot('--a--|');
+    var expected =   '-----a--|';
+    
+    expectObservable(source.delay(30, rxTestScheduler)).toBe(expected);
   });
 });

--- a/src/schedulers/TestScheduler.ts
+++ b/src/schedulers/TestScheduler.ts
@@ -88,12 +88,12 @@ export default class TestScheduler extends VirtualTimeScheduler {
     let len = marbles.length;
     let results: ({ frame: number, notification: Notification<any> })[] = [];
     let subIndex = marbles.indexOf('^');
-    let frameOffset = subIndex === -1 ? 0 : (subIndex * -10);
+    let frameOffset = subIndex === -1 ? 0 : (subIndex * -this.frameTimeFactor);
     let getValue = typeof values !== 'object' ? (x) => x : (x) => values[x];
     let groupStart = -1;
     
     for (let i = 0; i < len; i++) {
-      let frame = i * 10;
+      let frame = i * this.frameTimeFactor;
       let notification;
       let c = marbles[i];
       switch (c) {

--- a/src/schedulers/VirtualTimeScheduler.ts
+++ b/src/schedulers/VirtualTimeScheduler.ts
@@ -11,8 +11,10 @@ export default class VirtualTimeScheduler implements Scheduler {
   frame: number = 0;
   maxFrames: number = 750;
   
+  protected static frameTimeFactor: number = 10;
+  
   now() {
-    return 0;
+    return this.frame * VirtualTimeScheduler.frameTimeFactor;
   }
   
   flush() {


### PR DESCRIPTION
- replace test spec to use test marble
- virtual time scheduler returns virtual timeframe of current for now()

This PR replaces test spec for delay operator to use test marble.

In addition to  those, let TestScheduler & VirtualTimeScheduler supports `now()` to return 'current virtual time' based on test marble frame to support some operators utilizes it, such as `delay`.