### PR TITLE
fix(expand): accept scheduler parameter

### DIFF
--- a/spec/operators/expand-spec.js
+++ b/spec/operators/expand-spec.js
@@ -323,4 +323,28 @@ describe('Observable.prototype.expand()', function () {
         done();
       });
   });
+
+  it('should work when passing undefined for the optional arguments', function () {
+    var values = {
+      a: 1,
+      b: 1 + 1, // a + a,
+      c: 2 + 2, // b + b,
+      d: 4 + 4, // c + c,
+      e: 8 + 8, // d + d
+    };
+    var e1 =   hot('(a|)', values);
+    var e1subs =   '^           !   ';
+    var e2shape =  '---(z|)         ';
+    var expected = 'a--b--c--d--(e|)';
+
+    var result = e1.expand(function (x) {
+      if (x === 16) {
+        return Observable.empty();
+      }
+      return cold(e2shape, { z: x + x });
+    }, undefined, undefined);
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
 });

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -26,7 +26,7 @@ export interface CoreOperators<T> {
   delay?: (delay: number, scheduler?: Scheduler) => Observable<T>;
   distinctUntilChanged?: (compare?: (x: T, y: T) => boolean, thisArg?: any) => Observable<T>;
   do?: (next?: (x: T) => void, error?: (e: any) => void, complete?: () => void) => Observable<T>;
-  expand?: <R>(project: (x: T, ix: number) => Observable<R>) => Observable<R>;
+  expand?: <R>(project: (x: T, ix: number) => Observable<R>, concurrent: number, scheduler: Scheduler) => Observable<R>;
   filter?: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
   finally?: (ensure: () => void, thisArg?: any) => Observable<T>;
   first?: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -185,7 +185,7 @@ export class Observable<T> implements CoreOperators<T>  {
   delay: (delay: number, scheduler?: Scheduler) => Observable<T>;
   distinctUntilChanged: (compare?: (x: T, y: T) => boolean, thisArg?: any) => Observable<T>;
   do: (next?: (x: T) => void, error?: (e: any) => void, complete?: () => void) => Observable<T>;
-  expand: <R>(project: (x: T, ix: number) => Observable<R>) => Observable<R>;
+  expand: <R>(project: (x: T, ix: number) => Observable<R>, concurrent: number, scheduler: Scheduler) => Observable<R>;
   filter: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
   finally: (ensure: () => void, thisArg?: any) => Observable<T>;
   first: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -1,7 +1,11 @@
 import {Observable} from '../Observable';
+import {Scheduler} from '../Scheduler';
 import {ExpandOperator} from './expand-support';
 
 export function expand<T, R>(project: (value: T, index: number) => Observable<R>,
-                             concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
-  return this.lift(new ExpandOperator(project, concurrent));
+                             concurrent: number = Number.POSITIVE_INFINITY,
+                             scheduler: Scheduler = undefined): Observable<R> {
+  concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;
+
+  return this.lift(new ExpandOperator(project, concurrent, scheduler));
 }


### PR DESCRIPTION
Also moves the handling of the default value for optional parameters to
the expand function instead of the operator's ctor.

Closes #841.