### PR TITLE
refactor(Observable): Make 'protected' of Observable<T>._isScalar

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -17,7 +17,7 @@ import $$observable from './util/Symbol_observable';
 export default class Observable<T> implements CoreOperators<T>  {
   source: Observable<any>;
   operator: Operator<any, T>;
-  _isScalar: boolean = false;
+  protected _isScalar: boolean = false;
 
   /**
    * @constructor

--- a/src/observables/PromiseObservable.ts
+++ b/src/observables/PromiseObservable.ts
@@ -6,7 +6,7 @@ import immediate from '../schedulers/immediate';
 
 export default class PromiseObservable<T> extends Observable<T> {
 
-  _isScalar: boolean = false;
+  protected _isScalar: boolean = false;
   value: T;
 
   static create<T>(promise: Promise<T>, scheduler: Scheduler = immediate): Observable<T> {

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -27,7 +27,7 @@ export default class ScalarObservable<T> extends Observable<T> {
     (<any> this).schedule(state);
   }
 
-  _isScalar: boolean = true;
+  protected _isScalar: boolean = true;
 
   constructor(public value: T, private scheduler?: Scheduler) {
     super();


### PR DESCRIPTION
This property should be accessed only from a derived class. There's no need to make this public.