### PR TITLE
switch, mergeAll and concatAll signatures 

### DIFF
--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -40,7 +40,7 @@ export interface CoreOperators<T> {
   mapTo?: <R>(value: R) => Observable<R>;
   materialize?: () => Observable<Notification<T>>;
   merge?: (...observables: any[]) => Observable<any>;
-  mergeAll?: (concurrent?: any) => Observable<any>;
+  mergeAll?: (concurrent?: number) => Observable<T>;
   mergeMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   mergeMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   multicast?: (subjectFactory: () => Subject<T>) => ConnectableObservable<T>;

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -15,7 +15,7 @@ export interface CoreOperators<T> {
   combineAll?: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
   combineLatest?: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
   concat?: <R>(...observables: (Observable<any> | Scheduler)[]) => Observable<R>;
-  concatAll?: () => Observable<any>;
+  concatAll?: () => Observable<T>;
   concatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
   concatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
   count?: (predicate?: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any) => Observable<number>;

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -62,7 +62,7 @@ export interface CoreOperators<T> {
   skipUntil?: (notifier: Observable<any>) => Observable<T>;
   startWith?: (x: T) => Observable<T>;
   subscribeOn?: (scheduler: Scheduler, delay?: number) => Observable<T>;
-  switch?: <R>() => Observable<R>;
+  switch?: () => Observable<T>;
   switchMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
   switchMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
   take?: (count: number) => Observable<T>;

--- a/src/operators/concatAll.ts
+++ b/src/operators/concatAll.ts
@@ -12,6 +12,6 @@ import { MergeAllOperator } from './mergeAll-support';
  *
  * @returns {Observable} an observable of values merged from the incoming observables.
  */
-export default function concatAll(): Observable<any> {
+export default function concatAll<T>(): Observable<T> {
   return this.lift(new MergeAllOperator(1));
 }


### PR DESCRIPTION
Some operators dealing with observable sequences (`switch`, `mergeAll` and `concatAll`) can have more precise and consistent signatures. (thanks @kwonoj)