### PR TITLE
docs(README): add browser test coverage matrix

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 [![Coverage Status](https://coveralls.io/repos/ReactiveX/RxJS/badge.svg?branch=master&service=github)](https://coveralls.io/github/ReactiveX/RxJS?branch=master)
 [![npm version](https://badge.fury.io/js/%40reactivex%2Frxjs.svg)](http://badge.fury.io/js/%40reactivex%2Frxjs)
 
+[![Selenium Test Status](https://saucelabs.com/browser-matrix/rxjs5.svg)](https://saucelabs.com/u/rxjs5)
+
 # RxJS 5 (beta)
 
 Reactive Extensions Library for JavaScript. This is a rewrite of [Reactive-Extensions/RxJS](https://github.com/Reactive-Extensions/RxJS) and is intended to supersede it once this is ready. This rewrite is meant to have better performance, better modularity, better debuggable call stacks, while staying mostly backwards compatible, with some breaking changes that reduce the API surface.


### PR DESCRIPTION
relates to #998 

Now travis connected to saucelab with account name `rxjs5` for main repo, updating badge to display its latest status. (Unfortunately all flags are red currently :( )