### PR TITLE
feat(Observable): add let to allow fluent style query building

### DIFF
--- a/spec/operators/let-spec.js
+++ b/spec/operators/let-spec.js
@@ -1,0 +1,24 @@
+/* globals describe, it, expect */
+var Rx = require('../../dist/cjs/Rx');
+var Observable = Rx.Observable;
+
+describe('let', function () {
+  it('should be able to compose with let', function (done) {
+    var expected = ['aa', 'bb'];
+    var i = 0;
+
+    var foo = function (observable) {
+      return observable
+        .map(function (x) {
+          return x + x;
+        });
+    };
+
+    Observable
+      .fromArray(['a','b'])
+      .let(foo)
+      .subscribe(function (x) {
+        expect(x).toBe(expected[i++]);
+      }, null, done);
+  });
+});

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -223,6 +223,8 @@ export class Observable<T> implements CoreOperators<T>  {
   last: <R>(predicate?: (value: T, index: number) => boolean,
             resultSelector?: (value: T, index: number) => R,
             defaultValue?: any) => Observable<T> | Observable<R>;
+  let: <T, R>(func: (selector: Observable<T>) => Observable<R>) => Observable<R>;
+  letBind: <T, R>(func: (selector: Observable<T>) => Observable<R>) => Observable<R>;
   every: (predicate: (value: T, index: number) => boolean, thisArg?: any) => Observable<T>;
   map: <R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
   mapTo: <R>(value: R) => Observable<R>;

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -56,6 +56,7 @@ import './add/operator/groupBy';
 import './add/operator/ignoreElements';
 import './add/operator/every';
 import './add/operator/last';
+import './add/operator/let';
 import './add/operator/map';
 import './add/operator/mapTo';
 import './add/operator/materialize';

--- a/src/add/operator/let.ts
+++ b/src/add/operator/let.ts
@@ -1,0 +1,4 @@
+import {Observable} from '../../Observable';
+import {letProto} from '../../operator/let';
+Observable.prototype.let = letProto;
+Observable.prototype.letBind = letProto;

--- a/src/operator/let.ts
+++ b/src/operator/let.ts
@@ -1,0 +1,5 @@
+import {Observable} from '../Observable';
+
+export function letProto<T, R>(func: (selector: Observable<T>) => Observable<R>): Observable<R> {
+  return func(this);
+}

--- a/tools/generate-operator-patches.ts
+++ b/tools/generate-operator-patches.ts
@@ -42,12 +42,14 @@ const SpecialCasePrototypes = {
   'switch.ts': 'switch',
   'do.ts': 'do',
   'finally.ts': 'finally',
-  'catch.ts': 'catch'
+  'catch.ts': 'catch',
+  'let.ts': 'let'
 };
 
 const AdditionalAliases = {
   'mergeMap.ts': ['flatMap'],
-  'fromArray.ts': ['of']
+  'fromArray.ts': ['of'],
+  'let.ts': ['letBind']
 };
 
 const AliasMethodOverrides = {


### PR DESCRIPTION
Add let (and letBind for legacy browsers) operators, exactly like currently available in RxJS 4
(https://github.com/Reactive-Extensions/RxJS/blob/master/doc/api/core/operators/let.md)

I don't know if this operator is left out intentionally, but I like having it in RxJS 4 and it is missing here. Any specific reasons why it is not included, or has it just not been picked up yet?

Here's a pull request implementing the feature in the same way is it works in RxJS 4. Simple, but really useful.