### PR TITLE
refactor(Observable): remove exhaust from core rx

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -257,9 +257,7 @@ export class Observable<T> implements CoreOperators<T>  {
   startWith: (x: T) => Observable<T>;
   subscribeOn: (scheduler: Scheduler, delay?: number) => Observable<T>;
   switch: <R>() => Observable<R>;
-  exhaust: <T>() => Observable<T>;
   switchMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  exhaustMap: <T, R, R2>(project: (x: T, ix: number) => Observable<R>, rSelector?: (x: T, y: R, ix: number, iy: number) => R2) => Observable<R>;
   switchMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
   take: (count: number) => Observable<T>;
   takeUntil: (notifier: Observable<any>) => Observable<T>;

--- a/src/add/operator/exhaust.ts
+++ b/src/add/operator/exhaust.ts
@@ -1,5 +1,7 @@
 import {Observable} from '../../Observable';
 import {exhaust} from '../../operator/exhaust';
-Observable.prototype.exhaust = exhaust;
+import {KitchenSinkOperators} from '../../Rx.KitchenSink';
+const observableProto = (<KitchenSinkOperators<any>>Observable.prototype);
+observableProto.exhaust = exhaust;
 
 export var _void: void;

--- a/src/add/operator/exhaustMap.ts
+++ b/src/add/operator/exhaustMap.ts
@@ -1,5 +1,7 @@
 import {Observable} from '../../Observable';
 import {exhaustMap} from '../../operator/exhaustMap';
-Observable.prototype.exhaustMap = exhaustMap;
+import {KitchenSinkOperators} from '../../Rx.KitchenSink';
+const observableProto = (<KitchenSinkOperators<any>>Observable.prototype);
+observableProto.exhaustMap = exhaustMap;
 
 export var _void: void;


### PR DESCRIPTION
Relates to PR https://github.com/ReactiveX/RxJS/pull/1002,

found out reading https://github.com/justinwoo/RxJS/commit/767b1f54e2d73551f3f1c156f6e1714502cd79e4#commitcomment-14966118, `exhaust` and `exhausemap` lives on Observable core and KitchenSink both. Removed from `Observable` to match with original PR intended as 'removes both operators from Rx core output'.