### PR TITLE
Add rxSubscriber symbol

### DIFF
--- a/spec/observable-spec.js
+++ b/spec/observable-spec.js
@@ -110,11 +110,11 @@ describe('Observable', function () {
     });
 
     it('should return the given subject when called with a Subject', function () {
-      var source = Observable.of(42)
-      var subject = new Rx.Subject()
-      var subscriber = source.subscribe(subject)
-      expect(subscriber).toBe(subject)
-    })
+      var source = Observable.of(42);
+      var subject = new Rx.Subject();
+      var subscriber = source.subscribe(subject);
+      expect(subscriber).toBe(subject);
+    });
 
     describe('when called with an anonymous observer', function () {
       it('should accept an anonymous observer with just a next function', function () {

--- a/spec/subject-spec.js
+++ b/spec/subject-spec.js
@@ -19,6 +19,11 @@ describe('Subject', function () {
     subject.complete();
   });
 
+  it('should have the rxSubscriber Symbol', function () {
+    var subject = new Subject();
+    expect(subject[Rx.Symbol.rxSubscriber]()).toBe(subject);
+  });
+
   it('should pump values to multiple subscribers', function (done) {
     var subject = new Subject();
     var expected = ['foo', 'bar'];

--- a/spec/subscriber-spec.js
+++ b/spec/subscriber-spec.js
@@ -1,0 +1,10 @@
+/* globals describe, it, expect */
+var Rx = require('../dist/cjs/Rx');
+var Subscriber = Rx.Subscriber;
+
+describe('Subscriber', function () {
+  it('should have the rxSubscriber symbol', function () {
+    var sub = new Subscriber();
+    expect(sub[Rx.Symbol.rxSubscriber]()).toBe(sub);
+  });
+});

--- a/spec/symbol/rxSubscriber-spec.js
+++ b/spec/symbol/rxSubscriber-spec.js
@@ -1,0 +1,13 @@
+var Rx = require('../../dist/cjs/Rx');
+var RxKitchenSink = require('../../dist/cjs/Rx.KitchenSink');
+var Symbol = require('../../dist/cjs/util/SymbolShim').SymbolShim;
+
+describe('rxSubscriber symbol', function () {
+  it('should exist on Rx', function () {
+    expect(Rx.Symbol.rxSubscriber).toBe(Symbol.for('rxSubscriber'));
+  });
+
+  it('should exist on Rx.KitchenSink', function () {
+    expect(RxKitchenSink.Symbol.rxSubscriber).toBe(Symbol.for('rxSubscriber'));
+  });
+});

--- a/spec/util/SymbolShim-spec.js
+++ b/spec/util/SymbolShim-spec.js
@@ -1,23 +1,28 @@
 /* globals __root__ */
-var SymbolDefinition = require('../../dist/cjs/util/SymbolShim').SymbolDefinition;
+var SymbolShim = require('../../dist/cjs/util/SymbolShim');
 var Map = require('../../dist/cjs/util/Map').Map;
 var Rx = require('../../dist/cjs/Rx');
+var polyfillSymbol = SymbolShim.polyfillSymbol;
+var ensureIterator = SymbolShim.ensureIterator;
 
-describe('SymbolDefinition', function () {
+describe('SymbolShim', function () {
   it('should setup symbol if root does not have it', function () {
     var root = {};
 
-    var result = new SymbolDefinition(root);
+    var result = polyfillSymbol(root);
     expect(root.Symbol).toBeDefined();
     expect(result.observable).toBeDefined();
     expect(result.iterator).toBeDefined();
+    expect(result.for).toBeDefined();
   });
 
-  it('should have observable, iterator symbols', function () {
-    var result = new SymbolDefinition(__root__);
+  it('should add a for method', function () {
+    var root = {};
+    var result = polyfillSymbol(root);
+    expect(typeof result.for).toBe('function');
 
-    expect(typeof result.observable).toBe('symbol');
-    expect(typeof result.iterator).toBe('symbol');
+    var test = result.for('test');
+    expect(test).toBe('@@test');
   });
 
   describe('when symbols exists on root', function () {
@@ -29,7 +34,7 @@ describe('SymbolDefinition', function () {
         }
       };
 
-      var result = new SymbolDefinition(root);
+      var result = polyfillSymbol(root);
       expect(result.observable).toBe(root.Symbol.observable);
       expect(result.iterator).toBe(root.Symbol.iterator);
     });
@@ -43,60 +48,54 @@ describe('SymbolDefinition', function () {
         }
       };
 
-      var result = new SymbolDefinition(root);
+      var result = polyfillSymbol(root);
       expect(result.observable).toBe(root.Symbol.for('observable'));
     });
 
     it('should patch root if for symbol does not exist', function () {
       var root = {};
 
-      var result = new SymbolDefinition(root);
+      var result = polyfillSymbol(root);
       expect(result.observable).toBe('@@observable');
     });
   });
+});
 
-  describe('iterator symbol', function () {
-    it('should patch root using for symbol if exist', function () {
-      var root = {
-        Symbol: {
-          for: function (x) { return x; }
-        }
-      };
+describe('ensureIterator', function () {
+  it('should patch root using for symbol if exist', function () {
+    var root = {
+      Symbol: {
+        for: function (x) { return x; }
+      }
+    };
+    ensureIterator(root.Symbol, root);
+    expect(root.Symbol.iterator).toBe(root.Symbol.for('iterator'));
+  });
 
-      var result = new SymbolDefinition(root);
-      expect(result.iterator).toBe(root.Symbol.for('iterator'));
-    });
+  it('should patch using Set for mozilla bug', function () {
+    function Set() {
+    }
+    Set.prototype['@@iterator'] = function () {};
 
-    it('should patch root if for symbol does not exist', function () {
-      var root = {};
+    var root = {
+      Set: Set,
+      Symbol: {}
+    };
 
-      var result = new SymbolDefinition(root);
-      expect(result.iterator).toBe('@@iterator');
-    });
+    ensureIterator(root.Symbol, root);
+    expect(root.Symbol.iterator).toBe('@@iterator');
+  });
 
-    it('should patch using set for mozilla', function () {
-      var root = {
-        Set: function () {
-          var ret = {};
-          ret['@@iterator'] = function () {};
-          return ret;
-        }
-      };
+  it('should patch using map for es6-shim', function () {
+    var root = {
+      Map: Map,
+      Symbol: {}
+    };
 
-      var result = new SymbolDefinition(root);
-      expect(result.iterator).toBe('@@iterator');
-    });
+    root.Map.prototype.key = 'iteratorValue';
+    root.Map.prototype.entries = 'iteratorValue';
 
-    it('should patch using map for es6-shim', function () {
-      var root = {
-        Map: Map
-      };
-
-      root.Map.prototype.key = 'iteratorValue';
-      root.Map.prototype.entries = 'iteratorValue';
-
-      var result = new SymbolDefinition(root);
-      expect(result.iterator).toBe('key');
-    });
+    ensureIterator(root.Symbol, root);
+    expect(root.Symbol.iterator).toBe('key');
   });
 });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -10,6 +10,7 @@ import {GroupedObservable} from './operator/groupBy-support';
 import {ConnectableObservable} from './observable/ConnectableObservable';
 import {Subject} from './Subject';
 import {Notification} from './Notification';
+import {rxSubscriber} from'./symbol/rxSubscriber';
 
 /**
  * A representation of any set of values over any amount of time. This the most basic building block
@@ -89,8 +90,10 @@ export class Observable<T> implements CoreOperators<T>  {
     let subscriber: Subscriber<T>;
 
     if (observerOrNext && typeof observerOrNext === 'object') {
-      if (observerOrNext instanceof Subscriber || observerOrNext instanceof Subject) {
+      if (observerOrNext instanceof Subscriber) {
         subscriber = (<Subscriber<T>> observerOrNext);
+      } else if (observerOrNext[rxSubscriber]) {
+        subscriber = observerOrNext[rxSubscriber]();
       } else {
         subscriber = new Subscriber(<Observer<T>> observerOrNext);
       }

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -146,12 +146,17 @@ import {ImmediateScheduler} from './scheduler/ImmediateScheduler';
 import {TimeInterval} from './operator/extended/timeInterval';
 import {TestScheduler} from './testing/TestScheduler';
 import {VirtualTimeScheduler} from './scheduler/VirtualTimeScheduler';
+import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:enable:no-unused-variable */
 
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
   nextTick,
   immediate
+};
+
+var Symbol = {
+  rxSubscriber
 };
 /* tslint:enable:no-var-keyword */
 
@@ -171,5 +176,6 @@ export {
     ObjectUnsubscribedError,
     TestScheduler,
     VirtualTimeScheduler,
-    TimeInterval
+    TimeInterval,
+    Symbol
 };

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -122,12 +122,17 @@ import {immediate} from './scheduler/immediate';
 import {nextTick} from './scheduler/nextTick';
 import {NextTickScheduler} from './scheduler/NextTickScheduler';
 import {ImmediateScheduler} from './scheduler/ImmediateScheduler';
+import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:enable:no-unused-variable */
 
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
   nextTick,
   immediate
+};
+
+var Symbol = {
+  rxSubscriber
 };
 /* tslint:enable:no-var-keyword */
 
@@ -137,6 +142,7 @@ export {
     Observable,
     Subscriber,
     Subscription,
+    Symbol,
     AsyncSubject,
     ReplaySubject,
     BehaviorSubject,

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -4,6 +4,7 @@ import {Observable} from './Observable';
 import {Subscriber} from './Subscriber';
 import {Subscription} from './Subscription';
 import {SubjectSubscription} from './subject/SubjectSubscription';
+import {rxSubscriber} from './symbol/rxSubscriber';
 
 const subscriptionAdd = Subscription.prototype.add;
 const subscriptionRemove = Subscription.prototype.remove;
@@ -19,6 +20,10 @@ const _subscriberComplete = Subscriber.prototype._complete;
 export class Subject<T> extends Observable<T> implements Observer<T>, Subscription<T> {
   _subscriptions: Subscription<T>[];
   _unsubscribe: () => void;
+
+  [rxSubscriber]() {
+    return this;
+  }
 
   static create<T>(source: Observable<T>, destination: Observer<T>): Subject<T> {
     return new BidirectionalSubject(source, destination);

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -4,10 +4,15 @@ import {tryOrOnError} from './util/tryOrOnError';
 
 import {Observer} from './Observer';
 import {Subscription} from './Subscription';
+import {rxSubscriber} from './symbol/rxSubscriber';
 
 export class Subscriber<T> extends Subscription<T> implements Observer<T> {
   protected _subscription: Subscription<T>;
   protected _isUnsubscribed: boolean = false;
+
+  [rxSubscriber]() {
+    return this;
+  }
 
   get isUnsubscribed(): boolean {
     const subscription = this._subscription;

--- a/src/symbol/rxSubscriber.ts
+++ b/src/symbol/rxSubscriber.ts
@@ -1,0 +1,9 @@
+import {SymbolShim} from '../util/SymbolShim';
+
+/**
+ * rxSubscriber symbol is a symbol for retreiving an "Rx safe" Observer from an object
+ * "Rx safety" can be defined as an object that has all of the traits of an Rx Subscriber,
+ * including the ability to add and remove subscriptions to the subscription chain and
+ * guarantees involving event triggering (can't "next" after unsubscription, etc).
+ */
+export const rxSubscriber = SymbolShim.for('rxSubscriber');


### PR DESCRIPTION
Add an `rxSubscriber` symbol that can be used to designate any object as "safe" to use an an Rx Subscriber (sort of)...

The idea is basically this: If any object has `Rx.Symbol.rxSubscriber` implemented as a function, that function is expected to return an `Rx.Subscriber`. This allows Rx to shortcut the wrapping of observers (such as Subjects and the like) by calling this method and using what it returns instead.

It seems like a more flexible solution for this scenario than other solutions.

Other work done:

- Refactored SymbolShim (almost completely) to include a `for` method on the polyfill.
- Added `rxSubscriber` to both `Rx` and `Rx.KitchenSink` output
- Tests