### PR TITLE
refactor(race): Make Type paramerter more compatible with RxJS v4

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -242,7 +242,7 @@ export class Observable<T> implements CoreOperators<T>  {
   publishBehavior: (value: any) => ConnectableObservable<T>;
   publishReplay: (bufferSize?: number, windowTime?: number, scheduler?: Scheduler) => ConnectableObservable<T>;
   publishLast: () => ConnectableObservable<T>;
-  race: (...observables: Array<Observable<any>>) => Observable<any>;
+  race: (...observables: Array<Observable<T>>) => Observable<T>;
   reduce: <R>(project: (acc: R, x: T) => R, seed?: R) => Observable<R>;
   repeat: (count?: number) => Observable<T>;
   retry: (count?: number) => Observable<T>;

--- a/src/operator/race-static.ts
+++ b/src/operator/race-static.ts
@@ -8,7 +8,7 @@ import {isArray} from '../util/isArray';
  * @param {...Observables} ...observables sources used to race for which Observable emits first.
  * @returns {Observable} an Observable that mirrors the output of the first Observable to emit an item.
  */
-export function race<T>(...observables: Array<Observable<any> | Array<Observable<any>>>): Observable<T> {
+export function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T> {
   // if the only argument is an array, it was most likely called with
   // `pair([obs1, obs2, ...])`
   if (observables.length === 1) {

--- a/src/operator/race-support.ts
+++ b/src/operator/race-support.ts
@@ -20,11 +20,11 @@ export class RaceSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  _next(observable: any): void {
+  protected _next(observable: any): void {
     this.observables.push(observable);
   }
 
-  _complete() {
+  protected _complete() {
     const observables = this.observables;
     const len = observables.length;
     if (len === 0) {

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -8,11 +8,11 @@ import {isArray} from '../util/isArray';
  * @param {...Observables} ...observables sources used to race for which Observable emits first.
  * @returns {Observable} an Observable that mirrors the output of the first Observable to emit an item.
  */
-export function race<R>(...observables: Array<Observable<any> | Array<Observable<any>>>): Observable<R> {
+export function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T> {
   // if the only argument is an array, it was most likely called with
   // `pair([obs1, obs2, ...])`
   if (observables.length === 1 && isArray(observables[0])) {
-    observables = <Array<Observable<any>>>observables[0];
+    observables = <Array<Observable<T>>>observables[0];
   }
 
   observables.unshift(this);


### PR DESCRIPTION
- Clearfy `race()`'s type definition.
  - See also [RxJS v4's one](https://github.com/Reactive-Extensions/RxJS/blob/master/ts/core/linq/observable/amb.ts)
- ...And some micro refactoring