### PR TITLE
refactor(KitchenSink): remove thisArg from distinctUntilChanged signature

### DIFF
--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -8,7 +8,7 @@ import {Scheduler as IScheduler} from './Scheduler';
 export interface KitchenSinkOperators<T> extends CoreOperators<T> {
   isEmpty?: () => Observable<boolean>;
   elementAt?: (index: number, defaultValue?: any) => Observable<T>;
-  distinctUntilKeyChanged?: (key: string, compare?: (x: any, y: any) => boolean, thisArg?: any) => Observable<T>;
+  distinctUntilKeyChanged?: (key: string, compare?: (x: any, y: any) => boolean) => Observable<T>;
   find?: (predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any) => Observable<T>;
   findIndex?: (predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any) => Observable<number>;
   max?: <T, R>(comparer?: (x: R, y: T) => R) => Observable<R>;


### PR DESCRIPTION
Remove an obsolete thisArg from the signature of distinctUntilChanged in KitchenSink file.

For issue #878.