### PR TITLE
refactor(FromEventPatternObservable): remove to use tryCatch

### DIFF
--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -1,7 +1,5 @@
 import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
-import {tryCatch} from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
 import {Subscriber} from '../Subscriber';
 
 /**
@@ -33,26 +31,35 @@ export class FromEventPatternObservable<T, R> extends Observable<T> {
   }
 
   protected _subscribe(subscriber: Subscriber<T>) {
-    const addHandler = this.addHandler;
     const removeHandler = this.removeHandler;
-    const selector = this.selector;
 
-    const handler = selector ? function(e: any) {
-      let result = tryCatch(selector).apply(null, arguments);
-      if (result === errorObject) {
-        subscriber.error(result.e);
-      } else {
-        subscriber.next(result);
-      }
+    const handler = !!this.selector ? (...args: Array<any>) => {
+      this._callSelector(subscriber, args);
     } : function(e: any) { subscriber.next(e); };
 
-    let result = tryCatch(addHandler)(handler);
-    if (result === errorObject) {
-      subscriber.error(result.e);
-    }
+    this._callAddHandler(handler, subscriber);
     subscriber.add(new Subscription(() => {
       //TODO: determine whether or not to forward to error handler
       removeHandler(handler);
     }));
+  }
+
+  private _callSelector(subscriber: Subscriber<T>, args: Array<any>): void {
+    try {
+      const result: T = this.selector(...args);
+      subscriber.next(result);
+    }
+    catch (e) {
+      subscriber.error(e);
+    }
+  }
+
+  private _callAddHandler(handler: (e: any) => void, errorSubscriber: Subscriber<T>): void {
+    try {
+      this.addHandler(handler);
+    }
+    catch (e) {
+      errorSubscriber.error(e);
+    }
   }
 }


### PR DESCRIPTION
There is no perf regression.

This is the benchmark result on Node v5.6.0,
MacBook Air (13-inch, Mid 2012, 1.8 GHz Intel Core i5, 8 GB 1600 MHz DDR3).

## before

```
                                         |                     RxJS 4.0.7 |              RxJS 5.0.0-beta.2 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
            fromeventpattern - immediate |               148,483 (±1.75%) |               347,956 (±2.42%) |           2.34x |          134.3%
```


## after

```
                                         |                     RxJS 4.0.7 |              RxJS 5.0.0-beta.2 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
            fromeventpattern - immediate |               145,944 (±1.21%) |               351,992 (±2.82%) |           2.41x |          141.2%
```

