### PR TITLE
docs(README): Fix README imports, simplify md-doctest config

### DIFF
--- a/.markdown-doctest-setup.js
+++ b/.markdown-doctest-setup.js
@@ -17,11 +17,7 @@ it.asDiagram = function asDiagram() {
 
 module.exports = {
   require: {
-    '@reactivex/rxjs': Rx,
-    'rxjs/Observable': {Observable: Rx.Observable},
-    'rxjs/Rx': {Rx: Rx},
-    'rxjs/operator/map': require(__dirname + '/dist/cjs/operator/map'),
-    'rxjs/add/operator/map': require(__dirname + '/dist/cjs/add/operator/map')
+    '@reactivex/rxjs': Rx
   },
 
   globals: {
@@ -33,6 +29,12 @@ module.exports = {
     Observable: Rx.Observable,
     someObservable: Rx.Observable.range(1, 10),
     it: it
+  },
+
+  regexRequire: {
+    'rxjs/(.*)': function (_, moduleName) {
+      return require(__dirname + '/dist/cjs/' + moduleName);
+    }
   },
 
   babel: {

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ npm install rxjs-es
 To import the entire core set of functionality:
 
 ```js
-import {Rx} from 'rxjs/Rx';
+import Rx from 'rxjs/Rx';
 
 Rx.Observable.of(1,2,3)
 ```
@@ -60,7 +60,7 @@ npm install rxjs
 Import all core functionality:
 
 ```js
-var Rx = require('rxjs/Rx').Rx;
+var Rx = require('rxjs/Rx');
 
 Rx.Observable.of(1,2,3); // etc
 ```

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "jasmine": "2.4.1",
     "jasmine-core": "2.4.1",
     "lodash": "3.10.1",
-    "markdown-doctest": "^0.2.0",
+    "markdown-doctest": "^0.3.0",
     "mkdirp": "^0.5.1",
     "platform": "1.3.0",
     "promise": "7.0.3",


### PR DESCRIPTION
@blesh it looks like the way things are currently set up, you have to do `import Rx from 'rxjs/Rx';` instead of `import {Rx} from 'rxjs/Rx';`. I'm unsure which you were aiming for, but I've updated the README to reflect the current state of affairs.

I've also added support to `markdown-doctest` for the `require('rxjs/operator/map')` style of require, and hopefully any operator should be requirable without additional configuration.