### PR TITLE
test(mergeMapTo): add tests for limited concurrency cases

### DIFF
--- a/spec/operators/mergeMapTo-spec.js
+++ b/spec/operators/mergeMapTo-spec.js
@@ -222,6 +222,42 @@ describe('Observable.prototype.mergeMapTo()', function () {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should mergeMapTo many cold Observable, with parameter concurrency=1', function () {
+    var values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
+    var e1 =     hot('-a-------b-------c---|                                        ');
+    var e1subs =     '^                                                            !';
+    var inner =  cold('----i---j---k---l---|                                        ', values);
+    var innersubs = [' ^                   !                                        ',
+                     '                     ^                   !                    ',
+                     '                                         ^                   !'];
+    var expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
+
+    function resultSelector(oV, iV, oI, iI) { return iV; }
+    var result = e1.mergeMapTo(inner, resultSelector, 1);
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(inner.subscriptions).toBe(innersubs);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should mergeMap to many cold Observable, with parameter concurrency=2', function () {
+    var values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
+    var e1 =     hot('-a-------b-------c---|                    ');
+    var e1subs =     '^                                        !';
+    var inner =  cold('----i---j---k---l---|                    ', values);
+    var innersubs = [' ^                   !                    ',
+                     '         ^                   !            ',
+                     '                     ^                   !'];
+    var expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
+
+    function resultSelector(oV, iV, oI, iI) { return iV; }
+    var result = e1.mergeMapTo(inner, resultSelector, 2);
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(inner.subscriptions).toBe(innersubs);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should mergeMapTo many outer to arrays', function () {
     var e1 =   hot('2-----4--------3--------2-------|');
     var e1subs =   '^                               !';


### PR DESCRIPTION
Add tests for mergeMapTo, to assert its behavior when the concurrency parameter is set to 1 and 2.