### PR TITLE
chore(micro-perf): ensure csv parameter available

### DIFF
--- a/perf/micro/index.js
+++ b/perf/micro/index.js
@@ -164,7 +164,7 @@ Observable.create(function (observer) {
     return Observable.throw(new Error('could not execute specified test, check parameter : ' + testArgument));
   }
   // If we specified a CSV file, write it.
-  else if (csv !== -1) {
+  else if (csv && csv !== -1) {
     var fileName = testArgument[csv + 1];
     return Observable.create(function (obs) {
       var fileData = output.map(function (o) {


### PR DESCRIPTION
- let test runner does not prints error due to csv parameter is not
  supplied

This PR makes micro perf test runner does not print out error when run `npm run perf_micro` without supplying csv output parameter, by having additional checking.