### PR TITLE
fix(last): accept thisArg parameter

### DIFF
--- a/perf/micro/immediate-scheduler/operators/last-predicate-this.js
+++ b/perf/micro/immediate-scheduler/operators/last-predicate-this.js
@@ -9,7 +9,7 @@ module.exports = function (suite) {
   var testThis = {};
 
   var oldLastPredicateThisArg = RxOld.Observable.range(0, 50, RxOld.Scheduler.immediate).last(predicate, testThis);
-  var newLastPredicateThisArg = RxNew.Observable.range(0, 50).last(predicate, testThis);
+  var newLastPredicateThisArg = RxNew.Observable.range(0, 50).last(predicate, null, testThis);
 
   function _next(x) { }
   function _error(e) { }

--- a/spec/operators/last-spec.js
+++ b/spec/operators/last-spec.js
@@ -41,7 +41,21 @@ describe('Observable.prototype.last()', function () {
   it('should return a default value if no element found', function () {
     var e1 = Observable.empty();
     var expected = '(a|)';
-    expectObservable(e1.last(null, null, 'a')).toBe(expected);
+    expectObservable(e1.last(null, null, null, 'a')).toBe(expected);
+  });
+
+  it('should accept thisArg for predicate', function () {
+    var e1 =   hot('--a--|');
+    var expected = '-----(a|)';
+
+    var thisArg = { context: true };
+
+    function predicate(x) {
+      expect(this.context).toBe(true);
+      return true;
+    }
+
+    expectObservable(e1.last(predicate, null, thisArg)).toBe(expected);
   });
 
   it('should not return default value if an element is found', function () {


### PR DESCRIPTION
- last operator accepts thisArg for predicate function
- update test cases accordingly

Found differences between type definition in `CoreOperators` to actual implementation, `last` operator does not accept `thisArg` correctly. Updated implementation to accept parameter also expanded test coverage.