### PR TITLE
chore(package.json): update coverage script to run on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "lint_spec": "eslint spec/**/*.js --fix",
     "lint_src": "tslint -c .tslintrc src/*.ts src/**/*.ts src/**/**/*.ts",
     "lint": "npm run lint_src && npm run lint_spec && npm run lint_perf",
-    "cover": "istanbul cover -x \"*-spec.js index.js *-helper.js spec/helpers/*\" jasmine && npm run cover_remapping",
+    "cover": "istanbul cover -x \"*-spec.js index.js *-helper.js spec/helpers/*\" ./node_modules/jasmine/bin/jasmine.js && npm run cover_remapping",
     "cover_remapping": "remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.json && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.lcov -t lcovonly && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped -t html",
     "test": "jasmine && markdown-doctest",
     "watch": "watch \"echo triggering build && npm run build_test && echo build completed\" src -d -u -w=15",


### PR DESCRIPTION
relates to #465 

This PR makes coverage script run on windows also. Still `tslint` is not available at this moment, looking for possible solutions.