### PR TITLE
test(Subscriber): add test for no error propagation

### DIFF
--- a/spec/Subscriber-spec.js
+++ b/spec/Subscriber-spec.js
@@ -7,4 +7,29 @@ describe('Subscriber', function () {
     var sub = new Subscriber();
     expect(sub[Rx.Symbol.rxSubscriber]()).toBe(sub);
   });
+
+  describe('when created through create()', function () {
+    it('should not call error() if next() handler throws an error', function () {
+      var errorSpy = jasmine.createSpy('error');
+      var completeSpy = jasmine.createSpy('complete');
+
+      var subscriber = Subscriber.create(
+        function next(value) {
+          if (value === 2) {
+            throw 'error!';
+          }
+        },
+        errorSpy,
+        completeSpy
+      );
+
+      subscriber.next(1);
+      expect(function () {
+        subscriber.next(2);
+      }).toThrow('error!');
+
+      expect(errorSpy).not.toHaveBeenCalled();
+      expect(completeSpy).not.toHaveBeenCalled();
+    });
+  });
 });


### PR DESCRIPTION
Add test to assert that error happening in the next() handler should not propagate to the error()
handler.

For issue #1135.