### PR TITLE
Subject.create fix

### DIFF
--- a/spec/subject-spec.js
+++ b/spec/subject-spec.js
@@ -3,6 +3,7 @@ var Rx = require('../dist/cjs/Rx');
 
 var Subject = Rx.Subject;
 var nextTick = Rx.Scheduler.nextTick;
+var Observable = Rx.Observable;
 
 describe('Subject', function () {
   it('should pump values right on through itself', function (done) {
@@ -12,7 +13,7 @@ describe('Subject', function () {
     subject.subscribe(function (x) {
       expect(x).toBe(expected.shift());
     }, null, done);
-    
+
     subject.next('foo');
     subject.next('bar');
     subject.complete();
@@ -31,7 +32,7 @@ describe('Subject', function () {
     subject.subscribe(function (x) {
       expect(x).toBe(expected[j++]);
     }, null, done);
-    
+
     expect(subject.observers.length).toBe(2);
     subject.next('foo');
     subject.next('bar');
@@ -45,7 +46,7 @@ describe('Subject', function () {
     subject.subscribe(function (x) {
       expect(x).toBe(expected.shift());
     }, null, done);
-  
+
     subject.next('foo');
     subject.complete();
     subject.next('bar');
@@ -53,18 +54,63 @@ describe('Subject', function () {
 
   it('should clean out unsubscribed subscribers', function (done) {
     var subject = new Subject();
-    
+
     var sub1 = subject.subscribe(function (x) {
     });
-    
+
     var sub2 = subject.subscribe(function (x) {
     });
-    
+
     expect(subject.observers.length).toBe(2);
     sub1.unsubscribe();
     expect(subject.observers.length).toBe(1);
     sub2.unsubscribe();
     expect(subject.observers.length).toBe(0);
     done();
+  });
+
+  it('should have a static create function that works', function() {
+    expect(typeof Subject.create).toBe('function');
+    var source = Observable.of(1,2,3,4,5);
+    var nexts = [];
+    var error;
+    var complete = false;
+    var output = [];
+    var outputComplete = false;
+
+    var destination = {
+      isUnsubscribed: false,
+      next: function(x) {
+        nexts.push(x);
+      },
+      error: function(err) {
+        error = err;
+        this.isUnsubscribed = true;
+      },
+      complete: function() {
+        complete = true;
+        this.isUnsubscribed = true;
+      }
+    };
+
+    var sub = Subject.create(source, destination);
+
+    sub.subscribe(function(x) {
+      output.push(x);
+    }, null, function() {
+      outputComplete = true;
+    });
+
+    sub.next('a');
+    sub.next('b');
+    sub.next('c');
+    sub.complete();
+
+    expect(nexts).toEqual(['a','b','c']);
+    expect(complete).toBe(true);
+    expect(error).toBe(undefined);
+
+    expect(output).toEqual([1,2,3,4,5]);
+    expect(outputComplete).toBe(true);
   });
 });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -11,14 +11,14 @@ import $$observable from './util/Symbol_observable';
 /**
  * A representation of any set of values over any amount of time. This the most basic building block
  * of RxJS.
- *  
+ *
  * @class Observable<T>
  */
 export default class Observable<T> implements CoreOperators<T>  {
   source: Observable<any>;
   operator: Operator<any, T>;
   _isScalar: boolean = false;
-  
+
   /**
    * @constructor
    * @param {Function} subscribe the function that is
@@ -31,25 +31,25 @@ export default class Observable<T> implements CoreOperators<T>  {
       this._subscribe = subscribe;
     }
   }
-  
-  // HACK: Since TypeScript inherits static properties too, we have to 
+
+  // HACK: Since TypeScript inherits static properties too, we have to
   // fight against TypeScript here so Subject can have a different static create signature
   /**
    * @static
    * @method create
    * @param {Function} subscribe? the subscriber function to be passed to the Observable constructor
    * @returns {Observable} a new cold observable
-   * @description creates a new cold Observable by calling the Observable constructor 
+   * @description creates a new cold Observable by calling the Observable constructor
    */
   static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription<T>|Function|void) => {
     return new Observable<T>(subscribe);
   };
-  
+
   /**
    * @method lift
    * @param {Operator} operator the operator defining the operation to take on the observable
    * @returns {Observable} a new observable with the Operator applied
-   * @description creates a new Observable, with this Observable as the source, and the passed 
+   * @description creates a new Observable, with this Observable as the source, and the passed
    * operator defined as the new observable's operator.
    */
   lift<T, R>(operator: Operator<T, R>): Observable<T> {
@@ -70,7 +70,7 @@ export default class Observable<T> implements CoreOperators<T>  {
 
   /**
    * @method subscribe
-   * @param {Observer|Function} observerOrNext (optional) either an observer defining all functions to be called, 
+   * @param {Observer|Function} observerOrNext (optional) either an observer defining all functions to be called,
    *  or the first of three possible handlers, which is the handler for each value emitted from the observable.
    * @param {Function} error (optional) a handler for a terminal event resulting from an error. If no error handler is provided,
    *  the error will be thrown as unhandled
@@ -116,11 +116,11 @@ export default class Observable<T> implements CoreOperators<T>  {
         PromiseCtor = root.Promise;
       }
     }
-    
+
     if(!PromiseCtor) {
       throw new Error('no Promise impl found');
     }
-    
+
     return new PromiseCtor<void>((resolve, reject) => {
       this.subscribe(next, reject, resolve);
     });

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -16,12 +16,11 @@ const _subscriberNext = Subscriber.prototype._next;
 const _subscriberError = Subscriber.prototype._error;
 const _subscriberComplete = Subscriber.prototype._complete;
 
-const _observableSubscribe = Observable.prototype._subscribe;
 
 export default class Subject<T> extends Observable<T> implements Observer<T>, Subscription<T> {
   _subscriptions: Subscription<T>[];
   _unsubscribe: () => void;
-  
+
   static create<T>(source: Observable<T>, destination: Observer<T>): Subject<T> {
     return new BidirectionalSubject(source, destination);
   }
@@ -177,7 +176,8 @@ class BidirectionalSubject<T> extends Subject<T> {
   }
 
   _subscribe(subscriber: Subscriber<T>) {
-    return _observableSubscribe.call(this, subscriber);
+    const operator = this.operator;
+    return this.source._subscribe.call(this.source, operator ? operator.call(subscriber) : subscriber);
   }
 
   next(x) {


### PR DESCRIPTION
Calling `Subject.create` with an `Observable` that had never had an operator applied to it resulted in this error. This was because it called `Observable.prototype._subscribe` internally, and that method assumed there was an operator instance in `this.operator`, which in that case there would not have been.

This fix adds a check to see if there's an operator or not, and just uses the original subscriber if there isn't one.

This seems like a case for any subclassed observables that call `super._subscribe`, prior to having any operators applied.