### PR TITLE
chore(Rx): export observer interface

### DIFF
--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -131,6 +131,7 @@ import './add/operator/zip';
 import './add/operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
+import {Observer} from './Observer';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';
@@ -166,6 +167,7 @@ export {
     Subject,
     Scheduler,
     Observable,
+    Observer,
     Subscriber,
     Subscription,
     AsyncSubject,

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -107,6 +107,7 @@ import './add/operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
 import {Operator} from './Operator';
+import {Observer} from './Observer';
 import {Subscription} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';
@@ -139,6 +140,7 @@ export {
     Subject,
     Scheduler,
     Observable,
+    Observer,
     Operator,
     Subscriber,
     Subscription,


### PR DESCRIPTION
closes #1122

Exports 'Observer' interface in `Rx` / `KitchenSink` both.