### PR TITLE
The Subscriber refactor, operator updates, and scheduling fixes.

### DIFF
--- a/spec/Observable-spec.js
+++ b/spec/Observable-spec.js
@@ -121,13 +121,6 @@ describe('Observable', function () {
       expect(unsubscribeCalled).toBe(true);
     });
 
-    it('should return the given subject when called with a Subject', function () {
-      var source = Observable.of(42);
-      var subject = new Rx.Subject();
-      var subscriber = source.subscribe(subject);
-      expect(subscriber).toBe(subject);
-    });
-
     describe('when called with an anonymous observer', function () {
       it('should accept an anonymous observer with just a next function', function () {
         Observable.of(1).subscribe({

--- a/spec/Subject-spec.js
+++ b/spec/Subject-spec.js
@@ -21,7 +21,7 @@ describe('Subject', function () {
 
   it('should have the rxSubscriber Symbol', function () {
     var subject = new Subject();
-    expect(subject[Rx.Symbol.rxSubscriber]()).toBe(subject);
+    expect(typeof subject[Rx.Symbol.rxSubscriber]).toBe('function');
   });
 
   it('should pump values to multiple subscribers', function (done) {

--- a/spec/helpers/test-helper.js
+++ b/spec/helpers/test-helper.js
@@ -21,10 +21,23 @@ var glit = global.it;
 
 global.it = function (description, cb, timeout) {
   if (cb.length === 0) {
-    glit(description, function () {
+    glit(description, function (done) {
       global.rxTestScheduler = new Rx.TestScheduler(assertDeepEqual);
-      cb();
-      global.rxTestScheduler.flush();
+      var error;
+      var errorHappened = false;
+      try {
+        cb();
+        global.rxTestScheduler.flush();
+      } catch (e) {
+        errorHappened = true;
+        error = e;
+      } finally {
+        if (errorHappened) {
+          setTimeout(function () { done.fail(error); });
+        } else {
+          setTimeout(function () { done(); });
+        }
+      }
     });
   } else {
     glit.apply(this, arguments);
@@ -39,10 +52,23 @@ var glfit = global.fit;
 
 global.fit = function (description, cb, timeout) {
   if (cb.length === 0) {
-    glfit(description, function () {
+    glfit(description, function (done) {
       global.rxTestScheduler = new Rx.TestScheduler(assertDeepEqual);
-      cb();
-      global.rxTestScheduler.flush();
+      var error;
+      var errorHappened = false;
+      try {
+        cb();
+        global.rxTestScheduler.flush();
+      } catch (e) {
+        errorHappened = true;
+        error = e;
+      } finally {
+        if (errorHappened) {
+          setTimeout(function () { done.fail(error); });
+        } else {
+          setTimeout(function () { done(); });
+        }
+      }
     });
   } else {
     glfit.apply(this, arguments);

--- a/spec/schedulers/AsapScheduler-spec.js
+++ b/spec/schedulers/AsapScheduler-spec.js
@@ -1,0 +1,47 @@
+/* globals describe, it, expect, expectObservable, expectSubscriptions, rxTestScheduler, hot, cold */
+var Rx = require('../../dist/cjs/Rx.KitchenSink');
+var asap = Rx.Scheduler.asap;
+var Notification = Rx.Notification;
+
+describe('AsapScheduler', function () {
+  it('should exist', function () {
+    expect(asap).toBeDefined();
+  });
+
+  it('should schedule an action to happen later', function (done) {
+    var actionHappened = false;
+    asap.schedule(function () {
+      actionHappened = true;
+      done();
+    });
+    if (actionHappened) {
+      done.fail('Scheduled action happened synchronously');
+    }
+  });
+
+  it('should execute the rest of the scheduled actions if the first action is canceled', function (done) {
+    var actionHappened = false;
+    var firstSubscription = null;
+    var secondSubscription = null;
+
+    firstSubscription = asap.schedule(function () {
+      actionHappened = true;
+      if (secondSubscription) {
+        secondSubscription.unsubscribe();
+      }
+      done.fail('The first action should not have executed.');
+    });
+
+    secondSubscription = asap.schedule(function () {
+      if (!actionHappened) {
+        done();
+      }
+    });
+
+    if (actionHappened) {
+      done.fail('Scheduled action happened synchronously');
+    } else {
+      firstSubscription.unsubscribe();
+    }
+  });
+});

--- a/src/InnerSubscriber.ts
+++ b/src/InnerSubscriber.ts
@@ -2,22 +2,23 @@ import {Subscriber} from './Subscriber';
 import {OuterSubscriber} from './OuterSubscriber';
 
 export class InnerSubscriber<T, R> extends Subscriber<R> {
-  index: number = 0;
+  private index: number = 0;
 
   constructor(private parent: OuterSubscriber<T, R>, private outerValue: T, private outerIndex: number) {
     super();
   }
 
   _next(value: R) {
-    const index = this.index++;
-    this.parent.notifyNext(this.outerValue, value, this.outerIndex, index);
+    this.parent.notifyNext(this.outerValue, value, this.outerIndex, this.index++);
   }
 
   _error(error: any) {
     this.parent.notifyError(error, this);
+    this.unsubscribe();
   }
 
   _complete() {
     this.parent.notifyComplete(this);
+    this.unsubscribe();
   }
 }

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -64,15 +64,6 @@ export class Observable<T> implements CoreOperators<T>  {
   }
 
   /**
-   * @method Symbol.observable
-   * @returns {Observable} this instance of the observable
-   * @description an interop point defined by the es7-observable spec https://github.com/zenparsing/es-observable
-   */
-  [SymbolShim.observable]() {
-    return this;
-  }
-
-  /**
    * @method subscribe
    * @param {Observer|Function} observerOrNext (optional) either an observer defining all functions to be called,
    *  or the first of three possible handlers, which is the handler for each value emitted from the observable.
@@ -274,4 +265,13 @@ export class Observable<T> implements CoreOperators<T>  {
   withLatestFrom: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
   zip: <R>(...observables: Array<Observable<any> | ((...values: Array<any>) => R)>) => Observable<R>;
   zipAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
+
+  /**
+   * @method Symbol.observable
+   * @returns {Observable} this instance of the observable
+   * @description an interop point defined by the es7-observable spec https://github.com/zenparsing/es-observable
+   */
+  [SymbolShim.observable]() {
+    return this;
+  }
 }

--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -1,6 +1,13 @@
 export interface Observer<T> {
-  next?: (value: T) => void;
-  error?: (err?: any) => void;
-  complete?: () => void;
-  isUnsubscribed?: boolean;
+  isUnsubscribed: boolean;
+  next(value: T): void;
+  error(error: any): void;
+  complete(): void;
 }
+
+export const empty: Observer<any> = {
+  isUnsubscribed: true,
+  next(value: any): void { /* noop */},
+  error(err: any): void { throw err; },
+  complete(): void { /*noop*/ }
+};

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -1,10 +1,7 @@
-import {Observer} from './Observer';
 import {Subscriber} from './Subscriber';
 
-export interface Operator<T, R> {
-  call<T, R>(subscriber: Subscriber<R>): Subscriber<T>;
-}
-
-export function defaultCallFn<T, R>(observer: Observer<R>): Observer<T> {
-  return new Subscriber<T>(observer);
+export class Operator<T, R> {
+  call<T, R>(subscriber: Subscriber<R>): Subscriber<T> {
+    return new Subscriber<T>(subscriber);
+  }
 }

--- a/src/OuterSubscriber.ts
+++ b/src/OuterSubscriber.ts
@@ -1,16 +1,16 @@
-import {InnerSubscriber} from './InnerSubscriber';
 import {Subscriber} from './Subscriber';
+import {InnerSubscriber} from './InnerSubscriber';
 
 export class OuterSubscriber<T, R> extends Subscriber<T> {
-  notifyComplete(inner?: InnerSubscriber<T, R>): void {
-    this.destination.complete();
-  }
-
   notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
     this.destination.next(innerValue);
   }
 
-  notifyError(error?: any, inner?: InnerSubscriber<T, R>): void {
+  notifyError(error: any, innerSub: InnerSubscriber<T, R>): void {
     this.destination.error(error);
+  }
+
+  notifyComplete(innerSub: InnerSubscriber<T, R>): void {
+    this.destination.complete();
   }
 }

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -5,7 +5,7 @@ export interface Scheduler {
   now(): number;
   schedule<T>(work: (state?: any) => Subscription|void, delay?: number, state?: any): Subscription;
   flush(): void;
-  actions: Action[];
-  scheduled: boolean;
   active: boolean;
+  actions: Action[];
+  scheduledId: number;
 }

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -6,78 +6,78 @@ import {Subscription} from './Subscription';
 import {SubjectSubscription} from './subject/SubjectSubscription';
 import {rxSubscriber} from './symbol/rxSubscriber';
 
-const subscriptionAdd = Subscription.prototype.add;
-const subscriptionRemove = Subscription.prototype.remove;
-const subscriptionUnsubscribe = Subscription.prototype.unsubscribe;
-
-const subscriberNext = Subscriber.prototype.next;
-const subscriberError = Subscriber.prototype.error;
-const subscriberComplete = Subscriber.prototype.complete;
-const _subscriberNext = Subscriber.prototype._next;
-const _subscriberError = Subscriber.prototype._error;
-const _subscriberComplete = Subscriber.prototype._complete;
-
 export class Subject<T> extends Observable<T> implements Observer<T>, Subscription {
-  _subscriptions: Subscription[];
-  _unsubscribe: () => void;
-
-  [rxSubscriber]() {
-    return this;
-  }
 
   static create<T>(source: Observable<T>, destination: Observer<T>): Subject<T> {
-    return new BidirectionalSubject(source, destination);
+    return new Subject(source, destination);
   }
+
+  constructor(source?: Observable<T>, destination?: Observer<T>) {
+    super();
+    this.source = source;
+    this.destination = destination;
+  }
+
+  public observers: Observer<T>[] = [];
+  public isUnsubscribed: boolean = false;
 
   protected destination: Observer<T>;
 
-  observers: Observer<T>[] = [];
-  isUnsubscribed: boolean = false;
-
-  dispatching: boolean = false;
-  errorSignal: boolean = false;
-  errorInstance: any;
-  completeSignal: boolean = false;
+  protected isStopped: boolean = false;
+  protected hasErrored: boolean = false;
+  protected errorValue: any;
+  protected dispatching: boolean = false;
+  protected hasCompleted: boolean = false;
 
   lift<T, R>(operator: Operator<T, R>): Observable<T> {
-    const subject = new BidirectionalSubject(this, this.destination || this);
+    const subject = new Subject(this, this.destination || this);
     subject.operator = operator;
     return subject;
   }
 
-  _subscribe(subscriber: Subscriber<any>): Subscription {
-    if (subscriber.isUnsubscribed) {
-      return;
-    } else if (this.errorSignal) {
-      subscriber.error(this.errorInstance);
-      return;
-    } else if (this.completeSignal) {
-      subscriber.complete();
-      return;
-    } else if (this.isUnsubscribed) {
-      throw new Error('Cannot subscribe to a disposed Subject.');
+  add(subscription: Subscription|Function|void): void {
+    Subscription.prototype.add.call(this, subscription);
+  }
+
+  remove(subscription: Subscription): void {
+    Subscription.prototype.remove.call(this, subscription);
+  }
+
+  unsubscribe(): void {
+    Subscription.prototype.unsubscribe.call(this);
+  }
+
+  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+    if (this.source) {
+      return this.source.subscribe(subscriber);
+    } else {
+      if (subscriber.isUnsubscribed) {
+        return;
+      } else if (this.hasErrored) {
+        return subscriber.error(this.errorValue);
+      } else if (this.hasCompleted) {
+        return subscriber.complete();
+      } else if (this.isUnsubscribed) {
+        throw new Error('Cannot subscribe to a disposed Subject.');
+      }
+
+      const subscription = new SubjectSubscription(this, subscriber);
+
+      this.observers.push(subscriber);
+
+      return subscription;
     }
-
-    this.observers.push(subscriber);
-
-    return new SubjectSubscription(this, subscriber);
   }
 
-  add(subscription?) {
-    subscriptionAdd.call(this, subscription);
-  }
-
-  remove(subscription?) {
-    subscriptionRemove.call(this, subscription);
-  }
-
-  unsubscribe() {
-    this.observers = void 0;
-    subscriptionUnsubscribe.call(this);
+  _unsubscribe(): void {
+    this.source = null;
+    this.isStopped = true;
+    this.observers = null;
+    this.destination = null;
   }
 
   next(value: T): void {
-    if (this.isUnsubscribed) {
+    if (this.isStopped) {
       return;
     }
 
@@ -85,118 +85,105 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     this._next(value);
     this.dispatching = false;
 
-    if (this.errorSignal) {
-      this.error(this.errorInstance);
-    } else if (this.completeSignal) {
-      this.complete();
+    if (this.hasErrored) {
+      this._error(this.errorValue);
+    } else if (this.hasCompleted) {
+      this._complete();
     }
   }
 
   error(err?: any): void {
-    if (this.isUnsubscribed || this.completeSignal) {
+    if (this.isStopped) {
       return;
     }
 
-    this.errorSignal = true;
-    this.errorInstance = err;
+    this.isStopped = true;
+    this.hasErrored = true;
+    this.errorValue = err;
 
     if (this.dispatching) {
       return;
     }
 
     this._error(err);
-    this.unsubscribe();
   }
 
   complete(): void {
-    if (this.isUnsubscribed || this.errorSignal) {
+    if (this.isStopped) {
       return;
     }
 
-    this.completeSignal = true;
+    this.isStopped = true;
+    this.hasCompleted = true;
 
     if (this.dispatching) {
       return;
     }
 
     this._complete();
-    this.unsubscribe();
   }
 
   _next(value: T): void {
-    let index = -1;
-    const observers = this.observers.slice(0);
-    const len = observers.length;
+    if (this.destination) {
+      this.destination.next(value);
+    } else {
+      let index = -1;
+      const observers = this.observers.slice(0);
+      const len = observers.length;
 
-    while (++index < len) {
-      observers[index].next(value);
+      while (++index < len) {
+        observers[index].next(value);
+      }
     }
   }
 
   _error(err: any): void {
-    let index = -1;
-    const observers = this.observers;
-    const len = observers.length;
+    if (this.destination) {
+      this.destination.error(err);
+    } else {
+      let index = -1;
+      const observers = this.observers;
+      const len = observers.length;
 
-    // optimization -- block next, complete, and unsubscribe while dispatching
-    this.observers = void 0;
-    this.isUnsubscribed = true;
+      // optimization to block our SubjectSubscriptions from
+      // splicing themselves out of the observers list one by one.
+      this.observers = null;
+      this.isUnsubscribed = true;
 
-    while (++index < len) {
-      observers[index].error(err);
+      while (++index < len) {
+        observers[index].error(err);
+      }
+
+      this.isUnsubscribed = false;
+
+      this.unsubscribe();
     }
-
-    this.isUnsubscribed = false;
   }
 
   _complete(): void {
-    let index = -1;
-    const observers = this.observers;
-    const len = observers.length;
+    if (this.destination) {
+      this.destination.complete();
+    } else {
+      let index = -1;
+      const observers = this.observers;
+      const len = observers.length;
 
-    // optimization -- block next, complete, and unsubscribe while dispatching
-    this.observers = void 0; // optimization
-    this.isUnsubscribed = true;
+      // optimization to block our SubjectSubscriptions from
+      // splicing themselves out of the observers list one by one.
+      this.observers = null;
+      this.isUnsubscribed = true;
 
-    while (++index < len) {
-      observers[index].complete();
+      while (++index < len) {
+        observers[index].complete();
+      }
+
+      this.isUnsubscribed = false;
+
+      this.unsubscribe();
     }
-
-    this.isUnsubscribed = false;
-  }
-}
-
-class BidirectionalSubject<T> extends Subject<T> {
-  constructor(public source: Observable<any>, protected destination: Observer<any>) {
-    super();
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription {
-    const operator = this.operator;
-    return this.source._subscribe.call(this.source, operator ? operator.call(subscriber) : subscriber);
-  }
-
-  next(value?: T): void {
-    subscriberNext.call(this, value);
-  }
-
-  error(err?: any): void {
-    subscriberError.call(this, err);
-  }
-
-  complete(): void {
-    subscriberComplete.call(this);
-  }
-
-  _next(value: T): void {
-    _subscriberNext.call(this, value);
-  }
-
-  _error(err: any): void {
-    _subscriberError.call(this, err);
-  }
-
-  _complete(): void {
-    _subscriberComplete.call(this);
+  [rxSubscriber]() {
+    return new Subscriber<T>(this);
   }
 }

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -1,7 +1,7 @@
 import {Subject} from '../Subject';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
+import {Subscription} from '../Subscription';
 
 export class ConnectableObservable<T> extends Observable<T> {
 
@@ -48,9 +48,9 @@ class ConnectableSubscription<T> extends Subscription {
 
   _unsubscribe() {
     const connectable = this.connectable;
-    connectable.subject = void 0;
-    connectable.subscription = void 0;
-    this.connectable = void 0;
+    connectable.subject = null;
+    connectable.subscription = null;
+    this.connectable = null;
   }
 }
 
@@ -104,7 +104,7 @@ class RefCountSubscriber<T> extends Subscriber<T> {
     if (subConnection && subConnection === obsConnection) {
       observable.refCount = 0;
       obsConnection.unsubscribe();
-      observable.connection = void 0;
+      observable.connection = null;
       this.unsubscribe();
     }
   }
@@ -119,7 +119,7 @@ class RefCountSubscriber<T> extends Subscriber<T> {
       const subConnection = this.connection;
       if (subConnection && subConnection === obsConnection) {
         obsConnection.unsubscribe();
-        observable.connection = void 0;
+        observable.connection = null;
       }
     }
   }

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -83,15 +83,15 @@ export class IteratorObservable<T> extends Observable<T> {
     this.iterator = getIterator(iterator);
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber): Subscription | Function | void {
 
     let index = 0;
     const { iterator, project, thisArg, scheduler } = this;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(IteratorObservable.dispatch, 0, {
+      return scheduler.schedule(IteratorObservable.dispatch, 0, {
         index, thisArg, project, iterator, subscriber
-      }));
+      });
     } else {
       do {
         let result = iterator.next();

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -1,6 +1,7 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
+import {Subscription} from '../Subscription';
 
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
@@ -35,14 +36,14 @@ export class ScalarObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     const value = this.value;
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(ScalarObservable.dispatch, 0, {
+      return scheduler.schedule(ScalarObservable.dispatch, 0, {
         done: false, value, subscriber
-      }));
+      });
     } else {
       subscriber.next(value);
       if (!subscriber.isUnsubscribed) {

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -31,8 +31,8 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     const source = this.source;
     const scheduler = this.scheduler;
 
-    subscriber.add(scheduler.schedule(SubscribeOnObservable.dispatch, delay, {
+    return scheduler.schedule(SubscribeOnObservable.dispatch, delay, {
       source, subscriber
-    }));
+    });
   }
 }

--- a/src/observable/empty.ts
+++ b/src/observable/empty.ts
@@ -1,5 +1,6 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
+import {Subscription} from '../Subscription';
 
 export class EmptyObservable<T> extends Observable<T> {
 
@@ -15,12 +16,12 @@ export class EmptyObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber): Subscription | Function | void {
 
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(EmptyObservable.dispatch, 0, { subscriber }));
+      return scheduler.schedule(EmptyObservable.dispatch, 0, { subscriber });
     } else {
       subscriber.complete();
     }

--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -9,8 +9,6 @@ import {SymbolShim} from '../util/SymbolShim';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {ObserveOnSubscriber} from '../operator/observeOn-support';
-import {queue} from '../scheduler/queue';
-
 
 export class FromObservable<T> extends Observable<T> {
   constructor(private ish: any, private scheduler: Scheduler) {
@@ -39,7 +37,7 @@ export class FromObservable<T> extends Observable<T> {
   _subscribe(subscriber: Subscriber<T>) {
     const ish = this.ish;
     const scheduler = this.scheduler;
-    if (scheduler === queue) {
+    if (scheduler == null) {
       return ish[SymbolShim.observable]().subscribe(subscriber);
     } else {
       return ish[SymbolShim.observable]().subscribe(new ObserveOnSubscriber(subscriber, scheduler, 0));

--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -1,3 +1,5 @@
+import {isArray} from '../util/isArray';
+import {isPromise} from '../util/isPromise';
 import {PromiseObservable} from './fromPromise';
 import {IteratorObservable} from'./IteratorObservable';
 import {ArrayObservable} from './fromArray';
@@ -9,30 +11,29 @@ import {Subscriber} from '../Subscriber';
 import {ObserveOnSubscriber} from '../operator/observeOn-support';
 import {queue} from '../scheduler/queue';
 
-const isArray = Array.isArray;
 
 export class FromObservable<T> extends Observable<T> {
   constructor(private ish: any, private scheduler: Scheduler) {
     super(null);
   }
 
-  static create<T>(ish: any, scheduler: Scheduler = queue): Observable<T> {
-    if (ish) {
-      if (isArray(ish)) {
-        return new ArrayObservable(ish, scheduler);
-      } else if (typeof ish.then === 'function') {
-        return new PromiseObservable(ish, scheduler);
-      } else if (typeof ish[SymbolShim.observable] === 'function') {
-        if (ish instanceof Observable) {
+  static create<T>(ish: any, scheduler: Scheduler = null): Observable<T> {
+    if (ish != null) {
+      if (typeof ish[SymbolShim.observable] === 'function') {
+        if (ish instanceof Observable && !scheduler) {
           return ish;
         }
         return new FromObservable(ish, scheduler);
+      } if (isArray(ish)) {
+        return new ArrayObservable(ish, scheduler);
+      } else if (isPromise(ish)) {
+        return new PromiseObservable(ish, scheduler);
       } else if (typeof ish[SymbolShim.iterator] === 'function') {
         return new IteratorObservable(ish, null, null, scheduler);
       }
     }
 
-    throw new TypeError((typeof ish) + ' is not observable');
+    throw new TypeError((ish !== null && typeof ish || ish) + ' is not observable');
   }
 
   _subscribe(subscriber: Subscriber<T>) {

--- a/src/observable/fromArray.ts
+++ b/src/observable/fromArray.ts
@@ -15,7 +15,7 @@ export class ArrayObservable<T> extends Observable<T> {
     if (isScheduler(scheduler)) {
       array.pop();
     } else {
-      scheduler = void 0;
+      scheduler = null;
     }
 
     const len = array.length;

--- a/src/observable/fromArray.ts
+++ b/src/observable/fromArray.ts
@@ -3,6 +3,7 @@ import {Observable} from '../Observable';
 import {ScalarObservable} from './ScalarObservable';
 import {EmptyObservable} from './empty';
 import {isScheduler} from '../util/isScheduler';
+import {Subscription} from '../Subscription';
 
 export class ArrayObservable<T> extends Observable<T> {
 
@@ -59,7 +60,7 @@ export class ArrayObservable<T> extends Observable<T> {
     }
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber): Subscription | Function | void {
 
     let index = 0;
     const array = this.array;
@@ -67,9 +68,9 @@ export class ArrayObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(ArrayObservable.dispatch, 0, {
+      return scheduler.schedule(ArrayObservable.dispatch, 0, {
         array, index, count, subscriber
-      }));
+      });
     } else {
       for (let i = 0; i < count && !subscriber.isUnsubscribed; i++) {
         subscriber.next(array[i]);

--- a/src/observable/fromPromise.ts
+++ b/src/observable/fromPromise.ts
@@ -3,17 +3,16 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
-import {queue} from '../scheduler/queue';
 
 export class PromiseObservable<T> extends Observable<T> {
 
   public value: T;
 
-  static create<T>(promise: Promise<T>, scheduler: Scheduler = queue): Observable<T> {
+  static create<T>(promise: Promise<T>, scheduler: Scheduler = null): Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }
 
-  constructor(private promise: Promise<T>, public scheduler: Scheduler = queue) {
+  constructor(private promise: Promise<T>, public scheduler: Scheduler = null) {
     super();
   }
 
@@ -21,7 +20,7 @@ export class PromiseObservable<T> extends Observable<T> {
     const promise = this.promise;
     const scheduler = this.scheduler;
 
-    if (scheduler === queue) {
+    if (scheduler == null) {
       if (this._isScalar) {
         if (!subscriber.isUnsubscribed) {
           subscriber.next(this.value);

--- a/src/observable/range.ts
+++ b/src/observable/range.ts
@@ -1,5 +1,6 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
+import {Subscription} from '../Subscription';
 
 export class RangeObservable<T> extends Observable<T> {
 
@@ -39,7 +40,7 @@ export class RangeObservable<T> extends Observable<T> {
     this.scheduler = scheduler;
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber): Subscription | Function | void {
 
     let index = 0;
     let start = this.start;
@@ -47,9 +48,9 @@ export class RangeObservable<T> extends Observable<T> {
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(RangeObservable.dispatch, 0, {
+      return scheduler.schedule(RangeObservable.dispatch, 0, {
         index, end, start, subscriber
-      }));
+      });
     } else {
       do {
         if (index++ >= end) {

--- a/src/observable/throw.ts
+++ b/src/observable/throw.ts
@@ -1,5 +1,6 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
+import {Subscription} from '../Subscription';
 
 export class ErrorObservable<T> extends Observable<T> {
 
@@ -15,15 +16,15 @@ export class ErrorObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber) {
+  _subscribe(subscriber): Subscription | Function | void {
 
     const error = this.error;
     const scheduler = this.scheduler;
 
     if (scheduler) {
-      subscriber.add(scheduler.schedule(ErrorObservable.dispatch, 0, {
+      return scheduler.schedule(ErrorObservable.dispatch, 0, {
         error, subscriber
-      }));
+      });
     } else {
       subscriber.error(error);
     }

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -59,10 +59,6 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err: any) {
-    this.destination.error(err);
-  }
-
   _complete() {
     const destination = this.destination;
     const buffers = this.buffers;
@@ -72,6 +68,6 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
         destination.next(buffer);
       }
     }
-    destination.complete();
+    super._complete();
   }
 }

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -62,15 +62,19 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
 
   _error(err) {
     this.buffers.length = 0;
-    this.destination.error(err);
+    super._error(err);
   }
 
   _complete() {
-    const buffers = this.buffers;
+    const { buffers, destination } = this;
     while (buffers.length > 0) {
-      this.destination.next(buffers.shift());
+      destination.next(buffers.shift());
     }
-    this.destination.complete();
+    super._complete();
+  }
+
+  _unsubscribe() {
+    this.buffers = null;
   }
 
   openBuffer(): T[] {

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -41,7 +41,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
               private openings: Observable<O>,
               private closingSelector: (openValue: O) => Observable<any>) {
     super(destination);
-    this.add(this.openings._subscribe(new BufferToggleOpeningsSubscriber(this)));
+    this.add(this.openings.subscribe(new BufferToggleOpeningsSubscriber(this)));
   }
 
   _next(value: T) {
@@ -61,7 +61,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
       context.subscription = null;
     }
     this.contexts = null;
-    this.destination.error(err);
+    super._error(err);
   }
 
   _complete() {
@@ -74,7 +74,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
       context.subscription = null;
     }
     this.contexts = null;
-    this.destination.complete();
+    super._complete();
   }
 
   openBuffer(value: O) {
@@ -91,7 +91,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
       };
       contexts.push(context);
       const subscriber = new BufferToggleClosingsSubscriber(this, context);
-      const subscription = closingNotifier._subscribe(subscriber);
+      const subscription = closingNotifier.subscribe(subscriber);
       context.subscription.add(subscription);
       this.add(subscription);
     }

--- a/src/operator/concat-static.ts
+++ b/src/operator/concat-static.ts
@@ -1,6 +1,5 @@
 import {Observable} from '../Observable';
 import {Scheduler} from '../Scheduler';
-import {queue} from '../scheduler/queue';
 import {MergeAllOperator} from './mergeAll-support';
 import {ArrayObservable} from '../observable/fromArray';
 import {isScheduler} from '../util/isScheduler';
@@ -13,7 +12,7 @@ import {isScheduler} from '../util/isScheduler';
  * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
  */
 export function concat<R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
-  let scheduler: Scheduler = queue;
+  let scheduler: Scheduler = null;
   let args = <any[]>observables;
   if (isScheduler(args[observables.length - 1])) {
     scheduler = args.pop();

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -1,14 +1,14 @@
+import {asap} from '../scheduler/asap';
+import {isDate} from '../util/isDate';
 import {Operator} from '../Operator';
 import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
-import {queue} from '../scheduler/queue';
-import {isDate} from '../util/isDate';
 
 export function delay<T>(delay: number|Date,
-                         scheduler: Scheduler = queue) {
+                         scheduler: Scheduler = asap) {
   const absoluteDelay = isDate(delay);
-  const delayFor = absoluteDelay ? (+delay - scheduler.now()) : <number>delay;
+  const delayFor = absoluteDelay ? (+delay - scheduler.now()) : Math.abs(<number>delay);
   return this.lift(new DelayOperator(delayFor, scheduler));
 }
 

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -37,14 +37,6 @@ class SwitchFirstSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: any): void {
-    this.destination.next(innerValue);
-  }
-
-  notifyError(err: any): void {
-    this.destination.error(err);
-  }
-
   notifyComplete(innerSub: Subscription): void {
     this.remove(innerSub);
     this.hasSubscription = false;

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -16,8 +16,8 @@ class SwitchFirstOperator<T, R> implements Operator<T, R> {
 }
 
 class SwitchFirstSubscriber<T, R> extends OuterSubscriber<T, R> {
-  private hasSubscription: boolean = false;
   private hasCompleted: boolean = false;
+  private hasSubscription: boolean = false;
 
   constructor(destination: Subscriber<R>) {
     super(destination);

--- a/src/operator/expand-support.ts
+++ b/src/operator/expand-support.ts
@@ -4,8 +4,8 @@ import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
+import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
-import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export class ExpandOperator<T, R> implements Operator<T, R> {
@@ -80,7 +80,11 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyComplete(innerSub?: InnerSubscriber<T, R>): void {
+  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+    this._next(innerValue);
+  }
+
+  notifyComplete(innerSub: Subscription): void {
     const buffer = this.buffer;
     this.remove(innerSub);
     this.active--;
@@ -90,9 +94,5 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (this.hasCompleted && this.active === 0) {
       this.destination.complete();
     }
-  }
-
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
-    this._next(innerValue);
   }
 }

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -69,7 +69,7 @@ class GroupBySubscriber<T, R> extends Subscriber<T> {
           if (duration === errorObject) {
             this.error(duration.e);
           } else {
-            this.add(duration._subscribe(new GroupDurationSubscriber(key, group, this)));
+            this.add(duration.subscribe(new GroupDurationSubscriber(key, group, this)));
           }
         }
 

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -120,7 +120,7 @@ class GroupDurationSubscriber<T> extends Subscriber<T> {
   constructor(private key: string,
               private group: Subject<T>,
               private parent: GroupBySubscriber<any, T>) {
-    super(null);
+    super();
   }
 
   _next(value: T): void {

--- a/src/operator/merge-static.ts
+++ b/src/operator/merge-static.ts
@@ -2,12 +2,11 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {ArrayObservable} from '../observable/fromArray';
 import {MergeAllOperator} from './mergeAll-support';
-import {queue} from '../scheduler/queue';
 import {isScheduler} from '../util/isScheduler';
 
 export function merge<R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
- let scheduler: Scheduler = queue;
+ let scheduler: Scheduler = null;
   let last: any = observables[observables.length - 1];
   if (isScheduler(last)) {
     scheduler = <Scheduler>observables.pop();

--- a/src/operator/mergeMapTo-support.ts
+++ b/src/operator/mergeMapTo-support.ts
@@ -4,9 +4,9 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
+import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
-import {InnerSubscriber} from '../InnerSubscriber';
 
 export class MergeMapToOperator<T, R, R2> implements Operator<T, R> {
   constructor(private ish: any,
@@ -79,7 +79,7 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     this.destination.error(err);
   }
 
-  notifyComplete(innerSub: InnerSubscriber<T, R>): void {
+  notifyComplete(innerSub: Subscription): void {
     const buffer = this.buffer;
     this.remove(innerSub);
     this.active--;

--- a/src/operator/startWith.ts
+++ b/src/operator/startWith.ts
@@ -11,7 +11,7 @@ export function startWith<T>(...array: (T | Scheduler)[]): Observable<T> {
   if (isScheduler(scheduler)) {
     array.pop();
   } else {
-    scheduler = void 0;
+    scheduler = null;
   }
 
   const len = array.length;

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -54,28 +54,22 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
   }
 
   _complete(): void {
-    const innerSubscription = this.innerSubscription;
-    this.hasCompleted = true;
+    const {innerSubscription} = this;
     if (!innerSubscription || innerSubscription.isUnsubscribed) {
-      this.destination.complete();
+      super._complete();
     }
+  }
+
+  _unsubscribe() {
+    this.innerSubscription = null;
   }
 
   notifyComplete(innerSub: Subscription): void {
     this.remove(innerSub);
-    const prevSubscription = this.innerSubscription;
-    if (prevSubscription) {
-      prevSubscription.unsubscribe();
-    }
     this.innerSubscription = null;
-
-    if (this.hasCompleted) {
-      this.destination.complete();
+    if (this.isStopped) {
+      super._complete();
     }
-  }
-
-  notifyError(err: any): void {
-    this.destination.error(err);
   }
 
   notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -29,9 +29,8 @@ class SwitchMapOperator<T, R, R2> implements Operator<T, R> {
 }
 
 class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
-  private innerSubscription: Subscription;
-  private hasCompleted = false;
   private index: number = 0;
+  private innerSubscription: Subscription;
 
   constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => Observable<R>,

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -47,28 +47,22 @@ class SwitchMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
   }
 
   _complete() {
-    const innerSubscription = this.innerSubscription;
-    this.hasCompleted = true;
+    const {innerSubscription} = this;
     if (!innerSubscription || innerSubscription.isUnsubscribed) {
-      this.destination.complete();
+      super._complete();
     }
+  }
+
+  _unsubscribe() {
+    this.innerSubscription = null;
   }
 
   notifyComplete(innerSub: Subscription) {
     this.remove(innerSub);
-    const prevSubscription = this.innerSubscription;
-    if (prevSubscription) {
-      prevSubscription.unsubscribe();
-    }
     this.innerSubscription = null;
-
-    if (this.hasCompleted) {
-      this.destination.complete();
+    if (this.isStopped) {
+      super._complete();
     }
-  }
-
-  notifyError(err: any) {
-    this.destination.error(err);
   }
 
   notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -29,9 +29,8 @@ class SwitchMapToOperator<T, R, R2> implements Operator<T, R> {
 }
 
 class SwitchMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
+  private index: number = 0;
   private innerSubscription: Subscription;
-  private hasCompleted = false;
-  index: number = 0;
 
   constructor(destination: Subscriber<R>,
               private inner: Observable<R>,
@@ -40,12 +39,11 @@ class SwitchMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
   }
 
   _next(value: any) {
-    const index = this.index++;
     const innerSubscription = this.innerSubscription;
     if (innerSubscription) {
       innerSubscription.unsubscribe();
     }
-    this.add(this.innerSubscription = subscribeToResult(this, this.inner, value, index));
+    this.add(this.innerSubscription = subscribeToResult(this, this.inner, value, this.index++));
   }
 
   _complete() {

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -2,9 +2,9 @@ import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {queue} from '../scheduler/queue';
+import {asap} from '../scheduler/asap';
 
-export function timeInterval<T>(scheduler: Scheduler = queue): Observable<TimeInterval> {
+export function timeInterval<T>(scheduler: Scheduler = asap): Observable<TimeInterval> {
   return this.lift(new TimeIntervalOperator(scheduler));
 }
 

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -1,14 +1,14 @@
+import {asap} from '../scheduler/asap';
+import {isDate} from '../util/isDate';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {queue} from '../scheduler/queue';
-import {isDate} from '../util/isDate';
 
 export function timeout(due: number|Date,
                         errorToSend: any = null,
-                        scheduler: Scheduler = queue) {
+                        scheduler: Scheduler = asap) {
   let absoluteTimeout = isDate(due);
-  let waitFor = absoluteTimeout ? (+due - scheduler.now()) : <number>due;
+  let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, errorToSend, scheduler));
 }
 

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {queue} from '../scheduler/queue';
+import {asap} from '../scheduler/asap';
 import {Subscription} from '../Subscription';
 import {Observable} from '../Observable';
 import {isDate} from '../util/isDate';
@@ -10,9 +10,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
 
 export function timeoutWith<T, R>(due: number | Date,
                                   withObservable: Observable<R>,
-                                  scheduler: Scheduler = queue): Observable<T> | Observable<R> {
+                                  scheduler: Scheduler = asap): Observable<T> | Observable<R> {
   let absoluteTimeout = isDate(due);
-  let waitFor = absoluteTimeout ? (+due - scheduler.now()) : <number>due;
+  let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));
 }
 

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -47,7 +47,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
               private waitFor: number,
               private withObservable: Observable<any>,
               private scheduler: Scheduler) {
-    super(null);
+    super();
     destination.add(this);
     this.scheduleTimeout();
   }

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -55,7 +55,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
 
 class WindowClosingNotifierSubscriber<T> extends Subscriber<T> {
   constructor(private parent: WindowSubscriber<any>) {
-    super(null);
+    super();
   }
 
   _next() {

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -23,7 +23,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
   constructor(protected destination: Subscriber<Observable<T>>,
               private closingNotifier: Observable<any>) {
     super(destination);
-    this.add(closingNotifier._subscribe(new WindowClosingNotifierSubscriber(this)));
+    this.add(closingNotifier.subscribe(new WindowClosingNotifierSubscriber(this)));
     this.openWindow();
   }
 

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -81,7 +81,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
       this.window.error(err);
     } else {
       const closingNotification = this.closingNotification = new Subscription();
-      closingNotification.add(closingNotifier._subscribe(new WindowClosingNotifierSubscriber(this)));
+      closingNotification.add(closingNotifier.subscribe(new WindowClosingNotifierSubscriber(this)));
       this.add(closingNotification);
       this.add(window);
     }

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -90,7 +90,7 @@ class WindowSubscriber<T> extends Subscriber<T> {
 
 class WindowClosingNotifierSubscriber<T> extends Subscriber<T> {
   constructor(private parent: WindowSubscriber<any>) {
-    super(null);
+    super();
   }
 
   _next() {

--- a/src/operator/zip-support.ts
+++ b/src/operator/zip-support.ts
@@ -1,3 +1,4 @@
+import {isArray} from '../util/isArray';
 import {Operator} from '../Operator';
 import {Observer} from '../Observer';
 import {Observable} from '../Observable';
@@ -7,8 +8,6 @@ import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 import {SymbolShim} from '../util/SymbolShim';
-
-const isArray = Array.isArray;
 
 export class ZipOperator<T, R> implements Operator<T, R> {
 

--- a/src/operator/zip-support.ts
+++ b/src/operator/zip-support.ts
@@ -56,7 +56,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     for (let i = 0; i < len; i++) {
       let iterator = iterators[i];
       if (iterator.stillUnsubscribed) {
-        iterator.subscribe(iterator, i);
+        this.add(iterator.subscribe(iterator, i));
       } else {
         this.active--; // not an observable
       }
@@ -226,6 +226,6 @@ class ZipBufferIterator<T, R> extends OuterSubscriber<T, R> implements LookAhead
   }
 
   subscribe(value: any, index: number) {
-    this.add(subscribeToResult<any, any>(this, this.observable, this, index));
+    return subscribeToResult<any, any>(this, this.observable, this, index);
   }
 }

--- a/src/scheduler/AsapScheduler.ts
+++ b/src/scheduler/AsapScheduler.ts
@@ -1,13 +1,11 @@
-import {QueueScheduler} from './QueueScheduler';
-import {Subscription} from '../Subscription';
 import {Action} from './Action';
 import {AsapAction} from './AsapAction';
-import {QueueAction} from './QueueAction';
+import {Subscription} from '../Subscription';
+import {QueueScheduler} from './QueueScheduler';
 
 export class AsapScheduler extends QueueScheduler {
+  public scheduledId: number = null;
   scheduleNow<T>(work: (x?: any) => Subscription, state?: any): Action {
-    return (this.scheduled ?
-      new QueueAction(this, work) :
-      new AsapAction(this, work)).schedule(state);
+    return new AsapAction(this, work).schedule(state);
   }
 }

--- a/src/scheduler/QueueAction.ts
+++ b/src/scheduler/QueueAction.ts
@@ -1,49 +1,16 @@
-import {Subscription} from '../Subscription';
-import {Scheduler} from '../Scheduler';
 import {Action} from './Action';
+import {FutureAction} from './FutureAction';
 
-export class QueueAction<T> extends Subscription implements Action {
-
-  state: any;
-
-  constructor(public scheduler: Scheduler,
-              public work: (x?: any) => Subscription | void) {
-    super();
-  }
-
-  schedule(state?: any): Action {
-    if (this.isUnsubscribed) {
-      return this;
+export class QueueAction<T> extends FutureAction<T> {
+  _schedule(state?: any, delay: number = 0): Action {
+    if (delay > 0) {
+      return super._schedule(state, delay);
     }
-
+    this.delay = delay;
     this.state = state;
     const scheduler = this.scheduler;
     scheduler.actions.push(this);
     scheduler.flush();
     return this;
-  }
-
-  execute() {
-    if (this.isUnsubscribed) {
-      throw new Error('How did did we execute a canceled Action?');
-    }
-    this.work(this.state);
-  }
-
-  unsubscribe() {
-
-    const scheduler = this.scheduler;
-    const actions = scheduler.actions;
-    const index = actions.indexOf(this);
-
-    this.work = void 0;
-    this.state = void 0;
-    this.scheduler = void 0;
-
-    if (index !== -1) {
-      actions.splice(index, 1);
-    }
-
-    super.unsubscribe();
   }
 }

--- a/src/scheduler/QueueScheduler.ts
+++ b/src/scheduler/QueueScheduler.ts
@@ -5,16 +5,16 @@ import {FutureAction} from './FutureAction';
 import {Action} from './Action';
 
 export class QueueScheduler implements Scheduler {
-  actions: QueueAction<any>[] = [];
-  active: boolean = false;
-  scheduled: boolean = false;
+  public active: boolean = false;
+  public actions: QueueAction<any>[] = [];
+  public scheduledId: number = null;
 
   now() {
     return Date.now();
   }
 
   flush() {
-    if (this.active || this.scheduled) {
+    if (this.active || this.scheduledId) {
       return;
     }
     this.active = true;

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -5,7 +5,7 @@ import {Action} from './Action';
 export class VirtualTimeScheduler implements Scheduler {
   actions: Action[] = [];
   active: boolean = false;
-  scheduled: boolean = false;
+  scheduledId: number = null;
   index: number = 0;
   sorted: boolean = false;
   frame: number = 0;

--- a/src/subject/BehaviorSubject.ts
+++ b/src/subject/BehaviorSubject.ts
@@ -5,16 +5,14 @@ import {throwError} from '../util/throwError';
 import {ObjectUnsubscribedError} from '../util/ObjectUnsubscribedError';
 
 export class BehaviorSubject<T> extends Subject<T> {
-  private _hasError: boolean = false;
-  private _err: any;
 
   constructor(private _value: T) {
     super();
   }
 
   getValue(): T {
-    if (this._hasError) {
-      throwError(this._err);
+    if (this.hasErrored) {
+      throwError(this.errorValue);
     } else if (this.isUnsubscribed) {
       throwError(new ObjectUnsubscribedError());
     } else {
@@ -26,11 +24,9 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  _subscribe(subscriber: Subscriber<any>): Subscription {
+  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     const subscription = super._subscribe(subscriber);
-    if (!subscription) {
-      return;
-    } else if (!subscription.isUnsubscribed) {
+    if (subscription && !(<Subscription> subscription).isUnsubscribed) {
       subscriber.next(this._value);
     }
     return subscription;
@@ -41,7 +37,7 @@ export class BehaviorSubject<T> extends Subject<T> {
   }
 
   _error(err: any): void {
-    this._hasError = true;
-    super._error(this._err = err);
+    this.hasErrored = true;
+    super._error(this.errorValue = err);
   }
 }

--- a/src/subject/ReplaySubject.ts
+++ b/src/subject/ReplaySubject.ts
@@ -3,7 +3,7 @@ import {Scheduler} from '../Scheduler';
 import {queue} from '../scheduler/queue';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
-import {ObserveOnSubscriber} from '../operator/ObserveOn-support';
+import {ObserveOnSubscriber} from '../operator/observeOn-support';
 
 export class ReplaySubject<T> extends Subject<T> {
   private events: ReplayEvent<T>[] = [];

--- a/src/subject/SubjectSubscription.ts
+++ b/src/subject/SubjectSubscription.ts
@@ -1,7 +1,6 @@
 import {Subject} from '../Subject';
-import {Subscription} from '../Subscription';
 import {Observer} from '../Observer';
-import {Subscriber} from '../Subscriber';
+import {Subscription} from '../Subscription';
 
 export class SubjectSubscription<T> extends Subscription {
   isUnsubscribed: boolean = false;
@@ -20,15 +19,12 @@ export class SubjectSubscription<T> extends Subscription {
     const subject = this.subject;
     const observers = subject.observers;
 
-    this.subject = void 0;
+    this.subject = null;
 
     if (!observers || observers.length === 0 || subject.isUnsubscribed) {
       return;
     }
 
-    if (this.observer instanceof Subscriber) {
-      (<Subscriber<T>> this.observer).unsubscribe();
-    }
     const subscriberIndex = observers.indexOf(this.observer);
 
     if (subscriberIndex !== -1) {

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -19,7 +19,7 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     this.scheduler = scheduler;
   }
 
-  _subscribe(subscriber: Subscriber<any>): Subscription {
+  _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
     subscriber.add(new Subscription(() => {

--- a/src/util/isFunction.ts
+++ b/src/util/isFunction.ts
@@ -1,0 +1,3 @@
+export function isFunction(x) {
+  return typeof x === 'function';
+}

--- a/src/util/isNumeric.ts
+++ b/src/util/isNumeric.ts
@@ -1,9 +1,9 @@
-const is_array = Array.isArray;
+import {isArray} from '../util/isArray';
 
 export function isNumeric(val) {
   // parseFloat NaNs numeric-cast false positives (null|true|false|"")
   // ...but misinterprets leading-number strings, particularly hex literals ("0x...")
   // subtraction forces infinities to NaN
   // adding 1 corrects loss of precision from parseFloat (#15100)
-  return !is_array(val) && (val - parseFloat(val) + 1) >= 0;
+  return !isArray(val) && (val - parseFloat(val) + 1) >= 0;
 };

--- a/src/util/isObject.ts
+++ b/src/util/isObject.ts
@@ -1,0 +1,3 @@
+export function isObject(x) {
+  return x != null && typeof x === 'object';
+}

--- a/src/util/toSubscriber.ts
+++ b/src/util/toSubscriber.ts
@@ -1,0 +1,21 @@
+import {Observer} from '../Observer';
+import {Subscriber} from '../Subscriber';
+import {rxSubscriber} from '../symbol/rxSubscriber';
+
+export function toSubscriber<T>(
+  next?: Observer<T> | ((value: T) => void),
+  error?: (error: T) => void,
+  complete?: () => void): Subscriber<T> {
+
+  if (next && typeof next === 'object') {
+    if (next instanceof Subscriber) {
+      return (<Subscriber<T>> next);
+    } else if (typeof next[rxSubscriber] === 'function') {
+      return next[rxSubscriber]();
+    } else {
+      return new Subscriber(<Observer<T>> next);
+    }
+  }
+
+  return Subscriber.create(<((value: T) => void)> next, error, complete);
+}

--- a/src/util/tryOrThrowError.ts
+++ b/src/util/tryOrThrowError.ts
@@ -1,0 +1,11 @@
+export function tryOrThrowError(target: Function): (x?: any) => any {
+  function tryCatcher() {
+    try {
+      (<any> tryCatcher).target.apply(this, arguments);
+    } catch (e) {
+      throw e;
+    }
+  }
+  (<any> tryCatcher).target = target;
+  return tryCatcher;
+}


### PR DESCRIPTION
attention: @blesh @staltz @kwonoj 

1. Factors out the shared `Subscription` list from `Subscribers` and updates the `Observable`, `Subject`, and `Operator` implementations accordingly.
2. Refactors some operators that manage inner `Subscriptions` but weren't extending `OuterSubscriber` or using our `subscribeToResult` util. The more operators that use this pattern, the more operators that will interop with Array/Iterable/Promise/Observable-esque instances.
3. Includes fixes to our Scheduler Action implementations to ensure:
  - Actions scheduled to occur on the next tick still execute if the first scheduled action is canceled
  - Asap/Queued Actions that reschedule with a delay fallback to using `setTimeout` instead of rescheduling like they normally would.
4. fixes ReplaySubject to route messages through its scheduler (if specified), which mimics current RxJS v4 behavior.
5. fixes `Observables` and operators that default to the `queue` scheduler. Nothing should *ever* default to the `queue` scheduler, because
  - our Observables fall back to iterative loops if unspecified
  - timing operators that don't ensure their relative times are greater than zero will schedule and execute their logic synchronously. While not technically a bug, this is a horrible thing to do to an end user. Default to `asap` scheduler for timing operators (like `delay`).
6. Ensures all tests are run **asynchronously**, because Jasmine has difficulty with the boundaries between synchronous and asynchronous tests, and will non-deterministically fail for no reason.
7. Style updates:
  - `null` instead of `void 0` expressions
  - use our utility functions in more places
  - use more inherited properties instead of redefining them (in Subjects, operators)
  - call global functions from the root (`root.setTimeout` instead of `setTimeout`)