### PR TITLE
docs(esdoc): add playground environment in ESDoc-generated page

### DIFF
--- a/doc/asset/devtools-welcome.js
+++ b/doc/asset/devtools-welcome.js
@@ -1,0 +1,15 @@
+var welcomeText = (
+  ' ____           _ ____      \n'+
+  '|  _ \\ __  __  | / ___|    \n'+
+  '| |_) |\\ \\/ /  | \\___ \\  \n'+
+  '|  _ <  >  < |_| |___) |    \n'+
+  '|_| \\_\\/_/\\_\\___/|____/ \n'+
+  '\nTry this code to get started experimenting with RxJS:\n'+
+  '\n    var subscription = Rx.Observable.interval(500)'+
+  '.take(4).subscribe(function (x) { console.log(x) });\n'
+);
+if (console.info) {
+  console.info(welcomeText);
+} else {
+  console.log(welcomeText);
+}

--- a/doc/index.md
+++ b/doc/index.md
@@ -10,3 +10,5 @@ This is a rewrite of [Reactive-Extensions/RxJS](https://github.com/Reactive-Exte
 *Read the Manual on Observables, Observer, Subject, etc*
 ### [» Full reference](./identifiers.html)
 *Read detailed documentation on each operator*
+
+**Hint: open your DevTools to experiment with RxJS.**

--- a/esdoc.json
+++ b/esdoc.json
@@ -4,6 +4,10 @@
   "undocumentIdentifier": false,
   "title": "RxJS",
   "styles": ["./doc/styles/main.css"],
+  "scripts": [
+    "./dist/global/Rx.umd.min.js",
+    "./doc/asset/devtools-welcome.js"
+  ],
   "index": "./doc/index.md",
   "plugins": [
     {"name": "./tools/custom-esdoc-plugin.js"}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "build_perf": "npm run build_cjs && npm run build_global && webdriver-manager update && npm run perf",
     "build_test": "rm -rf dist/ && npm run lint && npm run build_cjs && npm run test_buildonly && npm run test_nobuild",
     "build_cover": "rm -rf dist/ && npm run lint && npm run build_cjs && npm run test_buildonly && npm run cover",
-    "build_docs": "npm run build_es6 && npm run tests2png && esdoc -c esdoc.json",
+    "build_docs": "npm run build_es6 && npm run build_global && npm run tests2png && esdoc -c esdoc.json",
     "publish_docs": "./publish_docs.sh",
     "lint_perf": "eslint perf/",
     "lint_spec": "tslint -c tslint.json spec/*.ts spec/**/*.ts spec/**/**/*.ts",


### PR DESCRIPTION
Add Rx.umd.js script to the ESDoc-generated page, so RxJS can be experimented in the DevTools. Also add a welcome message in the console, and a hint text in index.md.

To see this page live, open http://rxjs5-esdoc-rxjs-playground.surge.sh/

<img width="1245" alt="screen shot 2016-02-24 at 15 01 17" src="https://cloud.githubusercontent.com/assets/90512/13286138/dccf8518-db07-11e5-8d70-f72b8c8aa6e2.png">
