### PR TITLE
chore(mergeall-perf): fix mergeall micro perf benchmarks

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/mergeall.js
+++ b/perf/micro/current-thread-scheduler/operators/mergeall.js
@@ -1,12 +1,18 @@
 var RxOld = require('rx');
 var RxNew = require('../../../../index');
 
+var source = Array.apply(null, { length: 25 });
+
 module.exports = function (suite) {
-  var oldMergeAllWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread)
-    .map(RxOld.Observable.range(0, 25), RxOld.Scheduler.currentThread)
+  var oldMergeAllWithCurrentThreadScheduler = RxOld.Observable.fromArray(
+    source.map(function () { return RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread); }),
+    RxOld.Scheduler.currentThread
+  )
     .mergeAll();
-  var newMergeAllWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.immediate)
-    .mapTo(RxNew.Observable.range(0, 25, RxNew.Scheduler.immediate))
+  var newMergeAllWithCurrentThreadScheduler = RxNew.Observable.fromArray(
+    source.map(function () { return RxNew.Observable.range(0, 25, RxNew.Scheduler.immediate); }),
+    RxNew.Scheduler.immediate
+  )
     .mergeAll();
 
   function _next(x) { }

--- a/perf/micro/immediate-scheduler/operators/mergeall.js
+++ b/perf/micro/immediate-scheduler/operators/mergeall.js
@@ -1,12 +1,17 @@
 var RxOld = require('rx');
 var RxNew = require('../../../../index');
 
+var source = Array.apply(null, { length: 25 });
+
 module.exports = function (suite) {
-  var oldMergeAllWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate)
-    .map(RxOld.Observable.range(0, 25), RxOld.Scheduler.immediate)
+  var oldMergeAllWithImmediateScheduler = RxOld.Observable.fromArray(
+    source.map(function () { return RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate); }),
+    RxOld.Scheduler.immediate
+  )
     .mergeAll();
-  var newMergeAllWithImmediateScheduler = RxNew.Observable.range(0, 25)
-    .mapTo(RxNew.Observable.range(0, 25))
+  var newMergeAllWithImmediateScheduler = RxNew.Observable.fromArray(
+    source.map(function () { return RxNew.Observable.range(0, 25); })
+  )
     .mergeAll();
 
   function _next(x) { }


### PR DESCRIPTION
`mergeAll` operator micro perf benchmarks were incorrect, and in favor of RxJS5.
Using `mapTo` is error-prone in these kind of benchmarks. I just replaced them by simple `map`s.