### PR TITLE
fix(TestScheduler): stop sorting actual results

### DIFF
--- a/spec/operators/merge-map-spec.js
+++ b/spec/operators/merge-map-spec.js
@@ -1,8 +1,25 @@
+/* globals expectObservable, cold, hot, describe, it, expect */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 var Promise = require('promise');
 
 describe('Observable.prototype.mergeMap()', function () {
+  it('should mergeMap many regular interval inners', function () {
+    var a =   cold('----a---a---a---(a|)'                    );
+    var b =   cold(    '----b---b---(b|)'                    );
+    var c =   cold(                '----c---c---c---c---(c|)');
+    var d =   cold(                        '----(d|)'        );
+    var e1 =   hot('a---b-----------c-------d-------|'       );
+    var expected = '----a---(ab)(ab)(ab)c---c---(cd)c---(c|)';
+
+    var observableLookup = { a: a, b: b, c: c, d: d };
+    var source = e1.mergeMap(function (value) {
+      return observableLookup[value];
+    });
+
+    expectObservable(source).toBe(expected);
+  });
+
   it('should map values to constant resolved promises and merge', function (done) {
     var source = Rx.Observable.from([4,3,2,1]);
     var project = function (value) {

--- a/src/testing/ColdObservable.ts
+++ b/src/testing/ColdObservable.ts
@@ -29,12 +29,11 @@ export default class ColdObservable<T> extends Observable<T> implements Subscrip
   scheduleMessages(subscriber) {
     const messagesLength = this.messages.length;
     for (let i = 0; i < messagesLength; i++) {
-      const message = this.messages[i];
+      let message = this.messages[i];
       subscriber.add(
-        this.scheduler.schedule(
-          () => { message.notification.observe(subscriber); },
-          message.frame
-        )
+        this.scheduler.schedule(({message, subscriber}) => { message.notification.observe(subscriber); },
+          message.frame,
+          {message, subscriber})
       );
     }
   }

--- a/src/testing/TestScheduler.ts
+++ b/src/testing/TestScheduler.ts
@@ -100,7 +100,6 @@ export class TestScheduler extends VirtualTimeScheduler {
     const readyFlushTests = this.flushTests.filter(test => test.ready);
     while (readyFlushTests.length > 0) {
       let test = readyFlushTests.shift();
-      test.actual.sort((a, b) => a.frame === b.frame ? 0 : (a.frame > b.frame ? 1 : -1));
       this.assertDeepEqual(test.actual, test.expected);
     }
   }


### PR DESCRIPTION
- fixes an issue where actual results were being sorted when they should not have been
- ensures rescheduled Actions will be added to subscription and torn down when appropriate
- uses state to convey notification information to action work function rather than closure

closes #422