### PR TITLE
feat(AsyncSubject): initial implementation

### DIFF
--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -128,6 +128,7 @@ import './operators/zipAll';
 import {Subject} from './Subject';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
+import {AsyncSubject} from './subjects/AsyncSubject';
 import {ReplaySubject} from './subjects/ReplaySubject';
 import {BehaviorSubject} from './subjects/BehaviorSubject';
 import {ConnectableObservable} from './observable/ConnectableObservable';
@@ -156,6 +157,7 @@ export {
     Observable,
     Subscriber,
     Subscription,
+    AsyncSubject,
     ReplaySubject,
     BehaviorSubject,
     ConnectableObservable,

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -104,6 +104,7 @@ import './operators/zipAll';
 import {Subject} from './Subject';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
+import {AsyncSubject} from './subjects/AsyncSubject';
 import {ReplaySubject} from './subjects/ReplaySubject';
 import {BehaviorSubject} from './subjects/BehaviorSubject';
 import {ConnectableObservable} from './observable/ConnectableObservable';
@@ -129,6 +130,7 @@ export {
     Observable,
     Subscriber,
     Subscription,
+    AsyncSubject,
     ReplaySubject,
     BehaviorSubject,
     ConnectableObservable,

--- a/src/subjects/AsyncSubject.ts
+++ b/src/subjects/AsyncSubject.ts
@@ -1,0 +1,53 @@
+import {Subject} from '../Subject';
+import {Subscriber} from '../Subscriber';
+import {Subscription} from '../Subscription';
+
+export class AsyncSubject<T> extends Subject<T> {
+  _value: T = void 0;
+  _hasNext: boolean = false;
+  _isScalar: boolean = false;
+
+  constructor () {
+    super();
+  }
+
+  _subscribe(subscriber: Subscriber<any>): Subscription<T> {
+    const subscription = super._subscribe(subscriber);
+    if (!subscription) {
+      return;
+    } else if (!subscription.isUnsubscribed && this._hasNext) {
+      subscriber.next(this._value);
+      subscriber.complete();
+    }
+    return subscription;
+  }
+
+  _next(value: T): void {
+    this._value = value;
+    this._hasNext = true;
+  }
+
+  _complete(): void {
+    let index = -1;
+    const observers = this.observers;
+    const len = observers.length;
+
+    // optimization -- block next, complete, and unsubscribe while dispatching
+    this.observers = void 0; // optimization
+    this.isUnsubscribed = true;
+
+    if (this._hasNext) {
+      while (++index < len) {
+        let o = observers[index];
+        o.next(this._value);
+        o.complete();
+      }
+    } else {
+      while (++index < len) {
+        observers[index].complete();
+      }
+    }
+
+    this.isUnsubscribed = false;
+  }
+}


### PR DESCRIPTION
Initial implementation of the `AsyncSubject` from RxJS v4.x which has the following behavior:

1. Can take as many `next` calls as it wishes, but will not emit a value until `complete` has been called.
2. If no `next` calls have been made, then no subscriptions should be called.

Closes Issue #850 