### PR TITLE
refactor(operators): Make merge related operators' `_innerSub` private

### DIFF
--- a/src/operator/mergeMap-support.ts
+++ b/src/operator/mergeMap-support.ts
@@ -49,7 +49,7 @@ export class MergeMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  _innerSub(ish: any, value: T, index: number): void {
+  private _innerSub(ish: any, value: T, index: number): void {
     this.add(subscribeToResult<T, R>(this, ish, value, index));
   }
 

--- a/src/operator/mergeMapTo-support.ts
+++ b/src/operator/mergeMapTo-support.ts
@@ -46,11 +46,11 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  _innerSub(ish: any,
-            destination: Observer<R>,
-            resultSelector: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2,
-            value: T,
-            index: number): void {
+  private _innerSub(ish: any,
+                    destination: Observer<R>,
+                    resultSelector: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2,
+                    value: T,
+                    index: number): void {
     this.add(subscribeToResult<T, R>(this, ish, value, index));
   }
 

--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -56,7 +56,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  _innerSub(ish: any, value: T, index: number): void {
+  private _innerSub(ish: any, value: T, index: number): void {
     this.add(subscribeToResult<T, R>(this, ish, value, index));
   }
 


### PR DESCRIPTION
This methods is only used in them. We can hide their methods as private.