### PR TITLE
feat(switchFirstMap): rename switchMapFirst to switchFirstMap

### DIFF
--- a/spec/operators/switchFirstMap-spec.js
+++ b/spec/operators/switchFirstMap-spec.js
@@ -5,7 +5,7 @@ var Promise = require('promise');
 var Observable = Rx.Observable;
 var queueScheduler = Rx.Scheduler.queue;
 
-describe('Observable.prototype.switchMapFirst()', function () {
+describe('Observable.prototype.switchFirstMap()', function () {
   it('should handle outer throw', function () {
     var x =   cold('--a--b--c--|');
     var xsubs = [];
@@ -13,7 +13,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
     var e1subs =   '(^!)';
     var expected = '#';
 
-    var result = e1.switchMapFirst(function () { return x; });
+    var result = e1.switchFirstMap(function () { return x; });
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -27,7 +27,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
     var e1subs =   '(^!)';
     var expected = '|';
 
-    var result = e1.switchMapFirst(function () { return x; });
+    var result = e1.switchFirstMap(function () { return x; });
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -40,7 +40,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
     var e1subs =   '^';
     var expected = '-';
 
-    var result = e1.switchMapFirst(function () { return x; });
+    var result = e1.switchFirstMap(function () { return x; });
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -52,7 +52,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
     var e1subs =   '^  !';
     var expected = '---#';
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       throw 'error';
     });
 
@@ -67,7 +67,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
     var e1subs =   '^    !                  ';
     var expected = '-----#                  ';
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return x;
     }, function () {
       throw 'error';
@@ -91,7 +91,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y, z: z };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -116,7 +116,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y, z: z };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -140,7 +140,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y, z: z };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -162,7 +162,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -183,7 +183,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -206,7 +206,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y, z: z };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -228,7 +228,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -249,7 +249,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -270,7 +270,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -291,7 +291,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x, y: y };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -310,7 +310,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
 
     var observableLookup = { x: x };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     });
 
@@ -344,7 +344,7 @@ describe('Observable.prototype.switchMapFirst()', function () {
       n: ['z', 'n', 1, 3],
     };
 
-    var result = e1.switchMapFirst(function (value) {
+    var result = e1.switchFirstMap(function (value) {
       return observableLookup[value];
     }, function (innerValue, outerValue, innerIndex, outerIndex) {
       return [innerValue, outerValue, innerIndex, outerIndex];

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -238,7 +238,7 @@ export class Observable<T> implements CoreOperators<T>  {
   switch: <R>() => Observable<R>;
   switchFirst: <T>() => Observable<T>;
   switchMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  switchMapFirst: <T, R, R2>(project: (x: T, ix: number) => Observable<R>, rSelector?: (x: T, y: R, ix: number, iy: number) => R2) => Observable<R>;
+  switchFirstMap: <T, R, R2>(project: (x: T, ix: number) => Observable<R>, rSelector?: (x: T, y: R, ix: number, iy: number) => R2) => Observable<R>;
   switchMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
   take: (count: number) => Observable<T>;
   takeUntil: (notifier: Observable<any>) => Observable<T>;

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -16,7 +16,7 @@ export interface KitchenSinkOperators<T> extends CoreOperators<T> {
   timeInterval?: <T>(scheduler?: IScheduler) => Observable<T>;
   mergeScan?: <T, R>(project: (acc: R, x: T) => Observable<R>, seed: R, concurrent?: number) => Observable<R>;
   switchFirst?: () => Observable<T>;
-  switchMapFirst?: <R>(project: ((x: T, ix: number) => Observable<any>),
+  switchFirstMap?: <R>(project: ((x: T, ix: number) => Observable<any>),
                        projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
 }
 

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -87,7 +87,7 @@ import './add/operator/subscribeOn';
 import './add/operator/switch';
 import './add/operator/switchFirst';
 import './add/operator/switchMap';
-import './add/operator/switchMapFirst';
+import './add/operator/switchFirstMap';
 import './add/operator/switchMapTo';
 import './add/operator/take';
 import './add/operator/takeUntil';

--- a/src/add/operator/switchFirstMap.ts
+++ b/src/add/operator/switchFirstMap.ts
@@ -1,0 +1,3 @@
+import {Observable} from '../../Observable';
+import {switchFirstMap} from '../../operator/switchFirstMap';
+Observable.prototype.switchFirstMap = switchFirstMap;

--- a/src/add/operator/switchMapFirst.ts
+++ b/src/add/operator/switchMapFirst.ts
@@ -1,3 +1,0 @@
-import {Observable} from '../../Observable';
-import {switchMapFirst} from '../../operator/switchMapFirst';
-Observable.prototype.switchMapFirst = switchMapFirst;

--- a/src/operator/switchFirstMap.ts
+++ b/src/operator/switchFirstMap.ts
@@ -6,15 +6,15 @@ import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
-export function switchMapFirst<T, R, R2>(project: (value: T, index: number) => Observable<R>,
+export function switchFirstMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
                                          resultSelector?: (outerValue: T,
                                                            innerValue: R,
                                                            outerIndex: number,
                                                            innerIndex: number) => R2): Observable<R> {
-  return this.lift(new SwitchMapFirstOperator(project, resultSelector));
+  return this.lift(new SwitchFirstMapOperator(project, resultSelector));
 }
 
-class SwitchMapFirstOperator<T, R, R2> implements Operator<T, R> {
+class SwitchFirstMapOperator<T, R, R2> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => Observable<R>,
               private resultSelector?: (outerValue: T,
                                         innerValue: R,
@@ -23,11 +23,11 @@ class SwitchMapFirstOperator<T, R, R2> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {
-    return new SwitchMapFirstSubscriber(subscriber, this.project, this.resultSelector);
+    return new SwitchFirstMapSubscriber(subscriber, this.project, this.resultSelector);
   }
 }
 
-class SwitchMapFirstSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
+class SwitchFirstMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
   private hasSubscription: boolean = false;
   private hasCompleted: boolean = false;
   private index: number = 0;


### PR DESCRIPTION
Renaming `switchMapFirst` to `switchFirstMap` to match the naming scheme of `<mergingStrategy>Map`

related #915