### PR TITLE
refactor(Observable): Subjects no longer wrapped in Subscriber

### DIFF
--- a/spec/observable-spec.js
+++ b/spec/observable-spec.js
@@ -109,6 +109,13 @@ describe('Observable', function () {
       expect(unsubscribeCalled).toBe(true);
     });
 
+    it('should return the given subject when called with a Subject', function () {
+      var source = Observable.of(42)
+      var subject = new Rx.Subject()
+      var subscriber = source.subscribe(subject)
+      expect(subscriber).toBe(subject)
+    })
+
     describe('when called with an anonymous observer', function () {
       it('should accept an anonymous observer with just a next function', function () {
         Observable.of(1).subscribe({

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -89,7 +89,7 @@ export class Observable<T> implements CoreOperators<T>  {
     let subscriber: Subscriber<T>;
 
     if (observerOrNext && typeof observerOrNext === 'object') {
-      if (observerOrNext instanceof Subscriber) {
+      if (observerOrNext instanceof Subscriber || observerOrNext instanceof Subject) {
         subscriber = (<Subscriber<T>> observerOrNext);
       } else {
         subscriber = new Subscriber(<Observer<T>> observerOrNext);

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -1,3 +1,6 @@
+/* tslint:disable:no-unused-variable */
+import {Subject} from './Subject';
+/* tslint:enable:no-unused-variable */
 import {Observable} from './Observable';
 import {CoreOperators} from './CoreOperators';
 import {Scheduler as IScheduler} from './Scheduler';
@@ -125,7 +128,6 @@ import './operator/zip';
 import './operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
-import {Subject} from './Subject';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -1,3 +1,9 @@
+/* tslint:disable:no-unused-variable */
+// Subject imported before Observable to bypass circular dependency issue since
+// Subject extends Observable and Observable references Subject in it's
+// definition
+import {Subject} from './Subject';
+/* tslint:enable:no-unused-variable */
 import {Observable} from './Observable';
 
 // statics
@@ -101,7 +107,6 @@ import './operator/zip';
 import './operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
-import {Subject} from './Subject';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';


### PR DESCRIPTION
Observable.subscribe updated to check for instanceof Subject, test added, import order changed in Rx and KitchenSink to avoid circular dependency issue. closes #825, closes #748