### PR TITLE
feat(operator): add every operator

### DIFF
--- a/perf/micro/immediate-scheduler/operators/every-predicate-this.js
+++ b/perf/micro/immediate-scheduler/operators/every-predicate-this.js
@@ -1,0 +1,26 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+  
+  var predicate = function(x) {
+    return x < 50;
+  }
+  
+  var testThis = {};
+
+  var oldEveryPredicateThisArgs = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate).every(predicate, testThis);
+  var newEveryPredicateThisArgs = RxNew.Observable.range(0, 25).every(predicate, testThis);
+  
+  return suite
+      .add('old every(predicate, thisArg) with immediate scheduler', function () {
+          oldEveryPredicateThisArgs.subscribe(_next, _error, _complete);
+      })
+      .add('new every(predicate, thisArg) with immediate scheduler', function () {
+          newEveryPredicateThisArgs.subscribe(_next, _error, _complete);
+      });
+
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};

--- a/perf/micro/immediate-scheduler/operators/every-predicate.js
+++ b/perf/micro/immediate-scheduler/operators/every-predicate.js
@@ -1,0 +1,24 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+  
+  var predicate = function(x) {
+    return x < 50;
+  }
+
+  var oldEveryPredicateArgs = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate).every(predicate);
+  var newEveryPredicateArgs = RxNew.Observable.range(0, 25).every(predicate);
+  
+  return suite
+      .add('old every(predicate) with immediate scheduler', function () {
+          oldEveryPredicateArgs.subscribe(_next, _error, _complete);
+      })
+      .add('new every(predicate) with immediate scheduler', function () {
+          newEveryPredicateArgs.subscribe(_next, _error, _complete);
+      });
+
+  function _next(x) { }
+  function _error(e){ }
+  function _complete(){ }
+};

