### PR TITLE
feat(forkJoin): accept promise, resultselector as parameter of forkJoin

### DIFF
--- a/spec/observables/forkJoin-spec.js
+++ b/spec/observables/forkJoin-spec.js
@@ -1,14 +1,155 @@
-/* globals describe, it, expect */
+/* globals describe, it, expect, lowerCaseO, hot, expectObservable */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
 describe('Observable.forkJoin', function () {
-  it('should join the last values of the provided observables into an array', function (done) {
-    Observable.forkJoin(Observable.of(1, 2, 3, 'a'),
-      Observable.of('b'),
-      Observable.of(1, 2, 3, 4, 'c'))
-      .subscribe(function (x) {
-        expect(x).toEqual(['a', 'b', 'c']);
-      }, null, done);
+  it('should join the last values of the provided observables into an array', function () {
+    var e1 = Observable.forkJoin(
+               hot('--a--b--c--d--|'),
+               hot('(b|)'),
+               hot('--1--2--3--|')
+    );
+    var expected = '--------------(x|)';
+
+    expectObservable(e1).toBe(expected, {x: ['d', 'b', '3']});
+  });
+
+  it('should accept lowercase-o observables', function () {
+    var e1 = Observable.forkJoin(
+               hot('--a--b--c--d--|'),
+               hot('(b|)'),
+               lowerCaseO('1', '2', '3')
+    );
+    var expected = '--------------(x|)';
+
+    expectObservable(e1).toBe(expected, {x: ['d', 'b', '3']});
+  });
+
+  it('should accept promise', function (done) {
+    var e1 = Observable.forkJoin(
+               Observable.of(1),
+               Promise.resolve(2)
+    );
+
+    e1.subscribe(function (x) {
+      expect(x).toEqual([1,2]);
+    },
+    function (err) {
+      done.fail('should not be called');
+    },
+    done);
+  });
+
+  it('forkJoin n-ary parameters empty', function () {
+    var e1 = Observable.forkJoin(
+               hot('--a--b--c--d--|'),
+               hot('(b|)'),
+               hot('------------------|')
+    );
+    var expected = '------------------|';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin n-ary parameters empty before end', function () {
+    var e1 = Observable.forkJoin(
+               hot('--a--b--c--d--|'),
+               hot('(b|)'),
+               hot('---------|')
+    );
+    var expected = '---------|';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin empty empty', function () {
+    var e1 = Observable.forkJoin(
+               hot('--------------|'),
+               hot('---------|')
+    );
+    var expected = '---------|';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin none', function () {
+    var e1 = Observable.forkJoin();
+    var expected = '|';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin empty return', function () {
+    function selector(x, y) {
+      return x + y;
+    }
+
+    var e1 = Observable.forkJoin(
+               hot('--a--b--c--d--|'),
+               hot('---------|'),
+               selector);
+    var expected = '---------|';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin return return', function () {
+    function selector(x, y) {
+      return x + y;
+    }
+
+    var e1 = Observable.forkJoin(
+               hot('--a--b--c--d--|'),
+               hot('---2-----|'),
+               selector);
+    var expected = '--------------(x|)';
+
+    expectObservable(e1).toBe(expected, {x: 'd2'});
+  });
+
+  it('forkJoin empty throw', function () {
+    var e1 = Observable.forkJoin(
+               hot('------#'),
+               hot('---------|'));
+    var expected = '------#';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin empty throw', function () {
+    function selector(x, y) {
+      return x + y;
+    }
+
+    var e1 = Observable.forkJoin(
+               hot('------#'),
+               hot('---------|'),
+               selector);
+    var expected = '------#';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin return throw', function () {
+    var e1 = Observable.forkJoin(
+               hot('------#'),
+               hot('---a-----|'));
+    var expected = '------#';
+
+    expectObservable(e1).toBe(expected);
+  });
+
+  it('forkJoin return throw', function () {
+    function selector(x, y) {
+      return x + y;
+    }
+
+    var e1 = Observable.forkJoin(
+               hot('------#'),
+               hot('-------b-|'),
+               selector);
+    var expected = '------#';
+
+    expectObservable(e1).toBe(expected);
   });
 });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -138,7 +138,7 @@ export class Observable<T> implements CoreOperators<T>  {
   static concat: <T>(...observables: Array<Observable<any> | Scheduler>) => Observable<T>;
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
   static empty: <T>(scheduler?: Scheduler) => Observable<T>;
-  static forkJoin: <T>(...observables: Observable<any>[]) => Observable<T>;
+  static forkJoin: (...sources: Array<Observable<any> | Promise<any> | ((...values: Array<any>) => any)>) => Observable<any>;
   static from: <T>(iterable: any, scheduler?: Scheduler) => Observable<T>;
   static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;
   static fromEvent: <T>(element: any, eventName: string, selector?: (...args:Array<any>) => T) => Observable<T>;

--- a/src/observables/PromiseObservable.ts
+++ b/src/observables/PromiseObservable.ts
@@ -13,7 +13,7 @@ export class PromiseObservable<T> extends Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }
 
-  constructor(private promise: Promise<T>, public scheduler: Scheduler) {
+  constructor(private promise: Promise<T>, public scheduler: Scheduler = immediate) {
     super();
   }
 

--- a/src/operators/debounce.ts
+++ b/src/operators/debounce.ts
@@ -5,6 +5,7 @@ import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
 import {tryCatch} from '../util/tryCatch';
+import {isPromise} from '../util/isPromise';
 import {errorObject} from '../util/errorObject';
 
 export function debounce<T>(durationSelector: (value: T) => Observable<any> | Promise<any>): Observable<T> {
@@ -41,8 +42,7 @@ class DebounceSubscriber<T> extends Subscriber<T> {
     if (debounce === errorObject) {
       destination.error(errorObject.e);
     } else {
-      if (typeof debounce.subscribe !== 'function'
-        && typeof debounce.then === 'function') {
+      if (isPromise(debounce)) {
         debounce = PromiseObservable.create(debounce);
       }
 

--- a/src/util/isPromise.ts
+++ b/src/util/isPromise.ts
@@ -1,0 +1,3 @@
+export function isPromise(value: any): boolean {
+  return value && typeof value.subscribe !== 'function' && typeof value.then === 'function';
+}


### PR DESCRIPTION
closes #507 

`forkJoin` now accepts promises as well as result selector, and expanded test coverage.