### PR TITLE
refactor(observable): made create strongly typed by creating a factor…

### DIFF
--- a/spec/observables/ErrorObservable-spec.js
+++ b/spec/observables/ErrorObservable-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect, rxTestScheduler, expectObservable*/
 var Rx = require('../../dist/cjs/Rx');
 var ErrorObservable = require('../../dist/cjs/observable/throw').ErrorObservable;
+var create = require('../../dist/cjs/observable/throw').create;
 var Observable = Rx.Observable;
 
 describe('ErrorObservable', function () {
@@ -11,13 +12,13 @@ describe('ErrorObservable', function () {
 
   it('should create ErrorObservable via static create function', function () {
     var e = new ErrorObservable('error');
-    var r = ErrorObservable.create('error');
+    var r = create('error');
 
     expect(e).toEqual(r);
   });
 
   it('should accept scheduler', function () {
-    var e = ErrorObservable.create('error', rxTestScheduler);
+    var e = create('error', rxTestScheduler);
 
     expectObservable(e).toBe('#');
   });

--- a/spec/observables/IteratorObservable-spec.js
+++ b/spec/observables/IteratorObservable-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect, rxTestScheduler*/
 var Rx = require('../../dist/cjs/Rx');
 var IteratorObservable = require('../../dist/cjs/observable/IteratorObservable').IteratorObservable;
+var create = require('../../dist/cjs/observable/IteratorObservable').create;
 var Observable = Rx.Observable;
 
 describe('IteratorObservable', function () {
@@ -11,34 +12,34 @@ describe('IteratorObservable', function () {
 
   it('should create IteratorObservable via static create function', function () {
     var s = new IteratorObservable([]);
-    var r = IteratorObservable.create([]);
+    var r = create([]);
     expect(s).toEqual(r);
   });
 
   it('should not accept null (or truthy-equivalent to null) iterator', function () {
     expect(function () {
-      IteratorObservable.create(null);
+      create(null);
     }).toThrowError('iterator cannot be null.');
     expect(function () {
-      IteratorObservable.create(void 0);
+      create(void 0);
     }).toThrowError('iterator cannot be null.');
   });
 
   it('should not accept boolean as iterator', function () {
     expect(function () {
-      IteratorObservable.create(false);
+      create(false);
     }).toThrowError('Object is not iterable');
   });
 
   it('should not accept non-function project', function () {
     expect(function () {
-      IteratorObservable.create([], 42);
+      create([], 42);
     }).toThrowError('When provided, `project` must be a function.');
   });
 
   it('should emit members of an array iterator', function (done) {
     var expected = [10, 20, 30, 40];
-    IteratorObservable.create([10, 20, 30, 40])
+    create([10, 20, 30, 40])
       .subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
@@ -50,7 +51,7 @@ describe('IteratorObservable', function () {
   });
 
   it('should emit members of an array iterator on a particular scheduler', function () {
-    var source = IteratorObservable.create(
+    var source = create(
       [10, 20, 30, 40],
       function (x) { return x; },
       null,
@@ -63,7 +64,7 @@ describe('IteratorObservable', function () {
   });
 
   it('should emit members of an array iterator on a particular scheduler, project throws', function () {
-    var source = IteratorObservable.create(
+    var source = create(
       [10, 20, 30, 40],
       function (x) {
         if (x === 30) {
@@ -84,7 +85,7 @@ describe('IteratorObservable', function () {
   'but is unsubscribed early', function (done) {
     var expected = [10, 20, 30, 40];
 
-    var source = IteratorObservable.create(
+    var source = create(
       [10, 20, 30, 40],
       function (x) { return x; },
       null,
@@ -108,7 +109,7 @@ describe('IteratorObservable', function () {
 
   it('should emit members of an array iterator, and project them', function (done) {
     var expected = [100, 400, 900, 1600];
-    IteratorObservable.create([10, 20, 30, 40], function (x) { return x * x; })
+    create([10, 20, 30, 40], function (x) { return x * x; })
       .subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
@@ -128,7 +129,7 @@ describe('IteratorObservable', function () {
         return x * x;
       }
     }
-    IteratorObservable.create([10, 20, 30, 40], project)
+    create([10, 20, 30, 40], project)
       .subscribe(
         function (x) {
           expect(x).toBe(expected.shift());
@@ -144,7 +145,7 @@ describe('IteratorObservable', function () {
 
   it('should emit characters of a string iterator', function (done) {
     var expected = ['f', 'o', 'o'];
-    IteratorObservable.create('foo')
+    create('foo')
       .subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
@@ -157,7 +158,7 @@ describe('IteratorObservable', function () {
 
   it('should emit characters of a string iterator, and project them', function (done) {
     var expected = ['F', 'O', 'O'];
-    IteratorObservable.create('foo', function (x) { return x.toUpperCase(); })
+    create('foo', function (x) { return x.toUpperCase(); })
       .subscribe(
         function (x) { expect(x).toBe(expected.shift()); },
         done.fail,
@@ -183,6 +184,6 @@ describe('IteratorObservable', function () {
       done.fail
     );
 
-    IteratorObservable.create([10, 20, 30, 40, 50, 60]).subscribe(subscriber);
+    create([10, 20, 30, 40, 50, 60]).subscribe(subscriber);
   });
 });

--- a/spec/observables/ScalarObservable-spec.js
+++ b/spec/observables/ScalarObservable-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect, rxTestScheduler*/
 var Rx = require('../../dist/cjs/Rx');
 var ScalarObservable = require('../../dist/cjs/observable/ScalarObservable').ScalarObservable;
+var create = require('../../dist/cjs/observable/ScalarObservable').create;
 var EmptyObservable = require('../../dist/cjs/observable/empty').EmptyObservable;
 var ErrorObservable = require('../../dist/cjs/observable/throw').ErrorObservable;
 var Observable = Rx.Observable;
@@ -13,7 +14,7 @@ describe('ScalarObservable', function () {
 
   it('should create ScalarObservable via static create function', function () {
     var s = new ScalarObservable(1);
-    var r = ScalarObservable.create(1);
+    var r = create(1);
 
     expect(s).toEqual(r);
   });

--- a/spec/observables/SubscribeOnObservable-spec.js
+++ b/spec/observables/SubscribeOnObservable-spec.js
@@ -1,6 +1,7 @@
 /* globals describe, it, expect, hot, expectObservable, expectSubscriptions, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx');
 var SubscribeOnObservable = require('../../dist/cjs/observable/SubscribeOnObservable').SubscribeOnObservable;
+var create = require('../../dist/cjs/observable/SubscribeOnObservable').create;
 var Observable = Rx.Observable;
 
 describe('SubscribeOnObservable', function () {
@@ -23,7 +24,7 @@ describe('SubscribeOnObservable', function () {
 
   it('should create observable via staic create function', function () {
     var s = new SubscribeOnObservable(rxTestScheduler);
-    var r = SubscribeOnObservable.create(rxTestScheduler);
+    var r = create(rxTestScheduler);
 
     expect(s).toEqual(r);
   });

--- a/spec/observables/range-spec.js
+++ b/spec/observables/range-spec.js
@@ -1,5 +1,6 @@
 var Rx = require('../../dist/cjs/Rx');
 var RangeObservable = require('../../dist/cjs/observable/range').RangeObservable;
+var create = require('../../dist/cjs/observable/range').create;
 var Observable = Rx.Observable;
 var asap = Rx.Scheduler.asap;
 
@@ -33,12 +34,12 @@ describe('Observable.range', function () {
 describe('RangeObservable', function () {
   describe('create', function () {
     it('should create a RangeObservable', function () {
-      var observable = RangeObservable.create(12, 4);
+      var observable = create(12, 4);
       expect(observable instanceof RangeObservable).toBe(true);
     });
 
     it('should accept a scheduler', function () {
-      var observable = RangeObservable.create(12, 4, asap);
+      var observable = create(12, 4, asap);
       expect(observable.scheduler).toBe(asap);
     });
   });

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -18,24 +18,24 @@ import {combineLatest as combineLatestStatic} from './operator/combineLatest-sta
 import {concat as concatStatic} from './operator/concat-static';
 import {merge as mergeStatic} from './operator/merge-static';
 import {zip as zipStatic} from './operator/zip-static';
-import {BoundCallbackObservable} from './observable/bindCallback';
-import {BoundNodeCallbackObservable} from './observable/bindNodeCallback';
-import {DeferObservable} from './observable/defer';
-import {EmptyObservable} from './observable/empty';
-import {ForkJoinObservable} from './observable/forkJoin';
-import {FromObservable} from './observable/from';
-import {ArrayObservable} from './observable/fromArray';
-import {FromEventObservable} from './observable/fromEvent';
-import {FromEventPatternObservable} from './observable/fromEventPattern';
-import {PromiseObservable} from './observable/fromPromise';
-import {IntervalObservable} from './observable/interval';
-import {TimerObservable} from './observable/timer';
+import {create as createBoundCallbackObservable} from './observable/bindCallback';
+import {create as createBoundNodeCallbackObservable} from './observable/bindNodeCallback';
+import {create as createDeferObservable} from './observable/defer';
+import {create as createEmptyObservable} from './observable/empty';
+import {create as createForkJoinObservable} from './observable/forkJoin';
+import {create as createFromObservable} from './observable/from';
+import {create as createArrayObservable, ArrayObservable} from './observable/fromArray';
+import {create as createFromEventObservable} from './observable/fromEvent';
+import {create as createFromEventPatternObservable} from './observable/fromEventPattern';
+import {create as createPromiseObservable} from './observable/fromPromise';
+import {create as createIntervalObservable} from './observable/interval';
+import {create as createTimerObservable} from './observable/timer';
 import {race as raceStatic} from './operator/race-static';
-import {RangeObservable} from './observable/range';
-import {InfiniteObservable} from './observable/never';
-import {ErrorObservable} from './observable/throw';
+import {create as createRangeObservable} from './observable/range';
+import {create as createInfiniteObservable} from './observable/never';
+import {create as createErrorObservable} from './observable/throw';
 import {AjaxCreationMethod} from './observable/dom/ajax';
-import {WebSocketSubject} from './observable/dom/webSocket';
+import {create as createWebSocketSubject} from './observable/dom/webSocket';
 
 /**
  * A representation of any set of values over any amount of time. This the most basic building block
@@ -72,7 +72,7 @@ export class Observable<T> implements CoreOperators<T>  {
    * @returns {Observable} a new cold observable
    * @description creates a new cold Observable by calling the Observable constructor
    */
-  static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) => {
+  static create<T>(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) {
     return new Observable<T>(subscribe);
   };
 
@@ -156,27 +156,27 @@ export class Observable<T> implements CoreOperators<T>  {
 
   // static method stubs
   static ajax: AjaxCreationMethod;
-  static bindCallback: typeof BoundCallbackObservable.create;
-  static bindNodeCallback: typeof BoundNodeCallbackObservable.create;
+  static bindCallback: typeof createBoundCallbackObservable;
+  static bindNodeCallback: typeof createBoundNodeCallbackObservable;
   static combineLatest: typeof combineLatestStatic;
   static concat: typeof concatStatic;
-  static defer: typeof DeferObservable.create;
-  static empty: typeof EmptyObservable.create;
-  static forkJoin: typeof ForkJoinObservable.create;
-  static from: typeof FromObservable.create;
-  static fromArray: typeof ArrayObservable.create;
-  static fromEvent: typeof FromEventObservable.create;
-  static fromEventPattern: typeof FromEventPatternObservable.create;
-  static fromPromise: typeof PromiseObservable.create;
-  static interval: typeof IntervalObservable.create;
+  static defer: typeof createDeferObservable;
+  static empty: typeof createEmptyObservable;
+  static forkJoin: typeof createForkJoinObservable;
+  static from: typeof createFromObservable;
+  static fromArray: typeof createArrayObservable;
+  static fromEvent: typeof createFromEventObservable;
+  static fromEventPattern: typeof createFromEventPatternObservable;
+  static fromPromise: typeof createPromiseObservable;
+  static interval: typeof createIntervalObservable;
   static merge: typeof mergeStatic;
-  static never: typeof InfiniteObservable.create;
+  static never: typeof createInfiniteObservable;
   static of: typeof ArrayObservable.of;
   static race: typeof raceStatic;
-  static range: typeof RangeObservable.create;
-  static throw: typeof ErrorObservable.create;
-  static timer: typeof TimerObservable.create;
-  static webSocket: typeof WebSocketSubject.create;
+  static range: typeof createRangeObservable;
+  static throw: typeof createErrorObservable;
+  static timer: typeof createTimerObservable;
+  static webSocket: typeof createWebSocketSubject;
   static zip: typeof zipStatic;
 
   // core operators

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -6,12 +6,7 @@ import {Subscription} from './Subscription';
 import {SubjectSubscription} from './subject/SubjectSubscription';
 import {rxSubscriber} from './symbol/rxSubscriber';
 
-export class Subject<T> extends Observable<T> implements Observer<T>, Subscription {
-
-  static create: Function = <T>(source: Observable<T>, destination: Observer<T>): Subject<T> => {
-    return new Subject<T>(source, destination);
-  };
-
+export abstract class BaseSubject<T> extends Observable<T> implements Observer<T>, Subscription {
   constructor(source?: Observable<T>, destination?: Observer<T>) {
     super();
     this.source = source;
@@ -203,3 +198,16 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     return new Subscriber<T>(this);
   }
 }
+
+export class Subject<T> extends BaseSubject<T> {
+  static createSubject<T>(source: Observable<T>, destination: Observer<T>): Subject<T> {
+    return new Subject<T>(source, destination);
+  }
+
+  constructor(source?: Observable<T>, destination?: Observer<T>) {
+    super(source, destination);
+  }
+}
+
+// Back compatability
+(<any>Subject).create = Subject.createSubject;

--- a/src/add/observable/bindCallback.ts
+++ b/src/add/observable/bindCallback.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {BoundCallbackObservable} from '../../observable/bindCallback';
+import {create} from '../../observable/bindCallback';
 
-Observable.bindCallback = BoundCallbackObservable.create;
+Observable.bindCallback = create;
 
 export var _void: void;

--- a/src/add/observable/bindNodeCallback.ts
+++ b/src/add/observable/bindNodeCallback.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {BoundNodeCallbackObservable} from '../../observable/bindNodeCallback';
+import {create} from '../../observable/bindNodeCallback';
 
-Observable.bindNodeCallback = BoundNodeCallbackObservable.create;
+Observable.bindNodeCallback = create;
 
 export var _void: void;

--- a/src/add/observable/defer.ts
+++ b/src/add/observable/defer.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {DeferObservable} from '../../observable/defer';
+import {create} from '../../observable/defer';
 
-Observable.defer = DeferObservable.create;
+Observable.defer = create;
 
 export var _void: void;

--- a/src/add/observable/dom/ajax.ts
+++ b/src/add/observable/dom/ajax.ts
@@ -1,5 +1,5 @@
 import {Observable} from '../../../Observable';
-import { AjaxObservable, AjaxCreationMethod } from '../../../observable/dom/ajax';
-Observable.ajax = AjaxObservable.create;
+import { create } from '../../../observable/dom/ajax';
+Observable.ajax = create;
 
 export var _void: void;

--- a/src/add/observable/dom/webSocket.ts
+++ b/src/add/observable/dom/webSocket.ts
@@ -1,5 +1,5 @@
 import {Observable} from '../../../Observable';
-import {WebSocketSubject} from '../../../observable/dom/webSocket';
-Observable.webSocket = WebSocketSubject.create;
+import {create} from '../../../observable/dom/webSocket';
+Observable.webSocket = create;
 
 export var _void: void;

--- a/src/add/observable/empty.ts
+++ b/src/add/observable/empty.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {EmptyObservable} from '../../observable/empty';
+import {create} from '../../observable/empty';
 
-Observable.empty = EmptyObservable.create;
+Observable.empty = create;
 
 export var _void: void;

--- a/src/add/observable/forkJoin.ts
+++ b/src/add/observable/forkJoin.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {ForkJoinObservable} from '../../observable/forkJoin';
+import {create} from '../../observable/forkJoin';
 
-Observable.forkJoin = ForkJoinObservable.create;
+Observable.forkJoin = create;
 
 export var _void: void;

--- a/src/add/observable/from.ts
+++ b/src/add/observable/from.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {FromObservable} from '../../observable/from';
+import {create} from '../../observable/from';
 
-Observable.from = FromObservable.create;
+Observable.from = create;
 
 export var _void: void;

--- a/src/add/observable/fromArray.ts
+++ b/src/add/observable/fromArray.ts
@@ -3,9 +3,9 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {ArrayObservable} from '../../observable/fromArray';
+import {ArrayObservable, create} from '../../observable/fromArray';
 
-Observable.fromArray = ArrayObservable.create;
+Observable.fromArray = create;
 Observable.of = ArrayObservable.of;
 
 export var _void: void;

--- a/src/add/observable/fromEvent.ts
+++ b/src/add/observable/fromEvent.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {FromEventObservable} from '../../observable/fromEvent';
+import {create} from '../../observable/fromEvent';
 
-Observable.fromEvent = FromEventObservable.create;
+Observable.fromEvent = create;
 
 export var _void: void;

--- a/src/add/observable/fromEventPattern.ts
+++ b/src/add/observable/fromEventPattern.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {FromEventPatternObservable} from '../../observable/fromEventPattern';
+import {create} from '../../observable/fromEventPattern';
 
-Observable.fromEventPattern = FromEventPatternObservable.create;
+Observable.fromEventPattern = create;
 
 export var _void: void;

--- a/src/add/observable/fromPromise.ts
+++ b/src/add/observable/fromPromise.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {PromiseObservable} from '../../observable/fromPromise';
+import {create} from '../../observable/fromPromise';
 
-Observable.fromPromise = PromiseObservable.create;
+Observable.fromPromise = create;
 
 export var _void: void;

--- a/src/add/observable/interval.ts
+++ b/src/add/observable/interval.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {IntervalObservable} from '../../observable/interval';
+import {create} from '../../observable/interval';
 
-Observable.interval = IntervalObservable.create;
+Observable.interval = create;
 
 export var _void: void;

--- a/src/add/observable/never.ts
+++ b/src/add/observable/never.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {InfiniteObservable} from '../../observable/never';
+import {create} from '../../observable/never';
 
-Observable.never = InfiniteObservable.create;
+Observable.never = create;
 
 export var _void: void;

--- a/src/add/observable/range.ts
+++ b/src/add/observable/range.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {RangeObservable} from '../../observable/range';
+import {create} from '../../observable/range';
 
-Observable.range = RangeObservable.create;
+Observable.range = create;
 
 export var _void: void;

--- a/src/add/observable/throw.ts
+++ b/src/add/observable/throw.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {ErrorObservable} from '../../observable/throw';
+import {create} from '../../observable/throw';
 
-Observable.throw = ErrorObservable.create;
+Observable.throw = create;
 
 export var _void: void;

--- a/src/add/observable/timer.ts
+++ b/src/add/observable/timer.ts
@@ -3,8 +3,8 @@
  * Any manual edits to this file will be lost next time the script is run.
  **/
 import {Observable} from '../../Observable';
-import {TimerObservable} from '../../observable/timer';
+import {create} from '../../observable/timer';
 
-Observable.timer = TimerObservable.create;
+Observable.timer = create;
 
 export var _void: void;

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -9,15 +9,15 @@ import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
+export function create<T>(iterator: any,
+                          project?: ((x?: any, i?: number) => T) | any,
+                          thisArg?: any | Scheduler,
+                          scheduler?: Scheduler) {
+  return new IteratorObservable(iterator, project, thisArg, scheduler);
+}
+
 export class IteratorObservable<T> extends Observable<T> {
   private iterator: any;
-
-  static create<T>(iterator: any,
-                   project?: ((x?: any, i?: number) => T) | any,
-                   thisArg?: any | Scheduler,
-                   scheduler?: Scheduler) {
-    return new IteratorObservable(iterator, project, thisArg, scheduler);
-  }
 
   static dispatch(state: any) {
 

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -3,11 +3,11 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
-export class ScalarObservable<T> extends Observable<T> {
-  static create<T>(value: T, scheduler?: Scheduler): ScalarObservable<T> {
-    return new ScalarObservable(value, scheduler);
-  }
+export function create<T>(value: T, scheduler?: Scheduler): ScalarObservable<T> {
+  return new ScalarObservable(value, scheduler);
+}
 
+export class ScalarObservable<T> extends Observable<T> {
   static dispatch(state: any): void {
     const { done, value, subscriber } = state;
 

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -5,11 +5,11 @@ import {Observable} from '../Observable';
 import {asap} from '../scheduler/asap';
 import {isNumeric} from '../util/isNumeric';
 
-export class SubscribeOnObservable<T> extends Observable<T> {
-  static create<T>(source: Observable<T>, delay: number = 0, scheduler: Scheduler = asap): Observable<T> {
-    return new SubscribeOnObservable(source, delay, scheduler);
-  }
+export function create<T>(source: Observable<T>, delay: number = 0, scheduler: Scheduler = asap): Observable<T> {
+  return new SubscribeOnObservable(source, delay, scheduler);
+}
 
+export class SubscribeOnObservable<T> extends Observable<T> {
   static dispatch<T>({ source, subscriber }): Subscription {
     return source.subscribe(subscriber);
   }

--- a/src/observable/bindCallback.ts
+++ b/src/observable/bindCallback.ts
@@ -6,16 +6,16 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {AsyncSubject} from '../subject/AsyncSubject';
 
+export function create<T>(callbackFunc: Function,
+                          selector: Function | void = undefined,
+                          scheduler?: Scheduler): (...args: any[]) => Observable<T> {
+  return (...args: any[]): Observable<T> => {
+    return new BoundCallbackObservable<T>(callbackFunc, <any>selector, args, scheduler);
+  };
+}
+
 export class BoundCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
-
-  static create<T>(callbackFunc: Function,
-                   selector: Function | void = undefined,
-                   scheduler?: Scheduler): (...args: any[]) => Observable<T> {
-    return (...args: any[]): Observable<T> => {
-      return new BoundCallbackObservable<T>(callbackFunc, <any>selector, args, scheduler);
-    };
-  }
 
   constructor(private callbackFunc: Function,
               private selector: Function,

--- a/src/observable/bindNodeCallback.ts
+++ b/src/observable/bindNodeCallback.ts
@@ -6,16 +6,16 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {AsyncSubject} from '../subject/AsyncSubject';
 
+export function create<T>(callbackFunc: Function,
+                          selector: Function = undefined,
+                          scheduler?: Scheduler): Function {
+  return (...args: any[]): Observable<T> => {
+    return new BoundNodeCallbackObservable(callbackFunc, selector, args, scheduler);
+  };
+}
+
 export class BoundNodeCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
-
-  static create<T>(callbackFunc: Function,
-                   selector: Function = undefined,
-                   scheduler?: Scheduler): Function {
-    return (...args: any[]): Observable<T> => {
-      return new BoundNodeCallbackObservable(callbackFunc, selector, args, scheduler);
-    };
-  }
 
   constructor(private callbackFunc: Function,
               private selector: Function,

--- a/src/observable/defer.ts
+++ b/src/observable/defer.ts
@@ -3,12 +3,11 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
+export function create<T>(observableFactory: () => Observable<T>): Observable<T> {
+  return new DeferObservable(observableFactory);
+}
+
 export class DeferObservable<T> extends Observable<T> {
-
-  static create<T>(observableFactory: () => Observable<T>): Observable<T> {
-    return new DeferObservable(observableFactory);
-  }
-
   constructor(private observableFactory: () => Observable<T>) {
     super();
   }

--- a/src/observable/dom/ajax.ts
+++ b/src/observable/dom/ajax.ts
@@ -71,6 +71,21 @@ export function ajaxGetJSON<T, R>(url: string, resultSelector?: (data: T) => R, 
   const finalResultSelector = resultSelector ? (res: AjaxResponse) => resultSelector(res.response) : (res: AjaxResponse) => res.response;
   return new AjaxObservable<R>({ method: 'GET', url, responseType: 'json', resultSelector: finalResultSelector, headers });
 };
+
+export const create = (() => {
+  const create: any = (urlOrRequest: string | AjaxRequest) => {
+    return new AjaxObservable(urlOrRequest);
+  };
+
+  create.get = ajaxGet;
+  create.post = ajaxPost;
+  create.delete = ajaxDelete;
+  create.put = ajaxPut;
+  create.getJSON = ajaxGetJSON;
+
+  return <AjaxCreationMethod>create;
+})();
+
   /**
    * Creates an observable for an Ajax request with either a request object with url, headers, etc or a string for a URL.
    *
@@ -93,19 +108,6 @@ export function ajaxGetJSON<T, R>(url: string, resultSelector?: (data: T) => R, 
    * @returns {Observable} An observable sequence containing the XMLHttpRequest.
   */
 export class AjaxObservable<T> extends Observable<T> {
-  static create: AjaxCreationMethod = (() => {
-    const create: any = (urlOrRequest: string | AjaxRequest) => {
-      return new AjaxObservable(urlOrRequest);
-    };
-
-    create.get = ajaxGet;
-    create.post = ajaxPost;
-    create.delete = ajaxDelete;
-    create.put = ajaxPut;
-    create.getJSON = ajaxGetJSON;
-
-    return <AjaxCreationMethod>create;
-  })();
 
   private request: AjaxRequest;
 

--- a/src/observable/dom/webSocket.ts
+++ b/src/observable/dom/webSocket.ts
@@ -1,4 +1,4 @@
-import {Subject} from '../../Subject';
+import {BaseSubject} from '../../Subject';
 import {Subscriber} from '../../Subscriber';
 import {Observable} from '../../Observable';
 import {Operator} from '../../Operator';
@@ -20,7 +20,11 @@ export interface WebSocketSubjectConfig {
   WebSocketCtor?: { new(url: string, protocol?: string|Array<string>): WebSocket };
 }
 
-export class WebSocketSubject<T> extends Subject<T> {
+export function create<T>(urlConfigOrSource: string | WebSocketSubjectConfig): WebSocketSubject<T> {
+  return new WebSocketSubject(urlConfigOrSource);
+}
+
+export class WebSocketSubject<T> extends BaseSubject<T> {
   url: string;
   protocol: string|Array<string>;
   socket: WebSocket;
@@ -31,10 +35,6 @@ export class WebSocketSubject<T> extends Subject<T> {
 
   resultSelector(e: MessageEvent) {
     return JSON.parse(e.data);
-  }
-
-  static create<T>(urlConfigOrSource: string | WebSocketSubjectConfig): WebSocketSubject<T> {
-    return new WebSocketSubject(urlConfigOrSource);
   }
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig | Observable<T>, destination?: Observer<T>) {

--- a/src/observable/empty.ts
+++ b/src/observable/empty.ts
@@ -3,11 +3,11 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
-export class EmptyObservable<T> extends Observable<T> {
+export function create<T>(scheduler?: Scheduler): Observable<T> {
+  return new EmptyObservable<T>(scheduler);
+}
 
-  static create<T>(scheduler?: Scheduler): Observable<T> {
-    return new EmptyObservable<T>(scheduler);
-  }
+export class EmptyObservable<T> extends Observable<T> {
 
   static dispatch({ subscriber }) {
     subscriber.complete();

--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -10,28 +10,28 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {ObserveOnSubscriber} from '../operator/observeOn-support';
 
+export function create<T>(ish: any, scheduler: Scheduler = null): Observable<T> {
+  if (ish != null) {
+    if (typeof ish[SymbolShim.observable] === 'function') {
+      if (ish instanceof Observable && !scheduler) {
+        return ish;
+      }
+      return new FromObservable(ish, scheduler);
+    } if (isArray(ish)) {
+      return new ArrayObservable(ish, scheduler);
+    } else if (isPromise(ish)) {
+      return new PromiseObservable(ish, scheduler);
+    } else if (typeof ish[SymbolShim.iterator] === 'function' || typeof ish === 'string') {
+      return new IteratorObservable<T>(<any>ish, null, null, scheduler);
+    }
+  }
+
+  throw new TypeError((ish !== null && typeof ish || ish) + ' is not observable');
+}
+
 export class FromObservable<T> extends Observable<T> {
   constructor(private ish: Observable<T> | Promise<T> | Iterator<T> | ArrayLike<T>, private scheduler: Scheduler) {
     super(null);
-  }
-
-  static create<T>(ish: any, scheduler: Scheduler = null): Observable<T> {
-    if (ish != null) {
-      if (typeof ish[SymbolShim.observable] === 'function') {
-        if (ish instanceof Observable && !scheduler) {
-          return ish;
-        }
-        return new FromObservable(ish, scheduler);
-      } if (isArray(ish)) {
-        return new ArrayObservable(ish, scheduler);
-      } else if (isPromise(ish)) {
-        return new PromiseObservable(ish, scheduler);
-      } else if (typeof ish[SymbolShim.iterator] === 'function' || typeof ish === 'string') {
-        return new IteratorObservable<T>(<any>ish, null, null, scheduler);
-      }
-    }
-
-    throw new TypeError((ish !== null && typeof ish || ish) + ' is not observable');
   }
 
   protected _subscribe(subscriber: Subscriber<T>) {

--- a/src/observable/fromArray.ts
+++ b/src/observable/fromArray.ts
@@ -6,11 +6,11 @@ import {Subscriber} from '../Subscriber';
 import {isScheduler} from '../util/isScheduler';
 import {Subscription} from '../Subscription';
 
-export class ArrayObservable<T> extends Observable<T> {
+export function create<T>(array: T[], scheduler?: Scheduler) {
+  return new ArrayObservable(array, scheduler);
+}
 
-  static create<T>(array: T[], scheduler?: Scheduler) {
-    return new ArrayObservable(array, scheduler);
-  }
+export class ArrayObservable<T> extends Observable<T> {
 
   static of<T>(...array: Array<T | Scheduler>): Observable<T> {
     let scheduler = <Scheduler>array[array.length - 1];

--- a/src/observable/fromEvent.ts
+++ b/src/observable/fromEvent.ts
@@ -4,11 +4,11 @@ import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
-export class FromEventObservable<T, R> extends Observable<T> {
+export function create<T>(sourceObj: any, eventName: string, selector?: (...args: Array<any>) => T) {
+  return new FromEventObservable(sourceObj, eventName, selector);
+}
 
-  static create<T>(sourceObj: any, eventName: string, selector?: (...args: Array<any>) => T) {
-    return new FromEventObservable(sourceObj, eventName, selector);
-  }
+export class FromEventObservable<T, R> extends Observable<T> {
 
   constructor(private sourceObj: any, private eventName: string, private selector?: (...args: Array<any>) => T) {
     super();

--- a/src/observable/fromEventPattern.ts
+++ b/src/observable/fromEventPattern.ts
@@ -4,13 +4,13 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {Subscriber} from '../Subscriber';
 
-export class FromEventPatternObservable<T, R> extends Observable<T> {
+export function create<T>(addHandler: (handler: Function) => any,
+                          removeHandler: (handler: Function) => void,
+                          selector?: (...args: Array<any>) => T) {
+  return new FromEventPatternObservable(addHandler, removeHandler, selector);
+}
 
-  static create<T>(addHandler: (handler: Function) => any,
-                   removeHandler: (handler: Function) => void,
-                   selector?: (...args: Array<any>) => T) {
-    return new FromEventPatternObservable(addHandler, removeHandler, selector);
-  }
+export class FromEventPatternObservable<T, R> extends Observable<T> {
 
   constructor(private addHandler: (handler: Function) => any,
               private removeHandler: (handler: Function) => void,

--- a/src/observable/fromPromise.ts
+++ b/src/observable/fromPromise.ts
@@ -4,13 +4,13 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+export function create<T>(promise: Promise<T>, scheduler: Scheduler = null): Observable<T> {
+  return new PromiseObservable(promise, scheduler);
+}
+
 export class PromiseObservable<T> extends Observable<T> {
 
   public value: T;
-
-  static create<T>(promise: Promise<T>, scheduler: Scheduler = null): Observable<T> {
-    return new PromiseObservable(promise, scheduler);
-  }
 
   constructor(private promise: Promise<T>, public scheduler: Scheduler = null) {
     super();

--- a/src/observable/interval.ts
+++ b/src/observable/interval.ts
@@ -4,11 +4,11 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {asap} from '../scheduler/asap';
 
-export class IntervalObservable extends Observable<number> {
-  static create(period: number = 0, scheduler: Scheduler = asap): Observable<number> {
-    return new IntervalObservable(period, scheduler);
-  }
+export function create(period: number = 0, scheduler: Scheduler = asap): Observable<number> {
+  return new IntervalObservable(period, scheduler);
+}
 
+export class IntervalObservable extends Observable<number> {
   static dispatch(state: any): void {
     const { index, subscriber, period } = state;
 

--- a/src/observable/never.ts
+++ b/src/observable/never.ts
@@ -2,11 +2,11 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {noop} from '../util/noop';
 
-export class InfiniteObservable<T> extends Observable<T> {
-  static create<T>() {
-    return new InfiniteObservable<T>();
-  }
+export function create<T>() {
+  return new InfiniteObservable<T>();
+}
 
+export class InfiniteObservable<T> extends Observable<T> {
   constructor() {
     super();
   }

--- a/src/observable/range.ts
+++ b/src/observable/range.ts
@@ -3,11 +3,11 @@ import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
-export class RangeObservable extends Observable<number> {
+export function create(start: number = 0, end: number = 0, scheduler?: Scheduler): Observable<number> {
+  return new RangeObservable(start, end, scheduler);
+}
 
-  static create(start: number = 0, end: number = 0, scheduler?: Scheduler): Observable<number> {
-    return new RangeObservable(start, end, scheduler);
-  }
+export class RangeObservable extends Observable<number> {
 
   static dispatch(state: any) {
 

--- a/src/observable/throw.ts
+++ b/src/observable/throw.ts
@@ -2,11 +2,11 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
-export class ErrorObservable extends Observable<any> {
+export function create<T>(error: any, scheduler?: Scheduler) {
+  return new ErrorObservable(error, scheduler);
+}
 
-  static create<T>(error: any, scheduler?: Scheduler) {
-    return new ErrorObservable(error, scheduler);
-  }
+export class ErrorObservable extends Observable<any> {
 
   static dispatch({ error, subscriber }) {
     subscriber.error(error);

--- a/src/observable/timer.ts
+++ b/src/observable/timer.ts
@@ -7,11 +7,11 @@ import {isDate} from '../util/isDate';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
-export class TimerObservable extends Observable<number> {
+export function create(dueTime: number | Date = 0, period?: number | Scheduler, scheduler?: Scheduler): Observable<number> {
+  return new TimerObservable(dueTime, period, scheduler);
+}
 
-  static create(dueTime: number | Date = 0, period?: number | Scheduler, scheduler?: Scheduler): Observable<number> {
-    return new TimerObservable(dueTime, period, scheduler);
-  }
+export class TimerObservable extends Observable<number> {
 
   static dispatch(state: any) {
 

--- a/tools/generate-operator-patches.ts
+++ b/tools/generate-operator-patches.ts
@@ -97,9 +97,9 @@ ${typescriptHack}`;
 function generateNewObservableFileContents (op:OperatorWrapper): OperatorWrapper {
   var overrides = AliasMethodOverrides[op.path];
   var imports = `import {Observable} from '../../Observable';
-import {${op.exportedClassName}} from '../../observable/${op.path.replace('.ts','')}';`;
-  var patch = op.aliases.map((alias) => {
-    return `Observable.${alias} = ${op.exportedClassName}.${(overrides && overrides[alias]) || 'create'};`;
+import {${op.aliases.length > 1 ? op.exportedClassName + ', ' : ''}${'create'}} from '../../observable/${op.path.replace('.ts','')}';`;
+  var patch = op.aliases.map((alias, i) => {
+    return `Observable.${alias} = ${i > 0 ? op.exportedClassName + '.' + (overrides && overrides[alias]) : 'create'};`;
   }).join('\n');
 
   var contents = `${header}
@@ -164,7 +164,7 @@ function getAliases (op:OperatorWrapper): OperatorWrapper {
 }
 
 function checkForCreate (op: OperatorWrapper): boolean {
-  return /static create/.test(op.srcFileContents);
+  return /export (?:const|function) create/.test(op.srcFileContents);
 }
 
 if (process.argv.find((v) => v === '--exec')) {


### PR DESCRIPTION
…y for derived types

------
The last sticking point to enhance the typings, is that methods like `Observable.create` and `Subject.create` are defined as functions, due to how TypeScript inheritance works.  This also conflicts with other sub-typed observables, such as `ArrayObservable` and so on.

This changes sub-typed observables to no longer use the `create` method, but instead have a stand-alone `create` function that is exported alongside the Observable, instead of as a static member.

Subject is a special case, the default factory method is `createSubject` but we overwrite `Subject.create` to make sure this change is backwards compatible.

I have an alternative branch, that changes [sub-typed names to `factory`](https://github.com/david-driscoll/RxJS-1/tree/divide-subject) instead, but after working with it, this change seems better because it doesn't introduce a new name.