### PR TITLE
refactor(SymbolShim): export SymbolShim using factory

### DIFF
--- a/spec/util/SymbolShim-spec.js
+++ b/spec/util/SymbolShim-spec.js
@@ -1,0 +1,102 @@
+/* globals __root__ */
+var SymbolDefinition = require('../../dist/cjs/util/SymbolShim').SymbolDefinition;
+var Map = require('../../dist/cjs/util/Map').Map;
+var Rx = require('../../dist/cjs/Rx');
+
+describe('SymbolDefinition', function () {
+  it('should setup symbol if root does not have it', function () {
+    var root = {};
+
+    var result = new SymbolDefinition(root);
+    expect(root.Symbol).toBeDefined();
+    expect(result.observable).toBeDefined();
+    expect(result.iterator).toBeDefined();
+  });
+
+  it('should have observable, iterator symbols', function () {
+    var result = new SymbolDefinition(__root__);
+
+    expect(typeof result.observable).toBe('symbol');
+    expect(typeof result.iterator).toBe('symbol');
+  });
+
+  describe('when symbols exists on root', function () {
+    it('should use symbols from root', function () {
+      var root = {
+        Symbol: {
+          observable: {},
+          iterator: {}
+        }
+      };
+
+      var result = new SymbolDefinition(root);
+      expect(result.observable).toBe(root.Symbol.observable);
+      expect(result.iterator).toBe(root.Symbol.iterator);
+    });
+  });
+
+  describe('observable symbol', function () {
+    it('should patch root using for symbol if exist', function () {
+      var root = {
+        Symbol: {
+          for: function (x) { return x; }
+        }
+      };
+
+      var result = new SymbolDefinition(root);
+      expect(result.observable).toBe(root.Symbol.for('observable'));
+    });
+
+    it('should patch root if for symbol does not exist', function () {
+      var root = {};
+
+      var result = new SymbolDefinition(root);
+      expect(result.observable).toBe('@@observable');
+    });
+  });
+
+  describe('iterator symbol', function () {
+    it('should patch root using for symbol if exist', function () {
+      var root = {
+        Symbol: {
+          for: function (x) { return x; }
+        }
+      };
+
+      var result = new SymbolDefinition(root);
+      expect(result.iterator).toBe(root.Symbol.for('iterator'));
+    });
+
+    it('should patch root if for symbol does not exist', function () {
+      var root = {};
+
+      var result = new SymbolDefinition(root);
+      expect(result.iterator).toBe('@@iterator');
+    });
+
+    it('should patch using set for mozilla', function () {
+      var root = {
+        Set: function () {
+          var ret = {};
+          ret['@@iterator'] = function () {};
+          return ret;
+        }
+      };
+
+      var result = new SymbolDefinition(root);
+      expect(result.iterator).toBe('@@iterator');
+    });
+
+    it('should patch using map for es6-shim', function () {
+      var root = {
+        Map: Map
+      };
+
+      root.Map.prototype.key = 'iteratorValue';
+      root.Map.prototype.entries = 'iteratorValue';
+
+      var result = new SymbolDefinition(root);
+      expect(result.iterator).toBe('key');
+    });
+  });
+});

--- a/src/util/SymbolShim.ts
+++ b/src/util/SymbolShim.ts
@@ -1,48 +1,57 @@
 import {root} from './root';
 
-if (!root.Symbol) {
-  root.Symbol = {};
-}
+export class SymbolDefinition {
+  observable: symbol = null;
+  iterator: symbol = null;
 
-if (!root.Symbol.observable) {
-  if (typeof root.Symbol.for === 'function') {
-    root.Symbol.observable = root.Symbol.for('observable');
-  } else {
-    root.Symbol.observable = '@@observable';
-  }
-}
+  private applyObservable(): symbol {
+    const root = this.root;
 
-if (!root.Symbol.iterator) {
-  if (typeof root.Symbol.for === 'function') {
-    root.Symbol.iterator = root.Symbol.for('iterator');
-  } else if (root.Set && typeof new root.Set()['@@iterator'] === 'function') {
-    // Bug for mozilla version
-    root.Symbol.iterator = '@@iterator';
-  } else if (root.Map) {
-    // es6-shim specific logic
-    let keys = Object.getOwnPropertyNames(root.Map.prototype);
-    for (let i = 0; i < keys.length; ++i) {
-      let key = keys[i];
-      if (key !== 'entries' && key !== 'size' && root.Map.prototype[key] === root.Map.prototype['entries']) {
-        root.Symbol.iterator = key;
-        break;
+    if (!root.Symbol.observable) {
+      if (typeof root.Symbol.for === 'function') {
+        root.Symbol.observable = root.Symbol.for('observable');
+      } else {
+        root.Symbol.observable = '@@observable';
       }
     }
-  } else {
-    root.Symbol.iterator = '@@iterator';
+
+    return root.Symbol.observable;
+  }
+
+  private applyIterator(): symbol {
+    const root = this.root;
+
+    if (!root.Symbol.iterator) {
+      if (typeof root.Symbol.for === 'function') {
+        root.Symbol.iterator = root.Symbol.for('iterator');
+      } else if (root.Set && typeof new root.Set()['@@iterator'] === 'function') {
+        // Bug for mozilla version
+        root.Symbol.iterator = '@@iterator';
+      } else if (root.Map) {
+        // es6-shim specific logic
+        let keys = Object.getOwnPropertyNames(root.Map.prototype);
+        for (let i = 0; i < keys.length; ++i) {
+          let key = keys[i];
+          if (key !== 'entries' && key !== 'size' && root.Map.prototype[key] === root.Map.prototype['entries']) {
+            root.Symbol.iterator = key;
+            break;
+          }
+        }
+      } else {
+        root.Symbol.iterator = '@@iterator';
+      }
+    }
+
+    return root.Symbol.iterator;
+  }
+
+  constructor(private root: any) {
+    if (!root.Symbol) {
+      root.Symbol = {};
+    }
+
+    this.observable = this.applyObservable();
+    this.iterator = this.applyIterator();
   }
 }
-
-if (!root.Symbol.dispose) {
-  if (typeof root.Symbol.for === 'function') {
-    root.Symbol.dispose = root.Symbol.for('dispose');
-  } else {
-    root.Symbol.dispose = '@@dispose';
-  }
-}
-
-export module SymbolShim {
-  export const observable: symbol = root.Symbol.observable;
-  export const iterator: symbol = root.Symbol.iterator;
-  export const dispose: symbol = root.Symbol.dispose;
-};
+export const SymbolShim = new SymbolDefinition(root);


### PR DESCRIPTION
Following changes of PR https://github.com/ReactiveX/RxJS/pull/849, supposed to update PR but stuck whole day with meetings. apologize for being late :(

This PR introduces changes
- mimic export behavior of `Immediate`, symbol is exported by simple factory does root patching interally
- create test coverages of symbols

Maybe this could be not the recommended way, any suggestions would be welcome. will update PR accordingly.