### PR TITLE
docs(operators): fix ESDoc build to put operators under Observable class

### DIFF
--- a/esdoc.json
+++ b/esdoc.json
@@ -5,6 +5,9 @@
   "title": "RxJS",
   "styles": ["./doc/styles/main.css"],
   "index": "./doc/index.md",
+  "plugins": [
+    {"name": "./tools/custom-esdoc-plugin.js"}
+  ],
   "manual": {
     "asset": "./doc/asset",
     "overview": [

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -136,10 +136,10 @@ export class Observable<T> implements CoreOperators<T>  {
 
   /**
    * @constructor
-   * @param {Function} subscribe the function that is
-   * called when the Observable is initially subscribed to. This function is given a Subscriber, to which new values
-   * can be `next`ed, or an `error` method can be called to raise an error, or `complete` can be called to notify
-   * of a successful completion.
+   * @param {Function} subscribe the function that is  called when the Observable is
+   * initially subscribed to. This function is given a Subscriber, to which new values
+   * can be `next`ed, or an `error` method can be called to raise an error, or
+   * `complete` can be called to notify of a successful completion.
    */
   constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) {
     if (subscribe) {
@@ -150,22 +150,23 @@ export class Observable<T> implements CoreOperators<T>  {
   // HACK: Since TypeScript inherits static properties too, we have to
   // fight against TypeScript here so Subject can have a different static create signature
   /**
-   * @static
+   * Creates a new cold Observable by calling the Observable constructor
+   * @static true
+   * @owner Observable
    * @method create
    * @param {Function} subscribe? the subscriber function to be passed to the Observable constructor
-   * @returns {Observable} a new cold observable
-   * @description creates a new cold Observable by calling the Observable constructor
+   * @return {Observable} a new cold observable
    */
   static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) => {
     return new Observable<T>(subscribe);
   };
 
   /**
+   * Creates a new Observable, with this Observable as the source, and the passed
+   * operator defined as the new observable's operator.
    * @method lift
    * @param {Operator} operator the operator defining the operation to take on the observable
-   * @returns {Observable} a new observable with the Operator applied
-   * @description creates a new Observable, with this Observable as the source, and the passed
-   * operator defined as the new observable's operator.
+   * @return {Observable} a new observable with the Operator applied
    */
   lift<R>(operator: Operator<T, R>): Observable<R> {
     const observable = new Observable<R>();
@@ -175,15 +176,15 @@ export class Observable<T> implements CoreOperators<T>  {
   }
 
   /**
+   * Registers handlers for handling emitted values, error and completions from the observable, and
+   *  executes the observable's subscriber function, which will take action to set up the underlying data stream
    * @method subscribe
    * @param {PartialObserver|Function} observerOrNext (optional) either an observer defining all functions to be called,
    *  or the first of three possible handlers, which is the handler for each value emitted from the observable.
    * @param {Function} error (optional) a handler for a terminal event resulting from an error. If no error handler is provided,
    *  the error will be thrown as unhandled
    * @param {Function} complete (optional) a handler for a terminal event resulting from successful completion.
-   * @returns {Subscription} a subscription reference to the registered handlers
-   * @description registers handlers for handling emitted values, error and completions from the observable, and
-   *  executes the observable's subscriber function, which will take action to set up the underlying data stream
+   * @return {Subscription} a subscription reference to the registered handlers
    */
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
             error?: (error: any) => void,
@@ -213,7 +214,7 @@ export class Observable<T> implements CoreOperators<T>  {
    * @param {Function} next a handler for each value emitted by the observable
    * @param {any} [thisArg] a `this` context for the `next` handler function
    * @param {PromiseConstructor} [PromiseCtor] a constructor function used to instantiate the Promise
-   * @returns {Promise} a promise that either resolves on observable completion or
+   * @return {Promise} a promise that either resolves on observable completion or
    *  rejects with the handled error
    */
   forEach(next: (value: T) => void, thisArg: any, PromiseCtor?: typeof Promise): Promise<void> {
@@ -360,9 +361,9 @@ export class Observable<T> implements CoreOperators<T>  {
   zipAll: ZipAllSignature<T>;
 
   /**
+   * An interop point defined by the es7-observable spec https://github.com/zenparsing/es-observable
    * @method Symbol.observable
-   * @returns {Observable} this instance of the observable
-   * @description an interop point defined by the es7-observable spec https://github.com/zenparsing/es-observable
+   * @return {Observable} this instance of the observable
    */
   [SymbolShim.observable]() {
     return this;

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -6,12 +6,30 @@ import {Subscriber} from '../Subscriber';
 import {isScheduler} from '../util/isScheduler';
 import {Subscription} from '../Subscription';
 
+/**
+ *
+ */
 export class ArrayObservable<T> extends Observable<T> {
 
+  /**
+   * @param array
+   * @param scheduler
+   * @return {ArrayObservable}
+   * @static true
+   * @name fromArray
+   * @owner Observable
+   */
   static create<T>(array: T[], scheduler?: Scheduler) {
     return new ArrayObservable(array, scheduler);
   }
 
+  /**
+   * @param array
+   * @return {any}
+   * @static true
+   * @name of
+   * @owner Observable
+   */
   static of<T>(...array: Array<T | Scheduler>): Observable<T> {
     let scheduler = <Scheduler>array[array.length - 1];
     if (isScheduler(scheduler)) {

--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -6,6 +6,9 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {AsyncSubject} from '../subject/AsyncSubject';
 
+/**
+ *
+ */
 export class BoundCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
 
@@ -27,6 +30,21 @@ export class BoundCallbackObservable<T> extends Observable<T> {
   static create<T>(callbackFunc: Function, selector?: void, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
   static create<T>(callbackFunc: Function, selector?: (...args: any[]) => T, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
   /* tslint:enable:max-line-length */
+
+  /**
+   * Converts a callback function to an observable sequence.
+   * @param {function} callbackFunc Function with a callback as the last
+   * parameter.
+   * @param {function} selector A selector which takes the arguments from the
+   * callback to produce a single item to yield on next.
+   * @param {Scheduler} [scheduler] The scheduler on which to schedule
+   * the callbacks.
+   * @return {function(...params: *): Observable<T>} a function which returns the
+   * Observable that corresponds to the callback.
+   * @static true
+   * @name bindCallback
+   * @owner Observable
+   */
   static create<T>(callbackFunc: Function,
                    selector: Function | void = undefined,
                    scheduler?: Scheduler): (...args: any[]) => Observable<T> {

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -6,6 +6,9 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {AsyncSubject} from '../subject/AsyncSubject';
 
+/**
+ *
+ */
 export class BoundNodeCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
 
@@ -20,6 +23,17 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
   static create<T>(callbackFunc: Function, selector?: void, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
   static create<T>(callbackFunc: Function, selector?: (...args: any[]) => T, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
   /* tslint:enable:max-line-length */
+
+  /**
+   * Converts a node callback to an Observable.
+   * @param callbackFunc
+   * @param selector
+   * @param scheduler
+   * @return {function(...params: *): Observable<T>}
+   * @static true
+   * @name bindNodeCallback
+   * @owner Observable
+   */
   static create<T>(callbackFunc: Function,
                    selector: Function | void = undefined,
                    scheduler?: Scheduler): Function {

--- a/src/observable/DeferObservable.ts
+++ b/src/observable/DeferObservable.ts
@@ -3,8 +3,18 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
+/**
+ *
+ */
 export class DeferObservable<T> extends Observable<T> {
 
+  /**
+   * @param observableFactory
+   * @return {DeferObservable}
+   * @static true
+   * @name defer
+   * @owner Observable
+   */
   static create<T>(observableFactory: () => Observable<T>): Observable<T> {
     return new DeferObservable(observableFactory);
   }

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -3,8 +3,18 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
+/**
+ *
+ */
 export class EmptyObservable<T> extends Observable<T> {
 
+  /**
+   * @param scheduler
+   * @return {EmptyObservable<T>}
+   * @static true
+   * @name empty
+   * @owner Observable
+   */
   static create<T>(scheduler?: Scheduler): Observable<T> {
     return new EmptyObservable<T>(scheduler);
   }

--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -2,8 +2,19 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
+/**
+ *
+ */
 export class ErrorObservable extends Observable<any> {
 
+  /**
+   * @param error
+   * @param scheduler
+   * @return {ErrorObservable}
+   * @static true
+   * @name throw
+   * @owner Observable
+   */
   static create<T>(error: any, scheduler?: Scheduler) {
     return new ErrorObservable(error, scheduler);
   }

--- a/src/observable/ForkJoinObservable.ts
+++ b/src/observable/ForkJoinObservable.ts
@@ -5,12 +5,22 @@ import {EmptyObservable} from './EmptyObservable';
 import {isPromise} from '../util/isPromise';
 import {isArray} from '../util/isArray';
 
+/**
+ *
+ */
 export class ForkJoinObservable<T> extends Observable<T> {
   constructor(private sources: Array<Observable<any> | Promise<any>>,
               private resultSelector?: (...values: Array<any>) => T) {
     super();
   }
 
+  /**
+   * @param sources
+   * @return {any}
+   * @static true
+   * @name forkJoin
+   * @owner Observable
+   */
   static create<T>(...sources: Array<Observable<any> | Promise<any> |
                                   Array<Observable<any>> |
                                   ((...values: Array<any>) => any)>): Observable<T> {

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -34,8 +34,20 @@ function isEventTarget(sourceObj: any): sourceObj is EventTarget {
 
 export type EventTargetLike = EventTarget | NodeStyleEventEmmitter | JQueryStyleEventEmitter | NodeList | HTMLCollection;
 
+/**
+ *
+ */
 export class FromEventObservable<T, R> extends Observable<T> {
 
+  /**
+   * @param sourceObj
+   * @param eventName
+   * @param selector
+   * @return {FromEventObservable}
+   * @static true
+   * @name fromEvent
+   * @owner Observable
+   */
   static create<T>(sourceObj: EventTargetLike, eventName: string, selector?: (...args: Array<any>) => T): Observable<T> {
     return new FromEventObservable(sourceObj, eventName, selector);
   }

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -4,8 +4,20 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {Subscriber} from '../Subscriber';
 
+/**
+ *
+ */
 export class FromEventPatternObservable<T, R> extends Observable<T> {
 
+  /**
+   * @param addHandler
+   * @param removeHandler
+   * @param selector
+   * @return {FromEventPatternObservable}
+   * @static true
+   * @name fromEventPattern
+   * @owner Observable
+   */
   static create<T>(addHandler: (handler: Function) => any,
                    removeHandler: (handler: Function) => void,
                    selector?: (...args: Array<any>) => T) {

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -15,12 +15,25 @@ import {ObserveOnSubscriber} from '../operator/observeOn';
 
 const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 'number');
 
+/**
+ *
+ */
 export class FromObservable<T> extends Observable<T> {
   constructor(private ish: ObservableInput<T>, private scheduler: Scheduler) {
     super(null);
   }
 
-  static create<T>(ish: any, mapFnOrScheduler?: Scheduler | ((x: any, i: number) => T), thisArg?: any, lastScheduler?: Scheduler): Observable<T> {
+  /**
+   * @param ish
+   * @param mapFnOrScheduler
+   * @param thisArg
+   * @param lastScheduler
+   * @return {any}
+   * @static true
+   * @name from
+   * @owner Observable
+   */
+  static create<T>(ish: any, mapFnOrScheduler?: Scheduler | ((x: any, y: number) => T), thisArg?: any, lastScheduler?: Scheduler): Observable<T> {
     let scheduler: Scheduler = null;
     let mapFn: (x: any, i: number) => T = null;
     if (isFunction(mapFnOrScheduler)) {

--- a/src/observable/IntervalObservable.ts
+++ b/src/observable/IntervalObservable.ts
@@ -4,7 +4,18 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {asap} from '../scheduler/asap';
 
+/**
+ *
+ */
 export class IntervalObservable extends Observable<number> {
+  /**
+   * @param period
+   * @param scheduler
+   * @return {IntervalObservable}
+   * @static true
+   * @name interval
+   * @owner Observable
+   */
   static create(period: number = 0, scheduler: Scheduler = asap): Observable<number> {
     return new IntervalObservable(period, scheduler);
   }

--- a/src/observable/NeverObservable.ts
+++ b/src/observable/NeverObservable.ts
@@ -2,7 +2,16 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {noop} from '../util/noop';
 
+/**
+ *
+ */
 export class NeverObservable<T> extends Observable<T> {
+  /**
+   * @return {NeverObservable<T>}
+   * @static true
+   * @name never
+   * @owner Observable
+   */
   static create<T>() {
     return new NeverObservable<T>();
   }

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -4,10 +4,21 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ *
+ */
 export class PromiseObservable<T> extends Observable<T> {
 
   public value: T;
 
+  /**
+   * @param promise
+   * @param scheduler
+   * @return {PromiseObservable}
+   * @static true
+   * @name fromPromise
+   * @owner Observable
+   */
   static create<T>(promise: Promise<T>, scheduler: Scheduler = null): Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }

--- a/src/observable/RangeObservable.ts
+++ b/src/observable/RangeObservable.ts
@@ -3,8 +3,20 @@ import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
+/**
+ *
+ */
 export class RangeObservable extends Observable<number> {
 
+  /**
+   * @param start
+   * @param end
+   * @param scheduler
+   * @return {RangeObservable}
+   * @static true
+   * @name range
+   * @owner Observable
+   */
   static create(start: number = 0, end: number = 0, scheduler?: Scheduler): Observable<number> {
     return new RangeObservable(start, end, scheduler);
   }

--- a/src/observable/TimerObservable.ts
+++ b/src/observable/TimerObservable.ts
@@ -7,8 +7,20 @@ import {isDate} from '../util/isDate';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
+/**
+ *
+ */
 export class TimerObservable extends Observable<number> {
 
+  /**
+   * @param dueTime
+   * @param period
+   * @param scheduler
+   * @return {TimerObservable}
+   * @static true
+   * @name timer
+   * @owner Observable
+   */
   static create(dueTime: number | Date = 0, period?: number | Scheduler, scheduler?: Scheduler): Observable<number> {
     return new TimerObservable(dueTime, period, scheduler);
   }

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -90,7 +90,7 @@ export function ajaxGetJSON<T, R>(url: string, resultSelector?: (data: T) => R, 
    *   - crossDomain: true if a cross domain request, else false
    *   - createXHR: a function to override if you need to use an alternate XMLHttpRequest implementation.
    *   - resultSelector: a function to use to alter the output value type of the Observable. Gets {AjaxResponse} as an argument
-   * @returns {Observable} An observable sequence containing the XMLHttpRequest.
+   * @return {Observable} An observable sequence containing the XMLHttpRequest.
   */
 export class AjaxObservable<T> extends Observable<T> {
   static create: AjaxCreationMethod = (() => {

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -20,6 +20,9 @@ export interface WebSocketSubjectConfig {
   WebSocketCtor?: { new(url: string, protocol?: string|Array<string>): WebSocket };
 }
 
+/**
+ *
+ */
 export class WebSocketSubject<T> extends Subject<T> {
   url: string;
   protocol: string|Array<string>;
@@ -33,6 +36,13 @@ export class WebSocketSubject<T> extends Subject<T> {
     return JSON.parse(e.data);
   }
 
+  /**
+   * @param urlConfigOrSource
+   * @return {WebSocketSubject}
+   * @static true
+   * @name webSocket
+   * @owner Observable
+   */
   static create<T>(urlConfigOrSource: string | WebSocketSubjectConfig): WebSocketSubject<T> {
     return new WebSocketSubject<T>(urlConfigOrSource);
   }

--- a/src/operator/buffer.ts
+++ b/src/operator/buffer.ts
@@ -16,8 +16,10 @@ import {subscribeToResult} from '../util/subscribeToResult';
  *
  * @param {Observable<any>} closingNotifier an Observable that signals the
  * buffer to be emitted} from the returned observable.
- * @returns {Observable<T[]>} an Observable of buffers, which are arrays of
+ * @return {Observable<T[]>} an Observable of buffers, which are arrays of
  * values.
+ * @method buffer
+ * @owner Observable
  */
 export function buffer<T>(closingNotifier: Observable<any>): Observable<T[]> {
   return this.lift(new BufferOperator<T>(closingNotifier));

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -16,7 +16,9 @@ import {Observable} from '../Observable';
  * buffer. (e.g. if `startBufferEvery` is `2`, then a new buffer will be started
  * on every other value from the source.) A new buffer is started at the
  * beginning of the source by default.
- * @returns {Observable<T[]>} an Observable of arrays of buffered values.
+ * @return {Observable<T[]>} an Observable of arrays of buffered values.
+ * @method bufferCount
+ * @owner Observable
  */
 export function bufferCount<T>(bufferSize: number, startBufferEvery: number = null): Observable<T[]> {
   return this.lift(new BufferCountOperator<T>(bufferSize, startBufferEvery));

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -18,7 +18,9 @@ import {asap} from '../scheduler/asap';
  * @param {Scheduler} [scheduler] (optional, defaults to `asap` scheduler) The
  * scheduler on which to schedule the intervals that determine buffer
  * boundaries.
- * @returns {Observable<T[]>} an observable of arrays of buffered values.
+ * @return {Observable<T[]>} an observable of arrays of buffered values.
+ * @method bufferTime
+ * @owner Observable
  */
 export function bufferTime<T>(bufferTimeSpan: number,
                               bufferCreationInterval: number = null,

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -17,7 +17,9 @@ import {errorObject} from '../util/errorObject';
  * @param {Function} closingSelector a function that takes the value emitted by
  * the `openings` observable and returns an Observable, which, when it emits,
  * signals that the associated buffer should be emitted and cleared.
- * @returns {Observable<T[]>} an observable of arrays of buffered values.
+ * @return {Observable<T[]>} an observable of arrays of buffered values.
+ * @method bufferToggle
+ * @owner Observable
  */
 export function bufferToggle<T, O>(openings: Observable<O>,
                                    closingSelector: (value: O) => Observable<any>): Observable<T[]> {

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -18,7 +18,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  *
  * @param {function} closingSelector a function that takes no arguments and
  * returns an Observable that signals buffer closure.
- * @returns {Observable<T[]>} an observable of arrays of buffered values.
+ * @return {Observable<T[]>} an observable of arrays of buffered values.
+ * @method bufferWhen
+ * @owner Observable
  */
 export function bufferWhen<T>(closingSelector: () => Observable<any>): Observable<T[]> {
   return this.lift(new BufferWhenOperator<T>(closingSelector));

--- a/src/operator/cache.ts
+++ b/src/operator/cache.ts
@@ -3,6 +3,14 @@ import {publishReplay} from './publishReplay';
 import {Scheduler} from '../Scheduler';
 import {ConnectableObservable} from '../observable/ConnectableObservable';
 
+/**
+ * @param bufferSize
+ * @param windowTime
+ * @param scheduler
+ * @return {Observable<any>}
+ * @method cache
+ * @owner Observable
+ */
 export function cache<T>(bufferSize: number = Number.POSITIVE_INFINITY,
                          windowTime: number = Number.POSITIVE_INFINITY,
                          scheduler?: Scheduler): Observable<T> {

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -9,6 +9,8 @@ import {Observable} from '../Observable';
  *  is returned by the `selector` will be used to continue the observable chain.
  * @return {Observable} an observable that originates from either the source or the observable returned by the
  *  catch `selector` function.
+ * @method catch
+ * @owner Observable
  */
 export function _catch<T, R>(selector: (err: any, caught: Observable<T>) => Observable<R>): Observable<R> {
   const operator = new CatchOperator(selector);

--- a/src/operator/combineAll.ts
+++ b/src/operator/combineAll.ts
@@ -11,7 +11,9 @@ import {Observable} from '../Observable';
  *    - if there is no `project` function, an array of all of the most recent values is emitted by the returned observable.
  * @param {function} [project] an optional function to map the most recent values from each observable into a new result. Takes each of the
  *   most recent values from each collected observable as arguments, in order.
- * @returns {Observable} an observable of projected results or arrays of recent values.
+ * @return {Observable} an observable of projected results or arrays of recent values.
+ * @method combineAll
+ * @owner Observable
  */
 export function combineAll<R>(project?: (...values: Array<any>) => R): Observable<R> {
   return this.lift(new CombineLatestOperator(project));

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -16,8 +16,10 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * value of that, or just emitting the array of recent values directly if there is no `project` function.
  * @param {...Observable} observables the observables to combine the source with
  * @param {function} [project] an optional function to project the values from the combined recent values into a new value for emission.
- * @returns {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
+ * @return {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
  * the most recent values from each observable.
+ * @method combineLatest
+ * @owner Observable
  */
 export function combineLatest<T, R>(...observables: Array<ObservableInput<any> |
                                                        Array<ObservableInput<any>> |
@@ -59,16 +61,6 @@ export interface CombineLatestSignature<T> {
 }
 /* tslint:enable:max-line-length */
 
-/**
- * Combines the values from observables passed as arguments. This is done by subscribing
- * to each observable, in order, and collecting an array of each of the most recent values any time any of the observables
- * emits, then either taking that array and passing it as arguments to an option `project` function and emitting the return
- * value of that, or just emitting the array of recent values directly if there is no `project` function.
- * @param {...Observable} observables the observables to combine
- * @param {function} [project] an optional function to project the values from the combined recent values into a new value for emission.
- * @returns {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
- * the most recent values from each observable.
- */
 /* tslint:disable:max-line-length */
 export function combineLatestStatic<T>(v1: ObservableInput<T>, scheduler?: Scheduler): Observable<[T]>;
 export function combineLatestStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<[T, T2]>;
@@ -86,6 +78,20 @@ export function combineLatestStatic<R>(...observables: Array<ObservableInput<any
 export function combineLatestStatic<R>(array: ObservableInput<any>[], scheduler?: Scheduler): Observable<R>;
 export function combineLatestStatic<R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R, scheduler?: Scheduler): Observable<R>;
 /* tslint:enable:max-line-length */
+
+/**
+ * Combines the values from observables passed as arguments. This is done by subscribing
+ * to each observable, in order, and collecting an array of each of the most recent values any time any of the observables
+ * emits, then either taking that array and passing it as arguments to an option `project` function and emitting the return
+ * value of that, or just emitting the array of recent values directly if there is no `project` function.
+ * @param {...Observable} observables the observables to combine
+ * @param {function} [project] an optional function to project the values from the combined recent values into a new value for emission.
+ * @return {Observable} an observable of other projected values from the most recent values from each observable, or an array of each of
+ * the most recent values from each observable.
+ * @static true
+ * @name combineLatest
+ * @owner Observable
+ */
 export function combineLatestStatic<T, R>(...observables: Array<any | ObservableInput<any> |
                                                     Array<ObservableInput<any>> |
                                                     (((...values: Array<any>) => R)) |

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -10,7 +10,9 @@ import {MergeAllOperator} from './mergeAll';
  * on to the next.
  * @params {...Observable} the observables to concatenate
  * @params {Scheduler} [scheduler] an optional scheduler to schedule each observable subscription on.
- * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
+ * @return {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
+ * @method concat
+ * @owner Observable
  */
 export function concat<T, R>(...observables: Array<ObservableInput<any> | Scheduler>): Observable<R> {
   return concatStatic<T, R>(this, ...observables);
@@ -34,7 +36,10 @@ export interface ConcatSignature<T> {
  * into the returned observable. Will wait for each observable to complete before moving on to the next.
  * @params {...Observable} the observables to concatenate
  * @params {Scheduler} [scheduler] an optional scheduler to schedule each observable subscription on.
- * @returns {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
+ * @return {Observable} All values of each passed observable merged into a single observable, in order, in serial fashion.
+ * @static true
+ * @name concat
+ * @owner Observable
  */
 /* tslint:disable:max-line-length */
 export function concatStatic<T>(v1: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -9,7 +9,9 @@ import {MergeAllOperator} from './mergeAll';
  * Observables it emits generally complete slower than the source emits, you can run into
  * memory issues as the incoming observables collect in an unbounded buffer.
  *
- * @returns {Observable} an observable of values merged from the incoming observables.
+ * @return {Observable} an observable of values merged from the incoming observables.
+ * @method concatAll
+ * @owner Observable
  */
 export function concatAll<T>(): T {
   return this.lift(new MergeAllOperator<T>(1));

--- a/src/operator/concatMap.ts
+++ b/src/operator/concatMap.ts
@@ -17,8 +17,10 @@ import {Observable, ObservableInput} from '../Observable';
  * - `innerValue`: the value that came from the projected Observable
  * - `outerIndex`: the "index" of the value that came from the source
  * - `innerIndex`: the "index" of the value from the projected Observable
- * @returns {Observable} an observable of values merged from the projected Observables as they were subscribed to,
+ * @return {Observable} an observable of values merged from the projected Observables as they were subscribed to,
  * one at a time. Optionally, these values may have been projected from a passed `projectResult` argument.
+ * @method concatMap
+ * @owner Observable
  */
 export function concatMap<T, I, R>(project: (value: T, index: number) =>  ObservableInput<I>,
                                    resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {

--- a/src/operator/concatMapTo.ts
+++ b/src/operator/concatMapTo.ts
@@ -11,8 +11,10 @@ import {MergeMapToOperator} from './mergeMapTo';
  * - `innerValue`: the value that came from the projected Observable
  * - `outerIndex`: the "index" of the value that came from the source
  * - `innerIndex`: the "index" of the value from the projected Observable
- * @returns {Observable} an observable of values merged together by joining the passed observable
+ * @return {Observable} an observable of values merged together by joining the passed observable
  * with itself, one after the other, for each value emitted from the source.
+ * @method concatMapTo
+ * @owner Observable
  */
 export function concatMapTo<T, I, R>(observable: Observable<I>,
                                      resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -13,8 +13,10 @@ import {Subscriber} from '../Subscriber';
  *   - `value`: the value from the source observable
  *   - `index`: the "index" of the value from the source observable
  *   - `source`: the source observable instance itself.
- * @returns {Observable} an observable of one number that represents the count as described
+ * @return {Observable} an observable of one number that represents the count as described
  * above
+ * @method count
+ * @owner Observable
  */
 export function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<number> {
   return this.lift(new CountOperator(predicate, this));

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -15,7 +15,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * latest item, waits for a silence as long as the `durationSelector` specifies,
  * and only then emits the latest source item on the result Observable.
  * @param {function} durationSelector function for computing the timeout duration for each item.
- * @returns {Observable} an Observable the same as source Observable, but drops items.
+ * @return {Observable} an Observable the same as source Observable, but drops items.
+ * @method debounce
+ * @owner Observable
  */
 export function debounce<T>(durationSelector: (value: T) => ObservableOrPromise<number>): Observable<T> {
   return this.lift(new DebounceOperator(durationSelector));

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -15,7 +15,9 @@ import {asap} from '../scheduler/asap';
  * Optionally takes a scheduler for manging timers.
  * @param {number} dueTime the timeout value for the window of time required to not drop the item.
  * @param {Scheduler} [scheduler] the Scheduler to use for managing the timers that handle the timeout for each item.
- * @returns {Observable} an Observable the same as source Observable, but drops items.
+ * @return {Observable} an Observable the same as source Observable, but drops items.
+ * @method debounceTime
+ * @owner Observable
  */
 export function debounceTime<T>(dueTime: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new DebounceTimeOperator(dueTime, scheduler));

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -5,7 +5,9 @@ import {Subscriber} from '../Subscriber';
 /**
  * Returns an Observable that emits the elements of the source or a specified default value if empty.
  * @param {any} defaultValue the default value used if source is empty; defaults to null.
- * @returns {Observable} an Observable of the items emitted by the where empty values are replaced by the specified default value or null.
+ * @return {Observable} an Observable of the items emitted by the where empty values are replaced by the specified default value or null.
+ * @method defaultIfEmpty
+ * @owner Observable
  */
 export function defaultIfEmpty<T, R>(defaultValue: R = null): Observable<T | R> {
   return this.lift(new DefaultIfEmptyOperator(defaultValue));

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -11,7 +11,9 @@ import {Observable} from '../Observable';
  * by a given timeout or until a given Date.
  * @param {number|Date} delay the timeout value or date until which the emission of the source items is delayed.
  * @param {Scheduler} [scheduler] the Scheduler to use for managing the timers that handle the timeout for each item.
- * @returns {Observable} an Observable that delays the emissions of the source Observable by the specified timeout or Date.
+ * @return {Observable} an Observable that delays the emissions of the source Observable by the specified timeout or Date.
+ * @method delay
+ * @owner Observable
  */
 export function delay<T>(delay: number|Date,
                          scheduler: Scheduler = asap): Observable<T> {

--- a/src/operator/delayWhen.ts
+++ b/src/operator/delayWhen.ts
@@ -12,7 +12,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * by a subscription delay and a delay selector function for each element.
  * @param {Function} selector function to retrieve a sequence indicating the delay for each given element.
  * @param {Observable} sequence indicating the delay for the subscription to the source.
- * @returns {Observable} an Observable that delays the emissions of the source Observable by the specified timeout or Date.
+ * @return {Observable} an Observable that delays the emissions of the source Observable by the specified timeout or Date.
+ * @method delayWhen
+ * @owner Observable
  */
 export function delayWhen<T>(delayDurationSelector: (value: T) => Observable<any>,
                              subscriptionDelay?: Observable<any>): Observable<T> {

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -5,7 +5,9 @@ import {Notification} from '../Notification';
 
 /**
  * Returns an Observable that transforms Notification objects into the items or notifications they represent.
- * @returns {Observable} an Observable that emits items and notifications embedded in Notification objects emitted by the source Observable.
+ * @return {Observable} an Observable that emits items and notifications embedded in Notification objects emitted by the source Observable.
+ * @method dematerialize
+ * @owner Observable
  */
 export function dematerialize<T>(): Observable<any> {
   return this.lift(new DeMaterializeOperator());

--- a/src/operator/distinct.ts
+++ b/src/operator/distinct.ts
@@ -14,7 +14,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * An optional parameter is also provided such that an Observable can be provided to queue the internal HashSet to flush the values it holds.
  * @param {function} [compare] optional comparison function called to test if an item is distinct from previous items in the source.
  * @param {Observable} [flushes] optional Observable for flushing the internal HashSet of the operator.
- * @returns {Observable} an Observable that emits items from the source Observable with distinct values.
+ * @return {Observable} an Observable that emits items from the source Observable with distinct values.
+ * @method distinct
+ * @owner Observable
  */
 export function distinct<T>(compare?: (x: T, y: T) => boolean, flushes?: Observable<any>): Observable<T> {
   return this.lift(new DistinctOperator(compare, flushes));

--- a/src/operator/distinctKey.ts
+++ b/src/operator/distinctKey.ts
@@ -11,7 +11,9 @@ import {Observable} from '../Observable';
  * @param {string} key string key for object property lookup on each item.
  * @param {function} [compare] optional comparison function called to test if an item is distinct from previous items in the source.
  * @param {Observable} [flushes] optional Observable for flushing the internal HashSet of the operator.
- * @returns {Observable} an Observable that emits items from the source Observable with distinct values.
+ * @return {Observable} an Observable that emits items from the source Observable with distinct values.
+ * @method distinctKey
+ * @owner Observable
  */
 export function distinctKey<T>(key: string, compare?: (x: T, y: T) => boolean, flushes?: Observable<any>): Observable<T> {
   return distinct.call(this, function(x: T, y: T) {

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -9,7 +9,9 @@ import {Observable} from '../Observable';
  * If a comparator function is provided, then it will be called for each item to test for whether or not that value should be emitted.
  * If a comparator function is not provided, an equality check is used by default.
  * @param {function} [compare] optional comparison function called to test if an item is distinct from the previous item in the source.
- * @returns {Observable} an Observable that emits items from the source Observable with distinct values.
+ * @return {Observable} an Observable that emits items from the source Observable with distinct values.
+ * @method distinctUntilChanged
+ * @owner Observable
  */
 export function distinctUntilChanged<T, K>(compare?: (x: K, y: K) => boolean, keySelector?: (x: T) => K): Observable<T> {
   return this.lift(new DistinctUntilChangedOperator<T, K>(compare, keySelector));

--- a/src/operator/distinctUntilKeyChanged.ts
+++ b/src/operator/distinctUntilKeyChanged.ts
@@ -8,7 +8,9 @@ import {Observable} from '../Observable';
  * If a comparator function is not provided, an equality check is used by default.
  * @param {string} key string key for object property lookup on each item.
  * @param {function} [compare] optional comparison function called to test if an item is distinct from the previous item in the source.
- * @returns {Observable} an Observable that emits items from the source Observable with distinct values based on the key specified.
+ * @return {Observable} an Observable that emits items from the source Observable with distinct values based on the key specified.
+ * @method distinctUntilKeyChanged
+ * @owner Observable
  */
 export function distinctUntilKeyChanged<T>(key: string, compare?: (x: T, y: T) => boolean): Observable<T> {
   return distinctUntilChanged.call(this, function(x: T, y: T) {

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -11,6 +11,8 @@ import {PartialObserver} from '../Observer';
  * @param {function} [error] callback for errors in the source.
  * @param {function} [complete] callback for the completion of the source.
  * @reurns {Observable} a mirrored Observable with the specified Observer or callback attached for each item.
+ * @method do
+ * @owner Observable
  */
 export function _do<T>(nextOrObserver?: PartialObserver<T> | ((x: T) => void),
                        error?: (e: any) => void,

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -8,7 +8,9 @@ import {Observable} from '../Observable';
  * If default is given, missing indices will output this value on next; otherwise, outputs error.
  * @param {number} index the index of the value to be retrieved.
  * @param {any} [defaultValue] the default value returned for missing indices.
- * @returns {Observable} an Observable that emits a single item, if it is found. Otherwise, will emit the default value if given.
+ * @return {Observable} an Observable that emits a single item, if it is found. Otherwise, will emit the default value if given.
+ * @method elementAt
+ * @owner Observable
  */
 export function elementAt<T>(index: number, defaultValue?: T): Observable<T> {
   return this.lift(new ElementAtOperator(index, defaultValue));

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -7,7 +7,9 @@ import {Subscriber} from '../Subscriber';
  * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
  * @param {function} predicate a function for determining if an item meets a specified condition.
  * @param {any} [thisArg] optional object to use for `this` in the callback
- * @returns {Observable} an Observable of booleans that determines if all items of the source Observable meet the condition specified.
+ * @return {Observable} an Observable of booleans that determines if all items of the source Observable meet the condition specified.
+ * @method every
+ * @owner Observable
  */
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                          thisArg?: any): Observable<boolean> {

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -10,7 +10,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * until it completes before subscribing to the next.
  * Items that come in before the first has exhausted will be dropped.
  * Similar to `concatAll`, but will not hold on to items that come in before the first is exhausted.
- * @returns {Observable} an Observable which contains all of the items of the first Observable and following Observables in the source.
+ * @return {Observable} an Observable which contains all of the items of the first Observable and following Observables in the source.
+ * @method exhaust
+ * @owner Observable
  */
 export function exhaust<T>(): Observable<T> {
   return this.lift(new SwitchFirstOperator<T>());

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -11,7 +11,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * to create a new Observable, which are then concatenated together to produce a new Observable.
  * @param {function} project function called for each item of the source to produce a new Observable.
  * @param {function} [resultSelector] optional function for then selecting on each inner Observable.
- * @returns {Observable} an Observable containing all the projected Observables of each item of the source concatenated together.
+ * @return {Observable} an Observable containing all the projected Observables of each item of the source concatenated together.
+ * @method exhaustMap
+ * @owner Observable
  */
 export function exhaustMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>,
                                     resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -15,7 +15,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * @param {function} project the function for projecting the next emitted item of the Observable.
  * @param {number} [concurrent] the max number of observables that can be created concurrently. defaults to infinity.
  * @param {Scheduler} [scheduler] The Scheduler to use for managing the expansions.
- * @returns {Observable} an Observable containing the expansions of the source Observable.
+ * @return {Observable} an Observable containing the expansions of the source Observable.
+ * @method expand
+ * @owner Observable
  */
 export function expand<T, R>(project: (value: T, index: number) => Observable<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -9,7 +9,9 @@ import {Observable} from '../Observable';
  * @param {Function} select a function that is used to select the resulting values
  *  if it returns `true`, the value is emitted, if `false` the value is not passed to the resulting observable
  * @param {any} [thisArg] an optional argument to determine the value of `this` in the `select` function
- * @returns {Observable} an observable of values allowed by the select function
+ * @return {Observable} an observable of values allowed by the select function
+ * @method filter
+ * @owner Observable
  */
 export function filter<T>(select: (value: T, index: number) => boolean, thisArg?: any): Observable<T> {
   return this.lift(new FilterOperator(select, thisArg));

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -7,7 +7,9 @@ import {Observable} from '../Observable';
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
  * the source terminates on complete or error.
  * @param {function} finallySelector function to be called when source terminates.
- * @returns {Observable} an Observable that mirrors the source, but will call the specified function on termination.
+ * @return {Observable} an Observable that mirrors the source, but will call the specified function on termination.
+ * @method finally
+ * @owner Observable
  */
 export function _finally<T>(finallySelector: () => void): Observable<T> {
   return this.lift(new FinallyOperator(finallySelector));

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -6,7 +6,9 @@ import {Subscriber} from '../Subscriber';
  * Returns an Observable that searches for the first item in the source Observable that
  * matches the specified condition, and returns the first occurrence in the source.
  * @param {function} predicate function called with each item to test for condition matching.
- * @returns {Observable} an Observable of the first item that matches the condition.
+ * @return {Observable} an Observable of the first item that matches the condition.
+ * @method find
+ * @owner Observable
  */
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T> {
   if (typeof predicate !== 'function') {

--- a/src/operator/findIndex.ts
+++ b/src/operator/findIndex.ts
@@ -5,7 +5,9 @@ import {FindValueOperator} from './find';
  * Returns an Observable that searches for the first item in the source Observable that
  * matches the specified condition, and returns the the index of the item in the source.
  * @param {function} predicate function called with each item to test for condition matching.
- * @returns {Observable} an Observable of the index of the first item that matches the condition.
+ * @return {Observable} an Observable of the index of the first item that matches the condition.
+ * @method findIndex
+ * @owner Observable
  */
 export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<number> {
   return this.lift(new FindValueOperator(predicate, this, true, thisArg));

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -7,7 +7,9 @@ import {EmptyError} from '../util/EmptyError';
  * Returns an Observable that emits the first item of the source Observable that matches the specified condition.
  * Throws an error if matching element is not found.
  * @param {function} predicate function called with each item to test for condition matching.
- * @returns {Observable} an Observable of the first item that matches the condition.
+ * @return {Observable} an Observable of the first item that matches the condition.
+ * @method first
+ * @owner Observable
  */
 export function first<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
                             resultSelector?: (value: T, index: number) => R,

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -14,9 +14,11 @@ import {FastMap} from '../util/FastMap';
  *
  * @param {Function} keySelector - a function that extracts the key for each item
  * @param {Function} elementSelector - a function that extracts the return element for each item
- * @returns {Observable} an Observable that emits GroupedObservables, each of which corresponds
+ * @return {Observable} an Observable that emits GroupedObservables, each of which corresponds
  * to a unique key value and each of which emits those items from the source Observable that share
  * that key value.
+ * @method groupBy
+ * @owner Observable
  */
 export function groupBy<T, K, R>(keySelector: (value: T) => K,
                                  elementSelector?: (value: T) => R,

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -8,8 +8,10 @@ import {noop} from '../util/noop';
  *
  * <img src="./img/ignoreElements.png" width="100%">
  *
- * @returns {Observable} an empty Observable that only calls `complete`
+ * @return {Observable} an empty Observable that only calls `complete`
  * or `error`, based on which one is called by the source Observable.
+ * @method ignoreElements
+ * @owner Observable
  */
 export function ignoreElements<T>(): Observable<T> {
   return this.lift(new IgnoreElementsOperator());

--- a/src/operator/inspect.ts
+++ b/src/operator/inspect.ts
@@ -8,6 +8,12 @@ import {errorObject} from '../util/errorObject';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param durationSelector
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method inspect
+ * @owner Observable
+ */
 export function inspect<T>(durationSelector: (value: T) => ObservableOrPromise<any>): Observable<T> {
   return this.lift(new InspectOperator(durationSelector));
 }

--- a/src/operator/inspectTime.ts
+++ b/src/operator/inspectTime.ts
@@ -5,6 +5,13 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
+/**
+ * @param delay
+ * @param scheduler
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method inspectTime
+ * @owner Observable
+ */
 export function inspectTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new InspectTimeOperator(delay, scheduler));
 }

--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -7,7 +7,9 @@ import {Observable} from '../Observable';
  *
  * <img src="./img/isEmpty.png" width="100%">
  *
- * @returns {Observable} an Observable that emits a Boolean.
+ * @return {Observable} an Observable that emits a Boolean.
+ * @method isEmpty
+ * @owner Observable
  */
 export function isEmpty(): Observable<boolean> {
   return this.lift(new IsEmptyOperator());

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -12,9 +12,11 @@ import {EmptyError} from '../util/EmptyError';
  * <img src="./img/last.png" width="100%">
  *
  * @param {function} predicate - the condition any source emitted item has to satisfy.
- * @returns {Observable} an Observable that emits only the last item satisfying the given condition
+ * @return {Observable} an Observable that emits only the last item satisfying the given condition
  * from the source, or an NoSuchElementException if no such items are emitted.
  * @throws - Throws if no items that match the predicate are emitted by the source Observable.
+ * @method last
+ * @owner Observable
  */
 export function last<T, R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean,
                            resultSelector?: (value: T, index: number) => R | void,

--- a/src/operator/let.ts
+++ b/src/operator/let.ts
@@ -1,5 +1,11 @@
 import {Observable} from '../Observable';
 
+/**
+ * @param func
+ * @return {Observable<R>}
+ * @method let
+ * @owner Observable
+ */
 export function letProto<T, R>(func: (selector: Observable<T>) => Observable<R>): Observable<R> {
   return func(this);
 }

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -10,7 +10,9 @@ import {Observable} from '../Observable';
  *
  * @param {Function} project the function to create projection
  * @param {any} [thisArg] an optional argument to define what `this` is in the project function
- * @returns {Observable} a observable of projected values
+ * @return {Observable} a observable of projected values
+ * @method map
+ * @owner Observable
  */
 export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): Observable<R> {
   if (typeof project !== 'function') {

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -8,7 +8,9 @@ import {Observable} from '../Observable';
  * <img src="./img/mapTo.png" width="100%">
  *
  * @param {any} value the value to map each incoming value to
- * @returns {Observable} an observable of the passed value that emits every time the source does
+ * @return {Observable} an observable of the passed value that emits every time the source does
+ * @method mapTo
+ * @owner Observable
  */
 export function mapTo<T, R>(value: R): Observable<R> {
   return this.lift(new MapToOperator(value));

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -11,8 +11,10 @@ import {Notification} from '../Notification';
  * <img src="./img/materialize.png" width="100%">
  *
  * @scheduler materialize does not operate by default on a particular Scheduler.
- * @returns {Observable} an Observable that emits items that are the result of
+ * @return {Observable} an Observable that emits items that are the result of
  * materializing the items and notifications of the source Observable.
+ * @method materialize
+ * @owner Observable
  */
 export function materialize<T>(): Observable<Notification<T>> {
   return this.lift(new MaterializeOperator());

--- a/src/operator/max.ts
+++ b/src/operator/max.ts
@@ -9,7 +9,9 @@ import {ReduceOperator} from './reduce';
  *
  * @param {Function} optional comparer function that it will use instead of its default to compare the value of two
  * items.
- * @returns {Observable} an Observable that emits item with the largest number.
+ * @return {Observable} an Observable that emits item with the largest number.
+ * @method max
+ * @owner Observable
  */
 export function max<T>(comparer?: (x: T, y: T) => T): Observable<T> {
   const max: typeof comparer = (typeof comparer === 'function')

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -10,7 +10,9 @@ import {isScheduler} from '../util/isScheduler';
  * <img src="./img/merge.png" width="100%">
  *
  * @param {Observable} input Observables
- * @returns {Observable} an Observable that emits items that are the result of every input Observable.
+ * @return {Observable} an Observable that emits items that are the result of every input Observable.
+ * @method merge
+ * @owner Observable
  */
 export function merge<T, R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
   observables.unshift(this);
@@ -52,6 +54,13 @@ export function mergeStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: O
 export function mergeStatic<T>(...observables: (ObservableInput<T> | Scheduler | number)[]): Observable<T>;
 export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Scheduler | number)[]): Observable<R>;
 /* tslint:enable:max-line-length */
+/**
+ * @param observables
+ * @return {Observable<R>}
+ * @static true
+ * @name merge
+ * @owner Observable
+ */
 export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
  let scheduler: Scheduler = null;

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -5,6 +5,12 @@ import {Subscription} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param concurrent
+ * @return {Observable<R>|WebSocketSubject<Observable<any>>|Observable<Observable<any>>}
+ * @method mergeAll
+ * @owner Observable
+ */
 export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): T {
   return this.lift(new MergeAllOperator<T>(concurrent));
 }

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -14,8 +14,10 @@ import {InnerSubscriber} from '../InnerSubscriber';
  * <img src="./img/mergeMap.png" width="100%">
  *
  * @param {Function} a function that, when applied to an item emitted by the source Observable, returns an Observable.
- * @returns {Observable} an Observable that emits the result of applying the transformation function to each item
+ * @return {Observable} an Observable that emits the result of applying the transformation function to each item
  * emitted by the source Observable and merging the results of the Observables obtained from this transformation
+ * @method mergeMap
+ * @owner Observable
  */
 export function mergeMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>,
                                   resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R | number,

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -7,6 +7,14 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param observable
+ * @param resultSelector
+ * @param concurrent
+ * @return {Observable<R>|WebSocketSubject<*>|Observable<*>}
+ * @method mergeMapTo
+ * @owner Observable
+ */
 export function mergeMapTo<T, I, R>(observable: Observable<I>,
                                     resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R | number,
                                     concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {

--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -8,6 +8,14 @@ import {subscribeToResult} from '../util/subscribeToResult';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 
+/**
+ * @param project
+ * @param seed
+ * @param concurrent
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method mergeScan
+ * @owner Observable
+ */
 export function mergeScan<T, R>(project: (acc: R, value: T) => Observable<R>,
                                 seed: R,
                                 concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {

--- a/src/operator/min.ts
+++ b/src/operator/min.ts
@@ -8,7 +8,9 @@ import {ReduceOperator} from './reduce';
  * <img src="./img/min.png" width="100%">
  *
  * @param {Function} optional comparer function that it will use instead of its default to compare the value of two items.
- * @returns {Observable<R>} an Observable that emits item with the smallest number.
+ * @return {Observable<R>} an Observable that emits item with the smallest number.
+ * @method min
+ * @owner Observable
  */
 export function min<T>(comparer?: (x: T, y: T) => T): Observable<T> {
   const min: typeof comparer = (typeof comparer === 'function')

--- a/src/operator/multicast.ts
+++ b/src/operator/multicast.ts
@@ -11,9 +11,11 @@ import {ConnectableObservable} from '../observable/ConnectableObservable';
  * as many times as needed, without causing multiple subscriptions to the source stream.
  * Subscribers to the given source will receive all notifications of the source from the
  * time of the subscription forward.
- * @returns {Observable} an Observable that emits the results of invoking the selector
+ * @return {Observable} an Observable that emits the results of invoking the selector
  * on the items emitted by a `ConnectableObservable` that shares a single subscription to
  * the underlying stream.
+ * @method multicast
+ * @owner Observable
  */
 export function multicast<T>(subjectOrSubjectFactory: Subject<T> | (() => Subject<T>)): ConnectableObservable<T> {
   let subjectFactory: () => Subject<T>;

--- a/src/operator/observeOn.ts
+++ b/src/operator/observeOn.ts
@@ -5,6 +5,13 @@ import {PartialObserver} from '../Observer';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
 
+/**
+ * @param scheduler
+ * @param delay
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method observeOn
+ * @owner Observable
+ */
 export function observeOn<T>(scheduler: Scheduler, delay: number = 0): Observable<T> {
   return this.lift(new ObserveOnOperator(scheduler, delay));
 }

--- a/src/operator/pairwise.ts
+++ b/src/operator/pairwise.ts
@@ -9,7 +9,9 @@ import {Subscriber} from '../Subscriber';
  *
  * <img src="./img/pairwise.png" width="100%">
  *
- * @returns {Observable<R>} an observable of pairs of values.
+ * @return {Observable<R>} an observable of pairs of values.
+ * @method pairwise
+ * @owner Observable
  */
 export function pairwise<T>(): Observable<[T, T]> {
   return this.lift(new PairwiseOperator());

--- a/src/operator/partition.ts
+++ b/src/operator/partition.ts
@@ -2,6 +2,13 @@ import {not} from '../util/not';
 import {filter} from './filter';
 import {Observable} from '../Observable';
 
+/**
+ * @param predicate
+ * @param thisArg
+ * @return {Observable<T>[]}
+ * @method partition
+ * @owner Observable
+ */
 export function partition<T>(predicate: (value: T) => boolean, thisArg?: any): [Observable<T>, Observable<T>] {
   return [
     filter.call(this, predicate),

--- a/src/operator/pluck.ts
+++ b/src/operator/pluck.ts
@@ -7,7 +7,9 @@ import {map} from './map';
  * `undefined` for that value.
  *
  * @param {...args} properties the nested properties to pluck
- * @returns {Observable} Returns a new Observable sequence of property values
+ * @return {Observable} Returns a new Observable sequence of property values
+ * @method pluck
+ * @owner Observable
  */
 export function pluck<R>(...properties: string[]): Observable<R> {
   const length = properties.length;

--- a/src/operator/publish.ts
+++ b/src/operator/publish.ts
@@ -8,7 +8,9 @@ import {ConnectableObservable} from '../observable/ConnectableObservable';
  *
  * <img src="./img/publish.png" width="100%">
  *
- * @returns a ConnectableObservable that upon connection causes the source Observable to emit items to its Observers.
+ * @return a ConnectableObservable that upon connection causes the source Observable to emit items to its Observers.
+ * @method publish
+ * @owner Observable
  */
 export function publish<T>(): ConnectableObservable<T> {
   return multicast.call(this, new Subject<T>());

--- a/src/operator/publishBehavior.ts
+++ b/src/operator/publishBehavior.ts
@@ -2,6 +2,12 @@ import {BehaviorSubject} from '../subject/BehaviorSubject';
 import {multicast} from './multicast';
 import {ConnectableObservable} from '../observable/ConnectableObservable';
 
+/**
+ * @param value
+ * @return {ConnectableObservable<T>}
+ * @method publishBehavior
+ * @owner Observable
+ */
 export function publishBehavior<T>(value: T): ConnectableObservable<T> {
   return multicast.call(this, new BehaviorSubject<T>(value));
 }

--- a/src/operator/publishLast.ts
+++ b/src/operator/publishLast.ts
@@ -2,6 +2,11 @@ import {AsyncSubject} from '../subject/AsyncSubject';
 import {multicast} from './multicast';
 import {ConnectableObservable} from '../observable/ConnectableObservable';
 
+/**
+ * @return {ConnectableObservable<T>}
+ * @method publishLast
+ * @owner Observable
+ */
 export function publishLast<T>(): ConnectableObservable<T> {
   return multicast.call(this, new AsyncSubject<T>());
 }

--- a/src/operator/publishReplay.ts
+++ b/src/operator/publishReplay.ts
@@ -3,6 +3,14 @@ import {Scheduler} from '../Scheduler';
 import {multicast} from './multicast';
 import {ConnectableObservable} from '../observable/ConnectableObservable';
 
+/**
+ * @param bufferSize
+ * @param windowTime
+ * @param scheduler
+ * @return {ConnectableObservable<T>}
+ * @method publishReplay
+ * @owner Observable
+ */
 export function publishReplay<T>(bufferSize: number = Number.POSITIVE_INFINITY,
                                  windowTime: number = Number.POSITIVE_INFINITY,
                                  scheduler?: Scheduler): ConnectableObservable<T> {

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -12,7 +12,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * Returns an Observable that mirrors the first source Observable to emit an item
  * from the combination of this Observable and supplied Observables
  * @param {...Observables} ...observables sources used to race for which Observable emits first.
- * @returns {Observable} an Observable that mirrors the output of the first Observable to emit an item.
+ * @return {Observable} an Observable that mirrors the output of the first Observable to emit an item.
+ * @method race
+ * @owner Observable
  */
 export function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T> {
   // if the only argument is an array, it was most likely called with
@@ -33,7 +35,10 @@ export interface RaceSignature<T> {
 /**
  * Returns an Observable that mirrors the first source Observable to emit an item.
  * @param {...Observables} ...observables sources used to race for which Observable emits first.
- * @returns {Observable} an Observable that mirrors the output of the first Observable to emit an item.
+ * @return {Observable} an Observable that mirrors the output of the first Observable to emit an item.
+ * @static true
+ * @name race
+ * @owner Observable
  */
 export function raceStatic<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T>;
 export function raceStatic<T>(...observables: Array<Observable<any> | Array<Observable<any>>>): Observable<T> {

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -15,8 +15,10 @@ import {Subscriber} from '../Subscriber';
  * @param {initialValue} the initial (seed) accumulator value
  * @param {accumulator} an accumulator function to be invoked on each item emitted by the source Observable, the
  * result of which will be used in the next accumulator call.
- * @returns {Observable} an Observable that emits a single item that is the result of accumulating the output from the
+ * @return {Observable} an Observable that emits a single item that is the result of accumulating the output from the
  * items emitted by the source Observable.
+ * @method reduce
+ * @owner Observable
  */
 export function reduce<T, R>(project: (acc: R, value: T) => R, seed?: R): Observable<R> {
   return this.lift(new ReduceOperator(project, seed));

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -12,8 +12,10 @@ import {EmptyObservable} from '../observable/EmptyObservable';
  * @param {Scheduler} [scheduler] the Scheduler to emit the items on.
  * @param {number} [count] the number of times the source Observable items are repeated, a count of 0 will yield
  * an empty Observable.
- * @returns {Observable} an Observable that repeats the stream of items emitted by the source Observable at most
+ * @return {Observable} an Observable that repeats the stream of items emitted by the source Observable at most
  * count times.
+ * @method repeat
+ * @owner Observable
  */
 export function repeat<T>(count: number = -1): Observable<T> {
   if (count === 0) {

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -15,7 +15,9 @@ import {Observable} from '../Observable';
  * time and emits: [1, 2, 3, 4, 5] then the complete stream of emissions and notifications
  * would be: [1, 2, 1, 2, 3, 4, 5, `complete`].
  * @param {number} number of retry attempts before failing.
- * @returns {Observable} the source Observable modified with the retry logic.
+ * @return {Observable} the source Observable modified with the retry logic.
+ * @method retry
+ * @owner Observable
  */
 export function retry<T>(count: number = -1): Observable<T> {
   return this.lift(new RetryOperator(count, this));

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -22,7 +22,9 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * @param {notificationHandler} receives an Observable of notifications with which a user can `complete` or `error`,
  * aborting the retry.
  * @param {scheduler} the Scheduler on which to subscribe to the source Observable.
- * @returns {Observable} the source Observable modified with retry logic.
+ * @return {Observable} the source Observable modified with retry logic.
+ * @method retryWhen
+ * @owner Observable
  */
 export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>): Observable<T> {
   return this.lift(new RetryWhenOperator(notifier, this));

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -14,8 +14,10 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * <img src="./img/sample.png" width="100%">
  *
  * @param {Observable} sampler - the Observable to use for sampling the source Observable.
- * @returns {Observable<T>} an Observable that emits the results of sampling the items emitted by this Observable
+ * @return {Observable<T>} an Observable that emits the results of sampling the items emitted by this Observable
  * whenever the sampler Observable emits an item or completes.
+ * @method sample
+ * @owner Observable
  */
 export function sample<T>(notifier: Observable<any>): Observable<T> {
   return this.lift(new SampleOperator(notifier));

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -4,6 +4,13 @@ import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {asap} from '../scheduler/asap';
 
+/**
+ * @param delay
+ * @param scheduler
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method sampleTime
+ * @owner Observable
+ */
 export function sampleTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new SampleTimeOperator(delay, scheduler));
 }

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -11,7 +11,9 @@ import {Subscriber} from '../Subscriber';
  * <img src="./img/scan.png" width="100%">
  *
  * @param {any} [seed] The initial accumulator value.
- * @returns {Obervable} An observable of the accumulated values.
+ * @return {Obervable} An observable of the accumulated values.
+ * @method scan
+ * @owner Observable
  */
 export function scan<T, R>(accumulator: (acc: R, value: T) => R, seed?: T | R): Observable<R> {
   return this.lift(new ScanOperator(accumulator, seed));

--- a/src/operator/share.ts
+++ b/src/operator/share.ts
@@ -14,7 +14,9 @@ function shareSubjectFactory() {
  *
  * <img src="./img/share.png" width="100%">
  *
- * @returns {Observable<T>} an Observable that upon connection causes the source Observable to emit items to its Observers
+ * @return {Observable<T>} an Observable that upon connection causes the source Observable to emit items to its Observers
+ * @method share
+ * @owner Observable
  */
 export function share<T>(): Observable<T> {
   return multicast.call(this, shareSubjectFactory).refCount();

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -12,9 +12,11 @@ import {EmptyError} from '../util/EmptyError';
  * <img src="./img/single.png" width="100%">
  *
  * @param {Function} a predicate function to evaluate items emitted by the source Observable.
- * @returns {Observable<T>} an Observable that emits the single item emitted by the source Observable that matches
+ * @return {Observable<T>} an Observable that emits the single item emitted by the source Observable that matches
  * the predicate.
  .
+ * @method single
+ * @owner Observable
  */
 export function single<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T> {
   return this.lift(new SingleOperator(predicate, this));

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -8,8 +8,10 @@ import {Observable} from '../Observable';
  * <img src="./img/skip.png" width="100%">
  *
  * @param {Number} the `n` of times, items emitted by source Observable should be skipped.
- * @returns {Observable} an Observable that skips values emitted by the source Observable.
+ * @return {Observable} an Observable that skips values emitted by the source Observable.
  *
+ * @method skip
+ * @owner Observable
  */
 export function skip<T>(total: number): Observable<T> {
   return this.lift(new SkipOperator(total));

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -7,15 +7,17 @@ import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
-* Returns an Observable that skips items emitted by the source Observable until a second Observable emits an item.
-*
-* <img src="./img/skipUntil.png" width="100%">
-*
-* @param {Observable} the second Observable that has to emit an item before the source Observable's elements begin to
-* be mirrored by the resulting Observable.
-* @returns {Observable<T>} an Observable that skips items from the source Observable until the second Observable emits
-* an item, then emits the remaining items.
-*/
+ * Returns an Observable that skips items emitted by the source Observable until a second Observable emits an item.
+ *
+ * <img src="./img/skipUntil.png" width="100%">
+ *
+ * @param {Observable} the second Observable that has to emit an item before the source Observable's elements begin to
+ * be mirrored by the resulting Observable.
+ * @return {Observable<T>} an Observable that skips items from the source Observable until the second Observable emits
+ * an item, then emits the remaining items.
+ * @method skipUntil
+ * @owner Observable
+ */
 export function skipUntil<T>(notifier: Observable<any>): Observable<T> {
   return this.lift(new SkipUntilOperator(notifier));
 }

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -9,8 +9,10 @@ import {Subscriber} from '../Subscriber';
  * <img src="./img/skipWhile.png" width="100%">
  *
  * @param {Function} predicate - a function to test each item emitted from the source Observable.
- * @returns {Observable<T>} an Observable that begins emitting items emitted by the source Observable when the
+ * @return {Observable<T>} an Observable that begins emitting items emitted by the source Observable when the
  * specified predicate becomes false.
+ * @method skipWhile
+ * @owner Observable
  */
 export function skipWhile<T>(predicate: (value: T, index: number) => boolean): Observable<T> {
   return this.lift(new SkipWhileOperator(predicate));

--- a/src/operator/startWith.ts
+++ b/src/operator/startWith.ts
@@ -13,8 +13,10 @@ import {isScheduler} from '../util/isScheduler';
  * <img src="./img/startWith.png" width="100%">
  *
  * @param {Values} an Iterable that contains the items you want the modified Observable to emit first.
- * @returns {Observable} an Observable that emits the items in the specified Iterable and then emits the items
+ * @return {Observable} an Observable that emits the items in the specified Iterable and then emits the items
  * emitted by the source Observable.
+ * @method startWith
+ * @owner Observable
  */
 export function startWith<T>(...array: Array<T | Scheduler>): Observable<T> {
   let scheduler = <Scheduler>array[array.length - 1];

--- a/src/operator/subscribeOn.ts
+++ b/src/operator/subscribeOn.ts
@@ -8,8 +8,10 @@ import {SubscribeOnObservable} from '../observable/SubscribeOnObservable';
  * <img src="./img/subscribeOn.png" width="100%">
  *
  * @param {Scheduler} the Scheduler to perform subscription actions on.
- * @returns {Observable<T>} the source Observable modified so that its subscriptions happen on the specified Scheduler
+ * @return {Observable<T>} the source Observable modified so that its subscriptions happen on the specified Scheduler
  .
+ * @method subscribeOn
+ * @owner Observable
  */
 export function subscribeOn<T>(scheduler: Scheduler, delay: number = 0): Observable<T> {
   return new SubscribeOnObservable<T>(this, delay, scheduler);

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -17,8 +17,10 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * new one.
  *
  * @param {Function} a predicate function to evaluate items emitted by the source Observable.
- * @returns {Observable<T>} an Observable that emits the items emitted by the Observable most recently emitted by the
+ * @return {Observable<T>} an Observable that emits the items emitted by the Observable most recently emitted by the
  * source Observable.
+ * @method switch
+ * @owner Observable
  */
 export function _switch<T>(): T {
   return this.lift(new SwitchOperator());

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -13,8 +13,10 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * <img src="./img/switchMap.png" width="100%">
  *
  * @param {Observable} a function that, when applied to an item emitted by the source Observable, returns an Observable.
- * @returns {Observable} an Observable that emits the items emitted by the Observable returned from applying func to
+ * @return {Observable} an Observable that emits the items emitted by the Observable returned from applying func to
  * the most recently emitted item emitted by the source Observable.
+ * @method switchMap
+ * @owner Observable
  */
 export function switchMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>,
                                    resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -6,8 +6,18 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param observable
+ * @param resultSelector
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method switchMapTo
+ * @owner Observable
+ */
 export function switchMapTo<T, I, R>(observable: Observable<I>,
-                                     resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {
+                                     resultSelector?: (outerValue: T,
+                                                       innerValue: I,
+                                                       outerIndex: number,
+                                                       innerIndex: number) => R): Observable<R> {
   return this.lift(new SwitchMapToOperator(observable, resultSelector));
 }
 

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -4,6 +4,12 @@ import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
 import {EmptyObservable} from '../observable/EmptyObservable';
 import {Observable} from '../Observable';
 
+/**
+ * @param total
+ * @return {any}
+ * @method take
+ * @owner Observable
+ */
 export function take<T>(total: number): Observable<T> {
   if (total === 0) {
     return new EmptyObservable<T>();

--- a/src/operator/takeLast.ts
+++ b/src/operator/takeLast.ts
@@ -4,6 +4,12 @@ import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
 import {EmptyObservable} from '../observable/EmptyObservable';
 import {Observable} from '../Observable';
 
+/**
+ * @param total
+ * @return {any}
+ * @method takeLast
+ * @owner Observable
+ */
 export function takeLast<T>(total: number): Observable<T> {
   if (total === 0) {
     return new EmptyObservable<T>();

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -6,6 +6,12 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param notifier
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method takeUntil
+ * @owner Observable
+ */
 export function takeUntil<T>(notifier: Observable<any>): Observable<T> {
   return this.lift(new TakeUntilOperator(notifier));
 }

--- a/src/operator/takeWhile.ts
+++ b/src/operator/takeWhile.ts
@@ -2,6 +2,12 @@ import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 
+/**
+ * @param predicate
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method takeWhile
+ * @owner Observable
+ */
 export function takeWhile<T>(predicate: (value: T, index: number) => boolean): Observable<T> {
   return this.lift(new TakeWhileOperator(predicate));
 }

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -7,6 +7,12 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param durationSelector
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method throttle
+ * @owner Observable
+ */
 export function throttle<T>(durationSelector: (value: T) => ObservableOrPromise<number>): Observable<T> {
   return this.lift(new ThrottleOperator(durationSelector));
 }

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -5,6 +5,13 @@ import {Subscription} from '../Subscription';
 import {asap} from '../scheduler/asap';
 import {Observable} from '../Observable';
 
+/**
+ * @param delay
+ * @param scheduler
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method throttleTime
+ * @owner Observable
+ */
 export function throttleTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
   return this.lift(new ThrottleTimeOperator(delay, scheduler));
 }

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -4,6 +4,12 @@ import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {asap} from '../scheduler/asap';
 
+/**
+ * @param scheduler
+ * @return {Observable<TimeInterval<any>>|WebSocketSubject<T>|Observable<T>}
+ * @method timeInterval
+ * @owner Observable
+ */
 export function timeInterval<T>(scheduler: Scheduler = asap): Observable<TimeInterval<T>> {
   return this.lift(new TimeIntervalOperator(scheduler));
 }

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -5,6 +5,14 @@ import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 
+/**
+ * @param due
+ * @param errorToSend
+ * @param scheduler
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method timeout
+ * @owner Observable
+ */
 export function timeout<T>(due: number | Date,
                            errorToSend: any = null,
                            scheduler: Scheduler = asap): Observable<T> {

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -8,6 +8,14 @@ import {isDate} from '../util/isDate';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param due
+ * @param withObservable
+ * @param scheduler
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method timeoutWith
+ * @owner Observable
+ */
 export function timeoutWith<T, R>(due: number | Date,
                                   withObservable: Observable<R>,
                                   scheduler: Scheduler = asap): Observable<T | R> {

--- a/src/operator/toArray.ts
+++ b/src/operator/toArray.ts
@@ -2,6 +2,11 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 
+/**
+ * @return {Observable<any[]>|WebSocketSubject<T>|Observable<T>}
+ * @method toArray
+ * @owner Observable
+ */
 export function toArray<T>(): Observable<T[]> {
   return this.lift(new ToArrayOperator());
 }

--- a/src/operator/toPromise.ts
+++ b/src/operator/toPromise.ts
@@ -1,5 +1,11 @@
 import {root} from '../util/root';
 
+/**
+ * @param PromiseCtor
+ * @return {Promise<T>}
+ * @method toPromise
+ * @owner Observable
+ */
 export function toPromise<T>(PromiseCtor?: typeof Promise): Promise<T> {
   if (!PromiseCtor) {
     if (root.Rx && root.Rx.config && root.Rx.config.Promise) {

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -7,6 +7,12 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param closingNotifier
+ * @return {Observable<Observable<any>>|WebSocketSubject<T>|Observable<T>}
+ * @method window
+ * @owner Observable
+ */
 export function window<T>(closingNotifier: Observable<any>): Observable<Observable<T>> {
   return this.lift(new WindowOperator<T>(closingNotifier));
 }

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -3,6 +3,13 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Subject} from '../Subject';
 
+/**
+ * @param windowSize
+ * @param startWindowEvery
+ * @return {Observable<Observable<any>>|WebSocketSubject<T>|Observable<T>}
+ * @method windowCount
+ * @owner Observable
+ */
 export function windowCount<T>(windowSize: number,
                                startWindowEvery: number = 0): Observable<Observable<T>> {
   return this.lift(new WindowCountOperator<T>(windowSize, startWindowEvery));

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -6,6 +6,14 @@ import {Scheduler} from '../Scheduler';
 import {Action} from '../scheduler/Action';
 import {asap} from '../scheduler/asap';
 
+/**
+ * @param windowTimeSpan
+ * @param windowCreationInterval
+ * @param scheduler
+ * @return {Observable<Observable<any>>|WebSocketSubject<T>|Observable<T>}
+ * @method windowTime
+ * @owner Observable
+ */
 export function windowTime<T>(windowTimeSpan: number,
                               windowCreationInterval: number = null,
                               scheduler: Scheduler = asap): Observable<Observable<T>> {

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -11,6 +11,13 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param openings
+ * @param closingSelector
+ * @return {Observable<Observable<any>>|WebSocketSubject<T>|Observable<T>}
+ * @method windowToggle
+ * @owner Observable
+ */
 export function windowToggle<T, O>(openings: Observable<O>,
                                    closingSelector: (openValue: O) => Observable<any>): Observable<Observable<T>> {
   return this.lift(new WindowToggleOperator<T, O>(openings, closingSelector));

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -11,6 +11,12 @@ import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
+/**
+ * @param closingSelector
+ * @return {Observable<Observable<any>>|WebSocketSubject<T>|Observable<T>}
+ * @method windowWhen
+ * @owner Observable
+ */
 export function windowWhen<T>(closingSelector: () => Observable<any>): Observable<Observable<T>> {
   return this.lift(new WindowOperator<T>(closingSelector));
 }

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -22,6 +22,8 @@ import {subscribeToResult} from '../util/subscribeToResult';
  *  C:     --x----------------y-------------z-------------|
  * result: ---([a,d,x])---------([b,e,y])--------([c,f,z])---|
  * ```
+ * @method withLatestFrom
+ * @owner Observable
  */
 export function withLatestFrom<T, R>(...args: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R> {
   let project: any;

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -9,6 +9,12 @@ import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 import {SymbolShim} from '../util/SymbolShim';
 
+/**
+ * @param observables
+ * @return {Observable<R>}
+ * @method zip
+ * @owner Observable
+ */
 export function zipProto<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R> {
   observables.unshift(this);
   return zipStatic.apply(this, observables);
@@ -52,6 +58,14 @@ export function zipStatic<R>(...observables: Array<ObservableInput<any> | ((...v
 export function zipStatic<R>(array: ObservableInput<any>[]): Observable<R>;
 export function zipStatic<R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R): Observable<R>;
 /* tslint:enable:max-line-length */
+
+/**
+ * @param observables
+ * @return {Observable<R>}
+ * @static true
+ * @name zip
+ * @owner Observable
+ */
 export function zipStatic<T, R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R> {
   const project = <((...ys: Array<any>) => R)> observables[observables.length - 1];
   if (typeof project === 'function') {

--- a/src/operator/zipAll.ts
+++ b/src/operator/zipAll.ts
@@ -1,6 +1,12 @@
 import {ZipOperator} from './zip';
 import {Observable} from '../Observable';
 
+/**
+ * @param project
+ * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
+ * @method zipAll
+ * @owner Observable
+ */
 export function zipAll<T, R>(project?: (...values: Array<any>) => R): Observable<R> {
   return this.lift(new ZipOperator(project));
 }

--- a/tools/custom-esdoc-plugin.js
+++ b/tools/custom-esdoc-plugin.js
@@ -1,0 +1,53 @@
+// Fixes ESDoc structure by moving all "add-able" operator functions
+// (either prototype operator or static operator) under the Observable class.
+// Looks for the "@owner" tag, then moves the thing to that owner. "@owner" is
+// usually "Observable", but may be something else.
+exports.onHandleTag = function onHandleTag(ev) {
+  function getTagValue(tag, tagName) {
+    var unknownTags = tag.unknown;
+    if (!unknownTags) {
+      return null;
+    }
+    var unknownTagsLength = unknownTags.length;
+    for (var i = 0; i < unknownTagsLength; i++) {
+      if (unknownTags[i].tagName === tagName) {
+        return unknownTags[i].tagValue;
+      }
+    }
+    return null;
+  }
+
+  function getLongname(name) {
+    var index = ev.data.tag.findIndex(function (t) {
+      return t.name === name;
+    });
+    if (index === -1) {
+      throw new Error('Could not find longname for unknown tag named "' + name +
+        '"');
+    } else {
+      return ev.data.tag[index].longname;
+    }
+  }
+
+  var tagsLen = ev.data.tag.length;
+  for (var i = 0; i < tagsLen; i++) {
+    var tag = ev.data.tag[i];
+    var owner = getTagValue(tag, '@owner');
+    var name = getTagValue(tag, '@name');
+    var isStatic = getTagValue(tag, '@static');
+    if (owner) {
+      var ownerLongname = getLongname(owner);
+      tag.kind = 'method';
+      tag.static = false;
+      tag.memberof = ownerLongname;
+      if (name) {
+        tag.name = name;
+      }
+      if (isStatic) {
+        tag.static = true;
+      }
+      delete tag.importPath;
+      delete tag.importStyle;
+    }
+  }
+};


### PR DESCRIPTION
This moves operators from being top-level functions (they are not, because they are
added/monkey-patched to the Observable type) to being methods under the Observable class.

To see this page live, open http://rxjs5-esdoc-fix-reference-structure.surge.sh/

<img width="1276" alt="screen shot 2016-02-22 at 21 10 41" src="https://cloud.githubusercontent.com/assets/90512/13229280/c1501416-d9a8-11e5-83d4-0564aea5c657.png">
