### PR TITLE
refactor(expand): remove superfluous _isScalar check

### DIFF
--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -82,12 +82,8 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private subscribeToProjection(result: any, value: T, index: number): void {
-    if (result._isScalar) {
-      this._next(result.value);
-    } else {
-      this.active++;
-      this.add(subscribeToResult<T, R>(this, result, value, index));
-    }
+    this.active++;
+    this.add(subscribeToResult<T, R>(this, result, value, index));
   }
 
   protected _complete(): void {


### PR DESCRIPTION
This was removed because it was redundant and it could cause errors, but I was unable to
produce any, I think because of the nature of the operator.

As mentioned by @trxcllnt in #1315 