### PR TITLE
Added wallaby.js configuration

### DIFF
--- a/wallaby.js
+++ b/wallaby.js
@@ -1,0 +1,44 @@
+module.exports = wallaby => ({
+  files: [
+    'index.js',
+    'src/**/*.ts',
+    {pattern: 'spec/helpers/test-helper.js', instrument: false}
+  ],
+
+  tests: ['spec/**/*-spec.js'],
+
+  compilers: {
+    '**/*.ts': wallaby.compilers.typeScript({
+      module: 1,  // commonjs
+      target: 2,  // ES6
+      preserveConstEnums: true
+    })
+  },
+
+  preprocessors: {
+    '**/*.js': file => require('babel').transform(file.content, {sourceMap: true, loose: 'all'})
+  },
+
+  testFramework: 'jasmine',
+
+  env: {
+    type: 'node'
+  },
+
+  workers: {initial: 1, regular: 1},
+
+  bootstrap: function (w) {
+    // Remapping all require calls to `dist/cjs` right to `src`
+    var Module = require('module').Module;
+    if (!Module._originalRequire) {
+      var modulePrototype = Module.prototype;
+      Module._originalRequire = modulePrototype.require;
+      modulePrototype.require = function (filePath) {
+        return Module._originalRequire.call(this, filePath.replace('dist/cjs', 'src'));
+      };
+    }
+
+    // Global test helpers
+    require('./spec/helpers/test-helper');
+  }
+});


### PR DESCRIPTION
Hey,
I have been asked to [create wallaby.js config](https://github.com/wallabyjs/public/issues/311) for the project, so I thought I'd create the pull request in case if someone wants to use wallaby.js for contributing to RxJs. Even though the original build process is pretty tricky and tests are written against the compiled code, this wallaby config works for the original TypeScript, allowing to do realtime continuous testing/development (in Atom/WebStorm/Visual Studio):

![n](https://cloud.githubusercontent.com/assets/979966/10811033/2ede34b0-7e53-11e5-8a9a-44729a5ec314.gif)