### PR TITLE
Module composition streategy proposal

### DIFF
--- a/src/CoreObservable.ts
+++ b/src/CoreObservable.ts
@@ -1,0 +1,31 @@
+//Represents current 'Observable'
+
+export interface Operators<T> {
+  map?(): Operators<any>;
+  filter?(): Operators<any>;
+}
+
+export class CoreObservable<T> implements Operators<T> {
+  filter(): Operators<any> {
+    console.log('filter');
+    return this;
+  }
+
+  static of: () => CoreObservable<any>;
+}
+
+export function applyMixins(derivedCtor: any, baseCtors: any[]) {
+  derivedCtor.of = function () {
+    return new derivedCtor();
+  };
+
+  console.log('mixin called');
+
+  baseCtors.forEach(baseCtor => {
+      Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
+          derivedCtor.prototype[name] = baseCtor.prototype[name];
+      })
+  });
+}
+
+export default CoreObservable;

--- a/src/ExtendedObservable.ts
+++ b/src/ExtendedObservable.ts
@@ -1,0 +1,8 @@
+// Represents current 'KitchenSink'
+
+export default class ExtendedObservable<T> {
+  isEmpty(): ExtendedObservable<any> {
+    console.log('isEmpty');
+    return this;
+  }
+}

--- a/src/Rx.Core.ts
+++ b/src/Rx.Core.ts
@@ -1,0 +1,6 @@
+import CoreObservable from './CoreObservable';
+
+//core rx does not have anything to add
+export {
+  CoreObservable as Observable
+}

--- a/src/Rx.Extended.ts
+++ b/src/Rx.Extended.ts
@@ -1,0 +1,17 @@
+import CoreObservable from './CoreObservable';
+import {applyMixins} from './CoreObservable';
+import ExtendedObservable from './ExtendedObservable';
+
+//'KitchenSink' includes Core operator with additional 'isEmpty'
+class Observable<T> implements CoreObservable<T>, ExtendedObservable<T> {
+  filter: () => Observable<any>;
+  isEmpty: () => Observable<any>;
+
+  static of: () => Observable<any>;
+}
+
+applyMixins(Observable, [CoreObservable, ExtendedObservable])
+
+export {
+  Observable
+};

--- a/src/Rx.My.ts
+++ b/src/Rx.My.ts
@@ -1,0 +1,22 @@
+import CoreObservable from './CoreObservable';
+import {applyMixins} from './CoreObservable';
+
+//Creating new module based on flavor, adding custom operator
+export class CustomObservable<T> {
+  awesome(): CustomObservable<T>{
+    return this;
+  }
+}
+
+export class MyObservable<T> implements CoreObservable<T>, CustomObservable<T> {
+  filter: () => MyObservable<any>;
+  awesome: () => MyObservable<any>;
+
+  static of: () => MyObservable<any>;
+}
+
+applyMixins(MyObservable, [CoreObservable, CustomObservable])
+
+export {
+  MyObservable as Observable
+};

--- a/src/testIndex.ts
+++ b/src/testIndex.ts
@@ -1,0 +1,16 @@
+import * as Rx from './Rx.Core';
+import * as MyRx from './Rx.My';
+import * as RxExtended from './Rx.Extended';
+
+var rx = Rx.Observable.of();
+rx.filter(); //works
+//rx.isEmpty(); TS will complain
+
+var myRx = MyRx.Observable.of();
+myRx.awesome(); //new operator
+myRx.filter(); //works from core
+//myRx.isEmpty(); TS will complain
+
+var extended = RxExtended.Observable.of();
+extended.filter();
+extended.isEmpty(); //works


### PR DESCRIPTION
**This PR intended to show proof-of-concept of proposal, neither mature or intended to be actually merged**.

While seeing issues like https://github.com/ReactiveX/RxJS/issues/635, https://github.com/ReactiveX/RxJS/issues/642, came to feel if there's way to create module met requirements like

- type definition to be preserved over core, extended along with any custom observable module created in further
- reduce type signature duplication over difference places

This proposal is based on [Mixin](https://github.com/Microsoft/TypeScript-Handbook/blob/master/pages/Mixins.md) of typescript, compose class implementations to extend modules if necessary.


**How composition works**

Attached PR illustrates rough mechanisms of composition. First, there is `Core` implementation of observable having bare minimum set in `CoreObservable.ts`. In this PR it implements interface of CoreOperator, this could be ambient merging introduced in typescript nightly. (There's one caveat of ambient merging, mixin class should declare all interfaces even if it's not implemented in class)
`Rx.Core.ts` does exports it directly without any extension.

`ExtendedObservable.ts` represents fully features set of Observable module, corresponds to current 'KitchenSink'. it does implements additional operator. `Rx.Extended.ts` is place where actual composition occurs, it declares mixin `Observable<T>` which implements Core & Extended both, then call `applyMixin` to compose mixin class at runtime. This runtime composition occurs very first time module `ExtendedObservable` is imported.

`Rx.My.ts` is representing cases where any consumer would like to create custom module for own flavor. In this PR, it utilizes core observable along with adding new operator implementation.

`testIndex.ts` shows usage of each module, simply import it and type definition starts to work.

**Declaring Mixin**

When declaraing mixin, it does do some specifics
1. should include all factory function signatures like `of`, `lift`, etcs
: Actual implementation of factory functions are injected while applying mixin (line 18 in `CoreObservable`) it is important to declare signature in each mixin explicitly. This prevents issues like https://github.com/ReactiveX/RxJS/issues/642, extended observale generator to return extended type to allow correct type inference.
2. Mixin operator's stub declaration is property, not function. And it does have 'different' return type than original.
: For example. `CoreObservable::filter():Operators` should be declared in mixin as `MyObservable::filter():MyObservable`. This is for type inference as same as 1.

**Possible pros**
- explicit prototype injection in module declaration can go away (though mixin internally does this)
- type definition works for all cases (core, extended, even custom)

**Cons**
- Mixin declaration still requires some of stubs though it's reduced compare to current approach.
- Requires specific formats to declare mixin to make it work, such as property stub declaration with corresponding types.