### PR TITLE
fix(subscriptions): unsubscribe correctly when a Subscriber throws during synchronous dispatch.

### DIFF
--- a/spec/Observable-spec.js
+++ b/spec/Observable-spec.js
@@ -146,7 +146,7 @@ describe('Observable', function () {
       expect(unsubscribeCalled).toBe(true);
     });
 
-    it('should not run unsubscription logic when an error is thrown sending messages synchronously', function () {
+    it('should run unsubscription logic when an error is thrown sending messages synchronously', function () {
       var messageError = false;
       var messageErrorValue = false;
       var unsubscribeCalled = false;
@@ -167,7 +167,7 @@ describe('Observable', function () {
       }
 
       expect(sub).toBe(undefined);
-      expect(unsubscribeCalled).toBe(false);
+      expect(unsubscribeCalled).toBe(true);
       expect(messageError).toBe(true);
       expect(messageErrorValue).toBe('boo!');
     });
@@ -195,7 +195,7 @@ describe('Observable', function () {
 
       expect(sub).toBe(undefined);
       expect(subscriber.isUnsubscribed).toBe(true);
-      expect(unsubscribeCalled).toBe(false);
+      expect(unsubscribeCalled).toBe(true);
       expect(messageError).toBe(true);
       expect(messageErrorValue).toBe('boo!');
     });
@@ -268,7 +268,7 @@ describe('Observable', function () {
         }
 
         expect(sub).toBe(undefined);
-        expect(unsubscribeCalled).toBe(false);
+        expect(unsubscribeCalled).toBe(true);
         expect(messageError).toBe(true);
         expect(messageErrorValue).toBe('boo!');
       });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -118,6 +118,13 @@ export class Observable<T> implements CoreOperators<T>  {
       subscriber.add(this._subscribe(subscriber));
     }
 
+    if (subscriber.syncErrorThrowable) {
+      subscriber.syncErrorThrowable = false;
+      if (subscriber.syncErrorThrown) {
+        throw subscriber.syncErrorValue;
+      }
+    }
+
     return subscriber;
   }
 


### PR DESCRIPTION
Resolves #1186. Also adds more tests ensuring calls to `next`, `error`, and `complete` are called in the context of whatever Observer they were specified from (the `SafeSubscriber` in the case of callbacks, or the Object instance if given a duck-typed Observer).