### PR TITLE
Refactor scan

### DIFF
--- a/spec/operators/scan-spec.js
+++ b/spec/operators/scan-spec.js
@@ -21,6 +21,21 @@ describe('Observable.prototype.scan()', function () {
     expectObservable(source).toBe(expected, values);
   });
 
+  it('should scan without seed', function () {
+    var e1 = hot('--a--^--b--c--d--|');
+    var expected =    '---x--y--z--|';
+
+    var values = {
+      x: 'b',
+      y: 'bc',
+      z: 'bcd'
+    };
+
+    var source = e1.scan(function (acc, x) { return acc + x; });
+
+    expectObservable(source).toBe(expected, values);
+  });
+
   it('should handle errors', function () {
     var e1 = hot('--a--^--b--c--d--#');
     var expected =    '---u--v--w--#';

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -214,7 +214,7 @@ export class Observable<T> implements CoreOperators<T>  {
   retryWhen: (notifier: (errors: Observable<any>) => Observable<any>) => Observable<T>;
   sample: (notifier: Observable<any>) => Observable<T>;
   sampleTime: (delay: number, scheduler?: Scheduler) => Observable<T>;
-  scan: <R>(project: (acc: R, x: T) => R, acc?: R) => Observable<R>;
+  scan: <R>(accumulator: (acc: R, x: T) => R, seed?: T | R) => Observable<R>;
   share: () => Observable<T>;
   single: (predicate?: (value: T, index: number) => boolean, thisArg?: any) => Observable<T>;
   skip: (count: number) => Observable<T>;


### PR DESCRIPTION
This PR includes changes for

- expand test coverage of `scan` to complete code coverage
- update parameter name of `scan`, from `project`, `acc` to `accumulator` and `seed` for additional clarity.