### PR TITLE
timeoutWith: fixes and tests

### DIFF
--- a/spec/operators/timeoutWith-spec.js
+++ b/spec/operators/timeoutWith-spec.js
@@ -1,119 +1,260 @@
-/* globals describe, it, expect, expectObservable, hot, cold, rxTestScheduler */
+/* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.timeoutWith()', function () {
   it('should timeout after a specified period then subscribe to the passed observable', function () {
-    var e1 = Observable.never();
-    var e2 =  cold('--x--y--z--|');
+    var e1 =  cold('-');
+    var e1subs =   '^    !           ';
+    var e2 =       cold('--x--y--z--|');
+    var e2subs =   '     ^          !';
     var expected = '-------x--y--z--|';
 
-    expectObservable(e1.timeoutWith(50, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(50, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should timeout at a specified date then subscribe to the passed observable', function () {
-    var e1 = Observable.never();
-    var e2 = cold('--x--y--z--|');
+    var e1 =  cold('-');
+    var e1subs =   '^         !           ';
+    var e2 = cold(           '--x--y--z--|');
+    var e2subs =   '          ^          !';
     var expected = '------------x--y--z--|';
 
-    expectObservable(e1.timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should timeout after a specified period between emit then subscribe to the passed observable when source emits', function () {
+  it('should timeout after a specified period between emit then subscribe ' +
+  'to the passed observable when source emits', function () {
     var e1 =     hot('---a---b------c---|');
-    var e2 =    cold('-x-y-|');
-    var expected =   '---a---b----x-y-|';
+    var e1subs =     '^          !       ';
+    var e2 = cold(              '-x-y-|  ');
+    var e2subs =     '           ^    !  ';
+    var expected =   '---a---b----x-y-|  ';
 
-    expectObservable(e1.timeoutWith(40, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(40, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should timeout after a specified period then subscribe to the passed observable when source is empty', function () {
-    var e1 =   hot('-------------|');
-    var e2 =  cold('----x----|');
+  it('should allow unsubscribing explicitly and early', function () {
+    var e1 =     hot('---a---b-----c----|');
+    var e1subs =     '^          !       ';
+    var e2 = cold(              '-x---y| ');
+    var e2subs =     '           ^  !    ';
+    var expected =   '---a---b----x--    ';
+    var unsub =      '              !    ';
+
+    var result = e1.timeoutWith(40, e2, rxTestScheduler);
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should not break unsubscription chain when unsubscribed explicitly', function () {
+    var e1 =     hot('---a---b-----c----|');
+    var e1subs =     '^          !       ';
+    var e2 = cold(              '-x---y| ');
+    var e2subs =     '           ^  !    ';
+    var expected =   '---a---b----x--    ';
+    var unsub =      '              !    ';
+
+    var result = e1
+      .mergeMap(function (x) { return Observable.of(x); })
+      .timeoutWith(40, e2, rxTestScheduler)
+      .mergeMap(function (x) { return Observable.of(x); });
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should not subscribe to withObservable after explicit unsubscription', function () {
+    var e1 =  cold('---a------b------');
+    var e1subs =   '^    !           ';
+    var e2 =  cold(        'i---j---|');
+    var e2subs = [];
+    var expected = '---a--           ';
+    var unsub =    '     !           ';
+
+    var result = e1
+      .mergeMap(function (x) { return Observable.of(x); })
+      .timeoutWith(50, e2, rxTestScheduler)
+      .mergeMap(function (x) { return Observable.of(x); });
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should timeout after a specified period then subscribe to the ' +
+  'passed observable when source is empty', function () {
+    var e1 =   hot('-------------|      ');
+    var e1subs =   '^         !         ';
+    var e2 = cold(           '----x----|');
+    var e2subs =   '          ^        !';
     var expected = '--------------x----|';
 
-    expectObservable(e1.timeoutWith(100, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(100, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should timeout after a specified period between emit then never completes if other source does not complete', function () {
+  it('should timeout after a specified period between emit then never completes ' +
+  'if other source does not complete', function () {
     var e1 =   hot('--a--b--------c--d--|');
+    var e1subs =   '^        !           ';
     var e2 =  cold('-');
-    var expected = '--a--b----';
+    var e2subs =   '         ^           ';
+    var expected = '--a--b----           ';
 
-    expectObservable(e1.timeoutWith(40, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(40, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should timeout after a specified period then subscribe to the passed observable when source raises error after timeout', function () {
-    var e1 =   hot('-------------#');
-    var e2 =  cold('----x----|');
+  it('should timeout after a specified period then subscribe to the ' +
+  'passed observable when source raises error after timeout', function () {
+    var e1 =   hot('-------------#      ');
+    var e1subs =   '^         !         ';
+    var e2 =  cold(          '----x----|');
+    var e2subs =   '          ^        !';
     var expected = '--------------x----|';
 
-    expectObservable(e1.timeoutWith(100, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(100, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should timeout after a specified period between emit then never completes if other source emits but not complete', function () {
-    var e1 =   hot('-------------|');
-    var e2 =  cold('----x----');
+  it('should timeout after a specified period between emit then never completes ' +
+  'if other source emits but not complete', function () {
+    var e1 =   hot('-------------|     ');
+    var e1subs =   '^         !        ';
+    var e2 =            cold('----x----');
+    var e2subs =   '          ^        ';
     var expected = '--------------x----';
 
-    expectObservable(e1.timeoutWith(100, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(100, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should not timeout if source completes within timeout period', function () {
     var e1 =   hot('-----|');
-    var e2 =  cold('----x----');
+    var e1subs =   '^    !';
+    var e2 = cold(           '----x----');
+    var e2subs = [];
     var expected = '-----|';
 
-    expectObservable(e1.timeoutWith(100, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(100, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should not timeout if source raises error within timeout period', function () {
     var e1 =   hot('-----#');
-    var e2 =  cold('----x----|');
+    var e1subs =   '^    !';
+    var e2 = cold(           '----x----|');
+    var e2subs = [];
     var expected = '-----#';
 
-    expectObservable(e1.timeoutWith(100, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(100, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should not timeout if source emits within timeout period', function () {
     var e1 =   hot('--a--b--c--d--e--|');
+    var e1subs =   '^                !';
     var e2 =  cold('----x----|');
+    var e2subs = [];
     var expected = '--a--b--c--d--e--|';
 
-    expectObservable(e1.timeoutWith(50, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(50, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should timeout after specified Date then subscribe to the passed observable', function () {
     var e1 =   hot('--a--b--c--d--e--|');
-    var e2 =  cold('--z--|');
-    var expected = '--a--b---z--|';
+    var e1subs =   '^      !          ';
+    var e2 =  cold(       '--z--|     ');
+    var e2subs =   '       ^    !     ';
+    var expected = '--a--b---z--|     ';
 
-    expectObservable(e1.timeoutWith(new Date(rxTestScheduler.now() + 70), e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(new Date(rxTestScheduler.now() + 70), e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should not timeout if source completes within specified Date', function () {
     var e1 =   hot('--a--b--c--d--e--|');
+    var e1subs =   '^                !';
     var e2 =  cold('--x--|');
+    var e2subs = [];
     var expected = '--a--b--c--d--e--|';
 
     var timeoutValue = new Date(Date.now() + (expected.length + 2) * 10);
 
-    expectObservable(e1.timeoutWith(timeoutValue, e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(timeoutValue, e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
   it('should not timeout if source raises error within specified Date', function () {
     var e1 =   hot('---a---#');
+    var e1subs =   '^      !';
     var e2 =  cold('--x--|');
+    var e2subs = [];
     var expected = '---a---#';
 
-    expectObservable(e1.timeoutWith(new Date(Date.now() + 100), e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(new Date(Date.now() + 100), e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should timeout specified Date after specified Date then never completes if other source does not complete', function () {
+  it('should timeout specified Date after specified Date then never completes ' +
+  'if other source does not complete', function () {
     var e1 =   hot('---a---b---c---d---e---|');
+    var e1subs =   '^         !             ';
     var e2 =  cold('-');
-    var expected = '---a---b--';
+    var e2subs =   '          ^             ';
+    var expected = '---a---b---             ';
 
-    expectObservable(e1.timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler)).toBe(expected);
+    var result = e1.timeoutWith(new Date(rxTestScheduler.now() + 100), e2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 });

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -32,7 +32,6 @@ class TimeoutWithOperator<T, R> implements Operator<T, R> {
 
 class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
   private timeoutSubscription: Subscription<T> = undefined;
-  private timedOut: boolean = false;
   private index: number = 0;
   private _previousIndex: number = 0;
   get previousIndex(): number {
@@ -43,12 +42,13 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
     return this._hasCompleted;
   }
 
-  constructor(destination: Subscriber<T>,
+  constructor(public destination: Subscriber<T>,
               private absoluteTimeout: boolean,
               private waitFor: number,
               private withObservable: Observable<any>,
               private scheduler: Scheduler) {
-    super(destination);
+    super(null);
+    destination.add(this);
     this.scheduleTimeout();
   }
 
@@ -69,32 +69,28 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   _next(value: T) {
-    if (!this.timedOut) {
-      this.destination.next(value);
-      if (!this.absoluteTimeout) {
-        this.scheduleTimeout();
-      }
+    this.destination.next(value);
+    if (!this.absoluteTimeout) {
+      this.scheduleTimeout();
     }
   }
 
   _error(err) {
-    if (!this.timedOut) {
-      this.destination.error(err);
-      this._hasCompleted = true;
-    }
+    this.destination.error(err);
+    this._hasCompleted = true;
   }
 
   _complete() {
-    if (!this.timedOut) {
-      this.destination.complete();
-      this._hasCompleted = true;
-    }
+    this.destination.complete();
+    this._hasCompleted = true;
   }
 
   handleTimeout(): void {
-    const withObservable = this.withObservable;
-    this.timedOut = true;
-    this.add(this.timeoutSubscription = subscribeToResult(this, withObservable));
+    if (!this.isUnsubscribed) {
+      const withObservable = this.withObservable;
+      this.unsubscribe();
+      this.destination.add(this.timeoutSubscription = subscribeToResult(this, withObservable));
+    }
   }
 }
 


### PR DESCRIPTION
Because of the underlying shared Subscriber, timeoutWith was not unsubscribing from the source observable once the timeout happened. [To align with RxJS 4](https://github.com/Reactive-Extensions/RxJS/blob/master/tests/observable/timeout.js#L151-L187), this PR fixes that.