### PR TITLE
refactor(test): print out failure occurs from micro perf test

### DIFF
--- a/perf/micro/index.js
+++ b/perf/micro/index.js
@@ -58,4 +58,10 @@ Observable.create(function(observer) {
         return cycles.merge(complete).take(tests.length + 1);
     });
 })
-.subscribe(console.log.bind(console));
+.subscribe(console.log.bind(console), function(err) {
+    if (err.stack === undefined) {
+      console.log(err);
+    } else {
+      console.log(err.stack); 
+    }
+  });


### PR DESCRIPTION
Found out while working on https://github.com/ReactiveX/RxJS/pull/431, micro perf test runner silently terminates if some of test case fail and throw. Prints out stack trace (if available) or error to allow easier failure trace.

*After*
![micro-fail-output](https://cloud.githubusercontent.com/assets/1210596/10241305/0198c320-689c-11e5-920e-58f049070bff.png)
