### PR TITLE
Add ReactiveX docs link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,10 @@ Rx.Observable.of('hello world')
   .subscribe(function(x) { console.log(x); });
 ```
 
+## API Documentation
+
+Automatically generated documentation can be found on the ReactiveX website: http://reactivex.io/RxJS
+
 ## Goals
 
 - Provide better performance than preceding versions of RxJS


### PR DESCRIPTION
I also recommend adding a link to the docs in the project description (can only be done by the admin)

> A reactive programming library for JavaScript http://reactivex.io/RxJS/