### PR TITLE
chore(micro perf): bump up rx version to latest

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "platform": "^1.3.0",
     "promise": "^7.0.3",
     "protractor": "2.2.0",
-    "rx": "^4.0.1",
+    "rx": "latest",
     "tslint": "^2.5.0",
     "typescript": "^1.7.0-dev.20150901",
     "watch": "^0.16.0"


### PR DESCRIPTION
RxJS 4.0.6 has released, PR trying to bump up version as well.

Instead of manually picking version all time, use `latest` to pick last published version always. Somewhat debatable though thinking about recent perf test issues with `defaultIfEmpty`, if new package has regression micro perf test will be impacted directly. Still believe this'll gives convenience and expect regression occurs raraly, considering framework is quite mature already.