### PR TITLE
chore(package.json): bump esdoc version to latest (0.4.3)

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "commitizen": "2.4.4",
     "coveralls": "2.11.4",
     "cz-conventional-changelog": "1.1.4",
-    "esdoc": "0.2.5",
+    "esdoc": "0.4.3",
     "eslint": "1.5.1",
     "fs-extra": "0.24.0",
     "ghooks": "0.3.2",


### PR DESCRIPTION
Currently documentation generation appears to be broken because of esdoc/esdoc#73, which was fixed in the 0.2.6 release.

I have verified that it works correctly using 0.4.3.