### PR TITLE
feat(Operator): Expose the Operator interface to library consumers

### DIFF
--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -106,6 +106,7 @@ import './add/operator/zip';
 import './add/operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
+import {Operator} from './Operator';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';
@@ -138,6 +139,7 @@ export {
     Subject,
     Scheduler,
     Observable,
+    Operator,
     Subscriber,
     Subscription,
     Symbol,


### PR DESCRIPTION
First of all, getting started with this library in a typescript project is really easy. However, I found that adding custom operators is kind of annoying now. The Observable.lift() method is publicly exposed as I would expect, but its parameter is an Operator. Since that's not directly exposed by Rx.ts, it feels needlessly hard to implement your own operators. I read the part on the wiki about defining operators ([here](https://github.com/ReactiveX/RxJS/blob/master/doc/operator-creation.md)), but it seems needlessly convoluted to me. 

I would expect to be able to do this:

```TypeScript
import {Operator,Subscriber} from "@reactivex/rxjs";

export class MyOperator<T, R> implements Operator<T, R> {
    call<T, R>(subscriber: Subscriber<T>): Subscriber<T> {
        return new MySubscriber(subscriber);
    }
}

class MySubscriber<T> extends Subscriber<T> {
    constructor(destination: Subscriber<T>) {
        super(destination);
    }
    // whatever
}
```

Followed by this:

```TypeScript
import {Observable} from "@reactivex/rxjs";

var obs:Observable<string> = ...;
obs.lift(new MyOperator()).subscribe(...);
```

Am I missing something, or does the interface indeed needs to be exposed? I tested it locally at the change seems rather trivial.