### PR TITLE
Fix leaks when unsubscribe functions error

### DIFF
--- a/spec/Subscription-spec.js
+++ b/spec/Subscription-spec.js
@@ -1,0 +1,39 @@
+/* globals describe, it, expect */
+var Rx = require('../dist/cjs/Rx');
+var Subscription = Rx.Subscription;
+var Observable = Rx.Observable;
+
+describe('Subscription', function () {
+  it('should not leak', function (done) {
+    var tearDowns = [];
+
+    var source1 = Observable.create(function (observer) {
+      return function () {
+        tearDowns.push(1);
+      };
+    });
+
+    var source2 = Observable.create(function (observer) {
+      return function () {
+        tearDowns.push(2);
+        throw new Error('oops, I am a bad unsubscribe!');
+      };
+    });
+
+    var source3 = Observable.create(function (observer) {
+      return function () {
+        tearDowns.push(3);
+      };
+    });
+
+    var subscription = Observable.merge(source1, source2, source3).subscribe();
+
+    setTimeout(function () {
+      expect(function () {
+        subscription.unsubscribe();
+      }).toThrow();
+      expect(tearDowns).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+});

--- a/spec/Subscription-spec.js
+++ b/spec/Subscription-spec.js
@@ -31,7 +31,47 @@ describe('Subscription', function () {
     setTimeout(function () {
       expect(function () {
         subscription.unsubscribe();
-      }).toThrow();
+      }).toThrow(new Rx.UnsubscriptionError([new Error('oops, I am a bad unsubscribe!')]));
+      expect(tearDowns).toEqual([1, 2, 3]);
+      done();
+    });
+  });
+
+  it('should not leak when adding a bad custom subscription to a subscription', function (done) {
+    var tearDowns = [];
+
+    var sub = new Subscription();
+
+    var source1 = Observable.create(function (observer) {
+      return function () {
+        tearDowns.push(1);
+      };
+    });
+
+    var source2 = Observable.create(function (observer) {
+      return function () {
+        tearDowns.push(2);
+        sub.add({
+          unsubscribe: function () {
+            expect(sub.isUnsubscribed).toBe(true);
+            throw new Error('Who is your daddy, and what does he do?');
+          }
+        });
+      };
+    });
+
+    var source3 = Observable.create(function (observer) {
+      return function () {
+        tearDowns.push(3);
+      };
+    });
+
+    sub.add(Observable.merge(source1, source2, source3).subscribe());
+
+    setTimeout(function () {
+      expect(function () {
+        sub.unsubscribe();
+      }).toThrow(new Rx.UnsubscriptionError([new Error('Who is your daddy, and what does he do?')]));
       expect(tearDowns).toEqual([1, 2, 3]);
       done();
     });

--- a/src/Rx.DOM.ts
+++ b/src/Rx.DOM.ts
@@ -110,7 +110,7 @@ import './add/operator/zip';
 import './add/operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
-import {Subscription} from './Subscription';
+import {Subscription, UnsubscriptionError} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';
 import {ReplaySubject} from './subject/ReplaySubject';
@@ -159,5 +159,6 @@ export {
   Notification,
   EmptyError,
   ArgumentOutOfRangeError,
-  ObjectUnsubscribedError
+  ObjectUnsubscribedError,
+  UnsubscriptionError
 };

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -139,7 +139,7 @@ import './add/operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
 import {Observer} from './Observer';
-import {Subscription} from './Subscription';
+import {Subscription, UnsubscriptionError} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';
 import {ReplaySubject} from './subject/ReplaySubject';
@@ -185,6 +185,7 @@ export {
     EmptyError,
     ArgumentOutOfRangeError,
     ObjectUnsubscribedError,
+    UnsubscriptionError,
     TestScheduler,
     VirtualTimeScheduler,
     TimeInterval,

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -114,7 +114,7 @@ import './add/operator/zipAll';
 /* tslint:disable:no-unused-variable */
 import {Operator} from './Operator';
 import {Observer} from './Observer';
-import {Subscription} from './Subscription';
+import {Subscription, UnsubscriptionError} from './Subscription';
 import {Subscriber} from './Subscriber';
 import {AsyncSubject} from './subject/AsyncSubject';
 import {ReplaySubject} from './subject/ReplaySubject';
@@ -158,5 +158,6 @@ export {
     Notification,
     EmptyError,
     ArgumentOutOfRangeError,
-    ObjectUnsubscribedError
+    ObjectUnsubscribedError,
+    UnsubscriptionError
 };

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -88,7 +88,7 @@ export class Subscription {
         if (sub.isUnsubscribed || typeof sub.unsubscribe !== 'function') {
           break;
         } else if (this.isUnsubscribed) {
-            sub.unsubscribe();
+          sub.unsubscribe();
         } else {
           ((<any> this)._subscriptions || ((<any> this)._subscriptions = [])).push(sub);
         }


### PR DESCRIPTION
Relates to discussion in #1256 

Basically this adds a context that is passed around internally that collects all errors and throws them as a group in an `UnsubscriptionError` when the subscription tree is unsubscribed completely.