### PR TITLE
Proposal : remove circular reference using ambient merge

### DIFF
--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -1,9 +1,10 @@
-import {Observable} from './Observable';
 import {Scheduler} from './Scheduler';
-import {ConnectableObservable} from './observable/ConnectableObservable';
-import {Subject} from './Subject';
-import {GroupedObservable} from './operator/groupBy-support';
 import {Notification} from './Notification';
+
+import {Observable} from './ambient/Observable';
+import {Subject} from './ambient/Subject';
+import {GroupedObservable} from './ambient/GroupedObservable';
+import {ConnectableObservable} from './ambient/ConnectableObservable';
 
 export interface CoreOperators<T> {
   buffer?: (closingNotifier: Observable<any>) => Observable<T[]>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -6,10 +6,11 @@ import {Subscription} from './Subscription';
 import {root} from './util/root';
 import {CoreOperators} from './CoreOperators';
 import {SymbolShim} from './util/SymbolShim';
-import {GroupedObservable} from './operator/groupBy-support';
-import {ConnectableObservable} from './observable/ConnectableObservable';
-import {Subject} from './Subject';
 import {Notification} from './Notification';
+
+import {Subject} from './ambient/Subject';
+import {GroupedObservable} from './ambient/GroupedObservable';
+import {ConnectableObservable} from './ambient/ConnectableObservable';
 
 /**
  * A representation of any set of values over any amount of time. This the most basic building block
@@ -89,7 +90,7 @@ export class Observable<T> implements CoreOperators<T>  {
     let subscriber: Subscriber<T>;
 
     if (observerOrNext && typeof observerOrNext === 'object') {
-      if (observerOrNext instanceof Subscriber || observerOrNext instanceof Subject) {
+      if (observerOrNext instanceof Subscriber) { //|| observerOrNext instanceof Subject) {
         subscriber = (<Subscriber<T>> observerOrNext);
       } else {
         subscriber = new Subscriber(<Observer<T>> observerOrNext);
@@ -255,3 +256,9 @@ export class Observable<T> implements CoreOperators<T>  {
   zip: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
   zipAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
 }
+
+//let import occurs after Observable<T> is exported
+import {ArrayObservable} from './observable/fromArray';
+
+Observable.fromArray = ArrayObservable.create;
+Observable.of = ArrayObservable.of;

--- a/src/ambient/ConnectableObservable.ts
+++ b/src/ambient/ConnectableObservable.ts
@@ -1,0 +1,1 @@
+export interface ConnectableObservable<T> {}

--- a/src/ambient/GroupedObservable.ts
+++ b/src/ambient/GroupedObservable.ts
@@ -1,0 +1,1 @@
+export interface GroupedObservable<T> {}

--- a/src/ambient/Observable.ts
+++ b/src/ambient/Observable.ts
@@ -1,0 +1,1 @@
+export interface Observable<T> {}

--- a/src/ambient/Subject.ts
+++ b/src/ambient/Subject.ts
@@ -1,0 +1,1 @@
+export interface Subject<T> {}


### PR DESCRIPTION
### Proposal : not to be merged yet

This PR is proposal to resolve https://github.com/ReactiveX/RxJS/issues/899, via ambient declaration merging introduced in typescript (https://github.com/Microsoft/TypeScript/issues/3332).

In this PR, for any parents requires to have declaration of inherited childs, it imports ambient declarations instead of actual implementation of child to remove circular dependencies. Since reference to child from parents is mostly for type declaration only, this doesn't affect actual functionality in general.

Still for some cases functionality's breaking, such as this PR regresses https://github.com/ReactiveX/RxJS/pull/863 due to failed to check type of `Subject` since ambient declaration doesn't allow type checking. Yet this is proposal, PR does not include those refactoring but only include necessary changes.