### PR TITLE
perf(switchMapTo): remove tryCatch/errorObject (~2x improvement)

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/switchmapto-resultselector.js
+++ b/perf/micro/current-thread-scheduler/operators/switchmapto-resultselector.js
@@ -1,0 +1,21 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var resultSelector = function (x, y, ix, iy) { return x + y + ix + iy; };
+  var oldSwitchMapToWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread)
+    .flatMapLatest(RxOld.Observable.range(0, 10, RxOld.Scheduler.currentThread), resultSelector);
+  var newSwitchMapToWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue)
+    .switchMapTo(RxNew.Observable.range(0, 10, RxNew.Scheduler.queue), resultSelector);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMapTo with resultSelector and current thread scheduler', function () {
+      oldSwitchMapToWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMapTo with resultSelector and current thread scheduler', function () {
+      newSwitchMapToWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/current-thread-scheduler/operators/switchmapto.js
+++ b/perf/micro/current-thread-scheduler/operators/switchmapto.js
@@ -1,0 +1,20 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldSwitchMapToWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread)
+    .flatMapLatest(RxOld.Observable.range(0, 10, RxOld.Scheduler.currentThread));
+  var newSwitchMapToWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue)
+    .switchMapTo(RxNew.Observable.range(0, 10, RxNew.Scheduler.queue));
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMapTo with current thread scheduler', function () {
+      oldSwitchMapToWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMapTo with current thread scheduler', function () {
+      newSwitchMapToWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/switchmapto-resultselector.js
+++ b/perf/micro/immediate-scheduler/operators/switchmapto-resultselector.js
@@ -1,0 +1,21 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var resultSelector = function (x, y, ix, iy) { return x + y + ix + iy; };
+  var oldSwitchMapToWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate)
+    .flatMapLatest(RxOld.Observable.range(0, 10, RxOld.Scheduler.immediate), resultSelector);
+  var newSwitchMapToWithImmediateScheduler = RxNew.Observable.range(0, 25)
+    .switchMapTo(RxNew.Observable.range(0, 10), resultSelector);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMapTo with resultSelector and immediate scheduler', function () {
+      oldSwitchMapToWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMapTo with resultSelector and immediate scheduler', function () {
+      newSwitchMapToWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/switchmapto.js
+++ b/perf/micro/immediate-scheduler/operators/switchmapto.js
@@ -1,0 +1,20 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldSwitchMapToWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate)
+    .flatMapLatest(RxOld.Observable.range(0, 10, RxOld.Scheduler.immediate));
+  var newSwitchMapToWithImmediateScheduler = RxNew.Observable.range(0, 25)
+    .switchMapTo(RxNew.Observable.range(0, 10));
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMapTo with immediate scheduler', function () {
+      oldSwitchMapToWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMapTo with immediate scheduler', function () {
+      newSwitchMapToWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};


### PR DESCRIPTION
Before:
```
                                       |     RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
--------------------------------------------------------------------------------------------------
switchmapto-resultselector - immediate | 1,695 (±1.02%) |   12,229 (±1.15%) |  7.21x |     621.3%
               switchmapto - immediate | 2,910 (±0.80%) |   32,560 (±0.99%) | 11.19x |   1,018.8%
            switchmapto-resultselector | 2,621 (±0.87%) |   12,473 (±0.49%) |  4.76x |     375.9%
                           switchmapto | 3,300 (±2.11%) |   15,433 (±0.57%) |  4.68x |     367.7%
```

After:
```
                                       |     RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
--------------------------------------------------------------------------------------------------
switchmapto-resultselector - immediate | 1,645 (±2.07%) |   28,788 (±5.21%) | 17.50x |   1,650.5%
               switchmapto - immediate | 3,056 (±0.65%) |   31,656 (±1.17%) | 10.36x |     936.0%
            switchmapto-resultselector | 2,793 (±0.54%) |   14,322 (±1.15%) |  5.13x |     412.7%
                           switchmapto | 3,381 (±4.13%) |   15,969 (±3.86%) |  4.72x |     372.2%
```