### PR TITLE
style(reduce): change signatures and parameter name

### DIFF
--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -48,7 +48,7 @@ export interface CoreOperators<T> {
   publish?: () => ConnectableObservable<T>;
   publishBehavior?: (value: any) => ConnectableObservable<T>;
   publishReplay?: (bufferSize: number, windowTime: number, scheduler?: Scheduler) => ConnectableObservable<T>;
-  reduce?: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
+  reduce?: <T, R>(project: (acc: R, x: T) => R, seed?: R) => Observable<R>;
   repeat?: <T>(count: number) => Observable<T>;
   retry?: <T>(count: number) => Observable<T>;
   retryWhen?: (notifier: (errors: Observable<any>) => Observable<any>) => Observable<T>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -197,7 +197,7 @@ export default class Observable<T> implements CoreOperators<T>  {
   publish: () => ConnectableObservable<T>;
   publishBehavior: (value: any) => ConnectableObservable<T>;
   publishReplay: (bufferSize: number, windowTime: number, scheduler?: Scheduler) => ConnectableObservable<T>;
-  reduce: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
+  reduce: <T, R>(project: (acc: R, x: T) => R, seed?: R) => Observable<R>;
   repeat: <T>(count: number) => Observable<T>;
   retry: <T>(count: number) => Observable<T>;
   retryWhen: (notifier: (errors: Observable<any>) => Observable<any>) => Observable<T>;

--- a/src/observables/ScalarObservable.ts
+++ b/src/observables/ScalarObservable.ts
@@ -78,11 +78,11 @@ proto.filter = function <T>(select: (x: T, ix?: number) => boolean, thisArg?: an
   }
 };
 
-proto.reduce = function <T, R>(project: (acc: R, x: T) => R, acc?: R): Observable<R> {
-  if (typeof acc === 'undefined') {
+proto.reduce = function <T, R>(project: (acc: R, x: T) => R, seed?: R): Observable<R> {
+  if (typeof seed === 'undefined') {
     return <any>this;
   }
-  let result = tryCatch(project)(acc, this.value);
+  let result = tryCatch(project)(seed, this.value);
   if (result === errorObject) {
     return new ErrorObservable(errorObject.e);
   } else {

--- a/src/operators/reduce-support.ts
+++ b/src/operators/reduce-support.ts
@@ -6,16 +6,11 @@ import {errorObject} from '../util/errorObject';
 
 export class ReduceOperator<T, R> implements Operator<T, R> {
 
-  acc: R;
-  project: (acc: R, x: T) => R;
-
-  constructor(project: (acc: R, x: T) => R, acc?: R) {
-    this.acc = acc;
-    this.project = project;
+  constructor(private project: (acc: R, x: T) => R, private seed?: R) {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {
-    return new ReduceSubscriber(subscriber, this.project, this.acc);
+    return new ReduceSubscriber(subscriber, this.project, this.seed);
   }
 }
 
@@ -26,11 +21,11 @@ export class ReduceSubscriber<T, R> extends Subscriber<T> {
   hasValue: boolean = false;
   project: (acc: R, x: T) => R;
 
-  constructor(destination: Subscriber<T>, project: (acc: R, x: T) => R, acc?: R) {
+  constructor(destination: Subscriber<T>, project: (acc: R, x: T) => R, seed?: R) {
     super(destination);
-    this.acc = acc;
+    this.acc = seed;
     this.project = project;
-    this.hasSeed = typeof acc !== 'undefined';
+    this.hasSeed = typeof seed !== 'undefined';
   }
 
   _next(x) {

--- a/src/operators/reduce.ts
+++ b/src/operators/reduce.ts
@@ -1,6 +1,6 @@
 import Observable from '../Observable';
 import { ReduceOperator } from './reduce-support';
 
-export default function reduce<T, R>(project: (acc: R, x: T) => R, acc?: R): Observable<R> {
-  return this.lift(new ReduceOperator(project, acc));
+export default function reduce<T, R>(project: (acc: R, x: T) => R, seed?: R): Observable<R> {
+  return this.lift(new ReduceOperator(project, seed));
 }


### PR DESCRIPTION
The second parameter of reduce isn't the accumulator, but the seed.
This commit change `acc` name to `seed`, use a shorthand for parameter properties
and fix some signature types.