### PR TITLE
fix(bufferToggle): fix unsubscriptions of closing Observable

### DIFF
--- a/spec/operators/bufferToggle-spec.js
+++ b/spec/operators/bufferToggle-spec.js
@@ -121,14 +121,15 @@ describe('Observable.prototype.bufferToggle', function () {
 
   it('should emit buffers using varying cold closings, outer unsubscribed early', function () {
     var e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
-    var unsub =       '                  !                       ';
-    var subs =        '^                 !                       ';
+    var subs =        '^         !                               ';
     var e2 =     cold('--x-----------y--------z---|              ');
     var closings = [
       cold(             '---------------s--|                     '),
       cold(                         '----(s|)                    '),
       cold(                                  '---------------(s|)')];
-    var expected =    '-----------------i                        ';
+    var csub0 =       '  ^       !                               ';
+    var expected =    '-----------                               ';
+    var unsub =       '          !                               ';
     var values = {
       i: ['b','c','d','e']
     };
@@ -138,6 +139,9 @@ describe('Observable.prototype.bufferToggle', function () {
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(subs);
+    expectSubscriptions(closings[0].subscriptions).toBe(csub0);
+    expectSubscriptions(closings[1].subscriptions).toBe([]);
+    expectSubscriptions(closings[2].subscriptions).toBe([]);
   });
 
   it('should propagate error thrown from closingSelector', function () {

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -92,7 +92,8 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
       contexts.push(context);
       const subscriber = new BufferToggleClosingsSubscriber(this, context);
       const subscription = closingNotifier._subscribe(subscriber);
-      this.add(context.subscription.add(subscription));
+      context.subscription.add(subscription);
+      this.add(subscription);
     }
   }
 


### PR DESCRIPTION
Fix bufferToggle to unsubscribe from the closing Observables once the bufferToggle Observable is
unsubscribed.