### PR TITLE
chore(test): update karma, wallaby configuration

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -55,19 +55,19 @@ module.exports = function (config) {
     sl_ios7: {
       base: 'SauceLabs',
       browserName: 'iphone',
-      platform: 'OS X 10.10',
+      platform: 'OS X 10.11',
       version: '7.1'
     },
     sl_ios8: {
       base: 'SauceLabs',
       browserName: 'iphone',
-      platform: 'OS X 10.10',
+      platform: 'OS X 10.11',
       version: '8.4'
     },
     sl_ios9: {
       base: 'SauceLabs',
       browserName: 'iphone',
-      platform: 'OS X 10.10',
+      platform: 'OS X 10.11',
       version: '9.1'
     },
     sl_ie9: {
@@ -184,12 +184,15 @@ module.exports = function (config) {
     // how many browser should be started simultanous
     concurrency: 1,
 
+    browserNoActivityTimeout: 30000,
+
     sauceLabs: {
       testName: 'RxJS 5 browser test',
       options: {
         'command-timeout': 600,
-        'idle-timeout': 600,
-        'max-duration': 5400
+        'idle-timeout': 12000,
+        'max-duration': 10800,
+        'recordScreenshots': true
       }
     }
   });

--- a/wallaby.js
+++ b/wallaby.js
@@ -36,5 +36,6 @@ module.exports = wallaby => ({
 
     // Global test helpers
     require('./spec/helpers/test-helper');
+    require('./spec/helpers/ajax-helper');
   }
 });


### PR DESCRIPTION
This PR updates karma configuration to let browser test have more sufficient to not to be disconnected while test is running. Test disconnection usually occurs on VM based test (IOS, etcs). 