### PR TITLE
feat(scanCase): adds scanCase operator and unit tests

### DIFF
--- a/spec/operators/scanCase-spec.js
+++ b/spec/operators/scanCase-spec.js
@@ -1,0 +1,247 @@
+/* globals describe, it, fit, expect, expectObservable, expectSubscriptions, cold, hot */
+var Rx = require('../../dist/cjs/Rx');
+var Observable = Rx.Observable;
+
+describe('Observable.prototype.scanCase()', function () {
+  var concatSelect = function () {
+    return 'concat';
+  };
+
+  var addSelect = function () {
+    return 'add';
+  };
+
+  var strategy = {
+    concat: function (acc, x) {
+      return [].concat(acc, x);
+    },
+    add: function (acc, x) {
+      return acc + x;
+    },
+    addVal: function (acc, x) {
+      return acc + x.value;
+    },
+    subtract: function (acc, x) {
+      return acc - x.value | x;
+    },
+    throw: function () {
+      throw 'bad!';
+    }
+  };
+
+  it.asDiagram(
+    'scanCase((curr) => curr.op,' +
+    '{ add: (acc, curr) => acc + curr.value, substract: (acc, curr) => acc - curr.value },' +
+    '0)')('should scanCase', function () {
+      var values = {
+        a: { op: 'addVal', value: 1 }, b: { op: 'addVal', value: 3 }, c: { op: 'subtract', value: 2 },
+        x: 1, y: 4, z: 2
+      };
+      var e1 =        hot('--a--b--c|', values);
+      var e1subs =        '^        !';
+      var expected = '--x--y--z|';
+
+      var select = function (v) {
+        return v.op;
+      };
+
+      expectObservable(e1.scanCase(select, strategy, 0)).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+
+  it('shoud scanCase things', function () {
+    var e1 = hot('--a--^--b--c--d--e--f--g--|');
+    var e1subs =      '^                    !';
+    var expected =    '---u--v--w--x--y--z--|';
+
+    var values = {
+      u: ['b'],
+      v: ['b', 'c'],
+      w: ['b', 'c', 'd'],
+      x: ['b', 'c', 'd', 'e'],
+      y: ['b', 'c', 'd', 'e', 'f'],
+      z: ['b', 'c', 'd', 'e', 'f', 'g']
+    };
+
+    var source = e1.scanCase(concatSelect, strategy, []);
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should scanCase without seed', function () {
+    var e1 = hot('--a--^--b--c--d--|');
+    var e1subs =      '^           !';
+    var expected =    '---x--y--z--|';
+
+    var values = {
+      x: 'b',
+      y: 'bc',
+      z: 'bcd'
+    };
+
+    var source = e1.scanCase(addSelect, strategy);
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should handle errors', function () {
+    var e1 = hot('--a--^--b--c--d--#');
+    var e1subs =      '^           !';
+    var expected =    '---u--v--w--#';
+
+    var values = {
+      u: ['b'],
+      v: ['b', 'c'],
+      w: ['b', 'c', 'd']
+    };
+
+    var source = e1.scanCase(concatSelect, strategy, []);
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should handle errors in the accumation functions', function () {
+    var e1 = hot('--a--^--b--c--d--e--f--g--|');
+    var e1subs =      '^        !            ';
+    var expected =    '---u--v--#            ';
+
+    var values = {
+      u: ['b'],
+      v: ['b', 'c'],
+      w: ['b', 'c', 'd'],
+      x: ['b', 'c', 'd', 'e'],
+      y: ['b', 'c', 'd', 'e', 'f'],
+      z: ['b', 'c', 'd', 'e', 'f', 'g']
+    };
+
+    var source = e1.scanCase(function (x) {
+      return x === 'd' ? 'throw' : 'concat';
+    }, strategy, []);
+
+    expectObservable(source).toBe(expected, values, 'bad!');
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should handle errors in the select function', function () {
+    var e1 = hot('--a--^--b--c--d--e--f--g--|');
+    var e1subs =      '^        !            ';
+    var expected =    '---u--v--#            ';
+
+    var values = {
+      u: ['b'],
+      v: ['b', 'c'],
+      w: ['b', 'c', 'd'],
+      x: ['b', 'c', 'd', 'e'],
+      y: ['b', 'c', 'd', 'e', 'f'],
+      z: ['b', 'c', 'd', 'e', 'f', 'g']
+    };
+
+    var source = e1.scanCase(function (x) {
+      if (x === 'd') {
+        throw 'bad!';
+      }
+      return 'concat';
+    }, strategy, []);
+
+    expectObservable(source).toBe(expected, values, 'bad!');
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('handle missing accumulator', function () {
+    var e1 = hot('--a--^--b--c--d--|');
+    var e1subs =      '^           !';
+    var expected =    '---x--y--z--|';
+
+    var values = {
+      x: 'b',
+      y: 'b',
+      z: 'bd'
+    };
+
+    var source = e1.scanCase(function (x) {
+      return x === 'c' ? 'missing' : 'add';
+    }, strategy);
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('handle empty', function () {
+    var e1 =  cold('|');
+    var e1subs =   '(^!)';
+    var expected = '|';
+
+    var source = e1.scanCase(concatSelect, strategy, []);
+
+    expectObservable(source).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('handle never', function () {
+    var e1 =  cold('-');
+    var e1subs =   '^';
+    var expected = '-';
+
+    var source = e1.scanCase(concatSelect, strategy, []);
+
+    expectObservable(source).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('handle throw', function () {
+    var e1 =  cold('#');
+    var e1subs =   '(^!)';
+    var expected = '#';
+
+    var source = e1.scanCase(concatSelect, strategy, []);
+
+    expectObservable(source).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should allow unsubscribing explicitly and early', function () {
+    var e1 = hot('--a--^--b--c--d--e--f--g--|');
+    var unsub =       '              !       ';
+    var e1subs =      '^             !       ';
+    var expected =    '---u--v--w--x--       ';
+    var values = {
+      u: ['b'],
+      v: ['b', 'c'],
+      w: ['b', 'c', 'd'],
+      x: ['b', 'c', 'd', 'e'],
+      y: ['b', 'c', 'd', 'e', 'f'],
+      z: ['b', 'c', 'd', 'e', 'f', 'g']
+    };
+
+    var source = e1.scanCase(concatSelect, strategy, []);
+
+    expectObservable(source, unsub).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chains when result is unsubscribed explicitly', function () {
+    var e1 = hot('--a--^--b--c--d--e--f--g--|');
+    var e1subs =      '^             !       ';
+    var expected =    '---u--v--w--x--       ';
+    var unsub =       '              !       ';
+    var values = {
+      u: ['b'],
+      v: ['b', 'c'],
+      w: ['b', 'c', 'd'],
+      x: ['b', 'c', 'd', 'e'],
+      y: ['b', 'c', 'd', 'e', 'f'],
+      z: ['b', 'c', 'd', 'e', 'f', 'g']
+    };
+
+    var source = e1
+      .mergeMap(function (x) { return Observable.of(x); })
+      .scanCase(concatSelect, strategy, [])
+      .mergeMap(function (x) { return Observable.of(x); });
+
+    expectObservable(source, unsub).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+});

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -250,6 +250,9 @@ export class Observable<T> implements CoreOperators<T>  {
   sample: (notifier: Observable<any>) => Observable<T>;
   sampleTime: (delay: number, scheduler?: Scheduler) => Observable<T>;
   scan: <R>(accumulator: (acc: R, x: T) => R, seed?: T | R) => Observable<R>;
+  scanCase: <T, R>(selector: (value: T, index: number) => string | number | symbol,
+                   strategy: { key: string | number | symbol, acc: (acc: R, value: T) => R },
+                   seed?: T | R) => Observable<R>;
   share: () => Observable<T>;
   single: (predicate?: (value: T, index: number) => boolean) => Observable<T>;
   skip: (count: number) => Observable<T>;

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -111,6 +111,7 @@ import './add/operator/retryWhen';
 import './add/operator/sample';
 import './add/operator/sampleTime';
 import './add/operator/scan';
+import './add/operator/scanCase';
 import './add/operator/share';
 import './add/operator/single';
 import './add/operator/skip';

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -82,6 +82,7 @@ import './add/operator/retryWhen';
 import './add/operator/sample';
 import './add/operator/sampleTime';
 import './add/operator/scan';
+import './add/operator/scanCase';
 import './add/operator/share';
 import './add/operator/single';
 import './add/operator/skip';

--- a/src/add/operator/scanCase.ts
+++ b/src/add/operator/scanCase.ts
@@ -1,0 +1,7 @@
+
+import {Observable} from '../../Observable';
+import {scanCase} from '../../operator/scanCase';
+
+Observable.prototype.scanCase = scanCase;
+
+export var _void: void;

--- a/src/operator/scanCase.ts
+++ b/src/operator/scanCase.ts
@@ -1,0 +1,114 @@
+import {Operator} from '../Operator';
+import {Subscriber} from '../Subscriber';
+import {Observable} from '../Observable';
+
+/**
+ * Returns an Observable that applies a select function to each item.  The result of the select function is used as a
+ * key into the strategy object to find an accumulator function.  The accumulator is applied to each item emitted by the source Observable.
+ *
+ * @param {function} select The select function which gets called on each item and returns the key to an accumulator function in the strategy.
+ * @param {object} strategy An object with a key value pair for each possible return value of select.
+ * The values are accumulator functions which are applided to each item.
+ *
+ * @param {any} [seed] The initial accumulator value.
+ * @returns {Observable} An observable of the accumulated values.
+ */
+export function scanCase<T, R>(
+  selector: (value: T, index: number) => string | number | symbol,
+  strategy: {
+      key: string | number | symbol,
+      acc: (acc: R, value: T) => R
+  },
+  seed?: T | R): Observable<R> {
+  return this.lift(new ScanCaseOperator(selector, strategy, seed));
+}
+
+class ScanCaseOperator<T, R> implements Operator<T, R> {
+  constructor(
+    private select: (value: T, index: number) => string | number | symbol,
+    private strategy: { key: string | number | symbol, acc: (acc: R, value: T) => R },
+    private seed?: T | R) {
+  }
+
+  call(subscriber: Subscriber<T>): Subscriber<T> {
+    return new ScanCaseSubscriber(subscriber, this.select, this.strategy, this.seed);
+  }
+}
+
+class ScanCaseSubscriber<T, R> extends Subscriber<T> {
+  private _seed: T | R;
+  private _select: (value: T, index: number) => string | number | symbol;
+  private _strategy: { key: string | number | symbol, acc: (acc: R, value: T) => R };
+  private accumulatorSet: boolean = false;
+
+  count: number = 0;
+
+  get seed(): T | R {
+    return this._seed;
+  }
+
+  set seed(value: T | R) {
+    this.accumulatorSet = true;
+    this._seed = value;
+  }
+
+  get select(): (value: T, index: number) => string | number | symbol {
+    return this._select;
+  }
+
+  set select(value: (value: T, index: number) => string | number | symbol) {
+    this._select = value;
+  }
+
+  get strategy(): { key: string | number | symbol, acc: (acc: R, value: T) => R } {
+    return this._strategy;
+  }
+
+  set strategy(value: { key: string | number | symbol, acc: (acc: R, value: T) => R }) {
+    this._strategy = value;
+  }
+
+  constructor(
+    destination: Subscriber<T>,
+    select: (value: T, index: number) => string | number | symbol,
+    strategy: { key: string | number | symbol, acc: (acc: R, value: T) => R },
+    seed?: T | R) {
+      super(destination);
+      this.seed = seed;
+      this.select = select;
+      this.strategy = strategy;
+      this.accumulatorSet = typeof seed !== 'undefined';
+  }
+
+  protected _next(value: T): void {
+    if (!this.accumulatorSet) {
+      this.seed = value;
+      this.destination.next(value);
+    } else {
+      let accumulator: (acc: R, value: T) => R;
+      try {
+        const key = this.select(value, this.count);
+        accumulator = this.strategy[key];
+        this.count++;
+      } catch (err) {
+        return this.destination.error(err);
+      }
+      return this._tryNext(value, accumulator);
+    }
+  }
+
+  protected _tryNext(value: T, accumulator: (acc: R, value: T) => R): void {
+    let result: R;
+    try {
+      if (accumulator) {
+        result = accumulator(<R>this.seed, value);
+      } else {
+        result = <R>this.seed;
+      }
+    } catch (err) {
+      this.destination.error(err);
+    }
+    this.seed = result;
+    this.destination.next(result);
+  }
+}


### PR DESCRIPTION
This PR implements as scanCase operator.  ScanCase allows items to have different accumulator functions depending on the result of a select function.