### PR TITLE
chore(code-coverage): replace code coverage checker to codecov

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ env:
   - alias grunt=./node_modules/grunt-cli/bin/grunt
 
 before_install:
-  - npm install -g npm@3 && npm install grunt@0.4.1 grunt-cli grunt-contrib-connect grunt-run
+  - npm install -g npm@3 && npm install grunt@0.4.1 grunt-cli grunt-contrib-connect grunt-run codecov
 install:
   - npm install && npm run lint
 
@@ -36,5 +36,5 @@ script:
 
 after_success:
   - npm run cover
-  - cat ./coverage/coverage-remapped.lcov | ./node_modules/coveralls/bin/coveralls.js
+  - cat ./coverage/coverage-remapped.lcov | ./node_modules/codecov/bin/codecov
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -n "${SAUCE_ACCESS_KEY}" ] && npm run build_spec_browser && grunt --gruntfile spec/support/mocha.sauce.gruntfile.js || false'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![Build Status](https://travis-ci.org/ReactiveX/rxjs.svg?branch=master)](https://travis-ci.org/ReactiveX/rxjs)
-[![Coverage Status](https://coveralls.io/repos/ReactiveX/RxJS/badge.svg?branch=master&service=github)](https://coveralls.io/github/ReactiveX/RxJS?branch=master)
 [![npm version](https://badge.fury.io/js/%40reactivex%2Frxjs.svg)](http://badge.fury.io/js/%40reactivex%2Frxjs)
 [![Join the chat at https://gitter.im/Reactive-Extensions/RxJS](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Reactive-Extensions/RxJS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 

--- a/package.json
+++ b/package.json
@@ -151,7 +151,6 @@
     "color": "^0.11.1",
     "colors": "1.1.2",
     "commitizen": "^2.8.1",
-    "coveralls": "^2.11.8",
     "cz-conventional-changelog": "1.1.5",
     "doctoc": "^1.0.0",
     "esdoc": "^0.4.6",


### PR DESCRIPTION
**Description:**

This PR migrates current code coverage checker (coveralls) into codecov.io (https://codecov.io/)
There were couple of known failures (https://github.com/ReactiveX/RxJS/issues/1304), (https://github.com/ReactiveX/RxJS/issues/1440), codecov seems more reliably works in general.

To complete migrate, repo owner need to signup at codecov, add this repo to be monitored.

While I'm bit on fence to actually check this in or not, would like to use this PR as discussion point.

**Related issue (if exists):**

closes #1440