### PR TITLE
chore(package.json): add description to script

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,8 @@ The build and test structure is fairly primitive at the moment. There are variou
 - test: runs tests with `jasmine`, must have built prior to running.
 - tests2png: generates PNG marble diagrams from test cases.
 
+`npm run info` will list available script.
+
 ### Example
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -11,13 +11,49 @@
       "commit-msg": "node ./node_modules/validate-commit-msg/index.js"
     }
   },
+  "scripts-info": {
+    "info": "List available script",
+    "build_all": "Build all packages(ES6, CJS, AMD, Global) and generate packages",
+    "build_amd": "Build AMD package with clean up existing build, copy source into dist",
+    "build_cjs": "Build CJS package with clean up existing build, copy source into dist",
+    "build_es6": "Build ES6 package with clean up existing build, copy source into dist",
+    "build_closure_core": "Minify Global core build using closure compiler",
+    "build_closure_kitchensink": "Minify Global kitchenSink build using closure compiler",
+    "build_global": "Build Global package, then minify core & kitchensink build",
+    "build_perf": "Build CJS & Global build, run macro performance test",
+    "build_test": "Build CJS package & test spec, execute jasmine test runner",
+    "build_cover": "Run lint to current code, build CJS & test spec, execute test coverage",
+    "build_docs": "Build ES6 & global package, create documentation using it",
+    "build_spec": "Build test specs",
+    "check_circular_dependencies": "Check codebase has circular dependencies",
+    "clean_spec": "Clean up existing test spec build output",
+    "clean_dist_amd": "Clean up existing AMD package output",
+    "clean_dist_cjs": "Clean up existing CJS package output",
+    "clean_dist_es6": "Clean up existing ES6 package output",
+    "commit": "Run git commit wizard",
+    "compile_dist_amd": "Compile codebase into AMD module",
+    "compile_dist_cjs": "Compile codebase into CJS module",
+    "compile_dist_es6": "Compile codebase into ES6",
+    "cover": "Execute test coverage",
+    "lint_perf": "Run lint against performance test suite",
+    "lint_spec": "Run lint against test spec",
+    "lint_src": "Run lint against source",
+    "lint": "Run lint against everything",
+    "perf": "Run macro performance benchmark",
+    "perf_micro": "Run micro performance benchmark",
+    "test_jasmine": "Execute jasmine test runner against existing test spec build",
+    "test_karma": "Execute karma test runner against existing test spec build",
+    "test": "Clean up existing test spec build, build test spec and execute jasmine test runner",
+    "tests2png": "Generate marble diagram image from test spec",
+    "watch": "Watch codebase, trigger compile when source code changes"
+  },
   "scripts": {
+    "info": "npm-scripts-info",
     "postinstall": "typings install",
     "build_all": "npm run build_es6 && npm run build_amd && npm run build_cjs && npm run build_global && npm run generate_packages",
     "build_amd": "npm run clean_dist_amd && npm run copy_src_amd && npm run compile_dist_amd",
     "build_cjs": "npm run clean_dist_cjs && npm run copy_src_cjs && npm run compile_dist_cjs",
     "build_es6": "npm run clean_dist_es6 && npm run copy_src_es6 && npm run compile_dist_es6",
-
     "build_closure_core": "java -jar ./node_modules/google-closure-compiler/compiler.jar --js ./dist/global/Rx.umd.js --language_in ECMASCRIPT5 --create_source_map ./dist/global/Rx.umd.min.js.map --js_output_file ./dist/global/Rx.umd.min.js",
     "build_closure_kitchensink": "java -jar ./node_modules/google-closure-compiler/compiler.jar --js ./dist/global/Rx.KitchenSink.umd.js --language_in ECMASCRIPT5 --create_source_map ./dist/global/Rx.KitchenSink.umd.min.js.map --js_output_file ./dist/global/Rx.KitchenSink.umd.min.js",
     "build_global": "rm -rf ./dist/global && mkdirp ./dist/global && node tools/make-umd-bundle.js && node tools/make-system-bundle.js && npm run build_closure_core && npm run build_closure_kitchensink",
@@ -26,46 +62,34 @@
     "build_cover": "rm -rf ./dist/ && npm run lint && npm run build_cjs && npm run build_spec && npm run cover",
     "build_docs": "npm run build_es6 && npm run build_global && npm run tests2png && esdoc -c esdoc.json",
     "build_spec": "tsc --project ./spec --pretty",
-
     "check_circular_dependencies": "madge ./dist/cjs --circular",
-
     "clean_spec": "rm -rf spec-js",
     "clean_dist_amd": "rm -rf ./dist/amd",
     "clean_dist_cjs": "rm -rf ./dist/cjs",
     "clean_dist_es6": "rm -rf ./dist/es6",
-
     "copy_src_amd": "mkdirp ./dist/amd/src && cp -r ./src/* ./dist/amd/src",
     "copy_src_cjs": "mkdirp ./dist/cjs/src && cp -r ./src/* ./dist/cjs/src",
     "copy_src_es6": "mkdirp ./dist/es6/src && cp -r ./src/* ./dist/es6/src",
-
     "commit": "git-cz",
-
     "compile_dist_amd": "tsc ./typings/main.d.ts ./dist/amd/src/Rx.ts ./dist/amd/src/Rx.KitchenSink.ts ./dist/amd/src/Rx.DOM.ts ./dist/amd/src/add/observable/of.ts -m amd      --sourceMap --outDir ./dist/amd --target ES5    --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",
     "compile_dist_cjs": "tsc ./typings/main.d.ts ./dist/cjs/src/Rx.ts ./dist/cjs/src/Rx.KitchenSink.ts ./dist/cjs/src/Rx.DOM.ts ./dist/cjs/src/add/observable/of.ts -m commonjs --sourceMap --outDir ./dist/cjs --target ES5 -d --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",
     "compile_dist_es6": "tsc                                  ./dist/es6/src/Rx.ts ./dist/es6/src/Rx.KitchenSink.ts ./dist/es6/src/Rx.DOM.ts ./dist/es6/src/add/observable/of.ts -m es2015   --sourceMap --outDir ./dist/es6 --target ES6 -d --diagnostics --pretty --noImplicitAny --suppressImplicitAnyIndexErrors",
-
     "cover": "npm run cover_test && npm run cover_remapping",
     "cover_test": "istanbul cover -x \"*-spec.js index.js *-helper.js spec-js/helpers/*\" ./node_modules/jasmine/bin/jasmine.js",
     "cover_remapping": "remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.json && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped.lcov -t lcovonly && remap-istanbul -i coverage/coverage.json -o coverage/coverage-remapped -t html",
-
     "generate_packages": "node .make-packages.js",
-
     "lint_perf": "eslint perf/",
     "lint_spec": "tslint -c tslint.json spec/*.ts spec/**/*.ts spec/**/**/*.ts",
     "lint_src": "tslint -c tslint.json src/*.ts src/**/*.ts src/**/**/*.ts",
     "lint": "npm run lint_src && npm run lint_spec && npm run lint_perf",
-
     "perf": "protractor protractor.conf.js",
     "perf_micro": "node ./perf/micro/index.js",
-
     "prepublish": "npm run build_all",
     "publish_docs": "./publish_docs.sh",
-
     "test_jasmine": "jasmine",
     "test_karma": "karma start karma.conf.js",
     "test": "npm run clean_spec && npm run build_spec && npm run test_jasmine && npm run clean_spec",
     "tests2png": "npm run build_spec && mkdirp tmp/docs/img && mkdirp spec-js/support && cp spec/support/*.json spec-js/support/ && jasmine JASMINE_CONFIG_PATH=spec/support/tests2png.json",
-
     "watch": "watch \"echo triggering build && npm run build_test && echo build completed\" src -d -u -w=15"
   },
   "repository": {
@@ -149,6 +173,7 @@
     "markdown-doctest": "^0.3.2",
     "minimist": "^1.2.0",
     "mkdirp": "^0.5.1",
+    "npm-scripts-info": "^0.3.4",
     "platform": "1.3.0",
     "promise": "7.0.3",
     "protractor": "2.5.1",


### PR DESCRIPTION
This PR adds one additional npm script `npm run info`, display brief description to available npm script.

While npm has native feature to list out available script via `npm run`, it simply displays script command only without addition descriptions. This PR uses external module to display description for each script for easier access to contributors. 