### PR TITLE
Perf or no perf, there is no try...

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/do.js
+++ b/perf/micro/current-thread-scheduler/operators/do.js
@@ -1,0 +1,19 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var source = Array.from({ length: 100 }, function (_, i) { return i; });
+  var _old = RxOld.Observable.fromArray(source);
+  var _new = RxNew.Observable.fromArray(source);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old groupBy with current thread scheduler', function () {
+      _old.do(_next, _error, _complete).subscribe(_next);
+    })
+    .add('new groupBy with current thread scheduler', function () {
+      _new.do(_next, _error, _complete).subscribe();
+    });
+};

--- a/perf/micro/current-thread-scheduler/operators/switchmap.js
+++ b/perf/micro/current-thread-scheduler/operators/switchmap.js
@@ -1,0 +1,24 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldSwitchMapWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread)
+    .flatMapLatest(function (x) {
+      return RxOld.Observable.range(x, 25, RxOld.Scheduler.currentThread);
+    });
+  var newSwitchMapWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue)
+    .switchMap(function (x) {
+      return RxNew.Observable.range(x, 25, RxNew.Scheduler.queue);
+    });
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMap with current thread scheduler', function () {
+      oldSwitchMapWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMap with current thread scheduler', function () {
+      newSwitchMapWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/switchmap.js
+++ b/perf/micro/immediate-scheduler/operators/switchmap.js
@@ -1,0 +1,24 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldSwitchMapWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate)
+    .flatMapLatest(function (x) {
+      return RxOld.Observable.range(x, 25, RxOld.Scheduler.immediate);
+    });
+  var newSwitchMapWithImmediateScheduler = RxNew.Observable.range(0, 25)
+    .switchMap(function (x) {
+      return RxNew.Observable.range(x, 25);
+    });
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMap with immediate scheduler', function () {
+      oldSwitchMapWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMap with immediate scheduler', function () {
+      newSwitchMapWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/withlatestfrom.js
+++ b/perf/micro/immediate-scheduler/operators/withlatestfrom.js
@@ -1,0 +1,27 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  function add(x, y) {
+    return x + y;
+  }
+  var _old = RxOld.Observable.range(0, 25).withLatestFrom(
+    RxOld.Observable.range(0, 25),
+    add
+  );
+  var _new = RxNew.Observable.range(0, 25).withLatestFrom(
+    RxNew.Observable.range(0, 25),
+    add
+  );
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old withLatestFrom with immediate scheduler', function () {
+        _old.subscribe(_next, _error, _complete);
+      })
+      .add('new withLatestFrom with immediate scheduler', function () {
+        _new.subscribe(_next, _error, _complete);
+      });
+};

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -35,6 +35,8 @@ class CatchSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
+  // NOTE: overriding `error` instead of `_error` because we don't want
+  // to have this flag this subscriber as `isStopped`.
   error(err: any) {
     if (!this.isStopped) {
       let result: any;

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -40,7 +40,7 @@ class CountSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  next(value: T): void {
+  protected _next(value: T): void {
     if (this.predicate) {
       this._tryPredicate(value);
     } else {
@@ -63,7 +63,7 @@ class CountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  complete(): void {
+  protected _complete(): void {
     this.destination.next(this.count);
     this.destination.complete();
   }

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -35,7 +35,7 @@ class FilterSubscriber<T> extends Subscriber<T> {
 
   // the try catch block below is left specifically for
   // optimization and perf reasons. a tryCatcher is not necessary here.
-  next(value: T) {
+  protected _next(value: T) {
     let result: any;
     try {
       result = this.select.call(this.thisArg, value, this.count++);

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -41,6 +41,7 @@ class FilterSubscriber<T> extends Subscriber<T> {
       result = this.select.call(this.thisArg, value, this.count++);
     } catch (err) {
       this.destination.error(err);
+      return;
     }
     if (result) {
       this.destination.next(value);

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -81,7 +81,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
   }
 
   private _emitFinal(value: any) {
-    const destination = this.destination
+    const destination = this.destination;
     destination.next(value);
     destination.complete();
     this.hasCompleted = true;

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -39,7 +39,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
     super(destination);
   }
 
-  next(value: T): void {
+  protected _next(value: T): void {
     const index = this.index++;
     if (this.predicate) {
       this._tryPredicate(value, index);
@@ -87,7 +87,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
     this.hasCompleted = true;
   }
 
-  complete(): void {
+  protected _complete(): void {
     const destination = this.destination;
     if (!this.hasCompleted && typeof this.defaultValue !== 'undefined') {
       destination.next(this.defaultValue);

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -51,7 +51,7 @@ class LastSubscriber<T, R> extends Subscriber<T> {
     }
   }
 
-  next(value: T): void {
+  protected _next(value: T): void {
     const index = this.index++;
     if (this.predicate) {
       this._tryPredicate(value, index);
@@ -95,7 +95,7 @@ class LastSubscriber<T, R> extends Subscriber<T> {
     this.hasValue = true;
   }
 
-  complete(): void {
+  protected _complete(): void {
     const destination = this.destination;
     if (this.hasValue) {
       destination.next(this.lastValue);

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -41,7 +41,7 @@ class MapSubscriber<T, R> extends Subscriber<T> {
 
   // NOTE: This looks unoptimized, but it's actually purposefully NOT
   // using try/catch optimizations.
-  next(value: T) {
+  protected _next(value: T) {
     let result: any;
     try {
       result = this.project.call(this.thisArg, value, this.count++);

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -39,6 +39,8 @@ class MapSubscriber<T, R> extends Subscriber<T> {
     this.thisArg = thisArg || this;
   }
 
+  // NOTE: This looks unoptimized, but it's actually purposefully NOT
+  // using try/catch optimizations.
   next(value: T) {
     let result: any;
     try {

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -46,7 +46,7 @@ export class ReduceSubscriber<T, R> extends Subscriber<T> {
     this.hasSeed = typeof seed !== 'undefined';
   }
 
-  next(value: T) {
+  protected _next(value: T) {
     if (this.hasValue || (this.hasValue = this.hasSeed)) {
       this._tryReduce(value);
     } else {
@@ -66,7 +66,7 @@ export class ReduceSubscriber<T, R> extends Subscriber<T> {
     this.acc = result;
   }
 
-  complete() {
+  protected _complete() {
     if (this.hasValue || this.hasSeed) {
       this.destination.next(this.acc);
     }

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -47,7 +47,7 @@ class ScanSubscriber<T, R> extends Subscriber<T> {
     this.accumulatorSet = typeof seed !== 'undefined';
   }
 
-  next(value: T): void {
+  protected _next(value: T): void {
     if (!this.accumulatorSet) {
       this.seed = value;
       this.destination.next(value);

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -44,7 +44,7 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  next(value: T) {
+  protected _next(value: T) {
     let result: any;
     const index = this.index++;
     try {


### PR DESCRIPTION
I discovered today that adding custom tryCatcher members to operators with try/catch optimization concerns actually improved performance quite a bit.

So far: `map` doubled in overall speed (from factor of 1.7x to 3.2x on my machine),
`mergeMap` improved by a "factor" of a little more than 1x
`zip` improved by a "factor" of a little more than 1x-2x.

("factor" coming from micro perf output).

This will be part of an effort to go through and examine improvements that can be made where `tryCatch`/`errorObject` is being used.

See commits for details.

All of these perf tests are of course in V8/Node, however I don't see any reason they wouldn't carry over to other JIT'ed runtimes.

cc/ @trxcllnt 