### PR TITLE
fix(test): make explicit unsubscription for observable

### DIFF
--- a/spec/observables/fromEvent-spec.js
+++ b/spec/observables/fromEvent-spec.js
@@ -94,11 +94,12 @@ describe('Observable.fromEvent', function () {
       }
     };
 
-    var subscription = Observable.fromEvent(obj, 'click')
+    Observable.fromEvent(obj, 'click').take(1)
       .subscribe(function (e) {
         expect(e).toBe('test');
-        done();
-      });
+      }, function (err) {
+        done.fail('should not be called');
+      }, done);
 
     send('test');
   });
@@ -117,11 +118,12 @@ describe('Observable.fromEvent', function () {
       return x + '!';
     }
 
-    var subscription = Observable.fromEvent(obj, 'click', selector)
+    Observable.fromEvent(obj, 'click', selector).take(1)
       .subscribe(function (e) {
         expect(e).toBe('test!');
-        done();
-      });
+      }, function (err) {
+        done.fail('should not be called');
+      }, done);
 
     send('test');
   });

--- a/spec/operators/bufferWhen-spec.js
+++ b/spec/operators/bufferWhen-spec.js
@@ -230,17 +230,17 @@ describe('Observable.prototype.bufferWhen', function () {
     var closing = Observable.empty();
     var TOO_MANY_INVOCATIONS = 30;
 
-    var invoked = 0;
     source
       .bufferWhen(function () { return closing; })
+      .takeWhile(function (val, index) {
+        return index < TOO_MANY_INVOCATIONS;
+      })
       .subscribe(function (val) {
         expect(Array.isArray(val)).toBe(true);
         expect(val.length).toBe(0);
-        invoked++;
-        if (invoked > TOO_MANY_INVOCATIONS) {
-          done();
-        }
-      }, null, null);
+      }, function (err) {
+        done.fail('should not be called');
+      }, done);
   });
 
   it('should handle inner throw', function () {


### PR DESCRIPTION
Originated from https://github.com/ReactiveX/RxJS/pull/729#issuecomment-156780408 , with some of async test observables are not unsubscribed after test case is completed. 

In most cases it'll be harmless but would be better to unsubscribe it explicitly.

@staltz , would like to ask opinions tests for `bufferWhen`, if this revise would be legit or there should be better way to handle it.