### PR TITLE
windowTime: fixes and tests

### DIFF
--- a/spec/operators/windowTime-spec.js
+++ b/spec/operators/windowTime-spec.js
@@ -40,50 +40,58 @@ describe('Observable.prototype.windowTime', function () {
 
   it('should return a single empty window if source is empty', function () {
     var source =   cold('|');
+    var subs =          '(^!)';
     var expected =      '(w|)';
-    var w =         cold('|');
+    var w =        cold('|');
     var expectedValues = { w: w };
 
     var result = source.windowTime(50, 100, rxTestScheduler);
 
     expectObservable(result).toBe(expected, expectedValues);
+    expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should split a Just source into a single window identical to source', function () {
     var source =   cold('(a|)');
+    var subs =          '(^!)';
     var expected =      '(w|)';
-    var w =         cold('(a|)');
+    var w =        cold('(a|)');
     var expectedValues = { w: w };
 
     var result = source.windowTime(50, 100, rxTestScheduler);
 
     expectObservable(result).toBe(expected, expectedValues);
+    expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should be able to split a never Observable into timely empty windows', function () {
-    var source =    hot('^-----------');
-    var unsub =         '           !';
-    var expected =      'a--b--c--d--';
-    var a =        cold('---|        ');
-    var b =        cold(   '---|     ');
-    var c =        cold(      '---|  ');
-    var d =        cold(         '---');
+    var source =    hot('^----------');
+    var subs =          '^         !';
+    var expected =      'a--b--c--d-';
+    var a =        cold('---|       ');
+    var b =        cold(   '---|    ');
+    var c =        cold(      '---| ');
+    var d =        cold(         '--');
+    var unsub =         '          !';
     var expectedValues = { a: a, b: b, c: c, d: d };
 
     var result = source.windowTime(30, 30, rxTestScheduler);
 
     expectObservable(result, unsub).toBe(expected, expectedValues);
+    expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should emit an error-only window if outer is a simple throw-Observable', function () {
     var source =   cold('#');
+    var subs =          '(^!)';
     var expected =      '(w#)';
-    var w =         cold('#');
+    var w =        cold('#');
     var expectedValues = { w: w };
 
     var result = source.windowTime(50, 100, rxTestScheduler);
 
     expectObservable(result).toBe(expected, expectedValues);
+    expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should handle source Observable which eventually emits an error', function () {
@@ -108,19 +116,21 @@ describe('Observable.prototype.windowTime', function () {
   it('should emit windows given windowTimeSpan and windowCreationInterval, ' +
   'but outer is unsubscribed early', function () {
     var source = hot('--1--2--^--a--b--c--d--e--f--g--h--|');
-    var unsub =              '              !             ';
+    var subs =               '^          !                ';
     //  100 frames            0---------1---------2------|
     //  50                     ----|
     //  50                               ----|
     //  50                                         ----|
-    var expected =           'x---------y----             ';
+    var expected =           'x---------y-                ';
     var x = cold(            '---a-|                      ');
-    var y = cold(                      '--d--             ');
+    var y = cold(                      '--                ');
+    var unsub =              '           !                ';
     var values = { x: x, y: y };
 
     var result = source.windowTime(50, 100, rxTestScheduler);
 
     expectObservable(result, unsub).toBe(expected, values);
+    expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', function () {

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -58,7 +58,7 @@ export class Subscriber<T> extends Subscription<T> implements Observer<T> {
     }
   }
 
-  add(sub: Subscription<T> | Function | void): void {
+  add(sub: Subscription<any> | Function | void): void {
     // route add to the shared Subscription if it exists
     const _subscription = this._subscription;
     if (_subscription) {
@@ -68,7 +68,7 @@ export class Subscriber<T> extends Subscription<T> implements Observer<T> {
     }
   }
 
-  remove(sub: Subscription<T>): void {
+  remove(sub: Subscription<any>): void {
     // route remove to the shared Subscription if it exists
     if (this._subscription) {
       this._subscription.remove(sub);

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -47,7 +47,7 @@ export class Subscription<T> {
     }
   }
 
-  add(subscription: Subscription<T>|Function|void): void {
+  add(subscription: Subscription<any>|Function|void): void {
     // return early if:
     //  1. the subscription is null
     //  2. we're attempting to add our this
@@ -58,7 +58,7 @@ export class Subscription<T> {
       return;
     }
 
-    let sub = (<Subscription<T>> subscription);
+    let sub = (<Subscription<any>> subscription);
 
     switch (typeof subscription) {
       case 'function':
@@ -78,7 +78,7 @@ export class Subscription<T> {
     }
   }
 
-  remove(subscription: Subscription<T>): void {
+  remove(subscription: Subscription<any>): void {
 
     // return early if:
     //  1. the subscription is null

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -19,7 +19,7 @@ class WindowTimeOperator<T, R> implements Operator<T, R> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>): Subscriber<T> {
+  call(subscriber: Subscriber<Observable<T>>): Subscriber<T> {
     return new WindowTimeSubscriber(
       subscriber, this.windowTimeSpan, this.windowCreationInterval, this.scheduler
     );
@@ -29,7 +29,7 @@ class WindowTimeOperator<T, R> implements Operator<T, R> {
 class WindowTimeSubscriber<T> extends Subscriber<T> {
   private windows: Subject<T>[] = [];
 
-  constructor(destination: Subscriber<T>,
+  constructor(protected destination: Subscriber<Observable<T>>,
               private windowTimeSpan: number,
               private windowCreationInterval: number,
               private scheduler: Scheduler) {
@@ -72,9 +72,11 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
   }
 
   openWindow(): Subject<T> {
-    let window = new Subject<T>();
+    const window = new Subject<T>();
     this.windows.push(window);
-    this.destination.next(window);
+    const destination = this.destination;
+    destination.add(window);
+    destination.next(window);
     return window;
   }
 


### PR DESCRIPTION
Fix windowTime() operator to dispose window Subjects when the destination Subscriber is
unsubscribed.

Also allow a Subscription to add a child Subscription parameterized by `<any>`, not by `<T>`. There isn't a clear reason why all child Subscriptions should be type `<T>`, and there are cases where we need to
have a `<any>` child.