### PR TITLE
docs(scan): add inline docs to scan

### DIFF
--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -4,6 +4,13 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
+/**
+ * Applies an accumulator function to each input. Optional seed value is used as the initial value if supplied; otherwise, the first input is used.
+ * For aggregation with no intermediate results, see Observable.aggregate
+ * @param {Function} accumulator An accumulator function called on each input.
+ * @param {Any} [seed] The initial accumulator value.
+ * @returns {Obervable<R>} An observable of the accumulated values.
+ */
 export function scan<T, R>(accumulator: (acc: R, x: T) => R, seed?: T | R): Observable<R> {
   return this.lift(new ScanOperator(accumulator, seed));
 }


### PR DESCRIPTION
I'm going to end up having a whole lot of these doc PRs. Should I open a PR for each one so tracking changes/editing is easier, or smash them into a big commit/series of commits in this PR?

Also, is there a convention we should use for these docs? oldRxJS docs use a variety of terms like "source/observable/sequence/stream" and "input/output/element/event" and "trigger/emit(?)". Maybe I just missed where these conventions are defined.