### PR TITLE
improving perf for mapping over ArrayObservable and ScalarObservables

### DIFF
--- a/perf/micro/immediate-scheduler/operators/map-array.js
+++ b/perf/micro/immediate-scheduler/operators/map-array.js
@@ -1,0 +1,27 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+
+    var oldSelectWithImmediateScheduler = RxOld.Observable.fromArray([1,2,3,4,5,6,7,8,9,10], RxOld.Scheduler.immediate).map(square).map(double);
+    var newSelectWithImmediateScheduler = RxNew.Observable.of(1,2,3,4,5,6,7,8,9,10).map(square).map(double);
+
+    return suite
+        .add('old map of array with immediate scheduler', function () {
+            oldSelectWithImmediateScheduler.subscribe(_next, _error, _complete);
+        })
+        .add('new map of array with immediate scheduler', function () {
+            newSelectWithImmediateScheduler.subscribe(_next, _error, _complete);
+        });
+
+    function square(x) {
+        return x * x;
+    }
+
+    function double(x) {
+        return x + x;
+    }
+    function _next(x) { }
+    function _error(e){ }
+    function _complete(){ }
+};

--- a/perf/micro/immediate-scheduler/operators/map-scalar.js
+++ b/perf/micro/immediate-scheduler/operators/map-scalar.js
@@ -1,0 +1,27 @@
+var RxOld = require("rx");
+var RxNew = require("../../../../index");
+
+module.exports = function (suite) {
+
+    var oldSelectWithImmediateScheduler = RxOld.Observable.just(2, RxOld.Scheduler.immediate).map(square).map(double);
+    var newSelectWithImmediateScheduler = RxNew.Observable.of(2).map(square).map(double);
+
+    return suite
+        .add('old map of scalar with immediate scheduler', function () {
+            oldSelectWithImmediateScheduler.subscribe(_next, _error, _complete);
+        })
+        .add('new map of scalar with immediate scheduler', function () {
+            newSelectWithImmediateScheduler.subscribe(_next, _error, _complete);
+        });
+
+    function square(x) {
+        return x * x;
+    }
+
+    function double(x) {
+        return x + x;
+    }
+    function _next(x) { }
+    function _error(e){ }
+    function _complete(){ }
+};

