### PR TITLE
chore(micro-perf): fix scheduling of retry perf test

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/retry.js
+++ b/perf/micro/current-thread-scheduler/operators/retry.js
@@ -1,0 +1,35 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var maxRetryCount = 25;
+  var oldRetryCount = 0;
+  var newRetryCount = 0;
+
+  var _old = RxOld.Observable.ofWithScheduler(RxOld.Scheduler.currentThread, 5)
+    .flatMap(function (x) {
+      if (++oldRetryCount < maxRetryCount - 1) {
+        return RxOld.Observable.throw(new Error('error'),  RxOld.Scheduler.currentThread);
+      }
+      return RxOld.Observable.ofWithScheduler(RxOld.Scheduler.currentThread, x);
+    }).retry(maxRetryCount);
+
+  var _new = RxNew.Observable.of(5, RxNew.Scheduler.queue)
+    .mergeMap(function (x) {
+      if (++newRetryCount < maxRetryCount - 1) {
+        return RxNew.Observable.throw(new Error('error'), RxNew.Scheduler.queue);
+      }
+      return RxNew.Observable.of(x, RxNew.Scheduler.queue);
+    }).retry(maxRetryCount);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old retry with currentThread scheduler', function () {
+        _old.subscribe(_next, _error, _complete);
+      })
+      .add('new retry with currentThread scheduler', function () {
+        _new.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/retry.js
+++ b/perf/micro/immediate-scheduler/operators/retry.js
@@ -6,14 +6,15 @@ module.exports = function (suite) {
   var oldRetryCount = 0;
   var newRetryCount = 0;
 
-  var oldRetryWithImmediateScheduler = RxOld.Observable.of(5, RxOld.Scheduler.immediate)
+  var _old = RxOld.Observable.ofWithScheduler(RxOld.Scheduler.immediate, 5)
     .flatMap(function (x) {
       if (++oldRetryCount < maxRetryCount - 1) {
         return RxOld.Observable.throw(new Error('error'),  RxOld.Scheduler.immediate);
       }
-      return RxOld.Observable.of(x, RxOld.Scheduler.immediate);
+      return RxOld.Observable.ofWithScheduler(RxOld.Scheduler.immediate, x);
     }).retry(maxRetryCount);
-  var newRetryWithImmediateScheduler = RxNew.Observable.of(5)
+
+  var _new = RxNew.Observable.of(5)
     .mergeMap(function (x) {
       if (++newRetryCount < maxRetryCount - 1) {
         return RxNew.Observable.throw(new Error('error'));
@@ -26,9 +27,9 @@ module.exports = function (suite) {
   function _complete() { }
   return suite
       .add('old retry with immediate scheduler', function () {
-        oldRetryWithImmediateScheduler.subscribe(_next, _error, _complete);
+        _old.subscribe(_next, _error, _complete);
       })
       .add('new retry with immediate scheduler', function () {
-        newRetryWithImmediateScheduler.subscribe(_next, _error, _complete);
+        _new.subscribe(_next, _error, _complete);
       });
 };


### PR DESCRIPTION
* Fix `Observable.of()` usage in micro perf test with immediate scheduler
* Adds micro perf test using currentThread scheduler