### PR TITLE
refactor(find): remove unnecessary if statement from FindValueSubscriber

### DIFF
--- a/src/operators/extended/find-support.ts
+++ b/src/operators/extended/find-support.ts
@@ -44,10 +44,6 @@ export class FindValueSubscriber<T> extends Subscriber<T> {
   _next(value: T): void {
     const predicate = this.predicate;
 
-    if (predicate === undefined) {
-      this.destination.error(new TypeError('predicate must be a function'));
-    }
-
     let index = this.index++;
     let result = tryCatch(predicate)(value, index, this.source);
     if (result === errorObject) {


### PR DESCRIPTION
Remove code that checks for a valid type of predicate given to find() operators. The check is
unnecessary since the error resulting from an invalid predicate will be caught in tryCatch() util. This also gives us a tiny performance boost.