### PR TITLE
bufferWhen: tests and fixes

### DIFF
--- a/spec/operators/bufferWhen-spec.js
+++ b/spec/operators/bufferWhen-spec.js
@@ -17,6 +17,149 @@ describe('Observable.prototype.bufferWhen', function () {
     expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
   });
 
+  it('should emit buffers using varying cold closings', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
+    var subs =        '^                                  !      ';
+    var closings = [
+      cold(           '---------------s--|                       '),
+      cold(                          '----------(s|)             '),
+      cold(                                    '-------------(s|)')];
+    var expected =    '---------------x---------y---------(z|)   ';
+    var values = {
+      x: ['b','c','d'],
+      y: ['e','f','g'],
+      z: ['h']
+    };
+
+    var i = 0;
+    var result = e1.bufferWhen(function () { return closings[i++]; });
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should emit buffers using varying hot closings', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|   ');
+    var subs =        '^                                  !   ';
+    var closings = [
+      {obs: hot(  '-1--^--------------s---|                   '), // eslint-disable-line key-spacing
+       sub:           '^              !                       '}, // eslint-disable-line key-spacing
+      {obs: hot(  '--1-^----3--------4----------s-|           '), // eslint-disable-line key-spacing
+       sub:           '               ^         !             '}, // eslint-disable-line key-spacing
+      {obs: hot(  '1-2-^------3----4-------5--6-----------s--|'), // eslint-disable-line key-spacing
+       sub:           '                         ^         !   '}]; // eslint-disable-line key-spacing
+    var expected =    '---------------x---------y---------(z|)';
+    var values = {
+      x: ['b','c','d'],
+      y: ['e','f','g'],
+      z: ['h']
+    };
+
+    var i = 0;
+    var result = e1.bufferWhen(function () { return closings[i++].obs; });
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+    for (var j = 0; j < closings.length; j++) {
+      expectSubscriptions(closings[j].obs.subscriptions).toBe(closings[j].sub);
+    }
+  });
+
+  it('should emit buffers using varying empty delayed closings', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
+    var subs =        '^                                  !      ';
+    var closings = [
+      cold(           '---------------|                       '),
+      cold(                          '----------|             '),
+      cold(                                    '-------------|')];
+    var expected =    '---------------x---------y---------(z|)   ';
+    var values = {
+      x: ['b','c','d'],
+      y: ['e','f','g'],
+      z: ['h']
+    };
+
+    var i = 0;
+    var result = e1.bufferWhen(function () { return closings[i++]; });
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should emit buffers using varying cold closings, outer unsubscribed early', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
+    var unsub =       '                  !                       ';
+    var subs =        '^                 !                       ';
+    var closings = [
+      cold(           '---------------(s|)                       '),
+      cold(                          '----------(s|)             '),
+      cold(                                    '-------------(s|)')];
+    var expected =    '---------------x---                       ';
+    var values = {
+      x: ['b','c','d']
+    };
+
+    var i = 0;
+    var result = e1.bufferWhen(function () { return closings[i++]; });
+
+    expectObservable(result, unsub).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should propagate error thrown from closingSelector', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
+    var subs =        '^              !                          ';
+    var closings = [
+      cold(           '---------------s--|                       '),
+      cold(                          '----------(s|)             '),
+      cold(                                    '-------------(s|)')];
+    var expected =    '---------------(x#)                       ';
+    var values = { x: ['b','c','d'] };
+
+    var i = 0;
+    var result = e1.bufferWhen(function () {
+      if (i === 1) {
+        throw 'error';
+      }
+      return closings[i++];
+    });
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should propagate error emitted from a closing', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    var subs =        '^              !                    ';
+    var closings = [
+      cold(           '---------------s--|                 '),
+      cold(                          '#                    ')];
+    var expected =    '---------------(x#)                 ';
+    var values = { x: ['b','c','d'] };
+
+    var i = 0;
+    var result = e1.bufferWhen(function () { return closings[i++]; });
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should propagate error emitted late from a closing', function () {
+    var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    var subs =        '^                    !              ';
+    var closings = [
+      cold(           '---------------s--|                 '),
+      cold(                          '------#              ')];
+    var expected =    '---------------x-----#              ';
+    var values = { x: ['b','c','d'] };
+
+    var i = 0;
+    var result = e1.bufferWhen(function () { return closings[i++]; });
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
   it('should handle errors', function () {
     var e1 = hot('--a--^---b---c---d---e---f---#');
     var e2 = cold(    '---------------(s|)');
@@ -52,19 +195,24 @@ describe('Observable.prototype.bufferWhen', function () {
   });
 
   it('should handle never', function () {
-    var e1 = Observable.never();
-    var e2 = cold( '--------(s|)');
-    var expected = '--------x-------x-------x-------x-------x-------x-------x-------x-------x----';
+    var e1 =   hot('-');
+    var e2 = cold( '--------(s|)                                 ');
+    var unsub =    '                                            !';
+    var subs =     '^                                           !';
+    var expected = '--------x-------x-------x-------x-------x----';
     var values = {
       x: []
     };
 
-    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+    var source = e1.bufferWhen(function () { return e2; });
+
+    expectObservable(source, unsub).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
   it('should handle an inner never', function () {
     var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    var e2 = Observable.never();
+    var e2 = cold('-');
     var expected =    '-----------------------------------(x|)';
     var values = {
       x: ['b','c','d','e','f','g','h']
@@ -73,19 +221,31 @@ describe('Observable.prototype.bufferWhen', function () {
     expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
   });
 
-  it('should handle inner empty', function () {
-    var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    var e2 = Observable.empty();
-    var expected =    '-----------------------------------(x|)';
-    var values = {
-      x: ['b','c','d','e','f','g','h']
-    };
+  // bufferWhen is not supposed to handle a factory that returns always empty
+  // closing Observables, because doing such would constantly recreate a new
+  // buffer in a synchronous infinite loop until the stack overflows. This also
+  // happens with buffer in RxJS 4.
+  it('should NOT handle hot inner empty', function (done) {
+    var source = Observable.of(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    var closing = Observable.empty();
+    var TOO_MANY_INVOCATIONS = 30;
 
-    expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values);
+    var invoked = 0;
+    source
+      .bufferWhen(function () { return closing; })
+      .subscribe(function (val) {
+        expect(Array.isArray(val)).toBe(true);
+        expect(val.length).toBe(0);
+        invoked++;
+        if (invoked > TOO_MANY_INVOCATIONS) {
+          done();
+        }
+      }, null, null);
   });
 
   it('should handle inner throw', function () {
     var e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    var subs =        '(^!)';
     var e2 = Observable.throw('bad!');
     var expected =    '#';
     var values = {
@@ -93,15 +253,16 @@ describe('Observable.prototype.bufferWhen', function () {
     };
 
     expectObservable(e1.bufferWhen(function () { return e2; })).toBe(expected, values, 'bad!');
+    expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
   it('should handle disposing of source', function () {
     var e1 =         hot('--a--^---b---c---d---e---f---g---h------|');
-    var e1disp =         '-----^--------------------!';
+    var subs =                '^                   !';
+    var unsub =               '                    !';
     var e2 = cold(            '---------------(s|)');
     //                                        ---------------(s|)
     var expected =            '---------------x-----';
-    // var sourceSubs =     '-----^-------------------!';
     var values = {
       x: ['b','c','d'],
       y: ['e','f','g','h'],
@@ -109,7 +270,8 @@ describe('Observable.prototype.bufferWhen', function () {
     };
 
     var source = e1.bufferWhen(function () { return e2; });
-    expectObservable(source, e1disp).toBe(expected, values);
-    // expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+
+    expectObservable(source, unsub).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 });

--- a/src/operators/bufferWhen.ts
+++ b/src/operators/bufferWhen.ts
@@ -86,6 +86,6 @@ class BufferClosingNotifierSubscriber<T> extends Subscriber<T> {
   }
 
   _complete() {
-    // noop
+    this.parent.openBuffer();
   }
 }

--- a/src/subjects/SubjectSubscription.ts
+++ b/src/subjects/SubjectSubscription.ts
@@ -1,6 +1,7 @@
 import Subject from '../Subject';
 import Subscription from '../Subscription';
 import Observer from '../Observer';
+import Subscriber from '../Subscriber';
 
 export default class SubjectSubscription<T> extends Subscription<T> {
   isUnsubscribed: boolean = false;
@@ -25,6 +26,9 @@ export default class SubjectSubscription<T> extends Subscription<T> {
       return;
     }
 
+    if (this.observer instanceof Subscriber) {
+      (<Subscriber<T>> this.observer).unsubscribe();
+    }
     const subscriberIndex = observers.indexOf(this.observer);
 
     if (subscriberIndex !== -1) {


### PR DESCRIPTION
Add comprehensive marble tests for bufferWhen.

bufferWhen, as far as I can see, mirrors RxJS 4 `buffer` using a closingSelector function as parameter.
If so, then this PR fixes bufferWhen to behave like RxJS 4 buffer in some corner cases.

Relates to #381.