### PR TITLE
docs(README): Update markdown-doctest config and fix import typo

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -17,7 +17,11 @@ it.asDiagram = function asDiagram() {
 
 module.exports = {
   require: {
-    '@reactivex/rxjs': Rx
+    '@reactivex/rxjs': Rx,
+    'rxjs/Observable': {Observable: Rx.Observable},
+    'rxjs/Rx': {Rx: Rx},
+    'rxjs/operator/map': require(__dirname + '/dist/cjs/operator/map'),
+    'rxjs/add/operator/map': require(__dirname + '/dist/cjs/add/operator/map')
   },
 
   globals: {

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Import operators and use them _manually_ you can do the following (this is also 
 
 ```js
 var Observable = require('rxjs/Observable').Observable;
-var map = require('rxjx/operators/map').map;
+var map = require('rxjs/operator/map').map;
 
 map.call(Observable.of(1,2,3), function (x) { return x + '!!!'; });
 ```


### PR DESCRIPTION
In order to avoid having to update the config for this style of operator in future, I think I will add the ability to specify a fallback require function for `markdown-doctest`, so that we can handle this automatically.

Happy to note that it did catch a legitimate error :smile: 