### PR TITLE
refactor(Observable): Make the internal '_subscribe()' method protected.

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -159,7 +159,7 @@ export class Observable<T> implements CoreOperators<T>  {
     return new PromiseCtor<void>(promiseCallback);
   }
 
-  _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
     return this.source.subscribe(subscriber);
   }
 

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -47,7 +47,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     Subscription.prototype.unsubscribe.call(this);
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     if (this.source) {
       return this.source.subscribe(subscriber);
     } else {
@@ -69,7 +69,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     }
   }
 
-  _unsubscribe(): void {
+  protected _unsubscribe(): void {
     this.source = null;
     this.isStopped = true;
     this.observers = null;

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -13,7 +13,7 @@ export class ConnectableObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     return this._getSubject().subscribe(subscriber);
   }
 

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -84,7 +84,7 @@ export class IteratorObservable<T> extends Observable<T> {
     this.iterator = getIterator(iterator);
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
 
     let index = 0;
     const { iterator, project, thisArg, scheduler } = this;

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -31,7 +31,7 @@ export class ScalarObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     const value = this.value;
     const scheduler = this.scheduler;
 

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -26,7 +26,7 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     }
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     const delay = this.delayTime;
     const source = this.source;
     const scheduler = this.scheduler;

--- a/src/observable/bindCallback.ts
+++ b/src/observable/bindCallback.ts
@@ -24,7 +24,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
+  protected _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
     const callbackFunc = this.callbackFunc;
     const args = this.args;
     const scheduler = this.scheduler;

--- a/src/observable/bindNodeCallback.ts
+++ b/src/observable/bindNodeCallback.ts
@@ -24,7 +24,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
+  protected _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
     const callbackFunc = this.callbackFunc;
     const args = this.args;
     const scheduler = this.scheduler;

--- a/src/observable/defer.ts
+++ b/src/observable/defer.ts
@@ -13,7 +13,7 @@ export class DeferObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     const result = tryCatch(this.observableFactory)();
     if (result === errorObject) {
       subscriber.error(errorObject.e);

--- a/src/observable/dom/ajax.ts
+++ b/src/observable/dom/ajax.ts
@@ -135,7 +135,7 @@ export class AjaxObservable<T> extends Observable<T> {
     this.request = request;
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     return new AjaxSubscriber(subscriber, this.request);
   }
 }

--- a/src/observable/dom/webSocket.ts
+++ b/src/observable/dom/webSocket.ts
@@ -110,7 +110,7 @@ export class WebSocketSubject<T> extends Subject<T> {
     this.isUnsubscribed = false;
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     if (!this.observers) {
       this.observers = [];
     }

--- a/src/observable/empty.ts
+++ b/src/observable/empty.ts
@@ -17,7 +17,7 @@ export class EmptyObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
 
     const scheduler = this.scheduler;
 

--- a/src/observable/forkJoin.ts
+++ b/src/observable/forkJoin.ts
@@ -32,7 +32,7 @@ export class ForkJoinObservable<T> extends Observable<T> {
     return new ForkJoinObservable(<Array<Observable<any> | Promise<any>>>sources, resultSelector);
   }
 
-  _subscribe(subscriber: Subscriber<any>) {
+  protected _subscribe(subscriber: Subscriber<any>) {
     const sources = this.sources;
     const len = sources.length;
 

--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -34,7 +34,7 @@ export class FromObservable<T> extends Observable<T> {
     throw new TypeError((ish !== null && typeof ish || ish) + ' is not observable');
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     const ish = this.ish;
     const scheduler = this.scheduler;
     if (scheduler == null) {

--- a/src/observable/fromArray.ts
+++ b/src/observable/fromArray.ts
@@ -61,7 +61,7 @@ export class ArrayObservable<T> extends Observable<T> {
     }
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     let index = 0;
     const array = this.array;
     const count = array.length;

--- a/src/observable/fromEvent.ts
+++ b/src/observable/fromEvent.ts
@@ -35,7 +35,7 @@ export class FromEventObservable<T, R> extends Observable<T> {
     subscriber.add(new Subscription(unsubscribe));
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     const sourceObj = this.sourceObj;
     const eventName = this.eventName;
     const selector = this.selector;

--- a/src/observable/fromEventPattern.ts
+++ b/src/observable/fromEventPattern.ts
@@ -18,7 +18,7 @@ export class FromEventPatternObservable<T, R> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     const addHandler = this.addHandler;
     const removeHandler = this.removeHandler;
     const selector = this.selector;

--- a/src/observable/fromPromise.ts
+++ b/src/observable/fromPromise.ts
@@ -16,7 +16,7 @@ export class PromiseObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     const promise = this.promise;
     const scheduler = this.scheduler;
 

--- a/src/observable/interval.ts
+++ b/src/observable/interval.ts
@@ -33,7 +33,7 @@ export class IntervalObservable extends Observable<number> {
     }
   }
 
-  _subscribe(subscriber: Subscriber<number>) {
+  protected _subscribe(subscriber: Subscriber<number>) {
     const index = 0;
     const period = this.period;
     const scheduler = this.scheduler;

--- a/src/observable/never.ts
+++ b/src/observable/never.ts
@@ -11,7 +11,7 @@ export class InfiniteObservable<T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>): void {
+  protected _subscribe(subscriber: Subscriber<T>): void {
     noop();
   }
 }

--- a/src/observable/range.ts
+++ b/src/observable/range.ts
@@ -41,7 +41,7 @@ export class RangeObservable extends Observable<number> {
     this.scheduler = scheduler;
   }
 
-  _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
     let index = 0;
     let start = this.start;
     const end = this.end;

--- a/src/observable/throw.ts
+++ b/src/observable/throw.ts
@@ -16,7 +16,7 @@ export class ErrorObservable extends Observable<any> {
     super();
   }
 
-  _subscribe(subscriber: any): Subscription | Function | void {
+  protected _subscribe(subscriber: any): Subscription | Function | void {
     const error = this.error;
     const scheduler = this.scheduler;
 

--- a/src/observable/timer.ts
+++ b/src/observable/timer.ts
@@ -55,7 +55,7 @@ export class TimerObservable extends Observable<number> {
       (<number> dueTime);
   }
 
-  _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
     const index = 0;
     const { period, dueTime, scheduler } = this;
 

--- a/src/operator/groupBy-support.ts
+++ b/src/operator/groupBy-support.ts
@@ -34,7 +34,7 @@ export class GroupedObservable<K, T> extends Observable<T> {
     super();
   }
 
-  _subscribe(subscriber: Subscriber<T>) {
+  protected _subscribe(subscriber: Subscriber<T>) {
     const subscription = new Subscription();
     if (this.refCountSubscription && !this.refCountSubscription.isUnsubscribed) {
       subscription.add(new InnerRefCountSubscription(this.refCountSubscription));

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -22,7 +22,7 @@ export class GroupByObservable<T, K, R> extends Observable<GroupedObservable<K, 
     super();
   }
 
-  _subscribe(subscriber: Subscriber<any>): Subscription {
+  protected _subscribe(subscriber: Subscriber<any>): Subscription {
     const refCountSubscription = new RefCountSubscription();
     const groupBySubscriber = new GroupBySubscriber(
       subscriber, refCountSubscription, this.keySelector, this.elementSelector, this.durationSelector

--- a/src/subject/AsyncSubject.ts
+++ b/src/subject/AsyncSubject.ts
@@ -6,7 +6,7 @@ export class AsyncSubject<T> extends Subject<T> {
   value: T = null;
   hasNext: boolean = false;
 
-  _subscribe(subscriber: Subscriber<any>): Subscription|Function|void {
+  protected _subscribe(subscriber: Subscriber<any>): Subscription|Function|void {
     if (this.hasCompleted && this.hasNext) {
       subscriber.next(this.value);
     }

--- a/src/subject/BehaviorSubject.ts
+++ b/src/subject/BehaviorSubject.ts
@@ -24,7 +24,7 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     const subscription = super._subscribe(subscriber);
     if (subscription && !(<Subscription> subscription).isUnsubscribed) {
       subscriber.next(this._value);

--- a/src/subject/ReplaySubject.ts
+++ b/src/subject/ReplaySubject.ts
@@ -27,7 +27,7 @@ export class ReplaySubject<T> extends Subject<T> {
     super._next(value);
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
     const events = this._trimBufferThenGetEvents(this._getNow());
     const scheduler = this.scheduler;
 

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -19,7 +19,7 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     this.scheduler = scheduler;
   }
 
-  _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
     subscriber.add(new Subscription(() => {


### PR DESCRIPTION
- There is no reason that this member method should be public.
- If a third party user need some customize the behavior of it, then the person should make a custom operator.