### PR TITLE
fix(operators): reorder signature of resultSelectors

### DIFF
--- a/spec/operators/switchMap-spec.js
+++ b/spec/operators/switchMap-spec.js
@@ -13,10 +13,10 @@ describe('Observable.prototype.switchMap()', function () {
       expect(x).toBe(expected.shift());
     }, null, done);
   });
-  
+
   it('should unsub inner observables', function(){
     var unsubbed = [];
-    
+
     Observable.of('a', 'b').switchMap(function(x) {
       return Observable.create(function(subscriber) {
         subscriber.complete();
@@ -25,101 +25,101 @@ describe('Observable.prototype.switchMap()', function () {
         };
       });
     }).subscribe();
-    
+
     expect(unsubbed).toEqual(['a', 'b']);
   });
 
   it('should switch inner cold observables', function (){
-    var x =   cold(         '--a--b--c--d--e--|')
+    var x =   cold(         '--a--b--c--d--e--|');
     var y =   cold(                   '---f---g---h---i--|');
     var e1 =   hot('---------x---------y---------|');
     var expected = '-----------a--b--c----f---g---h---i--|';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected);    
+    })).toBe(expected);
   });
-  
+
   it('should switch inner hot observables', function (){
-    var x =    hot('-----a--b--c--d--e--|')
+    var x =    hot('-----a--b--c--d--e--|');
     var y =    hot('--p-o-o-p-------------f---g---h---i--|');
     var e1 =   hot('---------x---------y---------|');
     var expected = '-----------c--d--e----f---g---h---i--|';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected);    
+    })).toBe(expected);
   });
-  
+
   it('should switch inner empty and empty', function () {
     var x = Observable.empty();
     var y = Observable.empty();
     var e1 =   hot('---------x---------y---------|');
     var expected = '-----------------------------|';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected);    
+    })).toBe(expected);
   });
-  
+
   it('should switch inner empty and never', function() {
-    var x =   Observable.empty()
+    var x =   Observable.empty();
     var y =   Observable.never();
     var e1 =   hot('---------x---------y---------|');
     var expected = '----------------------------------';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected);    
+    })).toBe(expected);
   });
-  
+
   it('should switch inner never and empty', function (){
     var x = Observable.never();
     var y = Observable.empty();
     var e1 =   hot('---------x---------y---------|');
     var expected = '-----------------------------|';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected);    
+    })).toBe(expected);
   });
-  
+
   it('should switch inner never and throw', function (){
     var x = Observable.never();
     var y = Observable.throw(new Error('sad'));
     var e1 =   hot('---------x---------y---------|');
     var expected = '-------------------#';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected, undefined, new Error('sad'));    
+    })).toBe(expected, undefined, new Error('sad'));
   });
-  
+
   it('should switch inner empty and throw', function (){
     var x = Observable.empty();
     var y = Observable.throw(new Error('sad'));
     var e1 =   hot('---------x---------y---------|');
     var expected = '-------------------#';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected, undefined, new Error('sad'));    
+    })).toBe(expected, undefined, new Error('sad'));
   });
-  
+
   it('should handle outer empty', function (){
     var e1 = Observable.empty();
     var expected = '|';
@@ -127,7 +127,7 @@ describe('Observable.prototype.switchMap()', function () {
       return Observable.of(value);
     })).toBe(expected);
   });
-  
+
   it('should handle outer never', function (){
     var e1 = Observable.never();
     var expected = '----';
@@ -135,7 +135,7 @@ describe('Observable.prototype.switchMap()', function () {
       return Observable.of(value);
     })).toBe(expected);
   });
-  
+
   it('should handle outer throw', function (){
     var e1 = Observable.throw(new Error('wah'));
     var expected = '#';
@@ -143,41 +143,41 @@ describe('Observable.prototype.switchMap()', function () {
       return Observable.of(value);
     })).toBe(expected, undefined, new Error('wah'));
   });
-  
+
   it('should handle outer error', function (){
-    var x =   cold(         '--a--b--c--d--e--|')
+    var x =   cold(         '--a--b--c--d--e--|');
     var e1 =   hot('---------x---------#', undefined, new Error('boo-hoo'));
     var expected = '-----------a--b--c-#';
-    
+
     var observableLookup = { x: x };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
-    })).toBe(expected, undefined, new Error('boo-hoo'));    
+    })).toBe(expected, undefined, new Error('boo-hoo'));
   });
