### PR TITLE
test(switch): add more tests for switch

### DIFF
--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -32,7 +32,14 @@ global.expectObservable = function () {
   if (!global.rxTestScheduler) {
     throw 'tried to use expectObservable() in async test';
   }
-  return global.rxTestScheduler.expect.apply(global.rxTestScheduler, arguments);
+  return global.rxTestScheduler.expectObservable.apply(global.rxTestScheduler, arguments);
+};
+
+global.expectSubscriptions = function () {
+  if (!global.rxTestScheduler) {
+    throw 'tried to use expectSubscriptions() in async test';
+  }
+  return global.rxTestScheduler.expectSubscriptions.apply(global.rxTestScheduler, arguments);
 };
 
 var glit = global.it;

--- a/spec/operators/bufferTime-spec.js
+++ b/spec/operators/bufferTime-spec.js
@@ -59,7 +59,7 @@ describe('Observable.prototype.bufferTime', function () {
     var values = {
       w: ['a','b']
     };
-    var e1 =   hot('---a---b---c---#---e---f---g---|');
+    var e1 =   hot('---a---b---c---#');
     var expected = '----------w----#';
 
     expectObservable(e1.bufferTime(100, null, rxTestScheduler)).toBe(expected, values);

--- a/spec/operators/merge-map-spec.js
+++ b/spec/operators/merge-map-spec.js
@@ -137,12 +137,17 @@ describe('Observable.prototype.mergeMap()', function () {
 
   it('should mergeMap many outer values to many inner values', function () {
     var values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
-    var e1 =    hot('-a-------b-------c-------d-------|');
-    var inner = cold('----i---j---k---l---|', values);
-    var expected =  '-----i---j---(ki)(lj)(ki)(lj)(ki)(lj)k---l---|';
+    var e1 =     hot('-a-------b-------c-------d-------|');
+    var inner =  cold('----i---j---k---l---|', values);
+    var innersubs = ['-^-------------------!',
+                     '---------^-------------------!',
+                     '-----------------^-------------------!',
+                     '-------------------------^-------------------!'];
+    var expected =   '-----i---j---(ki)(lj)(ki)(lj)(ki)(lj)k---l---|';
 
     expectObservable(e1.mergeMap(function (value) { return inner; }))
       .toBe(expected, values);
+    expectSubscriptions(inner.subscriptions).toBe(innersubs);
   });
 
   it('should mergeMap many outer to many inner, complete late', function () {

--- a/spec/operators/switch-spec.js
+++ b/spec/operators/switch-spec.js
@@ -47,10 +47,14 @@ describe('Observable.prototype.switch()', function () {
 
   it('should handle a hot observable of observables', function () {
     var x = cold(        '--a---b---c--|');
+    var xsubs =    '------^-------!';
     var y = cold(                '---d--e---f---|');
+    var ysubs =    '--------------^-------------!';
     var e1 = hot(  '------x-------y------|', { x: x, y: y });
     var expected = '--------a---b----d--e---f---|';
     expectObservable(e1.switch()).toBe(expected);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
 
   it('should handle an observable of promises', function (done) {

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -309,7 +309,7 @@ import nextTick from './schedulers/nextTick';
 import immediate from './schedulers/immediate';
 import NextTickScheduler from './schedulers/NextTickScheduler';
 import ImmediateScheduler from './schedulers/ImmediateScheduler';
-import TestScheduler from './schedulers/TestScheduler';
+import {TestScheduler} from './testing/TestScheduler';
 import VirtualTimeScheduler from './schedulers/VirtualTimeScheduler';
 
 var Scheduler = {

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -42,7 +42,7 @@ export default class Subject<T> extends Observable<T> implements Observer<T>, Su
     return subject;
   }
 
-  _subscribe(subscriber: Observer<any>) : Subscription<T> {
+  _subscribe(subscriber: Subscriber<any>) : Subscription<T> {
 
     if (subscriber.isUnsubscribed) {
       return;

--- a/src/schedulers/VirtualTimeScheduler.ts
+++ b/src/schedulers/VirtualTimeScheduler.ts
@@ -14,7 +14,7 @@ export default class VirtualTimeScheduler implements Scheduler {
   protected static frameTimeFactor: number = 10;
 
   now() {
-    return this.frame * VirtualTimeScheduler.frameTimeFactor;
+    return this.frame;
   }
 
   flush() {

--- a/src/testing/ColdObservable.ts
+++ b/src/testing/ColdObservable.ts
@@ -1,0 +1,42 @@
+import Observable from '../Observable';
+import Subscription from '../Subscription';
+import Scheduler from '../Scheduler';
+import TestMessage from './TestMessage';
+import SubscriptionLog from './SubscriptionLog';
+import SubscriptionLoggable from './SubscriptionLoggable';
+import applyMixins from '../util/applyMixins';
+
+export default class ColdObservable<T> extends Observable<T> implements SubscriptionLoggable {
+  public subscriptions: SubscriptionLog[] = [];
+  scheduler: Scheduler;
+  logSubscribedFrame: () => number;
+  logUnsubscribedFrame: (index: number) => void;
+
+  constructor(private messages: TestMessage[],
+              scheduler: Scheduler) {
+    super(function (subscriber) {
+      const observable: ColdObservable<T> = this;
+      const index = observable.logSubscribedFrame();
+      subscriber.add(new Subscription(() => {
+        observable.logUnsubscribedFrame(index);
+      }));
+      observable.scheduleMessages(subscriber);
+      return subscriber;
+    });
+    this.scheduler = scheduler;
+  }
+
+  scheduleMessages(subscriber) {
+    const messagesLength = this.messages.length;
+    for (let i = 0; i < messagesLength; i++) {
+      const message = this.messages[i];
+      subscriber.add(
+        this.scheduler.schedule(
+          () => { message.notification.observe(subscriber); },
+          message.frame
+        )
+      );
+    }
+  }
+}
+applyMixins(ColdObservable, [SubscriptionLoggable]);

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -1,0 +1,44 @@
+import Subject from '../Subject';
+import Subscriber from './Subscriber';
+import Subscription from '../Subscription';
+import Scheduler from '../Scheduler';
+import TestMessage from './TestMessage';
+import SubscriptionLog from './SubscriptionLog';
+import SubscriptionLoggable from './SubscriptionLoggable';
+import applyMixins from '../util/applyMixins';
+
+export default class HotObservable<T> extends Subject<T> implements SubscriptionLoggable {
+  public subscriptions: SubscriptionLog[] = [];
+  scheduler: Scheduler;
+  logSubscribedFrame: () => number;
+  logUnsubscribedFrame: (index: number) => void;
+
+  constructor(private messages: TestMessage[],
+              scheduler: Scheduler) {
+    super();
+    this.scheduler = scheduler;
+  }
+
+  _subscribe(subscriber: Subscriber<any>): Subscription<T> {
+    const subject: HotObservable<T> = this;
+    const index = subject.logSubscribedFrame();
+    subscriber.add(new Subscription(() => {
+      subject.logUnsubscribedFrame(index);
+    }));
+    return super._subscribe(subscriber);
+  }
+
+  setup() {
+    const subject = this;
+    const messagesLength = subject.messages.length;
+    for (let i = 0; i < messagesLength; i++) {
+      const message = subject.messages[i];
+      this.scheduler.schedule(
+        () => { message.notification.observe(subject); },
+        message.frame
+      );
+    }
+  }
+}
+applyMixins(HotObservable, [SubscriptionLoggable]);
+

--- a/src/testing/SubscriptionLog.ts
+++ b/src/testing/SubscriptionLog.ts
@@ -1,18 +1,5 @@
 export default class SubscriptionLog {
-  private _subscribedFrame: number;
-  private _unsubscribedFrame: number;
-
-  get subscribedFrame(): number {
-    return this._subscribedFrame;
-  }
-
-  get unsubscribedFrame(): number {
-    return this._unsubscribedFrame;
-  }
-
-  constructor(subscribedFrame: number,
-              unsubscribedFrame: number = Number.POSITIVE_INFINITY) {
-    this._subscribedFrame = subscribedFrame;
-    this._unsubscribedFrame = unsubscribedFrame;
+  constructor(public subscribedFrame: number,
+              public unsubscribedFrame: number = Number.POSITIVE_INFINITY) {
   }
 }

--- a/src/testing/SubscriptionLog.ts
+++ b/src/testing/SubscriptionLog.ts
@@ -1,0 +1,18 @@
+export default class SubscriptionLog {
+  private _subscribedFrame: number;
+  private _unsubscribedFrame: number;
+
+  get subscribedFrame(): number {
+    return this._subscribedFrame;
+  }
+
+  get unsubscribedFrame(): number {
+    return this._unsubscribedFrame;
+  }
+
+  constructor(subscribedFrame: number,
+              unsubscribedFrame: number = Number.POSITIVE_INFINITY) {
+    this._subscribedFrame = subscribedFrame;
+    this._unsubscribedFrame = unsubscribedFrame;
+  }
+}

--- a/src/testing/SubscriptionLoggable.ts
+++ b/src/testing/SubscriptionLoggable.ts
@@ -1,0 +1,22 @@
+import Scheduler from '../Scheduler';
+import SubscriptionLog from './SubscriptionLog';
+
+export default class SubscriptionLoggable {
+  public subscriptions: SubscriptionLog[] = [];
+  scheduler: Scheduler;
+
+  logSubscribedFrame(): number {
+    this.subscriptions.push(new SubscriptionLog(this.scheduler.now()));
+    return this.subscriptions.length - 1;
+  }
+
+  logUnsubscribedFrame(index: number) {
+    const subscriptionLogs = this.subscriptions;
+    const oldSubscriptionLog = subscriptionLogs[index];
+    subscriptionLogs[index] = new SubscriptionLog(
+      oldSubscriptionLog.subscribedFrame,
+      this.scheduler.now()
+    );
+  }
+}
+

--- a/src/testing/TestMessage.ts
+++ b/src/testing/TestMessage.ts
@@ -1,0 +1,8 @@
+import Notification from '../Notification';
+
+interface TestMessage {
+  frame: number;
+  notification: Notification<any>;
+}
+
+export default TestMessage;

--- a/src/util/applyMixins.ts
+++ b/src/util/applyMixins.ts
@@ -1,0 +1,10 @@
+export default function applyMixins(derivedCtor: any, baseCtors: any[]) {
+  for (let i = 0, len = baseCtors.length; i < len; i++) {
+    const baseCtor = baseCtors[i];
+    const propertyKeys = Object.getOwnPropertyNames(baseCtor.prototype);
+    for (let j = 0, len2 = propertyKeys.length; j < len2; j++) {
+      const name = propertyKeys[j];
+      derivedCtor.prototype[name] = baseCtor.prototype[name];
+    }
+  }
+}


### PR DESCRIPTION
Add more marble diagram tests for switch() and switchMap() operators,
specially including subscription marble diagrams.

**This PR depends on PR #466. Merge that one before.** Merging that before will also change the diff you see for this PR.

Resolves #388.