### PR TITLE
fix(package): correct typings path

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,5 @@
   "engines": {
     "npm": "~2.0.0"
   },
-  "typings": "./dist/es6/Rx.d.ts"
+  "typings": "./dist/cjs/Rx.d.ts"
 }


### PR DESCRIPTION
non critical, but entry point for typings should point to same location as CJS output fixed in https://github.com/ReactiveX/RxJS/commit/64cd865a798804ecf31113cd7a6889689ac7eb8c - my fault, probably should have caught this on review. 