### PR TITLE
feat(OuterSubscriber): notifyNext passes innersubscriber when next emits

### DIFF
--- a/src/InnerSubscriber.ts
+++ b/src/InnerSubscriber.ts
@@ -8,16 +8,16 @@ export class InnerSubscriber<T, R> extends Subscriber<R> {
     super();
   }
 
-  protected _next(value: R) {
-    this.parent.notifyNext(this.outerValue, value, this.outerIndex, this.index++);
+  protected _next(value: R): void {
+    this.parent.notifyNext(this.outerValue, value, this.outerIndex, this.index++, this);
   }
 
-  protected _error(error: any) {
+  protected _error(error: any): void {
     this.parent.notifyError(error, this);
     this.unsubscribe();
   }
 
-  protected _complete() {
+  protected _complete(): void {
     this.parent.notifyComplete(this);
     this.unsubscribe();
   }

--- a/src/OuterSubscriber.ts
+++ b/src/OuterSubscriber.ts
@@ -2,7 +2,9 @@ import {Subscriber} from './Subscriber';
 import {InnerSubscriber} from './InnerSubscriber';
 
 export class OuterSubscriber<T, R> extends Subscriber<T> {
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.destination.next(innerValue);
   }
 

--- a/src/operator/buffer.ts
+++ b/src/operator/buffer.ts
@@ -3,6 +3,7 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -44,7 +45,9 @@ class BufferSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.buffer.push(value);
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     const buffer = this.buffer;
     this.buffer = [];
     this.destination.next(buffer);

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -6,6 +6,7 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -60,7 +61,9 @@ class BufferWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.subscribing = false;
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.openBuffer();
   }
 

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -6,6 +6,7 @@ import {isScheduler} from '../util/isScheduler';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -116,9 +117,11 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(observable: any, value: R, outerIndex: number, innerIndex: number) {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     const values = this.values;
-    values[outerIndex] = value;
+    values[outerIndex] = innerValue;
     const toRespond = this.toRespond;
 
     if (toRespond.length > 0) {

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -7,6 +7,7 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -68,7 +69,9 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.destination.complete();
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.emitValue();
   }
 

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -4,6 +4,7 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -64,7 +65,9 @@ class SwitchFirstMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     const { resultSelector, destination } = this;
     if (resultSelector) {
       const result = tryCatch(resultSelector)(outerValue, innerValue, outerIndex, innerIndex);

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -6,6 +6,7 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -96,7 +97,9 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this._next(innerValue);
   }
 

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -4,6 +4,7 @@ import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 import {subscribeToResult} from '../util/subscribeToResult';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 
 /**
  * Returns an Observable that emits items based on applying a function that you supply to each item emitted by the
@@ -80,7 +81,9 @@ export class MergeMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     if (this.resultSelector) {
       this._notifyResultSelector(outerValue, innerValue, outerIndex, innerIndex);
     } else {

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -6,6 +6,7 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function mergeMapTo<T, R, R2>(observable: Observable<R>,
@@ -67,7 +68,9 @@ export class MergeMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     const { resultSelector, destination } = this;
     if (resultSelector) {
       const result = tryCatch(resultSelector)(outerValue, innerValue, outerIndex, innerIndex);

--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -6,6 +6,7 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {subscribeToResult} from '../util/subscribeToResult';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 
 export function mergeScan<T, R>(project: (acc: R, value: T) => Observable<R>,
                                 seed: R,
@@ -70,7 +71,9 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     const { destination } = this;
     this.acc = innerValue;
     this.hasValue = true;

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -5,6 +5,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -79,7 +80,9 @@ export class RaceSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(observable: any, value: R, outerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     if (!this.hasFirst) {
       this.hasFirst = true;
 
@@ -95,6 +98,6 @@ export class RaceSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.subscriptions = null;
     }
 
-    this.destination.next(value);
+    this.destination.next(innerValue);
   }
 }

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -7,6 +7,7 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -92,7 +93,9 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.retries = null;
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
 
     const { errors, retries, retriesSubscription } = this;
     this.errors = null;

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -3,6 +3,7 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -43,7 +44,9 @@ class SampleSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.hasValue = true;
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.emitValue();
   }
 

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -3,6 +3,7 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -53,7 +54,9 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.hasValue = true;
   }
 

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -2,6 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -60,7 +61,9 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: any): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.destination.next(innerValue);
   }
 

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -3,6 +3,7 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -83,7 +84,9 @@ class SwitchMapSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     if (this.resultSelector) {
       this._tryNotifyNext(outerValue, innerValue, outerIndex, innerIndex);
     } else {

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -5,6 +5,7 @@ import {Subscription} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function switchMapTo<T, R, R2>(observable: Observable<R>,
@@ -63,7 +64,9 @@ class SwitchMapToSubscriber<T, R, R2> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     const { resultSelector, destination } = this;
     if (resultSelector) {
       const result = tryCatch(resultSelector)(outerValue, innerValue, outerIndex, innerIndex);

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -3,6 +3,7 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function takeUntil<T>(notifier: Observable<any>): Observable<T> {
@@ -26,7 +27,9 @@ class TakeUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.add(subscribeToResult(this, notifier));
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.complete();
   }
 

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -6,6 +6,7 @@ import {Subscription} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function throttle<T>(durationSelector: (value: T) => Observable<number> | Promise<number>): Observable<T> {
@@ -50,7 +51,9 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this._unsubscribe();
   }
 

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -8,6 +8,7 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function windowToggle<T, O>(openings: Observable<O>,
@@ -102,7 +103,9 @@ class WindowToggleSubscriber<T, R, O> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(outerValue: any, innerValue: any, outerIndex: number, innerIndex: number): void {
+  notifyNext(outerValue: any, innerValue: any,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
 
     if (outerValue === this.openings) {
 

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -2,6 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
@@ -62,11 +63,13 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  notifyNext(observable: any, value: any, observableIndex: number, index: number) {
-    this.values[observableIndex] = value;
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
+    this.values[outerIndex] = innerValue;
     const toRespond = this.toRespond;
     if (toRespond.length > 0) {
-      const found = toRespond.indexOf(observableIndex);
+      const found = toRespond.indexOf(outerIndex);
       if (found !== -1) {
         toRespond.splice(found, 1);
       }

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -5,6 +5,7 @@ import {Operator} from '../Operator';
 import {Observer} from '../Observer';
 import {Subscriber} from '../Subscriber';
 import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 import {SymbolShim} from '../util/SymbolShim';
 
@@ -237,7 +238,9 @@ class ZipBufferIterator<T, R> extends OuterSubscriber<T, R> implements LookAhead
     }
   }
 
-  notifyNext(outerValue: any, innerValue: any, outerIndex: number, innerIndex: number) {
+  notifyNext(outerValue: T, innerValue: any,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
     this.buffer.push(innerValue);
     this.parent.checkIterators();
   }


### PR DESCRIPTION
- notifyNext() passes inner subscriber as same as notifyError(), notifyComplete() does, supports subscription management

closes #1250

Ran some perf against after applying changes, couldn't see noticeable differences.

```

before

------------------------------------------------------------------------------------------
            buffer - immediate |   33,135 (±5.19%) |   94,162 (±6.56%) |  2.84x |   184.2%
     combinelatest - immediate |   11,154 (±3.08%) |  118,908 (±3.02%) | 10.66x |   966.0%
                 combinelatest |    8,443 (±3.54%) |   81,640 (±3.08%) |  9.67x |   867.0%
          debounce - immediate |    5,874 (±8.76%) |   23,409 (±5.11%) |  3.98x |   298.5%
          mergemap - immediate |    2,450 (±2.71%) |   23,331 (±2.82%) |  9.52x |   852.4%
                      mergemap |      606 (±2.93%) |    4,912 (±3.66%) |  8.11x |   711.2%
         skipuntil - immediate |   22,688 (±2.62%) |  101,935 (±5.70%) |  4.49x |   349.3%
            switch - immediate |    2,920 (±2.64%) |   26,361 (±3.44%) |  9.03x |   802.9%
                        switch |    5,317 (±3.48%) |   25,154 (±3.42%) |  4.73x |   373.1%
         takeuntil - immediate |    3,689 (±2.56%) |  106,054 (±5.00%) |  4.48x |   347.7%
               zip - immediate |    2,554 (±3.67%) |   71,988 (±2.33%) |  5.73x |   473.4%
               zip - immediate |    5,742 (±3.35%) |   68,654 (±2.19%) | 11.96x | 1,095.6%

after
------------------------------------------------------------------------------------------
            buffer - immediate |   32,050 (±6.50%) |   97,139 (±6.60%) |  3.03x |   203.1%
     combinelatest - immediate |  11,156 (±11.48%) |  121,978 (±2.40%) | 10.93x |   993.3%
                 combinelatest |    9,201 (±2.95%) |   82,289 (±2.97%) |  8.94x |   794.3%
          debounce - immediate |    5,706 (±7.35%) |   27,265 (±3.34%) |  4.78x |   377.9%
          mergemap - immediate |    2,661 (±2.95%) |   24,345 (±3.02%) |  9.15x |   815.0%
                      mergemap |      668 (±3.00%) |    5,073 (±2.77%) |  7.60x |   659.6%
         skipuntil - immediate |   21,837 (±2.87%) |  101,634 (±6.39%) |  4.65x |   365.4%
            switch - immediate |    2,837 (±2.65%) |   27,601 (±3.18%) |  9.73x |   872.9%
                        switch |    6,096 (±2.82%) |   25,593 (±3.19%) |  4.20x |   319.8%
         takeuntil - immediate |   23,559 (±2.51%) |  105,616 (±5.15%) |  4.48x |   348.3%
               zip - immediate |   12,793 (±3.45%) |   70,808 (±2.84%) |  5.54x |   453.5%
               zip - immediate |    6,021 (±3.10%) |   68,313 (±2.38%) | 11.35x | 1,034.6%

```