### PR TITLE
docs(MIGRATION): remove the non-exist usecase for throttle()

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -204,11 +204,7 @@ To reduce polymorphism and get better performance out of operators, some operato
       <td><code>debounceTime(delay: number, scheduler?: Scheduler)</code></td>
     </tr>
     <tr>
-      <td rowspan="2"><code>throttle</code></td>
-      <td><code>throttle(durationSelector: Observable)</code></td>
-      <td><code>throttle(durationSelector: Observable)</code></td>
-    </tr>
-    <tr>
+      <td><code>throttle</code></td>
       <td><code>throttle(delay: number, scheduler?: Scheduler)</code></td>
       <td><code>throttleTime(delay: number, scheduler?: Scheduler)</code></td>
     </tr>


### PR DESCRIPTION
RxJS v4's `throttle()` does not accept `Observable<T>` as a durationSelector. There are no need the migration path.

- https://github.com/Reactive-Extensions/RxJS/blob/8f12f812d497acf639588e90f74d504a9fc801ec/src/core/linq/observable/throttle.js#L9
- https://github.com/Reactive-Extensions/RxJS/blob/8f12f812d497acf639588e90f74d504a9fc801ec/ts/core/linq/observable/throttle.ts