### PR TITLE
refactor(throttle): remove tryCatch/errorObject

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/throttle.js
+++ b/perf/micro/current-thread-scheduler/operators/throttle.js
@@ -1,0 +1,22 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  // v4's `throttle()` does not accept a duration selector.
+  // So this test is just a sample for each revisions of RxNew.
+  var oldThrottleWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread)
+    .throttle(1);
+  var newThrottleWithImmediateScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue)
+    .throttle(function () { return RxNew.Observable.of(0); });
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old throttle() with immediate scheduler', function () {
+      oldThrottleWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new throttle() with immediate scheduler', function () {
+      newThrottleWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/throttle.js
+++ b/perf/micro/immediate-scheduler/operators/throttle.js
@@ -1,0 +1,22 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  // v4's `throttle()` does not accept a duration selector.
+  // So this test is just a sample for each revisions of RxNew.
+  var oldThrottleWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate)
+    .throttle(1);
+  var newThrottleWithImmediateScheduler = RxNew.Observable.range(0, 25)
+    .throttle(function () { return RxNew.Observable.of(0); });
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old throttle() with immediate scheduler', function () {
+      oldThrottleWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new throttle() with immediate scheduler', function () {
+      newThrottleWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -25,7 +25,7 @@ class ThrottleOperator<T> implements Operator<T, T> {
 class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
   private throttled: Subscription;
 
-  constructor(destination: Subscriber<any>,
+  constructor(protected destination: Subscriber<T>,
               private durationSelector: (value: T) => Observable<number> | Promise<number>) {
     super(destination);
   }
@@ -42,7 +42,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  _unsubscribe() {
+  protected _unsubscribe() {
     const throttled = this.throttled;
     if (throttled) {
       this.remove(throttled);


### PR DESCRIPTION
- This change is same kind of #1251.
- I have not benchmarked this yet. So this is purely refactoring to unify code style.
  - The current codebase does not have any benchmark about `throttle()`.
  - `throttle()` suppress the value traffic. How do we benchmark this without a throughput benchmark?