### PR TITLE
chore(test): expand browser test coverage

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,7 +7,7 @@ module.exports = function (config) {
     sl_chrome: {
       base: 'SauceLabs',
       browserName: 'chrome',
-      version: '47'
+      version: '46'
     },
     sl_chrome_beta: {
       base: 'SauceLabs',
@@ -34,17 +34,89 @@ module.exports = function (config) {
       browserName: 'firefox',
       version: 'dev'
     },
+    sl_safari7: {
+      base: 'SauceLabs',
+      browserName: 'safari',
+      platform: 'OS X 10.9',
+      version: '7'
+    },
+    sl_safari8: {
+      base: 'SauceLabs',
+      browserName: 'safari',
+      platform: 'OS X 10.10',
+      version: '8'
+    },
     sl_safari9: {
       base: 'SauceLabs',
       browserName: 'safari',
       platform: 'OS X 10.11',
       version: '9.0'
     },
+    sl_ios7: {
+      base: 'SauceLabs',
+      browserName: 'iphone',
+      platform: 'OS X 10.10',
+      version: '7.1'
+    },
+    sl_ios8: {
+      base: 'SauceLabs',
+      browserName: 'iphone',
+      platform: 'OS X 10.10',
+      version: '8.4'
+    },
     sl_ios9: {
       base: 'SauceLabs',
       browserName: 'iphone',
       platform: 'OS X 10.10',
       version: '9.1'
+    },
+    sl_ie9: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 2008',
+      version: '9'
+    },
+    sl_ie10: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 2012',
+      version: '10'
+    },
+    sl_ie11: {
+      base: 'SauceLabs',
+      browserName: 'internet explorer',
+      platform: 'Windows 8.1',
+      version: '11'
+    },
+    sl_edge: {
+      base: 'SauceLabs',
+      browserName: 'microsoftedge',
+      platform: 'Windows 10',
+      version: '20.10240'
+    },
+    sl_android_4_1: {
+      base: 'SauceLabs',
+      browserName: 'android',
+      platform: 'Linux',
+      version: '4.1'
+    },
+    sl_android_4_2: {
+      base: 'SauceLabs',
+      browserName: 'android',
+      platform: 'Linux',
+      version: '4.2'
+    },
+    sl_android_4_3: {
+      base: 'SauceLabs',
+      browserName: 'android',
+      platform: 'Linux',
+      version: '4.3'
+    },
+    sl_android_4_4: {
+      base: 'SauceLabs',
+      browserName: 'android',
+      platform: 'Linux',
+      version: '4.4'
     },
     sl_android5: {
       base: 'SauceLabs',
@@ -67,6 +139,7 @@ module.exports = function (config) {
     files: [
       'spec/helpers/marble-testing.js',
       'spec/helpers/test-helper.js',
+      'spec/helpers/ajax-helper.js',
       'spec/**/*-spec.js'
     ],
 


### PR DESCRIPTION
- expand browser list to be tested
- update karma configuration for newly added rx.dom test cases

closes #998 

This PR updates karma configurations to able to execute tests correctly, also expand browser matrix to cover all major browsers. There are browsers failing some of test cases can be triaged separately per each.