### PR TITLE
refactor(FutureAction): Make FutureAction & derived classes' members protected

### DIFF
--- a/src/scheduler/AnimationFrameAction.ts
+++ b/src/scheduler/AnimationFrameAction.ts
@@ -21,7 +21,7 @@ export class AnimationFrameAction<T> extends FutureAction<T> {
     return this;
   }
 
-  _unsubscribe(): void {
+  protected _unsubscribe(): void {
 
     const {scheduler} = this;
     const {scheduledId, actions} = scheduler;

--- a/src/scheduler/AnimationFrameAction.ts
+++ b/src/scheduler/AnimationFrameAction.ts
@@ -4,7 +4,7 @@ import {AnimationFrame} from '../util/AnimationFrame';
 
 export class AnimationFrameAction<T> extends FutureAction<T> {
 
-  _schedule(state?: any, delay: number = 0): Action {
+  protected _schedule(state?: any, delay: number = 0): Action {
     if (delay > 0) {
       return super._schedule(state, delay);
     }

--- a/src/scheduler/AsapAction.ts
+++ b/src/scheduler/AsapAction.ts
@@ -21,7 +21,7 @@ export class AsapAction<T> extends FutureAction<T> {
     return this;
   }
 
-  _unsubscribe(): void {
+  protected _unsubscribe(): void {
 
     const {scheduler} = this;
     const {scheduledId, actions} = scheduler;

--- a/src/scheduler/AsapAction.ts
+++ b/src/scheduler/AsapAction.ts
@@ -4,7 +4,7 @@ import {FutureAction} from './FutureAction';
 
 export class AsapAction<T> extends FutureAction<T> {
 
-  _schedule(state?: any, delay: number = 0): Action {
+  protected _schedule(state?: any, delay: number = 0): Action {
     if (delay > 0) {
       return super._schedule(state, delay);
     }

--- a/src/scheduler/FutureAction.ts
+++ b/src/scheduler/FutureAction.ts
@@ -49,7 +49,7 @@ export class FutureAction<T> extends Subscription implements Action {
     return this;
   }
 
-  _unsubscribe() {
+  protected _unsubscribe() {
 
     const {id, scheduler} = this;
     const {actions} = scheduler;

--- a/src/scheduler/FutureAction.ts
+++ b/src/scheduler/FutureAction.ts
@@ -28,7 +28,7 @@ export class FutureAction<T> extends Subscription implements Action {
     return this._schedule(state, delay);
   }
 
-  _schedule(state?: any, delay: number = 0): Action {
+  protected _schedule(state?: any, delay: number = 0): Action {
 
     this.delay = delay;
     this.state = state;

--- a/src/scheduler/QueueAction.ts
+++ b/src/scheduler/QueueAction.ts
@@ -2,7 +2,7 @@ import {Action} from './Action';
 import {FutureAction} from './FutureAction';
 
 export class QueueAction<T> extends FutureAction<T> {
-  _schedule(state?: any, delay: number = 0): Action {
+  protected _schedule(state?: any, delay: number = 0): Action {
     if (delay > 0) {
       return super._schedule(state, delay);
     }


### PR DESCRIPTION
There are no reasons to make these members public!

- `FutureAction._schedule()`
- `FutureAction._unsubscribe()`