### PR TITLE
Fixes mergeAll micro perf tests.

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/mergeall.js
+++ b/perf/micro/current-thread-scheduler/operators/mergeall.js
@@ -6,7 +6,7 @@ module.exports = function (suite) {
     .map(RxOld.Observable.range(0, 25), RxOld.Scheduler.currentThread)
     .mergeAll();
   var newMergeAllWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.immediate)
-    .map(RxNew.Observable.range(0, 25, RxNew.Scheduler.immediate))
+    .mapTo(RxNew.Observable.range(0, 25, RxNew.Scheduler.immediate))
     .mergeAll();
 
   function _next(x) { }

--- a/perf/micro/immediate-scheduler/operators/mergeall.js
+++ b/perf/micro/immediate-scheduler/operators/mergeall.js
@@ -6,7 +6,7 @@ module.exports = function (suite) {
     .map(RxOld.Observable.range(0, 25), RxOld.Scheduler.immediate)
     .mergeAll();
   var newMergeAllWithImmediateScheduler = RxNew.Observable.range(0, 25)
-    .map(RxNew.Observable.range(0, 25))
+    .mapTo(RxNew.Observable.range(0, 25))
     .mergeAll();
 
   function _next(x) { }


### PR DESCRIPTION
Sadly, the ~6000% speed up was erroneous :(

Actual numbers:
```
                                         |                     RxJS 4.0.6 |             RxJS 5.0.0-alpha.4 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                    mergeall - immediate |                 1,543 (±0.86%) |                13,700 (±0.99%) |           8.88x |          788.2%
                                mergeall |                 1,437 (±0.82%) |                 6,581 (±1.20%) |           4.58x |          358.0%
```