### PR TITLE
refactor(mergeMapTo): remove explicit errorobject checking

### DIFF
--- a/src/operators/mergeMapTo-support.ts
+++ b/src/operators/mergeMapTo-support.ts
@@ -38,12 +38,9 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
       const index = this.index++;
       const ish = this.ish;
       const destination = this.destination;
-      if (ish === errorObject) {
-        destination.error(ish.e);
-      } else {
-        this.active++;
-        this._innerSub(ish, destination, resultSelector, value, index);
-      }
+
+      this.active++;
+      this._innerSub(ish, destination, resultSelector, value, index);
     } else {
       this.buffer.push(value);
     }


### PR DESCRIPTION
This PR applies minor refactoring to `mergeMapTo` operator checks explicitly given parameter is `errorObject`.

current implementation of `mergeMapTo` check if given observable parameter is errorObject everytime, which can be represented as test cases 

```
var x = errorObject;

var e1 =   hot('a---b-----------c-------d-------|');
var expected = '#';
var source = e1.mergeMapTo(x);

expectObservable(source).toBe(expected);
```

which doesn't have usage in general since `mergeMapTo` requires observable as parameter.

Maybe there's possible usecases I could not think of - it'd be appreciate for opinions. If passing errorObject is valid usecase, will convert this PR to add above test case instead.