### PR TITLE
feat(combineLatest): accept array of observable as parameter

### DIFF
--- a/spec/observables/combineLatest-spec.js
+++ b/spec/observables/combineLatest-spec.js
@@ -1,4 +1,4 @@
-/* globals describe, it, expect, hot, cold, expectObservable */
+/* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 var immediateScheduler = Rx.Scheduler.immediate;
@@ -27,6 +27,18 @@ describe('Observable.combineLatest', function () {
       expect(i).toEqual(r.length);
       done();
     });
+  });
+
+  it('should accept array of observables', function () {
+    var firstSource =  hot('----a----b----c----|');
+    var secondSource = hot('--d--e--f--g--|');
+    var expected =         '----uv--wx-y--z----|';
+
+    var combined = Observable.combineLatest([firstSource, secondSource], function (a, b) {
+      return '' + a + b;
+    });
+
+    expectObservable(combined).toBe(expected, {u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg'});
   });
 
   it('should work with two nevers', function () {

--- a/spec/operators/combineLatest-spec.js
+++ b/spec/operators/combineLatest-spec.js
@@ -1,4 +1,4 @@
-/* globals describe, it, expect, hot, cold, expectObservable */
+/* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 var immediateScheduler = Rx.Scheduler.immediate;
@@ -143,6 +143,23 @@ describe('Observable.prototype.combineLatest', function () {
     expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should accept array of observables', function () {
+    var e1 =   hot('--a--^--b--c--|');
+    var e1subs =        '^        !';
+    var e2 =   hot('---e-^---f--g--|');
+    var e2subs =        '^         !';
+    var e3 =   hot('---h-^----i--j-|');
+    var e3subs =        '^         !';
+    var expected =      '-----wxyz-|';
+
+    var result = e1.combineLatest([e2, e3], function (x, y, z) { return x + y + z; });
+
+    expectObservable(result).toBe(expected, { w: 'bfi', x: 'cfi', y: 'cgi', z: 'cgj' });
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    expectSubscriptions(e3.subscriptions).toBe(e3subs);
   });
 
   it('should work with empty and error', function () {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -134,7 +134,10 @@ export class Observable<T> implements CoreOperators<T>  {
   }
 
   // static method stubs
-  static combineLatest: <T>(...observables: Array<Observable<any> | ((...values: Array<any>) => T) | Scheduler>) => Observable<T>;
+  static combineLatest: <T>(...observables: Array<Observable<any> |
+                                                  Array<Observable<any>> |
+                                                  ((...values: Array<any>) => T) |
+                                                  Scheduler>) => Observable<T>;
   static concat: <T>(...observables: Array<Observable<any> | Scheduler>) => Observable<T>;
   static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
   static empty: <T>(scheduler?: Scheduler) => Observable<T>;
@@ -166,7 +169,9 @@ export class Observable<T> implements CoreOperators<T>  {
   bufferWhen: (closingSelector: () => Observable<any>) => Observable<T[]>;
   catch: (selector: (err: any, source: Observable<T>, caught: Observable<any>) => Observable<any>) => Observable<T>;
   combineAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
-  combineLatest: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
+  combineLatest: <R>(...observables: Array<Observable<any> |
+                                     Array<Observable<any>> |
+                                     ((...values: Array<any>) => R)>) => Observable<R>;
   concat: <R>(...observables: (Observable<any> | Scheduler)[]) => Observable<R>;
   concatAll: () => Observable<any>;
   concatMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;


### PR DESCRIPTION
closes #594

Applies same mechanics of `forkJoin` to support array of observables, to close issue.