### PR TITLE
docs(README): Add Information where Docs can be found

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,8 @@
 
 Reactive Extensions Library for JavaScript. This is a rewrite of [Reactive-Extensions/RxJS](https://github.com/Reactive-Extensions/RxJS) and is intended to supersede it once this is ready. This rewrite is meant to have better performance, better modularity, better debuggable call stacks, while staying mostly backwards compatible, with some breaking changes that reduce the API surface.
 
+Documentation is currently a [Work In Progress](http://rxjs5-esdoc-manual-content-wip.surge.sh/) and temporarely available.
+
 [Apache 2.0 License](LICENSE.txt)
 
 - [Code of Conduct](CODE_OF_CONDUCT.md)


### PR DESCRIPTION
When I first looked for documentation about RXJS5, I was struggling to find any on github.io
Only after further investigation, when I thought that Github markdown files were the only way to browse documentation, I found [this](http://rxjs5-esdoc-manual-content-wip.surge.sh/manual/overview.html#introduction).