### PR TITLE
Adding plumbing to support more granular and maintainable typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
   },
   "scripts": {
     "build_all": "npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global && npm run generate_packages",
-    "build_amd": "rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5 --diagnostics --pretty",
-    "build_cjs": "rm -rf dist/cjs && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts src/Rx.KitchenSink.ts -m commonjs --outDir dist/cjs --sourcemap --target ES5 -d --diagnostics --pretty",
-    "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts src/Rx.KitchenSink.ts --outDir dist/es6 --sourceMap --target ES6 -d --diagnostics --pretty",
+    "build_amd": "npm run build_operators && rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5 --diagnostics --pretty",
+    "build_cjs": "npm run build_operators && rm -rf dist/cjs && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts src/Rx.KitchenSink.ts -m commonjs --outDir dist/cjs --sourcemap --target ES5 -d --diagnostics --pretty",
+    "build_es6": "npm run build_operators && rm -rf dist/es6 && tsc src/Rx.ts src/Rx.KitchenSink.ts --outDir dist/es6 --sourceMap --target ES6 -d --diagnostics --pretty",
     "build_closure": "java -jar ./node_modules/google-closure-compiler/compiler.jar ./dist/global/Rx.js --language_in ECMASCRIPT5 --create_source_map ./dist/global/Rx.min.js.map --js_output_file ./dist/global/Rx.min.js",
-    "build_global": "rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && npm run build_closure",
+    "build_global": "npm run build_operators && rm -rf dist/global && mkdir \"dist/global\" && browserify src/Rx.global.js --outfile dist/global/Rx.js && npm run build_closure",
     "build_perf": "npm run build_cjs && npm run build_global && webdriver-manager update && npm run perf",
     "build_test": "rm -rf dist/ && npm run lint && npm run build_cjs && jasmine",
     "build_cover": "rm -rf dist/ && npm run lint && npm run build_cjs && npm run cover",
@@ -37,7 +37,8 @@
     "generate_packages": "node .make-packages.js",
     "generate_operator_patches": "tsc -outDir dist/ ./tools/generate-operator-patches.ts && node ./dist/generate-operator-patches.js --exec",
     "commit": "git-cz",
-    "check_circular_dependencies": "madge ./dist/cjs --circular"
+    "check_circular_dependencies": "madge ./dist/cjs --circular",
+	"build_operators": "node typingsgen.js"
   },
   "repository": {
     "type": "git",

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -4,6 +4,9 @@ import {ConnectableObservable} from './observable/ConnectableObservable';
 import {Subject} from './Subject';
 import {GroupedObservable} from './operator/groupBy-support';
 import {Notification} from './Notification';
+/* tslint:disable */
+import * as operator from './operator-typings';
+/* tslint:enable */
 
 export interface CoreOperators<T> {
   buffer?: (closingNotifier: Observable<any>) => Observable<T[]>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -12,6 +12,25 @@ import {Subject} from './Subject';
 import {Notification} from './Notification';
 import {rxSubscriber} from'./symbol/rxSubscriber';
 
+import {combineLatest as combineLatestStatic} from './operator/combineLatest-static';
+import {concat as concatStatic} from './operator/concat-static';
+import {merge as mergeStatic} from './operator/merge-static';
+import {zip as zipStatic} from './operator/zip-static';
+import {BoundCallbackObservable} from './observable/bindCallback';
+import {DeferObservable} from './observable/defer';
+import {EmptyObservable} from './observable/empty';
+import {ForkJoinObservable} from './observable/forkJoin';
+import {FromObservable} from './observable/from';
+import {ArrayObservable} from './observable/fromArray';
+import {FromEventObservable} from './observable/fromEvent';
+import {FromEventPatternObservable} from './observable/fromEventPattern';
+import {PromiseObservable} from './observable/fromPromise';
+import {IntervalObservable} from './observable/interval';
+import {TimerObservable} from './observable/timer';
+import {RangeObservable} from './observable/range';
+import {InfiniteObservable} from './observable/never';
+import {ErrorObservable} from './observable/throw';
+
 /**
  * A representation of any set of values over any amount of time. This the most basic building block
  * of RxJS.
@@ -156,33 +175,25 @@ export class Observable<T> implements CoreOperators<T>  {
   }
 
   // static method stubs
-  static bindCallback: <T>(callbackFunc: Function, selector?: Function, scheduler?: Scheduler) => Function;
-  static combineLatest: <T>(...observables: Array<Observable<any> |
-                                                  Array<Observable<any>> |
-                                                  ((...values: Array<any>) => T) |
-                                                  Scheduler>) => Observable<T>;
-  static concat: <T>(...observables: Array<Observable<any> | Scheduler>) => Observable<T>;
-  static defer: <T>(observableFactory: () => Observable<T>) => Observable<T>;
-  static empty: <T>(scheduler?: Scheduler) => Observable<T>;
-  static forkJoin: (...sources: Array<Observable<any> |
-                                      Array<Observable<any>> |
-                                      Promise<any> |
-                                      ((...values: Array<any>) => any)>) => Observable<any>;
-  static from: <T>(iterable: any, scheduler?: Scheduler) => Observable<T>;
-  static fromArray: <T>(array: T[], scheduler?: Scheduler) => Observable<T>;
-  static fromEvent: <T>(element: any, eventName: string, selector?: (...args: Array<any>) => T) => Observable<T>;
-  static fromEventPattern: <T>(addHandler: (handler: Function) => void,
-                               removeHandler: (handler: Function) => void,
-                               selector?: (...args: Array<any>) => T) => Observable<T>;
-  static fromPromise: <T>(promise: Promise<T>, scheduler?: Scheduler) => Observable<T>;
-  static interval: (interval: number, scheduler?: Scheduler) => Observable<number>;
-  static merge: <T>(...observables: Array<Observable<any> | Scheduler | number>) => Observable<T>;
-  static never: <T>() => Observable<T>;
-  static of: <T>(...values: Array<T | Scheduler>) => Observable<T>;
-  static range: (start: number, end: number, scheduler?: Scheduler) => Observable<number>;
-  static throw: <T>(error: T) => Observable<T>;
-  static timer: (dueTime?: number | Date, period?: number | Scheduler, scheduler?: Scheduler) => Observable<number>;
-  static zip: <T>(...observables: Array<Observable<any> | ((...values: Array<any>) => T)>) => Observable<T>;
+  static bindCallback: typeof BoundCallbackObservable.create;
+  static combineLatest: typeof combineLatestStatic;
+  static concat: typeof concatStatic;
+  static defer: typeof DeferObservable.create;
+  static empty: typeof EmptyObservable.create;
+  static forkJoin: typeof ForkJoinObservable.create;
+  static from: typeof FromObservable.create;
+  static fromArray: typeof ArrayObservable.create;
+  static fromEvent: typeof FromEventObservable.create;
+  static fromEventPattern: typeof FromEventPatternObservable.create;
+  static fromPromise: typeof PromiseObservable.create;
+  static interval: typeof IntervalObservable.create;
+  static merge: typeof mergeStatic;
+  static never: typeof InfiniteObservable.create;
+  static of: typeof ArrayObservable.of;
+  static range: typeof RangeObservable.create;
+  static throw: typeof ErrorObservable.create;
+  static timer: typeof TimerObservable.create;
+  static zip: typeof zipStatic;
 
   // core operators
   buffer: (closingNotifier: Observable<any>) => Observable<T[]>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -12,6 +12,9 @@ import {Subject} from './Subject';
 import {Notification} from './Notification';
 import {rxSubscriber} from'./symbol/rxSubscriber';
 
+/* tslint:disable */
+import * as operator from './operator-typings';
+/* tslint:enable */
 import {combineLatest as combineLatestStatic} from './operator/combineLatest-static';
 import {concat as concatStatic} from './operator/concat-static';
 import {merge as mergeStatic} from './operator/merge-static';

--- a/src/operator-typings.ts
+++ b/src/operator-typings.ts
@@ -8,7 +8,7 @@ import {Observer} from './Observer';
 import {GroupedObservable} from './operator/groupBy-support';
 import {GroupByObservable} from './operator/groupBy';
 import {TimeInterval} from './operator/extended/timeInterval';
-import {ObservableOrPromise, ArrayOrIterator, _Selector, _IndexSelector, _SwitchMapResultSelector, _ObservableMergeMapProjector, _IteratorMergeMapProjector, _Predicate, _PredicateObservable, _Comparer, _Accumulator, _MergeAccumulator} from './types';
+import {ObservableInput, ObservableOrPromise, ArrayOrIterator, _Selector, _IndexSelector, _SwitchMapResultSelector, _ObservableMergeMapProjector, _IteratorMergeMapProjector, _Predicate, _PredicateObservable, _Comparer, _Accumulator, _MergeAccumulator} from './types';
 
 /* ||| MARKER ||| */
 /* ||| MARKER ||| */

--- a/src/operator-typings.ts
+++ b/src/operator-typings.ts
@@ -1,0 +1,14 @@
+/* tslint:disable:class-name */ /* tslint:disable:no-unused-variable */ /* tslint:disable:max-line-length */
+import {Observable} from './Observable';
+import {ConnectableObservable} from './observable/ConnectableObservable';
+import {Scheduler} from './Scheduler';
+import {Notification} from './Notification';
+import {Subject} from './Subject';
+import {Observer} from './Observer';
+import {GroupedObservable} from './operator/groupBy-support';
+import {GroupByObservable} from './operator/groupBy';
+import {TimeInterval} from './operator/extended/timeInterval';
+import {ObservableOrPromise, ArrayOrIterator, _Selector, _IndexSelector, _SwitchMapResultSelector, _ObservableMergeMapProjector, _IteratorMergeMapProjector, _Predicate, _PredicateObservable, _Comparer, _Accumulator, _MergeAccumulator} from './types';
+
+/* ||| MARKER ||| */
+/* ||| MARKER ||| */

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,6 +1,7 @@
 import {Observable} from './Observable';
 export type ObservableOrPromise<T> = Observable<T> | Promise<T>;
 export type ArrayOrIterator<T> = Iterator<T> | ArrayLike<T> | Array<T>;
+export type ObservableInput<T> = Observable<T> | Promise<T> | Iterator<T> | ArrayLike<T>;
 
 export type _Selector<T, TResult> = (value: T) => TResult;
 export type _IndexSelector<T, TResult> = (value: T, index: number) => TResult;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,16 @@
+import {Observable} from './Observable';
+export type ObservableOrPromise<T> = Observable<T> | Promise<T>;
+export type ArrayOrIterator<T> = Iterator<T> | ArrayLike<T> | Array<T>;
+
+export type _Selector<T, TResult> = (value: T) => TResult;
+export type _IndexSelector<T, TResult> = (value: T, index: number) => TResult;
+export type _SwitchMapResultSelector<T1, T2, TResult> = (outerValue: T1, innerValue: T2, outerIndex: number, innerIndex: number) => TResult;
+export type _ObservableMergeMapProjector<T, R> = (value: T, index: number) => ObservableOrPromise<R>;
+export type _IteratorMergeMapProjector<T, R> = (value: T, index: number) => ArrayOrIterator<R>;
+
+export type _Predicate<T> = _Selector<T, boolean>;
+export type _PredicateObservable<T> = (value: T, index: number, observable: Observable<T>) => boolean;
+
+export type _Comparer<T, TResult> = (value1: T, value2: T) => TResult;
+export type _Accumulator<T, TAcc> = (acc: TAcc, value: T) => TAcc;
+export type _MergeAccumulator<T, TAcc> = (acc: TAcc, value: T) => Observable<TAcc>;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,7 @@
     "indentSize": 2,
     "tabSize": 2
   },
-   "files": [
+  "files": [
     "typings/es6-build-shim.d.ts",
     "src/Rx.ts",
     "src/Rx.KitchenSink.ts"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,7 +12,8 @@
     "tabSize": 2
   },
    "files": [
-     "src/Rx.ts",
-     "src/Rx.KitchenSink.ts"
-   ]
+    "typings/es6-build-shim.d.ts",
+    "src/Rx.ts",
+    "src/Rx.KitchenSink.ts"
+  ]
 }

