### PR TITLE
chore(dep): update benchpress for compat with protractor 2.5. See ang…

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
   "homepage": "https://github.com/ReactiveX/RxJS",
   "devDependencies": {
     "benchmark": "1.0.0",
-    "benchpress": "2.0.0-alpha.37.2",
+    "benchpress": "2.0.0-beta.1",
     "browserify": "11.0.0",
     "color": "^0.11.1",
     "colors": "1.1.2",


### PR DESCRIPTION
…ular/protractor#2592

The selenium webdriver API changed between protractor 2.3 and 2.4. This change affects benchpress among other areas in angular2 codebase. Update benchpress dep version for compatibility with protractor 2.4+

Fixes #1228