### PR TITLE
Faster tests

### DIFF
--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -155,3 +155,15 @@ global.lowerCaseO = function lowerCaseO() {
 
   return o;
 };
+
+var ___start;
+beforeEach(function () {
+  ___start = Date.now();
+});
+
+afterEach(function () {
+  var elapsed = Date.now() - ___start;
+  if (elapsed > 500) {
+    throw 'slow test!';
+  }
+});

--- a/spec/operators/bufferWhen-spec.js
+++ b/spec/operators/bufferWhen-spec.js
@@ -1,19 +1,115 @@
-/* globals describe, it, expect */
+/* globals describe, it, expect, hot, cold, expectObservable */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.bufferWhen', function () {
-  it('should emit buffers that close and reopen', function (done) {
-    var expected = [
-      [0, 1, 2],
-      [3, 4, 5],
-      [6, 7, 8]
-    ];
-    Observable.interval(100)
-      .bufferWhen(function () { return Observable.timer(320); })
-      .take(3)
-      .subscribe(function (w) {
-        expect(w).toEqual(expected.shift());
-      }, null, done);
-  }, 2000);
+  it('should emit buffers that close and reopen', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    var e2 = cold(    '---------------(s|)');
+    //                                ---------------(s|)
+    var expected =    '---------------x--------------y----(z|)';
+    var values = {
+      x: ['b','c','d'],
+      y: ['e','f','g','h'],
+      z: []
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+  });
+
+  it('should handle errors', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---#');
+    var e2 = cold(    '---------------(s|)');
+    //                                ---------------(s|)
+    var expected =    '---------------x--------#';
+    var values = {
+      x: ['b','c','d']
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+  });
+
+  it('should handle empty', function () {
+    var e1 = Observable.empty();
+    var e2 = cold('--------(s|)');
+    var expected = '(x|)';
+    var values = {
+      x: []
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+  });
+
+  it('should handle throw', function () {
+    var e1 = Observable.throw('blah?');
+    var e2 = cold('--------(s|)');
+    var expected = '#';
+    var values = {
+      x: []
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values, 'blah?');
+  });
+
+  it('should handle never', function () {
+    var e1 = Observable.never();
+    var e2 = cold( '--------(s|)');
+    var expected = '--------x-------x-------x-------x-------x-------x-------x-------x-------x----';
+    var values = {
+      x: []
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+  });
+
+  it('should handle an inner never', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    var e2 = Observable.never();
+    var expected =    '-----------------------------------(x|)';
+    var values = {
+      x: ['b','c','d','e','f','g','h']
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+  });
+
+  it('should handle inner empty', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    var e2 = Observable.empty();
+    var expected =    '-----------------------------------(x|)';
+    var values = {
+      x: ['b','c','d','e','f','g','h']
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+  });
+
+  it('should handle inner throw', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    var e2 = Observable.throw('bad!');
+    var expected =    '#';
+    var values = {
+      x: ['b','c','d','e','f','g','h']
+    };
+
+    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values, 'bad!');
+  });
+
+  it('should handle disposing of source', function () {
+    var e1 =         hot('--a--^---b---c---d---e---f---g---h------|');
+    var e1disp =         '-----^--------------------!';
+    var e2 = cold(            '---------------(s|)');
+    //                                        ---------------(s|)
+    var expected =            '---------------x-----';
+    // var sourceSubs =     '-----^-------------------!';
+    var values = {
+      x: ['b','c','d'],
+      y: ['e','f','g','h'],
+      z: []
+    };
+
+    var source = e1.bufferWhen(function () { return e2; });
+    expectObservable(source, e1disp).toBe(expected, values);
+    // expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+  });
 });

