### PR TITLE
fix(package.json): loosen the engines/npm semver range to prevent fal…

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
     "watch": "0.16.0"
   },
   "engines": {
-    "npm": "~2.0.0"
+    "npm": ">=2.0.0"
   },
   "typings": "./dist/cjs/Rx.d.ts"
 }


### PR DESCRIPTION
…se warnings

This should get rid the following warning when installing rxjs:

```
npm WARN engine @reactivex/rxjs@5.0.0-alpha.7: wanted: {"npm":"~2.0.0"} (current: {"node":"4.2.1","npm":"2.14.7"})
```