### PR TITLE
Map transducing

### DIFF
--- a/perf/micro/immediate-scheduler/operators/map-mergeAll.js
+++ b/perf/micro/immediate-scheduler/operators/map-mergeAll.js
@@ -1,0 +1,24 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  function toObservableOld(x) {
+    return RxOld.Observable.range(0, 3);
+  }
+  function toObservableNew(x) {
+    return RxNew.Observable.range(0, 3);
+  }
+  var _old = RxOld.Observable.range(0, 50, RxOld.Scheduler.immediate).map(toObservableOld).mergeAll();
+  var _new = RxNew.Observable.range(0, 50).map(toObservableNew).mergeAll();
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old map and mergeAll with immediate scheduler', function () {
+        _old.subscribe(_next, _error, _complete);
+      })
+      .add('new map and mergeAll with immediate scheduler', function () {
+        _new.subscribe(_next, _error, _complete);
+      });
+};

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -4,9 +4,15 @@ import {Observer} from '../Observer';
 import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
+import {MergeMapOperator} from './mergeMap';
 
 export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): T {
-  return this.lift(new MergeAllOperator(concurrent));
+  const { source, operator } = this;
+  if (source && operator && operator.transduce) {
+    return source.lift(new MergeMapOperator(operator.transduce((x: any) => x, this), null, concurrent));
+  } else {
+    return this.lift(new MergeAllOperator(concurrent));
+  }
 }
 
 export class MergeAllOperator<T> implements Operator<Observable<T>, T> {


### PR DESCRIPTION
As a PoC, I've implemented transducing on map!

In this PR:

1. Chained map operators will collapse on themselves. This results in about a 20% performance boost when only two map operations are chained. That should grow with the number chained.
2. `map().mergeAll()` will flatten to `.mergeMap()` via magic. This results in about a 20% perf improvement over using `.map().mergeAll()` prior to this commit, and is ~15x faster than .map().mergeAll() in Rx4.

While I think we can land this here in master, this is a PoC to see what needs to be done.

One thing I learned while working on this is the `thisArg` makes creating this a little uncomfortable. As if I needed another reason to hate the `thisArg`s.