--- a/spec/operators/catch-spec.js
+++ b/spec/operators/catch-spec.js
@@ -18,7 +18,12 @@ describe('Observable.prototype.catch()', function () {
   
   it('should catch the error and allow the return of a new observable to use', function (done) {
     var expected = [1, 2, 'foo'];
-    Observable.of(1, 2, 3)
+    Observable.create(function(observer) {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.complete();
+    })
       .map(function (n) {
         if (n === 3) {
           throw 'bad';
@@ -40,7 +45,12 @@ describe('Observable.prototype.catch()', function () {
   it('should catch and allow the observable to be repeated with the third (caught) argument', function (done) {
     var expected = [1, 2, 1, 2, 1, 2];
     var retries = 0;
-    Observable.of(1, 2, 3)
+    Observable.create(function(observer) {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.complete();
+    })
       .map(function (n) {
         if (n === 3) {
           throw 'bad';
@@ -65,7 +75,12 @@ describe('Observable.prototype.catch()', function () {
   
   it('should complete if you return Observable.empty()', function (done) {
     var expected = [1, 2];
-    Observable.of(1, 2, 3)
+    Observable.create(function(observer) {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.complete();
+    })
       .map(function (n) {
         if (n === 3) {
           throw 'bad';
@@ -87,7 +102,12 @@ describe('Observable.prototype.catch()', function () {
   
   it('should error if you return Observable.throw()', function (done) {
     var expected = [1, 2];
-    Observable.of(1, 2, 3)
+    Observable.create(function(observer) {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.complete();
+    })
       .map(function (n) {
         if (n === 3) {
           throw 'bad';

--- a/spec/operators/materialize-spec.js
+++ b/spec/operators/materialize-spec.js
@@ -12,7 +12,12 @@ describe('Observable.prototype.materialize()', function () {
       Notification.createComplete()
     ];
     
-    Observable.of(1, 2, 3)
+    Observable.create(function(observer) {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.complete();
+    })
       .materialize()
       .subscribe(function (n) {
         expect(n instanceof Notification).toBe(true);
@@ -28,7 +33,13 @@ describe('Observable.prototype.materialize()', function () {
       Notification.createError('booooo')
     ];
     
-    Observable.of(1, 2, 3, 4)
+    Observable.create(function(observer) {
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.next(4);
+      observer.complete();
+    })
       .map(function (x) {
         if (x === 4) {
           throw 'booooo';

--- a/spec/operators/retry-spec.js
+++ b/spec/operators/retry-spec.js
@@ -6,7 +6,10 @@ describe('Observable.prototype.retry()', function () {
   it('should retry a number of times, without error, then complete', function (done) {
     var errors = 0;
     var retries = 2;
-    Observable.of(42)
+    Observable.create(function(observer) {
+      observer.next(42);
+      observer.complete();
+    })
       .map(function(x){
         if ((errors+=1) < retries){
           throw 'bad';
@@ -26,7 +29,10 @@ describe('Observable.prototype.retry()', function () {
   it('should retry a number of times, then call error handler', function (done) {
     var errors = 0;
     var retries = 2;
-    Observable.of(42)
+    Observable.create(function(observer) {
+      observer.next(42);
+      observer.complete();
+    })
       .map(function(x){
         if ((errors+=1) < retries){
           throw 'bad';
@@ -48,7 +54,10 @@ describe('Observable.prototype.retry()', function () {
   it('should retry until successful completion', function (done) {
     var errors = 0;
     var retries = 10;
-    Observable.of(42)
+    Observable.create(function(observer) {
+      observer.next(42);
+      observer.complete();
+    })
       .map(function(x){
         if ((errors+=1) < retries){
           throw 'bad';

--- a/src/operators/map.ts
+++ b/src/operators/map.ts
@@ -19,7 +19,16 @@ import bindCallback from '../util/bindCallback';
  */
 export default function map<T, R>(project: (x: T, ix?: number) => R, thisArg?: any): Observable<R> {
   const source = this;
-  if(source._isScalar) {
+  if(source instanceof ArrayObservable) {
+    const array = source.array;
+    let result = tryCatch((array, project, thisArg) => array.map(project, thisArg))(array, project, thisArg);
+    if(result === errorObject) {
+      return new ErrorObservable(result.e, source.scheduler);
+    } else {
+      return new ArrayObservable(result, source.scheduler);
+    }
+  }
+  else if(source._isScalar) {
     let result = tryCatch(bindCallback(project, thisArg, 2))(source.value, 0);
     if(result === errorObject) {
       return new ErrorObservable(result.e, source.scheduler);

--- a/src/operators/map.ts
+++ b/src/operators/map.ts
@@ -2,7 +2,9 @@ import Operator from '../Operator';
 import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
-
+import ScalarObservable from '../observables/ScalarObservable';
+import ArrayObservable from '../observables/ArrayObservable';
+import ErrorObservable from '../observables/ErrorObservable';
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import bindCallback from '../util/bindCallback';
@@ -16,7 +18,16 @@ import bindCallback from '../util/bindCallback';
  * @returns {Observable} a observable of projected values
  */
 export default function map<T, R>(project: (x: T, ix?: number) => R, thisArg?: any): Observable<R> {
-  return this.lift(new MapOperator(project, thisArg));
+  const source = this;
+  if(source._isScalar) {
+    let result = tryCatch(bindCallback(project, thisArg, 2))(source.value, 0);
+    if(result === errorObject) {
+      return new ErrorObservable(result.e, source.scheduler);
+    } else {
+      return new ScalarObservable(result, source.scheduler);
+    }
+  }
+  return source.lift(new MapOperator(project, thisArg));
 }
 
 class MapOperator<T, R> implements Operator<T, R> {


### PR DESCRIPTION
For mapping over scalar observables:

was

> old map of scalar with immediate scheduler x 648,735 ops/sec ±0.54% (94 runs sampled)
> new map of scalar with immediate scheduler x 1,329,174 ops/sec ±1.32% (94 runs sampled)
>	104.89% faster than Rx2

now

> old map of scalar with immediate scheduler x 632,782 ops/sec ±0.69% (94 runs sampled)
> new map of scalar with immediate scheduler x 4,032,053 ops/sec ±0.52% (95 runs sampled)
>	537.19% faster than Rx2

For mapping over array observables:

was

> old map of array with immediate scheduler x 147,364 ops/sec ±0.79% (91 runs sampled)
> new map of array with immediate scheduler x 267,194 ops/sec ±0.65% (94 runs sampled)
> 	81.32% faster than Rx2

now

> old map of array with immediate scheduler x 143,522 ops/sec ±1.18% (94 runs sampled)
> new map of array with immediate scheduler x 1,063,957 ops/sec ±0.63% (96 runs sampled)
>	641.32% faster than Rx2