### PR TITLE
refactor(build): use closure compiler to generate global output

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build_amd": "rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5",
     "build_cjs": "rm -rf dist/cjs && babel dist/es6 --out-dir dist/cjs --modules common --sourceMaps --loose all",
     "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts src/Rx.KitchenSink.ts --outDir dist/es6 --target ES6 -d",
-    "build_global": "rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && \"./node_modules/.bin/uglifyjs\" ./dist/global/Rx.js --source-map ./dist/global/Rx.min.js.map --screw-ie8 -o ./dist/global/Rx.min.js",
+    "build_closure": "java -jar ./node_modules/google-closure-compiler/compiler.jar ./dist/global/Rx.js --create_source_map ./dist/global/Rx.min.js.map --js_output_file ./dist/global/Rx.min.js",
+    "build_global": "rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && npm run build_closure",
     "build_perf": "npm run build_es6 && npm run build_cjs && npm run build_global && webdriver-manager update && npm run perf",
     "build_test": "rm -rf dist/ && npm run build_es6 && npm run build_cjs && jasmine && npm run lint",
     "build_docs": "./docgen.sh",
@@ -70,6 +71,7 @@
     "esdoc": "^0.2.5",
     "eslint": "^1.5.1",
     "glob": "^5.0.14",
+    "google-closure-compiler": "^20150920.0.0",
     "http-server": "^0.8.0",
     "jasmine": "^2.3.1",
     "jasmine-core": "^2.2.0",
@@ -79,8 +81,7 @@
     "protractor": "2.2.0",
     "rx": "^4.0.0",
     "tslint": "^2.5.0",
-    "typescript": "^1.7.0-dev.20150901",
-    "uglifyjs": "^2.4.10"
+    "typescript": "^1.7.0-dev.20150901"
   },
   "engines": {
     "npm": "~2.0.0"


### PR DESCRIPTION
Tried to create changes for https://github.com/ReactiveX/RxJS/issues/470.

* Uses [google-closure-compiler](https://www.npmjs.com/package/google-closure-compiler) package, requires JRE to be installed to execute `build_global`.
* Simply replacing `uglifyjs` to `closure` to generate output with source map, does not apply any other compilation options.

Not sure if this is feasible change for issue, trying to leverage as starting point. 
Generated size from closure is about 160kb, uglify does about 280kb. (except source map)
