### PR TITLE
refactor(Rx): split core from extended operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build_all": "npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global",
     "build_amd": "rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5",
     "build_cjs": "rm -rf dist/cjs && babel dist/es6 --out-dir dist/cjs --modules common --sourceMaps --loose all",
-    "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts --outDir dist/es6 --target ES6 -d",
+    "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts src/Rx.KitchenSink.ts --outDir dist/es6 --target ES6 -d",
     "build_global": "rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && \"./node_modules/.bin/uglifyjs\" ./dist/global/Rx.js --source-map ./dist/global/Rx.min.js.map --screw-ie8 -o ./dist/global/Rx.min.js",
     "build_perf": "npm run build_es6 && npm run build_cjs && npm run build_global && webdriver-manager update && npm run perf",
     "build_test": "rm -rf dist/ && npm run build_es6 && npm run build_cjs && jasmine",

--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -3,7 +3,7 @@
 jasmine.DEFAULT_TIMEOUT_INTERVAL = 1000;
 
 var _ = require("lodash");
-var Rx = require('../../dist/cjs/Rx');
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 
 global.rxTestScheduler = null;
 global.cold;

--- a/spec/schedulers/TestScheduler-spec.js
+++ b/spec/schedulers/TestScheduler-spec.js
@@ -1,5 +1,5 @@
 /* globals describe, it, expect */
-var Rx = require('../../dist/cjs/Rx');
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var TestScheduler = Rx.TestScheduler;
 var Notification = Rx.Notification;
 

--- a/spec/schedulers/VirtualTimeScheduler-spec.js
+++ b/spec/schedulers/VirtualTimeScheduler-spec.js
@@ -1,5 +1,5 @@
 /* globals describe, it, expect */
