### PR TITLE
refactor(src): remove unused references

### DIFF
--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -1,7 +1,3 @@
-import noop from './util/noop';
-import throwError from './util/throwError';
-import tryOrOnError from './util/tryOrOnError';
-
 interface Observer<T> {
   next(value: T): void;
   error(err?: any): void;

--- a/src/observables/ConnectableObservable.ts
+++ b/src/observables/ConnectableObservable.ts
@@ -1,5 +1,4 @@
 import Subject from '../Subject';
-import Scheduler from '../Scheduler';
 import Observable from '../Observable';
 import Subscription from '../Subscription';
 

--- a/src/observables/DeferObservable.ts
+++ b/src/observables/DeferObservable.ts
@@ -1,5 +1,4 @@
 import Observable from '../Observable';
-import Subscription from '../Subscription';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';

--- a/src/observables/ForkJoinObservable.ts
+++ b/src/observables/ForkJoinObservable.ts
@@ -1,5 +1,4 @@
 import Observable from '../Observable';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 export default class ForkJoinObservable<T> extends Observable<T> {

--- a/src/observables/FromEventObservable.ts
+++ b/src/observables/FromEventObservable.ts
@@ -1,4 +1,3 @@
-import Scheduler from '../Scheduler';
 import Observable from '../Observable';
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';

--- a/src/observables/FromEventPatternObservable.ts
+++ b/src/observables/FromEventPatternObservable.ts
@@ -1,4 +1,3 @@
-import Scheduler from '../Scheduler';
 import Observable from '../Observable';
 import Subscription from '../Subscription';
 import tryCatch from '../util/tryCatch';

--- a/src/observables/FromObservable.ts
+++ b/src/observables/FromObservable.ts
@@ -40,9 +40,9 @@ export default class FromObservable<T> extends Observable<T> {
     const ish = this.ish;
     const scheduler = this.scheduler;
     if (scheduler === immediate) {
-      return this.ish[$$observable]().subscribe(subscriber);
+      return ish[$$observable]().subscribe(subscriber);
     } else {
-      return this.ish[$$observable]().subscribe(new ObserveOnSubscriber(subscriber, scheduler, 0));
+      return ish[$$observable]().subscribe(new ObserveOnSubscriber(subscriber, scheduler, 0));
     }
   }
 }

--- a/src/observables/IteratorObservable.ts
+++ b/src/observables/IteratorObservable.ts
@@ -173,10 +173,6 @@ function numberIsFinite(value) {
   return typeof value === 'number' && root.isFinite(value);
 }
 
-function isNan(n) {
-  return n !== n;
-}
-
 function sign(value) {
   let valueAsNumber = +value;
   if (valueAsNumber === 0) {

--- a/src/operators/buffer.ts
+++ b/src/operators/buffer.ts
@@ -1,11 +1,6 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 /**
  * buffers the incoming observable values until the passed `closingNotifier` emits a value, at which point

--- a/src/operators/bufferCount.ts
+++ b/src/operators/bufferCount.ts
@@ -1,11 +1,6 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 /**
  * buffers a number of values from the source observable by `bufferSize` then emits the buffer and clears it, and starts a
@@ -56,7 +51,7 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
       buffer.push(value);
       if (buffer.length === bufferSize) {
         remove = i;
-        this.destination.next(buffer);
+        destination.next(buffer);
       }
     }
 

--- a/src/operators/bufferTime.ts
+++ b/src/operators/bufferTime.ts
@@ -1,15 +1,9 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
-import Subscription from '../Subscription';
 import Scheduler from '../Scheduler';
 import Action from '../schedulers/Action';
 import nextTick from '../schedulers/nextTick';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 /**
  * buffers values from the source for a specific time period. Optionally allows new buffers to be set up at an interval.

--- a/src/operators/bufferToggle.ts
+++ b/src/operators/bufferToggle.ts
@@ -1,13 +1,10 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
-import Subject from '../Subject';
 import Subscription from '../Subscription';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 /**
  * buffers values from the source by opening the buffer via signals from an observable provided to `openings`, and closing
@@ -40,7 +37,6 @@ interface BufferContext<T> {
 
 class BufferToggleSubscriber<T, O> extends Subscriber<T> {
   private contexts: Array<BufferContext<T>> = [];
-  private closingNotification: Subscription<any>;
 
   constructor(destination: Subscriber<T>,
               private openings: Observable<O>,

--- a/src/operators/bufferWhen.ts
+++ b/src/operators/bufferWhen.ts
@@ -1,13 +1,10 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
-import Subject from '../Subject';
 import Subscription from '../Subscription';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 /**
  * Opens a buffer immediately, then closes the buffer when the observable returned by calling `closingSelector` emits a value.

--- a/src/operators/catch.ts
+++ b/src/operators/catch.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 

--- a/src/operators/combineAll.ts
+++ b/src/operators/combineAll.ts
@@ -1,4 +1,3 @@
-import Observable from '../Observable';
 import {CombineLatestOperator} from './combineLatest-support';
 
 /**

--- a/src/operators/combineLatest-support.ts
+++ b/src/operators/combineLatest-support.ts
@@ -1,10 +1,5 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
-import Observable from '../Observable';
 import Subscriber from '../Subscriber';
-
-import ArrayObservable from '../observables/ArrayObservable';
-import EmptyObservable from '../observables/EmptyObservable';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';

--- a/src/operators/concat-static.ts
+++ b/src/operators/concat-static.ts
@@ -1,4 +1,3 @@
-import mergeAll from './mergeAll';
 import Observable from '../Observable';
 import Scheduler from '../Scheduler';
 import immediate from '../schedulers/immediate';
@@ -14,7 +13,6 @@ import { CoreOperators } from '../CoreOperators';
 export default function concat<R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
   let scheduler: Scheduler = immediate;
   let args = <any[]>observables;
-  const len = args.length;
   if (typeof (args[observables.length - 1]).schedule === 'function') {
     scheduler = args.pop();
     args.push(1, scheduler);

--- a/src/operators/concat.ts
+++ b/src/operators/concat.ts
@@ -1,4 +1,3 @@
-import mergeAll from './mergeAll';
 import Observable from '../Observable';
 import Scheduler from '../Scheduler';
 import { CoreOperators } from '../CoreOperators';

--- a/src/operators/defaultIfEmpty.ts
+++ b/src/operators/defaultIfEmpty.ts
@@ -1,11 +1,6 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Observable from '../Observable';
 import Subscriber from '../Subscriber';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function defaultIfEmpty<T, R>(defaultValue: R = null): Observable<T> | Observable<R> {
   return this.lift(new DefaultIfEmptyOperator(defaultValue));

--- a/src/operators/dematerialize.ts
+++ b/src/operators/dematerialize.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Notification from '../Notification';
 

--- a/src/operators/distinctUntilChanged.ts
+++ b/src/operators/distinctUntilChanged.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 import tryCatch from '../util/tryCatch';

--- a/src/operators/do.ts
+++ b/src/operators/do.ts
@@ -5,7 +5,6 @@ import Subscriber from '../Subscriber';
 import noop from '../util/noop';
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function _do<T>(nextOrObserver?: Observer<T>|((x: T) => void), error?: (e: any) => void, complete?: () => void) {
   let next;

--- a/src/operators/every.ts
+++ b/src/operators/every.ts
@@ -5,7 +5,6 @@ import ScalarObservable from '../observables/ScalarObservable';
 import ArrayObservable from '../observables/ArrayObservable';
 import ErrorObservable from '../observables/ErrorObservable';
 import Subscriber from '../Subscriber';
-import immediate from '../schedulers/immediate';
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import bindCallback from '../util/bindCallback';

--- a/src/operators/expand-support.ts
+++ b/src/operators/expand-support.ts
@@ -4,9 +4,6 @@ import Observable from '../Observable';
 import Subscriber from '../Subscriber';
 import Subscription from '../Subscription';
 
-import EmptyObservable from '../observables/EmptyObservable';
-import ScalarObservable from '../observables/ScalarObservable';
-
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import OuterSubscriber from '../OuterSubscriber';

--- a/src/operators/filter.ts
+++ b/src/operators/filter.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 import tryCatch from '../util/tryCatch';

--- a/src/operators/finally.ts
+++ b/src/operators/finally.ts
@@ -1,10 +1,7 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Subscription from '../Subscription';
 
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
 import bindCallback from '../util/bindCallback';
 
 export default function _finally<T>(finallySelector: () => void, thisArg?: any) {

--- a/src/operators/first.ts
+++ b/src/operators/first.ts
@@ -5,7 +5,6 @@ import Observer from '../Observer';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 import EmptyError from '../util/EmptyError';
 
 export default function first<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/operators/groupBy.ts
+++ b/src/operators/groupBy.ts
@@ -1,16 +1,12 @@
-import Operator from '../Operator';
-import Observer from '../Observer';
-import Subscription from '../Subscription';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subject from '../Subject';
 import Map from '../util/Map';
 import FastMap from '../util/FastMap';
-import {RefCountSubscription, GroupedObservable, InnerRefCountSubscription} from './groupBy-support';
+import {RefCountSubscription, GroupedObservable} from './groupBy-support';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export function groupBy<T, R>(keySelector: (value: T) => string,
                               elementSelector?: (value: T) => R,

--- a/src/operators/last.ts
+++ b/src/operators/last.ts
@@ -5,7 +5,6 @@ import Observer from '../Observer';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 import EmptyError from '../util/EmptyError';
 
 export default function last<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/operators/map.ts
+++ b/src/operators/map.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 

--- a/src/operators/mapTo.ts
+++ b/src/operators/mapTo.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 /**

--- a/src/operators/materialize.ts
+++ b/src/operators/materialize.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Notification from '../Notification';
 

--- a/src/operators/mergeAll-support.ts
+++ b/src/operators/mergeAll-support.ts
@@ -1,6 +1,5 @@
 import Observable from '../Observable';
 import Operator from '../Operator';
-import Subscriber from '../Subscriber';
 import Observer from '../Observer';
 import Subscription from '../Subscription';
 import OuterSubscriber from '../OuterSubscriber';

--- a/src/operators/mergeAll.ts
+++ b/src/operators/mergeAll.ts
@@ -1,8 +1,4 @@
 import Observable from '../Observable';
-import Operator from '../Operator';
-import Subscriber from '../Subscriber';
-import Observer from '../Observer';
-import Subscription from '../Subscription';
 import { MergeAllOperator } from './mergeAll-support';
 
 export default function mergeAll<R>(concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {

--- a/src/operators/mergeMap-support.ts
+++ b/src/operators/mergeMap-support.ts
@@ -7,7 +7,6 @@ import tryCatch from '../util/tryCatch';
 import { errorObject } from '../util/errorObject';
 import subscribeToResult from '../util/subscribeToResult';
 import OuterSubscriber from '../OuterSubscriber';
-import InnerSubscriber from '../InnerSubscriber';
 
 export class MergeMapOperator<T, R, R2> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => Observable<R>,
@@ -37,7 +36,6 @@ export class MergeMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
 
   _next(value: any) {
     if (this.active < this.concurrent) {
-      const resultSelector = this.resultSelector;
       const index = this.index++;
       const ish = tryCatch(this.project)(value, index);
       const destination = this.destination;

--- a/src/operators/reduce.ts
+++ b/src/operators/reduce.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 import tryCatch from '../util/tryCatch';

--- a/src/operators/repeat.ts
+++ b/src/operators/repeat.ts
@@ -1,9 +1,7 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import EmptyObservable from '../observables/EmptyObservable';
-import immediate from '../schedulers/immediate';
 import Subscription from '../Subscription';
 
 export default function repeat<T>(count: number = -1): Observable<T> {

--- a/src/operators/retry.ts
+++ b/src/operators/retry.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subscription from '../Subscription';

--- a/src/operators/retryWhen.ts
+++ b/src/operators/retryWhen.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subject from '../Subject';

--- a/src/operators/sample.ts
+++ b/src/operators/sample.ts
@@ -1,8 +1,6 @@
 import Observable from '../Observable';
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
-import Subscription from '../Subscription';
 
 export default function sample<T>(notifier: Observable<any>): Observable<T> {
   return this.lift(new SampleOperator(notifier));

--- a/src/operators/sampleTime.ts
+++ b/src/operators/sampleTime.ts
@@ -1,8 +1,6 @@
 import Observable from '../Observable';
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
-import Subscription from '../Subscription';
 import Scheduler from '../Scheduler';
 import nextTick from '../schedulers/nextTick';
 

--- a/src/operators/scan.ts
+++ b/src/operators/scan.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 import tryCatch from '../util/tryCatch';

--- a/src/operators/shareReplay.ts
+++ b/src/operators/shareReplay.ts
@@ -1,4 +1,3 @@
-import Observable from '../Observable';
 import Scheduler from '../Scheduler';
 import publishReplay from './publishReplay';
 

--- a/src/operators/skip.ts
+++ b/src/operators/skip.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 export default function skip(total) {

--- a/src/operators/skipUntil.ts
+++ b/src/operators/skipUntil.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 

--- a/src/operators/switchMap.ts
+++ b/src/operators/switchMap.ts
@@ -5,7 +5,6 @@ import Subscriber from '../Subscriber';
 import Subscription from '../Subscription';
 import tryCatch from '../util/tryCatch';
 import { errorObject } from '../util/errorObject';
-import { MergeMapSubscriber } from './mergeMap-support';
 import OuterSubscriber from '../OuterSubscriber';
 import subscribeToResult from '../util/subscribeToResult';
 

--- a/src/operators/take.ts
+++ b/src/operators/take.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 export default function take(total) {

--- a/src/operators/takeUntil.ts
+++ b/src/operators/takeUntil.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Observable from '../Observable';
 import Subscriber from '../Subscriber';
 

--- a/src/operators/throttle.ts
+++ b/src/operators/throttle.ts
@@ -1,14 +1,8 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
-import Observable from '../Observable';
 import Scheduler from '../Scheduler';
 import Subscription from '../Subscription';
 import nextTick from '../schedulers/nextTick';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function throttle<T>(delay: number, scheduler: Scheduler = nextTick) {
   return this.lift(new ThrottleOperator(delay, scheduler));

--- a/src/operators/timeout.ts
+++ b/src/operators/timeout.ts
@@ -1,9 +1,7 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Scheduler from '../Scheduler';
 import immediate from '../schedulers/immediate';
-import Subscription from '../Subscription';
 import isDate from '../util/isDate';
 
 export default function timeout(due: number|Date,

--- a/src/operators/timeoutWith.ts
+++ b/src/operators/timeoutWith.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Scheduler from '../Scheduler';
 import immediate from '../schedulers/immediate';

--- a/src/operators/toArray.ts
+++ b/src/operators/toArray.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 
 export default function toArray() {

--- a/src/operators/toPromise.ts
+++ b/src/operators/toPromise.ts
@@ -1,4 +1,3 @@
-import Subscriber from '../Subscriber';
 import { root } from '../util/root';
 
 export default function toPromise<T>(PromiseCtor?: PromiseConstructor): Promise<T> {

--- a/src/operators/window.ts
+++ b/src/operators/window.ts
@@ -1,12 +1,7 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subject from '../Subject';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function window<T>(closingNotifier: Observable<any>): Observable<Observable<T>> {
   return this.lift(new WindowOperator(closingNotifier));

--- a/src/operators/windowCount.ts
+++ b/src/operators/windowCount.ts
@@ -1,14 +1,7 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subject from '../Subject';
-import Subscription from '../Subscription';
-import Scheduler from '../Scheduler';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function windowCount<T>(windowSize: number,
                                        startWindowEvery: number = 0): Observable<Observable<T>> {

--- a/src/operators/windowTime.ts
+++ b/src/operators/windowTime.ts
@@ -1,16 +1,10 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subject from '../Subject';
-import Subscription from '../Subscription';
 import Scheduler from '../Scheduler';
 import Action from '../schedulers/Action';
 import nextTick from '../schedulers/nextTick';
-
-import tryCatch from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function windowTime<T>(windowTimeSpan: number,
                                       windowCreationInterval: number = null,

--- a/src/operators/windowToggle.ts
+++ b/src/operators/windowToggle.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subject from '../Subject';
@@ -7,7 +6,6 @@ import Subscription from '../Subscription';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function windowToggle<T, O>(openings: Observable<O>,
                                            closingSelector: (openValue: O) => Observable<any>): Observable<Observable<T>> {
@@ -34,7 +32,6 @@ interface WindowContext<T> {
 
 class WindowToggleSubscriber<T, O> extends Subscriber<T> {
   private contexts: Array<WindowContext<T>> = [];
-  private closingNotification: Subscription<any>;
 
   constructor(destination: Subscriber<T>,
               private openings: Observable<O>,

--- a/src/operators/windowWhen.ts
+++ b/src/operators/windowWhen.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 import Subject from '../Subject';
@@ -7,7 +6,6 @@ import Subscription from '../Subscription';
 
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import bindCallback from '../util/bindCallback';
 
 export default function window<T>(closingSelector: () => Observable<any>): Observable<Observable<T>> {
   return this.lift(new WindowOperator(closingSelector));

--- a/src/operators/withLatestFrom.ts
+++ b/src/operators/withLatestFrom.ts
@@ -1,5 +1,4 @@
 import Operator from '../Operator';
-import Observer from '../Observer';
 import Subscriber from '../Subscriber';
 import Observable from '../Observable';
 

--- a/src/operators/zip-support.ts
+++ b/src/operators/zip-support.ts
@@ -1,10 +1,7 @@
 import Operator from '../Operator';
 import Observer from '../Observer';
-import Scheduler from '../Scheduler';
 import Observable from '../Observable';
 import Subscriber from '../Subscriber';
-import Subscription from '../Subscription';
-import ArrayObservable from '../observables/ArrayObservable';
 import tryCatch from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import OuterSubscriber from '../OuterSubscriber';
@@ -54,7 +51,6 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   }
 
   _complete() {
-    const values = this.values;
     const iterators = this.iterators;
     const len = iterators.length;
     this.active = len;

--- a/src/operators/zipAll.ts
+++ b/src/operators/zipAll.ts
@@ -1,4 +1,3 @@
-import Observable from '../Observable';
 import { ZipOperator } from './zip-support';
 
 export default function zipAll<T, R>(project?: (...values: Array<any>) => R) {

--- a/src/schedulers/ImmediateScheduler.ts
+++ b/src/schedulers/ImmediateScheduler.ts
@@ -1,4 +1,3 @@
-import { Immediate } from '../util/Immediate';
 import Scheduler from '../Scheduler';
 import ImmediateAction from './ImmediateAction';
 import Subscription from '../Subscription';

--- a/src/schedulers/NextTickAction.ts
+++ b/src/schedulers/NextTickAction.ts
@@ -1,5 +1,4 @@
 import {Immediate} from '../util/Immediate';
-import Subscription from '../Subscription';
 import ImmediateAction from './ImmediateAction';
 import Action from './Action';
 

--- a/src/schedulers/NextTickScheduler.ts
+++ b/src/schedulers/NextTickScheduler.ts
@@ -1,4 +1,3 @@
-import { Immediate } from '../util/Immediate';
 import ImmediateScheduler from './ImmediateScheduler';
 import Subscription from '../Subscription';
 import Action from './Action';

--- a/src/schedulers/VirtualTimeScheduler.ts
+++ b/src/schedulers/VirtualTimeScheduler.ts
@@ -34,10 +34,7 @@ export default class VirtualTimeScheduler implements Scheduler {
   }
 
   addAction<T>(action: Action) {
-    const findDelay = action.delay;
     const actions = this.actions;
-    const len = actions.length;
-    const vaction = <VirtualAction<T>>action;
 
     actions.push(action);
 

--- a/src/subjects/BehaviorSubject.ts
+++ b/src/subjects/BehaviorSubject.ts
@@ -1,6 +1,5 @@
 import Subject from '../Subject';
-import SubjectSubscription from './SubjectSubscription';
-import Observer from '../Observer';
+import Subscriber from '../Subscriber';
 import Subscription from '../Subscription';
 
 export default class BehaviorSubject<T> extends Subject<T> {
@@ -8,7 +7,7 @@ export default class BehaviorSubject<T> extends Subject<T> {
     super();
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber: Subscriber<any>): Subscription<T> {
     const subscription = super._subscribe(subscriber);
     if (!subscription) {
       return;

--- a/src/subjects/ReplaySubject.ts
+++ b/src/subjects/ReplaySubject.ts
@@ -1,12 +1,10 @@
 import Subject from '../Subject';
-import SubjectSubscription from '../subjects/SubjectSubscription';
-import Observer from '../Observer';
 import Scheduler from '../Scheduler';
-import Subscription from '../Subscription';
 import immediate from '../schedulers/immediate';
+import Subscriber from '../Subscriber';
+import Subscription from '../Subscription';
 
 export default class ReplaySubject<T> extends Subject<T> {
-
   private bufferSize: number;
   private _windowTime: number;
   private scheduler: Scheduler;
@@ -27,7 +25,7 @@ export default class ReplaySubject<T> extends Subject<T> {
     super._next(value);
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber: Subscriber<any>): Subscription<T> {
     const events = this._getEvents(this._getNow());
     let index = -1;
     const len = events.length;

--- a/src/util/Immediate.ts
+++ b/src/util/Immediate.ts
@@ -4,7 +4,6 @@ All credit for this helper goes to http://github.com/YuzuJS/setImmediate
 
 // let JSGlobal = global || window || new Function('return this')(),
 
-import noop from './noop';
 import {root as JSGlobal} from './root';
 
 export let Immediate = {

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -3,9 +3,6 @@ import Observable from '../Observable';
 import $$iterator from '../util/Symbol_iterator';
 import $$observable from '../util/Symbol_observable';
 import Subscription from '../Subscription';
-import Observer from '../Observer';
-import tryCatch from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 import InnerSubscriber from '../InnerSubscriber';
 import OuterSubscriber from '../OuterSubscriber';
 


### PR DESCRIPTION
Clear most of unused references. 

[These variables](https://github.com/ReactiveX/RxJS/blob/master/src/util/root.ts#L24-L25) are only remaining unused references - wasn't sure if those can be safely removed or prepared for further usage. There are tslint rule `no-unused-variable` prevents further codebase to include unused, but to introduce rules remaining reference need to be clarified & resolved.