### PR TITLE
chore(test): use test marbles for filter operator spec

### DIFF
--- a/spec/operators/filter-spec.js
+++ b/spec/operators/filter-spec.js
@@ -1,17 +1,45 @@
-/* globals describe, it, expect */
+/* globals describe, it, expect, expectObservable, hot */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.filter()', function () {
-  it('should filter out values', function (done) {
-    var expected = [1, 3];
-    var i = 0;
-    Observable.fromArray([1, 2, 3]).filter(function (x) {
-      return x % 2 === 1;
-    })
-    .subscribe(function (x) {
-      expect(x).toBe(expected[i++]);
-    }, null, done);
+  function oddFilter(x) {
+    return (+x) % 2 === 1;
+  }
+
+  it('should filter out even values', function () {
+    var source = hot('--0--1--2--3--4--|');
+    var expected =   '-----1-----3-----|';
+
+    expectObservable(source.filter(oddFilter)).toBe(expected);
+  });
+
+  it('should propagate errors from the source', function() {
+    var source = hot('--0--1--2--3--4--#');
+    var expected =   '-----1-----3-----#';
+
+    expectObservable(source.filter(oddFilter)).toBe(expected);
+  });
+
+  it('should support Observable.empty', function() {
+    var source = Observable.empty();
+    var expected = "|";
+
+    expectObservable(source.filter(oddFilter)).toBe(expected);
+  });
+
+  it('should support Observable.never', function() {
+    var source = Observable.never();
+    var expected = "-";
+
+    expectObservable(source.filter(oddFilter)).toBe(expected);
+  });
+
+  it('should support Observable.throw', function() {
+    var source = Observable.throw(new Error('oops'));
+    var expected = '#';
+
+    expectObservable(source.filter(oddFilter)).toBe(expected, undefined, new Error('oops'));
   });
 
   it('should send errors down the error path', function (done) {
@@ -19,8 +47,8 @@ describe('Observable.prototype.filter()', function () {
       throw 'bad';
     })
       .subscribe(function (x) {
-      expect(true).toBe(false);
-    }, function (err) {
+        expect(true).toBe(false);
+      }, function (err) {
         expect(err).toBe('bad');
         done();
       }, function () {


### PR DESCRIPTION
Try covering #390. Hope this is sufficient and adhere to contributions guidelines.

Could not find tests from RxJS3/4 for filter.