### PR TITLE
fix(VirtualTimeScheduler): ignore negative delays

### DIFF
--- a/src/schedulers/VirtualTimeScheduler.ts
+++ b/src/schedulers/VirtualTimeScheduler.ts
@@ -34,14 +34,11 @@ export default class VirtualTimeScheduler implements Scheduler {
   }
   
   addAction<T>(action: Action) {
-    const findDelay = action.delay;
+    if (action.delay < 0) {
+      return;
+    }
     const actions = this.actions;
-    const len = actions.length;
-    const vaction = <VirtualAction<T>>action;
-    
-    
     actions.push(action);
-    
     actions.sort((a:VirtualAction<T>, b:VirtualAction<T>) => {
       return (a.delay === b.delay) ? (a.index === b.index ? 0 : (a.index > b.index ? 1 : -1)) : (a.delay > b.delay ? 1 : -1);
     });


### PR DESCRIPTION
Fix the VirtualTimeScheduler to ignore scheduled actions that have
a negative `delay`. There seems to no reason to schedule these, and all
tests still pass.

In addition, it allows us to do this in tests:
```js
    var source = hot('-1--2--^-3-4-5-6--7-8--9--|');

    var invoked = 0;
    var predicate = function (x) {
      invoked++;
      return isPrime(x);
    };

    source.filter(predicate)
      .subscribe(null, null, function () {
        expect(invoked).toEqual(7); // <---- this here
      });
```