### PR TITLE
Updates for thisArgs issue

### DIFF
--- a/spec/observable-spec.js
+++ b/spec/observable-spec.js
@@ -27,7 +27,7 @@ describe('Observable', function () {
       var expected = [1,2,3];
       var result = Observable.of(1,2,3).forEach(function (x) {
         expect(x).toBe(expected.shift());
-      }, Promise)
+      }, null, Promise)
       .then(done);
 
       expect(typeof result.then).toBe('function');
@@ -41,7 +41,7 @@ describe('Observable', function () {
       }, function (err) {
         expect(err).toBe('bad');
         done();
-      }, Promise);
+      }, null, Promise);
     });
 
     it('should allow Promise to be globally configured', function (done) {
@@ -59,6 +59,18 @@ describe('Observable', function () {
         expect(wasCalled).toBe(true);
         done();
       });
+    });
+
+    it('should accept a thisArg argument', function (done) {
+      var expected = [1,2,3];
+      var thisArg = {};
+      var result = Observable.of(1,2,3).forEach(function (x) {
+        expect(this).toBe(thisArg);
+        expect(x).toBe(expected.shift());
+      }, thisArg, Promise)
+      .then(done);
+
+      expect(typeof result.then).toBe('function');
     });
   });
 

--- a/spec/operators/skipWhile-spec.js
+++ b/spec/operators/skipWhile-spec.js
@@ -160,23 +160,6 @@ describe('Observable.prototype.skipWhile()', function () {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
-  it('should accept a thisArg', function () {
-    var source = hot('-1-^--2--3--4--5--6--|');
-    var sourceSubs =    '^                 !';
-    var expected =      '---------4--5--6--|';
-
-    function Skiper() {
-      this.doSkip = function (v) { return +v < 4; };
-    }
-
-    var skiper = new Skiper();
-
-    expectObservable(
-      source.skipWhile(function (v) { return this.doSkip(v); }, skiper)
-    ).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
   it('should handle Observable.empty', function () {
     var source = cold('|');
     var subs =        '(^!)';

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -30,7 +30,7 @@ export interface CoreOperators<T> {
   filter?: (predicate: (x: T) => boolean, ix?: number, thisArg?: any) => Observable<T>;
   finally?: (finallySelector: () => void) => Observable<T>;
   first?: <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-              resultSelector?: (value: T, index: number) => R, thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
+              resultSelector?: (value: T, index: number) => R, defaultValue?: any) => Observable<T> | Observable<R>;
   flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>),
                 projectResult?: (x: T, y: any, ix: number, iy: number) => R,
                 concurrent?: number) => Observable<R>;
@@ -41,7 +41,7 @@ export interface CoreOperators<T> {
   ignoreElements?: () => Observable<T>;
   last?: <R>(predicate?: (value: T, index: number) => boolean,
              resultSelector?: (value: T, index: number) => R,
-             thisArg?: any, defaultValue?: any) => Observable<T> | Observable<R>;
+             defaultValue?: any) => Observable<T> | Observable<R>;
   every?: (predicate: (value: T, index: number) => boolean, thisArg?: any) => Observable<T>;
   map?: <R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
   mapTo?: <R>(value: R) => Observable<R>;
@@ -69,7 +69,7 @@ export interface CoreOperators<T> {
   single?: (predicate?: (value: T, index: number) => boolean) => Observable<T>;
   skip?: (count: number) => Observable<T>;
   skipUntil?: (notifier: Observable<any>) => Observable<T>;
-  skipWhile?: (predicate: (x: T, index: number) => boolean, thisArg?: any) => Observable<T>;
+  skipWhile?: (predicate: (x: T, index: number) => boolean) => Observable<T>;
   startWith?: (x: T) => Observable<T>;
   subscribeOn?: (scheduler: Scheduler, delay?: number) => Observable<T>;
   switch?: () => Observable<T>;

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -3,17 +3,13 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import {bindCallback} from '../util/bindCallback';
 
-export function skipWhile<T>(predicate: (x: T, index: number) => boolean, thisArg?: any): Observable<T> {
-  return this.lift(new SkipWhileOperator(predicate, thisArg));
+export function skipWhile<T>(predicate: (x: T, index: number) => boolean): Observable<T> {
+  return this.lift(new SkipWhileOperator(predicate));
 }
 
 class SkipWhileOperator<T, R> implements Operator<T, R> {
-  private predicate: (x: T, index: number) => boolean;
-
-  constructor(predicate: (x: T, index: number) => boolean, thisArg?: any) {
-    this.predicate = <(x: T, index: number) => boolean>bindCallback(predicate, thisArg, 2);
+  constructor(private predicate: (x: T, index: number) => boolean) {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {


### PR DESCRIPTION
- removes `thisArgs` from `skipWhile`
- adds `thisArgs` to `forEach`
- removes some `thisArgs` cruft from `CoreOperators` interface.
- eliminates some closure in the `forEach` method