### PR TITLE
feat(TestScheduler): add support for testing promises synchronously

### DIFF
--- a/spec/helpers/marble-testing.js
+++ b/spec/helpers/marble-testing.js
@@ -12,6 +12,13 @@ function cold() {
   return global.rxTestScheduler.createColdObservable.apply(global.rxTestScheduler, arguments);
 }
 
+function promise() {
+  if (!global.rxTestScheduler) {
+    throw 'tried to use promise() in async test';
+  }
+  return global.rxTestScheduler.createPromise.apply(global.rxTestScheduler, arguments);
+}
+
 function expectObservable() {
   if (!global.rxTestScheduler) {
     throw 'tried to use expectObservable() in async test';
@@ -33,6 +40,7 @@ function assertDeepEqual(actual, expected) {
 module.exports = {
   hot: hot,
   cold: cold,
+  promise: promise,
   expectObservable: expectObservable,
   expectSubscriptions: expectSubscriptions,
   assertDeepEqual: assertDeepEqual

--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -10,6 +10,7 @@ var marbleHelpers = require('./marble-testing');
 global.rxTestScheduler = null;
 global.cold = marbleHelpers.cold;
 global.hot = marbleHelpers.hot;
+global.promise = marbleHelpers.promise;
 global.expectObservable = marbleHelpers.expectObservable;
 global.expectSubscriptions = marbleHelpers.expectSubscriptions;
 
@@ -17,15 +18,40 @@ var assertDeepEqual = marbleHelpers.assertDeepEqual;
 
 var glit = global.it;
 
-global.it = function (description, cb, timeout) {
-  if (cb.length === 0) {
+global.it = function (description, test, timeout) {
+  if (test.length === 0) {
     glit(description, function () {
       global.rxTestScheduler = new Rx.TestScheduler(assertDeepEqual);
-      cb();
+      test();
       global.rxTestScheduler.flush();
+      global.rxTestScheduler = null;
     });
   } else {
-    glit.apply(this, arguments);
+    glit(description, function (done) {
+      global.rxTestScheduler = new Rx.TestScheduler(assertDeepEqual);
+      test(done);
+      global.rxTestScheduler.flush();
+      global.rxTestScheduler = null;
+    }, timeout);
+  }
+};
+
+var glfit = global.fit;
+
+global.fit = function (description, test, timeout) {
+  if (test.length === 0) {
+    glfit(description, function () {
+      global.rxTestScheduler = new Rx.TestScheduler(assertDeepEqual);
+      test();
+      global.rxTestScheduler.flush();
+      global.rxTestScheduler = null;
+    });
+  } else {
+    glfit(description, function (done) {
+      global.rxTestScheduler = new Rx.TestScheduler(assertDeepEqual);
+      test(done);
+      global.rxTestScheduler.flush();
+    }, timeout);
   }
 };
 
@@ -67,10 +93,6 @@ beforeEach(function () {
       };
     }
   });
-});
-
-afterEach(function () {
-  global.rxTestScheduler = null;
 });
 
 (function () {

--- a/spec/operators/debounce-spec.js
+++ b/spec/operators/debounce-spec.js
@@ -117,6 +117,20 @@ describe('Observable.prototype.debounce()', function () {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should accept a Promise as the duration selector ', function () {
+    var e1 =    hot('--a--bc--d----|');
+    var ptemplate =   '--|          ';
+    var e1subs =    '^             !';
+    var expected =  '----a---c--d--|';
+
+    function durationSelector() {
+      return promise(ptemplate, 0);
+    }
+
+    expectObservable(e1.debounce(durationSelector)).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should delay element by same selector observable emits multiple', function () {
     var e1 =    hot('----a--b--c----d----e-------|');
     var e1subs =    '^                           !';

--- a/src/schedulers/VirtualTimeScheduler.ts
+++ b/src/schedulers/VirtualTimeScheduler.ts
@@ -29,7 +29,11 @@ export class VirtualTimeScheduler implements Scheduler {
         break;
       }
     }
-    actions.length = 0;
+    this._reset();
+  }
+
+  _reset() {
+    this.actions.length = 0;
     this.frame = 0;
   }
 

--- a/src/testing/TestPromise.ts
+++ b/src/testing/TestPromise.ts
@@ -1,0 +1,45 @@
+import {Scheduler} from '../Scheduler';
+import {TestMessage} from './TestMessage';
+
+export class TestPromise<T> {
+  public promise: Promise<T>;
+  private resolve: (value: T) => void;
+  private reject: (error: any) => void;
+
+  constructor(public messages: TestMessage[],
+              private scheduler: Scheduler) {
+    this.promise = new Promise((resolve, reject) => {
+      this.resolve = resolve;
+      this.reject = reject;
+    });
+  }
+
+  setup() {
+    if (this.messages.length !== 1) {
+      return;
+    }
+    const testPromise = this;
+    const promise = this.promise;
+    const { frame, notification } = this.messages[0];
+    const { kind, value, exception } = notification;
+    this.scheduler.schedule(
+      () => {
+        switch (kind) {
+          case 'N':
+            return testPromise.resolve.call(
+              promise,
+              { fromTestPromise: true, frame, value }
+            );
+          case 'E':
+            return testPromise.reject.call(
+              promise,
+              { fromTestPromise: true, frame, reason: exception }
+            );
+          case 'C':
+            return;
+        }
+      },
+      frame
+    );
+  }
+}


### PR DESCRIPTION
**DO NOT MERGE.**

FAILED attempt at adding support for testing promises synchronously with a VirtualTimeScheduler. This
commit is just to illustrate the attempt and highlight how exactly does it not work.

For issue #701.

- - -

After spending some time punching Promises in the face trying to make them behave synchronously like Observables, I gave up on this endeavor because I'm fairly convinced it's not possible. Here is one simple example:

```js
describe('debounce', function () {
  it('should accept a Promise as the duration selector ', function () {
    var e1 =    hot('--a--bc--d----|');
    var ptemplate =   '--|          ';
    var expected =  '----a---c--d--|';

    var result = e1.debounce(function durationSelector() {
      return promise(ptemplate, 42);
    });

    expectObservable(result).toBe(expected);
  });
```

And when executed:
```
Failures:
1) Observable.prototype.debounce() should accept a Promise as the duration selector 
  Message:
    Expected 
    {"frame":140,"notification":{"kind":"N","value":"d","hasValue":true}}
    {"frame":140,"notification":{"kind":"C","hasValue":false}}
    
    to deep equal 
    {"frame":40,"notification":{"kind":"N","value":"a","hasValue":true}}
    {"frame":80,"notification":{"kind":"N","value":"c","hasValue":true}}
    {"frame":110,"notification":{"kind":"N","value":"d","hasValue":true}}
    {"frame":140,"notification":{"kind":"C","hasValue":false}}
 ```

In other words this means: **because Promises call `then()` at the next tick**, which happens **after** the rxTestScheduler has passed through all those frames, the promise as the duration selector for debounce will debounce the events for the next tick, **and not** for frames 40, 80, 110, as we specified. There is not much we can do since this is due to debounce's implementation, not related to the TestPromise helper I made.

I quit the attempt to support marble diagrams for Promises because it seems the ROI won't be positive. This PR is just to report my activity. I'll close this PR and issue #701 too.

CC @blesh @kwonoj 