### PR TITLE
style(tslint): expand lint coverage to all source codes

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "build_docs": "./docgen.sh",
     "lint_perf": "eslint perf/ --fix",
     "lint_spec": "eslint spec/**/*.js --fix",
-    "lint_src": "tslint -c .tslintrc src/**/*.ts",
+    "lint_src": "tslint -c .tslintrc src/*.ts src/**/*.ts src/**/**/*.ts",
     "lint": "npm run lint_src && npm run lint_spec && npm run lint_perf",
     "cover": "istanbul cover -x \"*-spec.js index.js *-helper.js\" jasmine && npm run cover_remapping",
     "cover_remapping": "remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.json && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.lcov -t lcovonly && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped -t html",

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -29,19 +29,27 @@ export interface CoreOperators<T> {
   expand?: <R>(project: (x: T, ix: number) => Observable<R>) => Observable<R>;
   filter?: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
   finally?: (ensure: () => void, thisArg?: any) => Observable<T>;
-  first?: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
-  flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  first?: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+              resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
+  flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>),
+                projectResult?: (x: T, y: any, ix: number, iy: number) => R,
+                concurrent?: number) => Observable<R>;
   flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
-  groupBy?: <R>(keySelector: (value: T) => string, elementSelector?: (value: T) => R, durationSelector?: (group: GroupedObservable<R>) => Observable<any>) => Observable<GroupedObservable<R>>;
+  groupBy?: <R>(keySelector: (value: T) => string,
+                elementSelector?: (value: T) => R,
+                durationSelector?: (group: GroupedObservable<R>) => Observable<any>) => Observable<GroupedObservable<R>>;
   ignoreElements?: () => Observable<T>;
