### PR TITLE
feat(BehaviorSubject): add getValue method to access value

### DIFF
--- a/spec/subjects/behavior-subject-spec.js
+++ b/spec/subjects/behavior-subject-spec.js
@@ -4,6 +4,7 @@ var Rx = require('../../dist/cjs/Rx');
 var BehaviorSubject = Rx.BehaviorSubject;
 var nextTick = Rx.Scheduler.nextTick;
 var Observable = Rx.Observable;
+var ObjectUnsubscribedError = Rx.ObjectUnsubscribedError;
 
 describe('BehaviorSubject', function () {
   it('should extend Subject', function (done) {
@@ -11,6 +12,23 @@ describe('BehaviorSubject', function () {
     expect(subject instanceof Rx.Subject).toBe(true);
     done();
   });
+
+  it('should throw if it has received an error and getValue() is called', function () {
+    var subject = new BehaviorSubject(null);
+    subject.error(new Error('derp'));
+    expect(function () {
+      subject.getValue();
+    }).toThrow(new Error('derp'));
+  });
+
+  it('should throw an ObjectUnsubscribedError if getValue() is called ' +
+    'and the BehaviorSubject has been unsubscribed', function () {
+      var subject = new BehaviorSubject('hi there');
+      subject.unsubscribe();
+      expect(function () {
+        subject.getValue();
+      }).toThrow(new ObjectUnsubscribedError());
+    });
 
   it('should have a getValue() method to retrieve the current value', function () {
     var subject = new BehaviorSubject('staltz');

--- a/spec/subjects/behavior-subject-spec.js
+++ b/spec/subjects/behavior-subject-spec.js
@@ -12,6 +12,29 @@ describe('BehaviorSubject', function () {
     done();
   });
 
+  it('should have a getValue() method to retrieve the current value', function () {
+    var subject = new BehaviorSubject('staltz');
+    expect(subject.getValue()).toBe('staltz');
+
+    subject.next('oj');
+
+    expect(subject.getValue()).toBe('oj');
+  });
+
+  it('should not allow you to set `value` directly', function () {
+    var subject = new BehaviorSubject('flibberty');
+    subject.value = 'jibbets';
+    expect(subject.getValue()).toBe('flibberty');
+    expect(subject.value).toBe('flibberty');
+  });
+
+  it('should still allow you to retrieve the value from the value property', function () {
+    var subject = new BehaviorSubject('fuzzy');
+    expect(subject.value).toBe('fuzzy');
+    subject.next('bunny');
+    expect(subject.value).toBe('bunny');
+  });
+
   it('should start with an initialization value', function (done) {
     var subject = new BehaviorSubject('foo');
     var expected = ['foo', 'bar'];

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -137,6 +137,7 @@ import {BehaviorSubject} from './subject/BehaviorSubject';
 import {ConnectableObservable} from './observable/ConnectableObservable';
 import {Notification} from './Notification';
 import {EmptyError} from './util/EmptyError';
+import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {nextTick} from './scheduler/nextTick';
 import {immediate} from './scheduler/immediate';
@@ -167,6 +168,7 @@ export {
     Notification,
     EmptyError,
     ArgumentOutOfRangeError,
+    ObjectUnsubscribedError,
     TestScheduler,
     VirtualTimeScheduler,
     TimeInterval

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -117,7 +117,7 @@ import {ConnectableObservable} from './observable/ConnectableObservable';
 import {Notification} from './Notification';
 import {EmptyError} from './util/EmptyError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
-import {nextTick} from './scheduler/nextTick';
+import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {immediate} from './scheduler/immediate';
 import {NextTickScheduler} from './scheduler/NextTickScheduler';
 import {ImmediateScheduler} from './scheduler/ImmediateScheduler';
@@ -142,5 +142,6 @@ export {
     ConnectableObservable,
     Notification,
     EmptyError,
-    ArgumentOutOfRangeError
+    ArgumentOutOfRangeError,
+    ObjectUnsubscribedError
 };

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -119,6 +119,7 @@ import {EmptyError} from './util/EmptyError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {immediate} from './scheduler/immediate';
+import {nextTick} from './scheduler/nextTick';
 import {NextTickScheduler} from './scheduler/NextTickScheduler';
 import {ImmediateScheduler} from './scheduler/ImmediateScheduler';
 /* tslint:enable:no-unused-variable */

--- a/src/subject/BehaviorSubject.ts
+++ b/src/subject/BehaviorSubject.ts
@@ -3,8 +3,16 @@ import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
 export class BehaviorSubject<T> extends Subject<T> {
-  constructor(private value: any) {
+  constructor(private _value: T) {
     super();
+  }
+
+  getValue(): T {
+    return this._value;
+  }
+
+  get value(): T {
+    return this._value;
   }
 
   _subscribe(subscriber: Subscriber<any>): Subscription<T> {
@@ -12,12 +20,12 @@ export class BehaviorSubject<T> extends Subject<T> {
     if (!subscription) {
       return;
     } else if (!subscription.isUnsubscribed) {
-      subscriber.next(this.value);
+      subscriber.next(this._value);
     }
     return subscription;
   }
 
   _next(value: T): void {
-    super._next(this.value = value);
+    super._next(this._value = value);
   }
 }

--- a/src/subject/BehaviorSubject.ts
+++ b/src/subject/BehaviorSubject.ts
@@ -1,18 +1,29 @@
 import {Subject} from '../Subject';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
+import {throwError} from '../util/throwError';
+import {ObjectUnsubscribedError} from '../util/ObjectUnsubscribedError';
 
 export class BehaviorSubject<T> extends Subject<T> {
+  private _hasError: boolean = false;
+  private _err: any;
+
   constructor(private _value: T) {
     super();
   }
 
   getValue(): T {
-    return this._value;
+    if (this._hasError) {
+      throwError(this._err);
+    } else if (this.isUnsubscribed) {
+      throwError(new ObjectUnsubscribedError());
+    } else {
+      return this._value;
+    }
   }
 
   get value(): T {
-    return this._value;
+    return this.getValue();
   }
 
   _subscribe(subscriber: Subscriber<any>): Subscription<T> {
@@ -27,5 +38,10 @@ export class BehaviorSubject<T> extends Subject<T> {
 
   _next(value: T): void {
     super._next(this._value = value);
+  }
+
+  _error(err: any): void {
+    this._hasError = true;
+    super._error(this._err = err);
   }
 }

--- a/src/util/ObjectUnsubscribedError.ts
+++ b/src/util/ObjectUnsubscribedError.ts
@@ -1,0 +1,10 @@
+/**
+ * an error thrown when an action is invalid because the object
+ * has been unsubscribed
+ */
+export class ObjectUnsubscribedError extends Error {
+  constructor() {
+    super('object unsubscribed');
+    this.name = 'ObjectUnsubscribedError';
+  }
+}


### PR DESCRIPTION
- adds `getValue` method to get inner value
- further hides the value as `_value`
- adds `value` property getter
- purposefully excludes `value` property setter
- adds tests around `getValue` method and `value` property

fixes #758