### PR TITLE
fix(ajax): response properly based off responseType

### DIFF
--- a/spec/observables/dom/ajax-spec.js
+++ b/spec/observables/dom/ajax-spec.js
@@ -47,7 +47,7 @@ describe('Observable.ajax', function () {
         url: '/flibbertyJibbet',
         responseType: 'text',
         resultSelector: function (res) {
-          return res.responseText;
+          return res.response;
         }
       })
       .subscribe(function(x) {


### PR DESCRIPTION
@trxcllnt discovered an issue with accessing both response and responseText in Chrome if responseType was set
I copy-pastad his code in the name of speed with his blessing. I <3 Paul

Related: #1154 