### PR TITLE
refactor(Subscriber): update type declaration for Subscriber

### DIFF
--- a/src/OuterSubscriber.ts
+++ b/src/OuterSubscriber.ts
@@ -1,17 +1,16 @@
 import InnerSubscriber from './InnerSubscriber';
 import Subscriber from './Subscriber';
 
-
 export default class OuterSubscriber<T, R> extends Subscriber<T> {
-  notifyComplete(inner?: InnerSubscriber<T, R>) {
+  notifyComplete(inner?: InnerSubscriber<T, R>): void {
     this.destination.complete();
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {
+  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
     this.destination.next(innerValue);
   }
 
-  notifyError(error?: any, inner?: InnerSubscriber<T, R>) {
+  notifyError(error?: any, inner?: InnerSubscriber<T, R>): void {
     this.destination.error(error);
   }
 }

--- a/src/operators/count.ts
+++ b/src/operators/count.ts
@@ -24,7 +24,7 @@ import bindCallback from '../util/bindCallback';
 export default function count<T>(predicate?: (value: T,
                                               index: number,
                                               source: Observable<T>) => boolean,
-                                 thisArg?: any): Observable<T> {
+                                 thisArg?: any): Observable<number> {
   return this.lift(new CountOperator(predicate, thisArg, this));
 }
 
@@ -35,18 +35,18 @@ class CountOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {
-    return new CountSubscriber<T>(
+    return new CountSubscriber<T, R>(
       subscriber, this.predicate, this.thisArg, this.source
     );
   }
 }
 
-class CountSubscriber<T> extends Subscriber<T> {
+class CountSubscriber<T, R> extends Subscriber<T> {
   private predicate: Function;
   private count: number = 0;
   private index: number = 0;
 
-  constructor(destination: Observer<T>,
+  constructor(destination: Observer<R>,
               predicate?: (value: T, index: number, source: Observable<T>) => boolean,
               private thisArg?: any,
               private source?: Observable<T>) {
@@ -56,7 +56,7 @@ class CountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _next(value: T) {
+  _next(value: T): void {
     const predicate = this.predicate;
     let passed: any = true;
     if (predicate) {
@@ -71,7 +71,7 @@ class CountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete() {
+  _complete(): void {
     this.destination.next(this.count);
     this.destination.complete();
   }

--- a/src/operators/every.ts
+++ b/src/operators/every.ts
@@ -5,13 +5,12 @@ import ScalarObservable from '../observables/ScalarObservable';
 import ArrayObservable from '../observables/ArrayObservable';
 import ErrorObservable from '../observables/ErrorObservable';
 import Subscriber from '../Subscriber';
-import immediate from '../schedulers/immediate';
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import bindCallback from '../util/bindCallback';
 
 export default function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                                 thisArg?: any): Observable<T> {
+                                 thisArg?: any): Observable<boolean> {
   const source = this;
   let result;
 
@@ -42,16 +41,16 @@ class EveryOperator<T, R> implements Operator<T, R> {
               private source?: Observable<T>) {
   }
 
-  call(observer: Subscriber<R>): Subscriber<T> {
+  call(observer: Subscriber<boolean>): Subscriber<T> {
     return new EverySubscriber(observer, this.predicate, this.thisArg, this.source);
   }
 }
 
-class EverySubscriber<T> extends Subscriber<T> {
+class EverySubscriber<T, R> extends Subscriber<T> {
   private predicate: Function = undefined;
   private index: number = 0;
 
-  constructor(destination: Observer<T>,
+  constructor(destination: Observer<R>,
               predicate?: (value: T, index: number, source: Observable<T>) => boolean,
               private thisArg?: any,
               private source?: Observable<T>) {
@@ -67,7 +66,7 @@ class EverySubscriber<T> extends Subscriber<T> {
     this.destination.complete();
   }
 
-  _next(value: T) {
+  _next(value: T): void {
     const predicate = this.predicate;
 
     if (predicate === undefined) {
@@ -82,7 +81,7 @@ class EverySubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete() {
+  _complete(): void {
     this.notifyComplete(true);
   }
 }

--- a/src/operators/expand-support.ts
+++ b/src/operators/expand-support.ts
@@ -4,9 +4,6 @@ import Observable from '../Observable';
 import Subscriber from '../Subscriber';
 import Subscription from '../Subscription';
 
-import EmptyObservable from '../observables/EmptyObservable';
-import ScalarObservable from '../observables/ScalarObservable';
-
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import OuterSubscriber from '../OuterSubscriber';
@@ -28,7 +25,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   private hasCompleted: boolean = false;
   private buffer: any[];
 
-  constructor(destination: Observer<T>,
+  constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => Observable<R>,
               private concurrent: number = Number.POSITIVE_INFINITY) {
     super(destination);
@@ -37,7 +34,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  _next(value: any) {
+  _next(value: any): void {
     const index = this.index++;
     this.destination.next(value);
     if (this.active < this.concurrent) {
@@ -57,14 +54,14 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  _complete() {
+  _complete(): void {
     this.hasCompleted = true;
     if (this.hasCompleted && this.active === 0) {
       this.destination.complete();
     }
   }
 
-  notifyComplete(innerSub: Subscription<T>) {
+  notifyComplete(innerSub: Subscription<T>): void {
     const buffer = this.buffer;
     this.remove(innerSub);
     this.active--;
@@ -76,7 +73,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {
+  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
     this._next(innerValue);
   }
 }

--- a/src/operators/mergeMapTo-support.ts
+++ b/src/operators/mergeMapTo-support.ts
@@ -25,14 +25,14 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
   private active: number = 0;
   protected index: number = 0;
 
-  constructor(destination: Observer<T>,
+  constructor(destination: Subscriber<R>,
               private ish: any,
               private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2,
               private concurrent: number = Number.POSITIVE_INFINITY) {
     super(destination);
   }
 
-  _next(value: any) {
+  _next(value: any): void {
     if (this.active < this.concurrent) {
       const resultSelector = this.resultSelector;
       const index = this.index++;
@@ -53,18 +53,18 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
             destination: Observer<R>,
             resultSelector: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2,
             value: T,
-            index: number) {
+            index: number): void {
     this.add(subscribeToResult<T, R>(this, ish, value, index));
   }
 
-  _complete() {
+  _complete(): void {
     this.hasCompleted = true;
     if (this.active === 0 && this.buffer.length === 0) {
       this.destination.complete();
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {
+  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
     const { resultSelector, destination } = this;
     if (resultSelector) {
       const result = tryCatch(resultSelector)(outerValue, innerValue, outerIndex, innerIndex);
@@ -78,11 +78,11 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyError(err: any) {
+  notifyError(err: any): void {
     this.destination.error(err);
   }
 
-  notifyComplete(innerSub: InnerSubscriber<T, R>) {
+  notifyComplete(innerSub: InnerSubscriber<T, R>): void {
     const buffer = this.buffer;
     this.remove(innerSub);
     this.active--;

--- a/src/operators/single.ts
+++ b/src/operators/single.ts
@@ -21,7 +21,7 @@ class SingleOperator<T, R> implements Operator<T, R> {
               private source?: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new SingleSubscriber(subscriber, this.predicate, this.thisArg, this.source);
   }
 }
@@ -52,7 +52,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _next(value: T) {
+  _next(value: T): void {
     const predicate = this.predicate;
     const currentIndex = this.index++;
 
@@ -68,7 +68,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete() {
+  _complete(): void {
     const destination = this.destination;
 
     if (this.index > 0) {

--- a/src/operators/skip.ts
+++ b/src/operators/skip.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 export default function skip(total) {
@@ -7,26 +6,19 @@ export default function skip(total) {
 }
 
 class SkipOperator<T, R> implements Operator<T, R> {
-
-  total: number;
-
-  constructor(total: number) {
-    this.total = total;
+  constructor(private total: number) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new SkipSubscriber(subscriber, this.total);
   }
 }
 
 class SkipSubscriber<T> extends Subscriber<T> {
-
-  total: number;
   count: number = 0;
 
-  constructor(destination: Subscriber<T>, total: number) {
+  constructor(destination: Subscriber<T>, private total: number) {
     super(destination);
-    this.total = total;
   }
 
   _next(x) {

--- a/src/operators/switch.ts
+++ b/src/operators/switch.ts
@@ -11,10 +11,6 @@ export default function _switch<T>(): Observable<T> {
 }
 
 class SwitchOperator<T, R> implements Operator<T, R> {
-
-  constructor() {
-  }
-
   call(subscriber: Subscriber<R>): Subscriber<T> {
     return new SwitchSubscriber(subscriber);
   }
@@ -25,24 +21,24 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
   private hasCompleted: boolean = false;
   innerSubscription: Subscription<T>;
 
-  constructor(destination: Observer<T>) {
+  constructor(destination: Subscriber<R>) {
     super(destination);
   }
 
-  _next(value: any) {
+  _next(value: T): void {
     this.unsubscribeInner();
     this.active++;
     this.add(this.innerSubscription = subscribeToResult(this, value));
   }
 
-  _complete() {
+  _complete(): void {
     this.hasCompleted = true;
     if (this.active === 0) {
       this.destination.complete();
     }
   }
 
-  unsubscribeInner() {
+  private unsubscribeInner(): void {
     this.active = this.active > 0 ? this.active - 1 : 0;
     const innerSubscription = this.innerSubscription;
     if (innerSubscription) {
@@ -51,19 +47,18 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: any) {
+  notifyNext(outerValue: T, innerValue: any): void {
     this.destination.next(innerValue);
   }
 
-  notifyError(err: any) {
+  notifyError(err: any): void {
     this.destination.error(err);
   }
 
-  notifyComplete() {
+  notifyComplete(): void {
     this.unsubscribeInner();
     if (this.hasCompleted && this.active === 0) {
       this.destination.complete();
     }
   }
 }
-

--- a/src/operators/switchMap.ts
+++ b/src/operators/switchMap.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Observable from '../Observable';
 import Subscriber from '../Subscriber';
 import Subscription from '../Subscription';
@@ -31,18 +30,17 @@ class SwitchMapOperator<T, R, R2> implements Operator<T, R> {
 }
 
 class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
-
   private innerSubscription: Subscription<T>;
   private hasCompleted = false;
-  index: number = 0;
+  private index: number = 0;
 
-  constructor(destination: Observer<T>,
+  constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => Observable<R>,
               private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
     super(destination);
   }
 
-  _next(value: any) {
+  _next(value: T): void {
     const index = this.index++;
     const destination = this.destination;
     let result = tryCatch(this.project)(value, index);
@@ -57,7 +55,7 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  _complete() {
+  _complete(): void {
     const innerSubscription = this.innerSubscription;
     this.hasCompleted = true;
     if (!innerSubscription || innerSubscription.isUnsubscribed) {
@@ -65,7 +63,7 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyComplete(innerSub: Subscription<R>) {
+  notifyComplete(innerSub: Subscription<R>): void {
     this.remove(innerSub);
     const prevSubscription = this.innerSubscription;
     if (prevSubscription) {
@@ -78,11 +76,11 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyError(err: any) {
+  notifyError(err: any): void {
     this.destination.error(err);
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {
+  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
     const { resultSelector, destination } = this;
     if (resultSelector) {
       const result = tryCatch(resultSelector)(outerValue, innerValue, outerIndex, innerIndex);

--- a/src/operators/switchMapTo.ts
+++ b/src/operators/switchMapTo.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Observable from '../Observable';
 import Subscriber from '../Subscriber';
 import Subscription from '../Subscription';
@@ -28,9 +27,7 @@ class SwitchMapToOperator<T, R, R2> implements Operator<T, R> {
 }
 
 class SwitchMapToSubscriber<T, R, R2> extends MergeMapToSubscriber<T, R, R2> {
-  innerSubscription: Subscription<T>;
-
-  constructor(destination: Observer<T>,
+  constructor(destination: Subscriber<R>,
               observable: Observable<R>,
               resultSelector?: (outerValue: T,
                                 innerValue: R,

--- a/src/operators/take.ts
+++ b/src/operators/take.ts
@@ -7,32 +7,25 @@ export default function take(total) {
 }
 
 class TakeOperator<T, R> implements Operator<T, R> {
-
-  total: number;
-
-  constructor(total: number) {
-    this.total = total;
+  constructor(private total: number) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new TakeSubscriber(subscriber, this.total);
   }
 }
 
 class TakeSubscriber<T> extends Subscriber<T> {
+  private count: number = 0;
 
-  total: number;
-  count: number = 0;
-
-  constructor(destination: Subscriber<T>, total: number) {
+  constructor(destination: Subscriber<T>, private total: number) {
     super(destination);
-    this.total = total;
   }
 
-  _next(x) {
+  _next(value: T): void {
     const total = this.total;
     if (++this.count <= total) {
-      this.destination.next(x);
+      this.destination.next(value);
       if (this.count === total) {
         this.destination.complete();
       }

--- a/src/operators/windowCount.ts
+++ b/src/operators/windowCount.ts
@@ -21,7 +21,7 @@ class WindowCountOperator<T, R> implements Operator<T, R> {
               private startWindowEvery: number) {
   }
 
-  call(subscriber: Subscriber<T>): Subscriber<T> {
+  call(subscriber: Subscriber<Observable<T>>): Subscriber<T> {
     return new WindowCountSubscriber(subscriber, this.windowSize, this.startWindowEvery);
   }
 }
@@ -30,7 +30,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
   private windows: Subject<T>[] = [ new Subject<T>() ];
   private count: number = 0;
 
-  constructor(destination: Subscriber<T>,
+  constructor(destination: Subscriber<Observable<T>>,
               private windowSize: number,
               private startWindowEvery: number) {
     super(destination);


### PR DESCRIPTION
- Subscriber applies generic type constraint

`Subscriber` itself does have type constraint via generic, it actually doesn't work for values or creating new observables, like below code snippet 

```
Rx.Observable.create((observer: Rx.Subscriber<number>) => {
    observer.next(42);
    observer.next('a');
    observer.complete();

    return () => {
        console.log('disposed');
    };
})
```

should be caught by compiler since type constraint of given subscriber is `number`, but it doesn't by `Subscriber::next()` does not apply type constraint for values.

**type constraint is not applied for values**
![image](https://cloud.githubusercontent.com/assets/1210596/10721882/862891c8-7b67-11e5-8e02-5dd969fc5ba5.png)

PR makes `Subscriber` now follows given types more explicitly let compiler allows type checking for build time.

**type constraint applied after changes**
![image](https://cloud.githubusercontent.com/assets/1210596/10714571/0cbe0d1e-7ab2-11e5-9bd5-7e0ad1bb4d89.png)

This change also brings correct generic type checking for operators either operator passes same type or either different type like `<in, out>`. No functional changes are introduced, change affects only for type declaration.
