### PR TITLE
test(Subject): add tests for subjects used as Observer

### DIFF
--- a/spec/subject-spec.js
+++ b/spec/subject-spec.js
@@ -471,4 +471,20 @@ describe('Subject', function () {
     expect(output).toEqual([1,2,3,4,5]);
     expect(outputComplete).toBe(true);
   });
+
+  it('should be an Observer which can be given to Observable.subscribe', function (done) {
+    var source = Observable.of(1, 2, 3, 4, 5);
+    var subject = new Subject();
+    var expected = [1, 2, 3, 4, 5];
+
+    subject.subscribe(
+      function (x) {
+        expect(x).toBe(expected.shift());
+      },
+      done.fail,
+      done
+    );
+
+    source.subscribe(subject);
+  });
 });

--- a/spec/subjects/behavior-subject-spec.js
+++ b/spec/subjects/behavior-subject-spec.js
@@ -3,6 +3,7 @@ var Rx = require('../../dist/cjs/Rx');
 
 var BehaviorSubject = Rx.BehaviorSubject;
 var nextTick = Rx.Scheduler.nextTick;
+var Observable = Rx.Observable;
 
 describe('BehaviorSubject', function () {
   it('should extend Subject', function (done) {
@@ -114,5 +115,21 @@ describe('BehaviorSubject', function () {
       feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject
     )).toBe(sourceTemplate);
     expectObservable(subscriber1).toBe(expected1);
+  });
+
+  it('should be an Observer which can be given to Observable.subscribe', function (done) {
+    var source = Observable.of(1, 2, 3, 4, 5);
+    var subject = new BehaviorSubject(0);
+    var expected = [0, 1, 2, 3, 4, 5];
+
+    subject.subscribe(
+      function (x) {
+        expect(x).toBe(expected.shift());
+      },
+      done.fail,
+      done
+    );
+
+    source.subscribe(subject);
   });
 });

--- a/spec/subjects/replay-subject-spec.js
+++ b/spec/subjects/replay-subject-spec.js
@@ -3,6 +3,7 @@ var Rx = require('../../dist/cjs/Rx');
 
 var ReplaySubject = Rx.ReplaySubject;
 var nextTick = Rx.Scheduler.nextTick;
+var Observable = Rx.Observable;
 
 describe('ReplaySubject', function () {
   it('should extend Subject', function (done) {
@@ -205,5 +206,21 @@ describe('ReplaySubject', function () {
       )).toBe(sourceTemplate);
       expectObservable(subscriber1).toBe(expected1);
     });
+  });
+
+  it('should be an Observer which can be given to Observable.subscribe', function (done) {
+    var source = Observable.of(1, 2, 3, 4, 5);
+    var subject = new ReplaySubject(3);
+    var expected = [3, 4, 5];
+
+    source.subscribe(subject);
+
+    subject.subscribe(
+      function (x) {
+        expect(x).toBe(expected.shift());
+      },
+      done.fail,
+      done
+    );
   });
 });


### PR DESCRIPTION
Add tests for Subject, BehaviorSubject and ReplaySubject to check whether they can be used as plain
observers when given to Observable.subscribe().

Related to issue #825.