### PR TITLE
fix(Observable.prototype.forEach): removed thisArg to match es-observable spec

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -30,7 +30,7 @@ describe('Observable', () => {
       const expected = [1, 2, 3];
       const result = Observable.of(1, 2, 3).forEach(function (x) {
         expect(x).toBe(expected.shift());
-      }, null, Promise)
+      }, Promise)
       .then(done);
 
       expect(typeof result.then).toBe('function');
@@ -39,7 +39,7 @@ describe('Observable', () => {
     it('should reject promise when in error', (done: DoneSignature) => {
       Observable.throw('bad').forEach((x: any) => {
         done.fail('should not be called');
-      }, null, Promise).then(() => {
+      }, Promise).then(() => {
         done.fail('should not complete');
       }, (err: any) => {
         expect(err).toBe('bad');
@@ -63,18 +63,6 @@ describe('Observable', () => {
         expect(wasCalled).toBe(true);
         done();
       });
-    });
-
-    it('should accept a thisArg argument', (done: DoneSignature) => {
-      const expected = [1, 2, 3];
-      const thisArg = {};
-      const result = Observable.of(1, 2, 3).forEach(function (x) {
-        expect(this).toBe(thisArg);
-        expect(x).toBe(expected.shift());
-      }, thisArg, Promise)
-      .then(done);
-
-      expect(typeof result.then).toBe('function');
     });
 
     it('should reject promise if nextHandler throws', (done: DoneSignature) => {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -211,12 +211,11 @@ export class Observable<T> implements CoreOperators<T>  {
   /**
    * @method forEach
    * @param {Function} next a handler for each value emitted by the observable
-   * @param {any} [thisArg] a `this` context for the `next` handler function
    * @param {PromiseConstructor} [PromiseCtor] a constructor function used to instantiate the Promise
    * @returns {Promise} a promise that either resolves on observable completion or
    *  rejects with the handled error
    */
-  forEach(next: (value: T) => void, thisArg: any, PromiseCtor?: typeof Promise): Promise<void> {
+  forEach(next: (value: T) => void, PromiseCtor?: typeof Promise): Promise<void> {
     if (!PromiseCtor) {
       if (root.Rx && root.Rx.config && root.Rx.config.Promise) {
         PromiseCtor = root.Rx.config.Promise;
@@ -233,7 +232,7 @@ export class Observable<T> implements CoreOperators<T>  {
 
     return new PromiseCtor<void>((resolve, reject) => {
       source.subscribe((value: T) => {
-        const result: any = tryCatch(next).call(thisArg, value);
+        const result: any = tryCatch(next)(value);
         if (result === errorObject) {
           reject(errorObject.e);
         }


### PR DESCRIPTION
BREAKING CHANGE: thisArg removed to match [es-observable spec](https://github.com/zenparsing/es-observable/issues/79)