### PR TITLE
fix(fromEvent): added spread operator for events that emit more than one argument

### DIFF
--- a/spec/observables/fromEvent-spec.js
+++ b/spec/observables/fromEvent-spec.js
@@ -127,4 +127,75 @@ describe('Observable.fromEvent', function () {
 
     send('test');
   });
+
+  it('should not fail if no event arguments are passed and the selector does not return', function (done) {
+    var send;
+    var obj = {
+      on: function (name, handler) {
+        send = handler;
+      },
+      off: function () {
+      }
+    };
+
+    function selector() {
+    }
+
+    Observable.fromEvent(obj, 'click', selector).take(1)
+      .subscribe(function (e) {
+        expect(e).toBeUndefined();
+      }, function (err) {
+        done.fail('should not be called');
+      }, done);
+
+    send();
+  });
+
+  it('should return a value from the selector if no event arguments are passed', function (done) {
+    var send;
+    var obj = {
+      on: function (name, handler) {
+        send = handler;
+      },
+      off: function () {
+      }
+    };
+
+    function selector() {
+      return 'no arguments';
+    }
+
+    Observable.fromEvent(obj, 'click', selector).take(1)
+      .subscribe(function (e) {
+        expect(e).toBe('no arguments');
+      }, function (err) {
+        done.fail('should not be called');
+      }, done);
+
+    send();
+  });
+
+  it('should pass multiple arguments to selector from event emitter', function (done) {
+    var send;
+    var obj = {
+      on: function (name, handler) {
+        send = handler;
+      },
+      off: function () {
+      }
+    };
+
+    function selector(x, y, z) {
+      return [].slice.call(arguments);
+    }
+
+    Observable.fromEvent(obj, 'click', selector).take(1)
+      .subscribe(function (e) {
+        expect(e).toEqual([1,2,3]);
+      }, function (err) {
+        done.fail('should not be called');
+      }, done);
+
+    send(1, 2, 3);
+  });
 });

--- a/src/observable/fromEvent.ts
+++ b/src/observable/fromEvent.ts
@@ -39,8 +39,8 @@ export class FromEventObservable<T, R> extends Observable<T> {
     const sourceObj = this.sourceObj;
     const eventName = this.eventName;
     const selector = this.selector;
-    let handler = selector ? (e) => {
-      let result = tryCatch(selector)(e);
+    let handler = selector ? (...args) => {
+      let result = tryCatch(selector)(...args);
       if (result === errorObject) {
         subscriber.error(result.e);
       } else {


### PR DESCRIPTION
I added the spread operator to the first expression of the ternary operator, i.e. the condition when a selector is passed. I'm not sure if it makes sense to add it to the second expression. I also modified the spec to test for multiple arguments. 