### PR TITLE
chore(gitignore): ignore more editor-specific files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,15 @@
+# Editor-specific
+.idea/
+*.sublime-project
+*.sublime-workspace
+.settings
+
+# Installed libs
 node_modules/
+
+# Generated
 dist/
 tmp/
+
+# Misc
+npm-debug.log


### PR DESCRIPTION
Some people use IntelliJ IDEA (or WebStorm) for developing, which
generates .idea/ directory. This commit ignores that directory in
git.