### PR TITLE
fix(distinctUntilChanged): implement optional keySelector

### DIFF
--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -3,49 +3,62 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
-export function distinctUntilChanged<T>(compare?: (x: T, y: T) => boolean) {
-  return this.lift(new DistinctUntilChangedOperator(compare));
+export function distinctUntilChanged<T>(compare?: (x: any, y: any) => boolean, keySelector?: (x: T) => any) {
+  return this.lift(new DistinctUntilChangedOperator(compare, keySelector));
 }
 
 class DistinctUntilChangedOperator<T, R> implements Operator<T, R> {
-  constructor(private compare: (x: T, y: T) => boolean) {
+  constructor(private compare: (x: any, y: any) => boolean,
+              private keySelector: (x: T) => any) {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {
-    return new DistinctUntilChangedSubscriber(subscriber, this.compare);
+    return new DistinctUntilChangedSubscriber(subscriber, this.compare, this.keySelector);
   }
 }
 
 class DistinctUntilChangedSubscriber<T> extends Subscriber<T> {
-  private value: T;
-  private hasValue: boolean = false;
+  private key: any;
+  private hasKey: boolean = false;
 
-  constructor(destination: Subscriber<T>, compare: (x: T, y: T) => boolean) {
+  constructor(destination: Subscriber<T>,
+              compare: (x: any, y: any) => boolean,
+              private keySelector: (x: T) => any) {
     super(destination);
     if (typeof compare === 'function') {
       this.compare = compare;
     }
   }
 
-  private compare(x: T, y: T): boolean {
+  private compare(x: any, y: any): boolean {
     return x === y;
   }
 
   _next(value: T): void {
+
+    const keySelector = this.keySelector;
+    let key: any = value;
+
+    if (keySelector) {
+      key = tryCatch(this.keySelector)(value);
+      if (key === errorObject) {
+        return this.destination.error(errorObject.e);
+      }
+    }
+
     let result: any = false;
 
-    if (this.hasValue) {
-      result = tryCatch(this.compare)(this.value, value);
+    if (this.hasKey) {
+      result = tryCatch(this.compare)(this.key, key);
       if (result === errorObject) {
-        this.destination.error(errorObject.e);
-        return;
+        return this.destination.error(errorObject.e);
       }
     } else {
-      this.hasValue = true;
+      this.hasKey = true;
     }
 
     if (Boolean(result) === false) {
-      this.value = value;
+      this.key = key;
       this.destination.next(value);
     }
   }


### PR DESCRIPTION
Currently, `distinctUntilChanged` holds on to the [previous distinct `value`](https://github.com/ReactiveX/RxJS/blob/master/src/operator/distinctUntilChanged.ts#L48), which is incorrect. `distinctUntilChanged` should use an optional `keySelector` to [pick a key from each event](https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/linq/observable/distinctuntilchanged.js#L20), and only retain the `key` itself.