### PR TITLE
Engine setting: This library works with both npm2 and npm3

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "watch": "0.16.0"
   },
   "engines": {
-    "npm": "~2.0.0"
+    "npm": ">=2.0.0 <4.0.0"
   },
   "typings": "./dist/cjs/Rx.d.ts"
 }


### PR DESCRIPTION
Modified engines field so that it clearly states that RxJS also works with npm@3. 
This should get rid of the warning when installing a project dependent on RxJS
```
npm WARN engine @reactivex/rxjs@5.0.0-alpha.7: wanted: {"npm":"~2.0.0"} (current: {"node":"4.1.2","npm":"3.3.3"})
```

This commit fixes issue #572

Please note that I could not really test this locally: I read https://docs.npmjs.com/files/package.json#engines and modified the package.json

Does it look good?