### PR TITLE
chore(test): add micro-benchmark performance test for Observable.from…

### DIFF
--- a/perf/micro/immediate-scheduler/observable/fromeventpattern.js
+++ b/perf/micro/immediate-scheduler/observable/fromeventpattern.js
@@ -1,0 +1,40 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+var Event = require('events');
+
+module.exports = function fromEventPattern(suite) {
+  var eventName = 'testEvent';
+  
+  var oldRxEventEmitter = new Event.EventEmitter();
+  var newRxEventEmitter = new Event.EventEmitter();
+  
+  var oldFromEventPatternWithImmediateScheduler = RxOld.Observable.fromEventPattern(
+    function add (h) {
+      oldRxEventEmitter.addListener(eventName, h);
+    },
+    function remove (h) {
+      oldRxEventEmitter.removeListener(eventName, h);
+    }).take(1);
+    
+  var newFromEventPatternWithImmediateScheduler = RxNew.Observable.fromEventPattern(
+    function add (h) {
+      newRxEventEmitter.addListener(eventName, h);
+    },
+    function remove (h) {
+      newRxEventEmitter.removeListener(eventName, h);
+    }).take(1);
+
+  return suite
+      .add('old fromEventPattern with immediate scheduler', function () {
+          oldFromEventPatternWithImmediateScheduler.subscribe(_next, _error, _complete);
+          oldRxEventEmitter.emit(eventName);
+      })
+      .add('new fromEventPattern with immediate scheduler', function () {
+          newFromEventPatternWithImmediateScheduler.subscribe(_next, _error, _complete);
+          newRxEventEmitter.emit(eventName);
+      });
+
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};


### PR DESCRIPTION
…EventPattern

Try to cover #352.
Used EventEmitter as source then limit to single element as same as test for `fromEvent`.