### PR TITLE
fix(Subject): align parameter order to match with RxJS4

### DIFF
--- a/spec/Subject-spec.js
+++ b/spec/Subject-spec.js
@@ -411,7 +411,7 @@ describe('Subject', function () {
       }
     };
 
-    var sub = Subject.create(source, destination);
+    var sub = Subject.create(destination, source);
 
     sub.subscribe(function (x) {
       output.push(x);
@@ -456,7 +456,7 @@ describe('Subject', function () {
       }
     };
 
-    var sub = Subject.create(source, destination);
+    var sub = Subject.create(destination, source);
 
     sub.subscribe(function (x) {
       output.push(x);
@@ -571,7 +571,7 @@ describe('Subject', function () {
     it('should not eager', function () {
       var subscribed = false;
 
-      var subject = new Rx.Subject(new Rx.Observable(function (observer) {
+      var subject = new Rx.Subject(null, new Rx.Observable(function (observer) {
         subscribed = true;
         var subscription = Rx.Observable.of('x').subscribe(observer);
         return function () {

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -8,20 +8,16 @@ import {rxSubscriber} from './symbol/rxSubscriber';
 
 export class Subject<T> extends Observable<T> implements Observer<T>, Subscription {
 
-  static create: Function = <T>(source: Observable<T>, destination: Observer<T>): Subject<T> => {
-    return new Subject<T>(source, destination);
+  static create: Function = <T>(destination: Observer<T>, source: Observable<T>): Subject<T> => {
+    return new Subject<T>(destination, source);
   };
 
-  constructor(source?: Observable<T>, destination?: Observer<T>) {
+  constructor(protected destination?: Observer<T>, protected source?: Observable<T>) {
     super();
-    this.source = source;
-    this.destination = destination;
   }
 
   public observers: Observer<T>[] = [];
   public isUnsubscribed: boolean = false;
-
-  protected destination: Observer<T>;
 
   protected isStopped: boolean = false;
   protected hasErrored: boolean = false;
@@ -30,7 +26,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
   protected hasCompleted: boolean = false;
 
   lift<T, R>(operator: Operator<T, R>): Observable<T> {
-    const subject = new Subject(this, this.destination || this);
+    const subject = new Subject(this.destination || this, this);
     subject.operator = operator;
     return <any>subject;
   }

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -39,7 +39,7 @@ export class WebSocketSubject<T> extends Subject<T> {
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig | Observable<T>, destination?: Observer<T>) {
     if (urlConfigOrSource instanceof Observable) {
-      super(urlConfigOrSource, destination);
+      super(destination, urlConfigOrSource);
     } else {
       super();
       this.WebSocketCtor = root.WebSocket;


### PR DESCRIPTION
closes #1285 

This PR reorder parameter in definition of `Subject::create` to align with RxJS4.