--- a/spec/operators/every-spec.js
+++ b/spec/operators/every-spec.js
@@ -1,0 +1,96 @@
+/* globals describe, it, expect, expectObservable, hot */
+var Rx = require('../../dist/cjs/Rx');
+
+describe('Observable.prototype.every()', function() {
+  function truePredicate(x) {
+    return true;
+  }
+  
+  function predicate(x) {
+      return x % 5 === 0;
+  }
+  
+  it('should emit true if source is empty', function() {
+    var source = hot('-----|');
+    var expected =   '-----(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: true});
+  });
+  
+  it('should emit false if single source of element does not match with predicate', function() {
+    var source = hot('--a--|');
+    var expected =   '--(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: false});
+  });
+  
+  it('should emit false if none of element does not match with predicate', function() {
+    var source = hot('--a--b--c--d--e--|');
+    var expected =   '--(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: false});
+  });
+  
+  it('should return false if only some of element matches with predicate', function() {
+    var source = hot('--a--b--c--d--e--|', {a: 5, b: 10, c: 15});
+    var expected =   '-----------(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: false});
+  });
+  
+  it('should emit true if single source element match with predicate', function() {
+    var source = hot('--a--|', {a: 5});
+    var expected =   '-----(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: true});
+  });
+  
+  it('should emit true if all source element matches with predicate', function() {
+    var source = hot('--a--b--c--d--e--|', {a: 5, b: 10, c: 15, d: 20, e: 25});
+    var expected =   '-----------------(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: true});
+  });
+  
+  it('should raise error if source raises error', function() {
+    var source = hot('--#');
+    var expected =   '--#';
+    
+    expectObservable(source.every(truePredicate)).toBe(expected);
+  });
+  
+  it('should not completes if source never emits', function() {
+    var expected = '-';
+    
+    expectObservable(Rx.Observable.never().every(truePredicate)).toBe(expected);
+  });
+  
+  it('should emit true if source element matches with predicate after subscription', function() {
+    var source = hot('--z--^--a--b--c--d--e--|', {a: 5, b: 10, c: 15, d: 20, e: 25});
+    var expected =        '------------------(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: true});
+  });
+  
+  it('should emit false if source element does not match with predicate after subscription', function() {
+    var source = hot('--z--^--b--c--z--d--|', {a: 5, b: 10, c: 15, d: 20});
+    var expected =        '---------(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: false});
+  });
+  
+  it('should raise error if source raises error after subscription', function() {
+    var source = hot('--z--^--#');
+    var expected =        '---#';
+    
+    expectObservable(source.every(truePredicate)).toBe(expected);
+  });
+  
+  it('should emit true if source does not emit after subscription', function() {
+    var source = hot('--z--^-----|');
+    var expected =        '------(x|)';
+    
+    expectObservable(source.every(predicate)).toBe(expected, {x: true});
+  });
+  
+});

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -32,6 +32,7 @@ export interface CoreOperators<T> {
   groupBy?: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;
   ignoreElements?: () => Observable<T>;
   isEmpty?: () => Observable<boolean>;
+  every?: (predicate: (value: T, index:number) => boolean, thisArg?: any) => Observable<T>;
   last?: (predicate?: (value: T, index:number) => boolean, thisArg?: any, defaultValue?: any) => Observable<T>;
   map?: <T, R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
   mapTo?: <R>(value: R) => Observable<R>;

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -149,6 +149,9 @@ observableProto.groupBy = groupBy;
 import isEmpty from './operators/isEmpty';
 observableProto.isEmpty = isEmpty;
 
+import every from './operators/every';
+observableProto.every = every;
+
 import last from './operators/last';
 observableProto.last = last;
 

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -135,6 +135,9 @@ observableProto.ignoreElements = ignoreElements;
 import isEmpty from './operators/isEmpty';
 observableProto.isEmpty = isEmpty;
 
+import every from './operators/every';
+observableProto.every = every;
+
 import last from './operators/last';
 observableProto.last = last;
 

--- a/src/operators/every.ts
+++ b/src/operators/every.ts
@@ -1,0 +1,61 @@
+import Operator from '../Operator';
+import Observer from '../Observer';
+import Observable from '../Observable';
+import Subscriber from '../Subscriber';
+
+import tryCatch from '../util/tryCatch';
+import {errorObject} from '../util/errorObject';
+import bindCallback from '../util/bindCallback';
+
+export default function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>{
+  return this.lift(new EveryOperator(predicate, thisArg, this));
+}
+
+class EveryOperator<T, R> implements Operator<T, R> {
+  constructor(private predicate: (value: T, index: number, source: Observable<T>) => boolean, 
+    private thisArg?: any, private source?: Observable<T>) {
+    
+  }
+  
+  call(observer: Subscriber<R>): Subscriber<T> {
+    return new EverySubscriber(observer, this.predicate, this.thisArg, this.source);
+  }
+}
+
+class EverySubscriber<T> extends Subscriber<T> {
+  private predicate: Function = undefined;
+  private index: number = 0;
+  
+  constructor(destination: Observer<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean, 
+    private thisArg?: any, private source?: Observable<T>) {
+    super(destination);
+    
+    if(typeof predicate === 'function') {
+      this.predicate = bindCallback(predicate, thisArg, 3);
+    }
+  }
+  
+  private notifyComplete(everyValueMatch: boolean): void {
+    this.destination.next(everyValueMatch);
+    this.destination.complete();
+  }
+  
+  _next(value: T) {
+    const predicate = this.predicate;
+    
+    if (predicate === undefined) {
+      this.destination.error(new TypeError('predicate must be a function'));
+    }
+    
+    let result = tryCatch(predicate)(value, this.index++, this.source);
+    if (result === errorObject) {
+      this.destination.error(result.e);
+    } else if (!result) {
+      this.notifyComplete(false);
+    }
+  }
+  
+  _complete() {
+    this.notifyComplete(true);
+  }
+}


### PR DESCRIPTION
adding `every` operator.

Micro perf test shows noticeable slowness on new operator.

>old every(predicate) with immediate scheduler x 104,692 ops/sec ±1.20% (95 runs sampled)
>new every(predicate) with immediate scheduler x 87,236 ops/sec ±1.24% (90 runs sampled)
>        -16.67% slower than Rx2

>old every(predicate, thisArg) with immediate scheduler x 94,638 ops/sec ±1.37% (96 runs sampled)
>new every(predicate, thisArg) with immediate scheduler x 84,714 ops/sec ±0.53% (96 runs sampled)
>        -10.49% slower than Rx2

investigating root cause but not yet able to find it, created PR to share implementation to address mistake / errors that I'm missing.