### PR TITLE
fix(AsyncSubject): emit value when it's subscribed after complete

### DIFF
--- a/spec/subjects/async-subject-spec.js
+++ b/spec/subjects/async-subject-spec.js
@@ -23,6 +23,35 @@ describe('AsyncSubject', function () {
     expect(results).toEqual([2, 'done']);
   });
 
+  it('should emit the last value to subsequent subscriptions after complete', function () {
+    var subject = new AsyncSubject();
+    var results = [];
+
+    var observer = {
+      next: function (x) {
+        results.push(x);
+      },
+      error: null,
+      complete: function () {
+        results.push('done');
+      }
+    };
+    var subscription = subject.subscribe(observer);
+
+    subject.next(1);
+    expect(results).toEqual([]);
+    subject.next(2);
+    expect(results).toEqual([]);
+    subject.complete();
+    expect(results).toEqual([2, 'done']);
+
+    subscription.unsubscribe();
+
+    results = [];
+    subject.subscribe(observer);
+    expect(results).toEqual([2, 'done']);
+  });
+
   it('should just complete if no value has been nexted into it', function () {
     var subject = new AsyncSubject();
     var results = [];
@@ -35,6 +64,31 @@ describe('AsyncSubject', function () {
 
     expect(results).toEqual([]);
     subject.complete();
+    expect(results).toEqual(['done']);
+  });
+
+  it('should just complete to any subscription if no value has been nexted into it', function () {
+    var subject = new AsyncSubject();
+    var results = [];
+
+    var observer = {
+      next: function (x) {
+        results.push(x);
+      },
+      error: null,
+      complete: function () {
+        results.push('done');
+      }
+    };
+    var subscription = subject.subscribe(observer);
+
+    expect(results).toEqual([]);
+    subject.complete();
+    expect(results).toEqual(['done']);
+
+    subscription.unsubscribe();
+    results = [];
+    subject.subscribe(observer);
     expect(results).toEqual(['done']);
   });
 

--- a/src/subject/AsyncSubject.ts
+++ b/src/subject/AsyncSubject.ts
@@ -12,14 +12,11 @@ export class AsyncSubject<T> extends Subject<T> {
   }
 
   _subscribe(subscriber: Subscriber<any>): Subscription<T> {
-    const subscription = super._subscribe(subscriber);
-    if (!subscription) {
-      return;
-    } else if (!subscription.isUnsubscribed && this._hasNext) {
+    if (this.completeSignal && this._hasNext) {
       subscriber.next(this._value);
-      subscriber.complete();
     }
-    return subscription;
+
+    return super._subscribe(subscriber);
   }
 
   _next(value: T): void {


### PR DESCRIPTION
Currently, if a new subscription happens after `complete`, AsyncSubject will emit just `complete` instead of `next` and then `complete`.