### PR TITLE
GroupBy(Until) tests and fixes

### DIFF
--- a/spec/operators/groupBy-spec.js
+++ b/spec/operators/groupBy-spec.js
@@ -360,7 +360,9 @@ describe('Observable.prototype.groupBy()', function () {
       z: Rx.TestScheduler.parseMarbles(z, values)
     };
 
-    var fooUnsubscriptionFrame = Rx.TestScheduler.getUnsubscriptionFrame(unsubw);
+    var fooUnsubscriptionFrame = Rx.TestScheduler
+      .parseMarblesAsSubscriptions(unsubw)
+      .unsubscribedFrame;
 
     var source = e1
       .groupBy(function (val) {
@@ -423,10 +425,10 @@ describe('Observable.prototype.groupBy()', function () {
     };
 
     var unsubscriptionFrames = {
-      foo: Rx.TestScheduler.getUnsubscriptionFrame(unsubw),
-      bar: Rx.TestScheduler.getUnsubscriptionFrame(unsubx),
-      baz: Rx.TestScheduler.getUnsubscriptionFrame(unsuby),
-      qux: Rx.TestScheduler.getUnsubscriptionFrame(unsubz)
+      foo: Rx.TestScheduler.parseMarblesAsSubscriptions(unsubw).unsubscribedFrame,
+      bar: Rx.TestScheduler.parseMarblesAsSubscriptions(unsubx).unsubscribedFrame,
+      baz: Rx.TestScheduler.parseMarblesAsSubscriptions(unsuby).unsubscribedFrame,
+      qux: Rx.TestScheduler.parseMarblesAsSubscriptions(unsubz).unsubscribedFrame
     };
 
     var source = e1

--- a/spec/operators/groupBy-spec.js
+++ b/spec/operators/groupBy-spec.js
@@ -77,6 +77,45 @@ describe('Observable.prototype.groupBy()', function () {
       }, null, done);
   });
 
+  it('should handle an empty Observable', function () {
+    var e1 = cold('|');
+    var expected = '|';
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); });
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should handle a never Observable', function () {
+    var e1 = cold('-');
+    var expected = '-';
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); });
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should handle a just-throw Observable', function () {
+    var e1 = cold('#');
+    var expected = '#';
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); });
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should handle an Observable with a single value', function () {
+    var values = { a: '  foo' };
+    var e1 =   hot('^--a--|', values);
+    var expected = '---g--|';
+    var g = cold(     'a--|', values);
+    var expectedValues = { g: g };
+
+    var source = e1
+      .groupBy(function (val) { return val.toLowerCase().trim(); });
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
   it('should group values with a key comparer', function () {
     var values = {
       a: '  foo',

--- a/spec/operators/groupBy-spec.js
+++ b/spec/operators/groupBy-spec.js
@@ -116,7 +116,7 @@ describe('Observable.prototype.groupBy()', function () {
     expectObservable(source).toBe(expected, expectedValues);
   });
 
-  it('should group values with a key comparer', function () {
+  it('should group values with a keySelector', function () {
     var values = {
       a: '  foo',
       b: ' FoO ',
@@ -163,7 +163,7 @@ describe('Observable.prototype.groupBy()', function () {
     expectObservable(source).toBe(expected, expectedValues);
   });
 
-  it('should group values with a key comparer, assert GroupSubject key', function () {
+  it('should group values with a keySelector, assert GroupSubject key', function () {
     var values = {
       a: '  foo',
       b: ' FoO ',
@@ -188,7 +188,7 @@ describe('Observable.prototype.groupBy()', function () {
     expectObservable(source).toBe(expected, expectedValues);
   });
 
-  it('should group values with a key comparer, but outer throws', function () {
+  it('should group values with a keySelector, but outer throws', function () {
     var values = {
       a: '  foo',
       b: ' FoO ',
@@ -213,7 +213,7 @@ describe('Observable.prototype.groupBy()', function () {
     expectObservable(source).toBe(expected, expectedValues);
   });
 
-  it('should group values with a key comparer, inners propagate error from outer', function () {
+  it('should group values with a keySelector, inners propagate error from outer', function () {
     var values = {
       a: '  foo',
       b: ' FoO ',
@@ -267,7 +267,7 @@ describe('Observable.prototype.groupBy()', function () {
     expectObservable(source, unsub).toBe(expected, expectedValues);
   });
 
-  it('should group values with a key comparer, but comparer throws', function () {
+  it('should group values with a keySelector which eventually throws', function () {
     var values = {
       a: '  foo',
       b: ' FoO ',
@@ -302,7 +302,7 @@ describe('Observable.prototype.groupBy()', function () {
     expectObservable(source).toBe(expected, expectedValues);
   });
 
-  it('should group values with a key comparer and elementSelector, ' +
+  it('should group values with a keySelector and elementSelector, ' +
     'but elementSelector throws',
   function () {
     var values = {

--- a/spec/operators/groupBy-spec.js
+++ b/spec/operators/groupBy-spec.js
@@ -521,4 +521,646 @@ describe('Observable.prototype.groupBy()', function () {
 
     expectObservable(source, unsub).toBe(expectedOuter, outerValues);
   });
+
+  it('should allow using a keySelector, elementSelector, and durationSelector', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var reversedValues = mapObject(values, reverseString);
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--v---w---x-y-----z-------|';
+    var v = cold(         'a-b---(d|)'               , reversedValues);
+    var w = cold(             'c-------g-(h|)'       , reversedValues);
+    var x = cold(                 'e---------j-(k|)' , reversedValues);
+    var y = cold(                   'f-------------|', reversedValues);
+    var z = cold(                         'i-----l-|', reversedValues);
+    var expectedValues = { v: v, w: w, x: x, y: y, z: z };
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return reverseString(val); },
+        function (group) { return group.skip(2); }
+      );
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should allow using a keySelector and a durationSelector, outer throws', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-#', values);
+    var expected =      '--v---w---x-y-----z-------#';
+    var v = cold(         'a-b---(d|)'               , values);
+    var w = cold(             'c-------g-(h|)'       , values);
+    var x = cold(                 'e---------j-(k|)' , values);
+    var y = cold(                   'f-------------#', values);
+    var z = cold(                         'i-----l-#', values);
+    var expectedValues = { v: v, w: w, x: x, y: y, z: z };
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) { return group.skip(2); }
+      );
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should allow using a durationSelector, and outer unsubscribed early', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var unsub =         '           !';
+    var expected =      '--v---w---x-';
+    var v = cold(         'a-b---(d|)'               , values);
+    var w = cold(             'c-------g-(h|)'       , values);
+    var x = cold(                 'e---------j-(k|)' , values);
+    var expectedValues = { v: v, w: w, x: x };
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) { return group.skip(2); }
+      );
+    expectObservable(source, unsub).toBe(expected, expectedValues);
+  });
+
+  it('should allow using a durationSelector, outer and all inners unsubscribed early',
+  function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var unsub =         '           !';
+    var expected =      '--v---w---x-';
+    var v =             '--a-b---(d|)';
+    var w =             '------c-----';
+    var x =             '----------e-';
+
+    var expectedGroups = {
+      v: Rx.TestScheduler.parseMarbles(v, values),
+      w: Rx.TestScheduler.parseMarbles(w, values),
+      x: Rx.TestScheduler.parseMarbles(x, values)
+    };
+
+    var unsubscriptionFrame = Rx.TestScheduler
+      .parseMarblesAsSubscriptions(unsub)
+      .unsubscribedFrame;
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) { return group.skip(2); }
+      )
+      .map(function (group) {
+        var arr = [];
+
+        var subscription = group
+          .materialize()
+          .map(function (notification) {
+            return { frame: rxTestScheduler.frame, notification: notification };
+          })
+          .subscribe(function (value) {
+            arr.push(value);
+          });
+
+        rxTestScheduler.schedule(function () {
+          subscription.unsubscribe();
+        }, unsubscriptionFrame - rxTestScheduler.frame);
+        return arr;
+      });
+
+    expectObservable(source, unsub).toBe(expected, expectedGroups);
+  });
+
+  it('should allow using a durationSelector, but keySelector throws', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--v---w---x-y-----z-#'      ;
+    var v = cold(         'a-b---(d|)'               , values);
+    var w = cold(             'c-------g-(h|)'       , values);
+    var x = cold(                 'e---------#'      , values);
+    var y = cold(                   'f-------#'      , values);
+    var z = cold(                         'i-#'      , values);
+    var expectedValues = { v: v, w: w, x: x, y: y, z: z };
+
+    var invoked = 0;
+    var source = e1
+      .groupBy(
+        function (val) {
+          invoked++;
+          if (invoked === 10) {
+            throw 'error';
+          }
+          return val.toLowerCase().trim();
+        },
+        function (val) { return val; },
+        function (group) { return group.skip(2); }
+      );
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should allow using a durationSelector, but elementSelector throws', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--v---w---x-y-----z-#'      ;
+    var v = cold(         'a-b---(d|)'               , values);
+    var w = cold(             'c-------g-(h|)'       , values);
+    var x = cold(                 'e---------#'      , values);
+    var y = cold(                   'f-------#'      , values);
+    var z = cold(                         'i-#'      , values);
+    var expectedValues = { v: v, w: w, x: x, y: y, z: z };
+
+    var invoked = 0;
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) {
+          invoked++;
+          if (invoked === 10) {
+            throw 'error';
+          }
+          return val;
+        },
+        function (group) { return group.skip(2); }
+      );
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should allow using a durationSelector which eventually throws', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--v---w---x-#'              ;
+    var v = cold(         'a-b---(d|)'               , values);
+    var w = cold(             'c-----#'              , values);
+    var x = cold(                 'e-#'              , values);
+    var y = cold(                   '#'              , values);
+    var expectedValues = { v: v, w: w, x: x, y: y };
+
+    var invoked = 0;
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) {
+          invoked++;
+          if (invoked === 4) {
+            throw 'error';
+          }
+          return group.skip(2);
+        }
+      );
+    expectObservable(source).toBe(expected, expectedValues);
+  });
+
+  it('should allow an inner to be unsubscribed early but other inners continue, ' +
+  'with durationSelector', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var reversedValues = mapObject(values, reverseString);
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--v---w---x-y-----z-------|';
+    var v =             '--a-b---'                   ;
+    var unsubv =        '       !';
+    var w =             '------c-------g-(h|)'       ;
+    var x =             '----------e---------j-(k|)' ;
+    var y =             '------------f-------------|';
+    var z =             '------------------i-----l-|';
+
+    var expectedGroups = {
+      v: Rx.TestScheduler.parseMarbles(v, reversedValues),
+      w: Rx.TestScheduler.parseMarbles(w, reversedValues),
+      x: Rx.TestScheduler.parseMarbles(x, reversedValues),
+      y: Rx.TestScheduler.parseMarbles(y, reversedValues),
+      z: Rx.TestScheduler.parseMarbles(z, reversedValues)
+    };
+
+    var fooUnsubscriptionFrame = Rx.TestScheduler
+      .parseMarblesAsSubscriptions(unsubv)
+      .unsubscribedFrame;
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return reverseString(val); },
+        function (group) { return group.skip(2); }
+      )
+      .map(function (group, index) {
+        var arr = [];
+
+        var subscription = group
+          .materialize()
+          .map(function (notification) {
+            return { frame: rxTestScheduler.frame, notification: notification };
+          })
+          .subscribe(function (value) {
+            arr.push(value);
+          });
+
+        if (group.key === 'foo' && index === 0) {
+          rxTestScheduler.schedule(function () {
+            subscription.unsubscribe();
+          }, fooUnsubscriptionFrame - rxTestScheduler.frame);
+        }
+        return arr;
+      });
+    expectObservable(source).toBe(expected, expectedGroups);
+  });
+
+  it('should allow inners to be unsubscribed early at different times, with durationSelector',
+  function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--v---w---x-y-----z-------|';
+    var v =             '--a-b---'                   ;
+    var unsubv =        '       !'                   ;
+    var w =             '------c---'                 ;
+    var unsubw =        '         !'                 ;
+    var x =             '----------e---------j-'     ;
+    var unsubx =        '                     !'     ;
+    var y =             '------------f----'          ;
+    var unsuby =        '                !'          ;
+    var z =             '------------------i----'    ;
+    var unsubz =        '                      !'    ;
+
+    var expectedGroups = {
+      v: Rx.TestScheduler.parseMarbles(v, values),
+      w: Rx.TestScheduler.parseMarbles(w, values),
+      x: Rx.TestScheduler.parseMarbles(x, values),
+      y: Rx.TestScheduler.parseMarbles(y, values),
+      z: Rx.TestScheduler.parseMarbles(z, values)
+    };
+
+    var unsubscriptionFrames = {
+      foo: Rx.TestScheduler.parseMarblesAsSubscriptions(unsubv).unsubscribedFrame,
+      bar: Rx.TestScheduler.parseMarblesAsSubscriptions(unsubw).unsubscribedFrame,
+      baz: Rx.TestScheduler.parseMarblesAsSubscriptions(unsubx).unsubscribedFrame,
+      qux: Rx.TestScheduler.parseMarblesAsSubscriptions(unsuby).unsubscribedFrame,
+      foo2: Rx.TestScheduler.parseMarblesAsSubscriptions(unsubz).unsubscribedFrame
+    };
+    var hasUnsubscribed = {};
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) { return group.skip(2); }
+      )
+      .map(function (group) {
+        var arr = [];
+
+        var subscription = group
+          .materialize()
+          .map(function (notification) {
+            return { frame: rxTestScheduler.frame, notification: notification };
+          })
+          .subscribe(function (value) {
+            arr.push(value);
+          });
+
+        var unsubscriptionFrame = hasUnsubscribed[group.key] ?
+          unsubscriptionFrames[group.key + '2'] :
+          unsubscriptionFrames[group.key];
+        rxTestScheduler.schedule(function () {
+          subscription.unsubscribe();
+          hasUnsubscribed[group.key] = true;
+        }, unsubscriptionFrame - rxTestScheduler.frame);
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, expectedGroups);
+  });
+
+  it('should return inners that when subscribed late exhibit hot behavior', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    var expected =      '--v---w---x-y-----z-------|';
+    var subv =          '       ^                   ';
+    var v =             '--------(d|)'               ;
+    var subw =          '               ^           ';
+    var w =             '----------------(h|)'       ;
+    var subx =          '                     ^     ';
+    var x =             '----------------------(k|)' ;
+    var suby =          '                              ^';
+    var y =             '------------------------------|';
+    var subz =          '                                ^';
+    var z =             '--------------------------------|';
+
+    var expectedGroups = {
+      v: Rx.TestScheduler.parseMarbles(v, values),
+      w: Rx.TestScheduler.parseMarbles(w, values),
+      x: Rx.TestScheduler.parseMarbles(x, values),
+      y: Rx.TestScheduler.parseMarbles(y, values),
+      z: Rx.TestScheduler.parseMarbles(z, values)
+    };
+
+    var subscriptionFrames = {
+      foo: Rx.TestScheduler.parseMarblesAsSubscriptions(subv).subscribedFrame,
+      bar: Rx.TestScheduler.parseMarblesAsSubscriptions(subw).subscribedFrame,
+      baz: Rx.TestScheduler.parseMarblesAsSubscriptions(subx).subscribedFrame,
+      qux: Rx.TestScheduler.parseMarblesAsSubscriptions(suby).subscribedFrame,
+      foo2: Rx.TestScheduler.parseMarblesAsSubscriptions(subz).subscribedFrame
+    };
+    var hasSubscribed = {};
+
+    var source = e1
+      .groupBy(
+      function (val) { return val.toLowerCase().trim(); },
+      function (val) { return val; },
+      function (group) { return group.skip(2); }
+    )
+      .map(function (group) {
+        var arr = [];
+
+        var subscriptionFrame = hasSubscribed[group.key] ?
+          subscriptionFrames[group.key + '2'] :
+          subscriptionFrames[group.key];
+
+        rxTestScheduler.schedule(function () {
+          group
+            .materialize()
+            .map(function (notification) {
+              return { frame: rxTestScheduler.frame, notification: notification };
+            })
+            .subscribe(function (value) {
+              arr.push(value);
+            });
+          hasSubscribed[group.key] = true;
+        }, subscriptionFrame - rxTestScheduler.frame);
+
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, expectedGroups);
+  });
+
+  it('should return inner group that when subscribed late emits complete()', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      d: 'foO ',
+      i: 'FOO ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b---d---------i-----l-|', values);
+    var expected =      '--g-----------------------|';
+    var innerSub =      '                                ^';
+    var g =             '--------------------------------|';
+
+    var expectedGroups = {
+      g: Rx.TestScheduler.parseMarbles(g, values)
+    };
+
+    var innerSubscriptionFrame = Rx.TestScheduler
+      .parseMarblesAsSubscriptions(innerSub)
+      .subscribedFrame;
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) { return group.skip(7); }
+      )
+      .map(function (group) {
+        var arr = [];
+
+        rxTestScheduler.schedule(function () {
+          group
+            .materialize()
+            .map(function (notification) {
+              return { frame: rxTestScheduler.frame, notification: notification };
+            })
+            .subscribe(function (value) {
+              arr.push(value);
+            });
+        }, innerSubscriptionFrame - rxTestScheduler.frame);
+
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, expectedGroups);
+  });
+
+  it('should return inner group that when subscribed late emits error()', function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      d: 'foO ',
+      i: 'FOO ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b---d---------i-----l-#', values);
+    var expected =      '--g-----------------------#';
+    var innerSub =      '                                ^';
+    var g =             '--------------------------------#';
+
+    var expectedGroups = {
+      g: Rx.TestScheduler.parseMarbles(g, values)
+    };
+
+    var innerSubscriptionFrame = Rx.TestScheduler
+      .parseMarblesAsSubscriptions(innerSub)
+      .subscribedFrame;
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) { return group.skip(7); }
+      )
+      .map(function (group) {
+        var arr = [];
+
+        rxTestScheduler.schedule(function () {
+          group
+            .materialize()
+            .map(function (notification) {
+              return { frame: rxTestScheduler.frame, notification: notification };
+            })
+            .subscribe(function (value) {
+              arr.push(value);
+            });
+        }, innerSubscriptionFrame - rxTestScheduler.frame);
+
+        return arr;
+      });
+
+    expectObservable(source).toBe(expected, expectedGroups);
+  });
+
+  it('should return inner that does not throw when faulty outer is unsubscribed early',
+  function () {
+    var values = {
+      a: '  foo',
+      b: ' FoO ',
+      d: 'foO ',
+      i: 'FOO ',
+      l: '    fOo    '
+    };
+    var e1 = hot('-1--2--^-a-b---d---------i-----l-#', values);
+    var unsub =         '      !';
+    var expectedSubs =  '^     !';
+    var expected =      '--g----';
+    var innerSub =      '                                ^';
+    var g =                                             '-';
+
+    var expectedGroups = {
+      g: Rx.TestScheduler.parseMarbles(g, values)
+    };
+
+    var innerSubscriptionFrame = Rx.TestScheduler
+      .parseMarblesAsSubscriptions(innerSub)
+      .subscribedFrame;
+
+    var source = e1
+      .groupBy(
+        function (val) { return val.toLowerCase().trim(); },
+        function (val) { return val; },
+        function (group) { return group.skip(7); }
+      )
+      .map(function (group) {
+        var arr = [];
+
+        rxTestScheduler.schedule(function () {
+          group
+            .materialize()
+            .map(function (notification) {
+              return { frame: rxTestScheduler.frame, notification: notification };
+            })
+            .subscribe(function (value) {
+              arr.push(value);
+            });
+        }, innerSubscriptionFrame - rxTestScheduler.frame);
+
+        return arr;
+      });
+
+    expectObservable(source, unsub).toBe(expected, expectedGroups);
+    expectSubscriptions(e1.subscriptions).toBe(expectedSubs);
+  });
 });

--- a/src/operators/groupBy-support.ts
+++ b/src/operators/groupBy-support.ts
@@ -30,13 +30,13 @@ export class RefCountSubscription<T> extends Subscription<T> {
 export class GroupedObservable<T> extends Observable<T> {
   constructor(public key: string,
               private groupSubject: Subject<T>,
-              private refCountSubscription: RefCountSubscription<T>) {
+              private refCountSubscription?: RefCountSubscription<T>) {
     super();
   }
 
   _subscribe(subscriber: Subscriber<T>) {
     const subscription = new Subscription();
-    if (!this.refCountSubscription.isUnsubscribed) {
+    if (this.refCountSubscription && !this.refCountSubscription.isUnsubscribed) {
       subscription.add(new InnerRefCountSubscription(this.refCountSubscription));
     }
     subscription.add(this.groupSubject.subscribe(subscriber));

--- a/src/operators/groupBy.ts
+++ b/src/operators/groupBy.ts
@@ -116,7 +116,7 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
   }
 
   removeGroup(key: string) {
-    this.groups[key] = null;
+    this.groups.delete(key);
   }
 }
 

--- a/src/operators/groupBy.ts
+++ b/src/operators/groupBy.ts
@@ -69,7 +69,7 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
         let groupedObservable = new GroupedObservable<R>(key, group, this.refCountSubscription);
 
         if (durationSelector) {
-          let duration = tryCatch(durationSelector)(groupedObservable);
+          let duration = tryCatch(durationSelector)(new GroupedObservable<R>(key, group));
           if (duration === errorObject) {
             this.error(duration.e);
           } else {

--- a/src/util/FastMap.ts
+++ b/src/util/FastMap.ts
@@ -19,7 +19,7 @@ export default class FastMap {
   forEach(cb, thisArg) {
     const values = this._values;
     for (let key in values) {
-      if (values.hasOwnProperty(key)) {
+      if (values.hasOwnProperty(key) && values[key] !== null) {
         cb.call(thisArg, values[key], key);
       }
     }


### PR DESCRIPTION
Finishes the last bits and pieces of #375.

In summary:
- Add tests to match groupByUntil from RxJS legacy
- Add basic test cases (empty, never, etc) that were missing for groupBy
- Fix some bugs related to groupBy