### PR TITLE
fix(Subscription): instead of defining new const, just check private …

### DIFF
--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -28,13 +28,12 @@ export class Subscription<T> {
 
     this.isUnsubscribed = true;
 
-    const unsubscribe = this._unsubscribe;
     const subscriptions = this._subscriptions;
 
     this._subscriptions = void 0;
 
-    if (unsubscribe) {
-      unsubscribe.call(this);
+    if (this._unsubscribe) {
+      this._unsubscribe.call(this);
     }
 
     if (subscriptions != null) {


### PR DESCRIPTION
…variable

With the current implementation, after building to ES6 (or using latest published version with: npm install rxjs-es), trying to import any aspect of Rx results in this error in my webpack build:


```
ERROR in ./~/rxjs-es/Subscription.js
Module build failed: SyntaxError: /Users/wheslam/streamtest/node_modules/rxjs-es/Subscription.js: "unsubscribe" is read-only (This is an error on an internal node. Probably an internal error. Location has been estimated.)
```


I'm not really sure why this error is occurring as looking at the ES6 version of rxjs looks fine. Perhaps it is something to do with the bundling process?
Renaming the variable from 'const unsubscribe' to 'const unsubscribe2' fixes the problem - changing it to 'let unsubscribe' gives:


```
ERROR in ./~/rxjs-es/Subscription.js
Module build failed: TypeError: /Users/wheslam/streamtest/node_modules/rxjs-es/Subscription.js: Duplicate declaration "unsubscribe"
```


Making this change fixes it too - however I'm not particularly happy with this 'fix' as I'm not sure why it fixes it!
What are your thoughts on this? Any idea why this is happening?
(maybe I'm missing something obvious with the new ES6 module syntax)
Has anyone had any luck using rxjs-es in a webpack build yet? What was the original intention behind declaring a const in that way in the original implementation? Lots of questions. :)

See here for a simple test case:
https://github.com/willheslam/streamtest
git clone, npm install then npm run dev