### PR TITLE
groupBy fixes and tests

### DIFF
--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -56,6 +56,21 @@ global.it = function (description, cb, timeout) {
   }
 };
 
+function stringify(x) {
+  return JSON.stringify(x, function (key, value) {
+    if (Array.isArray(value)) {
+      return '[' + value
+        .map(function (i) {
+          return '\n\t' + stringify(i);
+        }) + '\n]';
+    }
+    return value;
+  })
+  .replace(/\\"/g, '"')
+  .replace(/\\t/g, '\t')
+  .replace(/\\n/g, '\n');
+}
+
 beforeEach(function () {
   jasmine.addMatchers({
     toDeepEqual: function (util, customEqualityTesters) {
@@ -66,11 +81,11 @@ beforeEach(function () {
           if (!result.pass && Array.isArray(actual) && Array.isArray(expected)) {
             result.message = 'Expected \n';
             actual.forEach(function (x) {
-              result.message += JSON.stringify(x) + '\n';
+              result.message += stringify(x) + '\n';
             });
             result.message += '\nto deep equal \n';
             expected.forEach(function (x) {
-              result.message += JSON.stringify(x) + '\n';
+              result.message += stringify(x) + '\n';
             });
           }
 

--- a/spec/operators/groupBy-spec.js
+++ b/spec/operators/groupBy-spec.js
@@ -1,8 +1,23 @@
 /* globals describe, it, expect */
-var Rx = require('../../dist/cjs/Rx');
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var Observable = Rx.Observable;
+var GroupedObservable = require('../../dist/cjs/operators/groupBy-support').GroupedObservable;
 
 describe('Observable.prototype.groupBy()', function () {
+  function reverseString(str) {
+    return str.split('').reverse().join('');
+  }
+
+  function mapObject(obj, fn) {
+    var out = {};
+    for (var p in obj) {
+      if (obj.hasOwnProperty(p)) {
+        out[p] = fn(obj[p]);
+      }
+    }
+    return out;
+  }
+
   it('should group values', function (done) {
     var expectedGroups = [
       { key: 1, values: [1, 3] },
@@ -60,5 +75,450 @@ describe('Observable.prototype.groupBy()', function () {
           expect(x).toBe(expectedGroup.values.shift());
         });
       }, null, done);
+  });
+
+  it('should group values with a key comparer', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--w---x---y-z-------------|';
+    var w = cold(         'a-b---d---------i-----l-|', values);
+    var x = cold(             'c-------g-h---------|', values);
+    var y = cold(                 'e---------j-k---|', values);
+    var z = cold(                   'f-------------|', values);
+    var expectedValues = { w: w, x: x, y: y, z: z };
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should emit GroupObservables', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO '
+    };
+    var e1 = hot('-1--2--^-a-b----|', values);
+    var expected =      '--g------|';
+    var expectedValues = { g: 'foo' };
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); })
+      .do(function (group) {
+        expect(group.key).toBe('foo');
+        expect(group instanceof GroupedObservable).toBe(true);
+      })
+      .map(function (group) { return group.key; });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should group values with a key comparer, assert GroupSubject key', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--w---x---y-z-------------|';
+    var expectedValues = { w: 'foo', x: 'bar', y: 'baz', z: 'qux' };
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); })
+      .map(function (g) { return g.key; });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should group values with a key comparer, but outer throws', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-#', values);
+    var expected =      '--w---x---y-z-------------#';
+    var expectedValues = { w: 'foo', x: 'bar', y: 'baz', z: 'qux' };
+
+    var source = e1
+      .groupBy(function (x) { return x.toLowerCase().trim(); })
+      .map(function (g) { return g.key; });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should group values with a key comparer, inners propagate error from outer', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-#', values);
+    var expected =      '--w---x---y-z-------------#';
+    var w = cold(         'a-b---d---------i-----l-#', values);
+    var x = cold(             'c-------g-h---------#', values);
+    var y = cold(                 'e---------j-k---#', values);
+    var z = cold(                   'f-------------#', values);
+    var expectedValues = { w: w, x: x, y: y, z: z };
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should allow outer to be unsubscribed early', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var unsub =         '           !';
+    var expected =      '--w---x---y-';
+    var expectedValues = { w: 'foo', x: 'bar', y: 'baz' };
+
+    var source = e1
+      .groupBy(function (x) { return x.toLowerCase().trim(); })
+      .map(function (group) { return group.key; });
+    expectObservable(source, unsub).toBe(expected, expectedValues);
+  });
+
+  it('should group values with a key comparer, but comparer throws', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--w---x---y-z-------#';
+    var w = cold(         'a-b---d---------i-#', values);
+    var x = cold(             'c-------g-h---#', values);
+    var y = cold(                 'e---------#', values);
+    var z = cold(                   'f-------#', values);
+    var expectedValues = { w: w, x: x, y: y, z: z };
+
+    var invoked = 0;
+    var source = e1
+      .groupBy(function (val) {
+        invoked++;
+        if (invoked === 10) {
+          throw 'error';
+        }
+        return val.toLowerCase().trim();
+      });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should group values with a key comparer and elementSelector, ' +
+    'but elementSelector throws',
+  function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var reversedValues = mapObject(values, reverseString);
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--w---x---y-z-------#';
+    var w = cold(         'a-b---d---------i-#', reversedValues);
+    var x = cold(             'c-------g-h---#', reversedValues);
+    var y = cold(                 'e---------#', reversedValues);
+    var z = cold(                   'f-------#', reversedValues);
+    var expectedValues = { w: w, x: x, y: y, z: z };
+
+    var invoked = 0;
+    var source = e1
+      .groupBy(function (val) {
+        return val.toLowerCase().trim();
+      }, function (val) {
+        invoked++;
+        if (invoked === 10) {
+          throw 'error';
+        }
+        return reverseString(val);
+      });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should allow the outer to be unsubscribed early but inners continue', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var unsub =         '         !';
+    var expected =      '--w---x---';
+    var w = cold(         'a-b---d---------i-----l-|', values);
+    var x = cold(             'c-------g-h---------|', values);
+    var expectedValues = { w: w, x: x };
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); });
+    expectObservable(source, unsub).toBe(expected, expectedValues);
+  });
+
+  it('should allow an inner to be unsubscribed early but other inners continue', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--w---x---y-z-------------|';
+    var w =             '--a-b---d-';
+    var unsubw =        '         !';
+    var x =             '------c-------g-h---------|';
+    var y =             '----------e---------j-k---|';
+    var z =             '------------f-------------|';
+
+    var expectedGroups = {
+      w: Rx.TestScheduler.parseMarbles(w, values),
+      x: Rx.TestScheduler.parseMarbles(x, values),
+      y: Rx.TestScheduler.parseMarbles(y, values),
+      z: Rx.TestScheduler.parseMarbles(z, values)
+    };
+
+    var fooUnsubscriptionFrame = Rx.TestScheduler.getUnsubscriptionFrame(unsubw);
+
+    var source = e1
+      .groupBy(function (val) {
+        return val.toLowerCase().trim();
+      })
+      .map(function (group) {
+        var arr = [];
+
+        var subscription = group
+          .materialize()
+          .map(function (notification) {
+            return { frame: rxTestScheduler.frame, notification: notification };
+          })
+          .subscribe(function (value) {
+            arr.push(value);
+          });
+
+        if (group.key === 'foo') {
+          rxTestScheduler.schedule(function () {
+            subscription.unsubscribe();
+          }, fooUnsubscriptionFrame - rxTestScheduler.frame);
+        }
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, expectedGroups);
+  });
+
+  it('should allow inners to be unsubscribed early at different times', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--w---x---y-z-------------|';
+    var w =             '--a-b---d-';
+    var unsubw =        '         !';
+    var x =             '------c------';
+    var unsubx =        '            !';
+    var y =             '----------e------';
+    var unsuby =        '                !';
+    var z =             '------------f-------';
+    var unsubz =        '                   !';
+
+    var expectedGroups = {
+      w: Rx.TestScheduler.parseMarbles(w, values),
+      x: Rx.TestScheduler.parseMarbles(x, values),
+      y: Rx.TestScheduler.parseMarbles(y, values),
+      z: Rx.TestScheduler.parseMarbles(z, values)
+    };
+
+    var unsubscriptionFrames = {
+      foo: Rx.TestScheduler.getUnsubscriptionFrame(unsubw),
+      bar: Rx.TestScheduler.getUnsubscriptionFrame(unsubx),
+      baz: Rx.TestScheduler.getUnsubscriptionFrame(unsuby),
+      qux: Rx.TestScheduler.getUnsubscriptionFrame(unsubz)
+    };
+
+    var source = e1
+      .groupBy(function (val) {
+        return val.toLowerCase().trim();
+      })
+      .map(function (group) {
+        var arr = [];
+
+        var subscription = group
+          .materialize()
+          .map(function (notification) {
+            return { frame: rxTestScheduler.frame, notification: notification };
+          })
+          .subscribe(function (value) {
+            arr.push(value);
+          });
+
+        rxTestScheduler.schedule(function () {
+          subscription.unsubscribe();
+        }, unsubscriptionFrames[group.key] - rxTestScheduler.frame);
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, expectedGroups);
+  });
+
+  it('should allow subscribing late to an inner Observable, outer completes', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      d: 'foO ',
+      i: 'FOO ',
+      l: '    fOo    '
+    };
+    var e1 = hot(  '--a-b---d---------i-----l-|', values);
+    var subs =     '^                         !';
+    var expected = '----------------------------|';
+
+    e1.groupBy(function (val) { return val.toLowerCase().trim(); })
+      .subscribe(function (group) {
+        rxTestScheduler.schedule(function () {
+          expectObservable(group).toBe(expected);
+        }, 260);
+      });
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should allow subscribing late to an inner Observable, outer throws', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      d: 'foO ',
+      i: 'FOO ',
+      l: '    fOo    '
+    };
+    var e1 = hot(  '--a-b---d---------i-----l-#', values);
+    var subs =     '^                         !';
+    var expected = '----------------------------#';
+
+    e1.groupBy(function (val) { return val.toLowerCase().trim(); })
+      .subscribe(function (group) {
+        rxTestScheduler.schedule(function () {
+          expectObservable(group).toBe(expected);
+        }, 260);
+      }, function () {});
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should allow subscribing late to inner, unsubscribe outer early', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      d: 'foO ',
+      i: 'FOO ',
+      l: '    fOo    '
+    };
+    var e1 = hot(       '--a-b---d---------i-----l-#', values);
+    var expectedOuter = '--w----------';
+    var unsub =         '            !';
+    var expectedInner = '-------------';
+    var outerValues = { w: 'foo' };
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); })
+      .do(function (group) {
+        rxTestScheduler.schedule(function () {
+          expectObservable(group).toBe(expectedInner);
+        }, 260);
+      })
+      .map(function (group) { return group.key; });
+
+    expectObservable(source, unsub).toBe(expectedOuter, outerValues);
   });
 });

