### PR TITLE
chore(spec): add support for Jasmine focused specs (fit())

### DIFF
--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -33,6 +33,20 @@ global.it.asDiagram = function () {
   return global.it;
 };
 
+var glfit = global.fit;
+
+global.fit = function (description, cb, timeout) {
+  if (cb.length === 0) {
+    glfit(description, function () {
+      global.rxTestScheduler = new Rx.TestScheduler(assertDeepEqual);
+      cb();
+      global.rxTestScheduler.flush();
+    });
+  } else {
+    glfit.apply(this, arguments);
+  }
+};
+
 function stringify(x) {
   return JSON.stringify(x, function (key, value) {
     if (Array.isArray(value)) {


### PR DESCRIPTION
This has been annoying me for a while, every time I tried to use `fit()` to run just one Jasmine test for debugging, it didn't work because we are monkey patching `it()`. So this PR just does the same monkey patching for `fit()`.