### PR TITLE
chore(test): add micro-benchmark performance test for Observable.inte…

### DIFF
--- a/perf/micro/current-thread-scheduler/observable/interval.js
+++ b/perf/micro/current-thread-scheduler/observable/interval.js
@@ -1,0 +1,19 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function interval(suite) {
+
+  var oldIntervalWithCurrentThreadScheduler = RxOld.Observable.interval(25, RxOld.Scheduler.currentThread).take(5);
+  var newIntervalWithCurrentThreadScheduler = RxNew.Observable.interval(25, RxNew.Scheduler.immediate).take(5);
+
+  return suite
+      .add('old interval with current thread scheduler', function () {
+          oldIntervalWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new interval with current thread scheduler', function () {
+          newIntervalWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+      });
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};

--- a/perf/micro/immediate-scheduler/observable/interval.js
+++ b/perf/micro/immediate-scheduler/observable/interval.js
@@ -1,0 +1,19 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function interval(suite) {
+
+  var oldIntervalWithImmediateScheduler = RxOld.Observable.interval(25, RxOld.Scheduler.immediate).take(5);
+  var newIntervalWithImmediateScheduler = RxNew.Observable.interval(25).take(5);
+
+  return suite
+      .add('old interval with immediate scheduler', function () {
+          oldIntervalWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new interval with immediate scheduler', function () {
+          newIntervalWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};


### PR DESCRIPTION
…rval

Try to cover #352.

Due to nature of `interval` limited elements number relatively small to reduce general test execution time.