### PR TITLE
test(last): expand test coverage of last operator

### DIFF
--- a/spec/operators/last-spec.js
+++ b/spec/operators/last-spec.js
@@ -61,4 +61,29 @@ describe('Observable.prototype.last()', function () {
     };
     expectObservable(e1.last(predicate, resultSelector)).toBe(expected);
   });
+
+  it('should raise error when predicate throws', function () {
+    var e1 = hot('--a--^---b---c---d---e--|');
+    var expected =    '--------#';
+    var predicate = function (x) {
+      if (x === 'c') {
+        throw 'error';
+      } else {
+        return false;
+      }
+    };
+
+    expectObservable(e1.last(predicate)).toBe(expected);
+  });
+
+  it('should raise error when result selector throws', function () {
+    var e1 = hot('--a--^---b---c---d---e--|');
+    var expected =    '--------#';
+    var predicate = function (x) { return x === 'c'; };
+    var resultSelector = function (x, i) {
+      throw 'error';
+    };
+
+    expectObservable(e1.last(predicate, resultSelector)).toBe(expected);
+  });
 });


### PR DESCRIPTION
Now test coverage of `last` operator becomes 100%. ([After PR](https://coveralls.io/builds/3959893/source?filename=src%2Foperators%2Flast.ts#L53) vs. [Before PR](https://coveralls.io/builds/3959821/source?filename=src%2Foperators%2Flast.ts#L52))