### PR TITLE
Add resultSelector argument to both `first` and `last` operators

### DIFF
--- a/spec/operators/first-spec.js
+++ b/spec/operators/first-spec.js
@@ -23,7 +23,7 @@ describe('Observable.prototype.first()', function() {
   it('should return the default value if source observable was empty', function() {
     var e1 = hot('-----^----|');
     var expected =    '-----(a|)';
-    expectObservable(e1.first(null, null, 'a')).toBe(expected);
+    expectObservable(e1.first(null, null, null, 'a')).toBe(expected);
   });
 
   it('should propagate error from the source observable', function() {
@@ -63,7 +63,7 @@ describe('Observable.prototype.first()', function() {
       expect(this).toEqual(42);
       return value % 2 === 1;
     };
-    expectObservable(e1.first(predicate, 42)).toBe(expected, {c: 3});
+    expectObservable(e1.first(predicate, null, 42)).toBe(expected, {c: 3});
   });
 
   it('should error when no value matches the predicate', function() {
@@ -81,7 +81,7 @@ describe('Observable.prototype.first()', function() {
     var predicate = function (value) {
       return value === 's';
     };
-    expectObservable(e1.first(predicate, null, 'd')).toBe(expected);
+    expectObservable(e1.first(predicate, null, null, 'd')).toBe(expected);
   });
 
   it('should propagate error when no value matches the predicate', function() {
@@ -113,5 +113,17 @@ describe('Observable.prototype.first()', function() {
       }
     };
     expectObservable(e1.first(predicate)).toBe(expected, null, 'error');
+  });
+  
+  it('should support a result selector argument', function() {
+    var e1 = hot('--a--^---b---c---d---e--|');
+    var expected =    '--------(x|)';
+    var predicate = function (x){ return x === 'c'; };
+    var resultSelector = function(x, i) {
+      expect(i).toBe(1);
+      expect(x).toBe('c');
+      return 'x';
+    };
+    expectObservable(e1.first(predicate, resultSelector)).toBe(expected);
   });
 });

--- a/spec/operators/first-spec.js
+++ b/spec/operators/first-spec.js
@@ -23,7 +23,7 @@ describe('Observable.prototype.first()', function() {
   it('should return the default value if source observable was empty', function() {
     var e1 = hot('-----^----|');
     var expected =    '-----(a|)';
-    expectObservable(e1.first(null, null, null, 'a')).toBe(expected);
+    expectObservable(e1.first(null, null, 'a')).toBe(expected);
   });
 
   it('should propagate error from the source observable', function() {
@@ -56,16 +56,6 @@ describe('Observable.prototype.first()', function() {
     expectObservable(e1.first(predicate)).toBe(expected, {c: 3});
   });
 
-  it('should return first value that matches a predicate using thisArg', function() {
-    var e1 = hot('--a-^--b--c--d--e--|', {a: 1, b: 2, c: 3, d: 4, e: 5});
-    var expected =   '------(c|)';
-    var predicate = function (value) {
-      expect(this).toEqual(42);
-      return value % 2 === 1;
-    };
-    expectObservable(e1.first(predicate, null, 42)).toBe(expected, {c: 3});
-  });
-
   it('should error when no value matches the predicate', function() {
     var e1 = hot('--a-^--b--c--a--c--|');
     var expected =   '---------------#';
@@ -81,7 +71,7 @@ describe('Observable.prototype.first()', function() {
     var predicate = function (value) {
       return value === 's';
     };
-    expectObservable(e1.first(predicate, null, null, 'd')).toBe(expected);
+    expectObservable(e1.first(predicate, null, 'd')).toBe(expected);
   });
 
   it('should propagate error when no value matches the predicate', function() {

--- a/spec/operators/last-spec.js
+++ b/spec/operators/last-spec.js
@@ -41,13 +41,13 @@ describe('Observable.prototype.last()', function(){
   it('should return a default value if no element found', function() {
     var e1 = Observable.empty();
     var expected = '(a|)';
-    expectObservable(e1.last(null, null, null, 'a')).toBe(expected);
+    expectObservable(e1.last(null, null, 'a')).toBe(expected);
   });
   
   it('should not return default value if an element is found', function (){
     var e1 = hot('--a---^---b---c---d---|');
     var expected =     '----------------(d|)';
-    expectObservable(e1.last(null, null, null, 'x')).toBe(expected);
+    expectObservable(e1.last(null, null, 'x')).toBe(expected);
   });
   
   it('should support a result selector argument', function() {

--- a/spec/operators/last-spec.js
+++ b/spec/operators/last-spec.js
@@ -1,5 +1,6 @@
 /* globals describe, it, expect, expectObservable, hot, cold */
 var Rx = require('../../dist/cjs/Rx');
+var Observable = Rx.Observable;
 
 describe('Observable.prototype.last()', function(){
   it('should take the last value of an observable', function(){
@@ -8,14 +9,20 @@ describe('Observable.prototype.last()', function(){
     expectObservable(e1.last()).toBe(expected)
   });
   
-  it('should error on empty', function() {
+  it('should error on nothing sent but completed', function() {
     var e1 = hot('--a--^----|');
     var expected =    '-----#';
     expectObservable(e1.last()).toBe(expected, null, new Rx.EmptyError());
   });
   
+  it('should error on empty', function (){
+    var e1 = Observable.empty()
+    var expected = '#';
+    expectObservable(e1.last()).toBe(expected, null, new Rx.EmptyError());
+  });
+  
   it('should go on forever on never', function() {
-    var e2 = hot('--^---');
+    var e2 = Observable.never();
     var expected = '----';
     expectObservable(e2.last()).toBe(expected);
   });
@@ -29,5 +36,29 @@ describe('Observable.prototype.last()', function(){
     }
     
     expectObservable(e1.last(predicate)).toBe(expected);
+  });
+  
+  it('should return a default value if no element found', function() {
+    var e1 = Observable.empty();
+    var expected = '(a|)';
+    expectObservable(e1.last(null, null, null, 'a')).toBe(expected);
+  });
+  
+  it('should not return default value if an element is found', function (){
+    var e1 = hot('--a---^---b---c---d---|');
+    var expected =     '----------------(d|)';
+    expectObservable(e1.last(null, null, null, 'x')).toBe(expected);
+  });
+  
+  it('should support a result selector argument', function() {
+    var e1 = hot('--a--^---b---c---d---e--|');
+    var expected =    '-------------------(x|)';
+    var predicate = function (x){ return x === 'c'; };
+    var resultSelector = function(x, i) {
+      expect(i).toBe(1);
+      expect(x).toBe('c');
+      return 'x';
+    };
+    expectObservable(e1.last(predicate, resultSelector)).toBe(expected);
   });
 });

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -26,7 +26,7 @@ export interface CoreOperators<T> {
   expand?: (project: (x: T, ix: number) => Observable<any>) => Observable<any>;
   filter?: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
   finally?: (ensure: () => void, thisArg?: any) => Observable<T>;
-  first?: (predicate?: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any, defaultValue?: any) => Observable<T>;
+  first?: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value:T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<R>;
   flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   groupBy?: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -32,7 +32,7 @@ export interface CoreOperators<T> {
   groupBy?: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;
   ignoreElements?: () => Observable<T>;
   isEmpty?: () => Observable<boolean>;
-  last?: (predicate?: (value: T, index:number) => boolean, thisArg?: any, defaultValue?: any) => Observable<T>;
+  last?: <R>(predicate?: (value: T, index:number) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T>;
   map?: <T, R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
   mapTo?: <R>(value: R) => Observable<R>;
   materialize?: () => Observable<any>;

--- a/src/operators/first.ts
+++ b/src/operators/first.ts
@@ -10,39 +10,32 @@ import EmptyError from '../util/EmptyError';
 
 export default function first<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
                                  resultSelector?: (value: T, index: number) => R,
-                                 thisArg?: any,
                                  defaultValue?: any): Observable<R> {
-  return this.lift(new FirstOperator(predicate, thisArg, resultSelector, defaultValue, this));
+  return this.lift(new FirstOperator(predicate, resultSelector, defaultValue, this));
 }
 
 class FirstOperator<T, R> implements Operator<T, R> {
   constructor(private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-              private thisArg?: any,
               private resultSelector?: (value: T, index: number) => R,
               private defaultValue?: any,
               private source?: Observable<T>) {
   }
 
   call(observer: Subscriber<R>): Subscriber<T> {
-    return new FirstSubscriber(observer, this.predicate, this.thisArg, this.resultSelector, this.defaultValue, this.source);
+    return new FirstSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source);
   }
 }
 
 class FirstSubscriber<T, R> extends Subscriber<T> {
-  private predicate: Function;
   private index: number = 0;
   private hasCompleted: boolean = false;
 
   constructor(destination: Observer<T>,
-              predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-              private thisArg?: any,
+              private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
               private resultSelector?: (value: T, index: number) => R,
               private defaultValue?: any,
               private source?: Observable<T>) {
     super(destination);
-    if (typeof predicate === 'function') {
-      this.predicate = bindCallback(predicate, thisArg, 3);
-    }
   }
 
   _next(value: any) {
@@ -50,7 +43,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
     const index = this.index++;
     let passed: any = true;
     if (predicate) {
-      passed = tryCatch(predicate)(value,index, this.source);
+      passed = tryCatch(predicate)(value, index, this.source);
       if (passed === errorObject) {
         destination.error(errorObject.e);
         return;

--- a/src/operators/last.ts
+++ b/src/operators/last.ts
@@ -8,38 +8,36 @@ import {errorObject} from '../util/errorObject';
 import bindCallback from '../util/bindCallback';
 import EmptyError from '../util/EmptyError';
 
-export default function last<T, R>(predicate?: (value: T, index: number, source:Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) : Observable<R> {
-  return this.lift(new LastOperator(predicate, resultSelector, thisArg, defaultValue, this));
+export default function last<T, R>(predicate?: (value: T, index: number, source:Observable<T>) => boolean, 
+  resultSelector?: (value: T, index: number) => R, defaultValue?: any) : Observable<R> {
+  return this.lift(new LastOperator(predicate, resultSelector, defaultValue, this));
 }
 
 class LastOperator<T, R> implements Operator<T, R> {
   constructor(private predicate?: (value: T, index: number, source:Observable<T>) => boolean, 
               private resultSelector?: (value: T, index: number) => R,
-              private thisArg?: any, private defaultValue?: any, private source?: Observable<T>) {
+              private defaultValue?: any, private source?: Observable<T>) {
     
   }
   
   call(observer: Subscriber<R>): Subscriber<T> {
-    return new LastSubscriber(observer, this.predicate, this.resultSelector, this.thisArg, this.defaultValue, this.source);
+    return new LastSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source);
   }
 }
 
 class LastSubscriber<T, R> extends Subscriber<T> {
   private lastValue: T;
   private hasValue: boolean = false;
-  private predicate: Function;
   private index: number = 0;
   
-  constructor(destination: Observer<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean, 
+  constructor(destination: Observer<T>, 
+    private predicate?: (value: T, index: number, source: Observable<T>) => boolean, 
     private resultSelector?: (value: T, index: number) => R,
-    private thisArg?: any, private defaultValue?: any, private source?: Observable<T>) {
+    private defaultValue?: any, private source?: Observable<T>) {
     super(destination);
     if(typeof defaultValue !== 'undefined') {
       this.lastValue = defaultValue;
       this.hasValue = true;
-    }
-    if(typeof predicate === 'function') {
-      this.predicate = bindCallback(predicate, thisArg, 3);
     }
   }
   

--- a/src/operators/last.ts
+++ b/src/operators/last.ts
@@ -8,27 +8,30 @@ import {errorObject} from '../util/errorObject';
 import bindCallback from '../util/bindCallback';
 import EmptyError from '../util/EmptyError';
 
-export default function last<T>(predicate?: (value: T, index: number, source:Observable<T>) => boolean, thisArg?: any, defaultValue?: any) : Observable<T> {
-  return this.lift(new LastOperator(predicate, thisArg, defaultValue, this));
+export default function last<T, R>(predicate?: (value: T, index: number, source:Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) : Observable<R> {
+  return this.lift(new LastOperator(predicate, resultSelector, thisArg, defaultValue, this));
 }
 
 class LastOperator<T, R> implements Operator<T, R> {
-  constructor(private predicate?: (value: T, index: number, source:Observable<T>) => boolean, private thisArg?: any, private defaultValue?: any, private source?: Observable<T>) {
+  constructor(private predicate?: (value: T, index: number, source:Observable<T>) => boolean, 
+              private resultSelector?: (value: T, index: number) => R,
+              private thisArg?: any, private defaultValue?: any, private source?: Observable<T>) {
     
   }
   
   call(observer: Subscriber<R>): Subscriber<T> {
-    return new LastSubscriber(observer, this.predicate, this.thisArg, this.defaultValue, this.source);
+    return new LastSubscriber(observer, this.predicate, this.resultSelector, this.thisArg, this.defaultValue, this.source);
   }
 }
 
-class LastSubscriber<T> extends Subscriber<T> {
+class LastSubscriber<T, R> extends Subscriber<T> {
   private lastValue: T;
   private hasValue: boolean = false;
   private predicate: Function;
   private index: number = 0;
   
   constructor(destination: Observer<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean, 
+    private resultSelector?: (value: T, index: number) => R,
     private thisArg?: any, private defaultValue?: any, private source?: Observable<T>) {
     super(destination);
     if(typeof defaultValue !== 'undefined') {
@@ -40,13 +43,25 @@ class LastSubscriber<T> extends Subscriber<T> {
     }
   }
   
-  _next(value: T) {
-    const predicate = this.predicate;
+  _next(value: any) {
+    const { predicate, resultSelector, destination } = this;
+    const index = this.index++;
+    
     if(predicate) {
-      let result = tryCatch(predicate)(value, this.index++, this.source);
-      if(result === errorObject) {
-        this.destination.error(result.e);
-      } else if (result) {
+      let found = tryCatch(predicate)(value, index, this.source);
+      if(found === errorObject) {
+        destination.error(errorObject.e);
+        return;
+      }
+    
+      if(found) {
+        if(resultSelector) {
+          value = tryCatch(resultSelector)(value, index);
+          if(value === errorObject) {
+            destination.error(errorObject.e);
+            return;
+          }
+        }
         this.lastValue = value;
         this.hasValue = true;
       }


### PR DESCRIPTION
Just what it says. This was primarily for

1. to enable a user to use `first` to select an `index` if they so choose, effectively replacing `findIndex` as any sort of need in CoreOperators.
2. Consistency, so that `first` and `last` have identical signatures...

To be bikeshedded: 

- the usefulness of the `thisArg`
- argument order