### PR TITLE
fix(operator): update type definitions for union types

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -133,8 +133,8 @@ export default class Observable<T> implements CoreOperators<T>  {
   }
 
   // static method stubs
-  static combineLatest: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T) | Scheduler)[]) => Observable<T>;
-  static concat: <T>(...observables: (Observable<any> | Scheduler)[]) => Observable<T>;
+  static combineLatest: <T>(...observables: Array<Observable<any> | ((...values: Array<any>) => T) | Scheduler>) => Observable<T>;
+  static concat: <T>(...observables: Array<Observable<any> | Scheduler>) => Observable<T>;
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
   static empty: <T>(scheduler?: Scheduler) => Observable<T>;
   static forkJoin: <T>(...observables: Observable<any>[]) => Observable<T>;
@@ -144,13 +144,13 @@ export default class Observable<T> implements CoreOperators<T>  {
   static fromEventPattern: <T>(addHandler: (handler:Function)=>void, removeHandler: (handler:Function) => void, selector?: (...args:Array<any>) => T) => Observable<T>;
   static fromPromise: <T>(promise: Promise<T>, scheduler?: Scheduler) => Observable<T>;
   static interval: (interval: number, scheduler?: Scheduler) => Observable<number>;
-  static merge: <T>(...observables: (Observable<any> | Scheduler | number)[]) => Observable<T>;
+  static merge: <T>(...observables: Array<Observable<any> | Scheduler | number>) => Observable<T>;
   static never: <T>() => Observable<T>;
-  static of: <T>(...values: (T | Scheduler)[]) => Observable<T>;
+  static of: <T>(...values: Array<T | Scheduler>) => Observable<T>;
   static range: (start: number, end: number, scheduler?: Scheduler) => Observable<number>;
   static throw: <T>(error: T) => Observable<T>;
   static timer: (dueTime: number, period?: number | Scheduler, scheduler?: Scheduler) => Observable<number>;
-  static zip: <T>(...observables: (Observable<any> | ((...values: Array<any>) => T)) []) => Observable<T>;
+  static zip: <T>(...observables: Array<Observable<any> | ((...values: Array<any>) => T)>) => Observable<T>;
 
   // core operators
 
@@ -161,7 +161,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   bufferWhen: <T>(closingSelector: () => Observable<any>) => Observable<T[]>;
   catch: (selector: (err: any, source: Observable<T>, caught: Observable<any>) => Observable<any>) => Observable<T>;
   combineAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
-  combineLatest: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R))[]) => Observable<R>;
+  combineLatest: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
   concat: (...observables: any[]) => Observable<any>;
   concatAll: () => Observable<any>;
   concatMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
@@ -226,7 +226,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   windowTime: <T>(windowTimeSpan: number, windowCreationInterval?: number, scheduler?: Scheduler) => Observable<Observable<T>>;
   windowToggle: <T, O>(openings: Observable<O>, closingSelector?: (openValue: O) => Observable<any>) => Observable<Observable<T>>;
   windowWhen: <T>(closingSelector: () => Observable<any>) => Observable<Observable<T>>;
-  withLatestFrom: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R))[]) => Observable<R>;
-  zip: <R>(...observables: (Observable<any> | ((...values: Array<any>) => R))[]) => Observable<R>;
+  withLatestFrom: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
+  zip: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
   zipAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
 }

--- a/src/observables/ArrayObservable.ts
+++ b/src/observables/ArrayObservable.ts
@@ -9,7 +9,7 @@ export default class ArrayObservable<T> extends Observable<T> {
     return new ArrayObservable(array, scheduler);
   }
 
