### PR TITLE
debounce: more tests and some fixes

### DIFF
--- a/src/operators/debounce.ts
+++ b/src/operators/debounce.ts
@@ -47,6 +47,7 @@ class DebounceSubscriber<T> extends Subscriber<T> {
       }
 
       this.lastValue = value;
+      this.clearDebounce();
       this.add(this.debouncedSubscription = debounce._subscribe(new DurationSelectorSubscriber(this, currentIndex)));
     }
   }
@@ -67,7 +68,8 @@ class DebounceSubscriber<T> extends Subscriber<T> {
   private clearDebounce(): void {
     const debouncedSubscription = this.debouncedSubscription;
 
-    if (debouncedSubscription !== null) {
+    if (debouncedSubscription) {
+      debouncedSubscription.unsubscribe();
       this.remove(debouncedSubscription);
       this.debouncedSubscription = null;
     }


### PR DESCRIPTION
Add some missing tests for debounce operator. While at it, I found some bugs with debounce, which are also fixed in this PR.

"Fix debounce operator to unsubscribe the ongoing duration Observable if the outer subscriber gets a
new 'next' value. Also fix the `clearDebounce()` method which was doing a null check, and is now doing
a truthyness check, to catch also undefined cases."