### PR TITLE
chore(tests2png): add exhaust PNG diagram

### DIFF
--- a/spec/helpers/tests2png/painter.js
+++ b/spec/helpers/tests2png/painter.js
@@ -351,6 +351,14 @@ function addGhostInnerInputs(inputStreams) {
       var message = inputStream.messages[j];
       if (isNestedStreamData(message) && typeof message.isGhost !== 'boolean') {
         var referenceTime = message.frame;
+        if (!message.notification.value.subscription) {
+          // There was no subscription at all, so this nested Observable is ghost
+          message.isGhost = true;
+          message.notification.value.isGhost = true;
+          message.frame = referenceTime;
+          message.notification.value.subscription = { start: referenceTime, end: 0 };
+          continue;
+        }
         var subscriptionTime = message.notification.value.subscription.start;
         if (referenceTime !== subscriptionTime) {
           message.isGhost = false;

--- a/spec/operators/exhaust-spec.js
+++ b/spec/operators/exhaust-spec.js
@@ -6,6 +6,16 @@ var Observable = Rx.Observable;
 var queueScheduler = Rx.Scheduler.queue;
 
 describe('Observable.prototype.exhaust()', function () {
+  it.asDiagram('exhaust')('should handle a hot observable of hot observables', function () {
+    var x =   cold(      '--a---b---c--|               ');
+    var y =   cold(              '---d--e---f---|      ');
+    var z =   cold(                    '---g--h---i---|');
+    var e1 = hot(  '------x-------y-----z-------------|', { x: x, y: y, z: z });
+    var expected = '--------a---b---c------g--h---i---|';
+
+    expectObservable(e1.exhaust()).toBe(expected);
+  });
+
   it('should switch to first immediately-scheduled inner Observable', function () {
     var e1 = cold( '(ab|)');
     var e1subs =   '(^!)';


### PR DESCRIPTION
Add test to draw PNG diagram for exhaust. Change painter.js to support exhaust (use case where an
inner Observable is emitted but never subscribed to).