-  
+
   it('should switch with resultSelector goodness', function (){
-    var x =   cold(         '--a--b--c--d--e--|')
+    var x =   cold(         '--a--b--c--d--e--|');
     var y =   cold(                   '---f---g---h---i--|');
     var e1 =   hot('---------x---------y---------|');
     var expected = '-----------a--b--c----f---g---h---i--|';
-    
+
     var observableLookup = { x: x, y: y };
-    
+
     var expectedValues = {
-      a: ['a', 'x', 0, 0],
-      b: ['b', 'x', 1, 0],
-      c: ['c', 'x', 2, 0],
-      f: ['f', 'y', 0, 1],
-      g: ['g', 'y', 1, 1],
-      h: ['h', 'y', 2, 1],
-      i: ['i', 'y', 3, 1]
+      a: ['x', 'a', 0, 0],
+      b: ['x', 'b', 0, 1],
+      c: ['x', 'c', 0, 2],
+      f: ['y', 'f', 1, 0],
+      g: ['y', 'g', 1, 1],
+      h: ['y', 'h', 1, 2],
+      i: ['y', 'i', 1, 3]
     };
-    
+
     expectObservable(e1.switchMap(function(value) {
       return observableLookup[value];
     }, function(innerValue, outerValue, innerIndex, outerIndex) {
       return [innerValue, outerValue, innerIndex, outerIndex];
-    })).toBe(expected, expectedValues);    
+    })).toBe(expected, expectedValues);
   });
 });

