### PR TITLE
Tests for bug #1041 with ConnectableObservable and retry/repeat

### DIFF
--- a/spec/operators/repeat-spec.js
+++ b/spec/operators/repeat-spec.js
@@ -262,4 +262,20 @@ describe('Observable.prototype.repeat()', function () {
 
     expectObservable(e1.repeat(2)).toBe(expected);
   });
+
+  it('should repeat a synchronous source (multicasted and refCounted) multiple times', function (done) {
+    var expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
+
+    Observable.of(1, 2, 3)
+      .multicast(function () { return new Rx.Subject(); })
+      .refCount()
+      .repeat(5)
+      .subscribe(
+        function (x) { expect(x).toBe(expected.shift()); },
+        done.fail,
+        function () {
+          expect(expected.length).toBe(0);
+          done();
+        });
+  });
 });

--- a/spec/operators/retry-spec.js
+++ b/spec/operators/retry-spec.js
@@ -189,4 +189,21 @@ describe('Observable.prototype.retry()', function () {
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
+
+  it('should retry a synchronous source (multicasted and refCounted) multiple times', function (done) {
+    var expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
+
+    Observable.of(1, 2, 3).concat(Observable.throw('bad!'))
+      .multicast(function () { return new Rx.Subject(); })
+      .refCount()
+      .retry(4)
+      .subscribe(
+        function (x) { expect(x).toBe(expected.shift()); },
+        function (err) {
+          expect(err).toBe('bad!');
+          expect(expected.length).toBe(0);
+          done();
+        },
+        done.fail);
+  });
 });


### PR DESCRIPTION
Add the `connect(callback)` flavor to `ConnectableObservable`, which is used internally in `refCount()` to
allow `connect(callback)` to give its subscription to its caller through the callback, before actually
performing the connection.

Resolves issue #1041.

Add test cases for this.