### PR TITLE
chore(package): Add 'typings' field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,6 @@
   },
   "engines": {
     "npm": "~2.0.0"
-  }
+  },
+  "typings": "./dist/es6/Rx.d.ts"
 }


### PR DESCRIPTION
This supports TypeScript 1.6 later's [`moduleResolution=node` option](https://github.com/Microsoft/TypeScript/wiki/Compiler-Options).