### PR TITLE
feat(async): adds AsyncScheduler and updates appropriate operators.

### DIFF
--- a/spec/observables/interval-spec.ts
+++ b/spec/observables/interval-spec.ts
@@ -16,7 +16,7 @@ describe('Observable.interval', () => {
   it('should specify default scheduler if incorrect scheduler specified', () => {
     const scheduler = (<any>Observable.interval(10, <any>jasmine.createSpy('dummy'))).scheduler;
 
-    expect(scheduler).toBe(Rx.Scheduler.asap);
+    expect(scheduler).toBe(Rx.Scheduler.async);
   });
 
   it('should emit when relative interval set to zero', () => {

--- a/src/Rx.DOM.ts
+++ b/src/Rx.DOM.ts
@@ -124,9 +124,11 @@ import {EmptyError} from './util/EmptyError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {asap} from './scheduler/asap';
+import {async} from './scheduler/async';
 import {queue} from './scheduler/queue';
 import {animationFrame} from './scheduler/animationFrame';
 import {AsapScheduler} from './scheduler/AsapScheduler';
+import {AsyncScheduler} from './scheduler/AsyncScheduler';
 import {QueueScheduler} from './scheduler/QueueScheduler';
 import {AnimationFrameScheduler} from './scheduler/AnimationFrameScheduler';
 import {rxSubscriber} from './symbol/rxSubscriber';
@@ -136,6 +138,7 @@ import {AjaxRequest, AjaxResponse, AjaxError, AjaxTimeoutError} from './observab
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
   asap,
+  async,
   queue,
   animationFrame
 };

--- a/src/Rx.KitchenSink.ts
+++ b/src/Rx.KitchenSink.ts
@@ -172,8 +172,10 @@ import {EmptyError} from './util/EmptyError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {asap} from './scheduler/asap';
+import {async} from './scheduler/async';
 import {queue} from './scheduler/queue';
 import {AsapScheduler} from './scheduler/AsapScheduler';
+import {AsyncScheduler} from './scheduler/AsyncScheduler';
 import {QueueScheduler} from './scheduler/QueueScheduler';
 import {TimeInterval} from './operator/timeInterval';
 import {TestScheduler} from './testing/TestScheduler';
@@ -184,6 +186,7 @@ import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
   asap,
+  async,
   queue
 };
 

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -129,8 +129,10 @@ import {EmptyError} from './util/EmptyError';
 import {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {asap} from './scheduler/asap';
+import {async} from './scheduler/async';
 import {queue} from './scheduler/queue';
 import {AsapScheduler} from './scheduler/AsapScheduler';
+import {AsyncScheduler} from './scheduler/AsyncScheduler';
 import {QueueScheduler} from './scheduler/QueueScheduler';
 import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:enable:no-unused-variable */
@@ -138,6 +140,7 @@ import {rxSubscriber} from './symbol/rxSubscriber';
 /* tslint:disable:no-var-keyword */
 var Scheduler = {
   asap,
+  async,
   queue
 };
 

--- a/src/observable/IntervalObservable.ts
+++ b/src/observable/IntervalObservable.ts
@@ -2,7 +2,7 @@ import {Subscriber} from '../Subscriber';
 import {isNumeric} from '../util/isNumeric';
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 
 /**
  *
@@ -16,7 +16,7 @@ export class IntervalObservable extends Observable<number> {
    * @name interval
    * @owner Observable
    */
-  static create(period: number = 0, scheduler: Scheduler = asap): Observable<number> {
+  static create(period: number = 0, scheduler: Scheduler = async): Observable<number> {
     return new IntervalObservable(period, scheduler);
   }
 
@@ -34,13 +34,13 @@ export class IntervalObservable extends Observable<number> {
     (<any> this).schedule(state, period);
   }
 
-  constructor(private period: number = 0, private scheduler: Scheduler = asap) {
+  constructor(private period: number = 0, private scheduler: Scheduler = async) {
     super();
     if (!isNumeric(period) || period < 0) {
       this.period = 0;
     }
     if (!scheduler || typeof scheduler.schedule !== 'function') {
-      this.scheduler = asap;
+      this.scheduler = async;
     }
   }
 

--- a/src/observable/TimerObservable.ts
+++ b/src/observable/TimerObservable.ts
@@ -1,7 +1,7 @@
 import {isNumeric} from '../util/isNumeric';
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 import {isScheduler} from '../util/isScheduler';
 import {isDate} from '../util/isDate';
 import {Subscription} from '../Subscription';
@@ -58,7 +58,7 @@ export class TimerObservable extends Observable<number> {
     }
 
     if (!isScheduler(scheduler)) {
-      scheduler = asap;
+      scheduler = async;
     }
 
     this.scheduler = scheduler;

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -3,7 +3,7 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Scheduler} from '../Scheduler';
 import {Action} from '../scheduler/Action';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 
 /**
  * Buffers values from the source for a specific time period. Optionally allows
@@ -15,7 +15,7 @@ import {asap} from '../scheduler/asap';
  * before emitting them and clearing them.
  * @param {number} [bufferCreationInterval] the interval at which to start new
  * buffers.
- * @param {Scheduler} [scheduler] (optional, defaults to `asap` scheduler) The
+ * @param {Scheduler} [scheduler] (optional, defaults to `async` scheduler) The
  * scheduler on which to schedule the intervals that determine buffer
  * boundaries.
  * @return {Observable<T[]>} an observable of arrays of buffered values.
@@ -24,7 +24,7 @@ import {asap} from '../scheduler/asap';
  */
 export function bufferTime<T>(bufferTimeSpan: number,
                               bufferCreationInterval: number = null,
-                              scheduler: Scheduler = asap): Observable<T[]> {
+                              scheduler: Scheduler = async): Observable<T[]> {
   return this.lift(new BufferTimeOperator<T>(bufferTimeSpan, bufferCreationInterval, scheduler));
 }
 

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -3,7 +3,7 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Subscription} from '../Subscription';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 
 /**
  * Returns the source Observable delayed by the computed debounce duration,
@@ -19,7 +19,7 @@ import {asap} from '../scheduler/asap';
  * @method debounceTime
  * @owner Observable
  */
-export function debounceTime<T>(dueTime: number, scheduler: Scheduler = asap): Observable<T> {
+export function debounceTime<T>(dueTime: number, scheduler: Scheduler = async): Observable<T> {
   return this.lift(new DebounceTimeOperator(dueTime, scheduler));
 }
 

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -1,4 +1,4 @@
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 import {isDate} from '../util/isDate';
 import {Operator} from '../Operator';
 import {Scheduler} from '../Scheduler';
@@ -16,7 +16,7 @@ import {Observable} from '../Observable';
  * @owner Observable
  */
 export function delay<T>(delay: number|Date,
-                         scheduler: Scheduler = asap): Observable<T> {
+                         scheduler: Scheduler = async): Observable<T> {
   const absoluteDelay = isDate(delay);
   const delayFor = absoluteDelay ? (+delay - scheduler.now()) : Math.abs(<number>delay);
   return this.lift(new DelayOperator(delayFor, scheduler));

--- a/src/operator/inspectTime.ts
+++ b/src/operator/inspectTime.ts
@@ -1,4 +1,4 @@
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 import {Operator} from '../Operator';
 import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
@@ -12,7 +12,7 @@ import {Subscription} from '../Subscription';
  * @method inspectTime
  * @owner Observable
  */
-export function inspectTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
+export function inspectTime<T>(delay: number, scheduler: Scheduler = async): Observable<T> {
   return this.lift(new InspectTimeOperator(delay, scheduler));
 }
 

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -2,7 +2,7 @@ import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 
 /**
  * @param delay
@@ -11,7 +11,7 @@ import {asap} from '../scheduler/asap';
  * @method sampleTime
  * @owner Observable
  */
-export function sampleTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
+export function sampleTime<T>(delay: number, scheduler: Scheduler = async): Observable<T> {
   return this.lift(new SampleTimeOperator(delay, scheduler));
 }
 

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -2,7 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Subscription} from '../Subscription';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 import {Observable} from '../Observable';
 
 /**
@@ -12,7 +12,7 @@ import {Observable} from '../Observable';
  * @method throttleTime
  * @owner Observable
  */
-export function throttleTime<T>(delay: number, scheduler: Scheduler = asap): Observable<T> {
+export function throttleTime<T>(delay: number, scheduler: Scheduler = async): Observable<T> {
   return this.lift(new ThrottleTimeOperator(delay, scheduler));
 }
 

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -2,7 +2,7 @@ import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 
 /**
  * @param scheduler
@@ -10,7 +10,7 @@ import {asap} from '../scheduler/asap';
  * @method timeInterval
  * @owner Observable
  */
-export function timeInterval<T>(scheduler: Scheduler = asap): Observable<TimeInterval<T>> {
+export function timeInterval<T>(scheduler: Scheduler = async): Observable<TimeInterval<T>> {
   return this.lift(new TimeIntervalOperator(scheduler));
 }
 

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -1,4 +1,4 @@
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 import {isDate} from '../util/isDate';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
@@ -15,7 +15,7 @@ import {Observable} from '../Observable';
  */
 export function timeout<T>(due: number | Date,
                            errorToSend: any = null,
-                           scheduler: Scheduler = asap): Observable<T> {
+                           scheduler: Scheduler = async): Observable<T> {
   let absoluteTimeout = isDate(due);
   let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, errorToSend, scheduler));

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 import {Subscription} from '../Subscription';
 import {Observable} from '../Observable';
 import {isDate} from '../util/isDate';
@@ -18,7 +18,7 @@ import {subscribeToResult} from '../util/subscribeToResult';
  */
 export function timeoutWith<T, R>(due: number | Date,
                                   withObservable: Observable<R>,
-                                  scheduler: Scheduler = asap): Observable<T | R> {
+                                  scheduler: Scheduler = async): Observable<T | R> {
   let absoluteTimeout = isDate(due);
   let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -4,7 +4,7 @@ import {Observable} from '../Observable';
 import {Subject} from '../Subject';
 import {Scheduler} from '../Scheduler';
 import {Action} from '../scheduler/Action';
-import {asap} from '../scheduler/asap';
+import {async} from '../scheduler/async';
 
 /**
  * @param windowTimeSpan
@@ -16,7 +16,7 @@ import {asap} from '../scheduler/asap';
  */
 export function windowTime<T>(windowTimeSpan: number,
                               windowCreationInterval: number = null,
-                              scheduler: Scheduler = asap): Observable<Observable<T>> {
+                              scheduler: Scheduler = async): Observable<Observable<T>> {
   return this.lift(new WindowTimeOperator<T>(windowTimeSpan, windowCreationInterval, scheduler));
 }
 

--- a/src/scheduler/AsyncScheduler.ts
+++ b/src/scheduler/AsyncScheduler.ts
@@ -1,0 +1,10 @@
+import {Action} from './Action';
+import {FutureAction} from './FutureAction';
+import {Subscription} from '../Subscription';
+import {QueueScheduler} from './QueueScheduler';
+
+export class AsyncScheduler extends QueueScheduler {
+  scheduleNow<T>(work: (x?: any) => Subscription, state?: any): Action {
+    return new FutureAction(this, work).schedule(state, 0);
+  }
+}

--- a/src/scheduler/FutureAction.ts
+++ b/src/scheduler/FutureAction.ts
@@ -8,6 +8,7 @@ export class FutureAction<T> extends Subscription implements Action {
   public id: number;
   public state: T;
   public delay: number;
+  private pending: boolean = false;
 
   constructor(public scheduler: Scheduler,
               public work: (x?: T) => Subscription | void) {
@@ -17,8 +18,14 @@ export class FutureAction<T> extends Subscription implements Action {
   execute() {
     if (this.isUnsubscribed) {
       throw new Error('How did did we execute a canceled Action?');
+    } else {
+      try {
+        this.work(this.state);
+      } catch (e) {
+        this.unsubscribe();
+        throw e;
+      }
     }
-    this.work(this.state);
   }
 
   schedule(state?: T, delay: number = 0): Action {
@@ -30,20 +37,81 @@ export class FutureAction<T> extends Subscription implements Action {
 
   protected _schedule(state?: T, delay: number = 0): Action {
 
-    this.delay = delay;
+    // Always replace the current state with the new state.
     this.state = state;
-    const id = this.id;
 
-    if (id != null) {
-      this.id = null;
-      root.clearTimeout(id);
+    // Set the pending flag indicating that this action has been scheduled, or
+    // has recursively rescheduled itself.
+    this.pending = true;
+
+    const id = this.id;
+    // If this action has an intervalID and the specified delay matches the
+    // delay we used to create the intervalID, don't call `setInterval` again.
+    if (id != null && this.delay === delay) {
+      return this;
     }
 
-    this.id = root.setTimeout(() => {
+    this.delay = delay;
+
+    // If this action has an intervalID, but was rescheduled with a different
+    // `delay` time, cancel the current intervalID and call `setInterval` with
+    // the new `delay` time.
+    if (id != null) {
       this.id = null;
-      const {scheduler} = this;
+      root.clearInterval(id);
+    }
+
+    //
+    // Important implementation note:
+    //
+    // By default, FutureAction only executes once. However, Actions have the
+    // ability to be rescheduled from within the scheduled callback (mimicking
+    // recursion for asynchronous methods). This allows us to implement single
+    // and repeated actions with the same code path without adding API surface
+    // area, and implement tail-call optimization over asynchronous boundaries.
+    //
+    // However, JS runtimes make a distinction between intervals scheduled by
+    // repeatedly calling `setTimeout` vs. a single `setInterval` call, with
+    // the latter providing a better guarantee of precision.
+    //
+    // In order to accommodate both single and repeatedly rescheduled actions,
+    // use `setInterval` here for both cases. By default, the interval will be
+    // canceled after its first execution, or if the action schedules itself to
+    // run again with a different `delay` time.
+    //
+    // If the action recursively schedules itself to run again with the same
+    // `delay` time, the interval is not canceled, but allowed to loop again.
+    // The check of whether the interval should be canceled or not is run every
+    // time the interval is executed. The first time an action fails to
+    // reschedule itself, the interval is canceled.
+    //
+    this.id = root.setInterval(() => {
+
+      this.pending = false;
+      const {id, scheduler} = this;
       scheduler.actions.push(this);
       scheduler.flush();
+
+      //
+      // Terminate this interval if the action didn't reschedule itself.
+      // Don't call `this.unsubscribe()` here, because the action could be
+      // rescheduled later. For example:
+      //
+      // ```
+      // scheduler.schedule(function doWork(counter) {
+      //   /* ... I'm a busy worker bee ... */
+      //   var originalAction = this;
+      //   /* wait 100ms before rescheduling this action again */
+      //   setTimeout(function () {
+      //     originalAction.schedule(counter + 1);
+      //   }, 100);
+      // }, 1000);
+      // ```
+
+      if (this.pending === false && id != null) {
+        this.id = null;
+        root.clearInterval(id);
+      }
     }, delay);
 
     return this;
@@ -51,13 +119,14 @@ export class FutureAction<T> extends Subscription implements Action {
 
   protected _unsubscribe() {
 
+    this.pending = false;
     const {id, scheduler} = this;
     const {actions} = scheduler;
     const index = actions.indexOf(this);
 
     if (id != null) {
       this.id = null;
-      root.clearTimeout(id);
+      root.clearInterval(id);
     }
 
     if (index !== -1) {

--- a/src/scheduler/async.ts
+++ b/src/scheduler/async.ts
@@ -1,0 +1,3 @@
+import {AsyncScheduler} from './AsyncScheduler';
+
+export const async = new AsyncScheduler();


### PR DESCRIPTION
Adds `Scheduler.async` which will always schedule an action to happen in the future. Fixes #1339. Updates `FutureAction` to use `setInterval` instead of repeated `setTimeout` calls as discussed with @mattpodwysocki in #1391.