### PR TITLE
chore(dep): update benchpress for compat with protractor in de…

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "homepage": "https://github.com/ReactiveX/RxJS",
   "devDependencies": {
     "benchmark": "1.0.0",
-    "benchpress": "2.0.0-alpha.37.2",
+    "benchpress": "^2.0.0-beta.1",
     "browserify": "11.0.0",
     "color": "^0.11.1",
     "colors": "1.1.2",


### PR DESCRIPTION
…vDep. See angular/angular#2592

The selenium webdriver API changed between protractor 2.3 and 2.4. This affects benchpress, and has since been fixed in the angular repo. Update version of benchpress in package.json

Fixes #1228