### PR TITLE
perf(every): remove tryCatch/errorObject (~1.5x improvement)

### DIFF
--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -1,9 +1,6 @@
 import {Operator} from '../Operator';
 import {Observer} from '../Observer';
 import {Observable} from '../Observable';
-import {ScalarObservable} from '../observable/ScalarObservable';
-import {ArrayObservable} from '../observable/ArrayObservable';
-import {ErrorObservable} from '../observable/ErrorObservable';
 import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
@@ -17,25 +14,6 @@ import {errorObject} from '../util/errorObject';
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                          thisArg?: any): Observable<boolean> {
   const source = this;
-  if (source._isScalar) {
-    const result: boolean = tryCatch(predicate).call(thisArg || this, source.value, 0, source);
-    if (result === errorObject) {
-      return new ErrorObservable(errorObject.e, source.scheduler);
-    } else {
-      return new ScalarObservable(result, source.scheduler);
-    }
-  }
-
-  if (source instanceof ArrayObservable) {
-    const array = (<ArrayObservable<T>>source).array;
-    const result = tryCatch((array: T[], predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg: any) =>
-                                    array.every(<any>predicate, thisArg))(array, predicate, thisArg);
-    if (result === errorObject) {
-      return new ErrorObservable(errorObject.e, source.scheduler);
-    } else {
-      return new ScalarObservable(result, source.scheduler);
-    }
-  }
   return source.lift(new EveryOperator(predicate, thisArg, source));
 }
 


### PR DESCRIPTION
Before:
```
                                   |       RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
------------------------------------------------------------------------------------------------
 every-predicate-array - immediate |  95,333 (±0.49%) |  288,517 (±0.30%) |  3.03x |     202.6%
every-predicate-scalar - immediate | 115,688 (±0.52%) |  815,531 (±0.24%) |  7.05x |     604.9%
  every-predicate-this - immediate |  41,195 (±0.25%) |  167,658 (±2.33%) |  4.07x |     307.0%
       every-predicate - immediate |  42,966 (±0.56%) |  159,729 (±0.28%) |  3.72x |     271.8%
```

After:
```
                                   |       RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
------------------------------------------------------------------------------------------------
 every-predicate-array - immediate |  95,115 (±0.46%) |  409,389 (±1.33%) |  4.30x |     330.4%
every-predicate-scalar - immediate | 113,744 (±0.50%) |  746,760 (±0.46%) |  6.57x |     556.5%
  every-predicate-this - immediate |  39,560 (±0.50%) |  278,940 (±0.33%) |  7.05x |     605.1%
       every-predicate - immediate |  42,001 (±0.40%) |  269,068 (±0.31%) |  6.41x |     540.6%
```