### PR TITLE
refactor groupBy behaviors for browser compatibility

### DIFF
--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -126,8 +126,9 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
     if (groups) {
       groups.forEach((group, key) => {
         group.error(err);
-        this.removeGroup(key);
       });
+
+      groups.clear();
     }
     this.destination.error(err);
   }
@@ -137,8 +138,9 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
     if (groups) {
       groups.forEach((group, key) => {
         group.complete();
-        this.removeGroup(key);
       });
+
+      groups.clear();
     }
     this.destination.complete();
   }

--- a/src/util/MapPolyfill.ts
+++ b/src/util/MapPolyfill.ts
@@ -29,7 +29,13 @@ export class MapPolyfill {
     return true;
   }
 
-  forEach(cb: Function, thisArg: any) {
+  clear(): void {
+    this._keys.length = 0;
+    this._values.length = 0;
+    this.size = 0;
+  }
+
+  forEach(cb: Function, thisArg: any): void {
     for (let i = 0; i < this.size; i++) {
       cb.call(thisArg, this._values[i], this._keys[i]);
     }


### PR DESCRIPTION
This PR fixes compatibility of `groupBy` on some browsers.

Root cause was removing groups for completion (error, complete..) inside of `map::foreach` to clear all groups, doesn't supported by polyfill implementation of map. PR introduces `map::clear()` interface for explicit clearing and utilize it.

cc @staltz for visibility.