### PR TITLE
chore(tests2png): add support for combine/concat/zip-All operators

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,6 +92,7 @@
     "benchmark": "1.0.0",
     "benchpress": "2.0.0-alpha.37.2",
     "browserify": "11.0.0",
+    "color": "^0.11.1",
     "colors": "1.1.2",
     "commitizen": "2.4.4",
     "coveralls": "2.11.4",

--- a/spec/operators/combineAll-spec.js
+++ b/spec/operators/combineAll-spec.js
@@ -4,6 +4,17 @@ var Observable = Rx.Observable;
 var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.combineAll()', function () {
+  it.asDiagram('combineAll')('should combine events from two observables', function () {
+    var x =    cold(               '-a-----b---|');
+    var y =    cold(               '--1-2-|     ');
+    var outer = hot('-x----y--------|           ', { x: x, y: y });
+    var expected =  '-----------------A-B--C---|';
+
+    var result = outer.combineAll(function (a, b) { return String(a) + String(b); });
+
+    expectObservable(result).toBe(expected, { A: 'a1', B: 'a2', C: 'b2' });
+  });
+
   it('should work with two nevers', function () {
     var e1 = cold( '-');
     var e1subs =   '^';

--- a/spec/operators/concatAll-spec.js
+++ b/spec/operators/concatAll-spec.js
@@ -3,6 +3,18 @@ var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
 describe('Observable.prototype.concatAll()', function () {
+  it.asDiagram('concatAll')('should concat an observable of observables', function () {
+    var x = cold(    '----a------b------|                 ');
+    var y = cold(                      '---c-d---|        ');
+    var z = cold(                               '---e--f-|');
+    var outer = hot('-x---y----z------|              ', { x: x, y: y, z: z });
+    var expected =  '-----a------b---------c-d------e--f-|';
+
+    var result = outer.concatAll();
+
+    expectObservable(result).toBe(expected);
+  });
+
   it('should concat sources from promise', function (done) {
     var sources = Rx.Observable.fromArray([
       new Promise(function (res) { res(0); }),
@@ -58,15 +70,6 @@ describe('Observable.prototype.concatAll()', function () {
       Rx.Observable.of('c')
     ]);
     var expected = '(a#)';
-
-    expectObservable(e1.concatAll()).toBe(expected);
-  });
-
-  it('should concat a hot observable of observables', function () {
-    var x = cold(     'a---b---c---|');
-    var y = cold(        'd---e---f---|');
-    var e1 =    hot('--x--y--|', { x: x, y: y });
-    var expected =  '--a---b---c---d---e---f---|';
 
     expectObservable(e1.concatAll()).toBe(expected);
   });

--- a/spec/operators/zipAll-spec.js
+++ b/spec/operators/zipAll-spec.js
@@ -4,6 +4,17 @@ var Observable = Rx.Observable;
 var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.zipAll', function () {
+  it.asDiagram('zipAll')('should combine paired events from two observables', function () {
+    var x =    cold(               '-a-----b-|');
+    var y =    cold(               '--1-2-----');
+    var outer = hot('-x----y--------|         ', { x: x, y: y });
+    var expected =  '-----------------A----B-|';
+
+    var result = outer.zipAll(function (a, b) { return String(a) + String(b); });
+
+    expectObservable(result).toBe(expected, { A: 'a1', B: 'b2' });
+  });
+
   it('should combine two observables', function () {
     var a =    hot('---1---2---3---');
     var asubs =    '^';


### PR DESCRIPTION
Support PNG diagrams for another category of operators:

![combineall](https://cloud.githubusercontent.com/assets/90512/12173657/bf47c4a0-b560-11e5-821b-3ff2f2efbc40.png)

- - -

![concatall](https://cloud.githubusercontent.com/assets/90512/12173659/c3332744-b560-11e5-8a05-179d1c536c40.png)

- - -

![zipall](https://cloud.githubusercontent.com/assets/90512/12173661/c7a3b7bc-b560-11e5-9ce5-58caec371906.png)


Improve tests2png/painter.js to support rendering ghost streams: reference to an inner Observable
not yet subscribed, belonging to a higher-order Observable. Operators concatAll, combineAll, and
zipAll match these cases, where we need to render both the not-yet-subscribed inner Observable
reference and its corresponding now-subscribed Observable. This commit helps generate more PNG
marble diagrams, and adds a few tests.

