### PR TITLE
chore(test): format test failure output more aligned

### DIFF
--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -90,6 +90,20 @@ function assertDeepEqual(actual, expected) {
       'undefined': false
   };
   
+  Object.defineProperty(Error.prototype, 'toJSON', {
+      value: function () {
+          var alt = {};
+  
+          Object.getOwnPropertyNames(this).forEach(function (key) {
+            if (key !== 'stack') {
+              alt[key] = this[key];
+            }
+          }, this);
+          return alt;
+      },
+      configurable: true
+  });
+    
   var _root = (objectTypes[typeof self] && self) || (objectTypes[typeof window] && window);
   
   var freeExports = objectTypes[typeof exports] && exports && !exports.nodeType && exports;


### PR DESCRIPTION
Built in `JSON.toStringify()` does not serialize `error` object, so test output was not able to format exception correctly. This PR overrides default behavior while running tests. 

*before*
<img width="480" alt="before" src="https://cloud.githubusercontent.com/assets/1210596/10109229/a26367be-637a-11e5-99f2-d0475f9d4aaf.png">

*after*
<img width="580" alt="after" src="https://cloud.githubusercontent.com/assets/1210596/10109236/a7192e06-637a-11e5-8e77-e13f2beb850d.png">