### PR TITLE
chore(package.json): bump up tslint dependency version

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
     "protractor": "2.5.1",
     "remap-istanbul": "0.3.1",
     "rx": "latest",
-    "tslint": "2.5.0",
+    "tslint": "3.2.0-dev.1",
     "typescript": "1.8.0-dev.20151115",
     "validate-commit-msg": "1.0.0",
     "watch": "0.16.0"


### PR DESCRIPTION
closes #465

Long awaited changes are finally landed in dev version of tslint, bump up dependency version to close opened issue.