### PR TITLE
chore(test): add micro-benchmark performance test for toPromise operator

### DIFF
--- a/perf/micro/immediate-scheduler/operators/topromise-ctor.js
+++ b/perf/micro/immediate-scheduler/operators/topromise-ctor.js
@@ -1,0 +1,18 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+
+  var oldToPromiseWithImmediateScheduler = RxOld.Observable.of(25, RxOld.Scheduler.immediate).toPromise(Promise);
+  var newToPromiseWithImmediateScheduler = RxNew.Observable.of(25).toPromise(Promise);
+
+  return suite
+    .add('old toPromise(ctor) with immediate scheduler', function () {
+      oldToPromiseWithImmediateScheduler.then(_then);
+    })
+    .add('new toPromise(ctor) with immediate scheduler', function () {
+      newToPromiseWithImmediateScheduler.then(_then);
+    });
+  
+  function _then(x) { }
+};

--- a/perf/micro/immediate-scheduler/operators/topromise.js
+++ b/perf/micro/immediate-scheduler/operators/topromise.js
@@ -1,0 +1,18 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+
+  var oldToPromiseWithImmediateScheduler = RxOld.Observable.of(25, RxOld.Scheduler.immediate).toPromise();
+  var newToPromiseWithImmediateScheduler = RxNew.Observable.of(25).toPromise();
+
+  return suite
+    .add('old toPromise() with immediate scheduler', function () {
+      oldToPromiseWithImmediateScheduler.then(_then);
+    })
+    .add('new toPromise() with immediate scheduler', function () {
+      newToPromiseWithImmediateScheduler.then(_then);
+    });
+  
+  function _then(x) { }
+};


### PR DESCRIPTION
Try to cover https://github.com/ReactiveX/RxJS/issues/350.

One of test system shows slower numbers such as

> old toPromise() with immediate scheduler x 351,507 ops/sec ±4.64% (81 runs sampled)
> new toPromise() with immediate scheduler x 322,127 ops/sec ±9.00% (65 runs sampled)
>        -8.36% slower than Rx2
>
> old toPromise(ctor) with immediate scheduler x 351,730 ops/sec ±5.72% (78 runs sampled)
> new toPromise(ctor) with immediate scheduler x 327,025 ops/sec ±9.27% (55 runs sampled)
>        -7.02% slower than Rx2

Not all of system shows slower numbers, bit unsure if test case design is correct. Would be appreciate to let me know if something doesn't look right - will update accordingly.