### PR TITLE
chore(tsconfig): Added codeFormatOptions

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,10 @@
     "target": "es6",
     "outDir": "dist/es6"
   },
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  },
    "files": [
      "src/Rx.ts",
      "src/Rx.KitchenSink.ts"


### PR DESCRIPTION
One more :smile: 

--------------------------------------------

This follows the spec defined by the typescript language services.
https://github.com/Microsoft/TypeScript/blob/master/tests/cases/fourslash/fourslash.ts#L70-L87

This is used by atom-typescript to pass off formatting options to the compiler.  I'm not aware of any other tools that use this, but extensions to tsconfig.json are not illegal unless they clash with the default properties.