### PR TITLE
fix(util): incorrect Symbol.iterator for es6-shim

### DIFF
--- a/src/util/Symbol_iterator.ts
+++ b/src/util/Symbol_iterator.ts
@@ -10,8 +10,18 @@ if (!root.Symbol.iterator) {
   } else if (root.Set && typeof new root.Set()['@@iterator'] === 'function') {
     // Bug for mozilla version
     root.Symbol.iterator = '@@iterator';
+  } else if (root.Map) {
+    // es6-shim specific logic
+    let keys = Object.getOwnPropertyNames(root.Map.prototype);
+    for (let i = 0; i < keys.length; ++i) {
+      let key = keys[i];
+      if (key !== 'entries' && key !== 'size' && root.Map.prototype[key] === root.Map.prototype['entries']) {
+        root.Symbol.iterator = key;
+        break;
+      }
+    }
   } else {
-    root.Symbol.iterator = '_es6shim_iterator_';
+    root.Symbol.iterator = '@@iterator';
   }
 }
 


### PR DESCRIPTION
In es6-shim, the string for Symbol.iterator has been changed from `_es6shim_iterator_` to `_es6-shim iterator_` in https://github.com/paulmillr/es6-shim/commit/f19261a5d84652f689834500f7a69aa93f6d174c

This PR retrieves it dynamically instead of hard-coding it, but it means that es6-shim must be loaded before rx.js