### PR TITLE
fix(TimerObservable): accepts absolute date for dueTime

### DIFF
--- a/spec/observables/timer-spec.js
+++ b/spec/observables/timer-spec.js
@@ -43,4 +43,19 @@ describe('Observable.timer', function () {
 
     expectObservable(source, unsub).toBe(expected, values);
   });
+
+  it('should schedule a value at a specified Date', function () {
+    var source = Observable.timer(new Date(rxTestScheduler.now() + 40), null, rxTestScheduler);
+    var expected = '----(a|)';
+
+    expectObservable(source).toBe(expected, {a: 0});
+  });
+
+  it('should start after delay and periodically emit values', function () {
+    var source = Observable.timer(new Date(rxTestScheduler.now() + 40), 20, rxTestScheduler).take(5);
+    var expected = '----a-b-c-d-(e|)';
+    var values = { a: 0, b: 1, c: 2, d: 3, e: 4};
+
+    expectObservable(source).toBe(expected, values);
+  });
 });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -152,7 +152,7 @@ export class Observable<T> implements CoreOperators<T>  {
   static of: <T>(...values: Array<T | Scheduler>) => Observable<T>;
   static range: (start: number, end: number, scheduler?: Scheduler) => Observable<number>;
   static throw: <T>(error: T) => Observable<T>;
-  static timer: (dueTime: number, period?: number | Scheduler, scheduler?: Scheduler) => Observable<number>;
+  static timer: (dueTime?: number | Date, period?: number | Scheduler, scheduler?: Scheduler) => Observable<number>;
   static zip: <T>(...observables: Array<Observable<any> | ((...values: Array<any>) => T)>) => Observable<T>;
 
   // core operators

--- a/src/observables/TimerObservable.ts
+++ b/src/observables/TimerObservable.ts
@@ -3,10 +3,11 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {nextTick} from '../schedulers/nextTick';
 import {isScheduler} from '../util/isScheduler';
+import {isDate} from '../util/isDate';
 
 export class TimerObservable<T> extends Observable<T> {
 
-  static create(dueTime: number = 0, period?: number | Scheduler, scheduler?: Scheduler): Observable<number> {
+  static create(dueTime: number | Date = 0, period?: number | Scheduler, scheduler?: Scheduler): Observable<number> {
     return new TimerObservable(dueTime, period, scheduler);
   }
 
@@ -35,9 +36,13 @@ export class TimerObservable<T> extends Observable<T> {
   }
 
   _period: number;
+  private dueTime: number = 0;
 
-  constructor(private dueTime: number = 0, private period?: number | Scheduler, private scheduler?: Scheduler) {
+  constructor(dueTime: number | Date = 0,
+              private period?: number | Scheduler,
+              private scheduler?: Scheduler) {
     super();
+
     if (isNumeric(period)) {
       this._period = Number(period) < 1 && 1 || Number(period);
     } else if (isScheduler(period)) {
@@ -47,6 +52,9 @@ export class TimerObservable<T> extends Observable<T> {
       scheduler = nextTick;
     }
     this.scheduler = scheduler;
+
+    const absoluteDueTime = isDate(dueTime);
+    this.dueTime = absoluteDueTime ? (+dueTime - this.scheduler.now()) : <number>dueTime;
   }
 
   _subscribe(subscriber) {


### PR DESCRIPTION
closes #648 

This PR changes `timerObservable` accepts absolute duetime, as well as expanded test coverage. 