### PR TITLE
fix forEach: nextHandler errors will reject returned Promise.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -27,7 +27,6 @@
         "max-depth": [2, 5],
         "complexity": [1, 8],
         "prefer-const": 1,
-        "indent": [2, 2],
         "no-trailing-spaces": [2, {"skipBlankLines": false}],
         "one-var": [2, "never"],
         "key-spacing": [2, {

--- a/.eslintrc
+++ b/.eslintrc
@@ -99,7 +99,6 @@
         "no-dupe-keys": 2,
         "no-dupe-args": 2,
         "no-constant-condition": 2,
-        "no-cond-assign": 2,
         "comma-style": [2, "last"],
         "no-lonely-if": 2
     },

--- a/spec/Observable-spec.js
+++ b/spec/Observable-spec.js
@@ -72,6 +72,21 @@ describe('Observable', function () {
 
       expect(typeof result.then).toBe('function');
     });
+
+    it('should reject promise if nextHandler throws', function (done) {
+      var results = [];
+      Observable.of(1,2,3).forEach(function (x) {
+        if (x === 3) {
+          throw new Error('NO THREES!');
+        };
+        results.push(x);
+      })
+      .then(done.fail, function (err) {
+        expect(err).toEqual(new Error('NO THREES!'));
+        expect(results).toEqual([1,2]);
+      })
+      .then(done);
+    });
   });
 
   describe('subscribe', function () {

--- a/spec/operators/retry-spec.js
+++ b/spec/operators/retry-spec.js
@@ -24,7 +24,7 @@ describe('Observable.prototype.retry()', function () {
       observer.complete();
     })
       .map(function (x) {
-        if ((errors += 1) < retries) {
+        if (++errors < retries) {
           throw 'bad';
         }
         errors = 0;
@@ -72,7 +72,7 @@ describe('Observable.prototype.retry()', function () {
       observer.complete();
     })
       .map(function (x) {
-        if ((errors += 1) < retries) {
+        if (++errors < retries) {
           throw 'bad';
         }
         errors = 0;


### PR DESCRIPTION
There are a few merge errors fixed in here as well. 

This introduces some closure in the forEach implementation, but I'm not super concerned about it for now.