### PR TITLE
refactor(ReplaySubject): rename an argument to ReplaySubject's ctor

### DIFF
--- a/src/subjects/ReplaySubject.ts
+++ b/src/subjects/ReplaySubject.ts
@@ -11,11 +11,11 @@ export default class ReplaySubject<T> extends Subject<T> {
   private events: ReplayEvent<T>[] = [];
 
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
-              _windowTime: number = Number.POSITIVE_INFINITY,
+              windowTime: number = Number.POSITIVE_INFINITY,
               scheduler?: Scheduler) {
     super();
     this.bufferSize = bufferSize < 1 ? 1 : bufferSize;
-    this._windowTime = _windowTime < 1 ? 1 : _windowTime;
+    this._windowTime = windowTime < 1 ? 1 : windowTime;
     this.scheduler = scheduler;
   }
 


### PR DESCRIPTION
Rename constructor argument `_windowTime` to `windowTime`, for better developer experience when using IDEs that suggest usage by showing a dropdown autocomplete menu. This might also positively impact documentation, which will should show `windowTime` instead of `_windowTime`. The underscore was only needed in order to avoid collision with the operator method `windowTime()` in Observable class.