### PR TITLE
refactor(operators): remove redundant observable patch

### DIFF
--- a/src/add/observable/IteratorObservable.ts
+++ b/src/add/observable/IteratorObservable.ts
@@ -1,3 +1,0 @@
-import {Observable} from '../../Observable';
-import {IteratorObservable} from '../../observable/IteratorObservable';
-Observable.IteratorObservable = IteratorObservable.create;

--- a/src/add/observable/ScalarObservable.ts
+++ b/src/add/observable/ScalarObservable.ts
@@ -1,3 +1,0 @@
-import {Observable} from '../../Observable';
-import {ScalarObservable} from '../../observable/ScalarObservable';
-Observable.ScalarObservable = ScalarObservable.create;

--- a/src/add/observable/SubscribeOnObservable.ts
+++ b/src/add/observable/SubscribeOnObservable.ts
@@ -1,3 +1,0 @@
-import {Observable} from '../../Observable';
-import {SubscribeOnObservable} from '../../observable/SubscribeOnObservable';
-Observable.SubscribeOnObservable = SubscribeOnObservable.create;


### PR DESCRIPTION
- remove observable patch does not have exposed interface and not being
  referenced

This PR removes 3 specific patch imports, `IteratorObservable`, `ScalarObservable`, `SubscribeOnObservable`.

Theses are not referenced at all, also `Observable` does not exposes interfaces build will break if this are actually referenced.