### PR TITLE
chore(DeferObservable): add benchmarks & minor perf

### DIFF
--- a/perf/micro/current-thread-scheduler/observable/defer.js
+++ b/perf/micro/current-thread-scheduler/observable/defer.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var oldObservableWithCurrentThreadScheduler = RxOld.Observable.empty(RxOld.Scheduler.currentThread);
+  var newObservableWithCurrentThreadScheduler = RxNew.Observable.empty(RxNew.Scheduler.queue);
+
+  function oldFactory() { return oldObservableWithCurrentThreadScheduler; }
+  function newFactory() { return newObservableWithCurrentThreadScheduler; }
+
+  var oldDeferWithCurrentThreadScheduler = RxOld.Observable.defer(oldFactory);
+  var newDeferWithCurrentThreadScheduler = RxNew.Observable.defer(newFactory);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  // add tests
+  return suite
+    .add('old defer with current thread scheduler', function () {
+      oldDeferWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new defer with current thread scheduler', function () {
+      newDeferWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/observable/defer.js
+++ b/perf/micro/immediate-scheduler/observable/defer.js
@@ -1,0 +1,25 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function empty(suite) {
+  var oldObservableWithImmediateScheduler = RxOld.Observable.empty(RxOld.Scheduler.immediate);
+  var newObservableWithImmediateScheduler = RxNew.Observable.empty();
+
+  function oldFactory() { return oldObservableWithImmediateScheduler; }
+  function newFactory() { return newObservableWithImmediateScheduler; }
+
+  var oldDeferWithImmediateScheduler = RxOld.Observable.defer(oldFactory);
+  var newDeferWithImmediateScheduler = RxNew.Observable.defer(newFactory);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  // add tests
+  return suite
+    .add('old defer with immediate scheduler', function () {
+      oldDeferWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new defer with immediate scheduler', function () {
+      newDeferWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/src/observable/DeferObservable.ts
+++ b/src/observable/DeferObservable.ts
@@ -73,12 +73,16 @@ class DeferSubscriber<T> extends OuterSubscriber<T, T> {
 
   private tryDefer(): void {
     try {
-      const result = this.factory.call(this);
-      if (result) {
-        this.add(subscribeToResult(this, result));
-      }
+      this._callFactory();
     } catch (err) {
       this._error(err);
+    }
+  }
+
+  private _callFactory(): void {
+    const result = this.factory();
+    if (result) {
+      this.add(subscribeToResult(this, result));
     }
   }
 }


### PR DESCRIPTION
This is the benchmark result on Node v5.9.0,
MacBook Pro (Retina, 15-inch, Mid 2014, 2.8 GHz Intel Core i7, 16 GB 1600 MHz DDR3).

## Before (https://github.com/ReactiveX/rxjs/pull/1393/commits/7116d1d5415404a2b69f591c1bfe0d00ab5bf4dc)

```
                                         |                     RxJS 4.1.0 |              RxJS 5.0.0-beta.3 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                       defer - immediate |             1,117,475 (±1.08%) |             1,979,565 (±1.09%) |           1.77x |           77.1%
                                   defer |               905,413 (±1.15%) |             1,187,348 (±1.42%) |           1.31x |           31.1%
```

## After changeset https://github.com/ReactiveX/rxjs/pull/1393/commits/09cd8d0e5ca587a4f383d5fd6dd821977eb18fc0

```
                                         |                     RxJS 4.1.0 |              RxJS 5.0.0-beta.3 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                       defer - immediate |             1,070,341 (±0.96%) |             2,003,761 (±1.21%) |           1.87x |           87.2%
                                   defer |               944,100 (±1.30%) |             1,234,359 (±1.25%) |           1.31x |           30.7%
```

## After changeset https://github.com/ReactiveX/rxjs/pull/1393/commits/70c32478007faf577ec46314556c82c0a7d2c7c1

```
                                         |                     RxJS 4.1.0 |              RxJS 5.0.0-beta.3 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                       defer - immediate |             1,058,502 (±1.15%) |             2,035,010 (±1.06%) |           1.92x |           92.3%
                                   defer |               914,642 (±1.26%) |             1,219,651 (±1.89%) |           1.33x |           33.3%
```

