### PR TITLE
Fix type signature of static operators

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -147,7 +147,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   static of: <T>(...values: (T | Scheduler)[]) => Observable<T>;
   static range: <T>(start: number, end: number, scheduler?: Scheduler) => Observable<number>;
   static throw: <T>(error: T) => Observable<T>;
-  static timer: (delay: number) => Observable<number>;
+  static timer: (dueTime: number, period?: number | Scheduler, scheduler?: Scheduler) => Observable<number>;
   static zip: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;
   ignoreElements: () => Observable<T>;
 }

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -141,7 +141,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   static fromEvent: <T>(element: any, eventName: string, selector: (...args:Array<any>) => T) => Observable<T>;
   static fromEventPattern: <T>(addHandler: (handler:Function)=>void, removeHandler: (handler:Function) => void, selector?: (...args:Array<any>) => T) => Observable<T>;
   static fromPromise: <T>(promise: Promise<T>, scheduler?: Scheduler) => Observable<T>;
-  static interval: (interval: number) => Observable<number>;
+  static interval: (interval: number, scheduler?: Scheduler) => Observable<number>;
   static merge: (...observables:any[]) => Observable<any>;
   static never: <T>() => Observable<T>;
   static of: <T>(...values: (T | Scheduler)[]) => Observable<T>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -132,17 +132,17 @@ export default class Observable<T> implements CoreOperators<T>  {
 
   // static method stubs
   static combineLatest: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T) | Scheduler)[]) => Observable<T>;
-  static concat: (...observables: any[]) => Observable<any>;
+  static concat: <T>(...observables: (Observable<any> | Scheduler)[]) => Observable<T>;
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
   static empty: <T>(scheduler?: Scheduler) => Observable<T>;
-  static forkJoin: (...observables: Observable<any>[]) => Observable<any[]>;
+  static forkJoin: <T>(...observables: Observable<any>[]) => Observable<T>;
   static from: <T>(iterable: any, scheduler?: Scheduler) => Observable<T>;
   static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;
   static fromEvent: <T>(element: any, eventName: string, selector: (...args:Array<any>) => T) => Observable<T>;
   static fromEventPattern: <T>(addHandler: (handler:Function)=>void, removeHandler: (handler:Function) => void, selector?: (...args:Array<any>) => T) => Observable<T>;
   static fromPromise: <T>(promise: Promise<T>, scheduler?: Scheduler) => Observable<T>;
   static interval: (interval: number, scheduler?: Scheduler) => Observable<number>;
-  static merge: (...observables:any[]) => Observable<any>;
+  static merge: <T>(...observables: (Observable<any> | Scheduler | number)[]) => Observable<T>;
   static never: <T>() => Observable<T>;
   static of: <T>(...values: (T | Scheduler)[]) => Observable<T>;
   static range: (start: number, end: number, scheduler?: Scheduler) => Observable<number>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -145,7 +145,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   static merge: (...observables:any[]) => Observable<any>;
   static never: <T>() => Observable<T>;
   static of: <T>(...values: (T | Scheduler)[]) => Observable<T>;
-  static range: <T>(start: number, end: number, scheduler?: Scheduler) => Observable<number>;
+  static range: (start: number, end: number, scheduler?: Scheduler) => Observable<number>;
   static throw: <T>(error: T) => Observable<T>;
   static timer: (dueTime: number, period?: number | Scheduler, scheduler?: Scheduler) => Observable<number>;
   static zip: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -134,7 +134,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   static combineLatest: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;
   static concat: (...observables: any[]) => Observable<any>;
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
-  static empty: <T>() => Observable<T>;
+  static empty: <T>(scheduler?: Scheduler) => Observable<T>;
   static forkJoin: (...observables: Observable<any>[]) => Observable<any[]>;
   static from: <T>(iterable: any, scheduler?: Scheduler) => Observable<T>;
   static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -140,7 +140,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;
   static fromEvent: <T>(element: any, eventName: string, selector: (...args:Array<any>) => T) => Observable<T>;
   static fromEventPattern: <T>(addHandler: (handler:Function)=>void, removeHandler: (handler:Function) => void, selector?: (...args:Array<any>) => T) => Observable<T>;
