### PR TITLE
test(first): add unsubscription-related tests

### DIFF
--- a/spec/operators/first-spec.js
+++ b/spec/operators/first-spec.js
@@ -56,6 +56,31 @@ describe('Observable.prototype.first()', function () {
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
+  it('should allow unsubscribing early and explicitly', function () {
+    var e1 = hot('--a--^-----b----c---d--|');
+    var e1subs =      '^  !               ';
+    var expected =    '----               ';
+    var unsub =       '   !               ';
+
+    expectObservable(e1.first(), unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chains when result is unsubscribed explicitly', function () {
+    var e1 = hot('--a--^-----b----c---d--|');
+    var e1subs =      '^  !               ';
+    var expected =    '----               ';
+    var unsub =       '   !               ';
+
+    var result = e1
+      .mergeMap(function (x) { return Observable.of(x); })
+      .first()
+      .mergeMap(function (x) { return Observable.of(x); });
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should return first value that matches a predicate', function () {
     var e1 = hot('--a-^--b--c--a--c--|');
     var expected =   '------(c|)';


### PR DESCRIPTION
Add test cases for first() operator, to verify it behaves correctly when the result Observable is
unsubscribed explicitly.