--- a/src/InnerSubscriber.ts
+++ b/src/InnerSubscriber.ts
@@ -6,20 +6,20 @@ import { errorObject } from './util/errorObject';
 
 export default class InnerSubscriber<T, R> extends Subscriber<R> {
   index: number = 0;
-  
+
   constructor(private parent: OuterSubscriber<T, R>, private outerValue: T, private outerIndex: number) {
     super();
   }
-  
+
   _next(value: R) {
     const index = this.index++;
-    this.parent.notifyNext(value, this.outerValue, index, this.outerIndex);
+    this.parent.notifyNext(this.outerValue, value, this.outerIndex, index);
   }
-  
+
   _error(error: any) {
     this.parent.notifyError(error, this);
   }
-  
+
   _complete() {
     this.parent.notifyComplete(this);
   }

--- a/src/OuterSubscriber.ts
+++ b/src/OuterSubscriber.ts
@@ -6,11 +6,11 @@ export default class OuterSubscriber<T, R> extends Subscriber<T> {
   notifyComplete(inner?: InnerSubscriber<T, R>) {
     this.destination.complete();
   }
-  
-  notifyNext(innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) {
+
+  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {
     this.destination.next(innerValue);
   }
-  
+
   notifyError(error?: any, inner?: InnerSubscriber<T, R>) {
     this.destination.error(error);
   }

--- a/src/operators/combineLatest-support.ts
+++ b/src/operators/combineLatest-support.ts
@@ -29,7 +29,7 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
   private values: any[] = [];
   private observables: any[] = [];
   private toRespond: number[] = [];
-  
+
   constructor(destination: Subscriber<R>, private project?: (...values: Array<any>) => R) {
     super(destination);
   }
@@ -39,7 +39,7 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
     toRespond.push(toRespond.length);
     this.observables.push(observable);
   }
-  
+
   _complete() {
     const observables = this.observables;
     const len = observables.length;
@@ -59,23 +59,23 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.destination.complete();
     }
   }
-  
-  notifyNext(value: R, observable: any, innerIndex: number, outerIndex: number) {
+
+  notifyNext(observable: any, value: R, outerIndex: number, innerIndex: number) {
     const values = this.values;
     values[outerIndex] = value;
     const toRespond = this.toRespond;
-    
+
     if(toRespond.length > 0) {
       const found = toRespond.indexOf(outerIndex);
       if(found !== -1) {
         toRespond.splice(found, 1);
       }
     }
-    
+
     if(toRespond.length === 0) {
       const project = this.project;
       const destination = this.destination;
-      
+
       if(project) {
         let result = tryCatch(project).apply(this, values);
         if(result === errorObject) {

--- a/src/operators/concatMapTo.ts
+++ b/src/operators/concatMapTo.ts
@@ -2,6 +2,6 @@ import Observable from '../Observable';
 import { MergeMapToOperator } from './mergeMapTo-support';
 
 export default function concatMapTo<T, R, R2>(observable: Observable<R>,
-                                          projectResult?: (innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) => R2) : Observable<R2> {
+                                              projectResult?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) : Observable<R2> {
   return this.lift(new MergeMapToOperator(observable, projectResult, 1));
 }

--- a/src/operators/expand-support.ts
+++ b/src/operators/expand-support.ts
@@ -13,7 +13,7 @@ import OuterSubscriber from '../OuterSubscriber';
 import subscribeToResult from '../util/subscribeToResult';
 
 export class ExpandOperator<T, R> implements Operator<T, R> {
-  constructor(private project: (value: T, index: number) => Observable<any>, 
+  constructor(private project: (value: T, index: number) => Observable<any>,
     private concurrent: number = Number.POSITIVE_INFINITY) {
   }
 
@@ -27,15 +27,15 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   private active: number = 0;
   private hasCompleted: boolean = false;
   private buffer: any[];
-  
-  constructor(destination: Observer<T>, private project: (value: T, index: number) => Observable<R>, 
+
+  constructor(destination: Observer<T>, private project: (value: T, index: number) => Observable<R>,
     private concurrent: number = Number.POSITIVE_INFINITY) {
     super(destination);
     if(concurrent < Number.POSITIVE_INFINITY) {
       this.buffer = [];
     }
   }
-  
+
   _next(value: any) {
     const index = this.index++;
     this.destination.next(value);
@@ -55,14 +55,14 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.buffer.push(value);
     }
   }
-  
+
   _complete() {
     this.hasCompleted = true;
     if(this.hasCompleted && this.active === 0) {
       this.destination.complete();
     }
   }
-  
+
   notifyComplete(innerSub: Subscription<T>) {
     const buffer = this.buffer;
     this.remove(innerSub);
@@ -74,8 +74,8 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.destination.complete();
     }
   }
-  
-  notifyNext(innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) {
+
+  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {
     this._next(innerValue);
   }
 }

--- a/src/operators/mergeMap.ts
+++ b/src/operators/mergeMap.ts
@@ -2,7 +2,7 @@ import Observable from '../Observable';
 import { MergeMapOperator } from './mergeMap-support';
 
 export default function mergeMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
-                                      resultSelector?: (innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) => R,
-                                      concurrent: number = Number.POSITIVE_INFINITY) {
+                                           resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R,
+                                           concurrent: number = Number.POSITIVE_INFINITY) {
   return this.lift(new MergeMapOperator(project, resultSelector, concurrent));
 }

--- a/src/operators/mergeMapTo.ts
+++ b/src/operators/mergeMapTo.ts
@@ -2,7 +2,7 @@ import Observable from '../Observable';
 import { MergeMapToOperator } from './mergeMapTo-support';
 
 export default function mergeMapTo<T, R, R2>(observable: Observable<R>,
-                                        resultSelector?: (innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) => R2,
-                                        concurrent: number = Number.POSITIVE_INFINITY) : Observable<R2> {
+                                             resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2,
+                                             concurrent: number = Number.POSITIVE_INFINITY) : Observable<R2> {
   return this.lift(new MergeMapToOperator(observable, resultSelector, concurrent));
 }

--- a/src/operators/switch.ts
+++ b/src/operators/switch.ts
@@ -28,20 +28,20 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
   constructor(destination: Observer<T>) {
     super(destination);
   }
-  
+
   _next(value: any) {
     this.unsubscribeInner();
     this.active++;
-    this.add(this.innerSubscription = subscribeToResult(this, value)); 
+    this.add(this.innerSubscription = subscribeToResult(this, value));
   }
-  
+
   _complete() {
     this.hasCompleted = true;
     if(this.active === 0) {
       this.destination.complete();
     }
   }
-  
+
   unsubscribeInner() {
     this.active = this.active > 0 ? this.active - 1 : 0;
     const innerSubscription = this.innerSubscription;
@@ -50,15 +50,15 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.remove(innerSubscription);
     }
   }
-  
-  notifyNext(value: any) {
-    this.destination.next(value);
+
+  notifyNext(outerValue: T, innerValue: any) {
+    this.destination.next(innerValue);
   }
-  
+
   notifyError(err: any) {
     this.destination.error(err);
   }
-  
+
   notifyComplete() {
     this.unsubscribeInner();
     if(this.hasCompleted && this.active === 0) {

--- a/src/operators/switchMapTo.ts
+++ b/src/operators/switchMapTo.ts
@@ -7,13 +7,13 @@ import Subscription from '../Subscription';
 import { MergeMapToSubscriber } from './mergeMapTo-support';
 
 export default function switchMapTo<T, R, R2>(observable: Observable<R>,
-                                             projectResult?: (innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) => R2): Observable<R2> {
+                                              projectResult?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2): Observable<R2> {
   return this.lift(new SwitchMapToOperator(observable, projectResult));
 }
 
 class SwitchMapToOperator<T, R, R2> implements Operator<T, R> {
   constructor(private observable: Observable<R>,
-              private resultSelector?: (innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) => R2) {
+              private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {
@@ -22,12 +22,11 @@ class SwitchMapToOperator<T, R, R2> implements Operator<T, R> {
 }
 
 class SwitchMapToSubscriber<T, R, R2> extends MergeMapToSubscriber<T, R, R2> {
-
   innerSubscription: Subscription<T>;
 
   constructor(destination: Observer<T>,
               observable: Observable<R>,
-              resultSelector?: (innerValue: R, outerValue: T, innerIndex: number, outerIndex: number) => R2) {
+              resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
     super(destination, observable, resultSelector, 1);
   }
 }

--- a/src/operators/withLatestFrom.ts
+++ b/src/operators/withLatestFrom.ts
@@ -9,17 +9,17 @@ import OuterSubscriber from '../OuterSubscriber';
 import subscribeToResult from '../util/subscribeToResult';
 
 /**
- * @param {Observable} observables the observables to get the latest values from. 
+ * @param {Observable} observables the observables to get the latest values from.
  * @param {Function} [project] optional projection function for merging values together. Receives all values in order
  *  of observables passed. (e.g. `a.withLatestFrom(b, c, (a1, b1, c1) => a1 + b1 + c1)`). If this is not passed, arrays
  *  will be returned.
  * @description merges each value from an observable with the latest values from the other passed observables.
  * All observables must emit at least one value before the resulting observable will emit
- * 
+ *
  * #### example
  * ```
  * A.withLatestFrom(B, C)
- * 
+ *
  *  A:     ----a-----------------b---------------c-----------|
  *  B:     ---d----------------e--------------f---------|
  *  C:     --x----------------y-------------z-------------|
@@ -47,23 +47,23 @@ class WithLatestFromOperator<T, R> implements Operator<T, R> {
 class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
   private values: any[];
   private toRespond: number[] = [];
-  
+
   constructor(destination: Subscriber<T>, private observables: Observable<any>[], private project?: (...values: any[]) => Observable<R>) {
     super(destination);
     const len = observables.length;
     this.values = new Array(len);
-    
+
     for (let i = 0; i < len; i++) {
       this.toRespond.push(i);
     }
-    
+
     for (let i = 0; i < len; i++) {
       let observable = observables[i];
       this.add(subscribeToResult<T, R>(this, observable, <any>observable, i));
     }
   }
-  
-  notifyNext(value, observable, index, observableIndex) {
+
+  notifyNext(observable, value, observableIndex, index) {
     this.values[observableIndex] = value;
     const toRespond = this.toRespond;
     if(toRespond.length > 0) {
@@ -73,11 +73,11 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
       }
     }
   }
-  
+
   notifyComplete() {
     // noop
   }
-  
+
   _next(value: T) {
     if (this.toRespond.length === 0) {
       const values = this.values;


### PR DESCRIPTION
This commit swaps around the arguments of resultSelector functions
of operators that internally create an Observable<Observable<T>>,
such as switchMap, mergeMap, and concatMap.

BREAKING CHANGES:
The function signature of resultSelectors used to be (innerValue,
outerValue, innerIndex, outerIndex) but this commits changes it to
be (outerValue, innerValue, outerIndex, innerIndex), to match
signatures in RxJS 4.

Resolves issue #415 