### PR TITLE
refactor(isEmpty): move isEmpty under KitchenSink

### DIFF
--- a/spec/operators/isEmpty-spec.js
+++ b/spec/operators/isEmpty-spec.js
@@ -1,5 +1,5 @@
 /* globals describe, it, expect, expectObservable, hot */
-var Rx = require('../../dist/cjs/Rx');
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 
 describe('Observable.prototype.isEmpty()', function(){
   it('should return true if source is empty', function () {

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -31,7 +31,6 @@ export interface CoreOperators<T> {
   flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   groupBy?: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;
   ignoreElements?: () => Observable<T>;
-  isEmpty?: () => Observable<boolean>;
   last?: <R>(predicate?: (value: T, index:number) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T>;
   every?: (predicate: (value: T, index:number) => boolean, thisArg?: any) => Observable<T>;
   map?: <T, R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -3,6 +3,7 @@ import Operator from './Operator';
 import { CoreOperators } from './CoreOperators';
 
 interface KitchenSinkOperators<T> extends CoreOperators<T> {
+  isEmpty?: () => Observable<boolean>;
   elementAt?: (index: number, defaultValue?: any) => Observable<T>;
   distinctUntilKeyChanged?: (key: string, compare?: (x: any, y: any) => boolean, thisArg?: any) => Observable<T>;
   find?: (predicate: (value: T, index: number, source:Observable<T>) => boolean, thisArg?: any) => Observable<T>;
@@ -152,7 +153,7 @@ observableProto.groupBy = groupBy;
 import ignoreElements from './operators/ignoreElements';
 observableProto.ignoreElements = ignoreElements;
 
-import isEmpty from './operators/isEmpty';
+import isEmpty from './operators/extended/isEmpty';
 observableProto.isEmpty = isEmpty;
 
 import every from './operators/every';

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -132,9 +132,6 @@ observableProto.groupBy = groupBy;
 import ignoreElements from './operators/ignoreElements';
 observableProto.ignoreElements = ignoreElements;
 
-import isEmpty from './operators/isEmpty';
-observableProto.isEmpty = isEmpty;
-
 import every from './operators/every';
 observableProto.every = every;
 

--- a/src/operators/extended/isEmpty.ts
+++ b/src/operators/extended/isEmpty.ts
@@ -1,6 +1,6 @@
-import Operator from '../Operator';
-import Observable from '../Observable';
-import Subscriber from '../Subscriber';
+import Operator from '../../Operator';
+import Observable from '../../Observable';
+import Subscriber from '../../Subscriber';
 
 export default function isEmpty() {
   return this.lift(new IsEmptyOperator());


### PR DESCRIPTION
Try to close https://github.com/ReactiveX/RxJS/issues/433 by moving under `KitchenSink`.