### PR TITLE
chore(test): update type definitions

### DIFF
--- a/spec/operators/combineAll-spec.ts
+++ b/spec/operators/combineAll-spec.ts
@@ -188,7 +188,7 @@ describe('Observable.prototype.combineAll', () => {
     const e3subs =        '^         !';
     const expected =      '-----wxyz-|';
 
-    const result = Observable.of(e1, e2, e3).combineAll(<any>((x: string, y: string, z: string) => x + y + z));
+    const result = Observable.of(e1, e2, e3).combineAll((x: string, y: string, z: string) => x + y + z);
 
     expectObservable(result).toBe(expected, { w: 'bfi', x: 'cfi', y: 'cgi', z: 'cgj' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -231,7 +231,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const expected = '(0123)(0123)---(0123)---(0123)--|';
 
-    const result = e1.concatMapTo(<any>['0', '1', '2', '3']);
+    const result = e1.concatMapTo(['0', '1', '2', '3']);
 
     expectObservable(result).toBe(expected);
   });
@@ -240,7 +240,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const expected = '(2345)(4567)---(3456)---(2345)--|';
 
-    const result = e1.concatMapTo(<any>['0', '1', '2', '3'],
+    const result = e1.concatMapTo(['0', '1', '2', '3'],
       (x: string, y: string) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result).toBe(expected);
@@ -250,7 +250,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 =   hot('2-----4--------3--------2-------#');
     const expected = '(0123)(0123)---(0123)---(0123)--#';
 
-    const result = e1.concatMapTo(<any>['0', '1', '2', '3']);
+    const result = e1.concatMapTo(['0', '1', '2', '3']);
 
     expectObservable(result).toBe(expected);
   });
@@ -259,7 +259,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 =   hot('2-----4--------3--------2-------#');
     const expected = '(2345)(4567)---(3456)---(2345)--#';
 
-    const result = e1.concatMapTo(<any>['0', '1', '2', '3'],
+    const result = e1.concatMapTo(['0', '1', '2', '3'],
       (x: string, y: string) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result).toBe(expected);
@@ -270,7 +270,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const unsub =    '             !';
     const expected = '(0123)(0123)--';
 
-    const result = e1.concatMapTo(<any>['0', '1', '2', '3']);
+    const result = e1.concatMapTo(['0', '1', '2', '3']);
 
     expectObservable(result, unsub).toBe(expected);
   });
@@ -280,7 +280,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const unsub =    '             !';
     const expected = '(2345)(4567)--';
 
-    const result = e1.concatMapTo(<any>['0', '1', '2', '3'],
+    const result = e1.concatMapTo(['0', '1', '2', '3'],
       (x: string, y: string) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result, unsub).toBe(expected);
@@ -290,7 +290,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const expected = '(2345)(4567)---#';
 
-    const result = e1.concatMapTo(<any>['0', '1', '2', '3'], (x: string, y: string) => {
+    const result = e1.concatMapTo(['0', '1', '2', '3'], (x: string, y: string) => {
       if (x === '3') {
         throw 'error';
       }

--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -25,7 +25,7 @@ describe('Observable.prototype.delay', () => {
     const subs =     '^          !';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.delay(<any>absoluteDelay, rxTestScheduler);
+    const result = e1.delay(absoluteDelay, rxTestScheduler);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -38,7 +38,7 @@ describe('Observable.prototype.delay', () => {
     const subs =        '^           !';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.delay(<any>absoluteDelay, rxTestScheduler);
+    const result = e1.delay(absoluteDelay, rxTestScheduler);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -63,7 +63,7 @@ describe('Observable.prototype.delay', () => {
     const subs =     '^       !';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.delay(<any>absoluteDelay, rxTestScheduler);
+    const result = e1.delay(absoluteDelay, rxTestScheduler);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -76,7 +76,7 @@ describe('Observable.prototype.delay', () => {
     const e1Sub =       '^           !';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.delay(<any>absoluteDelay, rxTestScheduler);
+    const result = e1.delay(absoluteDelay, rxTestScheduler);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1Sub);


### PR DESCRIPTION
This PR's continued effort as same as https://github.com/ReactiveX/RxJS/pull/1422 to update type definition usage in test cases.