### PR TITLE
refactor(subscriber): Make Subscriber and derived classes' internal methods protected

### DIFF
--- a/src/InnerSubscriber.ts
+++ b/src/InnerSubscriber.ts
@@ -8,16 +8,16 @@ export class InnerSubscriber<T, R> extends Subscriber<R> {
     super();
   }
 
-  _next(value: R) {
+  protected _next(value: R) {
     this.parent.notifyNext(this.outerValue, value, this.outerIndex, this.index++);
   }
 
-  _error(error: any) {
+  protected _error(error: any) {
     this.parent.notifyError(error, this);
     this.unsubscribe();
   }
 
-  _complete() {
+  protected _complete() {
     this.parent.notifyComplete(this);
     this.unsubscribe();
   }

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -63,16 +63,16 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     super.unsubscribe();
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     this.destination.next(value);
   }
 
-  _error(err: any): void {
+  protected _error(err: any): void {
     this.destination.error(err);
     this.unsubscribe();
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.destination.complete();
     this.unsubscribe();
   }

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -83,16 +83,16 @@ class RefCountSubscriber<T> extends Subscriber<T> {
     destination.add(this);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.destination.next(value);
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this._resetConnectable();
     this.destination.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     this._resetConnectable();
     this.destination.complete();
   }

--- a/src/observable/forkJoin.ts
+++ b/src/observable/forkJoin.ts
@@ -59,11 +59,11 @@ class AllSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     this._value = value;
   }
 
-  _complete(): void {
+  protected _complete(): void {
     const destination = this.destination;
 
     if (this._value == null) {

--- a/src/operator/buffer.ts
+++ b/src/operator/buffer.ts
@@ -40,7 +40,7 @@ class BufferSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.add(subscribeToResult(this, closingNotifier));
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.buffer.push(value);
   }
 

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -39,7 +39,7 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     const count = (this.count += 1);
     const destination = this.destination;
     const bufferSize = this.bufferSize;
@@ -66,7 +66,7 @@ class BufferCountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete() {
+  protected _complete() {
     const destination = this.destination;
     const buffers = this.buffers;
     while (buffers.length > 0) {

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -59,7 +59,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     const buffers = this.buffers;
     const len = buffers.length;
     for (let i = 0; i < len; i++) {
@@ -67,12 +67,12 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.buffers.length = 0;
     super._error(err);
   }
 
-  _complete() {
+  protected _complete() {
     const { buffers, destination } = this;
     while (buffers.length > 0) {
       destination.next(buffers.shift());

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -50,7 +50,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     this.add(this.openings.subscribe(new BufferToggleOpeningsSubscriber(this)));
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     const contexts = this.contexts;
     const len = contexts.length;
     for (let i = 0; i < len; i++) {
@@ -58,7 +58,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     }
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     const contexts = this.contexts;
     while (contexts.length > 0) {
       const context = contexts.shift();
@@ -70,7 +70,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     super._error(err);
   }
 
-  _complete() {
+  protected _complete() {
     const contexts = this.contexts;
     while (contexts.length > 0) {
       const context = contexts.shift();
@@ -121,15 +121,15 @@ class BufferToggleOpeningsSubscriber<T, O> extends Subscriber<O> {
     super(null);
   }
 
-  _next(value: O) {
+  protected _next(value: O) {
     this.parent.openBuffer(value);
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.parent.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     // noop
   }
 }
@@ -140,15 +140,15 @@ class BufferToggleClosingsSubscriber<T> extends Subscriber<any> {
     super(null);
   }
 
-  _next() {
+  protected _next() {
     this.parent.closeBuffer(this.context);
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.parent.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     this.parent.closeBuffer(this.context);
   }
 }

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -43,11 +43,11 @@ class BufferWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.openBuffer();
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.buffer.push(value);
   }
 
-  _complete() {
+  protected _complete() {
     const buffer = this.buffer;
     if (buffer) {
       this.destination.next(buffer);

--- a/src/operator/combineLatest-support.ts
+++ b/src/operator/combineLatest-support.ts
@@ -25,13 +25,13 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(observable: any) {
+  protected _next(observable: any) {
     const toRespond = this.toRespond;
     toRespond.push(toRespond.length);
     this.observables.push(observable);
   }
 
-  _complete() {
+  protected _complete() {
     const observables = this.observables;
     const len = observables.length;
     if (len === 0) {

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -43,7 +43,7 @@ class CountSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const predicate = this.predicate;
     let passed: any = true;
     if (predicate) {
@@ -58,7 +58,7 @@ class CountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.destination.next(this.count);
     this.destination.complete();
   }

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -43,7 +43,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     let subscription = this.durationSubscription;
     const duration = tryCatch(this.durationSelector)(value);
 
@@ -63,7 +63,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  _complete() {
+  protected _complete() {
     this.emitValue();
     this.destination.complete();
   }

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -41,14 +41,14 @@ class DebounceTimeSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.clearDebounce();
     this.lastValue = value;
     this.hasValue = true;
     this.add(this.debouncedSubscription = this.scheduler.schedule(dispatchNext, this.dueTime, this));
   }
 
-  _complete() {
+  protected _complete() {
     this.debouncedNext();
     this.destination.complete();
   }

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -28,12 +28,12 @@ class DefaultIfEmptySubscriber<T, R> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     this.isEmpty = false;
     this.destination.next(value);
   }
 
-  _complete(): void {
+  protected _complete(): void {
     if (this.isEmpty) {
       this.destination.next(this.defaultValue);
     }

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -80,17 +80,17 @@ class DelaySubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.scheduleNotification(Notification.createNext(value));
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.errored = true;
     this.queue = [];
     this.destination.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     this.scheduleNotification(Notification.createComplete());
   }
 }

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -22,7 +22,7 @@ class DeMaterializeSubscriber<T extends Notification<any>> extends Subscriber<T>
     super(destination);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     value.observe(this.destination);
   }
 }

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -44,7 +44,7 @@ class DistinctUntilChangedSubscriber<T, K> extends Subscriber<T> {
     return x === y;
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
 
     const keySelector = this.keySelector;
     let key: any = value;

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -58,7 +58,7 @@ class DoSubscriber<T> extends Subscriber<T> {
     this.__complete = complete;
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     const result = tryCatch(this.__next)(x);
     if (result === errorObject) {
       this.destination.error(errorObject.e);
@@ -67,7 +67,7 @@ class DoSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(e: any) {
+  protected _error(e: any) {
     const result = tryCatch(this.__error)(e);
     if (result === errorObject) {
       this.destination.error(errorObject.e);
@@ -76,7 +76,7 @@ class DoSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete() {
+  protected _complete() {
     const result = tryCatch(this.__complete)();
     if (result === errorObject) {
       this.destination.error(errorObject.e);

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -33,14 +33,14 @@ class ElementAtSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     if (this.index-- === 0) {
       this.destination.next(x);
       this.destination.complete();
     }
   }
 
-  _complete() {
+  protected _complete() {
     const destination = this.destination;
     if (this.index >= 0) {
       if (typeof this.defaultValue !== 'undefined') {

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -65,7 +65,7 @@ class EverySubscriber<T, R> extends Subscriber<T> {
     this.destination.complete();
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const result = tryCatch(this.predicate).call(this.thisArg || this, value, this.index++, this.source);
 
     if (result === errorObject) {
@@ -75,7 +75,7 @@ class EverySubscriber<T, R> extends Subscriber<T> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.notifyComplete(true);
   }
 }

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -30,14 +30,14 @@ class SwitchFirstSubscriber<T> extends OuterSubscriber<T, T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     if (!this.hasSubscription) {
       this.hasSubscription = true;
       this.add(subscribeToResult(this, value));
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.hasCompleted = true;
     if (!this.hasSubscription) {
       this.destination.complete();

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -43,7 +43,7 @@ class SwitchFirstMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     if (!this.hasSubscription) {
       const index = this.index++;
       const destination = this.destination;
@@ -57,7 +57,7 @@ class SwitchFirstMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.hasCompleted = true;
     if (!this.hasSubscription) {
       this.destination.complete();

--- a/src/operator/expand-support.ts
+++ b/src/operator/expand-support.ts
@@ -39,7 +39,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     subscriber.subscribeToProjection(result, value, index);
   }
 
-  _next(value: any): void {
+  protected _next(value: any): void {
     const destination = this.destination;
 
     if (destination.isUnsubscribed) {
@@ -73,7 +73,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.hasCompleted = true;
     if (this.hasCompleted && this.active === 0) {
       this.destination.complete();

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -35,7 +35,7 @@ class FilterSubscriber<T> extends Subscriber<T> {
     this.select = select;
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     const result = tryCatch(this.select).call(this.thisArg || this, x, this.count++);
     if (result === errorObject) {
       this.destination.error(errorObject.e);

--- a/src/operator/find-support.ts
+++ b/src/operator/find-support.ts
@@ -35,7 +35,7 @@ export class FindValueSubscriber<T> extends Subscriber<T> {
     destination.complete();
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const { predicate, thisArg } = this;
     const index = this.index++;
     const result = tryCatch(predicate).call(thisArg || this, value, index, this.source);
@@ -46,7 +46,7 @@ export class FindValueSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.notifyComplete(this.yieldIndex ? -1 : undefined);
   }
 }

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -41,7 +41,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const { destination, predicate, resultSelector } = this;
     const index = this.index++;
     let passed: any = true;
@@ -68,7 +68,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     const destination = this.destination;
     if (!this.hasCompleted && typeof this.defaultValue !== 'undefined') {
       destination.next(this.defaultValue);

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -45,7 +45,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> {
     this.add(destination);
   }
 
-  _next(x: T): void {
+  protected _next(x: T): void {
     let key = tryCatch(this.keySelector)(x);
     if (key === errorObject) {
       this.error(errorObject.e);
@@ -89,7 +89,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> {
     }
   }
 
-  _error(err: any): void {
+  protected _error(err: any): void {
     const groups = this.groups;
     if (groups) {
       groups.forEach((group, key) => {
@@ -100,7 +100,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> {
     this.destination.error(err);
   }
 
-  _complete(): void {
+  protected _complete(): void {
     const groups = this.groups;
     if (groups) {
       groups.forEach((group, key) => {
@@ -123,17 +123,17 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
     super();
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     this.group.complete();
     this.parent.removeGroup(this.key);
   }
 
-  _error(err: any): void {
+  protected _error(err: any): void {
     this.group.error(err);
     this.parent.removeGroup(this.key);
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.group.complete();
     this.parent.removeGroup(this.key);
   }

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -14,7 +14,7 @@ class IgnoreElementsOperator<T, R> implements Operator<T, R> {
 }
 
 class IgnoreElementsSubscriber<T> extends Subscriber<T> {
-  _next(unused: T): void {
+  protected _next(unused: T): void {
     noop();
   }
 }

--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -25,11 +25,11 @@ class IsEmptySubscriber extends Subscriber<boolean> {
     destination.complete();
   }
 
-  _next(value: boolean) {
+  protected _next(value: boolean) {
     this.notifyComplete(false);
   }
 
-  _complete() {
+  protected _complete() {
     this.notifyComplete(true);
   }
 }

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -40,7 +40,7 @@ class LastSubscriber<T, R> extends Subscriber<T> {
     }
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const { predicate, resultSelector, destination } = this;
     const index = this.index++;
 
@@ -70,7 +70,7 @@ class LastSubscriber<T, R> extends Subscriber<T> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     const destination = this.destination;
     if (this.hasValue) {
       destination.next(this.lastValue);

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -37,7 +37,7 @@ class MapSubscriber<T, R> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     const result = tryCatch(this.project).call(this.thisArg || this, x, this.count++);
     if (result === errorObject) {
       this.error(errorObject.e);

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -33,7 +33,7 @@ class MapToSubscriber<T, R> extends Subscriber<T> {
     this.value = value;
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     this.destination.next(this.value);
   }
 }

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -18,17 +18,17 @@ class MaterializeSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.destination.next(Notification.createNext(value));
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     const destination = this.destination;
     destination.next(Notification.createError(err));
     destination.complete();
   }
 
-  _complete() {
+  protected _complete() {
     const destination = this.destination;
     destination.next(Notification.createComplete());
     destination.complete();

--- a/src/operator/mergeAll-support.ts
+++ b/src/operator/mergeAll-support.ts
@@ -23,7 +23,7 @@ export class MergeAllSubscriber<T> extends OuterSubscriber<Observable<T>, T> {
     super(destination);
   }
 
-  _next(observable: Observable<T>) {
+  protected _next(observable: Observable<T>) {
     if (this.active < this.concurrent) {
       if (observable._isScalar) {
         this.destination.next((<any>observable).value);
@@ -36,7 +36,7 @@ export class MergeAllSubscriber<T> extends OuterSubscriber<Observable<T>, T> {
     }
   }
 
-  _complete() {
+  protected _complete() {
     this.hasCompleted = true;
     if (this.active === 0 && this.buffer.length === 0) {
       this.destination.complete();

--- a/src/operator/mergeMap-support.ts
+++ b/src/operator/mergeMap-support.ts
@@ -33,7 +33,7 @@ export class MergeMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: any): void {
+  protected _next(value: any): void {
     if (this.active < this.concurrent) {
       const index = this.index++;
       const ish = tryCatch(this.project)(value, index);
@@ -53,7 +53,7 @@ export class MergeMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     this.add(subscribeToResult<T, R>(this, ish, value, index));
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.hasCompleted = true;
     if (this.active === 0 && this.buffer.length === 0) {
       this.destination.complete();

--- a/src/operator/mergeMapTo-support.ts
+++ b/src/operator/mergeMapTo-support.ts
@@ -31,7 +31,8 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
               private concurrent: number = Number.POSITIVE_INFINITY) {
     super(destination);
   }
-  _next(value: any): void {
+
+  protected _next(value: any): void {
     if (this.active < this.concurrent) {
       const resultSelector = this.resultSelector;
       const index = this.index++;
@@ -53,7 +54,7 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     this.add(subscribeToResult<T, R>(this, ish, value, index));
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.hasCompleted = true;
     if (this.active === 0 && this.buffer.length === 0) {
       this.destination.complete();

--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -40,7 +40,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: any): void {
+  protected _next(value: any): void {
     if (this.active < this.concurrent) {
       const index = this.index++;
       const ish = tryCatch(this.project)(this.acc, value);
@@ -60,7 +60,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.add(subscribeToResult<T, R>(this, ish, value, index));
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.hasCompleted = true;
     if (this.active === 0 && this.buffer.length === 0) {
       if (this.hasValue === false) {

--- a/src/operator/observeOn-support.ts
+++ b/src/operator/observeOn-support.ts
@@ -30,15 +30,15 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
                                       new ObserveOnMessage(notification, this.destination)));
    }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     this.scheduleMessage(Notification.createNext(value));
   }
 
-  _error(err: any): void {
+  protected _error(err: any): void {
     this.scheduleMessage(Notification.createError(err));
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.scheduleMessage(Notification.createComplete());
   }
 }

--- a/src/operator/reduce-support.ts
+++ b/src/operator/reduce-support.ts
@@ -27,7 +27,7 @@ export class ReduceSubscriber<T, R> extends Subscriber<T> {
     this.hasSeed = typeof seed !== 'undefined';
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     if (this.hasValue || (this.hasValue = this.hasSeed)) {
       const result = tryCatch(this.project).call(this, this.acc, x);
       if (result === errorObject) {
@@ -41,7 +41,7 @@ export class ReduceSubscriber<T, R> extends Subscriber<T> {
     }
   }
 
-  _complete() {
+  protected _complete() {
     if (this.hasValue || this.hasSeed) {
       this.destination.next(this.acc);
     }

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -27,7 +27,7 @@ class SampleSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.add(subscribeToResult(this, notifier));
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.value = value;
     this.hasValue = true;
   }

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -26,7 +26,7 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
     this.add(scheduler.schedule(dispatchNotification, delay, { subscriber: this, delay }));
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.lastValue = value;
     this.hasValue = true;
   }

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -46,7 +46,7 @@ class ScanSubscriber<T, R> extends Subscriber<T> {
     this.accumulatorSet = typeof seed !== 'undefined';
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     if (!this.accumulatorSet) {
       this.seed = value;
       this.destination.next(value);

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -41,7 +41,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const predicate = this.predicate;
     const currentIndex = this.index++;
 
@@ -57,7 +57,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     const destination = this.destination;
 
     if (this.index > 0) {

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -22,7 +22,7 @@ class SkipSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     if (++this.count > this.total) {
       this.destination.next(x);
     }

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -29,13 +29,13 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.add(subscribeToResult(this, notifier));
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     if (this.hasValue) {
       super._next(value);
     }
   }
 
-  _complete() {
+  protected _complete() {
     if (this.isInnerStopped) {
       super._complete();
     } else {

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -26,7 +26,7 @@ class SkipWhileSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const destination = this.destination;
     if (this.skipping === true) {
       const index = this.index++;

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -23,13 +23,13 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     this.unsubscribeInner();
     this.active++;
     this.add(this.innerSubscription = subscribeToResult(this, value));
   }
 
-  _complete(): void {
+  protected _complete(): void {
     this.hasCompleted = true;
     if (this.active === 0) {
       this.destination.complete();

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -36,7 +36,7 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const index = this.index++;
     const destination = this.destination;
     let result = tryCatch(this.project)(value, index);
@@ -51,7 +51,7 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     const {innerSubscription} = this;
     if (!innerSubscription || innerSubscription.isUnsubscribed) {
       super._complete();

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -36,7 +36,7 @@ class SwitchMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: any) {
+  protected _next(value: any) {
     const innerSubscription = this.innerSubscription;
     if (innerSubscription) {
       innerSubscription.unsubscribe();
@@ -44,7 +44,7 @@ class SwitchMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     this.add(this.innerSubscription = subscribeToResult(this, this.inner, value, this.index++));
   }
 
-  _complete() {
+  protected _complete() {
     const {innerSubscription} = this;
     if (!innerSubscription || innerSubscription.isUnsubscribed) {
       super._complete();

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -31,7 +31,7 @@ class TakeSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const total = this.total;
     if (++this.count <= total) {
       this.destination.next(value);

--- a/src/operator/takeWhile.ts
+++ b/src/operator/takeWhile.ts
@@ -25,7 +25,7 @@ class TakeWhileSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const destination = this.destination;
     const result = tryCatch(this.predicate)(value, this.index++);
 

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -29,7 +29,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     if (!this.throttled) {
       const duration = tryCatch(this.durationSelector)(value);
       if (duration === errorObject) {

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -27,7 +27,7 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     if (!this.throttled) {
       this.add(this.throttled = this.scheduler.schedule(dispatchNext, this.delay, { subscriber: this }));
       this.destination.next(value);

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -33,7 +33,7 @@ class TimeIntervalSubscriber<T> extends Subscriber<T> {
     this.lastTime = scheduler.now();
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     let now = this.scheduler.now();
     let span = now - this.lastTime;
     this.lastTime = now;

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -62,7 +62,7 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
     this._previousIndex = currentIndex;
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.destination.next(value);
 
     if (!this.absoluteTimeout) {
@@ -70,12 +70,12 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.destination.error(err);
     this._hasCompleted = true;
   }
 
-  _complete() {
+  protected _complete() {
     this.destination.complete();
     this._hasCompleted = true;
   }

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -68,19 +68,19 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
     this._previousIndex = currentIndex;
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.destination.next(value);
     if (!this.absoluteTimeout) {
       this.scheduleTimeout();
     }
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.destination.error(err);
     this._hasCompleted = true;
   }
 
-  _complete() {
+  protected _complete() {
     this.destination.complete();
     this._hasCompleted = true;
   }

--- a/src/operator/toArray.ts
+++ b/src/operator/toArray.ts
@@ -20,11 +20,11 @@ class ToArraySubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  _next(x: T) {
+  protected _next(x: T) {
     this.array.push(x);
   }
 
-  _complete() {
+  protected _complete() {
     this.destination.next(this.array);
     this.destination.complete();
   }

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -27,16 +27,16 @@ class WindowSubscriber<T> extends Subscriber<T> {
     this.openWindow();
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.window.next(value);
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.window.error(err);
     this.destination.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     this.window.complete();
     this.destination.complete();
   }
@@ -51,6 +51,14 @@ class WindowSubscriber<T> extends Subscriber<T> {
     destination.add(newWindow);
     destination.next(newWindow);
   }
+
+  errorWindow(err: any) {
+    this._error(err);
+  }
+
+  completeWindow() {
+    this._complete();
+  }
 }
 
 class WindowClosingNotifierSubscriber extends Subscriber<any> {
@@ -58,15 +66,15 @@ class WindowClosingNotifierSubscriber extends Subscriber<any> {
     super();
   }
 
-  _next() {
+  protected _next() {
     this.parent.openWindow();
   }
 
-  _error(err: any) {
-    this.parent._error(err);
+  protected _error(err: any) {
+    this.parent.errorWindow(err);
   }
 
-  _complete() {
-    this.parent._complete();
+  protected _complete() {
+    this.parent.completeWindow();
   }
 }

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -32,7 +32,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     destination.next(firstWindow);
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     const startWindowEvery = (this.startWindowEvery > 0) ? this.startWindowEvery : this.windowSize;
     const destination = this.destination;
     const windowSize = this.windowSize;
@@ -54,7 +54,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     const windows = this.windows;
     while (windows.length > 0) {
       windows.shift().error(err);
@@ -62,7 +62,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     this.destination.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     const windows = this.windows;
     while (windows.length > 0) {
       windows.shift().complete();

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -47,7 +47,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     const windows = this.windows;
     const len = windows.length;
     for (let i = 0; i < len; i++) {
@@ -55,7 +55,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     const windows = this.windows;
     while (windows.length > 0) {
       windows.shift().error(err);
@@ -63,7 +63,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     this.destination.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     const windows = this.windows;
     while (windows.length > 0) {
       windows.shift().complete();

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -44,7 +44,7 @@ class WindowToggleSubscriber<T, R, O> extends OuterSubscriber<T, R> {
     this.add(this.openSubscription = subscribeToResult(this, openings, openings));
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     const { contexts } = this;
     if (contexts) {
       const len = contexts.length;
@@ -54,7 +54,7 @@ class WindowToggleSubscriber<T, R, O> extends OuterSubscriber<T, R> {
     }
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
 
     const { contexts } = this;
     this.contexts = null;
@@ -73,7 +73,7 @@ class WindowToggleSubscriber<T, R, O> extends OuterSubscriber<T, R> {
     super._error(err);
   }
 
-  _complete() {
+  protected _complete() {
     const { contexts } = this;
     this.contexts = null;
     if (contexts) {

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -31,17 +31,17 @@ class WindowSubscriber<T> extends Subscriber<T> {
     this.openWindow();
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     this.window.next(value);
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.window.error(err);
     this.destination.error(err);
     this._unsubscribeClosingNotification();
   }
 
-  _complete() {
+  protected _complete() {
     this.window.complete();
     this.destination.complete();
     this._unsubscribeClosingNotification();
@@ -93,15 +93,15 @@ class WindowClosingNotifierSubscriber extends Subscriber<any> {
     super();
   }
 
-  _next() {
+  protected _next() {
     this.parent.openWindow();
   }
 
-  _error(err: any) {
+  protected _error(err: any) {
     this.parent.error(err);
   }
 
-  _complete() {
+  protected _complete() {
     this.parent.openWindow();
   }
 }

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -79,7 +79,7 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
     // noop
   }
 
-  _next(value: T) {
+  protected _next(value: T) {
     if (this.toRespond.length === 0) {
       const values = this.values;
       const destination = this.destination;

--- a/src/operator/zip-support.ts
+++ b/src/operator/zip-support.ts
@@ -37,7 +37,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     this.values = values;
   }
 
-  _next(value: any) {
+  protected _next(value: any) {
     const iterators = this.iterators;
     const index = this.index++;
     if (isArray(value)) {
@@ -49,7 +49,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     }
   }
 
-  _complete() {
+  protected _complete() {
     const iterators = this.iterators;
     const len = iterators.length;
     this.active = len;


### PR DESCRIPTION
This change make these members `protected`:

- `Subscriber._next()`
- `Subscriber._error()`
- `Subscriber._complete()`

At current codebase, these members is only used in drived class of
`Subscriber` or itself. Thus we should hide them from public.
(If we need to make them public, then we should make them so).

## Exception
- `WindowSubscriber`'s members are used from
  `WindowClosingNotifierSubscriber`. So `WindowSubscriber`'s members are
  not `protected`.
    - These classes are a private class of `window.ts` modules.
    - I think this exception would not be a serious problem.