### PR TITLE
refactor(fromEvent): clearfy the type definition of Observable.fromEvent()

### DIFF
--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -4,30 +4,59 @@ import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
+export type NodeStyleEventEmmitter = {
+  addListener: (eventName: string, handler: Function) => void;
+  removeListener: (eventName: string, handler: Function) => void;
+};
+function isNodeStyleEventEmmitter(sourceObj: any): sourceObj is NodeStyleEventEmmitter {
+  return !!sourceObj && typeof sourceObj.addListener === 'function' && typeof sourceObj.removeListener === 'function';
+}
+
+export type JQueryStyleEventEmitter = {
+  on: (eventName: string, handler: Function) => void;
+  off: (eventName: string, handler: Function) => void;
+};
+function isJQueryStyleEventEmitter(sourceObj: any): sourceObj is JQueryStyleEventEmitter {
+  return !!sourceObj && typeof sourceObj.on === 'function' && typeof sourceObj.off === 'function';
+}
+
+function isNodeList(sourceObj: any): sourceObj is NodeList {
+  return !!sourceObj && sourceObj.toString() === '[object NodeList]';
+}
+
+function isHTMLCollection(sourceObj: any): sourceObj is HTMLCollection {
+  return !!sourceObj && sourceObj.toString() === '[object HTMLCollection]';
+}
+
+function isEventTarget(sourceObj: any): sourceObj is EventTarget {
+  return !!sourceObj && typeof sourceObj.addEventListener === 'function' && typeof sourceObj.removeEventListener === 'function';
+}
+
+export type EventTargetLike = EventTarget | NodeStyleEventEmmitter | JQueryStyleEventEmitter | NodeList | HTMLCollection;
+
 export class FromEventObservable<T, R> extends Observable<T> {
 
-  static create<T>(sourceObj: any, eventName: string, selector?: (...args: Array<any>) => T) {
+  static create<T>(sourceObj: EventTargetLike, eventName: string, selector?: (...args: Array<any>) => T): Observable<T> {
     return new FromEventObservable(sourceObj, eventName, selector);
   }
 
-  constructor(private sourceObj: any, private eventName: string, private selector?: (...args: Array<any>) => T) {
+  constructor(private sourceObj: EventTargetLike, private eventName: string, private selector?: (...args: Array<any>) => T) {
     super();
   }
 
-  private static setupSubscription<T>(sourceObj: any, eventName: string, handler: Function, subscriber: Subscriber<T>) {
+  private static setupSubscription<T>(sourceObj: EventTargetLike, eventName: string, handler: Function, subscriber: Subscriber<T>) {
     let unsubscribe: () => void;
-    let tag = sourceObj.toString();
-    if (tag === '[object NodeList]' || tag === '[object HTMLCollection]') {
+    if (isNodeList(sourceObj) || isHTMLCollection(sourceObj)) {
       for (let i = 0, len = sourceObj.length; i < len; i++) {
         FromEventObservable.setupSubscription(sourceObj[i], eventName, handler, subscriber);
       }
-    } else if (typeof sourceObj.addEventListener === 'function' && typeof sourceObj.removeEventListener === 'function') {
-      sourceObj.addEventListener(eventName, handler);
-      unsubscribe = () => sourceObj.removeEventListener(eventName, handler);
-    } else if (typeof sourceObj.on === 'function' && typeof sourceObj.off === 'function') {
+    } else if (isEventTarget(sourceObj)) {
+      sourceObj.addEventListener(eventName, <EventListener>handler);
+      unsubscribe = () => sourceObj.removeEventListener(eventName, <EventListener>handler);
+    } else if (isJQueryStyleEventEmitter(sourceObj)) {
       sourceObj.on(eventName, handler);
       unsubscribe = () => sourceObj.off(eventName, handler);
-    } else if (typeof sourceObj.addListener === 'function' && typeof sourceObj.removeListener === 'function') {
+    } else if (isNodeStyleEventEmmitter(sourceObj)) {
       sourceObj.addListener(eventName, handler);
       unsubscribe = () => sourceObj.removeListener(eventName, handler);
     }


### PR DESCRIPTION
This makes the type definition more compatible with [RxJS v4](https://github.com/Reactive-Extensions/RxJS/blob/8f12f812d497acf639588e90f74d504a9fc801ec/ts/core/linq/observable/fromevent.ts)