### PR TITLE
feat(Observable): export of, from by default

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -258,3 +258,12 @@ export class Observable<T> implements CoreOperators<T>  {
   zip: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
   zipAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
 }
+
+//import after Observable<T> is declared and exported
+import {ArrayObservable} from './observable/fromArray';
+
+Observable.fromArray = ArrayObservable.create;
+Observable.of = ArrayObservable.of;
+
+import {FromObservable} from './observable/from';
+Observable.from = FromObservable.create;

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -29,8 +29,6 @@ import './add/observable/bindCallback';
 import './add/observable/defer';
 import './add/observable/empty';
 import './add/observable/forkJoin';
-import './add/observable/from';
-import './add/observable/fromArray';
 import './add/observable/fromEvent';
 import './add/observable/fromEventPattern';
 import './add/observable/fromPromise';

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -15,8 +15,6 @@ import './add/observable/bindCallback';
 import './add/observable/defer';
 import './add/observable/empty';
 import './add/observable/forkJoin';
-import './add/observable/from';
-import './add/observable/fromArray';
 import './add/observable/fromEvent';
 import './add/observable/fromEventPattern';
 import './add/observable/fromPromise';

--- a/src/add/observable/from.ts
+++ b/src/add/observable/from.ts
@@ -1,3 +1,0 @@
-import {Observable} from '../../Observable';
-import {FromObservable} from '../../observable/from';
-Observable.from = FromObservable.create;

--- a/src/add/observable/fromArray.ts
+++ b/src/add/observable/fromArray.ts
@@ -1,4 +1,0 @@
-import {Observable} from '../../Observable';
-import {ArrayObservable} from '../../observable/fromArray';
-Observable.fromArray = ArrayObservable.create;
-Observable.of = ArrayObservable.of;


### PR DESCRIPTION
closes #894

Now circular reference issue is resolved in TOT, this changes will allow import Observable only makes to work with `of` and `from`.