### PR TITLE
Inline docs for operators (D - F)

### DIFF
--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -9,6 +9,16 @@ import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * Returns the source Observable delayed by the computed debounce duration,
+ * with the duration lengthened if a new source item arrives before the delay
+ * duration ends.
+ * In practice, for each item emitted on the source, this operator holds the
+ * latest item, waits for a silence as long as the `durationSelector` specifies,
+ * and only then emits the latest source item on the result Observable.
+ * @param {function} durationSelector function for computing the timeout duration for each item.
+ * @returns {Observable} an Observable the same as source Observable, but drops items.
+ */
 export function debounce<T>(durationSelector: (value: T) => Observable<any> | Promise<any>): Observable<T> {
   return this.lift(new DebounceOperator(durationSelector));
 }

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -5,6 +5,18 @@ import {Scheduler} from '../Scheduler';
 import {Subscription} from '../Subscription';
 import {asap} from '../scheduler/asap';
 
+/**
+ * Returns the source Observable delayed by the computed debounce duration,
+ * with the duration lengthened if a new source item arrives before the delay
+ * duration ends.
+ * In practice, for each item emitted on the source, this operator holds the
+ * latest item, waits for a silence for the `dueTime` length, and only then
+ * emits the latest source item on the result Observable.
+ * Optionally takes a scheduler for manging timers.
+ * @param {number} dueTime the timeout value for the window of time required to not drop the item.
+ * @param {Scheduler} [scheduler] the Scheduler to use for managing the timers that handle the timeout for each item.
+ * @returns {Observable} an Observable the same as source Observable, but drops items.
+ */
 export function debounceTime<T>(dueTime: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new DebounceTimeOperator(dueTime, scheduler));
 }

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -2,6 +2,11 @@ import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 
+/**
+ * Returns an Observable that emits the elements of the source or a specified default value if empty.
+ * @param {any} defaultValue the default value used if source is empty; defaults to null.
+ * @returns {Observable} an Observable of the items emitted by the where empty values are replaced by the specified default value or null.
+ */
 export function defaultIfEmpty<T, R>(defaultValue: R = null): Observable<T> | Observable<R> {
   return this.lift(new DefaultIfEmptyOperator(defaultValue));
 }

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -5,6 +5,13 @@ import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
 
