### PR TITLE
perf(skipWhile): remove tryCatch/errorObject (~1.6x improvement)

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/skipwhile.js
+++ b/perf/micro/current-thread-scheduler/operators/skipwhile.js
@@ -1,0 +1,21 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var predicate = function (value) { return value < 25; };
+  var oldSkipWhileWithCurrentThreadScheduler =
+    RxOld.Observable.range(0, 50, RxOld.Scheduler.currentThread).skipWhile(predicate);
+  var newSkipWhileWithCurrentThreadScheduler =
+    RxNew.Observable.range(0, 50, RxNew.Scheduler.queue).skipWhile(predicate);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old skipWhile with current thread scheduler', function () {
+        oldSkipWhileWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new skipWhile with current thread scheduler', function () {
+        newSkipWhileWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/skipwhile.js
+++ b/perf/micro/immediate-scheduler/operators/skipwhile.js
@@ -1,0 +1,21 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var predicate = function (value) { return value < 25; };
+  var oldSkipWhileWithImmediateScheduler =
+    RxOld.Observable.range(0, 50, RxOld.Scheduler.immediate).skipWhile(predicate);
+  var newSkipWhileWithImmediateScheduler =
+    RxNew.Observable.range(0, 50).skipWhile(predicate);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old skipWhile with immediate scheduler', function () {
+        oldSkipWhileWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new skipWhile with immediate scheduler', function () {
+        newSkipWhileWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};


### PR DESCRIPTION
Before:
```
                      |      RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
----------------------------------------------------------------------------------
skipwhile - immediate | 27,101 (±1.37%) |  122,827 (±0.29%) |  4.53x |     353.2%
            skipwhile |  8,034 (±1.32%) |   82,160 (±0.28%) | 10.23x |     922.7%
```

After:
```
                      |      RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
----------------------------------------------------------------------------------
skipwhile - immediate | 27,040 (±0.30%) |  197,417 (±0.28%) |  7.30x |     630.1%
            skipwhile |  8,842 (±2.08%) |  112,757 (±0.55%) | 12.75x |   1,175.2%
```