-  static of<T>(...array: (T | Scheduler)[]): Observable<T> {
+  static of<T>(...array: Array<T | Scheduler>): Observable<T> {
     let scheduler = <Scheduler>array[array.length - 1];
     if (scheduler && typeof scheduler.schedule === 'function') {
       array.pop();

--- a/src/operators/combineLatest-static.ts
+++ b/src/operators/combineLatest-static.ts
@@ -13,7 +13,7 @@ import Scheduler from '../Scheduler';
  * @returns {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
  * the most recent values from each observable.
  */
-export default function combineLatest<R>(...observables: (Observable<any> | ((...values: Array<any>) => R) | Scheduler)[]): Observable<R> {
+export default function combineLatest<R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R) | Scheduler>): Observable<R> {
   let project, scheduler;
 
   if (typeof (<any>observables[observables.length - 1]).schedule === 'function') {

--- a/src/operators/combineLatest.ts
+++ b/src/operators/combineLatest.ts
@@ -12,7 +12,7 @@ import { CombineLatestOperator } from './combineLatest-support';
  * @returns {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
  * the most recent values from each observable.
  */
-export default function combineLatest<R>(...observables: (Observable<any>|((...values: any[]) => R))[]): Observable<R> {
+export default function combineLatest<R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>): Observable<R> {
   observables.unshift(this);
   let project;
   if (typeof observables[observables.length - 1] === 'function') {

--- a/src/operators/concat-static.ts
+++ b/src/operators/concat-static.ts
@@ -11,7 +11,7 @@ import { CoreOperators } from '../CoreOperators';
  * @params {Scheduler} [scheduler] an optional scheduler to schedule each observable subscription on.
  * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
  */
-export default function concat<R>(...observables: (Observable<any>|Scheduler)[]): Observable<R> {
+export default function concat<R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
   let scheduler: Scheduler = immediate;
   let args = <any[]>observables;
   const len = args.length;

--- a/src/operators/merge-static.ts
+++ b/src/operators/merge-static.ts
@@ -4,7 +4,7 @@ import ArrayObservable from '../observables/ArrayObservable';
 import { MergeAllOperator } from './mergeAll-support';
 import immediate from '../schedulers/immediate';
 
-export default function merge<R>(...observables: (Observable<any>|Scheduler|number)[]): Observable<R> {
+export default function merge<R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
   let concurrent = Number.POSITIVE_INFINITY;
   let scheduler: Scheduler = immediate;
   let last: any = observables[observables.length - 1];

--- a/src/operators/withLatestFrom.ts
+++ b/src/operators/withLatestFrom.ts
@@ -26,7 +26,7 @@ import subscribeToResult from '../util/subscribeToResult';
  * result: ---([a,d,x])---------([b,e,y])--------([c,f,z])---|
  * ```
  */
-export default function withLatestFrom<R>(...args: (Observable<any>|((...values: any[]) => Observable<R>))[]): Observable<R> {
+export default function withLatestFrom<R>(...args: Array<Observable<any> | ((...values: Array<any>) => R)>): Observable<R> {
   let project;
   if (typeof args[args.length - 1] === 'function') {
     project = args.pop();

--- a/src/operators/zip-static.ts
+++ b/src/operators/zip-static.ts
@@ -2,7 +2,7 @@ import Observable from '../Observable';
 import ArrayObservable from '../observables/ArrayObservable';
 import { ZipOperator } from './zip-support';
 
-export default function zip<T, R>(...observables: (Observable<any> | ((...values: Array<any>) => R))[]): Observable<R> {
+export default function zip<T, R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>): Observable<R> {
   const project = <((...ys: Array<any>) => R)> observables[observables.length - 1];
   if (typeof project === 'function') {
     observables.pop();

--- a/src/operators/zip.ts
+++ b/src/operators/zip.ts
@@ -1,7 +1,7 @@
 import Observable from '../Observable';
 import zip from './zip-static';
 
-export default function zipProto<R>(...observables: (Observable<any> | ((...values: Array<any>) => R))[]): Observable<R> {
+export default function zipProto<R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>): Observable<R> {
   observables.unshift(this);
   return zip.apply(this, observables);
 }


### PR DESCRIPTION
- allow multiple type parameters can be accepted for observable,
operator supports array of union types

closes #581

This PR replaces array of union type declaration more explicit way by language spec (https://github.com/Microsoft/TypeScript/issues/805), get rid of type inference error by typescript compiler when multiple type of parameters are actually provided.