--- a/spec/operators/windowTime-spec.js
+++ b/spec/operators/windowTime-spec.js
@@ -1,35 +1,64 @@
-/* globals describe, it, expect */
-var Rx = require('../../dist/cjs/Rx');
+/* globals describe, it, expect, hot, expectObservable, rxTestScheduler */
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.windowTime', function () {
-  it('should emit windows at intervals', function (done) {
-    var expected = [
-      [0, 1, 2],
-      [3, 4, 5],
-      [6, 7, 8]
-    ];
-    Observable.interval(100)
-      .windowTime(320)
-      .take(3)
-      .mergeMap(function (x) { return x.toArray(); })
-      .subscribe(function (w) {
-        expect(w).toEqual(expected.shift());
-      }, null, done);
-  }, 2000);
+  it('should emit windows at intervals', function () {
+    var e1 = hot('--1--2--^--a--b--c--d--e--f--g--h--|');
+    //  100 frames        0---------1---------2------|
+    var expected =       'x---------y---------z------|';
+    var x =              '---a--b--c|';
+    var y =              '------------d--e--f-|';
+    var z =              '---------------------g--h--|';
 
-  it('should emit windows that have been created at intervals and close after the specified delay', function (done) {
-    var expected = [
-      [0, 1, 2, 3, 4],
-      [2, 3, 4, 5, 6],
-      [4, 5, 6, 7, 8]
-    ];
-    Observable.interval(100)
-      .windowTime(520, 220)
-      .take(3)
-      .mergeMap(function (x) { return x.toArray(); })
-      .subscribe(function (w) {
-        expect(w).toEqual(expected.shift());
-      }, null, done);
-  }, 2000);
+    var values = {
+      x: Rx.TestScheduler.parseMarbles(x),
+      y: Rx.TestScheduler.parseMarbles(y),
+      z: Rx.TestScheduler.parseMarbles(z)
+    };
+
+    var source = e1.windowTime(100, null, rxTestScheduler)
+      .map(function (obs) {
+        var arr = [];
+
+        obs.materialize().map(function (notification) {
+          return { frame: rxTestScheduler.frame, notification: notification };
+        }).subscribe(function (value) { arr.push(value); });
+
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, values);
+  });
+
+  it('should emit windows that have been created at intervals and close after the specified delay', function () {
+    var e1 = hot('--1--2--^--a--b--c--d--e--f--g--h--|');
+    //  100 frames        0---------1---------2------|
+    //  50                 ----|
+  //  50                           ----|
+    //  50                                     ----|
+    var expected =       'x---------y---------z------|';
+    var x =              '---a-|';
+    var y =              '------------d--(e|)';
+    var z =              '---------------------g--h|';
+
+    var values = {
+      x: Rx.TestScheduler.parseMarbles(x),
+      y: Rx.TestScheduler.parseMarbles(y),
+      z: Rx.TestScheduler.parseMarbles(z)
+    };
+
+    var source = e1.windowTime(50, 100, rxTestScheduler)
+      .map(function (obs) {
+        var arr = [];
+
+        obs.materialize().map(function (notification) {
+          return { frame: rxTestScheduler.frame, notification: notification };
+        }).subscribe(function (value) { arr.push(value); });
+
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, values);
+  });
 });

--- a/spec/operators/windowToggle-spec.js
+++ b/spec/operators/windowToggle-spec.js
@@ -1,19 +1,40 @@
 /* globals describe, it, expect */