--- a/typings/es6-build-shim.d.ts
+++ b/typings/es6-build-shim.d.ts
@@ -1,0 +1,1 @@
+declare type IterableShim<T> = Iterable<T>;

--- a/typingsgen.js
+++ b/typingsgen.js
@@ -1,0 +1,66 @@
+var fs = require('fs');
+var regex = /export interface .*?Operators<T> \{([\S|\s]*)\}/;
+
+var core = fs.readFileSync('./src/CoreOperators.ts').toString();
+var kitchenSink = fs.readFileSync('./src/Rx.KitchenSink.ts').toString();
+var combinedMethods = core.match(regex)[1].trim() + '\n' + kitchenSink.match(regex)[1].trim();
+var contents = combinedMethods.split('\n');
+
+var operators = {};
+var fileResult = '';
+
+for (var i = 0; i < contents.length; i++) {
+  var item = contents[i].trim();
+  if (item) {
+    var file = item.match(/(.*?)\: operator.operator_proto_(.*?)<T>;/);
+    if (!file) {
+      continue;
+    }
+
+    var filename = file[2].trim();
+    var fileContent;
+
+    if (fs.existsSync('./src/operator/' + filename + '.ts')) {
+        fileContent = fs.readFileSync('./src/operator/' + filename + '.ts').toString();
+    } else {
+        fileContent = fs.readFileSync('./src/operator/extended/' + filename + '.ts').toString();
+    }
+
+    var methods = [];
+
+    var r = new RegExp('export function [_]?' + filename + '([\\s|\\S]*?[\\;\\{])', 'g');
+
+    do {
+      var result = r.exec(fileContent);
+      if (result) {
+        var method = result[1].trim();
+        if (methods.length > 0 && method.indexOf('{') > -1) {
+          continue;
+        }
+
+        method = method.split(/\n/g)
+          .filter(function (x) { return !!x; })
+          .map(function (x) { return ('' + x).trim(); })
+          .join(' ')
+          .replace(/ = .*?([\,|\)])/g, '$1');
+
+        if (method[method.length - 1] === ';' || method[method.length - 1] === '{') {
+          method = method.substr(0, method.length - 1).trim();
+        }
+
+        method = method.replace(/^<T>/, '').replace(/^<T, /, '<');
+        methods.push(method);
+      }
+    } while(result);
+
+    if (!operators[filename]) {
+      operators[filename] = true;
+      fileResult += 'export interface operator_proto_' + filename + '<T> {\n  ' + methods.join(';\n  ') + ';\n}\n';
+    }
+  }
+}
+
+var typingsContent = fs.readFileSync('./src/operator-typings.ts').toString();
+fileResult = '/* ||| MARKER ||| */\n' + fileResult + '/* ||| MARKER ||| */';
+typingsContent = typingsContent.replace(/(\/\* \|\|\| MARKER \|\|\| \*\/[\s|\S]*?\/\* \|\|\| MARKER \|\|\| \*\/)/, fileResult);
+fs.writeFileSync('./src/operator-typings.ts', typingsContent);


