### PR TITLE
Add ES7 start event handler to Observer, Observable and Subject

### DIFF
--- a/spec/observable-spec.js
+++ b/spec/observable-spec.js
@@ -91,6 +91,13 @@ describe('Observable', function () {
       expect(mutatedByComplete).toBe(true);
     });
 
+    it('should accept a fourth argument for a start handler', function () {
+      Observable.create(function _subscriber(observer) {
+        expect(observer.isUnsubscribed).toBe(true);
+      })
+      .subscribe(null, null, null, function start(subscription) { subscription.unsubscribe(); });
+    });
+
     it('should return a Subscription that calls the unsubscribe function returned by the subscriber', function () {
       var unsubscribeCalled = false;
 
@@ -138,6 +145,16 @@ describe('Observable', function () {
         expect(function testEmptyObject() {
           Observable.empty().subscribe({});
         }).not.toThrow();
+      });
+
+      it('should accept an anonymous observer with only a start function', function () {
+        Observable.create(function _subscriber(observer) {
+          expect(observer.isUnsubscribed).toBe(true);
+        }).subscribe({
+          start: function start(subscription) {
+            subscription.unsubscribe();
+          }
+        });
       });
     });
   });

--- a/spec/subject-spec.js
+++ b/spec/subject-spec.js
@@ -19,6 +19,31 @@ describe('Subject', function () {
     subject.complete();
   });
 
+  it('should have a start method that does not pass through', function () {
+    var subject = new Subject();
+    expect(typeof subject.start).toBe('function');
+
+    var testSubscription = new Rx.Subscription();
+
+    subject.subscribe(null, null, null, function startHandler(subscription) {
+      expect(subscription).not.toBe(testSubscription);
+    });
+
+    subject.start(testSubscription);
+  });
+
+  it('should trigger observer\'s start handlers when they subscribe and if they unsubscribe it should prevent the ' +
+    'observer from being added to the observers list', function () {
+    var subject = new Subject();
+    subject.subscribe({
+      start: function start(subscription) {
+        expect(subject.observers.length).toBe(0);
+        subscription.unsubscribe();
+      }
+    });
+    expect(subject.observers.length).toBe(0);
+  });
+
   it('should pump values to multiple subscribers', function (done) {
     var subject = new Subject();
     var expected = ['foo', 'bar'];

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -84,7 +84,8 @@ export class Observable<T> implements CoreOperators<T>  {
    */
   subscribe(observerOrNext?: Observer<T> | ((value: T) => void),
             error?: (error: T) => void,
-            complete?: () => void): Subscription<T> {
+            complete?: () => void,
+            start?: (subscription: Subscription<T>) => void): Subscription<T> {
 
     let subscriber: Subscriber<T>;
 
@@ -96,9 +97,10 @@ export class Observable<T> implements CoreOperators<T>  {
       }
     } else {
       const next = <((x?) => void)> observerOrNext;
-      subscriber = Subscriber.create(next, error, complete);
+      subscriber = Subscriber.create(next, error, complete, start);
     }
 
+    subscriber.start(subscriber);
     subscriber.add(this._subscribe(subscriber));
 
     return subscriber;

--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -1,4 +1,7 @@
+import {Subscription} from './Subscription';
+
 export interface Observer<T> {
+  start?: (subscription: Subscription<T>) => void;
   next?: (value: T) => void;
   error?: (err?: any) => void;
   complete?: () => void;

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -54,8 +54,9 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     }
 
     this.observers.push(subscriber);
-
-    return new SubjectSubscription(this, subscriber);
+    const subscription = new SubjectSubscription(this, subscriber);
+    subscriber.start(subscription);
+    return subscription;
   }
 
   add(subscription?) {
@@ -116,6 +117,14 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
 
     this._complete();
     this.unsubscribe();
+  }
+
+  start(subscription: Subscription<T>): void {
+    // noop
+  }
+
+  _start(subscription: Subscription<T>): void {
+    // noop
   }
 
   _next(value: T): void {
@@ -183,6 +192,10 @@ class BidirectionalSubject<T> extends Subject<T> {
     subscriberComplete.call(this);
   }
 
+  start(subscription: Subscription<T>): void {
+    //noop
+  }
+
   _next(value: T): void {
     _subscriberNext.call(this, value);
   }
@@ -193,5 +206,9 @@ class BidirectionalSubject<T> extends Subject<T> {
 
   _complete(): void {
     _subscriberComplete.call(this);
+  }
+
+  _start(subscription: Subscription<T>): void {
+    //noop
   }
 }


### PR DESCRIPTION
See commit messages for more detailed explanations, but the high level is this:

`start` is a handler on `Observer` that is called synchronously on subscription _before_ the Observable's initializer is called. This enables "synchronous unsubscribe". This is all part of the ES7 Observable spec (issue around it can be found here: https://github.com/zenparsing/es-observable/issues/65)

For Subjects, after some discussion with @abersnaze of RxJava noteriety, it was determined that the basic `Subject` should noop incoming start messages it _observes_. However, when `subscribe` is called on the Subject, the start handler on the passed observer will be called prior to adding that observer to the Subject's `observers` list.

Since this is a critical change, with interesting discoveries...
cc/ @trxcllnt @staltz @trxcllnt @mattpodwysocki @zenparsing @jhusain @kwonoj 