### PR TITLE
Adjust description as ES7 features already came out.

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import 'rxjs/add/operator/map';
 Observable.of(1,2,3).map(x => x + '!!!'); // etc
 ```
 
-To import what you need and use it with ES7 function bind (best overall method, if possible):
+To import what you need and use it with ES next function bind (best overall method, if possible):
 
 ```js
 import {Observable} from 'rxjs/Observable';


### PR DESCRIPTION
The ES7(ES2016) **DO** only has two features: Array.prototype.includes & ** operator.
As [Function Bind Syntax](https://github.com/tc39/ecma262/blob/master/stage0.md) is still a stage 0 proposal, it not proper to regard it as a ES7 feature. (Seems at least ES9).