### PR TITLE
refactor(repeat): keep consistency on EmptyObservable instanciation

### DIFF
--- a/src/operators/repeat.ts
+++ b/src/operators/repeat.ts
@@ -6,7 +6,7 @@ import Subscription from '../Subscription';
 
 export default function repeat<T>(count: number = -1): Observable<T> {
   if (count === 0) {
-    return EmptyObservable.create();
+    return new EmptyObservable();
   } else {
     return this.lift(new RepeatOperator(count, this));
   }


### PR DESCRIPTION
`take` uses `new EmptyObservable` instead of `EmptyObservable.create` to
instanciate a new empty observable. This minor change is to keep the consistency
between `repeat` and `take`.