### PR TITLE
fix(fromObservable): expand compatibility for iterating string source

### DIFF
--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -26,7 +26,7 @@ export class FromObservable<T> extends Observable<T> {
         return new ArrayObservable(ish, scheduler);
       } else if (isPromise(ish)) {
         return new PromiseObservable(ish, scheduler);
-      } else if (typeof ish[SymbolShim.iterator] === 'function') {
+      } else if (typeof ish[SymbolShim.iterator] === 'function' || typeof ish === 'string') {
         return new IteratorObservable<T>(<any>ish, null, null, scheduler);
       }
     }


### PR DESCRIPTION
closes #1147

This PR enables utilization of `StringIterator` implementation in current codebase. While `IteratorObservable` already have those mechanism in place, it was not able to be executed in `fromObservable` by not allowing create `IteratorObservable` via string type source.

With this PR, string based source will create IteratorObservable either string has built in iterator or not.