### PR TITLE
docs(buffer): add PNG diagrams to JSDoc for buffer operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "cover_remapping": "remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.json && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.lcov -t lcovonly && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped -t html",
     "test": "jasmine",
     "test_karma": "karma start karma.conf.js",
-    "tests2png": "mkdirp img && JASMINE_CONFIG_PATH=spec/support/tests2png.json jasmine",
+    "tests2png": "mkdirp tmp/docs/img && JASMINE_CONFIG_PATH=spec/support/tests2png.json jasmine",
     "watch": "watch \"echo triggering build && npm run build_test && echo build completed\" src -d -u -w=15",
     "perf": "protractor protractor.conf.js",
     "perf_micro": "node ./perf/micro/index.js",

--- a/spec/helpers/tests2png/diagram-test-runner.js
+++ b/spec/helpers/tests2png/diagram-test-runner.js
@@ -69,7 +69,7 @@ function postProcessOutputMessage(msg) {
 }
 
 function makeFilename(operatorLabel) {
-  return /^(\w+)/.exec(operatorLabel)[1];
+  return /^(\w+)/.exec(operatorLabel)[1] + '.png';
 }
 
 var glit = global.it;
@@ -94,9 +94,9 @@ global.it.asDiagram = function asDiagram(operatorLabel) {
         var inputStreams = getInputStreams(global.rxTestScheduler);
         global.rxTestScheduler.flush();
         inputStreams = updateInputStreamsPostFlush(inputStreams, rxTestScheduler);
-        var filename = makeFilename(operatorLabel);
+        var filename = './tmp/docs/img/' + makeFilename(operatorLabel);
         painter(inputStreams, operatorLabel, outputStreams, filename);
-        console.log('Painted img/' + filename + '.png');
+        console.log('Painted ' + filename);
       });
     } else {
       throw new Error('Cannot generate PNG marble diagram for async test ' + description);

--- a/spec/helpers/tests2png/painter.js
+++ b/spec/helpers/tests2png/painter.js
@@ -324,7 +324,7 @@ module.exports = function painter(inputStreams, operatorLabel, outputStreams, fi
     heightSoFar += measureStreamHeight(maxFrame)(streamData);
   });
 
-  out.write('./img/' + filename + '.png', function (err) {
+  out.write(filename, function (err) {
     if (err) {
       return console.error(arguments);
     }


### PR DESCRIPTION
Add PNG marble diagram images on the inline documentation for each buffer-like operator, and fix
some typos and mistakes with JSDoc.