### PR TITLE
fix(benchpress): fix issues with benchmarks

### DIFF
--- a/perf/macro/bufferCount/index.html
+++ b/perf/macro/bufferCount/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/combineLatest/index.html
+++ b/perf/macro/combineLatest/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/groupBy/index.html
+++ b/perf/macro/groupBy/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/merge/index.html
+++ b/perf/macro/merge/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/mergeAll/index.html
+++ b/perf/macro/mergeAll/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/mergeAll/perf.js
+++ b/perf/macro/mergeAll/perf.js
@@ -15,10 +15,10 @@ var Rx2TestObservable = Rx.Observable.range(0, numIterations)
 var RxNextTestObservable = RxNext.Observable.range(0, numIterations)
   .map(function (x) { return RxNext.Observable.range(0, numIterations); });
 
-Rx2Merge.addEventListener('click', function () {
+Rx2MergeAll.addEventListener('click', function () {
   Rx2TestObservable.mergeAll().subscribe();
 });
 
-RxNextMerge.addEventListener('click', function () {
+RxNextMergeAll.addEventListener('click', function () {
   RxNextTestObservable.mergeAll().subscribe();
 });

--- a/perf/macro/mergeMap-scalar/index.html
+++ b/perf/macro/mergeMap-scalar/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/mergeMap/index.html
+++ b/perf/macro/mergeMap/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/mergeMap/perf.js
+++ b/perf/macro/mergeMap/perf.js
@@ -35,6 +35,6 @@ RxNextMergeMap.addEventListener('click', function () {
 });
 
 Rx2MergeMap.addEventListener('click', function () {
-  Rx2TestObservable.mergeMap(projectionRx2).subscribe();
+  Rx2TestObservable.flatMap(projectionRx2).subscribe();
 });
 

--- a/perf/macro/windowCount/index.html
+++ b/perf/macro/windowCount/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;

--- a/perf/macro/zip/index.html
+++ b/perf/macro/zip/index.html
@@ -3,7 +3,7 @@
 <head>
 	<meta charset="UTF-8">
 	<title>RxJS 3 Perf Tests</title>
-  <script src="../../../dist/global/Rx.js"></script>
+  <script src="../../../dist/global/Rx.umd.js"></script>
   <script type="text/javascript">
     window.RxNext = window.Rx;
     window.Rx = void 0;


### PR DESCRIPTION
Some benchmarks had errors that were causing perf tests to log 0:00 time
values for scriptTime metrics.

Fixed Issues:
 - Was using Rx.js instead of Rx.umd.js in all benchmarks
 - Was calling mergeMap on Rx2 observable instead of flatMap
 - Had mis-named variables in mergeAll spec