### PR TITLE
chore(micro-perf): add perf tests for mergeMap with resultSelector

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/mergemap-resultselector.js
+++ b/perf/micro/current-thread-scheduler/operators/mergemap-resultselector.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var resultSelector = function (x, y, ix, iy) { return x + y + ix + iy; };
+  var oldMergeMapWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread)
+    .flatMap(function (x) {
+      return RxOld.Observable.range(x, 25, RxOld.Scheduler.currentThread);
+    }, resultSelector);
+  var newMergeMapWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue)
+    .mergeMap(function (x) {
+      return RxNew.Observable.range(x, 25, RxNew.Scheduler.queue);
+    }, resultSelector);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old mergeMap with resultSelector and current thread scheduler', function () {
+      oldMergeMapWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new mergeMap with resultSelector and current thread scheduler', function () {
+      newMergeMapWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/mergemap-resultselector.js
+++ b/perf/micro/immediate-scheduler/operators/mergemap-resultselector.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var resultSelector = function (x, y, ix, iy) { return x + y + ix + iy; };
+  var oldMergeMapWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate)
+    .flatMap(function (x) {
+      return RxOld.Observable.range(x, 25, RxOld.Scheduler.immediate);
+    }, resultSelector);
+  var newMergeMapWithImmediateScheduler = RxNew.Observable.range(0, 25)
+    .mergeMap(function (x) {
+      return RxNew.Observable.range(x, 25);
+    }, resultSelector);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old mergeMap with resultSelector and immediate scheduler', function () {
+      oldMergeMapWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new mergeMap with resultSelector and immediate scheduler', function () {
+      newMergeMapWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};


### PR DESCRIPTION
Results on a Intel Core i7-3770 (Ivy Bridge) running Ubuntu:
```
                                    |     RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
-----------------------------------------------------------------------------------------------
mergemap-resultselector - immediate |   797 (±0.41%) |   10,263 (±0.39%) | 12.88x |   1,188.1%
               mergemap - immediate | 1,470 (±0.49%) |   15,446 (±3.53%) | 10.51x |     950.9%
            mergemap-resultselector |   316 (±0.22%) |    2,885 (±0.32%) |  9.13x |     813.3%
                           mergemap |   446 (±0.39%) |    3,364 (±0.36%) |  7.55x |     654.5%
```