### PR TITLE
Proposal : type definition test cases

### DIFF
--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -17,6 +17,7 @@ global.hot = marbleHelpers.hot;
 global.time = marbleHelpers.time;
 global.expectObservable = marbleHelpers.expectObservable;
 global.expectSubscriptions = marbleHelpers.expectSubscriptions;
+global.type = type;
 
 //amending type definition of jasmine which seems doesn't have this
 export interface DoneSignature {
@@ -75,6 +76,11 @@ global.it = it;
 global.fit = fit;
 if (!global.asDiagram) {
   global.asDiagram = asDiagram;
+}
+
+export function type(assertion: Function): void {
+  //intentionally does not execute to avoid unexpected side effect occurs by subscription,
+  //or infinite source. Suffecient to check build time only.
 }
 
 export function lowerCaseO<T>(...args): Rx.Observable<T> {

--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -1,5 +1,5 @@
 import * as Rx from '../../dist/cjs/Rx';
-declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions};
+declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions, type};
 
 const Observable = Rx.Observable;
 
@@ -100,5 +100,13 @@ describe('Observable.prototype.toArray', () => {
 
     expectObservable(e1.toArray()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  type(() => {
+    const typeValue = {
+      val: 3
+    };
+
+    Observable.of(typeValue).toArray().subscribe(x => { x[0].val.toString(); });
   });
 });


### PR DESCRIPTION
Now test cases are migrated in typescript, it is possible to integrate type definition test into existing test case execution environment. This PR is initial proposal of logistics. 

Changes are straightforward, test helper exports interface `type` for type definition assertion actually doesn't do anything but only serves as container of all type definition test. These will be verified via compile time of test cases. 

In test cases, very bottom of each test contains `type` assertion and list out possible type definition test cases, majorly
- operator input signature accepts parameter as expected
- operator chain, or subscription correctly delivers context of value type `<T>`
- etcs

intentionwise this is same as #1189 does, only difference is logistics.

/cc @david-driscoll for visibility also.