### PR TITLE
chore(package.json): add watch task for source changes

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,13 +11,14 @@
     "build_closure": "java -jar ./node_modules/google-closure-compiler/compiler.jar ./dist/global/Rx.js --create_source_map ./dist/global/Rx.min.js.map --js_output_file ./dist/global/Rx.min.js",
     "build_global": "rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && npm run build_closure",
     "build_perf": "npm run build_es6 && npm run build_cjs && npm run build_global && webdriver-manager update && npm run perf",
-    "build_test": "rm -rf dist/ && npm run build_es6 && npm run build_cjs && jasmine && npm run lint",
+    "build_test": "rm -rf dist/ && npm run lint && npm run build_es6 && npm run build_cjs && jasmine",
     "build_docs": "./docgen.sh",
     "lint_perf": "eslint perf/",
     "lint_spec": "eslint spec/**/*.js",
     "lint_src": "tslint -c .tslintrc src/**/*.ts",
     "lint": "npm run lint_src && npm run lint_spec && npm run lint_perf",
     "test": "jasmine",
+    "watch": "watch \"echo triggering build && npm run build_test && echo build completed\" src -d -u -w=15",
     "perf": "protractor protractor.conf.js",
     "prepublish": "npm run build_all"
   },
@@ -81,7 +82,8 @@
     "protractor": "2.2.0",
     "rx": "^4.0.0",
     "tslint": "^2.5.0",
-    "typescript": "^1.7.0-dev.20150901"
+    "typescript": "^1.7.0-dev.20150901",
+    "watch": "^0.16.0"
   },
   "engines": {
     "npm": "~2.0.0"


### PR DESCRIPTION
- watch task monitors source change to trigger build automatically
- lint executed prior to build test

closes #494, #495 

- now `build_test` will execute `lint` prior to any build / test execution.
- `watch` task is introduced via npm module `watch` (https://github.com/mikeal/watch). Monitor `src` directory's change, trigger `build_test` triggers subset of build all, includes lint, building es6 & cjs, execute test. To allow fast turnaround, tasks like `build_global` which took time has excluded. Waiting window is set to 15 sec as initial value avoid to triggering task too frequently. It is also possible to consider more complex task runner (gulp, grunt, etcs) but choose simplest path for now until actual requirement can't be resolved via npm task script.