-var Rx = require('../../dist/cjs/Rx');
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var VirtualTimeScheduler = Rx.VirtualTimeScheduler;
 
 describe('VirtualTimeScheduler', function() {

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -29,6 +29,7 @@ export interface CoreOperators<T> {
   flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   groupBy?: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;
+  ignoreElements: () => Observable<T>;
   isEmpty?: () => Observable<boolean>;
   last?: (predicate?: (value: T, index:number) => boolean, thisArg?: any, defaultValue?: any) => Observable<T>;
   map?: <T, R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -1,0 +1,77 @@
+import Observable from './Observable';
+import Scheduler from './Scheduler';
+import ConnectableObservable from './observables/ConnectableObservable';
+import Subject from './Subject'
+import GroupSubject from './subjects/GroupSubject';
+
+export interface CoreOperators<T> {
+  buffer?: <T>(closingNotifier: Observable<any>) => Observable<T[]>;
+  bufferCount?: <T>(bufferSize: number, startBufferEvery: number) => Observable<T[]>;
+  bufferTime?: <T>(bufferTimeSpan: number, bufferCreationInterval?: number, scheduler?: Scheduler) => Observable<T[]>;
+  bufferToggle?: <T, O>(openings: Observable<O>, closingSelector?: (openValue: O) => Observable<any>) => Observable<T[]>
+  bufferWhen?: <T>(closingSelector: () => Observable<any>) => Observable<T[]>;
+  catch?: (selector: (err: any, source: Observable<T>, caught: Observable<any>) => Observable<any>) => Observable<T>;
+  combineAll?: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
+  combineLatest?: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R)) []) => Observable<R>;
+  concat?: (...observables: any[]) => Observable<any>;
+  concatAll?: () => Observable<any>;
+  concatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  concatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  count?: () => Observable<number>;
+  debounce?: <R>(dueTime: number, scheduler?: Scheduler) => Observable<R>;
+  defaultIfEmpty?: <T, R>(defaultValue: R) => Observable<T>|Observable<R>;
+  delay?: <T>(delay: number, scheduler?: Scheduler) => Observable<T>;
+  distinctUntilChanged?: (compare?: (x: T, y: T) => boolean, thisArg?: any) => Observable<T>;
+  do?: <T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void) => Observable<T>;
+  expand?: (project: (x: T, ix: number) => Observable<any>) => Observable<any>;
+  filter?: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
+  finally?: (ensure: () => void, thisArg?: any) => Observable<T>;
+  flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  groupBy?: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;
+  isEmpty?: () => Observable<boolean>;
+  last?: (predicate?: (value: T, index:number) => boolean, thisArg?: any, defaultValue?: any) => Observable<T>;
+  map?: <T, R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
+  mapTo?: <R>(value: R) => Observable<R>;
+  materialize?: () => Observable<any>;
+  merge?: (...observables:any[]) => Observable<any>;
+  mergeAll?: (concurrent?: any) => Observable<any>;
+  mergeMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  mergeMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  multicast?: (subjectFactory: () => Subject<T>) => ConnectableObservable<T>;
+  observeOn?: (scheduler: Scheduler, delay?: number) => Observable<T>;
+  partition?: (predicate: (x: T) => boolean) => Observable<T>[];
+  publish?: () => ConnectableObservable<T>;
+  publishBehavior?: (value: any) => ConnectableObservable<T>;
+  publishReplay?: (bufferSize: number, windowTime: number, scheduler?: Scheduler) => ConnectableObservable<T>;
+  reduce?: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
+  repeat?: <T>(count: number) => Observable<T>;
+  retry?: <T>(count: number) => Observable<T>;
+  retryWhen?: (notifier: (errors: Observable<any>) => Observable<any>) => Observable<T>;
+  sample?: <T>(notifier: Observable<any>) => Observable<T>;
+  sampleTime?: <T>(delay: number, scheduler?: Scheduler) => Observable<T>;
+  scan?: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
+  single?: (predicate?: (value: T, index:number) => boolean, thisArg?: any) => Observable<T>;
+  skip?: (count: number) => Observable<T>;
+  skipUntil?: (notifier: Observable<any>) => Observable<T>;
+  startWith?: <T>(x: T) => Observable<T>;
+  subscribeOn?: (scheduler: Scheduler, delay?: number) => Observable<T>;
+  switch?: <R>() => Observable<R>;
+  switchMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  switchMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  take?: (count: number) => Observable<T>;
+  takeUntil?: (observable: Observable<any>) => Observable<T>;
+  throttle?: (delay: number, scheduler?: Scheduler) => Observable<T>;
+  timeout?: <T>(due: number|Date, errorToSend?: any, scheduler?: Scheduler) => Observable<T>;
+  timeoutWith?: <T>(due: number|Date, withObservable: Observable<any>, scheduler?: Scheduler) => Observable<T>;
+  toArray?: () => Observable<T[]>;
+  toPromise?: (PromiseCtor: PromiseConstructor) => Promise<T>;
+  window?: <T>(closingNotifier: Observable<any>) => Observable<Observable<T>>;
+  windowCount?: <T>(windowSize: number, startWindowEvery: number) => Observable<Observable<T>>;
+  windowTime?: <T>(windowTimeSpan: number, windowCreationInterval?: number, scheduler?: Scheduler) => Observable<Observable<T>>;
+  windowToggle?: <T, O>(openings: Observable<O>, closingSelector?: (openValue: O) => Observable<any>) => Observable<Observable<T>>
+  windowWhen?: <T>(closingSelector: () => Observable<any>) => Observable<Observable<T>>;
+  withLatestFrom?: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R)) []) => Observable<R>;
+  zip?: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R)) []) => Observable<R>;
+  zipAll?: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
+}

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,13 +1,10 @@
-import Subject from './Subject';
 import Observer from './Observer';
 import Operator from './Operator';
 import Scheduler from './Scheduler';
 import Subscriber from './Subscriber';
 import Subscription from './Subscription';
-import ConnectableObservable from './observables/ConnectableObservable';
-import GroupSubject from './subjects/GroupSubject';
-import {root} from './util/root';
-
+import { root } from './util/root';
+import { CoreOperators } from './CoreOperators';
 import $$observable from './util/Symbol_observable';
 
 
@@ -17,8 +14,7 @@ import $$observable from './util/Symbol_observable';
  *  
  * @class Observable<T>
  */
