### PR TITLE
Refactor window tests

### DIFF
--- a/spec/helpers/marble-testing.js
+++ b/spec/helpers/marble-testing.js
@@ -12,6 +12,13 @@ function cold() {
   return global.rxTestScheduler.createColdObservable.apply(global.rxTestScheduler, arguments);
 }
 
+function time() {
+  if (!global.rxTestScheduler) {
+    throw 'tried to use time() in async test';
+  }
+  return global.rxTestScheduler.createTime.apply(global.rxTestScheduler, arguments);
+}
+
 function expectObservable() {
   if (!global.rxTestScheduler) {
     throw 'tried to use expectObservable() in async test';
@@ -33,6 +40,7 @@ function assertDeepEqual(actual, expected) {
 module.exports = {
   hot: hot,
   cold: cold,
+  time: time,
   expectObservable: expectObservable,
   expectSubscriptions: expectSubscriptions,
   assertDeepEqual: assertDeepEqual

--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -11,6 +11,7 @@ var marbleHelpers = require('./marble-testing');
 global.rxTestScheduler = null;
 global.cold = marbleHelpers.cold;
 global.hot = marbleHelpers.hot;
+global.time = marbleHelpers.time;
 global.expectObservable = marbleHelpers.expectObservable;
 global.expectSubscriptions = marbleHelpers.expectSubscriptions;
 

--- a/spec/helpers/tests2png/diagram-test-runner.js
+++ b/spec/helpers/tests2png/diagram-test-runner.js
@@ -8,6 +8,7 @@ var painter = require('./painter');
 global.rxTestScheduler = null;
 global.cold = marbleHelpers.cold;
 global.hot = marbleHelpers.hot;
+global.time = marbleHelpers.time;
 global.expectObservable = marbleHelpers.expectObservable;
 global.expectSubscriptions = marbleHelpers.expectSubscriptions;
 

--- a/spec/operators/window-spec.js
+++ b/spec/operators/window-spec.js
@@ -198,30 +198,25 @@ describe('Observable.prototype.window', function () {
   });
 
   it('should dispose window Subjects if the outer is unsubscribed early', function () {
-    var virtualTimeScheduler = new Rx.VirtualTimeScheduler();
-    var source = new Rx.Subject();
-    var result = source.window(Observable.never());
-    var win;
-    var subscription;
+    var source = hot('--a--b--c--d--e--f--g--h--|');
+    var sourceSubs = '^        !                 ';
+    var expected =   'x---------                 ';
+    var x = cold(    '--a--b--c-                 ');
+    var unsub =      '         !                 ';
+    var late =  time('---------------|           ');
+    var values = { x: x };
 
-    virtualTimeScheduler.schedule(function () {
-      subscription = result.subscribe(function (w) { win = w; });
-    }, 0);
-    virtualTimeScheduler.schedule(function () { source.next('a'); }, 0);
-    virtualTimeScheduler.schedule(function () { source.next('b'); }, 10);
-    virtualTimeScheduler.schedule(function () { source.next('c'); }, 20);
-    virtualTimeScheduler.schedule(function () { subscription.unsubscribe(); }, 30);
-    virtualTimeScheduler.schedule(function () { source.next('d'); }, 40);
-    virtualTimeScheduler.schedule(function () { source.next('e'); }, 50);
-    virtualTimeScheduler.schedule(function () { source.next('f'); }, 60);
-    virtualTimeScheduler.schedule(function () { source.next('g'); }, 70);
-    virtualTimeScheduler.schedule(function () {
+    var window;
+    var result = source.window(Observable.never())
+      .do(function (w) { window = w; });
+
+    expectObservable(result, unsub).toBe(expected, values);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    rxTestScheduler.schedule(function () {
       expect(function () {
-        win.subscribe();
+        window.subscribe();
       }).toThrowError('Cannot subscribe to a disposed Subject.');
-    }, 80);
-
-    virtualTimeScheduler.flush();
+    }, late);
   });
 
   it('should make outer emit error when closing throws', function () {

--- a/spec/operators/windowCount-spec.js
+++ b/spec/operators/windowCount-spec.js
@@ -112,30 +112,25 @@ describe('Observable.prototype.windowCount', function () {
   });
 
   it('should dispose window Subjects if the outer is unsubscribed early', function () {
-    var virtualTimeScheduler = new Rx.VirtualTimeScheduler();
-    var source = new Rx.Subject();
-    var result = source.windowCount(10, 10);
-    var win;
-    var subscription;
+    var source = hot('--a--b--c--d--e--f--g--h--|');
+    var sourceSubs = '^        !                 ';
+    var expected =   'x---------                 ';
+    var x = cold(    '--a--b--c-                 ');
+    var unsub =      '         !                 ';
+    var late =  time('---------------|           ');
+    var values = { x: x };
 
-    virtualTimeScheduler.schedule(function () {
-      subscription = result.subscribe(function (w) { win = w; });
-    }, 0);
-    virtualTimeScheduler.schedule(function () { source.next('a'); }, 0);
-    virtualTimeScheduler.schedule(function () { source.next('b'); }, 10);
-    virtualTimeScheduler.schedule(function () { source.next('c'); }, 20);
-    virtualTimeScheduler.schedule(function () { subscription.unsubscribe(); }, 30);
-    virtualTimeScheduler.schedule(function () { source.next('d'); }, 40);
-    virtualTimeScheduler.schedule(function () { source.next('e'); }, 50);
-    virtualTimeScheduler.schedule(function () { source.next('f'); }, 60);
-    virtualTimeScheduler.schedule(function () { source.next('g'); }, 70);
-    virtualTimeScheduler.schedule(function () {
+    var window;
+    var result = source.windowCount(10, 10)
+      .do(function (w) { window = w; });
+
+    expectObservable(result, unsub).toBe(expected, values);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    rxTestScheduler.schedule(function () {
       expect(function () {
-        win.subscribe();
+        window.subscribe();
       }).toThrowError('Cannot subscribe to a disposed Subject.');
-    }, 80);
-
-    virtualTimeScheduler.flush();
+    }, late);
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', function () {

--- a/spec/operators/windowWhen-spec.js
+++ b/spec/operators/windowWhen-spec.js
@@ -151,30 +151,27 @@ describe('Observable.prototype.windowWhen', function () {
   });
 
   it('should dispose window Subjects if the outer is unsubscribed early', function () {
-    var virtualTimeScheduler = new Rx.VirtualTimeScheduler();
-    var source = new Rx.Subject();
-    var result = source.windowWhen(function () { return Observable.never(); });
-    var win;
-    var subscription;
+    var source = hot('--a--b--c--d--e--f--g--h--|');
+    var open =  cold('o-------------------------|');
+    var sourceSubs = '^        !                 ';
+    var expected =   'x---------                 ';
+    var x = cold(    '--a--b--c-                 ');
+    var unsub =      '         !                 ';
+    var late =  time('---------------|           ');
+    var values = { x: x };
 
-    virtualTimeScheduler.schedule(function () {
-      subscription = result.subscribe(function (w) { win = w; });
-    }, 0);
-    virtualTimeScheduler.schedule(function () { source.next('a'); }, 0);
-    virtualTimeScheduler.schedule(function () { source.next('b'); }, 10);
-    virtualTimeScheduler.schedule(function () { source.next('c'); }, 20);
-    virtualTimeScheduler.schedule(function () { subscription.unsubscribe(); }, 30);
-    virtualTimeScheduler.schedule(function () { source.next('d'); }, 40);
-    virtualTimeScheduler.schedule(function () { source.next('e'); }, 50);
-    virtualTimeScheduler.schedule(function () { source.next('f'); }, 60);
-    virtualTimeScheduler.schedule(function () { source.next('g'); }, 70);
-    virtualTimeScheduler.schedule(function () {
+    var window;
+    var result = source
+      .windowWhen(function () { return Observable.never(); })
+      .do(function (w) { window = w; });
+
+    expectObservable(result, unsub).toBe(expected, values);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    rxTestScheduler.schedule(function () {
       expect(function () {
-        win.subscribe();
+        window.subscribe();
       }).toThrowError('Cannot subscribe to a disposed Subject.');
-    }, 80);
-
-    virtualTimeScheduler.flush();
+    }, late);
   });
 
   it('should propagate error thrown from closingSelector', function () {

--- a/spec/schedulers/TestScheduler-spec.js
+++ b/spec/schedulers/TestScheduler-spec.js
@@ -85,6 +85,21 @@ describe('TestScheduler', function () {
     });
   });
 
+  describe('createTime()', function () {
+    it('should parse a simple time marble string to a number', function () {
+      var scheduler = new TestScheduler();
+      var time = scheduler.createTime('-----|');
+      expect(time).toBe(50);
+    });
+
+    it('should throw if not given good marble input', function () {
+      var scheduler = new TestScheduler();
+      expect(function () {
+        var time = scheduler.createTime('-a-b-#');
+      }).toThrow();
+    });
+  });
+
   describe('createColdObservable()', function () {
     it('should create a cold observable', function () {
       var expected = ['A', 'B'];
@@ -148,6 +163,17 @@ describe('TestScheduler', function () {
         var source = hot('---^-a-b-|', { a: 1, b: 2 });
         expect(source instanceof Rx.Subject).toBe(true);
         expectObservable(source).toBe('--a-b-|', { a: 1, b: 2 });
+      });
+    });
+
+    describe('time()', function () {
+      it('should exist', function () {
+        expect(time).toBeDefined();
+        expect(typeof time).toBe('function');
+      });
+
+      it('should parse a simple time marble string to a number', function () {
+        expect(time('-----|')).toBe(50);
       });
     });
 

--- a/src/testing/TestScheduler.ts
+++ b/src/testing/TestScheduler.ts
@@ -25,6 +25,14 @@ export class TestScheduler extends VirtualTimeScheduler {
     super();
   }
 
+  createTime(marbles: string): number {
+    const indexOf: number = marbles.indexOf('|');
+    if (indexOf === -1) {
+      throw new Error('Marble diagram for time should have a completion marker "|"');
+    }
+    return indexOf * TestScheduler.frameTimeFactor;
+  }
+
   createColdObservable<T>(marbles: string, values?: any, error?: any): Observable<T> {
     if (marbles.indexOf('^') !== -1) {
       throw new Error('Cold observable cannot have subscription offset "^"');


### PR DESCRIPTION
Add createTime() function to TestScheduler, which takes a simple marble diagram as string and
outputs a number for the time frame which the diagram represents.

Refactor window (and its variants) tests that check for window Subjects being disposed, to use
marble tests and not the VirtualTimeScheduler.

Makes @blesh happy.