### PR TITLE
chore(micro-perf): add perf tests for switchMap with resultSelector

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/switchmap-resultselector.js
+++ b/perf/micro/current-thread-scheduler/operators/switchmap-resultselector.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var resultSelector = function (x, y, ix, iy) { return x + y + ix + iy; };
+  var oldSwitchMapWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread)
+    .flatMapLatest(function (x) {
+      return RxOld.Observable.range(x, 25, RxOld.Scheduler.currentThread);
+    }, resultSelector);
+  var newSwitchMapWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue)
+    .switchMap(function (x) {
+      return RxNew.Observable.range(x, 25, RxNew.Scheduler.queue);
+    }, resultSelector);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMap with resultSelector and current thread scheduler', function () {
+      oldSwitchMapWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMap with resultSelector and current thread scheduler', function () {
+      newSwitchMapWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/switchmap-resultselector.js
+++ b/perf/micro/immediate-scheduler/operators/switchmap-resultselector.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var resultSelector = function (x, y, ix, iy) { return x + y + ix + iy; };
+  var oldSwitchMapWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate)
+    .flatMapLatest(function (x) {
+      return RxOld.Observable.range(x, 25, RxOld.Scheduler.immediate);
+    }, resultSelector);
+  var newSwitchMapWithImmediateScheduler = RxNew.Observable.range(0, 25)
+    .switchMap(function (x) {
+      return RxNew.Observable.range(x, 25);
+    }, resultSelector);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old switchMap with resultSelector and immediate scheduler', function () {
+      oldSwitchMapWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new switchMap with resultSelector and immediate scheduler', function () {
+      newSwitchMapWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};


### PR DESCRIPTION
Results on an Intel Core i7-3770 (Ivy Bridge) running Ubuntu:
```
                                     |     RxJS 4.0.7 | RxJS 5.0.0-beta.1 | factor | % improved
------------------------------------------------------------------------------------------------
switchmap-resultselector - immediate |   988 (±2.91%) |   10,345 (±1.25%) | 10.47x |     946.8%
               switchmap - immediate | 1,572 (±0.87%) |   16,578 (±2.06%) | 10.54x |     954.4%
            switchmap-resultselector | 2,248 (±1.21%) |   11,747 (±0.72%) |  5.23x |     422.6%
                           switchmap | 2,770 (±1.78%) |   12,852 (±1.27%) |  4.64x |     363.9%
```