### PR TITLE
refactor(Error): let derived error objects extends error

### DIFF
--- a/src/util/ArgumentOutOfRangeError.ts
+++ b/src/util/ArgumentOutOfRangeError.ts
@@ -1,4 +1,6 @@
-export class ArgumentOutOfRangeError implements Error {
-  name = 'ArgumentOutOfRangeError';
-  message = 'argument out of range';
+export class ArgumentOutOfRangeError extends Error {
+  constructor() {
+    super('argument out of range');
+    this.name = 'ArgumentOutOfRangeError';
+  }
 }

--- a/src/util/EmptyError.ts
+++ b/src/util/EmptyError.ts
@@ -1,4 +1,6 @@
-export class EmptyError implements Error {
-  name = 'EmptyError';
-  message = 'no elements in sequence';
+export class EmptyError extends Error {
+  constructor() {
+    super('no elements in sequence');
+    this.name = 'EmptyError';
+  }
 }


### PR DESCRIPTION
This PR aligns derived object extends `Error`, removes inconsistency when error is thrown on some browser.