### PR TITLE
chore(typings): Enabled noImplictAny

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,9 +13,9 @@
   },
   "scripts": {
     "build_all": "npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global && npm run generate_packages",
-    "build_amd": "rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5 --diagnostics --pretty",
-    "build_cjs": "rm -rf dist/cjs && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts src/Rx.KitchenSink.ts -m commonjs --outDir dist/cjs --sourcemap --target ES5 -d --diagnostics --pretty",
-    "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts src/Rx.KitchenSink.ts --outDir dist/es6 --sourceMap --target ES6 -d --diagnostics --pretty",
+    "build_amd": "rm -rf dist/amd && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts -m amd --outDir dist/amd --sourcemap --target ES5 --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",
+    "build_cjs": "rm -rf dist/cjs && tsc typings/es6-shim/es6-shim.d.ts src/Rx.ts src/Rx.KitchenSink.ts -m commonjs --outDir dist/cjs --sourcemap --target ES5 -d --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",
+    "build_es6": "rm -rf dist/es6 && tsc src/Rx.ts src/Rx.KitchenSink.ts --outDir dist/es6 --sourceMap --target ES6 -d --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",
     "build_closure": "java -jar ./node_modules/google-closure-compiler/compiler.jar ./dist/global/Rx.umd.js --language_in ECMASCRIPT5 --create_source_map ./dist/global/Rx.umd.min.js.map --js_output_file ./dist/global/Rx.umd.min.js",
     "build_global": "rm -rf dist/global && mkdir \"dist/global\" && node tools/make-umd-bundle.js && node tools/make-system-bundle.js && npm run build_closure",
     "build_perf": "npm run build_cjs && npm run build_global && webdriver-manager update && npm run perf",

--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -35,9 +35,9 @@ export interface CoreOperators<T> {
                 projectResult?: (x: T, y: any, ix: number, iy: number) => R,
                 concurrent?: number) => Observable<R>;
   flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
-  groupBy?: <R>(keySelector: (value: T) => string,
+  groupBy?: <K, R>(keySelector: (value: T) => string,
                 elementSelector?: (value: T) => R,
-                durationSelector?: (group: GroupedObservable<R>) => Observable<any>) => Observable<GroupedObservable<R>>;
+                durationSelector?: (group: GroupedObservable<K, R>) => Observable<any>) => Observable<GroupedObservable<K, R>>;
   ignoreElements?: () => Observable<T>;
   last?: <R>(predicate?: (value: T, index: number) => boolean,
              resultSelector?: (value: T, index: number) => R,

--- a/src/Notification.ts
+++ b/src/Notification.ts
@@ -47,7 +47,7 @@ export class Notification<T> {
       case 'E':
         return Observable.throw(this.exception);
       case 'C':
-        return Observable.empty();
+        return Observable.empty<T>();
     }
   }
 

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -51,7 +51,7 @@ export class Observable<T> implements CoreOperators<T>  {
    * can be `next`ed, or an `error` method can be called to raise an error, or `complete` can be called to notify
    * of a successful completion.
    */
-  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription|Function|void) {
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) {
     if (subscribe) {
       this._subscribe = subscribe;
     }
@@ -66,7 +66,7 @@ export class Observable<T> implements CoreOperators<T>  {
    * @returns {Observable} a new cold observable
    * @description creates a new cold Observable by calling the Observable constructor
    */
-  static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription|Function|void) => {
+  static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) => {
     return new Observable<T>(subscribe);
   };
 
@@ -77,8 +77,8 @@ export class Observable<T> implements CoreOperators<T>  {
    * @description creates a new Observable, with this Observable as the source, and the passed
    * operator defined as the new observable's operator.
    */
-  lift<T, R>(operator: Operator<T, R>): Observable<T> {
-    const observable = new Observable();
+  lift<T, R>(operator: Operator<T, R>): Observable<R> {
+    const observable = new Observable<R>();
     observable.source = this;
     observable.operator = operator;
     return observable;
@@ -132,7 +132,7 @@ export class Observable<T> implements CoreOperators<T>  {
       throw new Error('no Promise impl found');
     }
 
-    let nextHandler;
+    let nextHandler: any;
 
     if (thisArg) {
       nextHandler = function nextHandlerFn(value: any): void {
@@ -145,7 +145,7 @@ export class Observable<T> implements CoreOperators<T>  {
       nextHandler = next;
     }
 
-    const promiseCallback = function promiseCallbackFn(resolve, reject) {
+    const promiseCallback = function promiseCallbackFn(resolve: Function, reject: Function) {
       const { source, nextHandler } = <any>promiseCallbackFn;
       source.subscribe(nextHandler, reject, resolve);
     };
@@ -212,9 +212,9 @@ export class Observable<T> implements CoreOperators<T>  {
                projectResult?: (x: T, y: any, ix: number, iy: number) => R,
                concurrent?: number) => Observable<R>;
   flatMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
-  groupBy: <R>(keySelector: (value: T) => string,
+  groupBy: <K, R>(keySelector: (value: T) => string,
                elementSelector?: (value: T) => R,
-               durationSelector?: (group: GroupedObservable<R>) => Observable<any>) => Observable<GroupedObservable<R>>;
+               durationSelector?: (group: GroupedObservable<K, R>) => Observable<any>) => Observable<GroupedObservable<K, R>>;
   ignoreElements: () => Observable<T>;
   last: <R>(predicate?: (value: T, index: number) => boolean,
             resultSelector?: (value: T, index: number) => R,

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -3,7 +3,7 @@ import {Action} from './scheduler/Action';
 
 export interface Scheduler {
   now(): number;
-  schedule<T>(work: (state?: any) => Subscription|void, delay?: number, state?: any): Subscription;
+  schedule<T>(work: (state?: any) => Subscription | void, delay?: number, state?: any): Subscription;
   flush(): void;
   active: boolean;
   actions: Action[];

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -9,7 +9,7 @@ import {rxSubscriber} from './symbol/rxSubscriber';
 export class Subject<T> extends Observable<T> implements Observer<T>, Subscription {
 
   static create<T>(source: Observable<T>, destination: Observer<T>): Subject<T> {
-    return new Subject(source, destination);
+    return new Subject<T>(source, destination);
   }
 
   constructor(source?: Observable<T>, destination?: Observer<T>) {
@@ -32,7 +32,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
   lift<T, R>(operator: Operator<T, R>): Observable<T> {
     const subject = new Subject(this, this.destination || this);
     subject.operator = operator;
-    return subject;
+    return <any>subject;
   }
 
   add(subscription: Subscription|Function|void): void {

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -3,7 +3,7 @@ import {isObject} from './util/isObject';
 import {isFunction} from './util/isFunction';
 
 export class Subscription {
-  public static EMPTY: Subscription = (function(empty){
+  public static EMPTY: Subscription = (function(empty: any){
     empty.isUnsubscribed = true;
     return empty;
   }(new Subscription()));
@@ -46,7 +46,7 @@ export class Subscription {
     }
   }
 
-  add(subscription: Subscription|Function|void): void {
+  add(subscription: Subscription | Function | void): void {
     // return early if:
     //  1. the subscription is null
     //  2. we're attempting to add our this

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -13,7 +13,7 @@ export class ConnectableObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber: Subscriber<T>) {
     return this._getSubject().subscribe(subscriber);
   }
 
@@ -41,8 +41,8 @@ export class ConnectableObservable<T> extends Observable<T> {
   }
 }
 
-class ConnectableSubscription<T> extends Subscription {
-  constructor(protected connectable: ConnectableObservable<T>) {
+class ConnectableSubscription extends Subscription {
+  constructor(protected connectable: ConnectableObservable<any>) {
     super();
   }
 
@@ -62,9 +62,9 @@ class RefCountObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber: Subscriber<T>) {
     const connectable = this.connectable;
-    const refCountSubscriber = new RefCountSubscriber(subscriber, this);
+    const refCountSubscriber: RefCountSubscriber<T> = new RefCountSubscriber(subscriber, this);
     const subscription = connectable.subscribe(refCountSubscriber);
     if (!subscription.isUnsubscribed && ++this.refCount === 1) {
       refCountSubscriber.connection = this.connection = connectable.connect();

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -7,6 +7,7 @@ import {isFunction} from '../util/isFunction';
 import {SymbolShim} from '../util/SymbolShim';
 import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
+import {Subscriber} from '../Subscriber';
 
 export class IteratorObservable<T> extends Observable<T> {
   private iterator: any;
@@ -18,7 +19,7 @@ export class IteratorObservable<T> extends Observable<T> {
     return new IteratorObservable(iterator, project, thisArg, scheduler);
   }
 
-  static dispatch(state) {
+  static dispatch(state: any) {
 
     const { index, hasError, thisArg, project, iterator, subscriber } = state;
 
@@ -83,7 +84,7 @@ export class IteratorObservable<T> extends Observable<T> {
     this.iterator = getIterator(iterator);
   }
 
-  _subscribe(subscriber): Subscription | Function | void {
+  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
 
     let index = 0;
     const { iterator, project, thisArg, scheduler } = this;
@@ -166,7 +167,7 @@ function getIterator(obj: any) {
 
 const maxSafeInteger = Math.pow(2, 53) - 1;
 
-function toLength(o) {
+function toLength(o: any) {
   let len = +o.length;
   if (isNaN(len)) {
       return 0;
@@ -184,11 +185,11 @@ function toLength(o) {
   return len;
 }
 
-function numberIsFinite(value) {
+function numberIsFinite(value: any) {
   return typeof value === 'number' && root.isFinite(value);
 }
 
-function sign(value) {
+function sign(value: any) {
   let valueAsNumber = +value;
   if (valueAsNumber === 0) {
     return valueAsNumber;

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -13,7 +13,7 @@ export class ScalarObservable<T> extends Observable<T> {
     return new ScalarObservable(value, scheduler);
   }
 
-  static dispatch(state): void {
+  static dispatch(state: any): void {
     const { done, value, subscriber } = state;
 
     if (done) {
@@ -72,7 +72,7 @@ proto.filter = function <T>(select: (x: T, ix?: number) => boolean, thisArg?: an
   } else if (result) {
     return this;
   } else {
-    return new EmptyObservable();
+    return new EmptyObservable<T>();
   }
 };
 
@@ -107,7 +107,7 @@ proto.count = function <T>(predicate?: (value: T, index: number, source: Observa
 
 proto.skip = function <T>(count: number): Observable<T> {
   if (count > 0) {
-    return new EmptyObservable();
+    return new EmptyObservable<T>();
   }
   return this;
 };
@@ -116,5 +116,5 @@ proto.take = function <T>(count: number): Observable<T> {
   if (count > 0) {
     return this;
   }
-  return new EmptyObservable();
+  return new EmptyObservable<T>();
 };

--- a/src/observable/bindCallback.ts
+++ b/src/observable/bindCallback.ts
@@ -10,15 +10,15 @@ export class BoundCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
 
   static create<T>(callbackFunc: Function,
-                   selector: Function = undefined,
-                   scheduler?: Scheduler): Function {
-    return (...args): Observable<T> => {
-      return new BoundCallbackObservable(callbackFunc, selector, args, scheduler);
+                   selector: Function | void = undefined,
+                   scheduler?: Scheduler): (...args: any[]) => Observable<T> {
+    return (...args: any[]): Observable<T> => {
+      return new BoundCallbackObservable<T>(callbackFunc, <any>selector, args, scheduler);
     };
   }
 
   constructor(private callbackFunc: Function,
-              private selector,
+              private selector: Function,
               private args: any[],
               public scheduler: Scheduler) {
     super();
@@ -33,7 +33,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
     if (!scheduler) {
       if (!subject) {
         subject = this.subject = new AsyncSubject<T>();
-        const handler = function handlerFn(...innerArgs) {
+        const handler = function handlerFn(...innerArgs: any[]) {
           const source = (<any>handlerFn).source;
           const { selector, subject } = source;
           if (selector) {
@@ -73,7 +73,7 @@ function dispatch<T>(state: { source: BoundCallbackObservable<T>, subscriber: Su
   if (!subject) {
     subject = source.subject = new AsyncSubject<T>();
 
-    const handler = function handlerFn(...innerArgs) {
+    const handler = function handlerFn(...innerArgs: any[]) {
       const source = (<any>handlerFn).source;
       const { selector, subject } = source;
       if (selector) {

--- a/src/observable/empty.ts
+++ b/src/observable/empty.ts
@@ -1,11 +1,12 @@
 import {Scheduler} from '../Scheduler';
+import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
 export class EmptyObservable<T> extends Observable<T> {
 
   static create<T>(scheduler?: Scheduler): Observable<T> {
-    return new EmptyObservable(scheduler);
+    return new EmptyObservable<T>(scheduler);
   }
 
   static dispatch({ subscriber }) {
@@ -16,7 +17,7 @@ export class EmptyObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber): Subscription | Function | void {
+  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
 
     const scheduler = this.scheduler;
 

--- a/src/observable/forkJoin.ts
+++ b/src/observable/forkJoin.ts
@@ -7,16 +7,15 @@ import {isArray} from '../util/isArray';
 
 export class ForkJoinObservable<T> extends Observable<T> {
   constructor(private sources: Array<Observable<any> | Promise<any>>,
-              private resultSelector?: (...values: Array<any>) => any) {
+              private resultSelector?: (...values: Array<any>) => T) {
     super();
   }
 
-  static create(...sources: Array<Observable<any> |
+  static create<T>(...sources: Array<Observable<any> | Promise<any> |
                                   Array<Observable<any>> |
-                                  Promise<any> |
-                                  ((...values: Array<any>) => any)>): Observable<any> {
+                                  ((...values: Array<any>) => any)>): Observable<T> {
     if (sources === null || arguments.length === 0) {
-      return new EmptyObservable();
+      return new EmptyObservable<T>();
     }
 
     let resultSelector: (...values: Array<any>) => any = null;
@@ -49,7 +48,7 @@ export class ForkJoinObservable<T> extends Observable<T> {
 }
 
 class AllSubscriber<T> extends Subscriber<T> {
-  private _value: any = null;
+  private _value: T = null;
 
   constructor(destination: Subscriber<any>,
               private index: number,
@@ -60,7 +59,7 @@ class AllSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: any): void {
+  _next(value: T): void {
     this._value = value;
   }
 
@@ -95,7 +94,7 @@ function hasValue(x: any): boolean {
 }
 
 function emptyArray(len: number): any[] {
-  let arr = [];
+  let arr: any[] = [];
   for (let i = 0; i < len; i++) {
     arr.push(null);
   }

--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -11,7 +11,7 @@ import {Subscriber} from '../Subscriber';
 import {ObserveOnSubscriber} from '../operator/observeOn-support';
 
 export class FromObservable<T> extends Observable<T> {
-  constructor(private ish: any, private scheduler: Scheduler) {
+  constructor(private ish: Observable<T> | Promise<T> | Iterator<T> | ArrayLike<T>, private scheduler: Scheduler) {
     super(null);
   }
 
@@ -27,7 +27,7 @@ export class FromObservable<T> extends Observable<T> {
       } else if (isPromise(ish)) {
         return new PromiseObservable(ish, scheduler);
       } else if (typeof ish[SymbolShim.iterator] === 'function') {
-        return new IteratorObservable(ish, null, null, scheduler);
+        return new IteratorObservable<T>(<any>ish, null, null, scheduler);
       }
     }
 

--- a/src/observable/fromArray.ts
+++ b/src/observable/fromArray.ts
@@ -2,6 +2,7 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {ScalarObservable} from './ScalarObservable';
 import {EmptyObservable} from './empty';
+import {Subscriber} from '../Subscriber';
 import {isScheduler} from '../util/isScheduler';
 import {Subscription} from '../Subscription';
 
@@ -21,15 +22,15 @@ export class ArrayObservable<T> extends Observable<T> {
 
     const len = array.length;
     if (len > 1) {
-      return new ArrayObservable(array, scheduler);
+      return new ArrayObservable<T>(<any>array, scheduler);
     } else if (len === 1) {
-      return new ScalarObservable(array[0], scheduler);
+      return new ScalarObservable<T>(<any>array[0], scheduler);
     } else {
-      return new EmptyObservable(scheduler);
+      return new EmptyObservable<T>(scheduler);
     }
   }
 
-  static dispatch(state) {
+  static dispatch(state: any) {
 
     const { array, index, count, subscriber } = state;
 
@@ -60,8 +61,7 @@ export class ArrayObservable<T> extends Observable<T> {
     }
   }
 
-  _subscribe(subscriber): Subscription | Function | void {
-
+  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     let index = 0;
     const array = this.array;
     const count = array.length;

--- a/src/observable/fromEvent.ts
+++ b/src/observable/fromEvent.ts
@@ -15,7 +15,7 @@ export class FromEventObservable<T, R> extends Observable<T> {
   }
 
   private static setupSubscription<T>(sourceObj: any, eventName: string, handler: Function, subscriber: Subscriber<T>) {
-    let unsubscribe;
+    let unsubscribe: () => void;
     let tag = sourceObj.toString();
     if (tag === '[object NodeList]' || tag === '[object HTMLCollection]') {
       for (let i = 0, len = sourceObj.length; i < len; i++) {
@@ -35,18 +35,18 @@ export class FromEventObservable<T, R> extends Observable<T> {
     subscriber.add(new Subscription(unsubscribe));
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber: Subscriber<T>) {
     const sourceObj = this.sourceObj;
     const eventName = this.eventName;
     const selector = this.selector;
-    let handler = selector ? (...args) => {
+    let handler = selector ? (...args: any[]) => {
       let result = tryCatch(selector)(...args);
       if (result === errorObject) {
-        subscriber.error(result.e);
+        subscriber.error(errorObject.e);
       } else {
         subscriber.next(result);
       }
-    } : (e) => subscriber.next(e);
+    } : (e: any) => subscriber.next(e);
 
     FromEventObservable.setupSubscription(sourceObj, eventName, handler, subscriber);
   }

--- a/src/observable/fromEventPattern.ts
+++ b/src/observable/fromEventPattern.ts
@@ -2,6 +2,7 @@ import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
+import {Subscriber} from '../Subscriber';
 
 export class FromEventPatternObservable<T, R> extends Observable<T> {
 
@@ -17,19 +18,19 @@ export class FromEventPatternObservable<T, R> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber: Subscriber<T>) {
     const addHandler = this.addHandler;
     const removeHandler = this.removeHandler;
     const selector = this.selector;
 
-    const handler = selector ? function(e) {
+    const handler = selector ? function(e: any) {
       let result = tryCatch(selector).apply(null, arguments);
       if (result === errorObject) {
         subscriber.error(result.e);
       } else {
         subscriber.next(result);
       }
-    } : function(e) { subscriber.next(e); };
+    } : function(e: any) { subscriber.next(e); };
 
     let result = tryCatch(addHandler)(handler);
     if (result === errorObject) {

--- a/src/observable/interval.ts
+++ b/src/observable/interval.ts
@@ -4,12 +4,12 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {asap} from '../scheduler/asap';
 
-export class IntervalObservable<T> extends Observable<T> {
+export class IntervalObservable extends Observable<number> {
   static create(period: number = 0, scheduler: Scheduler = asap): Observable<number> {
     return new IntervalObservable(period, scheduler);
   }
 
-  static dispatch(state): void {
+  static dispatch(state: any): void {
     const { index, subscriber, period } = state;
 
     subscriber.next(index);
@@ -33,7 +33,7 @@ export class IntervalObservable<T> extends Observable<T> {
     }
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  _subscribe(subscriber: Subscriber<number>) {
     const index = 0;
     const period = this.period;
     const scheduler = this.scheduler;

--- a/src/observable/never.ts
+++ b/src/observable/never.ts
@@ -4,7 +4,7 @@ import {noop} from '../util/noop';
 
 export class InfiniteObservable<T> extends Observable<T> {
   static create<T>() {
-    return new InfiniteObservable();
+    return new InfiniteObservable<T>();
   }
 
   constructor() {

--- a/src/observable/range.ts
+++ b/src/observable/range.ts
@@ -1,14 +1,15 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
+import {Subscriber} from '../Subscriber';
 
-export class RangeObservable<T> extends Observable<T> {
+export class RangeObservable extends Observable<number> {
 
   static create(start: number = 0, end: number = 0, scheduler?: Scheduler): Observable<number> {
     return new RangeObservable(start, end, scheduler);
   }
 
-  static dispatch(state) {
+  static dispatch(state: any) {
 
     const { start, index, end, subscriber } = state;
 
@@ -40,8 +41,7 @@ export class RangeObservable<T> extends Observable<T> {
     this.scheduler = scheduler;
   }
 
-  _subscribe(subscriber): Subscription | Function | void {
-
+  _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
     let index = 0;
     let start = this.start;
     const end = this.end;

--- a/src/observable/throw.ts
+++ b/src/observable/throw.ts
@@ -2,7 +2,7 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
-export class ErrorObservable<T> extends Observable<T> {
+export class ErrorObservable extends Observable<any> {
 
   static create<T>(error: any, scheduler?: Scheduler) {
     return new ErrorObservable(error, scheduler);
@@ -16,8 +16,7 @@ export class ErrorObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber): Subscription | Function | void {
-
+  _subscribe(subscriber: any): Subscription | Function | void {
     const error = this.error;
     const scheduler = this.scheduler;
 

--- a/src/observable/timer.ts
+++ b/src/observable/timer.ts
@@ -5,14 +5,15 @@ import {asap} from '../scheduler/asap';
 import {isScheduler} from '../util/isScheduler';
 import {isDate} from '../util/isDate';
 import {Subscription} from '../Subscription';
+import {Subscriber} from '../Subscriber';
 
-export class TimerObservable<T> extends Observable<T> {
+export class TimerObservable extends Observable<number> {
 
   static create(dueTime: number | Date = 0, period?: number | Scheduler, scheduler?: Scheduler): Observable<number> {
     return new TimerObservable(dueTime, period, scheduler);
   }
 
-  static dispatch(state) {
+  static dispatch(state: any) {
 
     const { index, period, subscriber } = state;
     const action = (<any> this);
@@ -54,8 +55,7 @@ export class TimerObservable<T> extends Observable<T> {
       (<number> dueTime);
   }
 
-  _subscribe(subscriber): Subscription | Function | void {
-
+  _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
     const index = 0;
     const { period, dueTime, scheduler } = this;
 

--- a/src/operator/buffer.ts
+++ b/src/operator/buffer.ts
@@ -19,15 +19,15 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * values.
  */
 export function buffer<T>(closingNotifier: Observable<any>): Observable<T[]> {
-  return this.lift(new BufferOperator(closingNotifier));
+  return this.lift(new BufferOperator<T>(closingNotifier));
 }
 
-class BufferOperator<T, R> implements Operator<T, R> {
+class BufferOperator<T> implements Operator<T, T[]> {
 
   constructor(private closingNotifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>): Subscriber<T> {
+  call(subscriber: Subscriber<T[]>): Subscriber<T> {
     return new BufferSubscriber(subscriber, this.closingNotifier);
   }
 }
@@ -35,7 +35,7 @@ class BufferOperator<T, R> implements Operator<T, R> {
 class BufferSubscriber<T, R> extends OuterSubscriber<T, R> {
   private buffer: T[] = [];
 
-  constructor(destination: Subscriber<T>, closingNotifier: Observable<any>) {
+  constructor(destination: Subscriber<T[]>, closingNotifier: Observable<any>) {
     super(destination);
     this.add(subscribeToResult(this, closingNotifier));
   }

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -22,11 +22,11 @@ export function bufferCount<T>(bufferSize: number, startBufferEvery: number = nu
   return this.lift(new BufferCountOperator(bufferSize, startBufferEvery));
 }
 
-class BufferCountOperator<T, R> implements Operator<T, R> {
+class BufferCountOperator<T> implements Operator<T, T[]> {
   constructor(private bufferSize: number, private startBufferEvery: number) {
   }
 
-  call(subscriber: Subscriber<T>): Subscriber<T> {
+  call(subscriber: Subscriber<T[]>): Subscriber<T> {
     return new BufferCountSubscriber(subscriber, this.bufferSize, this.startBufferEvery);
   }
 }
@@ -35,7 +35,7 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
   private buffers: Array<T[]> = [[]];
   private count: number = 0;
 
-  constructor(destination: Subscriber<T>, private bufferSize: number, private startBufferEvery: number) {
+  constructor(destination: Subscriber<T[]>, private bufferSize: number, private startBufferEvery: number) {
     super(destination);
   }
 

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -26,13 +26,13 @@ export function bufferTime<T>(bufferTimeSpan: number,
   return this.lift(new BufferTimeOperator(bufferTimeSpan, bufferCreationInterval, scheduler));
 }
 
-class BufferTimeOperator<T, R> implements Operator<T, R> {
+class BufferTimeOperator<T> implements Operator<T, T[]> {
   constructor(private bufferTimeSpan: number,
               private bufferCreationInterval: number,
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>): Subscriber<T> {
+  call(subscriber: Subscriber<T[]>): Subscriber<T> {
     return new BufferTimeSubscriber(
       subscriber, this.bufferTimeSpan, this.bufferCreationInterval, this.scheduler
     );
@@ -42,7 +42,7 @@ class BufferTimeOperator<T, R> implements Operator<T, R> {
 class BufferTimeSubscriber<T> extends Subscriber<T> {
   private buffers: Array<T[]> = [];
 
-  constructor(destination: Subscriber<T>,
+  constructor(destination: Subscriber<T[]>,
               private bufferTimeSpan: number,
               private bufferCreationInterval: number,
               private scheduler: Scheduler) {
@@ -67,7 +67,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err) {
+  _error(err: any) {
     this.buffers.length = 0;
     super._error(err);
   }
@@ -85,7 +85,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
   }
 
   openBuffer(): T[] {
-    let buffer = [];
+    let buffer: T[] = [];
     this.buffers.push(buffer);
     return buffer;
   }
@@ -97,7 +97,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
   }
 }
 
-function dispatchBufferTimeSpanOnly(state) {
+function dispatchBufferTimeSpanOnly(state: any) {
   const subscriber: BufferTimeSubscriber<any> = state.subscriber;
 
   const prevBuffer = state.buffer;
@@ -111,7 +111,7 @@ function dispatchBufferTimeSpanOnly(state) {
   }
 }
 
-function dispatchBufferCreation(state) {
+function dispatchBufferCreation(state: any) {
   const { bufferCreationInterval, bufferTimeSpan, subscriber, scheduler } = state;
   const buffer = subscriber.openBuffer();
   const action = <Action>this;

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -20,18 +20,18 @@ import {errorObject} from '../util/errorObject';
  * @returns {Observable<T[]>} an observable of arrays of buffered values.
  */
 export function bufferToggle<T, O>(openings: Observable<O>,
-                                   closingSelector: (openValue: O) => Observable<any>): Observable<T[]> {
-  return this.lift(new BufferToggleOperator<T, T, O>(openings, closingSelector));
+                                   closingSelector: (value: O) => Observable<any>): Observable<T[]> {
+  return this.lift(new BufferToggleOperator(openings, closingSelector));
 }
 
-class BufferToggleOperator<T, R, O> implements Operator<T, R> {
+class BufferToggleOperator<T, O> implements Operator<T, T[]> {
 
   constructor(private openings: Observable<O>,
-              private closingSelector: (openValue: O) => Observable<any>) {
+              private closingSelector: (value: O) => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>): Subscriber<T> {
-    return new BufferToggleSubscriber<T, O>(subscriber, this.openings, this.closingSelector);
+  call(subscriber: Subscriber<T[]>): Subscriber<T> {
+    return new BufferToggleSubscriber(subscriber, this.openings, this.closingSelector);
   }
 }
 
@@ -43,9 +43,9 @@ interface BufferContext<T> {
 class BufferToggleSubscriber<T, O> extends Subscriber<T> {
   private contexts: Array<BufferContext<T>> = [];
 
-  constructor(destination: Subscriber<T>,
+  constructor(destination: Subscriber<T[]>,
               private openings: Observable<O>,
-              private closingSelector: (openValue: O) => Observable<any>) {
+              private closingSelector: (value: O) => Observable<any>) {
     super(destination);
     this.add(this.openings.subscribe(new BufferToggleOpeningsSubscriber(this)));
   }
@@ -89,14 +89,14 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
 
     let closingNotifier = tryCatch(closingSelector)(value);
     if (closingNotifier === errorObject) {
-      this._error(closingNotifier.e);
+      this._error(errorObject.e);
     } else {
       let context = {
-        buffer: [],
+        buffer: <T[]>[],
         subscription: new Subscription()
       };
       contexts.push(context);
-      const subscriber = new BufferToggleClosingsSubscriber(this, context);
+      const subscriber = new BufferToggleClosingsSubscriber<T>(this, context);
       const subscription = closingNotifier.subscribe(subscriber);
       context.subscription.add(subscription);
       this.add(subscription);
@@ -116,16 +116,16 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
   }
 }
 
-class BufferToggleOpeningsSubscriber<T> extends Subscriber<T> {
-  constructor(private parent: BufferToggleSubscriber<any, T>) {
+class BufferToggleOpeningsSubscriber<T, O> extends Subscriber<O> {
+  constructor(private parent: BufferToggleSubscriber<T, O>) {
     super(null);
   }
 
-  _next(value: T) {
+  _next(value: O) {
     this.parent.openBuffer(value);
   }
 
-  _error(err) {
+  _error(err: any) {
     this.parent.error(err);
   }
 
@@ -134,8 +134,8 @@ class BufferToggleOpeningsSubscriber<T> extends Subscriber<T> {
   }
 }
 
-class BufferToggleClosingsSubscriber<T> extends Subscriber<T> {
-  constructor(private parent: BufferToggleSubscriber<any, T>,
+class BufferToggleClosingsSubscriber<T> extends Subscriber<any> {
+  constructor(private parent: BufferToggleSubscriber<T, any>,
               private context: { subscription: any, buffer: T[] }) {
     super(null);
   }
@@ -144,7 +144,7 @@ class BufferToggleClosingsSubscriber<T> extends Subscriber<T> {
     this.parent.closeBuffer(this.context);
   }
 
-  _error(err) {
+  _error(err: any) {
     this.parent.error(err);
   }
 

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -23,12 +23,12 @@ export function bufferWhen<T>(closingSelector: () => Observable<any>): Observabl
   return this.lift(new BufferWhenOperator(closingSelector));
 }
 
-class BufferWhenOperator<T, R> implements Operator<T, R> {
+class BufferWhenOperator<T> implements Operator<T, T[]> {
 
   constructor(private closingSelector: () => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>): Subscriber<T> {
+  call(subscriber: Subscriber<T[]>): Subscriber<T> {
     return new BufferWhenSubscriber(subscriber, this.closingSelector);
   }
 }
@@ -38,7 +38,7 @@ class BufferWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
   private subscribing: boolean = false;
   private closingSubscription: Subscription;
 
-  constructor(destination: Subscriber<T>, private closingSelector: () => Observable<any>) {
+  constructor(destination: Subscriber<T[]>, private closingSelector: () => Observable<any>) {
     super(destination);
     this.openBuffer();
   }

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -12,7 +12,7 @@ import {errorObject} from '../util/errorObject';
  * @return {Observable} an observable that originates from either the source or the observable returned by the
  *  catch `selector` function.
  */
-export function _catch<T>(selector: (err: any, caught: Observable<any>) => Observable<any>): Observable<T> {
+export function _catch<T, R>(selector: (err: any, caught: Observable<T>) => Observable<R>): Observable<R> {
   const operator = new CatchOperator(selector);
   const caught = this.lift(operator);
   return (operator.caught = caught);
@@ -37,7 +37,7 @@ class CatchSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  error(err) {
+  error(err: any) {
     if (!this.isStopped) {
       const result = tryCatch(this.selector)(err, this.caught);
       if (result === errorObject) {

--- a/src/operator/combineAll.ts
+++ b/src/operator/combineAll.ts
@@ -1,4 +1,5 @@
 import {CombineLatestOperator} from './combineLatest-support';
+import {Observable} from '../Observable';
 
 /**
  * Takes an Observable of Observables, and collects all observables from it. Once the outer observable
@@ -12,6 +13,6 @@ import {CombineLatestOperator} from './combineLatest-support';
  *   most recent values from each collected observable as arguments, in order.
  * @returns {Observable} an observable of projected results or arrays of recent values.
  */
-export function combineAll<T, R>(project?: (...values: Array<any>) => R) {
+export function combineAll<T, R>(project?: (...values: Array<any>) => R): Observable<R> {
   return this.lift(new CombineLatestOperator(project));
 }

--- a/src/operator/combineLatest-static.ts
+++ b/src/operator/combineLatest-static.ts
@@ -15,10 +15,10 @@ import {isArray} from '../util/isArray';
  * @returns {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
  * the most recent values from each observable.
  */
-export function combineLatest<R>(...observables: Array<Observable<any> |
-                                                      Array<Observable<any>> |
-                                                      ((...values: Array<any>) => R) |
-                                                      Scheduler>): Observable<R> {
+export function combineLatest<T, R>(...observables: Array<any | Observable<any> |
+                                                    Array<Observable<any>> |
+                                                    (((...values: Array<any>) => R)) |
+                                                    Scheduler>): Observable<R> {
   let project: (...values: Array<any>) => R =  null;
   let scheduler: Scheduler = null;
 
@@ -36,5 +36,5 @@ export function combineLatest<R>(...observables: Array<Observable<any> |
     observables = <Array<Observable<any>>>observables[0];
   }
 
-  return new ArrayObservable(observables, scheduler).lift(new CombineLatestOperator(project));
+  return new ArrayObservable(observables, scheduler).lift<T, R>(new CombineLatestOperator<T, R>(project));
 }

--- a/src/operator/combineLatest-support.ts
+++ b/src/operator/combineLatest-support.ts
@@ -11,7 +11,7 @@ export class CombineLatestOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {
-    return new CombineLatestSubscriber<T, R>(subscriber, this.project);
+    return new CombineLatestSubscriber(subscriber, this.project);
   }
 }
 

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -13,10 +13,10 @@ import {isArray} from '../util/isArray';
  * @returns {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
  * the most recent values from each observable.
  */
-export function combineLatest<R>(...observables: Array<Observable<any> |
+export function combineLatest<T, R>(...observables: Array<Observable<any> |
                                                        Array<Observable<any>> |
                                                        ((...values: Array<any>) => R)>): Observable<R> {
-  let project: (...values: Array<any>) => R =  null;
+  let project: (...values: Array<any>) => R = null;
   if (typeof observables[observables.length - 1] === 'function') {
     project = <(...values: Array<any>) => R>observables.pop();
   }
@@ -24,10 +24,10 @@ export function combineLatest<R>(...observables: Array<Observable<any> |
   // if the first and only other argument besides the resultSelector is an array
   // assume it's been called with `combineLatest([obs1, obs2, obs3], project)`
   if (observables.length === 1 && isArray(observables[0])) {
-    observables = <Array<Observable<any>>>observables[0];
+    observables = <any>observables[0];
   }
 
   observables.unshift(this);
 
-  return new ArrayObservable(observables).lift(new CombineLatestOperator(project));
+  return new ArrayObservable(observables).lift<T, R>(new CombineLatestOperator<T, R>(project));
 }

--- a/src/operator/concat-static.ts
+++ b/src/operator/concat-static.ts
@@ -11,12 +11,12 @@ import {isScheduler} from '../util/isScheduler';
  * @params {Scheduler} [scheduler] an optional scheduler to schedule each observable subscription on.
  * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
  */
-export function concat<R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
+export function concat<T, R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
   let scheduler: Scheduler = null;
   let args = <any[]>observables;
   if (isScheduler(args[observables.length - 1])) {
     scheduler = args.pop();
   }
 
-  return new ArrayObservable(observables, scheduler).lift(new MergeAllOperator(1));
+  return new ArrayObservable(observables, scheduler).lift<Observable<T>, T | R>(new MergeAllOperator<T | R>(1));
 }

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -12,7 +12,7 @@ import {MergeAllOperator} from './mergeAll-support';
  * @params {Scheduler} [scheduler] an optional scheduler to schedule each observable subscription on.
  * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
  */
-export function concat<R>(...observables: (Observable<any> | Scheduler)[]): Observable<R> {
+export function concat<T, R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
   let args = <any[]>observables;
   args.unshift(this);
 
@@ -21,5 +21,5 @@ export function concat<R>(...observables: (Observable<any> | Scheduler)[]): Obse
     scheduler = args.pop();
   }
 
-   return new ArrayObservable(args, scheduler).lift(new MergeAllOperator(1));
+   return new ArrayObservable(args, scheduler).lift<Observable<T>, R>(new MergeAllOperator<R>(1));
 }

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -1,4 +1,3 @@
-import {Observable} from '../Observable';
 import {MergeAllOperator} from './mergeAll-support';
 
 /**
@@ -12,6 +11,6 @@ import {MergeAllOperator} from './mergeAll-support';
  *
  * @returns {Observable} an observable of values merged from the incoming observables.
  */
-export function concatAll<T>(): Observable<T> {
+export function concatAll<T>(): T {
   return this.lift(new MergeAllOperator(1));
 }

--- a/src/operator/concatMap.ts
+++ b/src/operator/concatMap.ts
@@ -1,5 +1,5 @@
-import {Observable} from '../Observable';
 import {MergeMapOperator} from './mergeMap-support';
+import {Observable} from '../Observable';
 
 /**
  * Maps values from the source observable into new Observables, then merges them in a serialized fashion,
@@ -11,7 +11,7 @@ import {MergeMapOperator} from './mergeMap-support';
  *
  * @param {function} project a function to map incoming values into Observables to be concatenated. accepts
  * the `value` and the `index` as arguments.
- * @param {function} [projectResult] an optional result selector that is applied to values before they're
+ * @param {function} [resultSelector] an optional result selector that is applied to values before they're
  * merged into the returned observable. The arguments passed to this function are:
  * - `outerValue`: the value that came from the source
  * - `innerValue`: the value that came from the projected Observable
@@ -20,7 +20,7 @@ import {MergeMapOperator} from './mergeMap-support';
  * @returns {Observable} an observable of values merged from the projected Observables as they were subscribed to,
  * one at a time. Optionally, these values may have been projected from a passed `projectResult` argument.
  */
-export function concatMap<T, R>(project: (value: T, index: number) => Observable<any>,
-                                projectResult?: (outerValue: T, innerValue: any, outerIndex: number, innerIndex: number) => R) {
-  return this.lift(new MergeMapOperator(project, projectResult, 1));
+export function concatMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
+                                    resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
+  return this.lift(new MergeMapOperator(project, resultSelector, 1));
 }

--- a/src/operator/concatMapTo.ts
+++ b/src/operator/concatMapTo.ts
@@ -5,7 +5,7 @@ import {MergeMapToOperator} from './mergeMapTo-support';
  * Maps values from the source to a specific observable, and merges them together in a serialized fashion.
  *
  * @param {Observable} observable the observable to map each source value to
- * @param {function} [projectResult] an optional result selector that is applied to values before they're
+ * @param {function} [resultSelector] an optional result selector that is applied to values before they're
  * merged into the returned observable. The arguments passed to this function are:
  * - `outerValue`: the value that came from the source
  * - `innerValue`: the value that came from the projected Observable
@@ -15,9 +15,10 @@ import {MergeMapToOperator} from './mergeMapTo-support';
  * with itself, one after the other, for each value emitted from the source.
  */
 export function concatMapTo<T, R, R2>(observable: Observable<R>,
-                                      projectResult?: (outerValue: T,
-                                                       innerValue: R,
-                                                       outerIndex: number,
-                                                       innerIndex: number) => R2): Observable<R2> {
-  return this.lift(new MergeMapToOperator(observable, projectResult, 1));
+                                      resultSelector?: (
+                                                outerValue: T,
+                                                innerValue: R,
+                                                outerIndex: number,
+                                                innerIndex: number) => R2): Observable<R2> {
+  return this.lift(new MergeMapToOperator(observable, resultSelector, 1));
 }

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -19,27 +19,25 @@ import {errorObject} from '../util/errorObject';
  * @returns {Observable} an observable of one number that represents the count as described
  * above
  */
-export function count<T>(predicate?: (value: T,
-                                      index: number,
-                                      source: Observable<T>) => boolean): Observable<number> {
+export function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<number> {
   return this.lift(new CountOperator(predicate, this));
 }
 
-class CountOperator<T, R> implements Operator<T, R> {
+class CountOperator<T> implements Operator<T, number> {
   constructor(private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
               private source?: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
-    return new CountSubscriber<T, R>(subscriber, this.predicate, this.source);
+  call(subscriber: Subscriber<number>): Subscriber<T> {
+    return new CountSubscriber(subscriber, this.predicate, this.source);
   }
 }
 
-class CountSubscriber<T, R> extends Subscriber<T> {
+class CountSubscriber<T> extends Subscriber<T> {
   private count: number = 0;
   private index: number = 0;
 
-  constructor(destination: Observer<R>,
+  constructor(destination: Observer<number>,
               private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
               private source?: Observable<T>) {
     super(destination);

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -19,15 +19,15 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * @param {function} durationSelector function for computing the timeout duration for each item.
  * @returns {Observable} an Observable the same as source Observable, but drops items.
  */
-export function debounce<T>(durationSelector: (value: T) => Observable<any> | Promise<any>): Observable<T> {
+export function debounce<T>(durationSelector: (value: T) => Observable<number> | Promise<number>): Observable<T> {
   return this.lift(new DebounceOperator(durationSelector));
 }
 
-class DebounceOperator<T, R> implements Operator<T, R> {
-  constructor(private durationSelector: (value: T) => Observable<any> | Promise<any>) {
+class DebounceOperator<T> implements Operator<T, T> {
+  constructor(private durationSelector: (value: T) => Observable<number> | Promise<number>) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new DebounceSubscriber(subscriber, this.durationSelector);
   }
 }
@@ -39,7 +39,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
   private durationSubscription: Subscription = null;
 
   constructor(destination: Subscriber<R>,
-              private durationSelector: (value: T) => any) {
+              private durationSelector: (value: T) => Observable<number> | Promise<number>) {
     super(destination);
   }
 

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -21,7 +21,7 @@ export function debounceTime<T>(dueTime: number, scheduler: Scheduler = asap): O
   return this.lift(new DebounceTimeOperator(dueTime, scheduler));
 }
 
-class DebounceTimeOperator<T, R> implements Operator<T, R> {
+class DebounceTimeOperator<T> implements Operator<T, T> {
   constructor(private dueTime: number, private scheduler: Scheduler) {
   }
 
@@ -74,6 +74,6 @@ class DebounceTimeSubscriber<T> extends Subscriber<T> {
   }
 }
 
-function dispatchNext(subscriber) {
+function dispatchNext(subscriber: DebounceTimeSubscriber<any>) {
   subscriber.debouncedNext();
 }

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -7,7 +7,7 @@ import {Subscriber} from '../Subscriber';
  * @param {any} defaultValue the default value used if source is empty; defaults to null.
  * @returns {Observable} an Observable of the items emitted by the where empty values are replaced by the specified default value or null.
  */
-export function defaultIfEmpty<T, R>(defaultValue: R = null): Observable<T> | Observable<R> {
+export function defaultIfEmpty<T, R>(defaultValue: R = null): Observable<T | R> {
   return this.lift(new DefaultIfEmptyOperator(defaultValue));
 }
 

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -4,6 +4,7 @@ import {Operator} from '../Operator';
 import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
+import {Observable} from '../Observable';
 
 /**
  * Returns an Observable that delays the emission of items from the source Observable
@@ -13,13 +14,13 @@ import {Notification} from '../Notification';
  * @returns {Observable} an Observable that delays the emissions of the source Observable by the specified timeout or Date.
  */
 export function delay<T>(delay: number|Date,
-                         scheduler: Scheduler = asap) {
+                         scheduler: Scheduler = asap): Observable<T> {
   const absoluteDelay = isDate(delay);
   const delayFor = absoluteDelay ? (+delay - scheduler.now()) : Math.abs(<number>delay);
   return this.lift(new DelayOperator(delayFor, scheduler));
 }
 
-class DelayOperator<T, R> implements Operator<T, R> {
+class DelayOperator<T> implements Operator<T, T> {
   constructor(private delay: number,
               private scheduler: Scheduler) {
   }
@@ -34,7 +35,7 @@ class DelaySubscriber<T> extends Subscriber<T> {
   private active: boolean = false;
   private errored: boolean = false;
 
-  private static dispatch(state): void {
+  private static dispatch(state: any): void {
     const source = state.source;
     const queue = source.queue;
     const scheduler = state.scheduler;
@@ -71,7 +72,7 @@ class DelaySubscriber<T> extends Subscriber<T> {
     }
 
     const scheduler = this.scheduler;
-    const message = new DelayMessage<T>(scheduler.now() + this.delay, notification);
+    const message = new DelayMessage(scheduler.now() + this.delay, notification);
     this.queue.push(message);
 
     if (this.active === false) {
@@ -83,7 +84,7 @@ class DelaySubscriber<T> extends Subscriber<T> {
     this.scheduleNotification(Notification.createNext(value));
   }
 
-  _error(err) {
+  _error(err: any) {
     this.errored = true;
     this.queue = [];
     this.destination.error(err);

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -2,6 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
+import {Observable} from '../Observable';
 
 /**
  * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from the previous item.
@@ -10,13 +11,15 @@ import {errorObject} from '../util/errorObject';
  * @param {function} [compare] optional comparison function called to test if an item is distinct from the previous item in the source.
  * @returns {Observable} an Observable that emits items from the source Observable with distinct values.
  */
-export function distinctUntilChanged<T>(compare?: (x: any, y: any) => boolean, keySelector?: (x: T) => any) {
-  return this.lift(new DistinctUntilChangedOperator(compare, keySelector));
+export function distinctUntilChanged<T>(compare?: (x: T, y: T) => boolean): Observable<T>;
+export function distinctUntilChanged<T, K>(compare: (x: K, y: K) => boolean, keySelector?: (x: T) => K): Observable<T>;
+export function distinctUntilChanged<T, K>(compare: (x: K, y: K) => boolean, keySelector?: (x: T) => K): Observable<T> {
+  return this.lift(new DistinctUntilChangedOperator<T, K>(compare, keySelector));
 }
 
-class DistinctUntilChangedOperator<T, R> implements Operator<T, R> {
-  constructor(private compare: (x: any, y: any) => boolean,
-              private keySelector: (x: T) => any) {
+class DistinctUntilChangedOperator<T, K> implements Operator<T, T> {
+  constructor(private compare: (x: K, y: K) => boolean,
+              private keySelector: (x: T) => K) {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {
@@ -24,13 +27,13 @@ class DistinctUntilChangedOperator<T, R> implements Operator<T, R> {
   }
 }
 
-class DistinctUntilChangedSubscriber<T> extends Subscriber<T> {
-  private key: any;
+class DistinctUntilChangedSubscriber<T, K> extends Subscriber<T> {
+  private key: K;
   private hasKey: boolean = false;
 
   constructor(destination: Subscriber<T>,
-              compare: (x: any, y: any) => boolean,
-              private keySelector: (x: T) => any) {
+              compare: (x: K, y: K) => boolean,
+              private keySelector: (x: T) => K) {
     super(destination);
     if (typeof compare === 'function') {
       this.compare = compare;

--- a/src/operator/distinctUntilKeyChanged.ts
+++ b/src/operator/distinctUntilKeyChanged.ts
@@ -1,4 +1,5 @@
 import {distinctUntilChanged} from './distinctUntilChanged';
+import {Observable} from '../Observable';
 
 /**
  * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from the previous item,
@@ -9,8 +10,8 @@ import {distinctUntilChanged} from './distinctUntilChanged';
  * @param {function} [compare] optional comparison function called to test if an item is distinct from the previous item in the source.
  * @returns {Observable} an Observable that emits items from the source Observable with distinct values based on the key specified.
  */
-export function distinctUntilKeyChanged<T>(key: string, compare?: (x: any, y: any) => boolean) {
-  return distinctUntilChanged.call(this, function(x, y) {
+export function distinctUntilKeyChanged<T>(key: string, compare?: (x: T, y: T) => boolean): Observable<T> {
+  return distinctUntilChanged.call(this, function(x: T, y: T) {
     if (compare) {
       return compare(x[key], y[key]);
     }

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -5,6 +5,7 @@ import {Subscriber} from '../Subscriber';
 import {noop} from '../util/noop';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
+import {Observable} from '../Observable';
 
 /**
  * Returns a mirrored Observable of the source Observable, but modified so that the provided Observer is called
@@ -15,8 +16,8 @@ import {errorObject} from '../util/errorObject';
  * @param {function} [complete] callback for the completion of the source.
  * @reurns {Observable} a mirrored Observable with the specified Observer or callback attached for each item.
  */
-export function _do<T>(nextOrObserver?: Observer<T>|((x: T) => void), error?: (e: any) => void, complete?: () => void) {
-  let next;
+export function _do<T>(nextOrObserver?: Observer<T> | ((x: T) => void), error?: (e: any) => void, complete?: () => void): Observable<T> {
+  let next: (x: T) => void;
   if (nextOrObserver && typeof nextOrObserver === 'object') {
     next = (<Observer<T>>nextOrObserver).next;
     error = (<Observer<T>>nextOrObserver).error;
@@ -27,7 +28,7 @@ export function _do<T>(nextOrObserver?: Observer<T>|((x: T) => void), error?: (e
   return this.lift(new DoOperator(next || noop, error || noop, complete || noop));
 }
 
-class DoOperator<T, R> implements Operator<T, R> {
+class DoOperator<T> implements Operator<T, T> {
 
   next: (x: T) => void;
   error: (e: any) => void;
@@ -57,7 +58,7 @@ class DoSubscriber<T> extends Subscriber<T> {
     this.__complete = complete;
   }
 
-  _next(x) {
+  _next(x: T) {
     const result = tryCatch(this.__next)(x);
     if (result === errorObject) {
       this.destination.error(errorObject.e);
@@ -66,7 +67,7 @@ class DoSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(e) {
+  _error(e: any) {
     const result = tryCatch(this.__error)(e);
     if (result === errorObject) {
       this.destination.error(errorObject.e);

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -1,6 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
+import {Observable} from '../Observable';
 
 /**
  * Returns an Observable that emits the item at the specified index in the source Observable.
@@ -9,13 +10,13 @@ import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
  * @param {any} [defaultValue] the default value returned for missing indices.
  * @returns {Observable} an Observable that emits a single item, if it is found. Otherwise, will emit the default value if given.
  */
-export function elementAt(index: number, defaultValue?: any) {
+export function elementAt<T>(index: number, defaultValue?: T): Observable<T> {
   return this.lift(new ElementAtOperator(index, defaultValue));
 }
 
-class ElementAtOperator<T, R> implements Operator<T, R> {
+class ElementAtOperator<T> implements Operator<T, T> {
 
-  constructor(private index: number, private defaultValue?: any) {
+  constructor(private index: number, private defaultValue?: T) {
     if (index < 0) {
       throw new ArgumentOutOfRangeError;
     }
@@ -26,13 +27,13 @@ class ElementAtOperator<T, R> implements Operator<T, R> {
   }
 }
 
-class ElementAtSubscriber<T, R> extends Subscriber<T> {
+class ElementAtSubscriber<T> extends Subscriber<T> {
 
-  constructor(destination: Subscriber<T>, private index: number, private defaultValue?: any) {
+  constructor(destination: Subscriber<T>, private index: number, private defaultValue?: T) {
     super(destination);
   }
 
-  _next(x) {
+  _next(x: T) {
     if (this.index-- === 0) {
       this.destination.next(x);
       this.destination.complete();

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -17,10 +17,8 @@ import {errorObject} from '../util/errorObject';
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                          thisArg?: any): Observable<boolean> {
   const source = this;
-  let result;
-
   if (source._isScalar) {
-    result = tryCatch(predicate).call(thisArg || this, source.value, 0, source);
+    const result: boolean = tryCatch(predicate).call(thisArg || this, source.value, 0, source);
     if (result === errorObject) {
       return new ErrorObservable(errorObject.e, source.scheduler);
     } else {
@@ -30,7 +28,8 @@ export function every<T>(predicate: (value: T, index: number, source: Observable
 
   if (source instanceof ArrayObservable) {
     const array = (<ArrayObservable<T>>source).array;
-    let result = tryCatch((array, predicate, thisArg) => array.every(<any>predicate, thisArg))(array, predicate, thisArg);
+    const result = tryCatch((array: T[], predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg: any) =>
+                                    array.every(<any>predicate, thisArg))(array, predicate, thisArg);
     if (result === errorObject) {
       return new ErrorObservable(errorObject.e, source.scheduler);
     } else {

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -16,17 +16,17 @@ export function exhaust<T>(): Observable<T> {
   return this.lift(new SwitchFirstOperator());
 }
 
-class SwitchFirstOperator<T, R> implements Operator<T, R> {
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+class SwitchFirstOperator<T> implements Operator<T, T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new SwitchFirstSubscriber(subscriber);
   }
 }
 
-class SwitchFirstSubscriber<T, R> extends OuterSubscriber<T, R> {
+class SwitchFirstSubscriber<T> extends OuterSubscriber<T, T> {
   private hasCompleted: boolean = false;
   private hasSubscription: boolean = false;
 
-  constructor(destination: Subscriber<R>) {
+  constructor(destination: Subscriber<T>) {
     super(destination);
   }
 

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -14,22 +14,20 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * @returns {Observable} an Observable containing all the projected Observables of each item of the source concatenated together.
  */
 export function exhaustMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
-                                     resultSelector?: (outerValue: T,
-                                                       innerValue: R,
-                                                       outerIndex: number,
-                                                       innerIndex: number) => R2): Observable<R> {
+                                     resultSelector?: (
+                                            outerValue: T,
+                                            innerValue: R,
+                                            outerIndex: number,
+                                            innerIndex: number) => R2): Observable<R2> {
   return this.lift(new SwitchFirstMapOperator(project, resultSelector));
 }
 
-class SwitchFirstMapOperator<T, R, R2> implements Operator<T, R> {
+class SwitchFirstMapOperator<T, R, R2> implements Operator<T, R2> {
   constructor(private project: (value: T, index: number) => Observable<R>,
-              private resultSelector?: (outerValue: T,
-                                        innerValue: R,
-                                        outerIndex: number,
-                                        innerIndex: number) => R2) {
+              private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<R2>): Subscriber<T> {
     return new SwitchFirstMapSubscriber(subscriber, this.project, this.resultSelector);
   }
 }
@@ -39,7 +37,7 @@ class SwitchFirstMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
   private hasCompleted: boolean = false;
   private index: number = 0;
 
-  constructor(destination: Subscriber<R>,
+  constructor(destination: Subscriber<R2>,
               private project: (value: T, index: number) => Observable<R>,
               private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
     super(destination);
@@ -51,7 +49,7 @@ class SwitchFirstMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
       const destination = this.destination;
       let result = tryCatch(this.project)(value, index);
       if (result === errorObject) {
-        destination.error(result.e);
+        destination.error(errorObject.e);
       } else {
         this.hasSubscription = true;
         this.add(subscribeToResult(this, result, value, index));

--- a/src/operator/expand-support.ts
+++ b/src/operator/expand-support.ts
@@ -1,5 +1,4 @@
 import {Operator} from '../Operator';
-import {Observable} from '../Observable';
 import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
@@ -7,6 +6,7 @@ import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
+import {Observable} from '../Observable';
 
 export class ExpandOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => Observable<R>,
@@ -52,7 +52,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
       destination.next(value);
       let result = tryCatch(this.project)(value, index);
       if (result === errorObject) {
-        destination.error(result.e);
+        destination.error(errorObject.e);
       } else if (!this.scheduler) {
         this.subscribeToProjection(result, value, index);
       } else {
@@ -64,7 +64,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  private subscribeToProjection(result, value: T, index: number): void {
+  private subscribeToProjection(result: any, value: T, index: number): void {
     if (result._isScalar) {
       this._next(result.value);
     } else {

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -1,6 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
+import {Observable} from '../Observable';
 
 /**
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
@@ -8,11 +9,11 @@ import {Subscription} from '../Subscription';
  * @param {function} finallySelector function to be called when source terminates.
  * @returns {Observable} an Observable that mirrors the source, but will call the specified function on termination.
  */
-export function _finally<T>(finallySelector: () => void) {
+export function _finally<T>(finallySelector: () => void): Observable<T> {
   return this.lift(new FinallyOperator(finallySelector));
 }
 
-class FinallyOperator<T, R> implements Operator<T, R> {
+class FinallyOperator<T> implements Operator<T, T> {
   constructor(private finallySelector: () => void) {
   }
 

--- a/src/operator/find-support.ts
+++ b/src/operator/find-support.ts
@@ -5,7 +5,7 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
-export class FindValueOperator<T, R> implements Operator<T, R> {
+export class FindValueOperator<T> implements Operator<T, T> {
   constructor(private predicate: (value: T, index: number, source: Observable<T>) => boolean,
               private source: Observable<T>,
               private yieldIndex: boolean,

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -13,7 +13,7 @@ import {EmptyError} from '../util/EmptyError';
  */
 export function first<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
                             resultSelector?: (value: T, index: number) => R,
-                            defaultValue?: any): Observable<T> | Observable<R> {
+                            defaultValue?: R): Observable<T> | Observable<R> {
   return this.lift(new FirstOperator(predicate, resultSelector, defaultValue, this));
 }
 

--- a/src/operator/groupBy-support.ts
+++ b/src/operator/groupBy-support.ts
@@ -27,8 +27,8 @@ export class RefCountSubscription extends Subscription {
   }
 }
 
-export class GroupedObservable<T> extends Observable<T> {
-  constructor(public key: string,
+export class GroupedObservable<K, T> extends Observable<T> {
+  constructor(public key: K,
               private groupSubject: Subject<T>,
               private refCountSubscription?: RefCountSubscription) {
     super();
@@ -61,4 +61,3 @@ export class InnerRefCountSubscription extends Subscription {
     }
   }
 }
-

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -8,21 +8,21 @@ import {RefCountSubscription, GroupedObservable} from './groupBy-support';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
-export function groupBy<T, R>(keySelector: (value: T) => string,
-                              elementSelector?: (value: T) => R,
-                              durationSelector?: (grouped: GroupedObservable<R>) => Observable<any>): GroupByObservable<T, R> {
-  return new GroupByObservable<T, R>(this, keySelector, elementSelector, durationSelector);
+export function groupBy<T, K, R>(keySelector: (value: T) => K,
+                                 elementSelector?: (value: T) => R,
+                                 durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>): GroupByObservable<T, K, R> {
+  return new GroupByObservable(this, keySelector, elementSelector, durationSelector);
 }
 
-export class GroupByObservable<T, R> extends Observable<GroupedObservable<R>> {
+export class GroupByObservable<T, K, R> extends Observable<GroupedObservable<K, R>> {
   constructor(public source: Observable<T>,
-              private keySelector: (value: T) => string,
+              private keySelector: (value: T) => K,
               private elementSelector?: (value: T) => R,
-              private durationSelector?: (grouped: GroupedObservable<R>) => Observable<any>) {
+              private durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>) {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+  _subscribe(subscriber: Subscriber<any>): Subscription {
     const refCountSubscription = new RefCountSubscription();
     const groupBySubscriber = new GroupBySubscriber(
       subscriber, refCountSubscription, this.keySelector, this.elementSelector, this.durationSelector
@@ -32,14 +32,14 @@ export class GroupByObservable<T, R> extends Observable<GroupedObservable<R>> {
   }
 }
 
-class GroupBySubscriber<T, R> extends Subscriber<T> {
-  private groups = null;
+class GroupBySubscriber<T, K, R> extends Subscriber<T> {
+  private groups: Map<K, Subject<T|R>> = null;
 
   constructor(destination: Subscriber<R>,
               private refCountSubscription: RefCountSubscription,
-              private keySelector: (value: T) => string,
+              private keySelector: (value: T) => K,
               private elementSelector?: (value: T) => R,
-              private durationSelector?: (grouped: GroupedObservable<R>) => Observable<any>) {
+              private durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>) {
     super();
     this.destination = destination;
     this.add(destination);
@@ -48,7 +48,7 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
   _next(x: T): void {
     let key = tryCatch(this.keySelector)(x);
     if (key === errorObject) {
-      this.error(key.e);
+      this.error(errorObject.e);
     } else {
       let groups = this.groups;
       const elementSelector = this.elementSelector;
@@ -58,16 +58,16 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
         groups = this.groups = typeof key === 'string' ? new FastMap() : new Map();
       }
 
-      let group: Subject<T|R> = groups.get(key);
+      let group = groups.get(key);
 
       if (!group) {
-        groups.set(key, group = new Subject());
-        let groupedObservable = new GroupedObservable<R>(key, group, this.refCountSubscription);
+        groups.set(key, group = new Subject<T|R>());
+        let groupedObservable = new GroupedObservable(key, group, this.refCountSubscription);
 
         if (durationSelector) {
-          let duration = tryCatch(durationSelector)(new GroupedObservable<R>(key, group));
+          let duration = tryCatch(durationSelector)(new GroupedObservable<K, R>(key, <any>group));
           if (duration === errorObject) {
-            this.error(duration.e);
+            this.error(errorObject.e);
           } else {
             this.add(duration.subscribe(new GroupDurationSubscriber(key, group, this)));
           }
@@ -79,7 +79,7 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
       if (elementSelector) {
         let value = tryCatch(elementSelector)(x);
         if (value === errorObject) {
-          this.error(value.e);
+          this.error(errorObject.e);
         } else {
           group.next(value);
         }
@@ -105,21 +105,21 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
     if (groups) {
       groups.forEach((group, key) => {
         group.complete();
-        this.removeGroup(group);
+        this.removeGroup(key);
       });
     }
     this.destination.complete();
   }
 
-  removeGroup(key: string): void {
+  removeGroup(key: K): void {
     this.groups.delete(key);
   }
 }
 
-class GroupDurationSubscriber<T> extends Subscriber<T> {
-  constructor(private key: string,
+class GroupDurationSubscriber<K, T> extends Subscriber<T> {
+  constructor(private key: K,
               private group: Subject<T>,
-              private parent: GroupBySubscriber<any, T>) {
+              private parent: GroupBySubscriber<any, K, T>) {
     super();
   }
 

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -1,8 +1,9 @@
+import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {noop} from '../util/noop';
 
-export function ignoreElements() {
+export function ignoreElements<T>(): Observable<T> {
   return this.lift(new IgnoreElementsOperator());
 };
 

--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -1,19 +1,20 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
+import {Observable} from '../Observable';
 
-export function isEmpty() {
+export function isEmpty(): Observable<boolean> {
   return this.lift(new IsEmptyOperator());
 }
 
-class IsEmptyOperator<T, R> implements Operator<T, R> {
-  call (observer: Subscriber<boolean>): Subscriber<T> {
-    return new IsEmptySubscriber<T>(observer);
+class IsEmptyOperator<T> implements Operator<boolean, boolean> {
+  call (observer: Subscriber<T>): Subscriber<boolean> {
+    return new IsEmptySubscriber(observer);
   }
 }
 
-class IsEmptySubscriber<T> extends Subscriber<T> {
+class IsEmptySubscriber extends Subscriber<boolean> {
 
-  constructor(destination: Subscriber<boolean>) {
+  constructor(destination: Subscriber<any>) {
     super(destination);
   }
 
@@ -24,7 +25,7 @@ class IsEmptySubscriber<T> extends Subscriber<T> {
     destination.complete();
   }
 
-  _next(value: T) {
+  _next(value: boolean) {
     this.notifyComplete(false);
   }
 

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -7,7 +7,7 @@ import {EmptyError} from '../util/EmptyError';
 
 export function last<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
                            resultSelector?: (value: T, index: number) => R,
-                           defaultValue?: any): Observable<T> | Observable<R> {
+                           defaultValue?: R): Observable<T> | Observable<R> {
   return this.lift(new LastOperator(predicate, resultSelector, defaultValue, this));
 }
 
@@ -24,7 +24,7 @@ class LastOperator<T, R> implements Operator<T, R> {
 }
 
 class LastSubscriber<T, R> extends Subscriber<T> {
-  private lastValue: T;
+  private lastValue: T | R;
   private hasValue: boolean = false;
   private index: number = 0;
 

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -12,7 +12,7 @@ import {errorObject} from '../util/errorObject';
  * @param {any} [thisArg] an optional argument to define what `this` is in the project function
  * @returns {Observable} a observable of projected values
  */
-export function map<T, R>(project: (x: T, ix?: number) => R, thisArg?: any): Observable<R> {
+export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): Observable<R> {
   if (typeof project !== 'function') {
     throw new TypeError('argument is not a function. Are you looking for `mapTo()`?');
   }
@@ -20,7 +20,7 @@ export function map<T, R>(project: (x: T, ix?: number) => R, thisArg?: any): Obs
 }
 
 class MapOperator<T, R> implements Operator<T, R> {
-  constructor(private project: (x: T, ix?: number) => R, private thisArg: any) {
+  constructor(private project: (value: T, index: number) => R, private thisArg: any) {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {
@@ -32,12 +32,12 @@ class MapSubscriber<T, R> extends Subscriber<T> {
   count: number = 0;
 
   constructor(destination: Subscriber<R>,
-              private project: (x: T, ix?: number) => R,
+              private project: (value: T, index: number) => R,
               private thisArg: any) {
     super(destination);
   }
 
-  _next(x) {
+  _next(x: T) {
     const result = tryCatch(this.project).call(this.thisArg || this, x, this.count++);
     if (result === errorObject) {
       this.error(errorObject.e);

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -1,12 +1,13 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
+import {Observable} from '../Observable';
 
 /**
  * Maps every value to the same value every time.
  * @param {any} value the value to map each incoming value to
  * @returns {Observable} an observable of the passed value that emits everytime the source does
  */
-export function mapTo<T, R>(value: R) {
+export function mapTo<T, R>(value: R): Observable<R> {
   return this.lift(new MapToOperator(value));
 }
 
@@ -32,7 +33,7 @@ class MapToSubscriber<T, R> extends Subscriber<T> {
     this.value = value;
   }
 
-  _next(x) {
+  _next(x: T) {
     this.destination.next(this.value);
   }
 }

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -7,14 +7,14 @@ export function materialize<T>(): Observable<Notification<T>> {
   return this.lift(new MaterializeOperator());
 }
 
-class MaterializeOperator<T, R> implements Operator<T, R> {
-  call(subscriber: Subscriber<T>): Subscriber<T> {
+class MaterializeOperator<T> implements Operator<T, Notification<T>> {
+  call(subscriber: Subscriber<Notification<T>>): Subscriber<T> {
     return new MaterializeSubscriber(subscriber);
   }
 }
 
 class MaterializeSubscriber<T> extends Subscriber<T> {
-  constructor(destination: Subscriber<T>) {
+  constructor(destination: Subscriber<Notification<T>>) {
     super(destination);
   }
 

--- a/src/operator/max.ts
+++ b/src/operator/max.ts
@@ -1,8 +1,8 @@
 import {Observable} from '../Observable';
 import {ReduceOperator} from './reduce-support';
 
-export function max<T, R>(comparer?: (x: R, y: T) => R): Observable<R> {
-  const max = (typeof comparer === 'function')
+export function max<T>(comparer?: (value1: T, value2: T) => T): Observable<T> {
+  const max: typeof comparer = (typeof comparer === 'function')
     ? comparer
     : (x, y) => x > y ? x : y;
   return this.lift(new ReduceOperator(max));

--- a/src/operator/merge-static.ts
+++ b/src/operator/merge-static.ts
@@ -4,7 +4,7 @@ import {ArrayObservable} from '../observable/fromArray';
 import {MergeAllOperator} from './mergeAll-support';
 import {isScheduler} from '../util/isScheduler';
 
-export function merge<R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
+export function merge<T, R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
  let scheduler: Scheduler = null;
   let last: any = observables[observables.length - 1];
@@ -21,5 +21,5 @@ export function merge<R>(...observables: Array<Observable<any> | Scheduler | num
     return <Observable<R>>observables[0];
   }
 
-  return new ArrayObservable(observables, scheduler).lift(new MergeAllOperator(concurrent));
+  return new ArrayObservable<Observable<T>>(<any>observables, scheduler).lift<Observable<T>, R>(new MergeAllOperator<R>(concurrent));
 }

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -2,7 +2,7 @@ import {Observable} from '../Observable';
 import {merge as mergeStatic} from './merge-static';
 import {Scheduler} from '../Scheduler';
 
-export function merge<R>(...observables: (Observable<any>|Scheduler|number)[]): Observable<R> {
+export function merge<T, R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
   observables.unshift(this);
   return mergeStatic.apply(this, observables);
 }

--- a/src/operator/mergeAll-support.ts
+++ b/src/operator/mergeAll-support.ts
@@ -5,7 +5,7 @@ import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
-export class MergeAllOperator<T, R> implements Operator<T, R> {
+export class MergeAllOperator<T> implements Operator<Observable<T>, T> {
   constructor(private concurrent: number) {
   }
 
@@ -14,22 +14,22 @@ export class MergeAllOperator<T, R> implements Operator<T, R> {
   }
 }
 
-export class MergeAllSubscriber<T, R> extends OuterSubscriber<T, R> {
+export class MergeAllSubscriber<T> extends OuterSubscriber<Observable<T>, T> {
   private hasCompleted: boolean = false;
-  private buffer: Observable<any>[] = [];
+  private buffer: Observable<T>[] = [];
   private active: number = 0;
 
   constructor(destination: Observer<T>, private concurrent: number) {
     super(destination);
   }
 
-  _next(observable: any) {
+  _next(observable: Observable<T>) {
     if (this.active < this.concurrent) {
       if (observable._isScalar) {
-        this.destination.next(observable.value);
+        this.destination.next((<any>observable).value);
       } else {
         this.active++;
-        this.add(subscribeToResult<T, R>(this, observable));
+        this.add(subscribeToResult<Observable<T>, T>(this, observable));
       }
     } else {
       this.buffer.push(observable);

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -1,6 +1,5 @@
-import {Observable} from '../Observable';
 import {MergeAllOperator} from './mergeAll-support';
 
-export function mergeAll<R>(concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
+export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): T {
   return this.lift(new MergeAllOperator(concurrent));
 }

--- a/src/operator/mergeMap-support.ts
+++ b/src/operator/mergeMap-support.ts
@@ -39,7 +39,7 @@ export class MergeMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
       const ish = tryCatch(this.project)(value, index);
       const destination = this.destination;
       if (ish === errorObject) {
-        destination.error(ish.e);
+        destination.error(errorObject.e);
       } else {
         this.active++;
         this._innerSub(ish, value, index);

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -2,10 +2,7 @@ import {Observable} from '../Observable';
 import {MergeMapOperator} from './mergeMap-support';
 
 export function mergeMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
-                                   resultSelector?: (outerValue: T,
-                                                     innerValue: R,
-                                                     outerIndex: number,
-                                                     innerIndex: number) => R,
-                                   concurrent: number = Number.POSITIVE_INFINITY) {
-  return this.lift(new MergeMapOperator(project, resultSelector, concurrent));
+                                   resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2 | number,
+                                   concurrent: number = Number.POSITIVE_INFINITY): Observable<R2> {
+  return this.lift(new MergeMapOperator(project, <any>resultSelector, concurrent));
 }

--- a/src/operator/mergeMapTo-support.ts
+++ b/src/operator/mergeMapTo-support.ts
@@ -8,13 +8,13 @@ import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
-export class MergeMapToOperator<T, R, R2> implements Operator<T, R> {
-  constructor(private ish: any,
+export class MergeMapToOperator<T, R, R2> implements Operator<Observable<T>, R2> {
+  constructor(private ish: Observable<R> | Promise<R>,
               private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2,
               private concurrent: number = Number.POSITIVE_INFINITY) {
     }
 
-  call(observer: Subscriber<R>): Subscriber<T> {
+  call(observer: Subscriber<R2>): Subscriber<T> {
     return new MergeMapToSubscriber(observer, this.ish, this.resultSelector, this.concurrent);
   }
 }
@@ -25,13 +25,12 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
   private active: number = 0;
   protected index: number = 0;
 
-  constructor(destination: Subscriber<R>,
-              private ish: any,
+  constructor(destination: Subscriber<R2>,
+              private ish: Observable<R> | Promise<R>,
               private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2,
               private concurrent: number = Number.POSITIVE_INFINITY) {
     super(destination);
   }
-
   _next(value: any): void {
     if (this.active < this.concurrent) {
       const resultSelector = this.resultSelector;

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -2,10 +2,7 @@ import {Observable} from '../Observable';
 import {MergeMapToOperator} from './mergeMapTo-support';
 
 export function mergeMapTo<T, R, R2>(observable: Observable<R>,
-                                     resultSelector?: (outerValue: T,
-                                                       innerValue: R,
-                                                       outerIndex: number,
-                                                       innerIndex: number) => R2,
+                                     resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2 | number,
                                      concurrent: number = Number.POSITIVE_INFINITY): Observable<R2> {
-  return this.lift(new MergeMapToOperator(observable, resultSelector, concurrent));
+  return this.lift(new MergeMapToOperator(observable, <any>resultSelector, concurrent));
 }

--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -7,14 +7,14 @@ import {errorObject} from '../util/errorObject';
 import {subscribeToResult} from '../util/subscribeToResult';
 import {OuterSubscriber} from '../OuterSubscriber';
 
-export function mergeScan<T, R>(project: (acc: R, x: T) => Observable<R>,
+export function mergeScan<T, R>(project: (acc: R, value: T) => Observable<R>,
                                 seed: R,
-                                concurrent: number = Number.POSITIVE_INFINITY) {
+                                concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
   return this.lift(new MergeScanOperator(project, seed, concurrent));
 }
 
 export class MergeScanOperator<T, R> implements Operator<T, R> {
-  constructor(private project: (acc: R, x: T) => Observable<R>,
+  constructor(private project: (acc: R, value: T) => Observable<R>,
               private seed: R,
               private concurrent: number) {
   }
@@ -34,7 +34,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
   protected index: number = 0;
 
   constructor(destination: Subscriber<R>,
-              private project: (acc: R, x: T) => Observable<R>,
+              private project: (acc: R, value: T) => Observable<R>,
               private acc: R,
               private concurrent: number) {
     super(destination);
@@ -46,7 +46,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
       const ish = tryCatch(this.project)(this.acc, value);
       const destination = this.destination;
       if (ish === errorObject) {
-        destination.error(ish.e);
+        destination.error(errorObject.e);
       } else {
         this.active++;
         this._innerSub(ish, value, index);

--- a/src/operator/min.ts
+++ b/src/operator/min.ts
@@ -1,8 +1,8 @@
 import {Observable} from '../Observable';
 import {ReduceOperator} from './reduce-support';
 
-export function min<T, R>(comparer?: (x: R, y: T) => R): Observable<R> {
-  const min = (typeof comparer === 'function')
+export function min<T>(comparer?: (value1: T, value2: T) => T): Observable<T> {
+  const min: typeof comparer = (typeof comparer === 'function')
     ? comparer
     : (x, y) => x < y ? x : y;
   return this.lift(new ReduceOperator(min));

--- a/src/operator/multicast.ts
+++ b/src/operator/multicast.ts
@@ -1,7 +1,7 @@
 import {Subject} from '../Subject';
 import {ConnectableObservable} from '../observable/ConnectableObservable';
 
-export function multicast<T>(subjectOrSubjectFactory: Subject<T>|(() => Subject<T>)) {
+export function multicast<T>(subjectOrSubjectFactory: Subject<T> | (() => Subject<T>)): ConnectableObservable<T> {
   let subjectFactory: () => Subject<T>;
   if (typeof subjectOrSubjectFactory === 'function') {
     subjectFactory = <() => Subject<T>>subjectOrSubjectFactory;

--- a/src/operator/observeOn-support.ts
+++ b/src/operator/observeOn-support.ts
@@ -4,7 +4,7 @@ import {Observer} from '../Observer';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
 
-export class ObserveOnOperator<T, R> implements Operator<T, R> {
+export class ObserveOnOperator<T> implements Operator<T, T> {
   constructor(private scheduler: Scheduler, private delay: number = 0) {
   }
 

--- a/src/operator/partition.ts
+++ b/src/operator/partition.ts
@@ -2,7 +2,7 @@ import {not} from '../util/not';
 import {filter} from './filter';
 import {Observable} from '../Observable';
 
-export function partition<T>(predicate: (x: any, i?: any, a?: any) => boolean, thisArg?: any): Observable<T>[] {
+export function partition<T>(predicate: (value: T) => boolean, thisArg?: any): [Observable<T>, Observable<T>] {
   return [
     filter.call(this, predicate),
     filter.call(this, not(predicate, thisArg))

--- a/src/operator/publish.ts
+++ b/src/operator/publish.ts
@@ -1,6 +1,7 @@
 import {Subject} from '../Subject';
 import {multicast} from './multicast';
+import {ConnectableObservable} from '../observable/ConnectableObservable';
 
-export function publish() {
-  return multicast.call(this, new Subject());
+export function publish<T>(): ConnectableObservable<T> {
+  return multicast.call(this, new Subject<T>());
 }

--- a/src/operator/publishBehavior.ts
+++ b/src/operator/publishBehavior.ts
@@ -1,6 +1,7 @@
 import {BehaviorSubject} from '../subject/BehaviorSubject';
 import {multicast} from './multicast';
+import {ConnectableObservable} from '../observable/ConnectableObservable';
 
-export function publishBehavior(value: any) {
-  return multicast.call(this, new BehaviorSubject(value));
+export function publishBehavior<T>(value: T): ConnectableObservable<T> {
+  return multicast.call(this, new BehaviorSubject<T>(value));
 }

--- a/src/operator/publishLast.ts
+++ b/src/operator/publishLast.ts
@@ -3,5 +3,5 @@ import {multicast} from './multicast';
 import {ConnectableObservable} from '../observable/ConnectableObservable';
 
 export function publishLast<T>(): ConnectableObservable<T> {
-  return multicast.call(this, new AsyncSubject());
+  return multicast.call(this, new AsyncSubject<T>());
 }

--- a/src/operator/publishReplay.ts
+++ b/src/operator/publishReplay.ts
@@ -1,9 +1,10 @@
 import {ReplaySubject} from '../subject/ReplaySubject';
 import {Scheduler} from '../Scheduler';
 import {multicast} from './multicast';
+import {ConnectableObservable} from '../observable/ConnectableObservable';
 
-export function publishReplay(bufferSize: number = Number.POSITIVE_INFINITY,
-                              windowTime: number = Number.POSITIVE_INFINITY,
-                              scheduler?: Scheduler) {
-  return multicast.call(this, new ReplaySubject(bufferSize, windowTime, scheduler));
+export function publishReplay<T>(bufferSize: number = Number.POSITIVE_INFINITY,
+                                 windowTime: number = Number.POSITIVE_INFINITY,
+                                 scheduler?: Scheduler): ConnectableObservable<T> {
+  return multicast.call(this, new ReplaySubject<T>(bufferSize, windowTime, scheduler));
 }

--- a/src/operator/reduce-support.ts
+++ b/src/operator/reduce-support.ts
@@ -5,7 +5,7 @@ import {errorObject} from '../util/errorObject';
 
 export class ReduceOperator<T, R> implements Operator<T, R> {
 
-  constructor(private project: (acc: R, x: T) => R, private seed?: R) {
+  constructor(private project: (acc: R, value: T) => R, private seed?: R) {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {
@@ -15,19 +15,19 @@ export class ReduceOperator<T, R> implements Operator<T, R> {
 
 export class ReduceSubscriber<T, R> extends Subscriber<T> {
 
-  acc: R;
+  acc: T | R;
   hasSeed: boolean;
   hasValue: boolean = false;
-  project: (acc: R, x: T) => R;
+  project: (acc: R, value: T) => R;
 
-  constructor(destination: Subscriber<T>, project: (acc: R, x: T) => R, seed?: R) {
+  constructor(destination: Subscriber<T>, project: (acc: R, value: T) => R, seed?: R) {
     super(destination);
     this.acc = seed;
     this.project = project;
     this.hasSeed = typeof seed !== 'undefined';
   }
 
-  _next(x) {
+  _next(x: T) {
     if (this.hasValue || (this.hasValue = this.hasSeed)) {
       const result = tryCatch(this.project).call(this, this.acc, x);
       if (result === errorObject) {

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -1,6 +1,6 @@
 import {Observable} from '../Observable';
 import {ReduceOperator} from './reduce-support';
 
-export function reduce<T, R>(project: (acc: R, x: T) => R, seed?: R): Observable<R> {
+export function reduce<T, R>(project: (acc: R, value: T) => R, seed?: R): Observable<R> {
   return this.lift(new ReduceOperator(project, seed));
 }

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -5,7 +5,7 @@ import {EmptyObservable} from '../observable/empty';
 
 export function repeat<T>(count: number = -1): Observable<T> {
   if (count === 0) {
-    return new EmptyObservable();
+    return new EmptyObservable<T>();
   } else if (count < 0) {
     return this.lift(new RepeatOperator(-1, this));
   } else {
@@ -13,11 +13,11 @@ export function repeat<T>(count: number = -1): Observable<T> {
   }
 }
 
-class RepeatOperator<T, R> implements Operator<T, R> {
+class RepeatOperator<T> implements Operator<T, T> {
   constructor(private count: number,
               private source: Observable<T>) {
   }
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new RepeatSubscriber(subscriber, this.count, this.source);
   }
 }
@@ -43,4 +43,3 @@ class RepeatSubscriber<T> extends Subscriber<T> {
     }
   }
 }
-

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -6,11 +6,12 @@ export function retry<T>(count: number = -1): Observable<T> {
   return this.lift(new RetryOperator(count, this));
 }
 
-class RetryOperator<T, R> implements Operator<T, R> {
+class RetryOperator<T> implements Operator<T, T> {
   constructor(private count: number,
               private source: Observable<T>) {
   }
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new RetrySubscriber(subscriber, this.count, this.source);
   }
 }

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -9,16 +9,16 @@ import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
-export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>) {
+export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>): Observable<T> {
   return this.lift(new RetryWhenOperator(notifier, this));
 }
 
-class RetryWhenOperator<T, R> implements Operator<T, R> {
+class RetryWhenOperator<T> implements Operator<T, T> {
   constructor(protected notifier: (errors: Observable<any>) => Observable<any>,
               protected source: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new RetryWhenSubscriber(subscriber, this.notifier, this.source);
   }
 }

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -9,11 +9,11 @@ export function sample<T>(notifier: Observable<any>): Observable<T> {
   return this.lift(new SampleOperator(notifier));
 }
 
-class SampleOperator<T, R> implements Operator<T, R> {
+class SampleOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<R>) {
+  call(subscriber: Subscriber<T>) {
     return new SampleSubscriber(subscriber, this.notifier);
   }
 }

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -8,11 +8,11 @@ export function sampleTime<T>(delay: number, scheduler: Scheduler = asap): Obser
   return this.lift(new SampleTimeOperator(delay, scheduler));
 }
 
-class SampleTimeOperator<T, R> implements Operator<T, R> {
+class SampleTimeOperator<T> implements Operator<T, T> {
   constructor(private delay: number, private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<R>) {
+  call(subscriber: Subscriber<T>) {
     return new SampleTimeSubscriber(subscriber, this.delay, this.scheduler);
   }
 }
@@ -39,7 +39,7 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
   }
 }
 
-function dispatchNotification<T>(state) {
+function dispatchNotification<T>(state: any) {
   let { subscriber, delay } = state;
   subscriber.notifyNext();
   (<any>this).schedule(state, delay);

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -7,13 +7,11 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {EmptyError} from '../util/EmptyError';
 
-export function single<T>(predicate?: (value: T,
-                                       index: number,
-                                       source: Observable<T>) => boolean): Observable<T> {
+export function single<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T> {
   return this.lift(new SingleOperator(predicate, this));
 }
 
-class SingleOperator<T, R> implements Operator<T, R> {
+class SingleOperator<T> implements Operator<T, T> {
   constructor(private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
               private source?: Observable<T>) {
   }
@@ -34,7 +32,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  private applySingleValue(value): void {
+  private applySingleValue(value: T): void {
     if (this.seenValue) {
       this.destination.error('Sequence contains more than one element');
     } else {
@@ -50,7 +48,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
     if (predicate) {
       let result = tryCatch(predicate)(value, currentIndex, this.source);
       if (result === errorObject) {
-        this.destination.error(result.e);
+        this.destination.error(errorObject.e);
       } else if (result) {
         this.applySingleValue(value);
       }

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -1,11 +1,12 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
+import {Observable} from '../Observable';
 
-export function skip(total) {
+export function skip<T>(total: number): Observable<T> {
   return this.lift(new SkipOperator(total));
 }
 
-class SkipOperator<T, R> implements Operator<T, R> {
+class SkipOperator<T> implements Operator<T, T> {
   constructor(private total: number) {
   }
 
@@ -21,7 +22,7 @@ class SkipSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(x) {
+  _next(x: T) {
     if (++this.count > this.total) {
       this.destination.next(x);
     }

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -9,11 +9,11 @@ export function skipUntil<T>(notifier: Observable<any>): Observable<T> {
   return this.lift(new SkipUntilOperator(notifier));
 }
 
-class SkipUntilOperator<T, R> implements Operator<T, R> {
+class SkipUntilOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<R>): Subscriber<T> {
+  call(subscriber: Subscriber<T>): Subscriber<T> {
     return new SkipUntilSubscriber(subscriber, this.notifier);
   }
 }

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -4,12 +4,12 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
-export function skipWhile<T>(predicate: (x: T, index: number) => boolean): Observable<T> {
+export function skipWhile<T>(predicate: (value: T, index: number) => boolean): Observable<T> {
   return this.lift(new SkipWhileOperator(predicate));
 }
 
 class SkipWhileOperator<T, R> implements Operator<T, R> {
-  constructor(private predicate: (x: T, index: number) => boolean) {
+  constructor(private predicate: (value: T, index: number) => boolean) {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {
@@ -22,7 +22,7 @@ class SkipWhileSubscriber<T> extends Subscriber<T> {
   private index: number = 0;
 
   constructor(destination: Subscriber<T>,
-              private predicate: (x: T, index: number) => boolean) {
+              private predicate: (value: T, index: number) => boolean) {
     super(destination);
   }
 
@@ -32,7 +32,7 @@ class SkipWhileSubscriber<T> extends Subscriber<T> {
       const index = this.index++;
       const result = tryCatch(this.predicate)(value, index);
       if (result === errorObject) {
-        destination.error(result.e);
+        destination.error(errorObject.e);
       } else {
         this.skipping = Boolean(result);
       }

--- a/src/operator/startWith.ts
+++ b/src/operator/startWith.ts
@@ -6,7 +6,7 @@ import {EmptyObservable} from '../observable/empty';
 import {concat} from './concat-static';
 import {isScheduler} from '../util/isScheduler';
 
-export function startWith<T>(...array: (T | Scheduler)[]): Observable<T> {
+export function startWith<T>(...array: Array<T | Scheduler>): Observable<T> {
   let scheduler = <Scheduler>array[array.length - 1];
   if (isScheduler(scheduler)) {
     array.pop();
@@ -16,10 +16,10 @@ export function startWith<T>(...array: (T | Scheduler)[]): Observable<T> {
 
   const len = array.length;
   if (len === 1) {
-    return concat(new ScalarObservable(array[0], scheduler), this);
+    return concat(new ScalarObservable<T>(<T>array[0], scheduler), <Observable<T>>this);
   } else if (len > 1) {
-    return concat(new ArrayObservable(array, scheduler), this);
+    return concat(new ArrayObservable<T>(<T[]>array, scheduler), <Observable<T>>this);
   } else {
-    return concat(new EmptyObservable(scheduler), this);
+    return concat(new EmptyObservable<T>(scheduler), <Observable<T>>this);
   }
 }

--- a/src/operator/subscribeOn.ts
+++ b/src/operator/subscribeOn.ts
@@ -3,5 +3,5 @@ import {Observable} from '../Observable';
 import {SubscribeOnObservable} from '../observable/SubscribeOnObservable';
 
 export function subscribeOn<T>(scheduler: Scheduler, delay: number = 0): Observable<T> {
-  return new SubscribeOnObservable(this, delay, scheduler);
+  return new SubscribeOnObservable<T>(this, delay, scheduler);
 }

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -1,11 +1,10 @@
 import {Operator} from '../Operator';
-import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
-export function _switch<T>(): Observable<T> {
+export function _switch<T>(): T {
   return this.lift(new SwitchOperator());
 }
 

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -8,19 +8,17 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function switchMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
-                                    resultSelector?: (outerValue: T,
-                                                      innerValue: R,
-                                                      outerIndex: number,
-                                                      innerIndex: number) => R2): Observable<R> {
+                                    resultSelector?: (
+                                             outerValue: T,
+                                             innerValue: R,
+                                             outerIndex: number,
+                                             innerIndex: number) => R2): Observable<R2> {
   return this.lift(new SwitchMapOperator(project, resultSelector));
 }
 
 class SwitchMapOperator<T, R, R2> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => Observable<R>,
-              private resultSelector?: (outerValue: T,
-                                        innerValue: R,
-                                        outerIndex: number,
-                                        innerIndex: number) => R2) {
+              private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {
@@ -43,7 +41,7 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     const destination = this.destination;
     let result = tryCatch(this.project)(value, index);
     if (result === errorObject) {
-      destination.error(result.e);
+      destination.error(errorObject.e);
     } else {
       const innerSubscription = this.innerSubscription;
       if (innerSubscription) {

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -8,19 +8,17 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function switchMapTo<T, R, R2>(observable: Observable<R>,
-                                      projectResult?: (outerValue: T,
-                                                       innerValue: R,
-                                                       outerIndex: number,
-                                                       innerIndex: number) => R2): Observable<R2> {
-  return this.lift(new SwitchMapToOperator(observable, projectResult));
+                                      resultSelector?: (
+                                                 outerValue: T,
+                                                 innerValue: R,
+                                                 outerIndex: number,
+                                                 innerIndex: number) => R2): Observable<R2> {
+  return this.lift(new SwitchMapToOperator(observable, resultSelector));
 }
 
 class SwitchMapToOperator<T, R, R2> implements Operator<T, R> {
   constructor(private observable: Observable<R>,
-              private resultSelector?: (outerValue: T,
-                                        innerValue: R,
-                                        outerIndex: number,
-                                        innerIndex: number) => R2) {
+              private resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -2,16 +2,17 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
 import {EmptyObservable} from '../observable/empty';
+import {Observable} from '../Observable';
 
-export function take(total) {
+export function take<T>(total: number): Observable<T> {
   if (total === 0) {
-    return new EmptyObservable();
+    return new EmptyObservable<T>();
   } else {
     return this.lift(new TakeOperator(total));
   }
 }
 
-class TakeOperator<T, R> implements Operator<T, R> {
+class TakeOperator<T> implements Operator<T, T> {
   constructor(private total: number) {
     if (this.total < 0) {
       throw new ArgumentOutOfRangeError;

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -5,11 +5,11 @@ import {Subscriber} from '../Subscriber';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
-export function takeUntil<T>(notifier: Observable<any>) {
+export function takeUntil<T>(notifier: Observable<any>): Observable<T> {
   return this.lift(new TakeUntilOperator(notifier));
 }
 
-class TakeUntilOperator<T, R> implements Operator<T, R> {
+class TakeUntilOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 

--- a/src/operator/takeWhile.ts
+++ b/src/operator/takeWhile.ts
@@ -8,7 +8,7 @@ export function takeWhile<T>(predicate: (value: T, index: number) => boolean): O
   return this.lift(new TakeWhileOperator(predicate));
 }
 
-class TakeWhileOperator<T, R> implements Operator<T, R> {
+class TakeWhileOperator<T> implements Operator<T, T> {
   constructor(private predicate: (value: T, index: number) => boolean) {
   }
 
@@ -30,7 +30,7 @@ class TakeWhileSubscriber<T> extends Subscriber<T> {
     const result = tryCatch(this.predicate)(value, this.index++);
 
     if (result == errorObject) {
-      destination.error(result.e);
+      destination.error(errorObject.e);
     } else if (Boolean(result)) {
       destination.next(value);
     } else {

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -8,12 +8,12 @@ import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
-export function throttle<T>(durationSelector: (value: T) => Observable<any> | Promise<any>): Observable<T> {
+export function throttle<T>(durationSelector: (value: T) => Observable<number> | Promise<number>): Observable<T> {
   return this.lift(new ThrottleOperator(durationSelector));
 }
 
-class ThrottleOperator<T, R> implements Operator<T, R> {
-  constructor(private durationSelector: (value: T) => Observable<any> | Promise<any>) {
+class ThrottleOperator<T> implements Operator<T, T> {
+  constructor(private durationSelector: (value: T) => Observable<number> | Promise<number>) {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {
@@ -25,7 +25,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
   private throttled: Subscription;
 
   constructor(destination: Subscriber<any>,
-              private durationSelector: (value: T) => Observable<any> | Promise<any>) {
+              private durationSelector: (value: T) => Observable<number> | Promise<number>) {
     super(destination);
   }
 

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -3,12 +3,13 @@ import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Subscription} from '../Subscription';
 import {asap} from '../scheduler/asap';
+import {Observable} from '../Observable';
 
-export function throttleTime<T>(delay: number, scheduler: Scheduler = asap) {
+export function throttleTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new ThrottleTimeOperator(delay, scheduler));
 }
 
-class ThrottleTimeOperator<T, R> implements Operator<T, R> {
+class ThrottleTimeOperator<T> implements Operator<T, T> {
   constructor(private delay: number, private scheduler: Scheduler) {
   }
 

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -4,36 +4,36 @@ import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {asap} from '../scheduler/asap';
 
-export function timeInterval<T>(scheduler: Scheduler = asap): Observable<TimeInterval> {
+export function timeInterval<T>(scheduler: Scheduler = asap): Observable<TimeInterval<T>> {
   return this.lift(new TimeIntervalOperator(scheduler));
 }
 
-export class TimeInterval {
-  constructor(public value: any, public interval: number) {
+export class TimeInterval<T> {
+  constructor(public value: T, public interval: number) {
 
   }
 };
 
-class TimeIntervalOperator<TimeInterval, R> implements Operator<TimeInterval, R> {
+class TimeIntervalOperator<T> implements Operator<T, TimeInterval<T>> {
   constructor(private scheduler: Scheduler) {
 
   }
 
-  call(observer: Subscriber<TimeInterval>): Subscriber<TimeInterval> {
+  call(observer: Subscriber<TimeInterval<T>>): Subscriber<T> {
     return new TimeIntervalSubscriber(observer, this.scheduler);
   }
 }
 
-class TimeIntervalSubscriber<TimeInterval> extends Subscriber<TimeInterval> {
+class TimeIntervalSubscriber<T> extends Subscriber<T> {
   private lastTime: number = 0;
 
-  constructor(destination: Subscriber<TimeInterval>, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<TimeInterval<T>>, private scheduler: Scheduler) {
     super(destination);
 
     this.lastTime = scheduler.now();
   }
 
-  _next(value: TimeInterval) {
+  _next(value: T) {
     let now = this.scheduler.now();
     let span = now - this.lastTime;
     this.lastTime = now;

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -3,24 +3,25 @@ import {isDate} from '../util/isDate';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
+import {Observable} from '../Observable';
 
-export function timeout(due: number|Date,
-                        errorToSend: any = null,
-                        scheduler: Scheduler = asap) {
+export function timeout<T>(due: number | Date,
+                           errorToSend: any = null,
+                           scheduler: Scheduler = asap): Observable<T> {
   let absoluteTimeout = isDate(due);
   let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, errorToSend, scheduler));
 }
 
-class TimeoutOperator<T, R> implements Operator<T, R> {
+class TimeoutOperator<T> implements Operator<T, T> {
   constructor(private waitFor: number,
               private absoluteTimeout: boolean,
               private errorToSend: any,
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<R>) {
-    return new TimeoutSubscriber(
+  call(subscriber: Subscriber<T>) {
+    return new TimeoutSubscriber<T>(
       subscriber, this.absoluteTimeout, this.waitFor, this.errorToSend, this.scheduler
     );
   }
@@ -69,7 +70,7 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err) {
+  _error(err: any) {
     this.destination.error(err);
     this._hasCompleted = true;
   }

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -10,20 +10,20 @@ import {subscribeToResult} from '../util/subscribeToResult';
 
 export function timeoutWith<T, R>(due: number | Date,
                                   withObservable: Observable<R>,
-                                  scheduler: Scheduler = asap): Observable<T> | Observable<R> {
+                                  scheduler: Scheduler = asap): Observable<T | R> {
   let absoluteTimeout = isDate(due);
   let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));
 }
 
-class TimeoutWithOperator<T, R> implements Operator<T, R> {
+class TimeoutWithOperator<T> implements Operator<T, T> {
   constructor(private waitFor: number,
               private absoluteTimeout: boolean,
               private withObservable: Observable<any>,
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<R>) {
+  call(subscriber: Subscriber<T>) {
     return new TimeoutWithSubscriber(
       subscriber, this.absoluteTimeout, this.waitFor, this.withObservable, this.scheduler
     );
@@ -75,7 +75,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  _error(err) {
+  _error(err: any) {
     this.destination.error(err);
     this._hasCompleted = true;
   }

--- a/src/operator/toArray.ts
+++ b/src/operator/toArray.ts
@@ -1,25 +1,26 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
+import {Observable} from '../Observable';
 
-export function toArray() {
+export function toArray<T>(): Observable<T[]> {
   return this.lift(new ToArrayOperator());
 }
 
-class ToArrayOperator<T, R> implements Operator<T, R> {
+class ToArrayOperator<T> implements Operator<T, T[]> {
   call(subscriber: Subscriber<T[]>): Subscriber<T> {
-    return new ToArraySubscriber<T>(subscriber);
+    return new ToArraySubscriber(subscriber);
   }
 }
 
 class ToArraySubscriber<T> extends Subscriber<T> {
 
-  array: T [] = [];
+  array: T[] = [];
 
   constructor(destination: Subscriber<T[]>) {
     super(destination);
   }
 
-  _next(x) {
+  _next(x: T) {
     this.array.push(x);
   }
 

--- a/src/operator/toPromise.ts
+++ b/src/operator/toPromise.ts
@@ -15,6 +15,6 @@ export function toPromise<T>(PromiseCtor?: PromiseConstructor): Promise<T> {
 
   return new PromiseCtor((resolve, reject) => {
     let value: any;
-    this.subscribe(x => value = x, err => reject(err), () => resolve(value));
+    this.subscribe((x: T) => value = x, (err: any) => reject(err), () => resolve(value));
   });
 }

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -7,7 +7,7 @@ export function window<T>(closingNotifier: Observable<any>): Observable<Observab
   return this.lift(new WindowOperator(closingNotifier));
 }
 
-class WindowOperator<T, R> implements Operator<T, R> {
+class WindowOperator<T> implements Operator<T, Observable<T>> {
 
   constructor(private closingNotifier: Observable<any>) {
   }
@@ -53,7 +53,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
   }
 }
 
-class WindowClosingNotifierSubscriber<T> extends Subscriber<T> {
+class WindowClosingNotifierSubscriber extends Subscriber<any> {
   constructor(private parent: WindowSubscriber<any>) {
     super();
   }

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -8,7 +8,7 @@ export function windowCount<T>(windowSize: number,
   return this.lift(new WindowCountOperator(windowSize, startWindowEvery));
 }
 
-class WindowCountOperator<T, R> implements Operator<T, R> {
+class WindowCountOperator<T> implements Operator<T, Observable<T>> {
 
   constructor(private windowSize: number,
               private startWindowEvery: number) {

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -12,7 +12,7 @@ export function windowTime<T>(windowTimeSpan: number,
   return this.lift(new WindowTimeOperator(windowTimeSpan, windowCreationInterval, scheduler));
 }
 
-class WindowTimeOperator<T, R> implements Operator<T, R> {
+class WindowTimeOperator<T> implements Operator<T, Observable<T>> {
 
   constructor(private windowTimeSpan: number,
               private windowCreationInterval: number,
@@ -36,7 +36,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     super(destination);
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
       let window = this.openWindow();
-      const closeState = { subscriber: this, window, context: null };
+      const closeState = { subscriber: this, window, context: <any>null };
       const creationState = { windowTimeSpan, windowCreationInterval, subscriber: this, scheduler };
       this.add(scheduler.schedule(dispatchWindowClose, windowTimeSpan, closeState));
       this.add(scheduler.schedule(dispatchWindowCreation, windowCreationInterval, creationState));
@@ -55,7 +55,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err) {
+  _error(err: any) {
     const windows = this.windows;
     while (windows.length > 0) {
       windows.shift().error(err);
@@ -102,11 +102,11 @@ function dispatchWindowTimeSpanOnly<T>(state: TimeSpanOnlyState<T>) {
   (<any>this).schedule(state, windowTimeSpan);
 }
 
-function dispatchWindowCreation(state) {
+function dispatchWindowCreation(state: any) {
   let { windowTimeSpan, subscriber, scheduler, windowCreationInterval } = state;
   let window = subscriber.openWindow();
   let action = <Action>this;
-  let context = { action, subscription: null };
+  let context = { action, subscription: <any>null };
   const timeSpanState = { subscriber, window, context };
   context.subscription = scheduler.schedule(dispatchWindowClose, windowTimeSpan, timeSpanState);
   action.add(context.subscription);

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -12,17 +12,17 @@ import {subscribeToResult} from '../util/subscribeToResult';
 
 export function windowToggle<T, O>(openings: Observable<O>,
                                    closingSelector: (openValue: O) => Observable<any>): Observable<Observable<T>> {
-  return this.lift(new WindowToggleOperator<T, T, O>(openings, closingSelector));
+  return this.lift(new WindowToggleOperator(openings, closingSelector));
 }
 
-class WindowToggleOperator<T, R, O> implements Operator<T, R> {
+class WindowToggleOperator<T, O> implements Operator<T, Observable<T>> {
 
   constructor(private openings: Observable<O>,
               private closingSelector: (openValue: O) => Observable<any>) {
   }
 
   call(subscriber: Subscriber<Observable<T>>): Subscriber<T> {
-    return new WindowToggleSubscriber<T, R, O>(
+    return new WindowToggleSubscriber(
       subscriber, this.openings, this.closingSelector
     );
   }
@@ -112,7 +112,6 @@ class WindowToggleSubscriber<T, R, O> extends OuterSubscriber<T, R> {
       if (closingNotifier === errorObject) {
         return this.error(errorObject.e);
       } else {
-
         const window = new Subject<T>();
         const subscription = new Subscription();
         const context = { window, subscription };

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -11,7 +11,7 @@ export function windowWhen<T>(closingSelector: () => Observable<any>): Observabl
   return this.lift(new WindowOperator(closingSelector));
 }
 
-class WindowOperator<T, R> implements Operator<T, R> {
+class WindowOperator<T> implements Operator<T, Observable<T>> {
 
   constructor(private closingSelector: () => Observable<any>) {
   }
@@ -76,7 +76,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
 
     const closingNotifier = tryCatch(this.closingSelector)();
     if (closingNotifier === errorObject) {
-      const err = closingNotifier.e;
+      const err = errorObject.e;
       this.destination.error(err);
       this.window.error(err);
     } else {
@@ -88,7 +88,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
   }
 }
 
-class WindowClosingNotifierSubscriber<T> extends Subscriber<T> {
+class WindowClosingNotifierSubscriber extends Subscriber<any> {
   constructor(private parent: WindowSubscriber<any>) {
     super();
   }
@@ -97,7 +97,7 @@ class WindowClosingNotifierSubscriber<T> extends Subscriber<T> {
     this.parent.openWindow();
   }
 
-  _error(err) {
+  _error(err: any) {
     this.parent.error(err);
   }
 

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -24,8 +24,8 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * result: ---([a,d,x])---------([b,e,y])--------([c,f,z])---|
  * ```
  */
-export function withLatestFrom<R>(...args: Array<Observable<any> | ((...values: Array<any>) => R)>): Observable<R> {
-  let project;
+export function withLatestFrom<T, R>(...args: Array<Observable<any> | ((...values: Array<any>) => R)>): Observable<R> {
+  let project: any;
   if (typeof args[args.length - 1] === 'function') {
     project = args.pop();
   }
@@ -39,7 +39,7 @@ class WithLatestFromOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<T>): Subscriber<T> {
-    return new WithLatestFromSubscriber<T, R>(subscriber, this.observables, this.project);
+    return new WithLatestFromSubscriber(subscriber, this.observables, this.project);
   }
 }
 
@@ -64,7 +64,7 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(observable, value, observableIndex, index) {
+  notifyNext(observable: any, value: any, observableIndex: number, index: number) {
     this.values[observableIndex] = value;
     const toRespond = this.toRespond;
     if (toRespond.length > 0) {

--- a/src/operator/zip-static.ts
+++ b/src/operator/zip-static.ts
@@ -7,5 +7,5 @@ export function zip<T, R>(...observables: Array<Observable<any> | ((...values: A
   if (typeof project === 'function') {
     observables.pop();
   }
-  return new ArrayObservable(observables).lift(new ZipOperator(project));
+  return new ArrayObservable(observables).lift<T, R>(new ZipOperator<T, R>(project));
 }

--- a/src/operator/zip-support.ts
+++ b/src/operator/zip-support.ts
@@ -18,7 +18,7 @@ export class ZipOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>): Subscriber<T> {
-    return new ZipSubscriber<T, R>(subscriber, this.project);
+    return new ZipSubscriber(subscriber, this.project);
   }
 }
 
@@ -26,7 +26,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   private index = 0;
   private values: any;
   private project: (...values: Array<any>) => R;
-  private iterators = [];
+  private iterators: LookAheadIterator<any>[] = [];
   private active = 0;
 
   constructor(destination: Subscriber<R>,
@@ -37,7 +37,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     this.values = values;
   }
 
-  _next(value) {
+  _next(value: any) {
     const iterators = this.iterators;
     const index = this.index++;
     if (isArray(value)) {
@@ -54,7 +54,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     const len = iterators.length;
     this.active = len;
     for (let i = 0; i < len; i++) {
-      let iterator = iterators[i];
+      let iterator: ZipBufferIterator<any, any> = <any>iterators[i];
       if (iterator.stillUnsubscribed) {
         this.add(iterator.subscribe(iterator, i));
       } else {
@@ -84,7 +84,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     }
 
     let shouldComplete = false;
-    const args = [];
+    const args: any[] = [];
     for (let i = 0; i < len; i++) {
       let iterator = iterators[i];
       let result = iterator.next();
@@ -220,7 +220,7 @@ class ZipBufferIterator<T, R> extends OuterSubscriber<T, R> implements LookAhead
     }
   }
 
-  notifyNext(outerValue, innerValue, outerIndex, innerIndex) {
+  notifyNext(outerValue: any, innerValue: any, outerIndex: number, innerIndex: number) {
     this.buffer.push(innerValue);
     this.parent.checkIterators();
   }

--- a/src/operator/zipAll.ts
+++ b/src/operator/zipAll.ts
@@ -1,5 +1,6 @@
 import {ZipOperator} from './zip-support';
+import {Observable} from '../Observable';
 
-export function zipAll<T, R>(project?: (...values: Array<any>) => R) {
+export function zipAll<T, R>(project?: (...values: Array<any>) => R): Observable<R> {
   return this.lift(new ZipOperator(project));
 }

--- a/src/scheduler/Action.ts
+++ b/src/scheduler/Action.ts
@@ -5,7 +5,7 @@ export interface Action extends Subscription {
   work: (state?: any) => void|Subscription;
   state?: any;
   delay?: number;
-  schedule(state?: any, delay?: number);
+  schedule(state?: any, delay?: number): void;
   execute(): void;
   scheduler: Scheduler;
 }

--- a/src/scheduler/QueueScheduler.ts
+++ b/src/scheduler/QueueScheduler.ts
@@ -19,7 +19,7 @@ export class QueueScheduler implements Scheduler {
     }
     this.active = true;
     const actions = this.actions;
-    for (let action; action = actions.shift(); ) {
+    for (let action: QueueAction<any>; action = actions.shift(); ) {
       action.execute();
     }
     this.active = false;

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -77,7 +77,7 @@ class VirtualAction<T> extends Subscription implements Action {
       return this;
     }
     const scheduler = this.scheduler;
-    let action;
+    let action: Action;
     if (this.calls++ === 0) {
       // the action is not being rescheduled.
       action = this;

--- a/src/subject/ReplaySubject.ts
+++ b/src/subject/ReplaySubject.ts
@@ -47,7 +47,7 @@ export class ReplaySubject<T> extends Subject<T> {
     return (this.scheduler || queue).now();
   }
 
-  private _trimBufferThenGetEvents(now): ReplayEvent<T>[] {
+  private _trimBufferThenGetEvents(now: number): ReplayEvent<T>[] {
     const bufferSize = this.bufferSize;
     const windowSize = this.windowSize;
     const events = this.events;

--- a/src/subject/SubjectSubscription.ts
+++ b/src/subject/SubjectSubscription.ts
@@ -2,10 +2,10 @@ import {Subject} from '../Subject';
 import {Observer} from '../Observer';
 import {Subscription} from '../Subscription';
 
-export class SubjectSubscription<T> extends Subscription {
+export class SubjectSubscription extends Subscription {
   isUnsubscribed: boolean = false;
 
-  constructor(public subject: Subject<T>, public observer: Observer<any>) {
+  constructor(public subject: Subject<any>, public observer: Observer<any>) {
     super();
   }
 

--- a/src/testing/ColdObservable.ts
+++ b/src/testing/ColdObservable.ts
@@ -5,6 +5,7 @@ import {TestMessage} from './TestMessage';
 import {SubscriptionLog} from './SubscriptionLog';
 import {SubscriptionLoggable} from './SubscriptionLoggable';
 import {applyMixins} from '../util/applyMixins';
+import {Subscriber} from '../Subscriber';
 
 export class ColdObservable<T> extends Observable<T> implements SubscriptionLoggable {
   public subscriptions: SubscriptionLog[] = [];
@@ -14,7 +15,7 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
 
   constructor(public messages: TestMessage[],
               scheduler: Scheduler) {
-    super(function (subscriber) {
+    super(function (subscriber: Subscriber<any>) {
       const observable: ColdObservable<T> = this;
       const index = observable.logSubscribedFrame();
       subscriber.add(new Subscription(() => {
@@ -26,7 +27,7 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
     this.scheduler = scheduler;
   }
 
-  scheduleMessages(subscriber) {
+  scheduleMessages(subscriber: Subscriber<any>) {
     const messagesLength = this.messages.length;
     for (let i = 0; i < messagesLength; i++) {
       const message = this.messages[i];

--- a/src/testing/TestScheduler.ts
+++ b/src/testing/TestScheduler.ts
@@ -6,6 +6,7 @@ import {ColdObservable} from './ColdObservable';
 import {HotObservable} from './HotObservable';
 import {TestMessage} from './TestMessage';
 import {SubscriptionLog} from './SubscriptionLog';
+import {Subscription} from '../Subscription';
 
 interface FlushableTest {
   ready: boolean;
@@ -41,7 +42,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       throw new Error('Cold observable cannot have unsubscription marker "!"');
     }
     const messages = TestScheduler.parseMarbles(marbles, values, error);
-    const cold = new ColdObservable(messages, this);
+    const cold = new ColdObservable<T>(messages, this);
     this.coldObservables.push(cold);
     return cold;
   }
@@ -51,7 +52,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       throw new Error('Hot observable cannot have unsubscription marker "!"');
     }
     const messages = TestScheduler.parseMarbles(marbles, values, error);
-    const subject = new HotObservable(messages, this);
+    const subject = new HotObservable<T>(messages, this);
     this.hotObservables.push(subject);
     return subject;
   }
@@ -75,7 +76,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     const flushTest: FlushableTest = { actual, ready: false };
     const unsubscriptionFrame = TestScheduler
       .parseMarblesAsSubscriptions(unsubscriptionMarbles).unsubscribedFrame;
-    let subscription;
+    let subscription: Subscription;
 
     this.schedule(() => {
       subscription = observable.subscribe(x => {
@@ -196,8 +197,8 @@ export class TestScheduler extends VirtualTimeScheduler {
     const subIndex = marbles.indexOf('^');
     const frameOffset = subIndex === -1 ? 0 : (subIndex * -this.frameTimeFactor);
     const getValue = typeof values !== 'object' ?
-      (x) => x :
-      (x) => {
+      (x: any) => x :
+      (x: any) => {
         // Support Observable-of-Observables
         if (materializeInnerObservables && values[x] instanceof ColdObservable) {
           return values[x].messages;
@@ -208,7 +209,7 @@ export class TestScheduler extends VirtualTimeScheduler {
 
     for (let i = 0; i < len; i++) {
       const frame = i * this.frameTimeFactor + frameOffset;
-      let notification;
+      let notification: Notification<any>;
       const c = marbles[i];
       switch (c) {
         case '-':

--- a/src/util/Immediate.ts
+++ b/src/util/Immediate.ts
@@ -46,7 +46,7 @@ export class ImmediateDefinition {
         this.setImmediate = this.createSetTimeoutSetImmediate();
       }
 
-      let ci = function clearImmediate(handle) {
+      let ci = function clearImmediate(handle: any) {
         delete (<any>clearImmediate).instance.tasksByHandle[handle];
       };
 
@@ -89,7 +89,7 @@ export class ImmediateDefinition {
 
   // This function accepts the same arguments as setImmediate, but
   // returns a function that requires no arguments.
-  partiallyApplied(handler, ...args) {
+  partiallyApplied(handler: any, ...args: any[]) {
     let fn = function result () {
       const { handler, args } = <any>result;
       if (typeof handler === 'function') {
@@ -105,7 +105,7 @@ export class ImmediateDefinition {
     return fn;
   }
 
-  addFromSetImmediateArguments(args) {
+  addFromSetImmediateArguments(args: any[]) {
     this.tasksByHandle[this.nextHandle] = this.partiallyApplied.apply(undefined, args);
     return this.nextHandle++;
   }
@@ -130,7 +130,7 @@ export class ImmediateDefinition {
     const root = this.root;
 
     let messagePrefix = 'setImmediate$' + root.Math.random() + '$';
-    let onGlobalMessage = function globalMessageHandler(event) {
+    let onGlobalMessage = function globalMessageHandler(event: any) {
       const instance = (<any>globalMessageHandler).instance;
       if (event.source === root &&
         typeof event.data === 'string' &&
@@ -155,7 +155,7 @@ export class ImmediateDefinition {
     return fn;
   }
 
-  runIfPresent(handle) {
+  runIfPresent(handle: any) {
     // From the spec: 'Wait until any invocations of this algorithm started before this one have completed.'
     // So if we're currently running a task, we'll need to delay this invocation.
     if (this.currentlyRunningATask) {
@@ -178,7 +178,7 @@ export class ImmediateDefinition {
 
   createMessageChannelSetImmediate() {
     let channel = new this.root.MessageChannel();
-    channel.port1.onmessage = (event) => {
+    channel.port1.onmessage = (event: any) => {
       let handle = event.data;
       this.runIfPresent(handle);
     };

--- a/src/util/MapPolyfill.ts
+++ b/src/util/MapPolyfill.ts
@@ -1,14 +1,14 @@
 export class MapPolyfill {
   public size = 0;
-  private _values = [];
-  private _keys = [];
+  private _values: any[] = [];
+  private _keys: any[] = [];
 
-  get(key): any {
+  get(key: any) {
     const i = this._keys.indexOf(key);
     return i === -1 ? undefined : this._values[i];
   }
 
-  set(key, value): any {
+  set(key: any, value: any) {
     const i = this._keys.indexOf(key);
     if (i === -1) {
       this._keys.push(key);
@@ -20,7 +20,7 @@ export class MapPolyfill {
     return this;
   }
 
-  delete(key): boolean {
+  delete(key: any): boolean {
     const i = this._keys.indexOf(key);
     if (i === -1) { return false; }
     this._values.splice(i, 1);
@@ -29,7 +29,7 @@ export class MapPolyfill {
     return true;
   }
 
-  forEach(cb, thisArg): void {
+  forEach(cb: Function, thisArg: any) {
     for (let i = 0; i < this.size; i++) {
       cb.call(thisArg, this._values[i], this._keys[i]);
     }

--- a/src/util/SymbolShim.ts
+++ b/src/util/SymbolShim.ts
@@ -1,6 +1,6 @@
 import {root} from './root';
 
-export function polyfillSymbol(root) {
+export function polyfillSymbol(root: any) {
   const Symbol = ensureSymbol(root);
   ensureIterator(Symbol, root);
   ensureObservable(Symbol);
@@ -8,7 +8,7 @@ export function polyfillSymbol(root) {
   return Symbol;
 }
 
-export function ensureFor(Symbol) {
+export function ensureFor(Symbol: any) {
   if (!Symbol.for) {
     Symbol.for = symbolForPolyfill;
   }
@@ -16,20 +16,20 @@ export function ensureFor(Symbol) {
 
 let id = 0;
 
-export function ensureSymbol(root) {
+export function ensureSymbol(root: any) {
   if (!root.Symbol) {
-    root.Symbol = function symbolFuncPolyfill(description) {
+    root.Symbol = function symbolFuncPolyfill(description: any) {
       return `@@Symbol(${description}):${id++}`;
     };
   }
   return root.Symbol;
 }
 
-export function symbolForPolyfill(key) {
+export function symbolForPolyfill(key: any) {
   return '@@' + key;
 }
 
-export function ensureIterator(Symbol, root) {
+export function ensureIterator(Symbol: any, root: any) {
   if (!Symbol.iterator) {
     if (typeof Symbol.for === 'function') {
       Symbol.iterator = Symbol.for('iterator');
@@ -52,7 +52,7 @@ export function ensureIterator(Symbol, root) {
   }
 }
 
-export function ensureObservable(Symbol) {
+export function ensureObservable(Symbol: any) {
   if (!Symbol.observable) {
     if (typeof Symbol.for === 'function') {
       Symbol.observable = Symbol.for('observable');

--- a/src/util/errorObject.ts
+++ b/src/util/errorObject.ts
@@ -1,1 +1,2 @@
-export var errorObject = { e: {} };
+// typeof any so that it we don't have to cast when comparing a result to the error object
+export var errorObject: any = { e: {} };

--- a/src/util/isArray.ts
+++ b/src/util/isArray.ts
@@ -1,1 +1,1 @@
-export const isArray = Array.isArray || (x => x && typeof x.length === 'number');
+export const isArray = Array.isArray || (<T>(x: any): x is T[] => x && typeof x.length === 'number');

--- a/src/util/isDate.ts
+++ b/src/util/isDate.ts
@@ -1,3 +1,3 @@
-export function isDate(value) {
+export function isDate(value: any): value is Date {
   return value instanceof Date && !isNaN(+value);
 }

--- a/src/util/isFunction.ts
+++ b/src/util/isFunction.ts
@@ -1,3 +1,3 @@
-export function isFunction(x) {
+export function isFunction(x: any): x is Function {
   return typeof x === 'function';
 }

--- a/src/util/isNumeric.ts
+++ b/src/util/isNumeric.ts
@@ -1,6 +1,6 @@
 import {isArray} from '../util/isArray';
 
-export function isNumeric(val) {
+export function isNumeric(val: any): val is number {
   // parseFloat NaNs numeric-cast false positives (null|true|false|"")
   // ...but misinterprets leading-number strings, particularly hex literals ("0x...")
   // subtraction forces infinities to NaN

--- a/src/util/isObject.ts
+++ b/src/util/isObject.ts
@@ -1,3 +1,3 @@
-export function isObject(x) {
+export function isObject(x: any): x is Object {
   return x != null && typeof x === 'object';
 }

--- a/src/util/isPromise.ts
+++ b/src/util/isPromise.ts
@@ -1,3 +1,3 @@
-export function isPromise(value: any): boolean {
-  return value && typeof value.subscribe !== 'function' && typeof value.then === 'function';
+export function isPromise<T>(value: any | Promise<T>): value is Promise<T> {
+  return value && typeof (<any>value).subscribe !== 'function' && typeof (value as any).then === 'function';
 }

--- a/src/util/isScheduler.ts
+++ b/src/util/isScheduler.ts
@@ -1,3 +1,4 @@
-export function isScheduler(value: any): boolean {
-  return value && typeof value.schedule === 'function';
+import {Scheduler} from '../Scheduler';
+export function isScheduler<T>(value: any): value is Scheduler {
+  return value && typeof (<any>value).schedule === 'function';
 }

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -37,15 +37,15 @@ export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
     }
   } else if (isPromise(result)) {
     result.then(
-      (value) => {
+      (value: any) => {
         if (!destination.isUnsubscribed) {
           destination.next(value);
           destination.complete();
         }
       },
-      (err) => destination.error(err)
+      (err: any) => destination.error(err)
     )
-    .then(null, err => {
+    .then(null, (err: any) => {
       // Escaping the Promise trap: globally throw unhandled errors
       root.setTimeout(() => { throw err; });
     });

--- a/src/util/throwError.ts
+++ b/src/util/throwError.ts
@@ -1,1 +1,1 @@
-export function throwError(e) { throw e; }
+export function throwError(e: any) { throw e; }

--- a/src/util/tryCatch.ts
+++ b/src/util/tryCatch.ts
@@ -11,7 +11,7 @@ function tryCatcher(): any {
   }
 }
 
-export function tryCatch(fn: Function): Function {
+export function tryCatch<T extends Function>(fn: T): T {
   tryCatchTarget = fn;
-  return tryCatcher;
+  return <any>tryCatcher;
 };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,8 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "declaration": true,
+    "noImplicitAny": true,
+    "suppressImplicitAnyIndexErrors": true,
     "target": "es6",
     "outDir": "dist/es6"
   },


### PR DESCRIPTION
With this change compliation time and performance is improved

------

@kwonoj  This was the quick way, there might a few places where the formatting, or in some cases the variable names used in method signatures that have changed.  If I need to reverse those let me know and I'll make a pass at it shortly.