### PR TITLE
test(behaviorSubject): refactor test case to compatible with IE9

### DIFF
--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -42,9 +42,13 @@ describe('BehaviorSubject', () => {
 
   it('should not allow you to set `value` directly', () => {
     const subject = new BehaviorSubject('flibberty');
-    expect(() => {
+
+    try {
       subject.value = 'jibbets';
-    }).toThrow();
+    } catch (e) {
+      //noop
+    }
+
     expect(subject.getValue()).toBe('flibberty');
     expect(subject.value).toBe('flibberty');
   });


### PR DESCRIPTION
- update test case to explicitly check value instead of set value throws, IE9 behaves to not throw
by not supporting strict mode in Object.defineProperty

closes #1408 