### PR TITLE
Scalar perf

### DIFF
--- a/package.json
+++ b/package.json
@@ -79,7 +79,7 @@
     "google-closure-compiler": "^20150920.0.0",
     "http-server": "^0.8.0",
     "istanbul": "^0.3.22",
-    "jasmine": "^2.3.1",
+    "jasmine": "^2.3.2",
     "jasmine-core": "^2.2.0",
     "lodash": "^3.5.0",
     "platform": "^1.3.0",

--- a/perf/micro/immediate-scheduler/operators/count-scalar.js
+++ b/perf/micro/immediate-scheduler/operators/count-scalar.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldConcatWithImmediateScheduler = RxOld.Observable.just(25, RxOld.Scheduler.immediate).count();
+  var newConcatWithImmediateScheduler = RxNew.Observable.of(25).count();
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old count over scalar with immediate scheduler', function () {
+        oldConcatWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new count over scalar with immediate scheduler', function () {
+        newConcatWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/count.js
+++ b/perf/micro/immediate-scheduler/operators/count.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldConcatWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate).count();
+  var newConcatWithImmediateScheduler = RxNew.Observable.range(0, 25).count();
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old count with immediate scheduler', function () {
+        oldConcatWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new count with immediate scheduler', function () {
+        newConcatWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/filter-scalar-false.js
+++ b/perf/micro/immediate-scheduler/operators/filter-scalar-false.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  function isEven(x) {
+    return x % 2 === 0;
+  }
+
+  function greaterThanTen(x) {
+    return x > 10;
+  }
+  var oldFilterWithImmediateScheduler = RxOld.Observable.just(45, RxOld.Scheduler.immediate).filter(greaterThanTen).filter(isEven);
+  var newFilterWithImmediateScheduler = RxNew.Observable.of(45).filter(greaterThanTen).filter(isEven);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old filter over scalar in the negative with immediate scheduler', function () {
+        oldFilterWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new filter over scalar in the negative with immediate scheduler', function () {
+        newFilterWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/filter-scalar-true.js
+++ b/perf/micro/immediate-scheduler/operators/filter-scalar-true.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  function isEven(x) {
+    return x % 2 === 0;
+  }
+
+  function greaterThanTen(x) {
+    return x > 10;
+  }
+  var oldFilterWithImmediateScheduler = RxOld.Observable.just(42, RxOld.Scheduler.immediate).filter(greaterThanTen).filter(isEven);
+  var newFilterWithImmediateScheduler = RxNew.Observable.of(42).filter(greaterThanTen).filter(isEven);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old filter over scalar in the affirmative with immediate scheduler', function () {
+        oldFilterWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new filter over scalar in the affirmative with immediate scheduler', function () {
+        newFilterWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/map-scalar.js
+++ b/perf/micro/immediate-scheduler/operators/map-scalar.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  function square(x) {
+    return x * x;
+  }
+
+  function double(x) {
+    return x + x;
+  }
+  var oldSelectWithImmediateScheduler = RxOld.Observable.just(42).map(square).map(double);
+  var newSelectWithImmediateScheduler = RxNew.Observable.of(42).map(square).map(double);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old map over scalar with immediate scheduler', function () {
+        oldSelectWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new map over scalar with immediate scheduler', function () {
+        newSelectWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/reduce-scalar-noseed.js
+++ b/perf/micro/immediate-scheduler/operators/reduce-scalar-noseed.js
@@ -1,0 +1,21 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  function add(acc, x) {
+    return x + x;
+  }
+  var oldReduceWithImmediateScheduler = RxOld.Observable.just(25, RxOld.Scheduler.immediate).reduce(add);
+  var newReduceWithImmediateScheduler = RxNew.Observable.of(25).reduce(add);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old reduce with immediate scheduler', function () {
+        oldReduceWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new reduce with immediate scheduler', function () {
+        newReduceWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/reduce-scalar.js
+++ b/perf/micro/immediate-scheduler/operators/reduce-scalar.js
@@ -1,0 +1,21 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  function add(acc, x) {
+    return x + x;
+  }
+  var oldReduceWithImmediateScheduler = RxOld.Observable.just(25, RxOld.Scheduler.immediate).reduce(add, 0);
+  var newReduceWithImmediateScheduler = RxNew.Observable.of(25).reduce(add, 0);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old reduce with immediate scheduler', function () {
+        oldReduceWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new reduce with immediate scheduler', function () {
+        newReduceWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/scan-scalar-noseed.js
+++ b/perf/micro/immediate-scheduler/operators/scan-scalar-noseed.js
@@ -6,17 +6,17 @@ module.exports = function (suite) {
     return x + x;
   }
 
