### PR TITLE
fix(package.json): install typings only after packages are installed

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "scripts": {
-    "preinstall": "typings install",
+    "postinstall": "typings install",
     "build_all": "npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global && npm run generate_packages",
     "build_amd": "rm -rf dist/amd && tsc typings/main.d.ts src/Rx.ts src/Rx.DOM.ts src/add/observable/of.ts -m amd --outDir dist/amd --sourcemap --sourceRoot src --target ES5 --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",
     "build_cjs": "rm -rf dist/cjs && tsc typings/main.d.ts src/Rx.ts src/Rx.KitchenSink.ts src/Rx.DOM.ts src/add/observable/of.ts -m commonjs --outDir dist/cjs --sourcemap --sourceRoot src --target ES5 -d --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",


### PR DESCRIPTION
Tiny PR. :baby: :baby_bottle: 

use postinstall hook, not preinstall hook, to run typings install.

This was important because `typings install` cannot be run before `typings` itself is installed (and I don't have it installed globally. Also Travis won't have), otherwise we get this error:

```
$ RxJSNext (master) npm install

> @reactivex/rxjs@5.0.0-beta.2 preinstall /Users/amed/Development/RxJSNext
> typings install

sh: typings: command not found

npm ERR! Darwin 15.3.0
npm ERR! argv "/Users/amed/.nvm/versions/node/v4.2.2/bin/node" "/Users/amed/.nvm/versions/node/v4.2.2/bin/npm" "i"
npm ERR! node v4.2.2
npm ERR! npm  v2.14.7
npm ERR! file sh
npm ERR! code ELIFECYCLE
npm ERR! errno ENOENT
npm ERR! syscall spawn
npm ERR! @reactivex/rxjs@5.0.0-beta.2 preinstall: `typings install`
npm ERR! spawn ENOENT
npm ERR! 
npm ERR! Failed at the @reactivex/rxjs@5.0.0-beta.2 preinstall script 'typings install'.
npm ERR! This is most likely a problem with the @reactivex/rxjs package,
npm ERR! not with npm itself.
npm ERR! Tell the author that this fails on your system:
npm ERR!     typings install
npm ERR! You can get their info via:
npm ERR!     npm owner ls @reactivex/rxjs
npm ERR! There is likely additional logging output above.

npm ERR! Please include the following file with any support request:
npm ERR!     /Users/amed/Development/RxJSNext/npm-debug.log
```