### PR DESCRIPTION
This is based on the original #715, I've broken it out into 2 branches so far, with other branches to follow after getting some feedback.

Today Rx has 3 or 4 places where the typings have to be updated, for the consumer to be able to actually get type information and consume that type information.

* Observable.ts
* Rx.KitchenSink.ts
* CoreOperators.ts
* The operator in question

The goal here is to be able to add well defined typings for an operator, and then extract that type information using a common convention, into another interface.  This extraction is an automated process, such that as changes are made to the operator the interface will automatically be updated.
This new interface for the operator can then be used where it needs to be, by simply using `typeof`.  

#715 was a proof of concept for me, and I only added all the typings I did because I was testing it with `omnisharp-atom` and `omnisharp-client`, both which use Rx4 extensively.  Once all the work was done, the compile times were reduced, and there were minimal changes that needed to be made to the source for things to "compile" correctly (I ran into other issues, but that isn't important to this case)

#### Pros
* All the type information now lives with the operator
* Only have to make a change to 1 file, to update the consumer.
* Allows us to have enhanced types for the operators, things like tuples for `combineLatest` instead of `Observable<any[]>

#### Cons
* Additional step in the build workflow.
* Adds some magic contributors need to know about
* The operator injection onto `Observable` might be obsolete with TS 1.8
  * I don't think we'll have the ability to type `this` yet, which is still one thing this tooling would be valuable for.
* Currently doing this one operator at a time breaks the build, for no other reason than a stackoverflow. :(
* _I'm sure there are cons I'm missing at the moment_


