### PR TITLE
chore(package.json): upgrade lodash to v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ env:
   - alias jasmine=./node_modules/.bin/jasmine
   - alias tsc=./node_modules/.bin/tsc
 
+before_install:
+  - npm install -g npm@3
 install:
   - npm install && npm run lint
 

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "karma-chrome-launcher": "0.2.2",
     "karma-jasmine": "^0.3.6",
     "karma-sauce-launcher": "0.3.0",
-    "lodash": "3.10.1",
+    "lodash": "4.1.0",
     "madge": "^0.5.3",
     "markdown-doctest": "^0.3.0",
     "minimist": "^1.2.0",


### PR DESCRIPTION
Attempt to solve issue #1257.
@kwonoj when running the tests on IE10, I noticed an error of `getNative is undefined`, where `getNative` was part of lodash, so this PR updates lodash. The tests still did not pass in IE10, but for different (unknown) reasons. Anyway, let's see if this PR helps with issue #1257 after we run on saucelabs.