### PR TITLE
fix(Subject): throw ObjectUnsubscribedError when unsubecribed …

### DIFF
--- a/spec/Subject-spec.js
+++ b/spec/Subject-spec.js
@@ -129,9 +129,6 @@ describe('Subject', function () {
     subscription1.unsubscribe();
 
     subject.complete();
-    subject.next(9);
-    subject.complete();
-    subject.error(new Error('err'));
 
     subscription2.unsubscribe();
 
@@ -180,9 +177,6 @@ describe('Subject', function () {
     subscription1.unsubscribe();
 
     subject.error(new Error('err'));
-    subject.next(9);
-    subject.complete();
-    subject.error(new Error('err'));
 
     subscription2.unsubscribe();
 
@@ -221,9 +215,6 @@ describe('Subject', function () {
     subscription1.unsubscribe();
 
     subject.complete();
-    subject.next(9);
-    subject.complete();
-    subject.error(new Error('err'));
 
     subscription2.unsubscribe();
 
@@ -507,6 +498,57 @@ describe('Subject', function () {
       done);
 
     source.subscribe(subject);
+  });
+
+  it('should throw ObjectUnsubscribedError when emit after unsubscribed', function () {
+    var subject = new Rx.Subject();
+    subject.unsubscribe();
+
+    expect(function () {
+      subject.next('a');
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+
+    expect(function () {
+      subject.error('a');
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+
+    expect(function () {
+      subject.complete();
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+  });
+
+  it('should throw ObjectUnsubscribedError when emit after completed', function () {
+    var subject = new Rx.Subject();
+    subject.complete();
+
+    expect(function () {
+      subject.next('a');
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+
+    expect(function () {
+      subject.error('a');
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+
+    expect(function () {
+      subject.complete();
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+  });
+
+  it('should throw ObjectUnsubscribedError when emit after error', function () {
+    var subject = new Rx.Subject();
+    subject.error('e');
+
+    expect(function () {
+      subject.next('a');
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+
+    expect(function () {
+      subject.error('a');
+    }).toThrow(new Rx.ObjectUnsubscribedError());
+
+    expect(function () {
+      subject.complete();
+    }).toThrow(new Rx.ObjectUnsubscribedError());
   });
 
   describe('asObservable', function () {

--- a/spec/observables/zip-spec.js
+++ b/spec/observables/zip-spec.js
@@ -179,20 +179,20 @@ describe('Observable.zip', function () {
     });
 
     it('should work with non-empty observable and empty iterable', function () {
-      var a = hot('---^----#--|');
-      var asubs =    '^    !   ';
+      var a = hot('---^----#');
+      var asubs =    '^    !';
       var b = [];
-      var expected = '-----#   ';
+      var expected = '-----#';
 
       expectObservable(Observable.zip(a,b)).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
     it('should work with observable which raises error and non-empty iterable', function () {
-      var a = hot('---^----#--|');
-      var asubs =    '^    !   ';
+      var a = hot('---^----#');
+      var asubs =    '^    !';
       var b = [1];
-      var expected = '-----#   ';
+      var expected = '-----#';
 
       expectObservable(Observable.zip(a,b)).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/catch-spec.js
+++ b/spec/operators/catch-spec.js
@@ -79,7 +79,7 @@ describe('Observable.prototype.catch()', function () {
   });
 
   it('should catch error and replace it with a hot Observable', function () {
-    var e1 =   hot('--a--b--#----|     ');
+    var e1 =   hot('--a--b--#          ');
     var e1subs =   '^       !          ';
     var e2 =   hot('1-2-3-4-5-6-7-8-9-|');
     var e2subs =   '        ^         !';

--- a/spec/operators/concatAll-spec.js
+++ b/spec/operators/concatAll-spec.js
@@ -105,7 +105,7 @@ describe('Observable.prototype.concatAll()', function () {
       y: cold(       'a-b---------|'),
       z: cold(                 'c-d-e-f-|'),
     };
-    var e1 =   hot('--y---------z---#-------------|', values);
+    var e1 =   hot('--y---------z---#    ', values);
     var expected = '--a-b---------c-#';
 
     expectObservable(e1.concatAll()).toBe(expected);

--- a/spec/operators/groupBy-spec.js
+++ b/spec/operators/groupBy-spec.js
@@ -1,4 +1,4 @@
-/* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions */
+/* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var Observable = Rx.Observable;
 var GroupedObservable = require('../../dist/cjs/operator/groupBy').GroupedObservable;

--- a/spec/operators/map-spec.js
+++ b/spec/operators/map-spec.js
@@ -137,7 +137,7 @@ describe('Observable.prototype.map()', function () {
   });
 
   it('should map with index until completed', function () {
-    var a = hot('-5-^-4--3---2----1--|--8--|--#');
+    var a = hot('-5-^-4--3---2----1--|');
     var asubs =    '^                !';
     var expected = '--a--b---c----d--|';
     var values = {a: 5, b: 14, c: 23, d: 32};
@@ -155,7 +155,7 @@ describe('Observable.prototype.map()', function () {
   });
 
   it('should map with index until an error occurs', function () {
-    var a = hot('-5-^-4--3---2----1--#--8--|', undefined, 'too bad');
+    var a = hot('-5-^-4--3---2----1--#', undefined, 'too bad');
     var asubs =    '^                !';
     var expected = '--a--b---c----d--#';
     var values = {a: 5, b: 14, c: 23, d: 32};
@@ -173,7 +173,7 @@ describe('Observable.prototype.map()', function () {
   });
 
   it('should map using a custom thisArg', function () {
-    var a = hot('-5-^-4--3---2----1--|--8--|--#');
+    var a = hot('-5-^-4--3---2----1--|');
     var asubs =    '^                !';
     var expected = '--a--b---c----d--|';
     var values = {a: 5, b: 14, c: 23, d: 32};
@@ -195,7 +195,7 @@ describe('Observable.prototype.map()', function () {
   });
 
   it('should map twice', function () {
-    var a = hot('-0----1-^-2---3--4-5--6--7-8-|--9-#-|');
+    var a = hot('-0----1-^-2---3--4-5--6--7-8-|');
     var asubs =         '^                    !';
     var expected =      '--a---b--c-d--e--f-g-|';
     var values = {a: 2, b: 3, c: 4, d: 5, e: 6, f: 7, g: 8};

--- a/spec/operators/mergeAll-spec.js
+++ b/spec/operators/mergeAll-spec.js
@@ -359,7 +359,7 @@ describe('Observable.prototype.mergeAll()', function () {
     var ysubs =    '  ^           !                ';
     var z = cold(              'c-d-e-f-|          ');
     var zsubs =    '            ^   !              ';
-    var e1 =   hot('--y---------z---#-------------|', { y: y, z: z });
+    var e1 =   hot('--y---------z---#              ', { y: y, z: z });
     var e1subs =   '^               !              ';
     var expected = '--a-b-------c-d-#              ';
 

--- a/spec/operators/multicast-spec.js
+++ b/spec/operators/multicast-spec.js
@@ -503,7 +503,7 @@ describe('Observable.prototype.multicast()', function () {
       source.connect();
     });
 
-    it('should not throw `cannot subscribe to a disposed subject` when used in ' +
+    it('should not throw ObjectUnsubscribedError when used in ' +
     'a switchMap', function (done) {
       var source = Observable.of(1, 2, 3)
         .multicast(function () { return new Subject(); })
@@ -548,7 +548,7 @@ describe('Observable.prototype.multicast()', function () {
       source.connect();
     });
 
-    it('should not throw `cannot subscribe to a disposed subject` when used in ' +
+    it('should not throw ObjectUnsubscribedError when used in ' +
     'a switchMap', function (done) {
       var source = Observable.of(1, 2, 3)
         .multicast(new Subject())

--- a/spec/operators/skipUntil-spec.js
+++ b/spec/operators/skipUntil-spec.js
@@ -218,10 +218,14 @@ describe('Observable.prototype.skipUntil()', function () {
     var e1 =   hot( '--a--b--c--d--e--|');
     var e1subs =   ['^                !',
                     '^                !']; // for the explicit subscribe some lines below
-    var skip = hot( '-------------x--|');
+    var skip = new Rx.Subject();
     var expected =  '-';
 
-    e1.subscribe(function () {
+    e1.subscribe(function (x) {
+      if (x === 'd' && !skip.isUnsubscribed) {
+        skip.next('x');
+      }
+
       skip.unsubscribe();
     });
 

--- a/spec/operators/takeUntil-spec.js
+++ b/spec/operators/takeUntil-spec.js
@@ -18,7 +18,7 @@ describe('Observable.prototype.takeUntil()', function () {
   it('should take values and raises error when notifier raises error', function () {
     var e1 =     hot('--a--b--c--d--e--f--g--|');
     var e1subs =     '^            !          ';
-    var e2 =     hot('-------------#--|       ');
+    var e2 =     hot('-------------#          ');
     var e2subs =     '^            !          ';
     var expected =   '--a--b--c--d-#          ';
 

--- a/spec/operators/window-spec.js
+++ b/spec/operators/window-spec.js
@@ -215,7 +215,7 @@ describe('Observable.prototype.window', function () {
     rxTestScheduler.schedule(function () {
       expect(function () {
         window.subscribe();
-      }).toThrowError('Cannot subscribe to a disposed Subject.');
+      }).toThrow(new Rx.ObjectUnsubscribedError());
     }, late);
   });
 

--- a/spec/operators/windowCount-spec.js
+++ b/spec/operators/windowCount-spec.js
@@ -145,7 +145,7 @@ describe('Observable.prototype.windowCount', function () {
     rxTestScheduler.schedule(function () {
       expect(function () {
         window.subscribe();
-      }).toThrowError('Cannot subscribe to a disposed Subject.');
+      }).toThrow(new Rx.ObjectUnsubscribedError());
     }, late);
   });
 

--- a/spec/operators/windowTime-spec.js
+++ b/spec/operators/windowTime-spec.js
@@ -183,12 +183,9 @@ describe('Observable.prototype.windowTime', function () {
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
     rxTestScheduler.schedule(function () {
-      try {
+      expect(function () {
         window.subscribe();
-      }
-      catch (err) {
-        expect(err.message).toBe('Cannot subscribe to a disposed Subject.');
-      }
+      }).toThrow(new Rx.ObjectUnsubscribedError());
     }, 150);
   });
 

--- a/spec/operators/windowToggle-spec.js
+++ b/spec/operators/windowToggle-spec.js
@@ -1,4 +1,4 @@
-/* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions */
+/* globals describe, it, expect, hot, cold, expectObservable, expectSubscriptions, rxTestScheduler */
 var Rx = require('../../dist/cjs/Rx.KitchenSink');
 var Observable = Rx.Observable;
 
@@ -214,7 +214,7 @@ describe('Observable.prototype.windowToggle', function () {
     rxTestScheduler.schedule(function () {
       expect(function () {
         window.subscribe();
-      }).toThrowError('Cannot subscribe to a disposed Subject.');
+      }).toThrow(new Rx.ObjectUnsubscribedError());
     }, late);
   });
 
@@ -284,7 +284,7 @@ describe('Observable.prototype.windowToggle', function () {
   });
 
   it('should handle errors', function () {
-    var e1 = hot('--a--^---b---c---d---e--#f---g---h------|');
+    var e1 = hot('--a--^---b---c---d---e--#                ');
     var e1subs =      '^                  !                ';
     var e2 =     cold('--x-----------y--------z---|        ');
     var e2subs =      '^                  !                ';

--- a/spec/operators/windowWhen-spec.js
+++ b/spec/operators/windowWhen-spec.js
@@ -170,7 +170,7 @@ describe('Observable.prototype.windowWhen', function () {
     rxTestScheduler.schedule(function () {
       expect(function () {
         window.subscribe();
-      }).toThrowError('Cannot subscribe to a disposed Subject.');
+      }).toThrow(new Rx.ObjectUnsubscribedError());
     }, late);
   });
 

--- a/spec/operators/zip-spec.js
+++ b/spec/operators/zip-spec.js
@@ -178,20 +178,20 @@ describe('zip', function () {
     });
 
     it('should work with non-empty observable and empty iterable', function () {
-      var a = hot('---^----#--|');
-      var asubs =    '^    !   ';
+      var a = hot('---^----#');
+      var asubs =    '^    !';
       var b = [];
-      var expected = '-----#   ';
+      var expected = '-----#';
 
       expectObservable(a.zip(b)).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
     it('should work with observable which raises error and non-empty iterable', function () {
-      var a = hot('---^----#--|');
-      var asubs =    '^    !   ';
+      var a = hot('---^----#');
+      var asubs =    '^    !';
       var b = [1];
-      var expected = '-----#   ';
+      var expected = '-----#';
 
       expectObservable(a.zip(b)).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/zipAll-spec.js
+++ b/spec/operators/zipAll-spec.js
@@ -189,20 +189,20 @@ describe('Observable.prototype.zipAll', function () {
     });
 
     it('should work with non-empty observable and empty iterable', function () {
-      var a = hot('---^----#--|');
-      var asubs =    '^    !   ';
+      var a = hot('---^----#');
+      var asubs =    '^    !';
       var b = [];
-      var expected = '-----#   ';
+      var expected = '-----#';
 
       expectObservable(Observable.of(a,b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
     it('should work with observable which raises error and non-empty iterable', function () {
-      var a = hot('---^----#--|');
-      var asubs =    '^    !   ';
+      var a = hot('---^----#');
+      var asubs =    '^    !';
       var b = [1];
-      var expected = '-----#   ';
+      var expected = '-----#';
 
       expectObservable(Observable.of(a,b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/subjects/AsyncSubject-spec.js
+++ b/spec/subjects/AsyncSubject-spec.js
@@ -70,8 +70,6 @@ describe('AsyncSubject', function () {
     expect(observer.results).toEqual([]);
     subject.complete();
     expect(observer.results).toEqual([2, 'done']);
-    subject.next(3);
-    expect(observer.results).toEqual([2, 'done']);
   });
 
   it('should not emit values if unsubscribed before complete', function () {

--- a/spec/subjects/BehaviorSubject-spec.js
+++ b/spec/subjects/BehaviorSubject-spec.js
@@ -96,7 +96,10 @@ describe('BehaviorSubject', function () {
 
     subject.next('foo');
     subject.complete();
-    subject.next('bar');
+
+    expect(function () {
+      subject.next('bar');
+    }).toThrow(new Rx.ObjectUnsubscribedError());
   });
 
   it('should clean out unsubscribed subscribers', function (done) {

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -51,7 +51,10 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     const windows = this.windows;
     const len = windows.length;
     for (let i = 0; i < len; i++) {
-      windows[i].next(value);
+      const window = windows[i];
+      if (!window.isUnsubscribed) {
+        window.next(value);
+      }
     }
   }
 
@@ -66,7 +69,10 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
   protected _complete() {
     const windows = this.windows;
     while (windows.length > 0) {
-      windows.shift().complete();
+      const window = windows.shift();
+      if (!window.isUnsubscribed) {
+        window.complete();
+      }
     }
     this.destination.complete();
   }


### PR DESCRIPTION
This PR tries to close #859, now `Subject` throws `ObjectUnsubscribedError` if it's unsubscribed. Updated operator behavior and test cases also to not emit after subject completion(error, complete, unsub) 