-  var oldScanScalarWithImmediateScheduler = RxOld.Observable.of(25, RxOld.Scheduler.immediate).scan(add, 0);
-  var newScanScalarWithImmediateScheduler = RxNew.Observable.of(25).scan(add, 0);
+  var oldScanScalarWithImmediateScheduler = RxOld.Observable.of(25, RxOld.Scheduler.immediate).scan(add);
+  var newScanScalarWithImmediateScheduler = RxNew.Observable.of(25).scan(add);
 
   function _next(x) { }
   function _error(e) { }
   function _complete() { }
   return suite
-    .add('old scalar observable scan with immediate scheduler', function () {
+    .add('old scalar observable scan with immediate scheduler with no seed', function () {
       oldScanScalarWithImmediateScheduler.subscribe(_next, _error, _complete);
     })
-    .add('new scalar observable scan with immediate scheduler', function () {
+    .add('new scalar observable scan with immediate scheduler with no seed', function () {
       newScanScalarWithImmediateScheduler.subscribe(_next, _error, _complete);
     });
 };

--- a/perf/micro/immediate-scheduler/operators/skip-scalar-0.js
+++ b/perf/micro/immediate-scheduler/operators/skip-scalar-0.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldSkipWithImmediateScheduler = RxOld.Observable.just(50, RxOld.Scheduler.immediate).skip(0);
+  var newSkipWithImmediateScheduler = RxNew.Observable.of(50).skip(0);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old skip with immediate scheduler', function () {
+      oldSkipWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new skip with immediate scheduler', function () {
+      newSkipWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/skip-scalar-outofbounds.js
+++ b/perf/micro/immediate-scheduler/operators/skip-scalar-outofbounds.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldSkipWithImmediateScheduler = RxOld.Observable.just(50, RxOld.Scheduler.immediate).skip(25);
+  var newSkipWithImmediateScheduler = RxNew.Observable.of(50).skip(25);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old skip with immediate scheduler', function () {
+      oldSkipWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new skip with immediate scheduler', function () {
+      newSkipWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/take-scalar.js
+++ b/perf/micro/immediate-scheduler/operators/take-scalar.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldTakeWithImmediateScheduler = RxOld.Observable.just(50, RxOld.Scheduler.immediate).take(5);
+  var newTakeWithImmediateScheduler = RxNew.Observable.of(50).take(5);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old take with immediate scheduler', function () {
+        oldTakeWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new take with immediate scheduler', function () {
+        newTakeWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/spec/observables/ScalarObservable-spec.js
+++ b/spec/observables/ScalarObservable-spec.js
@@ -1,0 +1,129 @@
+var Rx = require('../../dist/cjs/Rx');
+var ScalarObservable = require('../../dist/cjs/observables/ScalarObservable');
+var EmptyObservable = require('../../dist/cjs/observables/EmptyObservable');
+var ErrorObservable = require('../../dist/cjs/observables/ErrorObservable');
+var Observable = Rx.Observable;
+
+describe('ScalarObservable', function () {
+  it('should create expose a value property', function () {
+    var s = new ScalarObservable(1);
+    expect(s.value).toBe(1);
+  });
+
+  describe('prototype.map()', function () {
+    it('should map to a new ScalarObservable', function () {
+      var s = new ScalarObservable(1);
+      var r = s.map(function (x) { return x + '!!!'; });
+      expect(r instanceof ScalarObservable).toBe(true);
+      expect(r.value).toBe('1!!!');
+    });
+
+    it('should return an ErrorObservable if map errors', function () {
+      var s = new ScalarObservable(1);
+      var r = s.map(function (x) { throw 'bad!'; });
+      expect(r instanceof ErrorObservable).toBe(true);
+      expect(r.error).toBe('bad!');
+    });
+  });
+
+  describe('prototype.count()', function () {
+    it('should map to a new ScalarObservable of 1', function () {
+      var s = new ScalarObservable(1);
+      var r = s.count();
+      expect(r instanceof ScalarObservable).toBe(true);
+      expect(r.value).toBe(1);
+    });
+
+    it('should map to a new ScalarObservable of 1 if predicate matches', function () {
+      var s = new ScalarObservable(1);
+      var r = s.count(function (x) { return x === 1; });
+      expect(r instanceof ScalarObservable).toBe(true);
+      expect(r.value).toBe(1);
+    });
+
+    it('should map to a new ScalarObservable of 0 if predicate does not match', function () {
+      var s = new ScalarObservable(1);
+      var r = s.count(function (x) { return x === 0; });
+      expect(r instanceof ScalarObservable).toBe(true);
+      expect(r.value).toBe(0);
+    });
+
+    it('should map to a new ErrorObservable if predicate errors', function () {
+      var s = new ScalarObservable(1);
+      var r = s.count(function () { throw 'bad!'; });
+      expect(r instanceof ErrorObservable).toBe(true);
+      expect(r.error).toBe('bad!');
+    });
+  });
+
+  describe('prototype.filter()', function () {
+    it('should return itself if the filter matches its value', function () {
+      var s = new ScalarObservable(1);
+      var r = s.filter(function (x) { return x === 1; });
+      expect(s).toBe(r);
+    });
+
+    it('should return EmptyObservable if filter does not match', function () {
+      var s = new ScalarObservable(1);
+      var r = s.filter(function (x) { return x === 0; });
+      expect(r instanceof EmptyObservable).toBe(true);
+    });
+
+    it('should map to a new ErrorObservable if predicate errors', function () {
+      var s = new ScalarObservable(1);
+      var r = s.filter(function () { throw 'bad!'; });
+      expect(r instanceof ErrorObservable).toBe(true);
+      expect(r.error).toBe('bad!');
+    });
+  });
+
+  describe('prototype.take()', function () {
+    it('should return itself if count > 0', function () {
+      var s = new ScalarObservable(1);
+      var r = s.take(1);
+      expect(s).toBe(r);
+    });
+
+    it('should return EmptyObservable if count === 0', function () {
+      var s = new ScalarObservable(1);
+      var r = s.take(0);
+      expect(r instanceof EmptyObservable).toBe(true);
+    });
+  });
+
+  describe('prototype.skip()', function () {
+    it('should return itself if count === 0', function () {
+      var s = new ScalarObservable(1);
+      var r = s.skip(0);
+      expect(s).toBe(r);
+    });
+
+    it('should return EmptyObservable if count > 0', function () {
+      var s = new ScalarObservable(1);
+      var r = s.skip(1);
+      expect(r instanceof EmptyObservable).toBe(true);
+    });
+  });
+
+  describe('prototype.reduce()', function () {
+    it('should return a ScalarObservable of the result if there is a seed', function () {
+      var s = new ScalarObservable(1);
+      var r = s.reduce(function (a, x) { return a + x; }, 1);
+      expect(r instanceof ScalarObservable).toBe(true);
+      expect(r.value).toBe(2);
+    });
+
+    it('should return itself if there is no seed', function () {
+      var s = new ScalarObservable(1);
+      var r = s.reduce(function (a, x) { return a + x; });
+      expect(r).toBe(s);
+    });
+  });
+});
+
+// If you uncomment this, jasmine breaks? WEIRD
+// describe('reality', function () {
+//   it('should exist in this universe', function () {
+//     expect(true).toBe(true);
+//   });
+// });

--- a/spec/operators/retry-spec.js
+++ b/spec/operators/retry-spec.js
@@ -6,7 +6,10 @@ describe('Observable.prototype.retry()', function () {
   it('should retry a number of times, without error, then complete', function (done) {
     var errors = 0;
     var retries = 2;
-    Observable.of(42)
+    Observable.create(function (observer) {
+      observer.next(42);
+      observer.complete();
+    })
       .map(function (x) {
         if ((errors += 1) < retries) {
           throw 'bad';
@@ -27,7 +30,10 @@ describe('Observable.prototype.retry()', function () {
   it('should retry a number of times, then call error handler', function (done) {
     var errors = 0;
     var retries = 2;
-    Observable.of(42)
+    Observable.create(function (observer) {
+      observer.next(42);
+      observer.complete();
+    })
       .map(function (x) {
         if ((errors += 1) < retries) {
           throw 'bad';
@@ -50,7 +56,10 @@ describe('Observable.prototype.retry()', function () {
   it('should retry until successful completion', function (done) {
     var errors = 0;
     var retries = 10;
-    Observable.of(42)
+    Observable.create(function (observer) {
+      observer.next(42);
+      observer.complete();
+    })
       .map(function (x) {
         if ((errors += 1) < retries) {
           throw 'bad';

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -93,4 +93,11 @@ export default class ScalarObservable<T> extends Observable<T> {
   count(): Observable<number> {
     return new ScalarObservable(1);
   }
+
+  skip(count: number): Observable<T> {
+    if (count > 0) {
+      return new EmptyObservable();
+    }
+    return this;
+  }
 }

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -73,4 +73,16 @@ export default class ScalarObservable<T> extends Observable<T> {
       return new EmptyObservable();
     }
   }
+
+  reduce<R>(project: (acc: R, x: T) => R, acc?: R): Observable<R> {
+    if (typeof acc === 'undefined') {
+      return <any>this;
+    }
+    let result = tryCatch(project)(acc, this.value);
+    if (result === errorObject) {
+      return new ErrorObservable(errorObject.e);
+    } else {
+      return new ScalarObservable(result);
+    }
+  }
 }

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -1,5 +1,9 @@
 import Scheduler from '../Scheduler';
 import Observable from '../Observable';
+import tryCatch from '../util/tryCatch';
+import { errorObject } from '../util/errorObject';
+import ErrorObservable from './ErrorObservable';
+import EmptyObservable from './EmptyObservable';
 
 export default class ScalarObservable<T> extends Observable<T> {
 
@@ -47,6 +51,15 @@ export default class ScalarObservable<T> extends Observable<T> {
       if (!subscriber.isUnsubscribed) {
         subscriber.complete();
       }
+    }
+  }
+
+  map<R>(project: (x: T, ix?: number) => R, thisArg?: any): Observable<R> {
+    let result = tryCatch(project).call(thisArg || this, this.value, 0);
+    if (result === errorObject) {
+      return new ErrorObservable(errorObject.e);
+    } else {
+      return new ScalarObservable(project.call(thisArg || this, this.value, 0));
     }
   }
 }

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -85,4 +85,8 @@ export default class ScalarObservable<T> extends Observable<T> {
       return new ScalarObservable(result);
     }
   }
+
+  scan<R>(project: (acc: R, x: T) => R, acc?: R): Observable<R> {
+    return this.reduce(project, acc);
+  }
 }

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -89,4 +89,8 @@ export default class ScalarObservable<T> extends Observable<T> {
   scan<R>(project: (acc: R, x: T) => R, acc?: R): Observable<R> {
     return this.reduce(project, acc);
   }
+
+  count(): Observable<number> {
+    return new ScalarObservable(1);
+  }
 }

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -100,4 +100,11 @@ export default class ScalarObservable<T> extends Observable<T> {
     }
     return this;
   }
+
+  take(count: number): Observable<T> {
+    if (count > 0) {
+      return this;
+    }
+    return new EmptyObservable();
+  }
 }

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -62,4 +62,15 @@ export default class ScalarObservable<T> extends Observable<T> {
       return new ScalarObservable(project.call(thisArg || this, this.value, 0));
     }
   }
+
+  filter(select: (x: T, ix?: number) => boolean, thisArg?: any): Observable<T> {
+    let result = tryCatch(select).call(thisArg || this, this.value, 0);
+    if (result === errorObject) {
+      return new ErrorObservable(errorObject.e);
+    } else if (result) {
+      return this;
+    } else {
+      return new EmptyObservable();
+    }
+  }
 }

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -90,8 +90,17 @@ export default class ScalarObservable<T> extends Observable<T> {
     return this.reduce(project, acc);
   }
 
-  count(): Observable<number> {
-    return new ScalarObservable(1);
+  count(predicate?: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<number> {
+    if (!predicate) {
+      return new ScalarObservable(1);
+    } else {
+      let result = tryCatch(predicate).call(thisArg || this, this.value, 0, this);
+      if (result === errorObject) {
+        return new ErrorObservable(errorObject.e);
+      } else {
+        return new ScalarObservable(result ? 1 : 0);
+      }
+    }
   }
 
   skip(count: number): Observable<T> {


### PR DESCRIPTION
Adding a bunch of overrides to ScalarObservable to optimize performance. This is an approach different than what we've done in the past, in that it puts an override directly on ScalarObservable, rather than doing type-checking in the functions themselves.

Here is a list of results (Before and After):

```
Before

                                         |                     RxJS 4.0.1 |             RxJS 5.0.0-alpha.3 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
         filter-scalar-false - immediate |               717,228 (±1.17%) |             1,516,863 (±0.45%) |           2.11x |          111.5%
          filter-scalar-true - immediate |               524,921 (±0.62%) |               966,993 (±0.65%) |           1.84x |           84.2%
                  map-scalar - immediate |               641,470 (±0.87%) |             1,372,438 (±0.62%) |           2.14x |          114.0%
        reduce-scalar-noseed - immediate |               687,545 (±1.95%) |             2,429,996 (±0.81%) |           3.53x |          253.4%
               reduce-scalar - immediate |               483,549 (±0.72%) |             1,119,916 (±1.03%) |           2.32x |          131.6%
          scan-scalar-noseed - immediate |               220,031 (±0.60%) |             2,422,950 (±0.67%) |          11.01x |        1,001.2%
                 scan-scalar - immediate |               189,861 (±1.00%) |             1,161,650 (±0.51%) |           6.12x |          511.8%
                count-scalar - immediate |               745,924 (±0.67%) |             2,462,605 (±0.58%) |           3.30x |          230.1%
               skip-scalar-0 - immediate |               703,792 (±0.76%) |             2,545,683 (±0.52%) |           3.62x |          261.7%
     skip-scalar-outofbounds - immediate |               635,857 (±0.61%) |             1,825,839 (±0.78%) |           2.87x |          187.1%
                 take-scalar - immediate |               707,963 (±0.50%) |             2,576,310 (±0.68%) |           3.64x |          263.9%








After

                                         |                     RxJS 4.0.1 |             RxJS 5.0.0-alpha.3 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
         filter-scalar-false - immediate |               704,688 (±3.42%) |             6,231,688 (±0.79%) |           8.84x |          784.3%
          filter-scalar-true - immediate |               520,997 (±0.97%) |             1,970,056 (±0.53%) |           3.78x |          278.1%
                  map-scalar - immediate |               626,140 (±1.73%) |             4,051,141 (±0.76%) |           6.47x |          547.0%
        reduce-scalar-noseed - immediate |               674,846 (±1.43%) |             4,074,599 (±0.88%) |           6.04x |          503.8%
               reduce-scalar - immediate |               468,252 (±0.53%) |             2,007,994 (±0.71%) |           4.29x |          328.8%
          scan-scalar-noseed - immediate |               217,599 (±2.10%) |             4,043,362 (±0.80%) |          18.58x |        1,758.2%
                 scan-scalar - immediate |               192,236 (±0.52%) |             1,970,688 (±0.94%) |          10.25x |          925.1%
                count-scalar - immediate |               691,734 (±2.01%) |             4,107,881 (±0.73%) |           5.94x |          493.9%
               skip-scalar-0 - immediate |               704,049 (±1.31%) |             4,115,490 (±0.65%) |           5.85x |          484.5%
     skip-scalar-outofbounds - immediate |               647,033 (±0.55%) |             2,456,657 (±0.85%) |           3.80x |          279.7%
                 take-scalar - immediate |               688,545 (±1.71%) |             4,030,593 (±0.54%) |           5.85x |          485.4%
```