-  static fromPromise: <T>(promise: Promise<T>) => Observable<T>;
+  static fromPromise: <T>(promise: Promise<T>, scheduler?: Scheduler) => Observable<T>;
   static interval: (interval: number) => Observable<number>;
   static merge: (...observables:any[]) => Observable<any>;
   static never: <T>() => Observable<T>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -131,7 +131,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   }
 
   // static method stubs
-  static combineLatest: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;
+  static combineLatest: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T) | Scheduler)[]) => Observable<T>;
   static concat: (...observables: any[]) => Observable<any>;
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
   static empty: <T>(scheduler?: Scheduler) => Observable<T>;

--- a/src/observables/DeferObservable.ts
+++ b/src/observables/DeferObservable.ts
@@ -6,7 +6,7 @@ import {errorObject} from '../util/errorObject';
 
 export default class DeferObservable<T> extends Observable<T> {
 
-  static create<T>(observableFactory) {
+  static create<T>(observableFactory: () => Observable<T>): Observable<T> {
     return new DeferObservable(observableFactory);
   }
 

--- a/src/observables/EmptyObservable.ts
+++ b/src/observables/EmptyObservable.ts
@@ -3,7 +3,7 @@ import Observable from '../Observable';
 
 export default class EmptyObservable<T> extends Observable<T> {
 
-  static create<T>(scheduler?: Scheduler) {
+  static create<T>(scheduler?: Scheduler): Observable<T> {
     return new EmptyObservable(scheduler);
   }
 

--- a/src/observables/IntervalObservable.ts
+++ b/src/observables/IntervalObservable.ts
@@ -5,7 +5,7 @@ import nextTick from '../schedulers/nextTick';
 
 export default class IntervalObservable<T> extends Observable<T> {
 
-  static create(period: number = 0, scheduler: Scheduler = nextTick) {
+  static create(period: number = 0, scheduler: Scheduler = nextTick): Observable<number> {
     return new IntervalObservable(period, scheduler);
   }
 

--- a/src/observables/PromiseObservable.ts
+++ b/src/observables/PromiseObservable.ts
@@ -9,7 +9,7 @@ export default class PromiseObservable<T> extends Observable<T> {
   _isScalar: boolean = false;
   value: T;
 
-  static create<T>(promise: Promise<T>, scheduler: Scheduler = immediate) {
+  static create<T>(promise: Promise<T>, scheduler: Scheduler = immediate): Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }
 

--- a/src/observables/RangeObservable.ts
+++ b/src/observables/RangeObservable.ts
@@ -3,7 +3,7 @@ import Observable from '../Observable';
 
 export default class RangeObservable<T> extends Observable<T> {
 
-  static create(start: number = 0, end: number = 0, scheduler?: Scheduler) {
+  static create(start: number = 0, end: number = 0, scheduler?: Scheduler): Observable<number> {
     return new RangeObservable(start, end, scheduler);
   }
 

--- a/src/observables/TimerObservable.ts
+++ b/src/observables/TimerObservable.ts
@@ -5,7 +5,7 @@ import nextTick from '../schedulers/nextTick';
 
 export default class TimerObservable<T> extends Observable<T> {
 
-  static create(dueTime: number = 0, period?: number | Scheduler, scheduler?: Scheduler) {
+  static create(dueTime: number = 0, period?: number | Scheduler, scheduler?: Scheduler): Observable<number> {
     return new TimerObservable(dueTime, period, scheduler);
   }
 

--- a/src/operators/combineLatest-static.ts
+++ b/src/operators/combineLatest-static.ts
@@ -3,7 +3,7 @@ import ArrayObservable from '../observables/ArrayObservable';
 import { CombineLatestOperator } from './combineLatest-support';
 import Scheduler from '../Scheduler';
 
-export default function combineLatest<T, R>(...observables: (Observable<any> | ((...values: Array<any>) => R) | Scheduler)[]): Observable<R> {
+export default function combineLatest<R>(...observables: (Observable<any> | ((...values: Array<any>) => R) | Scheduler)[]): Observable<R> {
   let project, scheduler;
 
   if (typeof (<any>observables[observables.length - 1]).schedule === 'function') {


### PR DESCRIPTION
Fix the type signature of a lot of static operators.

We could avoid this kind of mismatch if the operator assignments on `Rx.ts` were type-checked. But I'm not sure how we could enforce that.