### PR TITLE
chore(test-helper): setup promise polyfill for browser testing

### DIFF
--- a/spec/Observable-spec.js
+++ b/spec/Observable-spec.js
@@ -35,8 +35,8 @@ describe('Observable', function () {
 
     it('should reject promise when in error', function (done) {
       Observable.throw('bad').forEach(function (x) {
-        throw 'should not be called';
-      }).then(function () {
+        done.fail('should not be called');
+      }, null, Promise).then(function () {
         done.fail('should not complete');
       }, function (err) {
         expect(err).toBe('bad');

--- a/spec/observables/forkJoin-spec.js
+++ b/spec/observables/forkJoin-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect, lowerCaseO, hot, expectObservable */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
+var Promise = require('promise');
 
 describe('Observable.forkJoin', function () {
   it('should join the last values of the provided observables into an array', function () {

--- a/spec/observables/from-promise-spec.js
+++ b/spec/observables/from-promise-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
+var Promise = require('promise');
 
 describe('Observable.fromPromise', function () {
   it('should emit one value from a resolved promise', function (done) {

--- a/spec/operators/concatAll-spec.js
+++ b/spec/operators/concatAll-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
+var Promise = require('promise');
 
 describe('Observable.prototype.concatAll()', function () {
   it('should concat sources from promise', function (done) {

--- a/spec/operators/debounce-spec.js
+++ b/spec/operators/debounce-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
+var Promise = require('promise');
 
 describe('Observable.prototype.debounce()', function () {
   function getTimerSelector(x) {
@@ -357,12 +358,13 @@ describe('Observable.prototype.debounce()', function () {
     e1.debounce(function () {
       return new Promise(function (resolve) { resolve(42); });
     }).subscribe(function (x) {
-      expect(x).toEqual(expected.shift()); },
-      function () { throw 'should not be called'; },
-      function () {
-        expect(expected.length).toBe(0);
-        done();
-      });
+      expect(x).toEqual(expected.shift());
+    }, function (err) {
+      done.fail('should not be called');
+    }, function () {
+      expect(expected.length).toBe(0);
+      done();
+    });
   });
 
   it('should raises error when promise rejects', function (done) {

--- a/spec/operators/mergeAll-spec.js
+++ b/spec/operators/mergeAll-spec.js
@@ -1,6 +1,7 @@
-/* globals describe, it, expect, expectObservable, hot, cold */
+/* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
+var Promise = require('promise');
 
 describe('Observable.prototype.mergeAll()', function () {
   it.asDiagram('mergeAll')('should merge a hot observable of cold observables', function () {

--- a/spec/operators/throttle-spec.js
+++ b/spec/operators/throttle-spec.js
@@ -1,7 +1,8 @@
-/* globals describe, it, expect, expectObservable, expectSubscription, hot, cold */
+/* globals describe, it, expect, expectObservable, expectSubscriptions, hot, cold */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 var Scheduler = Rx.Scheduler;
+var Promise = require('promise');
 
 describe('Observable.prototype.throttle()', function () {
   it.asDiagram('throttle')('should immediately emit the first value in each time window', function () {


### PR DESCRIPTION
relates to #998

Updates references to `promise` in testcases where it uses.