### PR TITLE
test(build): add test to ensure no circular dependencies in CJS output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ install:
   - npm install && npm run lint
 
 script:
-  - npm test && node ./node_modules/markdown-doctest/bin/cmd.js && npm run cover
+  - npm test && node ./node_modules/markdown-doctest/bin/cmd.js && npm run cover #&& npm run check_circular_dependencies
 
 after_script:
   - cat ./coverage/coverage-remapped.lcov  | ./node_modules/coveralls/bin/coveralls.js

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "prepublish": "npm run build_all",
     "generate_packages": "node .make-packages.js",
     "generate_operator_patches": "tsc -outDir dist/ ./tools/generate-operator-patches.ts && node ./dist/generate-operator-patches.js --exec",
-    "commit": "git-cz"
+    "commit": "git-cz",
+    "check_circular_dependencies": "madge ./dist/cjs --circular"
   },
   "repository": {
     "type": "git",
@@ -98,6 +99,7 @@
     "jasmine": "2.4.1",
     "jasmine-core": "2.4.1",
     "lodash": "3.10.1",
+    "madge": "^0.5.3",
     "markdown-doctest": "^0.2.0",
     "mkdirp": "^0.5.1",
     "platform": "1.3.0",


### PR DESCRIPTION
The line in travis yaml should be uncommented when ready to run this check