### PR TITLE
fix(repeat): preserve Subscriber chain in repeat()

### DIFF
--- a/spec/operators/repeat-spec.js
+++ b/spec/operators/repeat-spec.js
@@ -70,6 +70,26 @@ describe('Observable.prototype.repeat()', function () {
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
+  it('should not break unsubscription chain when unsubscribed explicitly', function () {
+    var e1 =  cold('--a--b--|                                    ');
+    var subs =    ['^       !                                    ',
+                   '        ^       !                            ',
+                   '                ^       !                    ',
+                   '                        ^       !            ',
+                   '                                ^       !    ',
+                   '                                        ^   !'];
+    var unsub =    '                                            !';
+    var expected = '--a--b----a--b----a--b----a--b----a--b----a--';
+
+    var result = e1
+      .mergeMap(function (x) { return Observable.of(x); })
+      .repeat()
+      .mergeMap(function (x) { return Observable.of(x); });
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
   it('should consider negative count as repeat indefinitely', function () {
     var e1 =  cold('--a--b--|                                    ');
     var subs =    ['^       !                                    ',


### PR DESCRIPTION
Fix repeat() operator to add its own Subscriber to the destination Subscriber, in order to avoid
breaking unsubscription chains.