### PR TITLE
chore(typings): added type signatures for concat/exhaust/merge/switch

### DIFF
--- a/src/CoreOperators.ts
+++ b/src/CoreOperators.ts
@@ -1,6 +1,3 @@
-import {Observable} from './Observable';
-import {Scheduler} from './Scheduler';
-
 import {CombineLatestSignature} from './operator/combineLatest';
 import {WithLatestFromSignature} from './operator/withLatestFrom';
 import {ZipSignature} from './operator/zip';
@@ -70,6 +67,21 @@ import {TimeoutSignature} from './operator/timeout';
 import {TimeoutWithSignature} from './operator/timeoutWith';
 import {ToArraySignature} from './operator/toArray';
 import {ToPromiseSignature} from './operator/toPromise';
+import {CombineAllSignature} from './operator/combineAll';
+import {ConcatSignature} from './operator/concat';
+import {ConcatAllSignature} from './operator/concatAll';
+import {ConcatMapSignature} from './operator/concatMap';
+import {ConcatMapToSignature} from './operator/concatMapTo';
+import {MapSignature} from './operator/map';
+import {MapToSignature} from './operator/mapTo';
+import {MergeSignature} from './operator/merge';
+import {MergeAllSignature} from './operator/mergeAll';
+import {MergeMapSignature} from './operator/mergeMap';
+import {MergeMapToSignature} from './operator/mergeMapTo';
+import {SwitchSignature} from './operator/switch';
+import {SwitchMapSignature} from './operator/switchMap';
+import {SwitchMapToSignature} from './operator/switchMapTo';
+import {ZipAllSignature} from './operator/zipAll';
 
 export interface CoreOperators<T> {
   buffer: BufferSignature<T>;
@@ -79,12 +91,12 @@ export interface CoreOperators<T> {
   bufferWhen: BufferWhenSignature<T>;
   cache: CacheSignature<T>;
   catch: CatchSignature<T>;
-  combineAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
+  combineAll: CombineAllSignature<T>;
   combineLatest: CombineLatestSignature<T>;
-  concat?: <R>(...observables: (Observable<any> | Scheduler)[]) => Observable<R>;
-  concatAll?: () => Observable<T>;
-  concatMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  concatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  concat: ConcatSignature<T>;
+  concatAll: ConcatAllSignature<T>;
+  concatMap: ConcatMapSignature<T>;
+  concatMapTo: ConcatMapToSignature<T>;
   count: CountSignature<T>;
   dematerialize: DematerializeSignature<T>;
   debounce: DebounceSignature<T>;
@@ -98,10 +110,8 @@ export interface CoreOperators<T> {
   filter: FilterSignature<T>;
   finally: FinallySignature<T>;
   first: FirstSignature<T>;
-  flatMap?: <R>(project: ((x: T, ix: number) => Observable<any>),
-                projectResult?: (x: T, y: any, ix: number, iy: number) => R,
-                concurrent?: number) => Observable<R>;
-  flatMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  flatMap: MergeMapSignature<T>;
+  flatMapTo: MergeMapToSignature<T>;
   groupBy: GroupBySignature<T>;
   ignoreElements: IgnoreElementsSignature<T>;
   inspect: InspectSignature<T>;
@@ -110,14 +120,13 @@ export interface CoreOperators<T> {
   let: LetSignature<T>;
   letBind: LetSignature<T>;
   every: EverySignature<T>;
-  map?: <R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
-  mapTo?: <R>(value: R) => Observable<R>;
+  map: MapSignature<T>;
+  mapTo: MapToSignature<T>;
   materialize: MaterializeSignature<T>;
-  merge?: (...observables: any[]) => Observable<any>;
-  mergeAll?: (concurrent?: number) => Observable<T>;
-  mergeMap?: <R>(project: ((x: T, ix: number) => Observable<any>),
-                 projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
-  mergeMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  merge: MergeSignature<T>;
+  mergeAll: MergeAllSignature<T>;
+  mergeMap: MergeMapSignature<T>;
+  mergeMapTo: MergeMapToSignature<T>;
   multicast: MulticastSignature<T>;
   observeOn: ObserveOnSignature<T>;
   partition: PartitionSignature<T>;
@@ -141,9 +150,9 @@ export interface CoreOperators<T> {
   skipWhile: SkipWhileSignature<T>;
   startWith: StartWithSignature<T>;
   subscribeOn: SubscribeOnSignature<T>;
-  switch?: () => Observable<T>;
-  switchMap?: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  switchMapTo?: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  switch: SwitchSignature<T>;
+  switchMap: SwitchMapSignature<T>;
+  switchMapTo: SwitchMapToSignature<T>;
   take: TakeSignature<T>;
   takeLast: TakeLastSignature<T>;
   takeUntil: TakeUntilSignature<T>;
@@ -161,5 +170,5 @@ export interface CoreOperators<T> {
   windowWhen: WindowWhenSignature<T>;
   withLatestFrom: WithLatestFromSignature<T>;
   zip: ZipSignature<T>;
-  zipAll?: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
+  zipAll: ZipAllSignature<T>;
 }

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,6 +1,5 @@
 import {PartialObserver} from './Observer';
 import {Operator} from './Operator';
-import {Scheduler} from './Scheduler';
 import {Subscriber} from './Subscriber';
 import {Subscription} from './Subscription';
 import {root} from './util/root';
@@ -102,6 +101,21 @@ import {TimeoutSignature} from './operator/timeout';
 import {TimeoutWithSignature} from './operator/timeoutWith';
 import {ToArraySignature} from './operator/toArray';
 import {ToPromiseSignature} from './operator/toPromise';
+import {CombineAllSignature} from './operator/combineAll';
+import {ConcatSignature} from './operator/concat';
+import {ConcatAllSignature} from './operator/concatAll';
+import {ConcatMapSignature} from './operator/concatMap';
+import {ConcatMapToSignature} from './operator/concatMapTo';
+import {MapSignature} from './operator/map';
+import {MapToSignature} from './operator/mapTo';
+import {MergeSignature} from './operator/merge';
+import {MergeAllSignature} from './operator/mergeAll';
+import {MergeMapSignature} from './operator/mergeMap';
+import {MergeMapToSignature} from './operator/mergeMapTo';
+import {SwitchSignature} from './operator/switch';
+import {SwitchMapSignature} from './operator/switchMap';
+import {SwitchMapToSignature} from './operator/switchMapTo';
+import {ZipAllSignature} from './operator/zipAll';
 
 export type ObservableOrPromise<T> = Observable<T> | Promise<T>;
 export type ArrayOrIterator<T> = Iterator<T> | ArrayLike<T>;
@@ -264,12 +278,12 @@ export class Observable<T> implements CoreOperators<T>  {
   bufferWhen: BufferWhenSignature<T>;
   cache: CacheSignature<T>;
   catch: CatchSignature<T>;
-  combineAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
+  combineAll: CombineAllSignature<T>;
   combineLatest: CombineLatestSignature<T>;
-  concat: <R>(...observables: (Observable<any> | Scheduler)[]) => Observable<R>;
-  concatAll: () => Observable<any>;
-  concatMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  concatMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  concat: ConcatSignature<T>;
+  concatAll: ConcatAllSignature<T>;
+  concatMap: ConcatMapSignature<T>;
+  concatMapTo: ConcatMapToSignature<T>;
   count: CountSignature<T>;
   dematerialize: DematerializeSignature<T>;
   debounce: DebounceSignature<T>;
@@ -283,10 +297,8 @@ export class Observable<T> implements CoreOperators<T>  {
   filter: FilterSignature<T>;
   finally: FinallySignature<T>;
   first: FirstSignature<T>;
-  flatMap: <R>(project: ((x: T, ix: number) => Observable<any>),
-               projectResult?: (x: T, y: any, ix: number, iy: number) => R,
-               concurrent?: number) => Observable<R>;
-  flatMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  flatMap: MergeMapSignature<T>;
+  flatMapTo: MergeMapToSignature<T>;
   groupBy: GroupBySignature<T>;
   ignoreElements: IgnoreElementsSignature<T>;
   inspect: InspectSignature<T>;
@@ -295,15 +307,13 @@ export class Observable<T> implements CoreOperators<T>  {
   let: LetSignature<T>;
   letBind: LetSignature<T>;
   every: EverySignature<T>;
-  map: <R>(project: (x: T, ix?: number) => R, thisArg?: any) => Observable<R>;
-  mapTo: <R>(value: R) => Observable<R>;
+  map: MapSignature<T>;
+  mapTo: MapToSignature<T>;
   materialize: MaterializeSignature<T>;
-  merge: (...observables: any[]) => Observable<any>;
-  mergeAll: (concurrent?: any) => Observable<any>;
-  mergeMap: <R>(project: ((x: T, ix: number) => Observable<any>),
-                projectResult?: (x: T, y: any, ix: number, iy: number) => R,
-                concurrent?: number) => Observable<R>;
-  mergeMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R, concurrent?: number) => Observable<R>;
+  merge: MergeSignature<T>;
+  mergeAll: MergeAllSignature<T>;
+  mergeMap: MergeMapSignature<T>;
+  mergeMapTo: MergeMapToSignature<T>;
   multicast: MulticastSignature<T>;
   observeOn: ObserveOnSignature<T>;
   partition: PartitionSignature<T>;
@@ -327,9 +337,9 @@ export class Observable<T> implements CoreOperators<T>  {
   skipWhile: SkipWhileSignature<T>;
   startWith: StartWithSignature<T>;
   subscribeOn: SubscribeOnSignature<T>;
-  switch: <R>() => Observable<R>;
-  switchMap: <R>(project: ((x: T, ix: number) => Observable<any>), projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
-  switchMapTo: <R>(observable: Observable<any>, projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  switch: SwitchSignature<T>;
+  switchMap: SwitchMapSignature<T>;
+  switchMapTo: SwitchMapToSignature<T>;
   take: TakeSignature<T>;
   takeLast: TakeLastSignature<T>;
   takeUntil: TakeUntilSignature<T>;
@@ -347,7 +357,7 @@ export class Observable<T> implements CoreOperators<T>  {
   windowWhen: WindowWhenSignature<T>;
   withLatestFrom: WithLatestFromSignature<T>;
   zip: ZipSignature<T>;
-  zipAll: <R>(project?: (...values: Array<any>) => R) => Observable<R>;
+  zipAll: ZipAllSignature<T>;
 
   /**
    * @method Symbol.observable

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -15,6 +15,8 @@ import {MinSignature} from './operator/min';
 import {PairwiseSignature} from './operator/pairwise';
 import {TimeIntervalSignature} from './operator/timeInterval';
 import {MergeScanSignature} from './operator/mergeScan';
+import {SwitchFirstSignature} from './operator/exhaust';
+import {SwitchFirstMapSignature} from './operator/exhaustMap';
 
 export interface KitchenSinkOperators<T> extends CoreOperators<T> {
   isEmpty?: IsEmptySignature<T>;
@@ -29,9 +31,8 @@ export interface KitchenSinkOperators<T> extends CoreOperators<T> {
   pairwise?: PairwiseSignature<T>;
   timeInterval?: TimeIntervalSignature<T>;
   mergeScan?: MergeScanSignature<T>;
-  exhaust?: () => Observable<T>;
-  exhaustMap?: <R>(project: ((x: T, ix: number) => Observable<any>),
-                       projectResult?: (x: T, y: any, ix: number, iy: number) => R) => Observable<R>;
+  exhaust?: SwitchFirstSignature<T>;
+  exhaustMap?: SwitchFirstMapSignature<T>;
 }
 
 // statics

--- a/src/add/operator/mergeMap.ts
+++ b/src/add/operator/mergeMap.ts
@@ -2,7 +2,7 @@
 import {Observable} from '../../Observable';
 import {mergeMap} from '../../operator/mergeMap';
 
-Observable.prototype.mergeMap = mergeMap;
-Observable.prototype.flatMap = mergeMap;
+Observable.prototype.mergeMap = <any>mergeMap;
+Observable.prototype.flatMap = <any>mergeMap;
 
 export var _void: void;

--- a/src/add/operator/mergeMapTo.ts
+++ b/src/add/operator/mergeMapTo.ts
@@ -2,6 +2,6 @@
 import {Observable} from '../../Observable';
 import {mergeMapTo} from '../../operator/mergeMapTo';
 
-Observable.prototype.mergeMapTo = mergeMapTo;
+Observable.prototype.mergeMapTo = <any>mergeMapTo;
 
 export var _void: void;

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -24,7 +24,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
                    selector: Function | void = undefined,
                    scheduler?: Scheduler): Function {
     return (...args: any[]): Observable<T> => {
-      return new BoundNodeCallbackObservable(callbackFunc, <any>selector, args, scheduler);
+      return new BoundNodeCallbackObservable<T>(callbackFunc, <any>selector, args, scheduler);
     };
   }
 

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -35,11 +35,11 @@ export class FromObservable<T> extends Observable<T> {
         if (ish instanceof Observable && !scheduler) {
           return ish;
         }
-        return new FromObservable(ish, scheduler);
+        return new FromObservable<T>(ish, scheduler);
       } else if (isArray(ish)) {
-        return new ArrayObservable(ish, scheduler);
+        return new ArrayObservable<T>(ish, scheduler);
       } else if (isPromise(ish)) {
-        return new PromiseObservable(ish, scheduler);
+        return new PromiseObservable<T>(ish, scheduler);
       } else if (typeof ish[SymbolShim.iterator] === 'function' || typeof ish === 'string') {
         return new IteratorObservable<T>(<any>ish, null, null, scheduler);
       } else if (isArrayLike(ish)) {

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -34,7 +34,7 @@ export class WebSocketSubject<T> extends Subject<T> {
   }
 
   static create<T>(urlConfigOrSource: string | WebSocketSubjectConfig): WebSocketSubject<T> {
-    return new WebSocketSubject(urlConfigOrSource);
+    return new WebSocketSubject<T>(urlConfigOrSource);
   }
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig | Observable<T>, destination?: Observer<T>) {

--- a/src/operator/combineAll.ts
+++ b/src/operator/combineAll.ts
@@ -13,6 +13,11 @@ import {Observable} from '../Observable';
  *   most recent values from each collected observable as arguments, in order.
  * @returns {Observable} an observable of projected results or arrays of recent values.
  */
-export function combineAll<T, R>(project?: (...values: Array<any>) => R): Observable<R> {
+export function combineAll<R>(project?: (...values: Array<any>) => R): Observable<R> {
   return this.lift(new CombineLatestOperator(project));
+}
+
+export interface CombineAllSignature<T> {
+  (): Observable<T[]>;
+  <R>(project?: (...values: Array<T>) => R): Observable<R>;
 }

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -1,4 +1,4 @@
-import {Observable} from '../Observable';
+import {Observable, ObservableInput} from '../Observable';
 import {Scheduler} from '../Scheduler';
 import {isScheduler} from '../util/isScheduler';
 import {ArrayObservable} from '../observable/ArrayObservable';
@@ -12,9 +12,22 @@ import {MergeAllOperator} from './mergeAll';
  * @params {Scheduler} [scheduler] an optional scheduler to schedule each observable subscription on.
  * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
  */
-export function concat<T, R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
-  return concatStatic(this, ...observables);
+export function concat<T, R>(...observables: Array<ObservableInput<any> | Scheduler>): Observable<R> {
+  return concatStatic<T, R>(this, ...observables);
 }
+
+/* tslint:disable:max-line-length */
+export interface ConcatSignature<T> {
+  (scheduler?: Scheduler): Observable<T>;
+  <T2>(v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
+  <T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
+  <T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
+  <T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
+  <T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+  (...observables: Array<ObservableInput<T> | Scheduler>): Observable<T>;
+  <R>(...observables: Array<ObservableInput<any> | Scheduler>): Observable<R>;
+}
+/* tslint:enable:max-line-length */
 
 /**
  * Joins multiple observables together by subscribing to them one at a time and merging their results
@@ -23,12 +36,22 @@ export function concat<T, R>(...observables: Array<Observable<any> | Scheduler>)
  * @params {Scheduler} [scheduler] an optional scheduler to schedule each observable subscription on.
  * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
  */
-export function concatStatic<T, R>(...observables: Array<Observable<any> | Scheduler>): Observable<R> {
+/* tslint:disable:max-line-length */
+export function concatStatic<T>(v1: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;
+export function concatStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
+export function concatStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
+export function concatStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
+export function concatStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function concatStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function concatStatic<T>(...observables: (ObservableInput<T> | Scheduler)[]): Observable<T>;
+export function concatStatic<T, R>(...observables: (ObservableInput<any> | Scheduler)[]): Observable<R>;
+/* tslint:enable:max-line-length */
+export function concatStatic<T, R>(...observables: Array<ObservableInput<any> | Scheduler>): Observable<R> {
   let scheduler: Scheduler = null;
   let args = <any[]>observables;
   if (isScheduler(args[observables.length - 1])) {
     scheduler = args.pop();
   }
 
-  return new ArrayObservable(observables, scheduler).lift(new MergeAllOperator<T | R>(1));
+  return new ArrayObservable(observables, scheduler).lift(new MergeAllOperator<R>(1));
 }

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -12,5 +12,9 @@ import {MergeAllOperator} from './mergeAll';
  * @returns {Observable} an observable of values merged from the incoming observables.
  */
 export function concatAll<T>(): T {
-  return this.lift(new MergeAllOperator(1));
+  return this.lift(new MergeAllOperator<T>(1));
+}
+
+export interface ConcatAllSignature<T> {
+  (): T;
 }

--- a/src/operator/concatMap.ts
+++ b/src/operator/concatMap.ts
@@ -1,5 +1,5 @@
 import {MergeMapOperator} from './mergeMap';
-import {Observable} from '../Observable';
+import {Observable, ObservableInput} from '../Observable';
 
 /**
  * Maps values from the source observable into new Observables, then merges them in a serialized fashion,
@@ -20,7 +20,13 @@ import {Observable} from '../Observable';
  * @returns {Observable} an observable of values merged from the projected Observables as they were subscribed to,
  * one at a time. Optionally, these values may have been projected from a passed `projectResult` argument.
  */
-export function concatMap<T, R, R2>(project: (value: T, index: number) => Observable<R>,
-                                    resultSelector?: (outerValue: T, innerValue: R, outerIndex: number, innerIndex: number) => R2) {
+export function concatMap<T, I, R>(project: (value: T, index: number) =>  ObservableInput<I>,
+                                   resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
   return this.lift(new MergeMapOperator(project, resultSelector, 1));
+}
+
+export interface ConcatMapSignature<T> {
+  <R>(project: (value: T, index: number) =>  ObservableInput<R>): Observable<R>;
+  <I, R>(project: (value: T, index: number) =>  ObservableInput<I>,
+         resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
 }

--- a/src/operator/concatMapTo.ts
+++ b/src/operator/concatMapTo.ts
@@ -1,4 +1,4 @@
-import {Observable} from '../Observable';
+import {Observable, ObservableInput} from '../Observable';
 import {MergeMapToOperator} from './mergeMapTo';
 
 /**
@@ -14,11 +14,13 @@ import {MergeMapToOperator} from './mergeMapTo';
  * @returns {Observable} an observable of values merged together by joining the passed observable
  * with itself, one after the other, for each value emitted from the source.
  */
-export function concatMapTo<T, R, R2>(observable: Observable<R>,
-                                      resultSelector?: (
-                                                outerValue: T,
-                                                innerValue: R,
-                                                outerIndex: number,
-                                                innerIndex: number) => R2): Observable<R2> {
+export function concatMapTo<T, I, R>(observable: Observable<I>,
+                                     resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {
   return this.lift(new MergeMapToOperator(observable, resultSelector, 1));
+}
+
+export interface ConcatMapToSignature<T> {
+  <R>(observable: ObservableInput<R>): Observable<R>;
+  <I, R>(observable: ObservableInput<I>,
+         resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
 }

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -13,7 +13,11 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * @returns {Observable} an Observable which contains all of the items of the first Observable and following Observables in the source.
  */
 export function exhaust<T>(): Observable<T> {
-  return this.lift(new SwitchFirstOperator());
+  return this.lift(new SwitchFirstOperator<T>());
+}
+
+export interface SwitchFirstSignature<T> {
+  (): T;
 }
 
 class SwitchFirstOperator<T> implements Operator<T, T> {

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -19,6 +19,10 @@ export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any
   return this.lift(new MapOperator(project, thisArg));
 }
 
+export interface MapSignature<T> {
+  <R>(project: (value: T, index: number) => R, thisArg?: any): Observable<R>;
+}
+
 class MapOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => R, private thisArg: any) {
   }

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -14,6 +14,10 @@ export function mapTo<T, R>(value: R): Observable<R> {
   return this.lift(new MapToOperator(value));
 }
 
+export interface MapToSignature<T> {
+  <R>(value: R): Observable<R>;
+}
+
 class MapToOperator<T, R> implements Operator<T, R> {
 
   value: R;

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -1,4 +1,4 @@
-import {Observable} from '../Observable';
+import {Observable, ObservableInput} from '../Observable';
 import {Scheduler} from '../Scheduler';
 import {ArrayObservable} from '../observable/ArrayObservable';
 import {MergeAllOperator} from './mergeAll';
@@ -12,12 +12,47 @@ import {isScheduler} from '../util/isScheduler';
  * @param {Observable} input Observables
  * @returns {Observable} an Observable that emits items that are the result of every input Observable.
  */
-export function merge<T, R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
+export function merge<T, R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
   observables.unshift(this);
   return mergeStatic.apply(this, observables);
 }
 
-export function mergeStatic<T, R>(...observables: Array<Observable<any> | Scheduler | number>): Observable<R> {
+/* tslint:disable:max-line-length */
+export interface MergeSignature<T> {
+  (scheduler?: Scheduler): Observable<T>;
+  (concurrent?: number, scheduler?: Scheduler): Observable<T>;
+  <T2>(v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
+  <T2>(v2: ObservableInput<T2>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2>;
+  <T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
+  <T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3>;
+  <T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
+  <T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
+  <T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
+  <T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
+  <T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+  <T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+  (...observables: Array<ObservableInput<T> | Scheduler | number>): Observable<T>;
+  <R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R>;
+}
+/* tslint:enable:max-line-length */
+
+/* tslint:disable:max-line-length */
+export function mergeStatic<T>(v1: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;
+export function mergeStatic<T>(v1: ObservableInput<T>, concurrent?: number, scheduler?: Scheduler): Observable<T>;
+export function mergeStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
+export function mergeStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2>;
+export function mergeStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
+export function mergeStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3>;
+export function mergeStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
+export function mergeStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
+export function mergeStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function mergeStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function mergeStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function mergeStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function mergeStatic<T>(...observables: (ObservableInput<T> | Scheduler | number)[]): Observable<T>;
+export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Scheduler | number)[]): Observable<R>;
+/* tslint:enable:max-line-length */
+export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
  let scheduler: Scheduler = null;
   let last: any = observables[observables.length - 1];

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -6,7 +6,11 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): T {
-  return this.lift(new MergeAllOperator(concurrent));
+  return this.lift(new MergeAllOperator<T>(concurrent));
+}
+
+export interface MergeAllSignature<T> {
+  (): T;
 }
 
 export class MergeAllOperator<T> implements Operator<Observable<T>, T> {

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -36,7 +36,7 @@ export interface RaceSignature<T> {
  * @returns {Observable} an Observable that mirrors the output of the first Observable to emit an item.
  */
 export function raceStatic<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T>;
-export function raceStatic<R>(...observables: Array<Observable<any> | Array<Observable<any>>>): Observable<R> {
+export function raceStatic<T>(...observables: Array<Observable<any> | Array<Observable<any>>>): Observable<T> {
   // if the only argument is an array, it was most likely called with
   // `pair([obs1, obs2, ...])`
   if (observables.length === 1) {
@@ -47,7 +47,7 @@ export function raceStatic<R>(...observables: Array<Observable<any> | Array<Obse
     }
   }
 
-  return new ArrayObservable(observables).lift(new RaceOperator());
+  return new ArrayObservable<T>(<any>observables).lift(new RaceOperator<T>());
 }
 
 export class RaceOperator<T> implements Operator<T, T> {

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -24,6 +24,10 @@ export function _switch<T>(): T {
   return this.lift(new SwitchOperator());
 }
 
+export interface SwitchSignature<T> {
+  (): T;
+}
+
 class SwitchOperator<T, R> implements Operator<T, R> {
   call(subscriber: Subscriber<R>): Subscriber<T> {
     return new SwitchSubscriber(subscriber);

--- a/src/operator/zipAll.ts
+++ b/src/operator/zipAll.ts
@@ -4,3 +4,8 @@ import {Observable} from '../Observable';
 export function zipAll<T, R>(project?: (...values: Array<any>) => R): Observable<R> {
   return this.lift(new ZipOperator(project));
 }
+
+export interface ZipAllSignature<T> {
+  (): Observable<T[]>;
+  <R>(project?: (...values: Array<T>) => R): Observable<R>;
+}


### PR DESCRIPTION
also adds signatures for the "All", "Map", and "MapTo" variants.