### PR TITLE
refactor(Subscription): remove to use tryCatch

### DIFF
--- a/perf/micro/index.js
+++ b/perf/micro/index.js
@@ -75,7 +75,9 @@ var output = [];
 output.push(['name', 'old ops/sec', 'old error margin', 'new ops/sec', 'new error margin', 'factor', 'percent improved']);
 
 Observable.create(function (observer) {
-  ['perf/micro/immediate-scheduler/**/*.js', 'perf/micro/current-thread-scheduler/**/*.js']
+  ['perf/micro/immediate-scheduler/**/*.js',
+   'perf/micro/current-thread-scheduler/**/*.js',
+   'perf/micro/subscription/**/*.js']
   .forEach(function (pattern) {
     try {
       glob.sync(pattern).forEach(function (file) {

--- a/perf/micro/subscription/add/add-function.js
+++ b/perf/micro/subscription/add/add-function.js
@@ -1,0 +1,24 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var OldDisposable = RxOld.CompositeDisposable;
+  var NewSubscription = RxNew.Subscription;
+
+  function unsubscriber() {}
+
+  // add tests
+  return suite
+    .add('old add function', function () {
+      var s = new OldDisposable();
+      s.add(new OldDisposable());
+      s.add(new OldDisposable());
+      s.add(new OldDisposable());
+    })
+    .add('new add function', function () {
+      var s = new NewSubscription(unsubscriber);
+      s.add(unsubscriber);
+      s.add(unsubscriber);
+      s.add(unsubscriber);
+    });
+};

--- a/perf/micro/subscription/add/add-subscription.js
+++ b/perf/micro/subscription/add/add-subscription.js
@@ -1,0 +1,24 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var OldDisposable = RxOld.CompositeDisposable;
+  var NewSubscription = RxNew.Subscription;
+
+  function unsubscriber() {}
+
+  // add tests
+  return suite
+    .add('old add subscription', function () {
+      var s = new OldDisposable();
+      s.add(new OldDisposable());
+      s.add(new OldDisposable());
+      s.add(new OldDisposable());
+    })
+    .add('new add subscription', function () {
+      var s = new NewSubscription(unsubscriber);
+      s.add(new NewSubscription(unsubscriber));
+      s.add(new NewSubscription(unsubscriber));
+      s.add(new NewSubscription(unsubscriber));
+    });
+};

--- a/perf/micro/subscription/remove/remove-subscription.js
+++ b/perf/micro/subscription/remove/remove-subscription.js
@@ -1,0 +1,36 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var OldDisposable = RxOld.CompositeDisposable;
+  var NewSubscription = RxNew.Subscription;
+
+  function unsubscriber() {}
+
+  // add tests
+  return suite
+    .add('old remove subscription', function () {
+      var s = new OldDisposable();
+      var item1 = new OldDisposable();
+      var item2 = new OldDisposable();
+      var item3 = new OldDisposable();
+      s.add(item1);
+      s.add(item2);
+      s.add(item3);
+      s.remove(item1);
+      s.remove(item2);
+      s.remove(item3);
+    })
+    .add('new remove subscription', function () {
+      var s = new NewSubscription(unsubscriber);
+      var item1 = new NewSubscription(unsubscriber);
+      var item2 = new NewSubscription(unsubscriber);
+      var item3 = new NewSubscription(unsubscriber);
+      s.add(item1);
+      s.add(item2);
+      s.add(item3);
+      s.remove(item1);
+      s.remove(item2);
+      s.remove(item3);
+    });
+};

--- a/perf/micro/subscription/unsubscribe/unsubscribe-simple-with-unsubscriber.js
+++ b/perf/micro/subscription/unsubscribe/unsubscribe-simple-with-unsubscriber.js
@@ -1,0 +1,23 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var OldDisposable = RxOld.Disposable;
+  var NewSubscription = RxNew.Subscription;
+
+  var oldI = 0;
+  function oldDisposer() { oldI++; }
+  var newI = 0;
+  function newDisposer() { newI++; }
+
+  // add tests
+  return suite
+    .add('old unsubscribe with unsubscriber', function () {
+      var s = new OldDisposable.create(oldDisposer);
+      s.dispose();
+    })
+    .add('new unsubscribe with unsubscriber', function () {
+      var s = new NewSubscription(newDisposer);
+      s.unsubscribe();
+    });
+};

--- a/perf/micro/subscription/unsubscribe/unsubscribe-simple-without-unsubscriber.js
+++ b/perf/micro/subscription/unsubscribe/unsubscribe-simple-without-unsubscriber.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var OldDisposable = RxOld.Disposable;
+  var NewSubscription = RxNew.Subscription;
+
+  // add tests
+  return suite
+    .add('old unsubscribe without unsubscriber', function () {
+      var s = new OldDisposable.create();
+      s.dispose();
+    })
+    .add('new unsubscribe without unsubscriber', function () {
+      var s = new NewSubscription();
+      s.unsubscribe();
+    });
+};

--- a/perf/micro/subscription/unsubscribe/unsubscribe-with-children.js
+++ b/perf/micro/subscription/unsubscribe/unsubscribe-with-children.js
@@ -1,0 +1,26 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var OldDisposable = RxOld.CompositeDisposable;
+  var NewSubscription = RxNew.Subscription;
+
+  function unsubscriber() {}
+
+  // add tests
+  return suite
+    .add('old unsubscribe with children', function () {
+      var s = new OldDisposable();
+      s.add(new OldDisposable());
+      s.add(new OldDisposable());
+      s.add(new OldDisposable());
+      s.dispose();
+    })
+    .add('new unsubscribe with children', function () {
+      var s = new NewSubscription(unsubscriber);
+      s.add(new NewSubscription(unsubscriber));
+      s.add(new NewSubscription(unsubscriber));
+      s.add(new NewSubscription(unsubscriber));
+      s.unsubscribe();
+    });
+};

--- a/perf/micro/subscription/unsubscribe/unsubscribe-with-descendant.js
+++ b/perf/micro/subscription/unsubscribe/unsubscribe-with-descendant.js
@@ -1,0 +1,26 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var OldDisposable = RxOld.CompositeDisposable;
+  var NewSubscription = RxNew.Subscription;
+
+  function unsubscriber() {}
+
+  // add tests
+  return suite
+    .add('old unsubscribe with descendant', function () {
+      var s = new OldDisposable();
+      var d = new OldDisposable();
+      d.add(new OldDisposable());
+      s.add(d);
+      s.dispose();
+    })
+    .add('new unsubscribe with descendant', function () {
+      var s = new NewSubscription(unsubscriber);
+      var d = new NewSubscription();
+      d.add(new NewSubscription(unsubscriber));
+      s.add(d);
+      s.unsubscribe();
+    });
+};

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -13,7 +13,9 @@ export class Subscription {
   public isUnsubscribed: boolean = false;
 
   constructor(_unsubscribe?: () => void) {
-    if (_unsubscribe) {
+    // Check `_unsubscribe`to avoid override `this._unsubscribe` accidentally.
+    // Dn't call `super(_unsubscribe)` from a derived class.
+    if (!!_unsubscribe) {
       (<any> this)._unsubscribe = _unsubscribe;
     }
   }

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -19,14 +19,13 @@ export class Subscription {
   }
 
   unsubscribe(): void {
-    let hasErrors = false;
-    let errors: any[];
-
     if (this.isUnsubscribed) {
       return;
     }
-
     this.isUnsubscribed = true;
+
+    let hasErrors = false;
+    let errors: any[] = [];
 
     const { _unsubscribe, _subscriptions } = (<any> this);
 
@@ -36,7 +35,7 @@ export class Subscription {
       let trial = tryCatch(_unsubscribe).call(this);
       if (trial === errorObject) {
         hasErrors = true;
-        (errors = errors || []).push(errorObject.e);
+        errors.push(errorObject.e);
       }
     }
 
@@ -51,7 +50,6 @@ export class Subscription {
           let trial = tryCatch(sub.unsubscribe).call(sub);
           if (trial === errorObject) {
             hasErrors = true;
-            errors = errors || [];
             let err = errorObject.e;
             if (err instanceof UnsubscriptionError) {
               errors = errors.concat(err.errors);


### PR DESCRIPTION
- This is just refactoring to remove to use tryCatch. 
- To make types more strictly, we would need to overhaul `Subscription` and separate an interface from `Subscription` class...