-export default class Observable<T>  {
-
+export default class Observable<T> implements CoreOperators<T>  {
   source: Observable<any>;
   operator: Operator<any, T>;
   _isScalar: boolean = false;
@@ -37,8 +33,7 @@ export default class Observable<T>  {
   }
   
   // HACK: Since TypeScript inherits static properties too, we have to 
-  // fight against TypeScript here so Subject can have a different static create signature.
-  
+  // fight against TypeScript here so Subject can have a different static create signature
   /**
    * @static
    * @method create
@@ -135,125 +130,24 @@ export default class Observable<T>  {
     return this.source._subscribe(this.operator.call(subscriber));
   }
 
-  // TODO: convert this to an `abstract` class in TypeScript 1.6.
-
+  // static method stubs
+  static combineLatest: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;
+  static concat: (...observables: any[]) => Observable<any>;
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
+  static empty: <T>() => Observable<T>;
+  static forkJoin: (...observables: Observable<any>[]) => Observable<any[]>;
   static from: <T>(iterable: any, scheduler?: Scheduler) => Observable<T>;
   static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;
   static fromEvent: <T>(element: any, eventName: string, selector: (...args:Array<any>) => T) => Observable<T>;
   static fromEventPattern: <T>(addHandler: (handler:Function)=>void, removeHandler: (handler:Function) => void, selector?: (...args:Array<any>) => T) => Observable<T>;
-  static throw: <T>(error: T) => Observable<T>;
-  static empty: <T>() => Observable<T>;
+  static fromPromise: <T>(promise: Promise<T>) => Observable<T>;
+  static interval: (interval: number) => Observable<number>;
+  static merge: (...observables:any[]) => Observable<any>;
   static never: <T>() => Observable<T>;
   static of: <T>(...values: (T | Scheduler)[]) => Observable<T>;
   static range: <T>(start: number, end: number, scheduler?: Scheduler) => Observable<number>;
-  static fromPromise: <T>(promise: Promise<T>) => Observable<T>;
+  static throw: <T>(error: T) => Observable<T>;
   static timer: (delay: number) => Observable<number>;
-  static interval: (interval: number) => Observable<number>;
-  static forkJoin: (...observables: Observable<any>[]) => Observable<any[]>;
-  
-  static concat: (...observables: any[]) => Observable<any>;
-  concat: (...observables: any[]) => Observable<any>;
-  concatAll: () => Observable<any>;
-  concatMap: <R>(project: ((x: T, ix: number) => Observable<any>),
-                 projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  concatMapTo: <R>(observable: Observable<any>,
-                   projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-
-  static merge: (...observables:any[]) => Observable<any>;
-  merge: (...observables:any[]) => Observable<any>;
-  mergeAll: (concurrent?: any) => Observable<any>;
-  flatMap: <R>(project: ((x: T, ix: number) => Observable<any>),
-               projectResult?: (x: T, y: any, ix: number, iy: number) => R,
-               concurrent?: number) => Observable<R>;
-  flatMapTo: <R>(observable: Observable<any>,
-                 projectResult?: (x: T, y: any, ix: number, iy: number) => R,
-                 concurrent?: number) => Observable<R>;
-  mergeMap: <R>(project: ((x: T, ix: number) => Observable<any>),
-               projectResult?: (x: T, y: any, ix: number, iy: number) => R,
-               concurrent?: number) => Observable<R>;
-  mergeMapTo: <R>(observable: Observable<any>,
-                 projectResult?: (x: T, y: any, ix: number, iy: number) => R,
-                 concurrent?: number) => Observable<R>;
-
-  expand: (project: (x: T, ix: number) => Observable<any>) => Observable<any>;
-  delay: <T>(delay: number, scheduler?: Scheduler) => Observable<T>;
-
-  switch: <R>() => Observable<R>;
-  switchMap: <R>(project: ((x: T, ix: number) => Observable<any>),
-                    projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  switchMapTo: <R>(observable: Observable<any>,
-                      projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-
-  static combineLatest: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;
-  combineLatest: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R)) []) => Observable<R>;
-  combineAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
-  withLatestFrom: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R)) []) => Observable<R>;
   static zip: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;
-  zip: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R)) []) => Observable<R>;
-  zipAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
-
-  do: <T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void) => Observable<T>;
-  map: <T, R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
-  mapTo: <R>(value: R) => Observable<R>;
-  toArray: () => Observable<T[]>;
-  count: () => Observable<number>;
-  scan: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
-  reduce: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
-  startWith: <T>(x: T) => Observable<T>;
-  debounce: <R>(dueTime: number, scheduler?: Scheduler) => Observable<R>;
-  
-  isEmpty: () => Observable<boolean>;
-  elementAt: (index: number, defaultValue?: any) => Observable<T>;
-  last: (predicate?: (value: T, index:number) => boolean, thisArg?: any, defaultValue?: any) => Observable<T>;
-  single: (predicate?: (value: T, index:number) => boolean, thisArg?: any) => Observable<T>;
-  
-  filter: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
-  distinctUntilChanged: (compare?: (x: T, y: T) => boolean, thisArg?: any) => Observable<T>;
-  distinctUntilKeyChanged: (key: string, compare?: (x: any, y: any) => boolean, thisArg?: any) => Observable<T>;
   ignoreElements: () => Observable<T>;
-  skip: (count: number) => Observable<T>;
-  skipUntil: (notifier: Observable<any>) => Observable<T>;
-  take: (count: number) => Observable<T>;
-  takeUntil: (observable: Observable<any>) => Observable<T>;
-  partition: (predicate: (x: T) => boolean) => Observable<T>[];
-  toPromise: (PromiseCtor: PromiseConstructor) => Promise<T>;
-  defaultIfEmpty: <T, R>(defaultValue: R) => Observable<T>|Observable<R>;
-  // HACK: this should be Observable<Notification<T>>, but the build process didn't like it. :(
-  //   this will be fixed when we can move everything to the TypeScript compiler I suspect.
-  materialize: () => Observable<any>;
-  throttle: (delay: number, scheduler?: Scheduler) => Observable<T>;
-
-  observeOn: (scheduler: Scheduler, delay?: number) => Observable<T>;
-  subscribeOn: (scheduler: Scheduler, delay?: number) => Observable<T>;
-
-  publish: () => ConnectableObservable<T>;
-  publishBehavior: (value: any) => ConnectableObservable<T>;
-  publishReplay: (bufferSize: number, windowTime: number, scheduler?: Scheduler) => ConnectableObservable<T>;
-  multicast: (subjectFactory: () => Subject<T>) => ConnectableObservable<T>;
-
-  catch: (selector: (err: any, source: Observable<T>, caught: Observable<any>) => Observable<any>) => Observable<T>;
-  retry: <T>(count: number) => Observable<T>;
-  retryWhen: (notifier: (errors: Observable<any>) => Observable<any>) => Observable<T>;
-  repeat: <T>(count: number) => Observable<T>;
-  
-  groupBy: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;
-  window: <T>(closingNotifier: Observable<any>) => Observable<Observable<T>>;
-  windowWhen: <T>(closingSelector: () => Observable<any>) => Observable<Observable<T>>;
-  windowToggle: <T, O>(openings: Observable<O>, closingSelector?: (openValue: O) => Observable<any>) => Observable<Observable<T>>
-  windowTime: <T>(windowTimeSpan: number, windowCreationInterval?: number, scheduler?: Scheduler) => Observable<Observable<T>>;
-  windowCount: <T>(windowSize: number, startWindowEvery: number) => Observable<Observable<T>>;
-  
-  buffer: <T>(closingNotifier: Observable<any>) => Observable<T[]>;
-  bufferWhen: <T>(closingSelector: () => Observable<any>) => Observable<T[]>;
-  bufferToggle: <T, O>(openings: Observable<O>, closingSelector?: (openValue: O) => Observable<any>) => Observable<T[]>
-  bufferTime: <T>(bufferTimeSpan: number, bufferCreationInterval?: number, scheduler?: Scheduler) => Observable<T[]>;
-  bufferCount: <T>(bufferSize: number, startBufferEvery: number) => Observable<T[]>;
-  
-  sample: <T>(notifier: Observable<any>) => Observable<T>;
-  sampleTime: <T>(delay: number, scheduler?: Scheduler) => Observable<T>;
-  
-  finally: (ensure: () => void, thisArg?: any) => Observable<T>;
-  timeout: <T>(due: number|Date, errorToSend?: any, scheduler?: Scheduler) => Observable<T>;
-  timeoutWith: <T>(due: number|Date, withObservable: Observable<any>, scheduler?: Scheduler) => Observable<T>;
 }

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -1,4 +1,11 @@
 import Observable from './Observable';
+import Operator from './Operator';
+import { CoreOperators } from './CoreOperators';
+
+interface KitchenSinkOperators<T> extends CoreOperators<T> {
+  elementAt?: (index: number, defaultValue?: any) => Observable<T>;
+  distinctUntilKeyChanged?: (key: string, compare?: (x: any, y: any) => boolean, thisArg?: any) => Observable<T>;
+}
 
 // operators
 import combineLatestStatic from './operators/combineLatest-static';
@@ -57,8 +64,7 @@ Observable.zip = zipStatic
 
 
 // Operators 
-import { CoreOperators } from './CoreOperators';
-const observableProto = (<CoreOperators<any>>Observable.prototype);
+const observableProto = (<KitchenSinkOperators<any>>Observable.prototype);
 
 import buffer from './operators/buffer';
 observableProto.buffer = buffer;
@@ -110,17 +116,21 @@ observableProto.delay = delay;
 
 import distinctUntilChanged from './operators/distinctUntilChanged';
 observableProto.distinctUntilChanged = distinctUntilChanged;
-import ignoreElements from './operators/ignoreElements';
+
+import distinctUntilKeyChanged from './operators/extended/distinctUntilKeyChanged';
+observableProto.distinctUntilKeyChanged = distinctUntilKeyChanged;
 
 import _do from './operators/do';
 observableProto.do = _do;
+
+import elementAt from './operators/extended/elementAt';
+observableProto.elementAt = elementAt;
 
 import expand from './operators/expand';
 observableProto.expand = expand;
 
 import filter from './operators/filter';
 observableProto.filter = filter;
-observableProto.ignoreElements = ignoreElements;
 
 import _finally from './operators/finally';
 observableProto.finally = _finally;
@@ -278,6 +288,8 @@ import nextTick from './schedulers/nextTick';
 import immediate from './schedulers/immediate';
 import NextTickScheduler from './schedulers/NextTickScheduler';
 import ImmediateScheduler from './schedulers/ImmediateScheduler';
+import TestScheduler from './schedulers/TestScheduler';
+import VirtualTimeScheduler from './schedulers/VirtualTimeScheduler';
 
 var Scheduler = {
   nextTick,
@@ -296,4 +308,6 @@ export {
     Notification,
     EmptyError,
     ArgumentOutOfRangeError,
+    TestScheduler,
+    VirtualTimeScheduler
 };

--- a/src/operators/extended/distinctUntilKeyChanged.ts
+++ b/src/operators/extended/distinctUntilKeyChanged.ts
@@ -1,4 +1,4 @@
-import distinctUntilChanged from './distinctUntilChanged';
+import distinctUntilChanged from '../distinctUntilChanged';
 
 export default function distinctUntilKeyChanged<T>(key: string, compare?: (x: any, y: any) => boolean, thisArg?: any) {
   return distinctUntilChanged.call(this, function(x, y) {

--- a/src/operators/extended/elementAt.ts
+++ b/src/operators/extended/elementAt.ts
@@ -1,7 +1,7 @@
-import Operator from '../Operator';
-import Observer from '../Observer';
-import Subscriber from '../Subscriber';
-import ArgumentOutOfRangeError from '../util/ArgumentOutOfRangeError';
+import Operator from '../../Operator';
+import Observer from '../../Observer';
+import Subscriber from '../../Subscriber';
+import ArgumentOutOfRangeError from '../../util/ArgumentOutOfRangeError';
 
 export default function elementAt(index: number, defaultValue?: any) {
   return this.lift(new ElementAtOperator(index, defaultValue));


### PR DESCRIPTION
- moves non-core operators to entended directory
- adds Rx.KitchenSink module
- removes non-core operators from Rx module
- removes TestScheduler from Rx module
- removes VirtualTimeScheduler from Rx module
- updates tests appropriately
- adds Rx.KitchenSink to es6 build process
- reorganizes operators as they appear in files to be in alphabetical order and separated by static and members

closes #401