### PR TITLE
chore(test): fix README on running perf benchmarks

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,20 +63,7 @@ npm run build_all
 
 ## Performance Tests
 
-First you'll need to host the root directory under a web server, the simplest way to do that is to install `http-server` with `npm i -g http-server`,
-then start it in the home directory. After that you can run `npm run build_perf` or `npm run perf` to run the performance tests with `protractor` (which also
-needs to be globally installed)
+Run `npm run build_perf` or `npm run perf` to run the performance tests with `protractor`.
 
 ## Adding documentation
 RxNext uses [ESDoc](https://esdoc.org/) to generate API documentation. Refer to ESDoc's documentation for syntax. Run `npm run build_docs` to generate.
-
-### Prerequisites
-Running the performance tests requires `protractor` globally installed and an http server of some sort. `http-server` the node module
-will work:
-
-```sh
-npm i -g protractor http-server
-```
-
-
-

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "build_cjs": "rm -rf dist/cjs && babel dist/es6 --out-dir dist/cjs --modules common --sourceMaps --loose all",
     "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts --outDir dist/es6 --target ES6 -d",
     "build_global": "rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && \"./node_modules/.bin/uglifyjs\" ./dist/global/Rx.js --source-map ./dist/global/Rx.min.js.map --screw-ie8 -o ./dist/global/Rx.min.js",
-    "build_perf": "npm run build_es6 && npm run build_cjs && npm run build_global && npm run perf",
+    "build_perf": "npm run build_es6 && npm run build_cjs && npm run build_global && webdriver-manager update && npm run perf",
     "build_test": "rm -rf dist/ && npm run build_es6 && npm run build_cjs && jasmine",
     "build_docs": "./docgen.sh",
     "test": "jasmine",


### PR DESCRIPTION
No more recommendation of having globally installed packages.
Add `webdriver-manager update` execution prior to running protractor.