### PR TITLE
refactor(test): reorder some test case to avoid unexpected jasmine be…

### DIFF
--- a/spec/operators/publish-spec.js
+++ b/spec/operators/publish-spec.js
@@ -16,6 +16,27 @@ describe('Observable.prototype.publish()', function () {
     published.connect();
   });
 
+  it('To match RxJS 4 behavior, it should NOT allow you to reconnect by subscribing again', function (done) {
+    var expected = [1, 2, 3, 4];
+    var i = 0;
+
+    var source = Observable.of(1, 2, 3, 4).publish();
+
+    source.subscribe(function (x) {
+      expect(x).toBe(expected[i++]);
+    },
+    null,
+    function () {
+      source.subscribe(function (x) {
+        done.fail('should not be called');
+      }, null, done);
+
+      source.connect();
+    });
+
+    source.connect();
+  });
+
   it('should return a ConnectableObservable', function () {
     var source = Observable.of(1).publish();
     expect(source instanceof Rx.ConnectableObservable).toBe(true);
@@ -299,26 +320,5 @@ describe('Observable.prototype.publish()', function () {
     expect(results2).toEqual([1, 2, 3, 4]);
     expect(subscriptions).toBe(1);
     done();
-  });
-
-  it('To match RxJS 4 behavior, it should NOT allow you to reconnect by subscribing again', function (done) {
-    var expected = [1, 2, 3, 4];
-    var i = 0;
-
-    var source = Observable.of(1, 2, 3, 4).publish();
-
-    source.subscribe(function (x) {
-      expect(x).toBe(expected[i++]);
-    },
-    null,
-    function () {
-      source.subscribe(function (x) {
-        throw 'this should not be called';
-      }, null, done);
-
-      source.connect();
-    });
-
-    source.connect();
   });
 });

--- a/spec/operators/publishBehavior-spec.js
+++ b/spec/operators/publishBehavior-spec.js
@@ -1,4 +1,4 @@
-/* globals describe, it, expect */
+/* globals describe, it, expect, expectObservable, expectSubscriptions */
 var Rx = require('../../dist/cjs/Rx');
 var Observable = Rx.Observable;
 
@@ -13,6 +13,28 @@ describe('Observable.prototype.publishBehavior()', function () {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     published.connect();
+  });
+
+  it('should follow the RxJS 4 behavior and NOT allow you to reconnect by subscribing again', function (done) {
+    var expected = [0, 1, 2, 3, 4];
+    var i = 0;
+
+    var source = Observable.of(1, 2, 3, 4).publishBehavior(0);
+
+    source.subscribe(
+      function (x) {
+        expect(x).toBe(expected[i++]);
+      },
+      null,
+      function () {
+        source.subscribe(function (x) {
+          done.fail('should not be called');
+        }, null, done);
+
+        source.connect();
+      });
+
+    source.connect();
   });
 
   it('should return a ConnectableObservable', function () {
@@ -321,27 +343,5 @@ describe('Observable.prototype.publishBehavior()', function () {
 
     expect(results).toEqual([]);
     done();
-  });
-
-  it('should follow the RxJS 4 behavior and NOT allow you to reconnect by subscribing again', function (done) {
-    var expected = [0, 1, 2, 3, 4];
-    var i = 0;
-
-    var source = Observable.of(1, 2, 3, 4).publishBehavior(0);
-
-    source.subscribe(
-      function (x) {
-        expect(x).toBe(expected[i++]);
-      },
-      null,
-      function () {
-        source.subscribe(function (x) {
-          throw 'should not be called';
-        }, null, done);
-
-        source.connect();
-      });
-
-    source.connect();
   });
 });


### PR DESCRIPTION
…havior

Latest travis log (https://travis-ci.org/ReactiveX/RxJS/builds/108206549) shows couple of tests are failing on some browser unexpectedly. This is similar to previous cases of test starts to fail by adding one or another - just simply reordering test makes passes it. Assume it's somewhat related with jasmine's async test handling, meanwhile simply reorder couple of tests to make test executes successfully.