### PR TITLE
catch: fixes and tests related to Subscriber chains

### DIFF
--- a/spec/operators/catch-spec.js
+++ b/spec/operators/catch-spec.js
@@ -24,7 +24,7 @@ describe('Observable.prototype.catch()', function () {
   });
 
   it('should catch error and replace it with a cold Observable', function () {
-    var e1 =   hot('--a--b--#----|     ');
+    var e1 =   hot('--a--b--#          ');
     var e1subs =   '^       !          ';
     var e2 =  cold(        '1-2-3-4-5-|');
     var e2subs =   '        ^         !';
@@ -39,13 +39,30 @@ describe('Observable.prototype.catch()', function () {
 
   it('should allow unsubscribing explicitly and early', function () {
     var e1 =   hot('--1-2-3-4-5-6---#');
-    var unsub =    '       !         ';
     var e1subs =   '^      !         ';
     var expected = '--1-2-3-         ';
+    var unsub =    '       !         ';
 
     var result = e1.catch(function () {
       return Observable.of('X', 'Y', 'Z');
     });
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chain when unsubscribed explicitly', function () {
+    var e1 =   hot('--1-2-3-4-5-6---#');
+    var e1subs =   '^      !         ';
+    var expected = '--1-2-3-         ';
+    var unsub =    '       !         ';
+
+    var result = e1
+      .mergeMap(function (x) { return Observable.of(x); })
+      .catch(function () {
+        return Observable.of('X', 'Y', 'Z');
+      })
+      .mergeMap(function (x) { return Observable.of(x); });
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -39,6 +39,7 @@ class CatchSubscriber<T> extends Subscriber<T> {
               private caught: Observable<any>) {
     super(null);
     this.lastSubscription = this;
+    this.destination.add(this);
   }
 
   _next(value: T) {


### PR DESCRIPTION
Fix Catch() operator to include CatchSubscriber in the destination Subscriber, in order not to break
unsubscription chains. Add test that catch() should not break unsubscription chain.

@trxcllnt and @blesh continuing discussions in #840, see this. I did not use `super(destination)` but I made sure the Subscriber chain is preserved. In other words, it solves the bug, perhaps not the way you wanted. I don't know how to solve it with `super(destination)`.

Here's some reasoning of the problems I found with `super(destination)` **specific to catch**:

We need to support this:
```js
  it('should catch error and replace it with a cold Observable', function () {
    var e1 =   hot('--a--b--#          ');
    var e1subs =   '^       !          ';
    var e2 =  cold(        '1-2-3-4-5-|');
    var e2subs =   '        ^         !';
    var expected = '--a--b--1-2-3-4-5-|';

    var result = e1.catch(function (err) { return e2; });

    expectObservable(result).toBe(expected);
    expectSubscriptions(e1.subscriptions).toBe(e1subs);
    expectSubscriptions(e2.subscriptions).toBe(e2subs);
  });
```

In other words, we NEED to unsubscribe from `e1` when it errors.

<img width="744" alt="screen shot 2015-12-04 at 11 55 31" src="https://cloud.githubusercontent.com/assets/90512/11586773/f70e5712-9a7d-11e5-8e88-7d276ace8804.png">

Because `e1`'s Subscription is added to the shared `destination` at the bottom, it would **only** be unsubscribed when the `destination` is unsubscribed. That's **not** what we want. We need to unsubscribe from `e1` when it errors, without unsubscribing from `destination`, which in turn should happen only when `destination` see's `e2`'s `complete`.

Makes sense?  