+/**
+ * Returns an Observable that delays the emission of items from the source Observable
+ * by a given timeout or until a given Date.
+ * @param {number|Date} delay the timeout value or date until which the emission of the source items is delayed.
+ * @param {Scheduler} [scheduler] the Scheduler to use for managing the timers that handle the timeout for each item.
+ * @returns {Observable} an Observable that delays the emissions of the source Observable by the specified timeout or Date.
+ */
 export function delay<T>(delay: number|Date,
                          scheduler: Scheduler = asap) {
   const absoluteDelay = isDate(delay);

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -3,6 +3,10 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
 
+/**
+ * Returns an Observable that transforms Notification objects into the items or notifications they represent.
+ * @returns {Observable} an Observable that emits items and notifications embedded in Notification objects emitted by the source Observable.
+ */
 export function dematerialize<T>(): Observable<any> {
   return this.lift(new DeMaterializeOperator());
 }

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -3,6 +3,13 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
+/**
+ * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from the previous item.
+ * If a comparator function is provided, then it will be called for each item to test for whether or not that value should be emitted.
+ * If a comparator function is not provided, an equality check is used by default.
+ * @param {function} [compare] optional comparison function called to test if an item is distinct from the previous item in the source.
+ * @returns {Observable} an Observable that emits items from the source Observable with distinct values.
+ */
 export function distinctUntilChanged<T>(compare?: (x: any, y: any) => boolean, keySelector?: (x: T) => any) {
   return this.lift(new DistinctUntilChangedOperator(compare, keySelector));
 }

--- a/src/operator/distinctUntilKeyChanged.ts
+++ b/src/operator/distinctUntilKeyChanged.ts
@@ -1,5 +1,14 @@
 import {distinctUntilChanged} from './distinctUntilChanged';
 
+/**
+ * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from the previous item,
+ * using a property accessed by using the key provided to check if the two items are distinct.
+ * If a comparator function is provided, then it will be called for each item to test for whether or not that value should be emitted.
+ * If a comparator function is not provided, an equality check is used by default.
+ * @param {string} key string key for object property lookup on each item.
+ * @param {function} [compare] optional comparison function called to test if an item is distinct from the previous item in the source.
+ * @returns {Observable} an Observable that emits items from the source Observable with distinct values based on the key specified.
+ */
 export function distinctUntilKeyChanged<T>(key: string, compare?: (x: any, y: any) => boolean) {
   return distinctUntilChanged.call(this, function(x, y) {
     if (compare) {

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -6,6 +6,15 @@ import {noop} from '../util/noop';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
+/**
+ * Returns a mirrored Observable of the source Observable, but modified so that the provided Observer is called
+ * for every item emitted by the source.
+ * This operator is useful for debugging your observables for the correct values or performing other side effects.
+ * @param {Observer|function} [nextOrObserver] a normal observer callback or callback for onNext.
+ * @param {function} [error] callback for errors in the source.
+ * @param {function} [complete] callback for the completion of the source.
+ * @reurns {Observable} a mirrored Observable with the specified Observer or callback attached for each item.
+ */
 export function _do<T>(nextOrObserver?: Observer<T>|((x: T) => void), error?: (e: any) => void, complete?: () => void) {
   let next;
   if (nextOrObserver && typeof nextOrObserver === 'object') {

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -2,6 +2,13 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
 
+/**
+ * Returns an Observable that emits the item at the specified index in the source Observable.
+ * If default is given, missing indices will output this value on next; otherwise, outputs error.
+ * @param {number} index the index of the value to be retrieved.
+ * @param {any} [defaultValue] the default value returned for missing indices.
+ * @returns {Observable} an Observable that emits a single item, if it is found. Otherwise, will emit the default value if given.
+ */
 export function elementAt(index: number, defaultValue?: any) {
   return this.lift(new ElementAtOperator(index, defaultValue));
 }

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -8,6 +8,12 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
+/**
+ * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
+ * @param {function} predicate a function for determining if an item meets a specified condition.
+ * @param {any} [thisArg] optional object to use for `this` in the callback
+ * @returns {Observable} an Observable of booleans that determines if all items of the source Observable meet the condition specified.
+ */
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                          thisArg?: any): Observable<boolean> {
   const source = this;

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -5,6 +5,13 @@ import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * Returns an Observable that takes a source of observables and propagates the first observable exclusively
+ * until it completes before subscribing to the next.
+ * Items that come in before the first has exhausted will be dropped.
+ * Similar to `concatAll`, but will not hold on to items that come in before the first is exhausted.
+ * @returns {Observable} an Observable which contains all of the items of the first Observable and following Observables in the source.
+ */
 export function exhaust<T>(): Observable<T> {
   return this.lift(new SwitchFirstOperator());
 }

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -6,6 +6,13 @@ import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * Returns an Observable that applies the given function to each item of the source Observable
+ * to create a new Observable, which are then concatenated together to produce a new Observable.
+ * @param {function} project function called for each item of the source to produce a new Observable.
+ * @param {function} [resultSelector] optional function for then selecting on each inner Observable.
+ * @returns {Observable} an Observable containing all the projected Observables of each item of the source concatenated together.
+ */
 export function exhaustMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
                                      resultSelector?: (outerValue: T,
                                                        innerValue: R,

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -2,6 +2,14 @@ import {Observable} from '../Observable';
 import {Scheduler} from '../Scheduler';
 import {ExpandOperator} from './expand-support';
 
+/**
+ * Returns an Observable where for each item in the source Observable, the supplied function is applied to each item,
+ * resulting in a new value to then be applied again with the function.
+ * @param {function} project the function for projecting the next emitted item of the Observable.
+ * @param {number} [concurrent] the max number of observables that can be created concurrently. defaults to infinity.
+ * @param {Scheduler} [scheduler] The Scheduler to use for managing the expansions.
+ * @returns {Observable} an Observable containing the expansions of the source Observable.
+ */
 export function expand<T, R>(project: (value: T, index: number) => Observable<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,
                              scheduler: Scheduler = undefined): Observable<R> {

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -2,6 +2,12 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ * Returns an Observable that mirrors the source Observable, but will call a specified function when
+ * the source terminates on complete or error.
+ * @param {function} finallySelector function to be called when source terminates.
+ * @returns {Observable} an Observable that mirrors the source, but will call the specified function on termination.
+ */
 export function _finally<T>(finallySelector: () => void) {
   return this.lift(new FinallyOperator(finallySelector));
 }

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -1,6 +1,12 @@
 import {FindValueOperator} from './find-support';
 import {Observable} from '../Observable';
 
+/**
+ * Returns an Observable that searches for the first item in the source Observable that
+ * matches the specified condition, and returns the first occurence in the source.
+ * @param {function} predicate function called with each item to test for condition matching.
+ * @returns {Observable} an Observable of the first item that matches the condition.
+ */
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T> {
   if (typeof predicate !== 'function') {
     throw new TypeError('predicate is not a function');

--- a/src/operator/findIndex.ts
+++ b/src/operator/findIndex.ts
@@ -1,6 +1,12 @@
 import {Observable} from '../Observable';
 import {FindValueOperator} from './find-support';
 
+/**
+ * Returns an Observable that searches for the first item in the source Observable that
+ * matches the specified condition, and returns the the index of the item in the source.
+ * @param {function} predicate function called with each item to test for condition matching.
+ * @returns {Observable} an Observable of the index of the first item that matches the condition.
+ */
 export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<number> {
   return this.lift(new FindValueOperator(predicate, this, true, thisArg));
 }

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -5,6 +5,12 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {EmptyError} from '../util/EmptyError';
 
+/**
+ * Returns an Observable that emits the first item of the source Observable that matches the specified condition.
+ * Throws an error if matching element is not found.
+ * @param {function} predicate function called with each item to test for condition matching.
+ * @returns {Observable} an Observable of the first item that matches the condition.
+ */
 export function first<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
                             resultSelector?: (value: T, index: number) => R,
                             defaultValue?: any): Observable<T> | Observable<R> {

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -4,6 +4,14 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
+/**
+ * Returns an Observable that applies a specified accumulator function to each item emitted by the source Observable.
+ * If a seed value is specified, then that value will be used as the initial value for the accumulator.
+ * If no seed value is specified, the first item of the source is used as the seed.
+ * @param {function} accumulator The accumulator function called on each item.
+ * @param {any} [seed] The initial accumulator value.
+ * @returns {Obervable} An observable of the accumulated values.
+ */
 export function scan<T, R>(accumulator: (acc: R, x: T) => R, seed?: T | R): Observable<R> {
   return this.lift(new ScanOperator(accumulator, seed));
 }


### PR DESCRIPTION
Not much, just simple inline docs written for operators D-F that were missing inline docs.

Some things I did that you may find not so great for ease of reading:

- Each element of the source observable is called an `input`
- The source observable is called the `source`
- Observables are often referred to as simply `sequence` (as in, "input sequence" or "output sequence")
- Each element of the returned/resulting observable is called an `output`
- The returned/resulting observable is often referred to as the `[verb]ed sequence`
- Avoided "invoke" in favor of "called"
- Avoided "project" or "predicate" in favor of just saying "[a] function [that is] called"

With the assumption that anyone looking for the most accurate information possible will probably be looking at the type signatures first, specs second, implementation third, so having a simple-enough explanation is better than being as literate as possible.

Figured I'd stop here for now to see feedback and fix some of my terrible mistakes while there's only a little over a dozen for now.

Also: anyone with strong opinions on JSDoc type signatures?