### PR TITLE
refactor(Observable): remove create() from internal sublasses

### DIFF
--- a/spec/observables/IteratorObservable-spec.js
+++ b/spec/observables/IteratorObservable-spec.js
@@ -9,37 +9,31 @@ describe('IteratorObservable', function () {
     expect(source instanceof IteratorObservable).toBe(true);
   });
 
-  it('should create IteratorObservable via static create function', function () {
-    var s = new IteratorObservable([]);
-    var r = IteratorObservable.create([]);
-    expect(s).toEqual(r);
-  });
-
   it('should not accept null (or truthy-equivalent to null) iterator', function () {
     expect(function () {
-      IteratorObservable.create(null);
+      var source = new IteratorObservable(null);
     }).toThrowError('iterator cannot be null.');
     expect(function () {
-      IteratorObservable.create(void 0);
+      var source = new IteratorObservable(void 0);
     }).toThrowError('iterator cannot be null.');
   });
 
   it('should not accept boolean as iterator', function () {
     expect(function () {
-      IteratorObservable.create(false);
+      var source = new IteratorObservable(false);
     }).toThrowError('Object is not iterable');
   });
 
   it('should not accept non-function project', function () {
     expect(function () {
-      IteratorObservable.create([], 42);
+      var source = new IteratorObservable([], 42);
     }).toThrowError('When provided, `project` must be a function.');
   });
 
   it('should emit members of an array iterator', function (done) {
     var expected = [10, 20, 30, 40];
-    IteratorObservable.create([10, 20, 30, 40])
-      .subscribe(
+    var source = new IteratorObservable([10, 20, 30, 40]);
+    source.subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
         function () {
@@ -50,7 +44,7 @@ describe('IteratorObservable', function () {
   });
 
   it('should emit members of an array iterator on a particular scheduler', function () {
-    var source = IteratorObservable.create(
+    var source = new IteratorObservable(
       [10, 20, 30, 40],
       function (x) { return x; },
       null,
@@ -63,7 +57,7 @@ describe('IteratorObservable', function () {
   });
 
   it('should emit members of an array iterator on a particular scheduler, project throws', function () {
-    var source = IteratorObservable.create(
+    var source = new IteratorObservable(
       [10, 20, 30, 40],
       function (x) {
         if (x === 30) {
@@ -84,7 +78,7 @@ describe('IteratorObservable', function () {
   'but is unsubscribed early', function (done) {
     var expected = [10, 20, 30, 40];
 
-    var source = IteratorObservable.create(
+    var source = new IteratorObservable(
       [10, 20, 30, 40],
       function (x) { return x; },
       null,
@@ -108,8 +102,8 @@ describe('IteratorObservable', function () {
 
   it('should emit members of an array iterator, and project them', function (done) {
     var expected = [100, 400, 900, 1600];
-    IteratorObservable.create([10, 20, 30, 40], function (x) { return x * x; })
-      .subscribe(
+    var source = new IteratorObservable([10, 20, 30, 40], function (x) { return x * x; });
+    source.subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
         function () {
@@ -128,8 +122,8 @@ describe('IteratorObservable', function () {
         return x * x;
       }
     }
-    IteratorObservable.create([10, 20, 30, 40], project)
-      .subscribe(
+    var source = new IteratorObservable([10, 20, 30, 40], project);
+    source.subscribe(
         function (x) {
           expect(x).toBe(expected.shift());
         },
@@ -144,8 +138,8 @@ describe('IteratorObservable', function () {
 
   it('should emit characters of a string iterator', function (done) {
     var expected = ['f', 'o', 'o'];
-    IteratorObservable.create('foo')
-      .subscribe(
+    var source = new IteratorObservable('foo');
+    source.subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
         function () {
@@ -157,8 +151,8 @@ describe('IteratorObservable', function () {
 
   it('should emit characters of a string iterator, and project them', function (done) {
     var expected = ['F', 'O', 'O'];
-    IteratorObservable.create('foo', function (x) { return x.toUpperCase(); })
-      .subscribe(
+    var source = new IteratorObservable('foo', function (x) { return x.toUpperCase(); });
+    source.subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
         function () {
@@ -183,6 +177,7 @@ describe('IteratorObservable', function () {
       done.fail
     );
 
-    IteratorObservable.create([10, 20, 30, 40, 50, 60]).subscribe(subscriber);
+    var source = new IteratorObservable([10, 20, 30, 40, 50, 60]);
+    source.subscribe(subscriber);
   });
 });

--- a/spec/observables/ScalarObservable-spec.js
+++ b/spec/observables/ScalarObservable-spec.js
@@ -11,13 +11,6 @@ describe('ScalarObservable', function () {
     expect(s.value).toBe(1);
   });
 
-  it('should create ScalarObservable via static create function', function () {
-    var s = new ScalarObservable(1);
-    var r = ScalarObservable.create(1);
-
-    expect(s).toEqual(r);
-  });
-
   it('should not schedule further if subscriber unsubscribed', function () {
     var s = new ScalarObservable(1, rxTestScheduler);
     var subscriber = new Rx.Subscriber();

--- a/spec/observables/SubscribeOnObservable-spec.js
+++ b/spec/observables/SubscribeOnObservable-spec.js
@@ -21,13 +21,6 @@ describe('SubscribeOnObservable', function () {
     expect(scheduler).toBe(Rx.Scheduler.asap);
   });
 
-  it('should create observable via staic create function', function () {
-    var s = new SubscribeOnObservable(rxTestScheduler);
-    var r = SubscribeOnObservable.create(rxTestScheduler);
-
-    expect(s).toEqual(r);
-  });
-
   it('should subscribe after specified delay', function () {
     var e1 =   hot('--a--b--|');
     var expected = '-----b--|';

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -12,13 +12,6 @@ import {Subscriber} from '../Subscriber';
 export class IteratorObservable<T> extends Observable<T> {
   private iterator: any;
 
-  static create<T>(iterator: any,
-                   project?: ((x?: any, i?: number) => T) | any,
-                   thisArg?: any | Scheduler,
-                   scheduler?: Scheduler) {
-    return new IteratorObservable(iterator, project, thisArg, scheduler);
-  }
-
   static dispatch(state: any) {
 
     const { index, hasError, thisArg, project, iterator, subscriber } = state;

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -4,10 +4,6 @@ import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
 export class ScalarObservable<T> extends Observable<T> {
-  static create<T>(value: T, scheduler?: Scheduler): ScalarObservable<T> {
-    return new ScalarObservable(value, scheduler);
-  }
-
   static dispatch(state: any): void {
     const { done, value, subscriber } = state;
 

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -6,10 +6,6 @@ import {asap} from '../scheduler/asap';
 import {isNumeric} from '../util/isNumeric';
 
 export class SubscribeOnObservable<T> extends Observable<T> {
-  static create<T>(source: Observable<T>, delay: number = 0, scheduler: Scheduler = asap): Observable<T> {
-    return new SubscribeOnObservable(source, delay, scheduler);
-  }
-
   static dispatch<T>({ source, subscriber }): Subscription {
     return source.subscribe(subscriber);
   }


### PR DESCRIPTION
Currently, there are some Observable subclasses that are not directly
exported by a static operator of Observable but still have a `create()`
factory method. This method is not being used anywhere inside the
codebase besides explicit spec tests. The other operators that create
these special Observables are instantiating it via the constructor.

By removing these methods, we address issue #1183 as the patch generator
script looks for observables with `create()` to generate a patch such
as: `Observable.from = FromObservable.create;`.

Closes #1183