--- a/spec/schedulers/TestScheduler-spec.js
+++ b/spec/schedulers/TestScheduler-spec.js
@@ -200,6 +200,16 @@ describe('TestScheduler', function () {
         expectObservable(myObservable).toBe('---a---b--|', values);
         expectSubscriptions(myObservable.subscriptions).toBe(subs);
       });
+
+      it('should support testing metastreams', function () {
+        var x = cold('-a-b|');
+        var y = cold('-c-d|');
+        var myObservable = hot('---x---y----|', { x: x, y: y });
+        var expected =         '---x---y----|';
+        var expectedx = cold('-a-b|');
+        var expectedy = cold('-c-d|');
+        expectObservable(myObservable).toBe(expected, { x: expectedx, y: expectedy });
+      });
     });
   });
 });

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -2,7 +2,7 @@ import Observable from './Observable';
 import Scheduler from './Scheduler';
 import ConnectableObservable from './observables/ConnectableObservable';
 import Subject from './Subject'
-import GroupSubject from './subjects/GroupSubject';
+import {GroupedObservable} from './operators/groupBy-support';
 
 export interface CoreOperators<T> {
   buffer?: <T>(closingNotifier: Observable<any>) => Observable<T[]>;
@@ -29,7 +29,7 @@ export interface CoreOperators<T> {
   first?: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value:T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<R>;
   flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
-  groupBy?: <T, R>(keySelector: (value:T) => string, durationSelector?: (group:GroupSubject<R>) => Observable<any>, elementSelector?: (value:T) => R) => Observable<R>;
+  groupBy?: <T, R>(keySelector: (value:T) => string, elementSelector?: (value:T) => R, durationSelector?: (group: GroupedObservable<R>) => Observable<any>) => Observable<GroupedObservable<R>>;
   ignoreElements?: () => Observable<T>;
   last?: <R>(predicate?: (value: T, index:number) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T>;
   every?: (predicate: (value: T, index:number) => boolean, thisArg?: any) => Observable<T>;

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -147,7 +147,7 @@ observableProto.finally = _finally;
 import first from './operators/first';
 observableProto.first = first;
 
-import groupBy from './operators/groupBy';
+import {groupBy} from './operators/groupBy';
 observableProto.groupBy = groupBy;
 
 import ignoreElements from './operators/ignoreElements';

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -124,7 +124,7 @@ observableProto.finally = _finally;
 import first from './operators/first';
 observableProto.first = first;
 
-import groupBy from './operators/groupBy';
+import {groupBy} from './operators/groupBy';
 observableProto.groupBy = groupBy;
 
 import ignoreElements from './operators/ignoreElements';

--- a/src/operators/groupBy-support.ts
+++ b/src/operators/groupBy-support.ts
@@ -1,0 +1,64 @@
+import Subscription from '../Subscription';
+import Subject from '../Subject';
+import Subscriber from '../Subscriber';
+import Observable from '../Observable';
+
+export class RefCountSubscription<T> extends Subscription<T> {
+  primary: Subscription<T>;
+  attemptedToUnsubscribePrimary: boolean = false;
+  count: number = 0;
+
+  constructor() {
+    super();
+  }
+
+  setPrimary(subscription: Subscription<T>) {
+    this.primary = subscription;
+  }
+
+  unsubscribe() {
+    if (!this.isUnsubscribed && !this.attemptedToUnsubscribePrimary) {
+      this.attemptedToUnsubscribePrimary = true;
+      if (this.count === 0) {
+        super.unsubscribe();
+        this.primary.unsubscribe();
+      }
+    }
+  }
+}
+
+export class GroupedObservable<T> extends Observable<T> {
+  constructor(public key: string,
+              private groupSubject: Subject<T>,
+              private refCountSubscription: RefCountSubscription<T>) {
+    super();
+  }
+
+  _subscribe(subscriber: Subscriber<T>) {
+    const subscription = new Subscription();
+    if (!this.refCountSubscription.isUnsubscribed) {
+      subscription.add(new InnerRefCountSubscription(this.refCountSubscription));
+    }
+    subscription.add(this.groupSubject.subscribe(subscriber));
+    return subscription;
+  }
+}
+
+export class InnerRefCountSubscription<T> extends Subscription<T> {
+  constructor(private parent: RefCountSubscription<T>) {
+    super();
+    parent.count++;
+  }
+
+  unsubscribe() {
+    if (!this.parent.isUnsubscribed && !this.isUnsubscribed) {
+      super.unsubscribe();
+      this.parent.count--;
+      if (this.parent.count === 0 && this.parent.attemptedToUnsubscribePrimary) {
+        this.parent.unsubscribe();
+        this.parent.primary.unsubscribe();
+      }
+    }
+  }
+}
+

--- a/src/subjects/GroupSubject.ts
+++ b/src/subjects/GroupSubject.ts
@@ -1,7 +1,0 @@
-import Subject from '../Subject';
-
-export default class GroupSubject<T> extends Subject<T> {
-  constructor(public key: string) {
-    super();
-  }
-}

--- a/src/testing/ColdObservable.ts
+++ b/src/testing/ColdObservable.ts
@@ -12,7 +12,7 @@ export default class ColdObservable<T> extends Observable<T> implements Subscrip
   logSubscribedFrame: () => number;
   logUnsubscribedFrame: (index: number) => void;
 
-  constructor(private messages: TestMessage[],
+  constructor(public messages: TestMessage[],
               scheduler: Scheduler) {
     super(function (subscriber) {
       const observable: ColdObservable<T> = this;

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -13,7 +13,7 @@ export default class HotObservable<T> extends Subject<T> implements Subscription
   logSubscribedFrame: () => number;
   logUnsubscribedFrame: (index: number) => void;
 
-  constructor(private messages: TestMessage[],
+  constructor(public messages: TestMessage[],
               scheduler: Scheduler) {
     super();
     this.scheduler = scheduler;


### PR DESCRIPTION
See issue #375 for the discussion on the problems this PR tries to solve.

Main problems fixed were:
- Add support for testing Observable-of-Observables in the TestScheduler
- Fix a corner-case with groupBy where the outer did not propagate an error happened in the `elementSelector` function
- Fix a major feature of groupBy: inner Observables should be hot, their subscriptions are independent of the outer's unsubscription

The last bullet point took me most of the time, and I rewrote `groupBy.ts` and introduced `groupBy-support.ts` to fix it.
