### PR TITLE
Scheduler rename

### DIFF
--- a/spec/observables/IteratorObservable-spec.js
+++ b/spec/observables/IteratorObservable-spec.js
@@ -88,7 +88,7 @@ describe('IteratorObservable', function () {
       [10, 20, 30, 40],
       function (x) { return x; },
       null,
-      Rx.Scheduler.immediate
+      Rx.Scheduler.queue
     );
 
     var subscriber = Rx.Subscriber.create(

--- a/spec/observables/SubscribeOnObservable-spec.js
+++ b/spec/observables/SubscribeOnObservable-spec.js
@@ -18,7 +18,7 @@ describe('SubscribeOnObservable', function () {
     var e1 = hot('--a--b--|');
     var scheduler = new SubscribeOnObservable(e1, 0, jasmine.createSpy('dummy')).scheduler;
 
-    expect(scheduler).toBe(Rx.Scheduler.nextTick);
+    expect(scheduler).toBe(Rx.Scheduler.asap);
   });
 
   it('should create observable via staic create function', function () {

--- a/spec/observables/combineLatest-spec.js
+++ b/spec/observables/combineLatest-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.combineLatest', function () {
   it('should combineLatest the provided observables', function () {
@@ -17,11 +17,11 @@ describe('Observable.combineLatest', function () {
   });
 
   it('should combine an immediately-scheduled source with an immediately-scheduled second', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [[1, 4], [2, 4], [2, 5], [3, 5], [3, 6], [3, 7], [3, 8]];
     var i = 0;
-    Observable.combineLatest(a, b, immediateScheduler).subscribe(function (vals) {
+    Observable.combineLatest(a, b, queueScheduler).subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);
     }, null, function () {
       expect(i).toEqual(r.length);

--- a/spec/observables/concat-spec.js
+++ b/spec/observables/concat-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, expectObservable, expectSubscriptions, cold */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.concat', function () {
   it('should emit elements from multiple sources', function () {
@@ -315,12 +315,12 @@ describe('Observable.concat', function () {
   });
 
   it('should concat an immediately-scheduled source with an immediately-scheduled second', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [1, 2, 3, 4, 5, 6, 7, 8];
     var i = 0;
 
-    Observable.concat(a, b, immediateScheduler).subscribe(function (vals) {
+    Observable.concat(a, b, queueScheduler).subscribe(function (vals) {
       expect(vals).toBe(r[i++]);
     }, null, done);
   });

--- a/spec/observables/interval-spec.js
+++ b/spec/observables/interval-spec.js
@@ -12,7 +12,7 @@ describe('Observable.interval', function () {
   it('should specify default scheduler if incorrect scheduler specified', function () {
     var scheduler = Observable.interval(10, jasmine.createSpy('dummy')).scheduler;
 
-    expect(scheduler).toBe(Rx.Scheduler.nextTick);
+    expect(scheduler).toBe(Rx.Scheduler.asap);
   });
 
   it('should emit when relative interval set to zero', function () {

--- a/spec/observables/interval-spec.js
+++ b/spec/observables/interval-spec.js
@@ -1,7 +1,6 @@
 /* globals describe, it, expect, spyOn */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediate = Rx.Scheduler.immediate;
 var Observer = Rx.Observer;
 
 describe('Observable.interval', function () {

--- a/spec/observables/of-spec.js
+++ b/spec/observables/of-spec.js
@@ -26,7 +26,7 @@ describe('Observable.of', function () {
   });
 
   it('should return a scalar observable if only passed one value and a scheduler', function () {
-    var obs = Observable.of('one', Rx.Scheduler.immediate);
+    var obs = Observable.of('one', Rx.Scheduler.queue);
     expect(obs instanceof ScalarObservable).toBe(true);
   });
 
@@ -41,7 +41,7 @@ describe('Observable.of', function () {
   });
 
   it('should return an empty observable if passed only a scheduler', function () {
-    var obs = Observable.of(Rx.Scheduler.immediate);
+    var obs = Observable.of(Rx.Scheduler.queue);
     expect(obs instanceof EmptyObservable).toBe(true);
   });
 

--- a/spec/observables/range-spec.js
+++ b/spec/observables/range-spec.js
@@ -1,7 +1,7 @@
 var Rx = require('../../dist/cjs/Rx');
 var RangeObservable = require('../../dist/cjs/observable/range').RangeObservable;
 var Observable = Rx.Observable;
-var nextTick = Rx.Scheduler.nextTick;
+var asap = Rx.Scheduler.asap;
 
 describe('Observable.range', function () {
   it('should synchronously create a range of values by default', function () {
@@ -14,14 +14,14 @@ describe('Observable.range', function () {
 
   it('should accept a scheduler' , function (done) {
     var expected = [12, 13, 14, 15];
-    spyOn(nextTick, 'schedule').and.callThrough();
+    spyOn(asap, 'schedule').and.callThrough();
 
-    var source = Observable.range(12, 4, nextTick);
+    var source = Observable.range(12, 4, asap);
 
-    expect(source.scheduler).toBe(nextTick);
+    expect(source.scheduler).toBe(asap);
 
     source.subscribe(function (x) {
-      expect(nextTick.schedule).toHaveBeenCalled();
+      expect(asap.schedule).toHaveBeenCalled();
       var exp = expected.shift();
       expect(x).toBe(exp);
     }, done.throw, done);
@@ -36,8 +36,8 @@ describe('RangeObservable', function () {
     });
 
     it('should accept a scheduler', function () {
-      var observable = RangeObservable.create(12, 4, nextTick);
-      expect(observable.scheduler).toBe(nextTick);
+      var observable = RangeObservable.create(12, 4, asap);
+      expect(observable.scheduler).toBe(asap);
     });
   });
 

--- a/spec/observables/timer-spec.js
+++ b/spec/observables/timer-spec.js
@@ -1,7 +1,6 @@
 /* globals describe, it, expect, expectObservable, hot, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediate = Rx.Scheduler.immediate;
 var Observer = Rx.Observer;
 
 describe('Observable.timer', function () {

--- a/spec/observables/zip-spec.js
+++ b/spec/observables/zip-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold, Symbol */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.zip', function () {
   it('should combine a source with a second', function () {
@@ -562,8 +562,8 @@ describe('Observable.zip', function () {
   });
 
   it('should combine an immediately-scheduled source with an immediately-scheduled second', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [[1, 4], [2, 5], [3, 6]];
     var i = 0;
 

--- a/spec/operators/combineAll-spec.js
+++ b/spec/operators/combineAll-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, hot, cold, expectObservable */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.combineAll()', function () {
   it('should work with two nevers', function () {
@@ -412,11 +412,11 @@ describe('Observable.prototype.combineAll()', function () {
   });
 
   it('should combine two immediately-scheduled observables', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [[1, 4], [2, 4], [2, 5], [3, 5], [3, 6], [3, 7], [3, 8]];
     var i = 0;
-    Observable.of(a, b, immediateScheduler).combineAll().subscribe(function (vals) {
+    Observable.of(a, b, queueScheduler).combineAll().subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);
     }, null, function () {
       expect(i).toEqual(r.length);

--- a/spec/operators/combineLatest-spec.js
+++ b/spec/operators/combineLatest-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.combineLatest', function () {
   it('should work with two nevers', function () {

--- a/spec/operators/merge-spec.js
+++ b/spec/operators/merge-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.merge', function () {
   it('should merge a source with a second', function (done) {
@@ -15,11 +15,11 @@ describe('Observable.prototype.merge', function () {
   });
 
   it('should merge an immediately-scheduled source with an immediately-scheduled second', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [1, 2, 4, 3, 5, 6, 7, 8];
     var i = 0;
-    a.merge(b, immediateScheduler).subscribe(function (val) {
+    a.merge(b, queueScheduler).subscribe(function (val) {
       expect(val).toBe(r[i++]);
     }, null, done);
   });
@@ -258,11 +258,11 @@ describe('Observable.prototype.mergeAll', function () {
   });
 
   it('should merge two immediately-scheduled observables', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [1, 2, 4, 3, 5, 6, 7, 8];
     var i = 0;
-    Observable.of(a, b, immediateScheduler).mergeAll().subscribe(function (val) {
+    Observable.of(a, b, queueScheduler).mergeAll().subscribe(function (val) {
       expect(val).toBe(r[i++]);
     }, null, done);
   });

--- a/spec/operators/switch-spec.js
+++ b/spec/operators/switch-spec.js
@@ -3,7 +3,7 @@ var Rx = require('../../dist/cjs/Rx');
 var Promise = require('promise');
 
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.switch()', function () {
   it.asDiagram('switch')('should switch a hot observable of cold observables', function () {
@@ -16,11 +16,11 @@ describe('Observable.prototype.switch()', function () {
   });
 
   it('should switch to each immediately-scheduled inner Observable', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, queueScheduler);
     var r = [1, 4, 5, 6];
     var i = 0;
-    Observable.of(a, b, immediateScheduler)
+    Observable.of(a, b, queueScheduler)
       .switch()
       .subscribe(function (x) {
         expect(x).toBe(r[i++]);

--- a/spec/operators/switchFirst-spec.js
+++ b/spec/operators/switchFirst-spec.js
@@ -3,7 +3,7 @@ var Rx = require('../../dist/cjs/Rx');
 var Promise = require('promise');
 
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.switchFirst()', function () {
   it('should switch to first immediately-scheduled inner Observable', function () {

--- a/spec/operators/switchMap-spec.js
+++ b/spec/operators/switchMap-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.switchMap()', function () {
   it('should switch with a selector function', function (done) {

--- a/spec/operators/switchMapFirst-spec.js
+++ b/spec/operators/switchMapFirst-spec.js
@@ -3,7 +3,7 @@ var Rx = require('../../dist/cjs/Rx');
 var Promise = require('promise');
 
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.switchMapFirst()', function () {
   it('should handle outer throw', function () {

--- a/spec/operators/switchMapTo-spec.js
+++ b/spec/operators/switchMapTo-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, cold, hot, expectObservable, expectSubscriptions */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.switchMapTo()', function () {
   it('should switch a synchronous many outer to a synchronous many inner', function (done) {

--- a/spec/operators/zip-spec.js
+++ b/spec/operators/zip-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('zip', function () {
   it('should combine a source with a second', function () {
@@ -561,8 +561,8 @@ describe('zip', function () {
   });
 
   it('should combine an immediately-scheduled source with an immediately-scheduled second', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [[1, 4], [2, 5], [3, 6]];
     var i = 0;
 

--- a/spec/operators/zipAll-spec.js
+++ b/spec/operators/zipAll-spec.js
@@ -1,7 +1,7 @@
 /* globals describe, it, expect, expectSubscriptions, expectObservable */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
-var immediateScheduler = Rx.Scheduler.immediate;
+var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.zipAll', function () {
   it('should combine two observables', function () {
@@ -654,12 +654,12 @@ describe('Observable.prototype.zipAll', function () {
   });
 
   it('should combine two immediately-scheduled observables', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
-    var b = Observable.of(4, 5, 6, 7, 8, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
+    var b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     var r = [[1, 4], [2, 5], [3, 6]];
     var i = 0;
 
-    var result = Observable.of(a, b, immediateScheduler).zipAll();
+    var result = Observable.of(a, b, queueScheduler).zipAll();
 
     result.subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);
@@ -667,12 +667,12 @@ describe('Observable.prototype.zipAll', function () {
   });
 
   it('should combine a source with an immediately-scheduled source', function (done) {
-    var a = Observable.of(1, 2, 3, immediateScheduler);
+    var a = Observable.of(1, 2, 3, queueScheduler);
     var b = Observable.of(4, 5, 6, 7, 8);
     var r = [[1, 4], [2, 5], [3, 6]];
     var i = 0;
 
-    var result = Observable.of(a, b, immediateScheduler).zipAll();
+    var result = Observable.of(a, b, queueScheduler).zipAll();
 
     result.subscribe(function (vals) {
       expect(vals).toDeepEqual(r[i++]);

--- a/spec/scheduler-spec.js
+++ b/spec/scheduler-spec.js
@@ -3,14 +3,14 @@ var Rx = require('../dist/cjs/Rx');
 
 var Scheduler = Rx.Scheduler;
 
-describe('Scheduler.immediate', function () {
+describe('Scheduler.queue', function () {
   it('should schedule things recursively', function () {
     var call1 = false;
     var call2 = false;
-    Scheduler.immediate.active = false;
-    Scheduler.immediate.schedule(function () {
+    Scheduler.queue.active = false;
+    Scheduler.queue.schedule(function () {
       call1 = true;
-      Scheduler.immediate.schedule(function () {
+      Scheduler.queue.schedule(function () {
         call2 = true;
       });
     });
@@ -20,7 +20,7 @@ describe('Scheduler.immediate', function () {
 
   it('should schedule things in the future too', function (done) {
     var called = false;
-    Scheduler.immediate.schedule(function () {
+    Scheduler.queue.schedule(function () {
       called = true;
     }, 50);
 

--- a/spec/subject-spec.js
+++ b/spec/subject-spec.js
@@ -2,7 +2,7 @@
 var Rx = require('../dist/cjs/Rx');
 
 var Subject = Rx.Subject;
-var nextTick = Rx.Scheduler.nextTick;
+var asap = Rx.Scheduler.asap;
 var Observable = Rx.Observable;
 
 describe('Subject', function () {

--- a/spec/subjects/behavior-subject-spec.js
+++ b/spec/subjects/behavior-subject-spec.js
@@ -2,7 +2,7 @@
 var Rx = require('../../dist/cjs/Rx');
 
 var BehaviorSubject = Rx.BehaviorSubject;
-var nextTick = Rx.Scheduler.nextTick;
+var asap = Rx.Scheduler.asap;
 var Observable = Rx.Observable;
 var ObjectUnsubscribedError = Rx.ObjectUnsubscribedError;
 

--- a/spec/subjects/replay-subject-spec.js
+++ b/spec/subjects/replay-subject-spec.js
@@ -2,7 +2,7 @@
 var Rx = require('../../dist/cjs/Rx');
 
 var ReplaySubject = Rx.ReplaySubject;
-var nextTick = Rx.Scheduler.nextTick;
+var asap = Rx.Scheduler.asap;
 var Observable = Rx.Observable;
 
 describe('ReplaySubject', function () {

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -140,9 +140,9 @@ import {EmptyError} from './util/EmptyError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {nextTick} from './scheduler/nextTick';
-import {immediate} from './scheduler/immediate';
+import {queue} from './scheduler/queue';
 import {NextTickScheduler} from './scheduler/NextTickScheduler';
-import {ImmediateScheduler} from './scheduler/ImmediateScheduler';
+import {QueueScheduler} from './scheduler/QueueScheduler';
 import {TimeInterval} from './operator/extended/timeInterval';
 import {TestScheduler} from './testing/TestScheduler';
 import {VirtualTimeScheduler} from './scheduler/VirtualTimeScheduler';
@@ -152,7 +152,7 @@ import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
   nextTick,
-  immediate
+  queue
 };
 
 var Symbol = {

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -139,9 +139,9 @@ import {Notification} from './Notification';
 import {EmptyError} from './util/EmptyError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
-import {nextTick} from './scheduler/nextTick';
+import {asap} from './scheduler/asap';
 import {queue} from './scheduler/queue';
-import {NextTickScheduler} from './scheduler/NextTickScheduler';
+import {AsapScheduler} from './scheduler/AsapScheduler';
 import {QueueScheduler} from './scheduler/QueueScheduler';
 import {TimeInterval} from './operator/extended/timeInterval';
 import {TestScheduler} from './testing/TestScheduler';
@@ -151,7 +151,7 @@ import {rxSubscriber} from './symbol/rxSubscriber';
 
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
-  nextTick,
+  asap,
   queue
 };
 

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -118,17 +118,17 @@ import {Notification} from './Notification';
 import {EmptyError} from './util/EmptyError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
-import {immediate} from './scheduler/immediate';
+import {queue} from './scheduler/queue';
 import {nextTick} from './scheduler/nextTick';
 import {NextTickScheduler} from './scheduler/NextTickScheduler';
-import {ImmediateScheduler} from './scheduler/ImmediateScheduler';
+import {QueueScheduler} from './scheduler/QueueScheduler';
 import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:enable:no-unused-variable */
 
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
   nextTick,
-  immediate
+  queue
 };
 
 var Symbol = {

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -118,16 +118,16 @@ import {Notification} from './Notification';
 import {EmptyError} from './util/EmptyError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
+import {asap} from './scheduler/asap';
 import {queue} from './scheduler/queue';
-import {nextTick} from './scheduler/nextTick';
-import {NextTickScheduler} from './scheduler/NextTickScheduler';
+import {AsapScheduler} from './scheduler/AsapScheduler';
 import {QueueScheduler} from './scheduler/QueueScheduler';
 import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:enable:no-unused-variable */
 
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
-  nextTick,
+  asap,
   queue
 };
 

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -2,11 +2,11 @@ import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 import {Observable} from '../Observable';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 import {isNumeric} from '../util/isNumeric';
 
 export class SubscribeOnObservable<T> extends Observable<T> {
-  static create<T>(source: Observable<T>, delay: number = 0, scheduler: Scheduler = nextTick): Observable<T> {
+  static create<T>(source: Observable<T>, delay: number = 0, scheduler: Scheduler = asap): Observable<T> {
     return new SubscribeOnObservable(source, delay, scheduler);
   }
 
@@ -16,13 +16,13 @@ export class SubscribeOnObservable<T> extends Observable<T> {
 
   constructor(public source: Observable<T>,
               private delayTime: number = 0,
-              private scheduler: Scheduler = nextTick) {
+              private scheduler: Scheduler = asap) {
     super();
     if (!isNumeric(delayTime) || delayTime < 0) {
       this.delayTime = 0;
     }
     if (!scheduler || typeof scheduler.schedule !== 'function') {
-      this.scheduler = nextTick;
+      this.scheduler = asap;
     }
   }
 

--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -7,7 +7,7 @@ import {SymbolShim} from '../util/SymbolShim';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {ObserveOnSubscriber} from '../operator/observeOn-support';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 
 const isArray = Array.isArray;
 
@@ -16,7 +16,7 @@ export class FromObservable<T> extends Observable<T> {
     super(null);
   }
 
-  static create<T>(ish: any, scheduler: Scheduler = immediate): Observable<T> {
+  static create<T>(ish: any, scheduler: Scheduler = queue): Observable<T> {
     if (ish) {
       if (isArray(ish)) {
         return new ArrayObservable(ish, scheduler);
@@ -38,7 +38,7 @@ export class FromObservable<T> extends Observable<T> {
   _subscribe(subscriber: Subscriber<T>) {
     const ish = this.ish;
     const scheduler = this.scheduler;
-    if (scheduler === immediate) {
+    if (scheduler === queue) {
       return ish[SymbolShim.observable]().subscribe(subscriber);
     } else {
       return ish[SymbolShim.observable]().subscribe(new ObserveOnSubscriber(subscriber, scheduler, 0));

--- a/src/observable/fromPromise.ts
+++ b/src/observable/fromPromise.ts
@@ -2,18 +2,18 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Subscription} from '../Subscription';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 
 export class PromiseObservable<T> extends Observable<T> {
 
   _isScalar: boolean = false;
   value: T;
 
-  static create<T>(promise: Promise<T>, scheduler: Scheduler = immediate): Observable<T> {
+  static create<T>(promise: Promise<T>, scheduler: Scheduler = queue): Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }
 
-  constructor(private promise: Promise<T>, public scheduler: Scheduler = immediate) {
+  constructor(private promise: Promise<T>, public scheduler: Scheduler = queue) {
     super();
   }
 
@@ -21,7 +21,7 @@ export class PromiseObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
     const promise = this.promise;
 
-    if (scheduler === immediate) {
+    if (scheduler === queue) {
       if (this._isScalar) {
         subscriber.next(this.value);
         subscriber.complete();

--- a/src/observable/interval.ts
+++ b/src/observable/interval.ts
@@ -2,10 +2,10 @@ import {Subscriber} from '../Subscriber';
 import {isNumeric} from '../util/isNumeric';
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 
 export class IntervalObservable<T> extends Observable<T> {
-  static create(period: number = 0, scheduler: Scheduler = nextTick): Observable<number> {
+  static create(period: number = 0, scheduler: Scheduler = asap): Observable<number> {
     return new IntervalObservable(period, scheduler);
   }
 
@@ -23,13 +23,13 @@ export class IntervalObservable<T> extends Observable<T> {
     (<any> this).schedule(state, period);
   }
 
-  constructor(private period: number = 0, private scheduler: Scheduler = nextTick) {
+  constructor(private period: number = 0, private scheduler: Scheduler = asap) {
     super();
     if (!isNumeric(period) || period < 0) {
       this.period = 0;
     }
     if (!scheduler || typeof scheduler.schedule !== 'function') {
-      this.scheduler = nextTick;
+      this.scheduler = asap;
     }
   }
 

--- a/src/observable/timer.ts
+++ b/src/observable/timer.ts
@@ -1,7 +1,7 @@
 import {isNumeric} from '../util/isNumeric';
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 import {isScheduler} from '../util/isScheduler';
 import {isDate} from '../util/isDate';
 
@@ -49,7 +49,7 @@ export class TimerObservable<T> extends Observable<T> {
       scheduler = <Scheduler> period;
     }
     if (!isScheduler(scheduler)) {
-      scheduler = nextTick;
+      scheduler = asap;
     }
     this.scheduler = scheduler;
 

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -3,19 +3,19 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Scheduler} from '../Scheduler';
 import {Action} from '../scheduler/Action';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 
 /**
  * buffers values from the source for a specific time period. Optionally allows new buffers to be set up at an interval.
  * @param {number} the amount of time to fill each buffer for before emitting them and clearing them.
  * @param {number} [bufferCreationInterval] the interval at which to start new buffers.
- * @param {Scheduler} [scheduler] (optional, defaults to `nextTick` scheduler) The scheduler on which to schedule the
+ * @param {Scheduler} [scheduler] (optional, defaults to `asap` scheduler) The scheduler on which to schedule the
  *  intervals that determine buffer boundaries.
  * @returns {Observable<T[]>} an observable of arrays of buffered values.
  */
 export function bufferTime<T>(bufferTimeSpan: number,
                               bufferCreationInterval: number = null,
-                              scheduler: Scheduler = nextTick): Observable<T[]> {
+                              scheduler: Scheduler = asap): Observable<T[]> {
   return this.lift(new BufferTimeOperator(bufferTimeSpan, bufferCreationInterval, scheduler));
 }
 

--- a/src/operator/concat-static.ts
+++ b/src/operator/concat-static.ts
@@ -1,6 +1,6 @@
 import {Observable} from '../Observable';
 import {Scheduler} from '../Scheduler';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 import {MergeAllOperator} from './mergeAll-support';
 import {ArrayObservable} from '../observable/fromArray';
 import {isScheduler} from '../util/isScheduler';
@@ -13,7 +13,7 @@ import {isScheduler} from '../util/isScheduler';
  * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
  */
 export function concat<R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
-  let scheduler: Scheduler = immediate;
+  let scheduler: Scheduler = queue;
   let args = <any[]>observables;
   if (isScheduler(args[observables.length - 1])) {
     scheduler = args.pop();

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -3,9 +3,9 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Subscription} from '../Subscription';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 
-export function debounceTime<T>(dueTime: number, scheduler: Scheduler = nextTick): Observable<T> {
+export function debounceTime<T>(dueTime: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new DebounceTimeOperator(dueTime, scheduler));
 }
 

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -2,11 +2,11 @@ import {Operator} from '../Operator';
 import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 import {isDate} from '../util/isDate';
 
 export function delay<T>(delay: number|Date,
-                         scheduler: Scheduler = immediate) {
+                         scheduler: Scheduler = queue) {
   const absoluteDelay = isDate(delay);
   const delayFor = absoluteDelay ? (+delay - scheduler.now()) : <number>delay;
   return this.lift(new DelayOperator(delayFor, scheduler));

--- a/src/operator/extended/timeInterval.ts
+++ b/src/operator/extended/timeInterval.ts
@@ -2,9 +2,9 @@ import {Operator} from '../../Operator';
 import {Observable} from '../../Observable';
 import {Subscriber} from '../../Subscriber';
 import {Scheduler} from '../../Scheduler';
-import {immediate} from '../../scheduler/immediate';
+import {queue} from '../../scheduler/queue';
 
-export function timeInterval<T>(scheduler: Scheduler = immediate): Observable<TimeInterval> {
+export function timeInterval<T>(scheduler: Scheduler = queue): Observable<TimeInterval> {
   return this.lift(new TimeIntervalOperator(scheduler));
 }
 

--- a/src/operator/merge-static.ts
+++ b/src/operator/merge-static.ts
@@ -2,12 +2,12 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {ArrayObservable} from '../observable/fromArray';
 import {MergeAllOperator} from './mergeAll-support';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 import {isScheduler} from '../util/isScheduler';
 
 export function merge<R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
- let scheduler: Scheduler = immediate;
+ let scheduler: Scheduler = queue;
   let last: any = observables[observables.length - 1];
   if (isScheduler(last)) {
     scheduler = <Scheduler>observables.pop();

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -2,9 +2,9 @@ import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 
-export function sampleTime<T>(delay: number, scheduler: Scheduler = nextTick): Observable<T> {
+export function sampleTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new SampleTimeOperator(delay, scheduler));
 }
 

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -2,9 +2,9 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Subscription} from '../Subscription';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 
-export function throttleTime<T>(delay: number, scheduler: Scheduler = nextTick) {
+export function throttleTime<T>(delay: number, scheduler: Scheduler = asap) {
   return this.lift(new ThrottleTimeOperator(delay, scheduler));
 }
 

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -1,12 +1,12 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 import {isDate} from '../util/isDate';
 
 export function timeout(due: number|Date,
                         errorToSend: any = null,
-                        scheduler: Scheduler = immediate) {
+                        scheduler: Scheduler = queue) {
   let absoluteTimeout = isDate(due);
   let waitFor = absoluteTimeout ? (+due - scheduler.now()) : <number>due;
   return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, errorToSend, scheduler));

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 import {Subscription} from '../Subscription';
 import {Observable} from '../Observable';
 import {isDate} from '../util/isDate';
@@ -10,7 +10,7 @@ import {subscribeToResult} from '../util/subscribeToResult';
 
 export function timeoutWith<T, R>(due: number | Date,
                                   withObservable: Observable<R>,
-                                  scheduler: Scheduler = immediate): Observable<T> | Observable<R> {
+                                  scheduler: Scheduler = queue): Observable<T> | Observable<R> {
   let absoluteTimeout = isDate(due);
   let waitFor = absoluteTimeout ? (+due - scheduler.now()) : <number>due;
   return this.lift(new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -4,11 +4,11 @@ import {Observable} from '../Observable';
 import {Subject} from '../Subject';
 import {Scheduler} from '../Scheduler';
 import {Action} from '../scheduler/Action';
-import {nextTick} from '../scheduler/nextTick';
+import {asap} from '../scheduler/asap';
 
 export function windowTime<T>(windowTimeSpan: number,
                               windowCreationInterval: number = null,
-                              scheduler: Scheduler = nextTick): Observable<Observable<T>> {
+                              scheduler: Scheduler = asap): Observable<Observable<T>> {
   return this.lift(new WindowTimeOperator(windowTimeSpan, windowCreationInterval, scheduler));
 }
 

--- a/src/scheduler/AsapAction.ts
+++ b/src/scheduler/AsapAction.ts
@@ -2,7 +2,7 @@ import {Immediate} from '../util/Immediate';
 import {QueueAction} from './QueueAction';
 import {Action} from './Action';
 
-export class NextTickAction<T> extends QueueAction<T> {
+export class AsapAction<T> extends QueueAction<T> {
   private id: any;
 
   schedule(state?: any): Action {

--- a/src/scheduler/AsapScheduler.ts
+++ b/src/scheduler/AsapScheduler.ts
@@ -1,13 +1,13 @@
 import {QueueScheduler} from './QueueScheduler';
 import {Subscription} from '../Subscription';
 import {Action} from './Action';
-import {NextTickAction} from './NextTickAction';
+import {AsapAction} from './AsapAction';
 import {QueueAction} from './QueueAction';
 
-export class NextTickScheduler extends QueueScheduler {
+export class AsapScheduler extends QueueScheduler {
   scheduleNow<T>(work: (x?: any) => Subscription<T>, state?: any): Action {
     return (this.scheduled ?
       new QueueAction(this, work) :
-      new NextTickAction(this, work)).schedule(state);
+      new AsapAction(this, work)).schedule(state);
   }
 }

--- a/src/scheduler/FutureAction.ts
+++ b/src/scheduler/FutureAction.ts
@@ -1,14 +1,14 @@
 import {Subscription} from '../Subscription';
-import {ImmediateScheduler} from './ImmediateScheduler';
+import {QueueScheduler} from './QueueScheduler';
 import {Action} from './Action';
-import {ImmediateAction} from './ImmediateAction';
+import {QueueAction} from './QueueAction';
 
-export class FutureAction<T> extends ImmediateAction<T> {
+export class FutureAction<T> extends QueueAction<T> {
 
   id: any;
   delay: number;
 
-  constructor(public scheduler: ImmediateScheduler,
+  constructor(public scheduler: QueueScheduler,
               public work: (x?: any) => Subscription<T> | void) {
     super(scheduler, work);
   }

--- a/src/scheduler/NextTickAction.ts
+++ b/src/scheduler/NextTickAction.ts
@@ -1,8 +1,8 @@
 import {Immediate} from '../util/Immediate';
-import {ImmediateAction} from './ImmediateAction';
+import {QueueAction} from './QueueAction';
 import {Action} from './Action';
 
-export class NextTickAction<T> extends ImmediateAction<T> {
+export class NextTickAction<T> extends QueueAction<T> {
   private id: any;
 
   schedule(state?: any): Action {

--- a/src/scheduler/NextTickScheduler.ts
+++ b/src/scheduler/NextTickScheduler.ts
@@ -1,13 +1,13 @@
-import {ImmediateScheduler} from './ImmediateScheduler';
+import {QueueScheduler} from './QueueScheduler';
 import {Subscription} from '../Subscription';
 import {Action} from './Action';
 import {NextTickAction} from './NextTickAction';
-import {ImmediateAction} from './ImmediateAction';
+import {QueueAction} from './QueueAction';
 
-export class NextTickScheduler extends ImmediateScheduler {
+export class NextTickScheduler extends QueueScheduler {
   scheduleNow<T>(work: (x?: any) => Subscription<T>, state?: any): Action {
     return (this.scheduled ?
-      new ImmediateAction(this, work) :
+      new QueueAction(this, work) :
       new NextTickAction(this, work)).schedule(state);
   }
 }

--- a/src/scheduler/QueueAction.ts
+++ b/src/scheduler/QueueAction.ts
@@ -2,7 +2,7 @@ import {Subscription} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 import {Action} from './Action';
 
-export class ImmediateAction<T> extends Subscription<T> implements Action {
+export class QueueAction<T> extends Subscription<T> implements Action {
 
   state: any;
 

--- a/src/scheduler/QueueScheduler.ts
+++ b/src/scheduler/QueueScheduler.ts
@@ -1,11 +1,11 @@
 import {Scheduler} from '../Scheduler';
-import {ImmediateAction} from './ImmediateAction';
+import {QueueAction} from './QueueAction';
 import {Subscription} from '../Subscription';
 import {FutureAction} from './FutureAction';
 import {Action} from './Action';
 
-export class ImmediateScheduler implements Scheduler {
-  actions: ImmediateAction<any>[] = [];
+export class QueueScheduler implements Scheduler {
+  actions: QueueAction<any>[] = [];
   active: boolean = false;
   scheduled: boolean = false;
 
@@ -32,7 +32,7 @@ export class ImmediateScheduler implements Scheduler {
   }
 
   scheduleNow<T>(work: (x?: any) => Subscription<T> | void, state?: any): Action {
-    return new ImmediateAction(this, work).schedule(state);
+    return new QueueAction(this, work).schedule(state);
   }
 
   scheduleLater<T>(work: (x?: any) => Subscription<T> | void, delay: number, state?: any): Action {

--- a/src/scheduler/asap.ts
+++ b/src/scheduler/asap.ts
@@ -1,0 +1,3 @@
+import {AsapScheduler} from './AsapScheduler';
+
+export const asap = new AsapScheduler();

--- a/src/scheduler/immediate.ts
+++ b/src/scheduler/immediate.ts
@@ -1,3 +1,0 @@
-import {ImmediateScheduler} from './ImmediateScheduler';
-
-export const immediate = new ImmediateScheduler();

--- a/src/scheduler/nextTick.ts
+++ b/src/scheduler/nextTick.ts
@@ -1,3 +1,0 @@
-import {NextTickScheduler} from './NextTickScheduler';
-
-export const nextTick = new NextTickScheduler();

--- a/src/scheduler/queue.ts
+++ b/src/scheduler/queue.ts
@@ -1,0 +1,3 @@
+import {QueueScheduler} from './QueueScheduler';
+
+export const queue = new QueueScheduler();

--- a/src/subject/ReplaySubject.ts
+++ b/src/subject/ReplaySubject.ts
@@ -1,6 +1,6 @@
 import {Subject} from '../Subject';
 import {Scheduler} from '../Scheduler';
-import {immediate} from '../scheduler/immediate';
+import {queue} from '../scheduler/queue';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
@@ -37,7 +37,7 @@ export class ReplaySubject<T> extends Subject<T> {
   }
 
   private _getNow(): number {
-    return (this.scheduler || immediate).now();
+    return (this.scheduler || queue).now();
   }
 
   private _trimBufferThenGetEvents(now): ReplayEvent<T>[] {


### PR DESCRIPTION
This is just a straight renaming, per discussions on #838 

The result is as follows:

|RxJS 4| RxJS 5|
|---|---|
|currentThread|queue|
|default|asap|

Additional schedulers are still to be implemented.