### PR TITLE
refactor(Subject): Make Subject and derived classes' internal methods protected

### DIFF
--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -123,7 +123,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     this._complete();
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     if (this.destination) {
       this.destination.next(value);
     } else {
@@ -137,7 +137,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     }
   }
 
-  _error(err: any): void {
+  protected _error(err: any): void {
     if (this.destination) {
       this.destination.error(err);
     } else {
@@ -160,7 +160,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     }
   }
 
-  _complete(): void {
+  protected _complete(): void {
     if (this.destination) {
       this.destination.complete();
     } else {

--- a/src/subject/AsyncSubject.ts
+++ b/src/subject/AsyncSubject.ts
@@ -14,12 +14,12 @@ export class AsyncSubject<T> extends Subject<T> {
     return super._subscribe(subscriber);
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     this.value = value;
     this.hasNext = true;
   }
 
-  _complete(): void {
+  protected _complete(): void {
     let index = -1;
     const observers = this.observers;
     const len = observers.length;

--- a/src/subject/BehaviorSubject.ts
+++ b/src/subject/BehaviorSubject.ts
@@ -32,11 +32,11 @@ export class BehaviorSubject<T> extends Subject<T> {
     return subscription;
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     super._next(this._value = value);
   }
 
-  _error(err: any): void {
+  protected _error(err: any): void {
     this.hasErrored = true;
     super._error(this.errorValue = err);
   }

--- a/src/subject/ReplaySubject.ts
+++ b/src/subject/ReplaySubject.ts
@@ -20,7 +20,7 @@ export class ReplaySubject<T> extends Subject<T> {
     this.windowSize = windowSize < 1 ? 1 : windowSize;
   }
 
-  _next(value: T): void {
+  protected _next(value: T): void {
     const now = this._getNow();
     this.events.push(new ReplayEvent(now, value));
     this._trimBufferThenGetEvents(now);


### PR DESCRIPTION
This change make these members `protected`:

- `Subject._next()`
- `Subject._error()`
- `Subject._complete()`

At current codebase, these members is only used in drived class of
`Subject` or itself. Thus we should hide them from public.