### PR TITLE
fix(Notification): ensure `do` and `observe` handle partial observation

### DIFF
--- a/spec/Notification-spec.js
+++ b/spec/Notification-spec.js
@@ -133,6 +133,27 @@ describe('Notification', function () {
 
       expect(invoked).toBe(true);
     });
+
+    it('should handle next if no next was passed', function () {
+      var n = Notification.createNext();
+      expect(function () {
+        n.do(null, null, null);
+      }).not.toThrow();
+    });
+
+    it('should handle error if no error was passed', function () {
+      var n = Notification.createError();
+      expect(function () {
+        n.do(null, null, null);
+      }).not.toThrow();
+    });
+
+    it('should handle complete if no complete was passed', function () {
+      var n = Notification.createComplete();
+      expect(function () {
+        n.do(null, null, null);
+      }).not.toThrow();
+    });
   });
 
   describe('accept', function () {
@@ -276,6 +297,27 @@ describe('Notification', function () {
 
       n.observe(observer);
       expect(observed).toBe(true);
+    });
+
+    it('should not error for complete notifications if no complete handler', function () {
+      var n = Notification.createComplete();
+      expect(function () {
+        n.observe({});
+      }).not.toThrow();
+    });
+
+    it('should not error for error notifications if no error handler', function () {
+      var n = Notification.createError();
+      expect(function () {
+        n.observe({});
+      }).not.toThrow();
+    });
+
+    it('should not error for next notifications if no next complete', function () {
+      var n = Notification.createNext();
+      expect(function () {
+        n.observe({});
+      }).not.toThrow();
     });
   });
 });

--- a/src/Notification.ts
+++ b/src/Notification.ts
@@ -11,11 +11,11 @@ export class Notification<T> {
   observe(observer: Observer<T>): any {
     switch (this.kind) {
       case 'N':
-        return observer.next(this.value);
+        return observer.next && observer.next(this.value);
       case 'E':
-        return observer.error(this.exception);
+        return observer.error && observer.error(this.exception);
       case 'C':
-        return observer.complete();
+        return observer.complete && observer.complete();
     }
   }
 
@@ -23,11 +23,11 @@ export class Notification<T> {
     const kind = this.kind;
     switch (kind) {
       case 'N':
-        return next(this.value);
+        return next && next(this.value);
       case 'E':
-        return error(this.exception);
+        return error && error(this.exception);
       case 'C':
-        return complete();
+        return complete && complete();
     }
   }
 


### PR DESCRIPTION
- `do` will now handle notifying a handler that isn't present. (e.g. `notification.do(null, errorFn, null)`)
- `observe` will now handle partial observers.

Relates to #1211...

Rather than enforce the shape of the Observer passed to `observe`, we can allow any shape of Observer. If someone wants to use a generator as an observer passed to `Notification.prototype.observe` I see no reason to prevent them just because they don't have `error` or `complete` functions.