### PR TITLE
chore(travis): do not repeat build twice

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ install:
   - npm install
 
 script:
-  - npm run build_cover
+  - npm test && npm run cover
 
 after_script:
   - cat ./coverage/coverage-remapped.lcov  | ./node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "jasmine": "2.3.2",
     "jasmine-core": "2.3.4",
     "jsonfile": "2.2.2",
-    "lodash": "3.5.0",
+    "lodash": "3.10.1",
     "multi-stage-sourcemap": "0.2.1",
     "platform": "1.3.0",
     "promise": "7.0.3",


### PR DESCRIPTION
Found travis actually run build twice per each trigger, which caused build turnaround delay. With this PR travis will build once only. Originally time took around ~3min on travis, after this PR it takes around ~2min. 