-var Rx = require('../../dist/cjs/Rx');
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.windowToggle', function () {
   it('should emit windows that are opened by an observable from the first argument ' +
     'and closed by an observable returned by the function in the second argument',
-  function (done) {
-    Observable.interval(100).take(10)
-      .windowToggle(Observable.timer(320).mapTo('test'), function (n) {
-        expect(n).toBe('test');
-        return Observable.timer(320);
-      })
-      .mergeMap(function (w) { return w.toArray(); })
-      .subscribe(function (w) {
-        expect(w).toEqual([3, 4, 5]);
-      }, null, done);
-  }, 2000);
+  function () {
+    var e1 = hot('--1--2--^--a--b--c--d--e--f--g--h--|');
+    var e2 = cold(       '--------x-------x-------x--|');
+    var e3 = cold(               '----------(x|)');
+    //                                    ----------(x|)
+    //                                            ----------(x|)
+    var expected =       '--------x-------y-------z--|';
+    var x =              '---------c--d--e--(f|)';
+    var y =              '------------------f--g--h-|';
+    var z =              '---------------------------|';
+
+    var values = {
+      x: Rx.TestScheduler.parseMarbles(x),
+      y: Rx.TestScheduler.parseMarbles(y),
+      z: Rx.TestScheduler.parseMarbles(z)
+    };
+
+    var source = e1.windowToggle(e2, function (value) {
+      expect(value).toBe('x');
+      return e3;
+    }).map(function (obs) {
+      var arr = [];
+
+      obs.materialize().map(function (notification) {
+        return { frame: rxTestScheduler.frame, notification: notification };
+      }).subscribe(function (value) { arr.push(value); });
+
+      return arr;
+    });
+
+    expectObservable(source).toBe(expected, values);
+  });
 });

--- a/spec/operators/windowWhen-spec.js
+++ b/spec/operators/windowWhen-spec.js
@@ -1,20 +1,37 @@
 /* globals describe, it, expect */
-var Rx = require('../../dist/cjs/Rx');
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.windowWhen', function () {
-  it('should emit windows that close and reopen', function (done) {
-    var expected = [
-      [0, 1, 2],
-      [3, 4, 5],
-      [6, 7, 8]
-    ];
-    Observable.interval(100)
-      .windowWhen(function () { return Observable.timer(320); })
-      .take(3)
-      .mergeMap(function (x) { return x.toArray(); })
-      .subscribe(function (w) {
-        expect(w).toEqual(expected.shift());
-      }, null, done);
-  }, 2000);
+  it('should emit windows that close and reopen', function () {
+    var e1 = hot('--a--^--b--c--d--e--f--g--h--i--|');
+    var e2 = cold(    '-----------(x|)');
+    //                            -----------(x|)
+    // a              '---b--c--d-|');
+    var a =           '---b--c--d-|';
+    // b                         '-e--f--g--h|')
+    var b =           '------------e--f--g--h|';
+    // c                                    '--i--|'
+    var c =           '------------------------i--|';
+    var expected =    'a----------b----------c----|';
+
+    var values = {
+      a: Rx.TestScheduler.parseMarbles(a),
+      b: Rx.TestScheduler.parseMarbles(b),
+      c: Rx.TestScheduler.parseMarbles(c)
+    };
+
+    var source = e1.windowWhen(function () { return e2; })
+      .map(function (x) {
+        var arr = [];
+
+        x.materialize().map(function (notification) {
+          return { frame: rxTestScheduler.frame, notification: notification };
+        }).subscribe(function (value) { arr.push(value); });
+
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, values);
+  });
 });

--- a/spec/scheduler-spec.js
+++ b/spec/scheduler-spec.js
@@ -13,24 +13,24 @@ describe('Scheduler.immediate', function() {
       Scheduler.immediate.schedule(function(){
         call2 = true;
       });
-    });   
+    });
     expect(call1).toBe(true);
     expect(call2).toBe(true);
   });
-  
+
   it('should schedule things in the future too', function (done) {
     var called = false;
     Scheduler.immediate.schedule(function () {
       called = true;
-    }, 500);
-    
+    }, 50);
+
     setTimeout(function () {
       expect(called).toBe(false);
-    }, 400);
-    
+    }, 40);
+
     setTimeout(function() {
       expect(called).toBe(true);
       done();
-    }, 700);
-  })
+    }, 70);
+  });
 });


### PR DESCRIPTION
Started removing more timer-based tests.

- updates tests for `bufferWhen` to more of a full-suite of marble tests.
- fixes `windowWhen` to use marble tests

ATTENTION @staltz ... the windowWhen tests will interest you. We can probably weaponize that approach into something you can use for `groupBy`.