### PR TITLE
fix(concat): accept scheduler parameter

### DIFF
--- a/spec/operators/concat-spec.js
+++ b/spec/operators/concat-spec.js
@@ -1,4 +1,4 @@
-/* globals describe, it, expect, expectObservable, hot, cold */
+/* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx');
 
 describe('Observable.prototype.concat()', function () {
@@ -220,5 +220,38 @@ describe('Observable.prototype.concat()', function () {
     expectObservable(e1.concat(e2)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should accept scheduler with multiple observables', function () {
+    var e1 =   cold('---a|');
+    var e1subs =    '^   !';
+    var e2 =   cold(    '---b--|');
+    var e2subs =    '    ^     !';
+    var e3 =   cold(          '---c--|');
+    var e3subs =    '          ^     !';
+    var expected =  '---a---b-----c--|';
+
+    expectObservable(e1.concat(e2, e3, rxTestScheduler)).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    expectSubscriptions(e3.subscriptions).toBe(e3subs);
+  });
+
+  it('should accept scheduler without observable parameters', function () {
+    var e1 =   cold('---a-|');
+    var e1subs =    '^    !';
+    var expected =  '---a-|';
+
+    expectObservable(e1.concat(rxTestScheduler)).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should emit self without parameters', function () {
+    var e1 =   cold('---a-|');
+    var e1subs =    '^    !';
+    var expected =  '---a-|';
+
+    expectObservable(e1.concat()).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/src/operators/concat.ts
+++ b/src/operators/concat.ts
@@ -1,7 +1,8 @@
 import {Observable} from '../Observable';
 import {Scheduler} from '../Scheduler';
-import {CoreOperators} from '../CoreOperators';
 import {isScheduler} from '../util/isScheduler';
+import {ArrayObservable} from '../observables/ArrayObservable';
+import {MergeAllOperator} from './mergeAll-support';
 
 /**
  * Joins this observable with multiple other observables by subscribing to them one at a time, starting with the source,
@@ -14,8 +15,11 @@ import {isScheduler} from '../util/isScheduler';
 export function concat<R>(...observables: (Observable<any> | Scheduler)[]): Observable<R> {
   let args = <any[]>observables;
   args.unshift(this);
-  if (args.length > 1 && isScheduler(args[args.length - 1])) {
-    args.splice(args.length - 2, 0, 1);
+
+  let scheduler: Scheduler = null;
+  if (isScheduler(args[args.length - 1])) {
+    scheduler = args.pop();
   }
-  return (<CoreOperators<any>>Observable.fromArray(args)).mergeAll(1);
+
+   return new ArrayObservable(args, scheduler).lift(new MergeAllOperator(1));
 }


### PR DESCRIPTION
- accept scheduler as last parameter
- expand test coverage

This PR applies similar mechanics of `merge-static` implementation does, support `concat` operator to accept `Scheduler` also expanded test coverages.