### PR TITLE
refactor(KitchenSink): add first, ignoreElements to interface

### DIFF
--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -143,8 +143,14 @@ observableProto.findIndex = findIndex;
 import _finally from './operators/finally';
 observableProto.finally = _finally;
 
+import first from './operators/first';
+observableProto.first = first;
+
 import groupBy from './operators/groupBy';
 observableProto.groupBy = groupBy;
+
+import ignoreElements from './operators/ignoreElements';
+observableProto.ignoreElements = ignoreElements;
 
 import isEmpty from './operators/isEmpty';
 observableProto.isEmpty = isEmpty;


### PR DESCRIPTION
Add two missing interfaces from `CoreOperator` to `KitchenSink`.