### PR TITLE
perf(find): remove tryCatch/errorObject (~2x improvement)

### DIFF
--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -1,8 +1,6 @@
 import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {tryCatch} from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
 
 /**
  * Returns an Observable that searches for the first item in the source Observable that
@@ -50,11 +48,13 @@ export class FindValueSubscriber<T> extends Subscriber<T> {
   protected _next(value: T): void {
     const { predicate, thisArg } = this;
     const index = this.index++;
-    const result = tryCatch(predicate).call(thisArg || this, value, index, this.source);
-    if (result === errorObject) {
-      this.destination.error(result.e);
-    } else if (result) {
-      this.notifyComplete(this.yieldIndex ? index : value);
+    try {
+      const result = predicate.call(thisArg || this, value, index, this.source);
+      if (result) {
+        this.notifyComplete(this.yieldIndex ? index : value);
+      }
+    } catch (err) {
+      this.destination.error(err);
     }
   }
 


### PR DESCRIPTION
Before:
```
                                     |      RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
--------------------------------------------------------------------------------------------------
     find-predicate-this - immediate | 29,171 (±2.92%) |  105,817 (±6.19%) |  3.63x |    262.7%
          find-predicate - immediate | 29,907 (±4.09%) |  105,518 (±4.74%) |  3.53x |    252.8%
findindex-predicate-this - immediate | 27,812 (±5.25%) |  101,001 (±4.81%) |  3.63x |    263.2%
     findindex-predicate - immediate | 23,861 (±0.49%) |  106,057 (±6.61%) |  4.44x |    344.5%
```
After:
```
                                     |      RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
--------------------------------------------------------------------------------------------------
     find-predicate-this - immediate | 28,205 (±1.06%) |  172,276 (±1.07%) |  6.11x |    510.8%
          find-predicate - immediate | 23,809 (±0.38%) |  166,764 (±0.74%) |  7.00x |    600.4%
findindex-predicate-this - immediate | 20,838 (±1.41%) |  163,357 (±1.17%) |  7.84x |    683.9%
     findindex-predicate - immediate | 21,957 (±1.40%) |  163,965 (±0.54%) |  7.47x |    646.7%
```