### PR TITLE
fix(typings): set map function parameter for Observable.from as optional

### DIFF
--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -20,7 +20,7 @@ export class FromObservable<T> extends Observable<T> {
     super(null);
   }
 
-  static create<T>(ish: any, mapFnOrScheduler: Scheduler | ((x: any, y: number) => T), thisArg?: any, lastScheduler?: Scheduler): Observable<T> {
+  static create<T>(ish: any, mapFnOrScheduler?: Scheduler | ((x: any, y: number) => T), thisArg?: any, lastScheduler?: Scheduler): Observable<T> {
     let scheduler: Scheduler = null;
     let mapFn: (x: number, y: any) => T = null;
     if (isFunction(mapFnOrScheduler)) {


### PR DESCRIPTION
without this change typescript returns TS2346 error when we use Observable.from with one parameter.

I think that it will be nice if tests will be written in typescript because it will eliminate situations like this.