### PR TITLE
test(operators): remove duplicate tests for buffer, concat, concatAll

### DIFF
--- a/spec/operators/buffer-spec.js
+++ b/spec/operators/buffer-spec.js
@@ -217,26 +217,4 @@ describe('Observable.prototype.buffer()', function () {
     expectObservable(a.buffer(b).take(1)).toBe(expected, expectedValues);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
-
-  it('should not break unsubscription chain when unsubscribed explicitly', function () {
-    var s = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
-    var unsub =         '              !                  ';
-    var sSubs =         '^             !                  ';
-    var n = hot('--------^--a-------b---cd|               ');
-    var nSubs =         '^             !                  ';
-    var expected =      '---a-------b---                  ';
-    var expectedValues = {
-      a: ['3'],
-      b: ['4', '5']
-    };
-
-    var result = s
-      .mergeMap(function (x) { return Observable.of(x); })
-      .buffer(n)
-      .mergeMap(function (x) { return Observable.of(x); });
-
-    expectObservable(result, unsub).toBe(expected, expectedValues);
-    expectSubscriptions(s.subscriptions).toBe(sSubs);
-    expectSubscriptions(n.subscriptions).toBe(nSubs);
-  });
 });

--- a/spec/operators/concat-spec.js
+++ b/spec/operators/concat-spec.js
@@ -281,22 +281,4 @@ describe('Observable.prototype.concat()', function () {
     expectObservable(e1.concat()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
-
-  it('should not break unsubscription chain when unsubscribed explicitly', function () {
-    var e1 =   cold('---a-a--a|            ');
-    var e1subs =    '^        !            ';
-    var e2 =   cold(         '-----b-b--b-|');
-    var e2subs =    '         ^       !    ';
-    var unsub =     '                 !    ';
-    var expected =  '---a-a--a-----b-b     ';
-
-    var r = e1
-      .mergeMap(function (x) { return Observable.of(x); })
-      .concat(e2)
-      .mergeMap(function (x) { return Observable.of(x); });
-
-    expectObservable(r, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
 });

--- a/spec/operators/concatAll-spec.js
+++ b/spec/operators/concatAll-spec.js
@@ -419,22 +419,4 @@ describe('Observable.prototype.concatAll()', function () {
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
-
-  it('should not break unsubscription chain when unsubscribed explicitly', function () {
-    var e1 =   cold('---a-a--a|            ');
-    var e1subs =    '^        !            ';
-    var e2 =   cold(         '-----b-b--b-|');
-    var e2subs =    '         ^       !    ';
-    var unsub =     '                 !    ';
-    var expected =  '---a-a--a-----b-b     ';
-
-    var r = Observable.of(e1, e2)
-      .mergeMap(function (x) { return Observable.of(x); })
-      .concatAll()
-      .mergeMap(function (x) { return Observable.of(x); });
-
-    expectObservable(r, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
 });


### PR DESCRIPTION
Remove duplicate tests related to verifying unsubscription chains not broken, on buffer-spec,
concat-spec, and concatAll-spec.