### PR TITLE
chore(tsconfig.json): update tsc build configuration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 *.sublime-project
 *.sublime-workspace
 .settings
+.vscode
 
 # Installed libs
 node_modules/

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,12 @@
     "removeComments": false,
     "preserveConstEnums": true,
     "sourceMap": true,
-    "target": "es5",
-    "module": "commonjs",
-    "outDir": "dist/cjs"
-  }
+    "declaration": true,
+    "target": "es6",
+    "outDir": "dist/es6"
+  },
+   "files": [
+     "src/Rx.ts",
+     "src/Rx.KitchenSink.ts"
+   ]
 }


### PR DESCRIPTION
- tsconfig points es6 build configuration by default

Though tsconfig.json is not being used via actual build script, it's no harm to align it with build script for anyone who want simply invoke `tsc` to get es6 build. One of minor changes while waiting PR related code coverage check is resolved, to avoid PR created with failed check.