### PR TITLE
feat(Observable): add pairwise operator

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -57,6 +57,7 @@
 - [mergeAll](function/index.html#static-function-mergeAll)
 - [multicast](function/index.html#static-function-multicast)
 - [observeOn](function/index.html#static-function-observeOn)
+- [pairwise](function/index.html#static-function-pairwise)
 - [partition](function/index.html#static-function-partition)
 - [publish](function/index.html#static-function-publish)
 - [publishBehavior](function/index.html#static-function-publishBehavior)

--- a/perf/micro/immediate-scheduler/operators/pairwise.js
+++ b/perf/micro/immediate-scheduler/operators/pairwise.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldPairwiseWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate).pairwise();
+  var newPairwiseWithImmediateScheduler = RxNew.Observable.range(0, 25).pairwise();
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old pairwise with immediate scheduler', function () {
+      oldPairwiseWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new pairwise with immediate scheduler', function () {
+      newPairwiseWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/spec/operators/pairwise-spec.js
+++ b/spec/operators/pairwise-spec.js
@@ -1,0 +1,88 @@
+/* globals describe, it, expect, expectObservable, expectSubscriptions, cold, hot */
+var Rx = require('../../dist/cjs/Rx');
+var Observable = Rx.Observable;
+
+describe('Observable.prototype.pairwise()', function () {
+  it('should pairwise things', function () {
+    var e1 = hot('--a--^--b--c--d--e--f--g--|');
+    var e1subs =      '^                    !';
+    var expected =    '------v--w--x--y--z--|';
+
+    var values = {
+      v: ['b', 'c'],
+      w: ['c', 'd'],
+      x: ['d', 'e'],
+      y: ['e', 'f'],
+      z: ['f', 'g']
+    };
+
+    var source = e1.pairwise();
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not emit on single-element streams', function () {
+    var e1 = hot('-----^--b----|');
+    var e1subs =      '^       !';
+    var expected =    '--------|';
+
+    var values = {
+    };
+
+    var source = e1.pairwise();
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should handle mid-stream throw', function () {
+    var e1 = hot('--a--^--b--c--d--e--#');
+    var e1subs =      '^              !';
+    var expected =    '------v--w--x--#';
+
+    var values = {
+      v: ['b', 'c'],
+      w: ['c', 'd'],
+      x: ['d', 'e']
+    };
+
+    var source = e1.pairwise();
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should handle empty', function () {
+    var e1 =  cold('|');
+    var e1subs =   '(^!)';
+    var expected = '|';
+
+    var source = e1.pairwise();
+
+    expectObservable(source).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should handle never', function () {
+    var e1 =  cold('-');
+    var e1subs =   '^';
+    var expected = '-';
+
+    var source = e1.pairwise();
+
+    expectObservable(source).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should handle throw', function () {
+    var e1 =  cold('#');
+    var e1subs =   '(^!)';
+    var expected = '#';
+
+    var source = e1.pairwise();
+
+    expectObservable(source).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+});

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -15,6 +15,7 @@ export interface KitchenSinkOperators<T> extends CoreOperators<T> {
   inspectTime?: (delay: number, scheduler?: IScheduler) => Observable<T>;
   max?: <T, R>(comparer?: (x: R, y: T) => R) => Observable<R>;
   min?: <T, R>(comparer?: (x: R, y: T) => R) => Observable<R>;
+  pairwise?: <R>() => Observable<R>;
   timeInterval?: <T>(scheduler?: IScheduler) => Observable<T>;
   mergeScan?: <T, R>(project: (acc: R, x: T) => Observable<R>, seed: R, concurrent?: number) => Observable<R>;
   exhaust?: () => Observable<T>;
@@ -93,6 +94,7 @@ import './add/operator/mergeScan';
 import './add/operator/min';
 import './add/operator/multicast';
 import './add/operator/observeOn';
+import './add/operator/pairwise';
 import './add/operator/partition';
 import './add/operator/publish';
 import './add/operator/publishBehavior';

--- a/src/add/operator/pairwise.ts
+++ b/src/add/operator/pairwise.ts
@@ -1,0 +1,7 @@
+import {Observable} from '../../Observable';
+import {pairwise} from '../../operator/pairwise';
+import {KitchenSinkOperators} from '../../Rx.KitchenSink';
+const observableProto = (<KitchenSinkOperators<any>>Observable.prototype);
+observableProto.pairwise = pairwise;
+
+export var _void: void;

--- a/src/operator/pairwise.ts
+++ b/src/operator/pairwise.ts
@@ -1,0 +1,38 @@
+import {Operator} from '../Operator';
+import {Observable} from '../Observable';
+import {Subscriber} from '../Subscriber';
+
+/**
+ * Returns a new observable that triggers on the second and following inputs.
+ * An input that triggers an event will return an pair of [(N - 1)th, Nth].
+ * The (N-1)th is stored in the internal state until Nth input occurs.
+ * @returns {Observable<R>} an observable of pairs of values.
+ */
+export function pairwise<T>(): Observable<T> {
+  return this.lift(new PairwiseOperator());
+}
+
+class PairwiseOperator<T, R> implements Operator<T, R> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
+    return new PairwiseSubscriber(subscriber);
+  }
+}
+
+class PairwiseSubscriber<T> extends Subscriber<T> {
+  private prev: T;
+  private hasPrev: boolean = false;
+
+  constructor(destination: Subscriber<T>) {
+    super(destination);
+  }
+
+  _next(value: T): void {
+    if (this.hasPrev) {
+      this.destination.next([this.prev, value]);
+    } else {
+      this.hasPrev = true;
+    }
+
+    this.prev = value;
+  }
+}


### PR DESCRIPTION
bring in pairwise operator from [RxJS4](https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/pairwise.md).

Uses the same "has previous" and "previous" value with new array each time approach.

edit: @Frikki said that this is pretty much `bufferCount` but with a static buffer size, so maybe this isn't needed. At least pairwise will be faster!!!! Maybe. I use pairwise in RxJS4 :frowning: 