### PR TITLE
fix(publish): copy readme and license, remove scripts

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -1,6 +1,8 @@
 var pkg = require('./package.json');
 var fs = require('fs');
 
+delete pkg.scripts;
+
 var cjsPkg = pkg;
 var es6Pkg = pkg;
 
@@ -15,4 +17,9 @@ es6Pkg.main = 'Rx.js';
 es6Pkg.typings = 'Rx.d.ts';
 
 fs.writeFileSync('dist/cjs/package.json', JSON.stringify(cjsPkg, null, 2));
+fs.writeFileSync('dist/cjs/LICENSE.txt', fs.readFileSync('./LICENSE.txt').toString());
+fs.writeFileSync('dist/cjs/README.md', fs.readFileSync('./README.md').toString());
+
 fs.writeFileSync('dist/es6/package.json', JSON.stringify(es6Pkg, null, 2));
+fs.writeFileSync('dist/es6/LICENSE.txt', fs.readFileSync('./LICENSE.txt').toString());
+fs.writeFileSync('dist/es6/README.md', fs.readFileSync('./README.md').toString());


### PR DESCRIPTION
This change makes sure the README.md and LICENSE.txt files are
included in the CJS and ES6 distributions. The change also
removes all scripts from the npm package, since no scripts are
expectd to be run when installed by end-users.

Fixes #845