### PR TITLE
chore(KitchenSink): export Operator

### DIFF
--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -146,6 +146,7 @@ import './add/operator/zip';
 import './add/operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
+import {Operator} from './Operator';
 import {Observer} from './Observer';
 import {Subscription, UnsubscriptionError} from './Subscription';
 import {Subscriber} from './Subscriber';
@@ -183,6 +184,7 @@ export {
     Scheduler,
     Observable,
     Observer,
+    Operator,
     Subscriber,
     Subscription,
     AsyncSubject,


### PR DESCRIPTION
- export Operator as same as Rx core does

Found kitchenSink does not exports operator, amending quickly.