-  last?: <R>(predicate?: (value: T, index: number) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
+  last?: <R>(predicate?: (value: T, index: number) => boolean,
+             resultSelector?: (value: T, index: number) => R,
+             thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
   every?: (predicate: (value: T, index: number) => boolean, thisArg?: any) => Observable<T>;
   map?: <R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
   mapTo?: <R>(value: R) => Observable<R>;
   materialize?: () => Observable<Notification<T>>;
   merge?: (...observables: any[]) => Observable<any>;
   mergeAll?: (concurrent?: number) => Observable<T>;
-  mergeMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  mergeMap?: <R>(project: ((x: T, ix: number) => Observable<any>),
+                 projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   mergeMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   multicast?: (subjectFactory: () => Subject<T>) => ConnectableObservable<T>;
   observeOn?: (scheduler: Scheduler, delay?: number) => Observable<T>;

--- a/src/InnerSubscriber.ts
+++ b/src/InnerSubscriber.ts
@@ -1,8 +1,5 @@
 import {Subscriber} from './Subscriber';
-import {Observer} from './Observer';
 import {OuterSubscriber} from './OuterSubscriber';
-import {tryCatch} from './util/tryCatch';
-import {errorObject} from './util/errorObject';
 
 export class InnerSubscriber<T, R> extends Subscriber<R> {
   index: number = 0;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -88,8 +88,8 @@ export class Observable<T> implements CoreOperators<T>  {
 
     let subscriber: Subscriber<T>;
 
-    if (observerOrNext && typeof observerOrNext === "object") {
-      if(observerOrNext instanceof Subscriber) {
+    if (observerOrNext && typeof observerOrNext === 'object') {
+      if (observerOrNext instanceof Subscriber) {
         subscriber = (<Subscriber<T>> observerOrNext);
       } else {
         subscriber = new Subscriber(<Observer<T>> observerOrNext);
@@ -111,16 +111,16 @@ export class Observable<T> implements CoreOperators<T>  {
    * @returns {Promise} a promise that either resolves on observable completion or
    *  rejects with the handled error
    */
-  forEach(next:(value:T) => void, PromiseCtor?: PromiseConstructor): Promise<void> {
-    if(!PromiseCtor) {
-      if(root.Rx && root.Rx.config && root.Rx.config.Promise) {
+  forEach(next: (value: T) => void, PromiseCtor?: PromiseConstructor): Promise<void> {
+    if (!PromiseCtor) {
+      if (root.Rx && root.Rx.config && root.Rx.config.Promise) {
         PromiseCtor = root.Rx.config.Promise;
       } else if (root.Promise) {
         PromiseCtor = root.Promise;
       }
     }
 
-    if(!PromiseCtor) {
+    if (!PromiseCtor) {
       throw new Error('no Promise impl found');
     }
 
@@ -141,8 +141,10 @@ export class Observable<T> implements CoreOperators<T>  {
   static forkJoin: <T>(...observables: Observable<any>[]) => Observable<T>;
   static from: <T>(iterable: any, scheduler?: Scheduler) => Observable<T>;
   static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;
-  static fromEvent: <T>(element: any, eventName: string, selector?: (...args:Array<any>) => T) => Observable<T>;
-  static fromEventPattern: <T>(addHandler: (handler:Function)=>void, removeHandler: (handler:Function) => void, selector?: (...args:Array<any>) => T) => Observable<T>;
+  static fromEvent: <T>(element: any, eventName: string, selector?: (...args: Array<any>) => T) => Observable<T>;
+  static fromEventPattern: <T>(addHandler: (handler: Function) => void,
+                               removeHandler: (handler: Function) => void,
+                               selector?: (...args: Array<any>) => T) => Observable<T>;
   static fromPromise: <T>(promise: Promise<T>, scheduler?: Scheduler) => Observable<T>;
   static interval: (interval: number, scheduler?: Scheduler) => Observable<number>;
   static merge: <T>(...observables: Array<Observable<any> | Scheduler | number>) => Observable<T>;
@@ -157,7 +159,7 @@ export class Observable<T> implements CoreOperators<T>  {
   buffer: (closingNotifier: Observable<any>) => Observable<T[]>;
   bufferCount: (bufferSize: number, startBufferEvery: number) => Observable<T[]>;
   bufferTime: (bufferTimeSpan: number, bufferCreationInterval?: number, scheduler?: Scheduler) => Observable<T[]>;
-  bufferToggle: <O>(openings: Observable<O>, closingSelector?: (openValue: O) => Observable<any>) => Observable<T[]>
+  bufferToggle: <O>(openings: Observable<O>, closingSelector?: (openValue: O) => Observable<any>) => Observable<T[]>;
   bufferWhen: (closingSelector: () => Observable<any>) => Observable<T[]>;
   catch: (selector: (err: any, source: Observable<T>, caught: Observable<any>) => Observable<any>) => Observable<T>;
   combineAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
@@ -177,19 +179,28 @@ export class Observable<T> implements CoreOperators<T>  {
   expand: <R>(project: (x: T, ix: number) => Observable<R>) => Observable<R>;
   filter: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
   finally: (ensure: () => void, thisArg?: any) => Observable<T>;
-  first: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
-  flatMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  first: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+             resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
+  flatMap: <R>(project: ((x: T, ix: number) => Observable<any>),
+               projectResult?: (x: T, y: any, ix: number, iy: number) => R,
+               concurrent?: number) => Observable<R>;
   flatMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
-  groupBy: <R>(keySelector: (value:T) => string, elementSelector?: (value: T) => R, durationSelector?: (group: GroupedObservable<R>) => Observable<any>) => Observable<GroupedObservable<R>>;
+  groupBy: <R>(keySelector: (value: T) => string,
+               elementSelector?: (value: T) => R,
+               durationSelector?: (group: GroupedObservable<R>) => Observable<any>) => Observable<GroupedObservable<R>>;
   ignoreElements: () => Observable<T>;
-  last: <R>(predicate?: (value: T, index: number) => boolean, resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
+  last: <R>(predicate?: (value: T, index: number) => boolean,
+            resultSelector?: (value: T, index: number) => R,
+            thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
   every: (predicate: (value: T, index: number) => boolean, thisArg?: any) => Observable<T>;
   map: <R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
   mapTo: <R>(value: R) => Observable<R>;
   materialize: () => Observable<Notification<T>>;
   merge: (...observables: any[]) => Observable<any>;
   mergeAll: (concurrent?: any) => Observable<any>;
-  mergeMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  mergeMap: <R>(project: ((x: T, ix: number) => Observable<any>),
+                projectResult?: (x: T, y: any, ix: number, iy: number) => R,
+                concurrent?: number) => Observable<R>;
   mergeMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
   multicast: (subjectFactory: () => Subject<T>) => ConnectableObservable<T>;
   observeOn: (scheduler: Scheduler, delay?: number) => Observable<T>;

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -1,5 +1,4 @@
 import {Observable} from './Observable';
-import {Operator} from './Operator';
 import {CoreOperators} from './CoreOperators';
 import {Scheduler as IScheduler} from './Scheduler';
 
@@ -16,11 +15,16 @@ interface KitchenSinkOperators<T> extends CoreOperators<T> {
 }
 
 // operators
+/* tslint:disable:no-use-before-declare */
 import {combineLatest as combineLatestStatic} from './operators/combineLatest-static';
 Observable.combineLatest = combineLatestStatic;
 
 import {concat as concatStatic} from './operators/concat-static';
 Observable.concat = concatStatic;
+
+import {merge as mergeStatic} from './operators/merge-static';
+Observable.merge = mergeStatic;
+/* tslint:enable:no-use-before-declare */
 
 import {DeferObservable} from './observables/DeferObservable';
 Observable.defer = DeferObservable.create;
@@ -48,9 +52,6 @@ Observable.fromPromise = PromiseObservable.create;
 
 import {IntervalObservable} from './observables/IntervalObservable';
 Observable.interval = IntervalObservable.create;
-
-import {merge as mergeStatic} from './operators/merge-static';
-Observable.merge = mergeStatic;
 
 import {InfiniteObservable} from './observables/InfiniteObservable';
 Observable.never = InfiniteObservable.create;
@@ -317,6 +318,7 @@ observableProto.zip = zipProto;
 import {zipAll} from './operators/zipAll';
 observableProto.zipAll = zipAll;
 
+/* tslint:disable:no-unused-variable */
 import {Subject} from './Subject';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
@@ -333,11 +335,14 @@ import {ImmediateScheduler} from './schedulers/ImmediateScheduler';
 import {TimeInterval} from './operators/extended/timeInterval';
 import {TestScheduler} from './testing/TestScheduler';
 import {VirtualTimeScheduler} from './schedulers/VirtualTimeScheduler';
+/* tslint:enable:no-unused-variable */
 
+/* tslint:disable:no-var-keyword */
 var Scheduler = {
   nextTick,
   immediate
 };
+/* tslint:enable:no-var-keyword */
 
 export {
     Subject,

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -1,11 +1,16 @@
 import {Observable} from './Observable';
 
 // operators
+/* tslint:disable:no-use-before-declare */
 import {combineLatest as combineLatestStatic} from './operators/combineLatest-static';
 Observable.combineLatest = combineLatestStatic;
 
 import {concat as concatStatic} from './operators/concat-static';
 Observable.concat = concatStatic;
+
+import {merge as mergeStatic} from './operators/merge-static';
+Observable.merge = mergeStatic;
+/* tslint:enable:no-use-before-declare */
 
 import {DeferObservable} from './observables/DeferObservable';
 Observable.defer = DeferObservable.create;
@@ -33,9 +38,6 @@ Observable.fromPromise = PromiseObservable.create;
 
 import {IntervalObservable} from './observables/IntervalObservable';
 Observable.interval = IntervalObservable.create;
-
-import {merge as mergeStatic} from './operators/merge-static';
-Observable.merge = mergeStatic;
 
 import {InfiniteObservable} from './observables/InfiniteObservable';
 Observable.never = InfiniteObservable.create;
@@ -276,6 +278,7 @@ observableProto.zip = zipProto;
 import {zipAll} from './operators/zipAll';
 observableProto.zipAll = zipAll;
 
+/* tslint:disable:no-unused-variable */
 import {Subject} from './Subject';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
@@ -289,11 +292,14 @@ import {nextTick} from './schedulers/nextTick';
 import {immediate} from './schedulers/immediate';
 import {NextTickScheduler} from './schedulers/NextTickScheduler';
 import {ImmediateScheduler} from './schedulers/ImmediateScheduler';
+/* tslint:enable:no-unused-variable */
 
+/* tslint:disable:no-var-keyword */
 var Scheduler = {
   nextTick,
   immediate
 };
+/* tslint:enable:no-var-keyword */
 
 export {
     Subject,

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -3,14 +3,9 @@ import {Action} from './schedulers/Action';
 
 export interface Scheduler {
   now(): number;
-  
   schedule<T>(work: (state?: any) => Subscription<T>|void, delay?: number, state?: any): Subscription<T>;
-  
   flush(): void;
-  
   actions: Action[];
-  
   scheduled: boolean;
-  
   active: boolean;
 }

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -16,7 +16,6 @@ const _subscriberNext = Subscriber.prototype._next;
 const _subscriberError = Subscriber.prototype._error;
 const _subscriberComplete = Subscriber.prototype._complete;
 
-
 export class Subject<T> extends Observable<T> implements Observer<T>, Subscription<T> {
   _subscriptions: Subscription<T>[];
   _unsubscribe: () => void;
@@ -51,7 +50,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
       subscriber.complete();
       return;
     } else if (this.isUnsubscribed) {
-      throw new Error("Cannot subscribe to a disposed Subject.");
+      throw new Error('Cannot subscribe to a disposed Subject.');
     }
 
     this.observers.push(subscriber);
@@ -119,7 +118,6 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     this.unsubscribe();
   }
 
-
   _next(value: T): void {
     let index = -1;
     const observers = this.observers.slice(0);
@@ -130,7 +128,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     }
   }
 
-  _error(err: any): void{
+  _error(err: any): void {
     let index = -1;
     const observers = this.observers;
     const len = observers.length;
@@ -139,14 +137,14 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     this.observers = void 0;
     this.isUnsubscribed = true;
 
-    while(++index < len) {
+    while (++index < len) {
       observers[index].error(err);
     }
 
     this.isUnsubscribed = false;
   }
 
-  _complete(): void{
+  _complete(): void {
     let index = -1;
     const observers = this.observers;
     const len = observers.length;

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -29,13 +29,13 @@ export class Subscriber<T> extends Subscription<T> implements Observer<T> {
     }
   }
 
-  static create<T>(next    ?: (x?: T) => void,
-                   error   ?: (e?: any) => void,
+  static create<T>(next?: (x?: T) => void,
+                   error?: (e?: any) => void,
                    complete?: () => void): Subscriber<T> {
     const subscriber = new Subscriber<T>();
-    subscriber._next = (typeof next === "function") && tryOrOnError(next) || noop;
-    subscriber._error = (typeof error === "function") && error || throwError;
-    subscriber._complete = (typeof complete === "function") && complete || noop;
+    subscriber._next = (typeof next === 'function') && tryOrOnError(next) || noop;
+    subscriber._error = (typeof error === 'function') && error || throwError;
+    subscriber._complete = (typeof complete === 'function') && complete || noop;
     return subscriber;
   }
 

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -1,16 +1,19 @@
+import {noop} from './util/noop';
+
 export class Subscription<T> {
   public static EMPTY: Subscription<void> = (function(empty){
     empty.isUnsubscribed = true;
     return empty;
   }(new Subscription<void>()));
-  
+
   isUnsubscribed: boolean = false;
 
   _subscriptions: Subscription<any>[];
-  
-  _unsubscribe(): void { 
+
+  _unsubscribe(): void {
+    noop();
   }
-  
+
   constructor(_unsubscribe?: () => void) {
     if (_unsubscribe) {
       this._unsubscribe = _unsubscribe;
@@ -29,7 +32,7 @@ export class Subscription<T> {
     const subscriptions = this._subscriptions;
 
     this._subscriptions = void 0;
-    
+
     if (unsubscribe) {
       unsubscribe.call(this);
     }
@@ -45,7 +48,7 @@ export class Subscription<T> {
   }
 
   add(subscription: Subscription<T>|Function|void): void {
-    // return early if: 
+    // return early if:
     //  1. the subscription is null
     //  2. we're attempting to add our this
     //  3. we're attempting to add the static `empty` Subscription
@@ -57,11 +60,11 @@ export class Subscription<T> {
 
     let sub = (<Subscription<T>> subscription);
 
-    switch(typeof subscription) {
-      case "function":
+    switch (typeof subscription) {
+      case 'function':
         sub = new Subscription<void>(<(() => void) > subscription);
-      case "object":
-        if (sub.isUnsubscribed || typeof sub.unsubscribe !== "function") {
+      case 'object':
+        if (sub.isUnsubscribed || typeof sub.unsubscribe !== 'function') {
           break;
         } else if (this.isUnsubscribed) {
             sub.unsubscribe();
@@ -77,7 +80,7 @@ export class Subscription<T> {
 
   remove(subscription: Subscription<T>): void {
 
-    // return early if: 
+    // return early if:
     //  1. the subscription is null
     //  2. we're attempting to remove ourthis
     //  3. we're attempting to remove the static `empty` Subscription

--- a/src/operators/expand-support.ts
+++ b/src/operators/expand-support.ts
@@ -1,10 +1,10 @@
 import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export class ExpandOperator<T, R> implements Operator<T, R> {
@@ -59,7 +59,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyComplete(innerSub: Subscription<T>): void {
+  notifyComplete(innerSub?: InnerSubscriber<T, R>): void {
     const buffer = this.buffer;
     this.remove(innerSub);
     this.active--;

--- a/src/operators/extended/elementAt.ts
+++ b/src/operators/extended/elementAt.ts
@@ -1,5 +1,4 @@
 import {Operator} from '../../Operator';
-import {Observer} from '../../Observer';
 import {Subscriber} from '../../Subscriber';
 import {ArgumentOutOfRangeError} from '../../util/ArgumentOutOfRangeError';
 
@@ -7,36 +6,36 @@ export function elementAt(index: number, defaultValue?: any) {
   return this.lift(new ElementAtOperator(index, defaultValue));
 }
 
-class ElementAtOperator<T, R> implements Operator<T,R> {
-  
+class ElementAtOperator<T, R> implements Operator<T, R> {
+
   constructor(private index: number, private defaultValue?: any) {
     if (index < 0) {
       throw new ArgumentOutOfRangeError;
     }
   }
-  
+
   call(subscriber: Subscriber<T>): Subscriber<T> {
     return new ElementAtSubscriber(subscriber, this.index, this.defaultValue);
   }
 }
 
 class ElementAtSubscriber<T, R> extends Subscriber<T> {
-  
+
   constructor(destination: Subscriber<T>, private index: number, private defaultValue?: any) {
     super(destination);
   }
-  
+
   _next(x) {
     if (this.index-- === 0) {
       this.destination.next(x);
       this.destination.complete();
     }
   }
-  
+
   _complete() {
     const destination = this.destination;
     if (this.index >= 0) {
-      if(typeof this.defaultValue !== 'undefined') {
+      if (typeof this.defaultValue !== 'undefined') {
         destination.next(this.defaultValue);
       } else {
         destination.error(new ArgumentOutOfRangeError);

--- a/src/operators/extended/find-support.ts
+++ b/src/operators/extended/find-support.ts
@@ -1,5 +1,4 @@
 import {Operator} from '../../Operator';
-import {Observer} from '../../Observer';
 import {Observable} from '../../Observable';
 import {Subscriber} from '../../Subscriber';
 
@@ -8,11 +7,12 @@ import {errorObject} from '../../util/errorObject';
 import {bindCallback} from '../../util/bindCallback';
 
 export class FindValueOperator<T, R> implements Operator<T, R> {
-  constructor(private predicate: (value: T, index: number, source:Observable<T>) => boolean, private source:Observable<T>,
-    private yieldIndex: boolean, private thisArg?: any) {
-    
+  constructor(private predicate: (value: T, index: number, source: Observable<T>) => boolean,
+              private source: Observable<T>,
+              private yieldIndex: boolean,
+              private thisArg?: any) {
   }
-  
+
   call(observer: Subscriber<T>): Subscriber<T> {
     return new FindValueSubscriber(observer, this.predicate, this.source, this.yieldIndex, this.thisArg);
   }
@@ -21,40 +21,43 @@ export class FindValueOperator<T, R> implements Operator<T, R> {
 export class FindValueSubscriber<T> extends Subscriber<T> {
   private predicate: Function;
   private index: number = 0;
-  
-  constructor(destination: Subscriber<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, 
-    private source: Observable<T>, private yieldIndex: boolean, private thisArg?: any) {
+
+  constructor(destination: Subscriber<T>,
+              predicate: (value: T, index: number, source: Observable<T>) => boolean,
+              private source: Observable<T>,
+              private yieldIndex: boolean,
+              private thisArg?: any) {
     super(destination);
-    
-    if(typeof predicate === 'function') {
+
+    if (typeof predicate === 'function') {
       this.predicate = bindCallback(predicate, thisArg, 3);
     }
   }
-  
+
   private notifyComplete(value: any): void {
     const destination = this.destination;
-    
+
     destination.next(value);
     destination.complete();
   }
-  
-  _next(value: T) {
+
+  _next(value: T): void {
     const predicate = this.predicate;
-    
+
     if (predicate === undefined) {
       this.destination.error(new TypeError('predicate must be a function'));
     }
-    
+
     let index = this.index++;
     let result = tryCatch(predicate)(value, index, this.source);
-    if(result === errorObject) {
+    if (result === errorObject) {
       this.destination.error(result.e);
     } else if (result) {
       this.notifyComplete(this.yieldIndex ? index : value);
     }
   }
-  
-  _complete() {
+
+  _complete(): void {
     this.notifyComplete(this.yieldIndex ? -1 : undefined);
   }
 }

--- a/src/operators/extended/find.ts
+++ b/src/operators/extended/find.ts
@@ -1,6 +1,6 @@
 import {Observable} from '../../Observable';
 import {FindValueOperator} from './find-support';
 
-export function find<T>(predicate: (value: T, index: number, source:Observable<T>) => boolean, thisArg?: any): Observable<T> {
+export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T> {
   return this.lift(new FindValueOperator(predicate, this, false, thisArg));
 }

--- a/src/operators/extended/findIndex.ts
+++ b/src/operators/extended/findIndex.ts
@@ -1,6 +1,6 @@
 import {Observable} from '../../Observable';
 import {FindValueOperator} from './find-support';
 
-export function findIndex<T>(predicate: (value: T, index: number, source:Observable<T>) => boolean, thisArg?: any): Observable<number> {
+export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<number> {
   return this.lift(new FindValueOperator(predicate, this, true, thisArg));
 }

--- a/src/operators/extended/isEmpty.ts
+++ b/src/operators/extended/isEmpty.ts
@@ -1,5 +1,4 @@
 import {Operator} from '../../Operator';
-import {Observable} from '../../Observable';
 import {Subscriber} from '../../Subscriber';
 
 export function isEmpty() {

--- a/src/operators/extended/timeInterval.ts
+++ b/src/operators/extended/timeInterval.ts
@@ -1,5 +1,4 @@
 import {Operator} from '../../Operator';
-import {Observer} from '../../Observer';
 import {Observable} from '../../Observable';
 import {Subscriber} from '../../Subscriber';
 import {Scheduler} from '../../Scheduler';


### PR DESCRIPTION
`tslint` glob only expanded to specific path (`src/**`) instead of fully expanded (`src/*, src/**/**/*`). Updated parameter also aligned files to lint friendly. 