### PR TITLE
chore(build): generate package.json for npm distro

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -1,0 +1,18 @@
+var pkg = require('./package.json');
+var fs = require('fs');
+
+var cjsPkg = pkg;
+var es6Pkg = pkg;
+
+//override stuff for CJS package
+cjsPkg.name = 'rxjs';
+cjsPkg.main = 'Rx.js';
+cjsPkg.typings = 'Rx.d.ts';
+
+//override stuff for ES6 package
+es6Pkg.name = 'rxjs-es6';
+es6Pkg.main = 'Rx.js';
+es6Pkg.typings = 'Rx.d.ts';
+
+fs.writeFileSync('dist/cjs/package.json', JSON.stringify(cjsPkg, null, 2));
+fs.writeFileSync('dist/es6/package.json', JSON.stringify(es6Pkg, null, 2));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "build_all": "npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global",
+    "build_all": "npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global && npm run generate_packages",
     "build_amd": "rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5 --diagnostics --pretty",
     "build_cjs": "rm -rf dist/cjs && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts src/Rx.KitchenSink.ts -m commonjs --outDir dist/cjs --sourcemap --target ES5 -d --diagnostics --pretty",
     "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts src/Rx.KitchenSink.ts --outDir dist/es6 --sourceMap --target ES6 -d --diagnostics --pretty",
@@ -33,6 +33,7 @@
     "perf": "protractor protractor.conf.js",
     "perf_micro": "node ./perf/micro/index.js",
     "prepublish": "npm run build_all",
+    "generate_packages": "node .make-packages.js",
     "commit": "git-cz"
   },
   "repository": {


### PR DESCRIPTION
Simple script that runs post build to add package.json with specific overrides for ES6/CJS deployment.