### PR TITLE
fix(mergeMap): allow conccurent to be set as the second argument for …

### DIFF
--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -20,8 +20,12 @@ import {InnerSubscriber} from '../InnerSubscriber';
  * @owner Observable
  */
 export function mergeMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>,
-                                  resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R | number,
+                                  resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
                                   concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
+  if (typeof resultSelector === 'number') {
+    concurrent = <number>resultSelector;
+    resultSelector = null;
+  }
   return this.lift(new MergeMapOperator(project, <any>resultSelector, concurrent));
 }
 

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -16,8 +16,12 @@ import {subscribeToResult} from '../util/subscribeToResult';
  * @owner Observable
  */
 export function mergeMapTo<T, I, R>(observable: Observable<I>,
-                                    resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R | number,
+                                    resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
                                     concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
+  if (typeof resultSelector === 'number') {
+    concurrent = <number>resultSelector;
+    resultSelector = null;
+  }
   return this.lift(new MergeMapToOperator(observable, <any>resultSelector, concurrent));
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Allow `concurrent` to be supplied as the second argument for `mergeMap` and `mergeMapTo`.

**Related issue (if exists):**
see #1448 for discussion

**Perf Details**

On my machine the numbers were kind of hit or miss, so it's worth a second look by someone else as well.  But the numbers look to not really be affected all that much.

```
---------------------------------------------------------------------------------------------------------------------------------------------------
-- BEFORE
---------------------------------------------------------------------------------------------------------------------------------------------------
                                         |                     RxJS 4.0.7 |              RxJS 5.0.0-beta.2 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                    mergemap - immediate |                 1,871 (±4.96%) |                24,602 (±5.36%) |          13.15x |        1,215.2%
                                mergemap |                   575 (±4.30%) |                 3,779 (±5.71%) |           6.57x |          556.9%
---------------------------------------------------------------------------------------------------------------------------------------------------
                    mergemap - immediate |                 1,675 (±5.89%) |                20,097 (±5.73%) |          12.00x |        1,100.2%
                                mergemap |                   617 (±5.99%) |                 4,508 (±5.15%) |           7.30x |          630.5%
---------------------------------------------------------------------------------------------------------------------------------------------------
                    mergemap - immediate |                 2,300 (±3.36%) |                28,980 (±3.07%) |          12.60x |        1,159.8%
                                mergemap |                   761 (±3.28%) |                 5,644 (±3.56%) |           7.42x |          641.6%
---------------------------------------------------------------------------------------------------------------------------------------------------
-- AFTER
---------------------------------------------------------------------------------------------------------------------------------------------------
                                         |                     RxJS 4.0.7 |              RxJS 5.0.0-beta.2 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                    mergemap - immediate |                 2,156 (±6.06%) |                27,358 (±5.14%) |          12.69x |        1,168.8%
                                mergemap |                   678 (±5.41%) |                 5,260 (±5.54%) |           7.75x |          675.3%
---------------------------------------------------------------------------------------------------------------------------------------------------
                    mergemap - immediate |                 1,781 (±6.55%) |                22,664 (±6.63%) |          12.72x |        1,172.4%
                                mergemap |                   589 (±4.92%) |                 4,865 (±5.04%) |           8.26x |          725.7%
---------------------------------------------------------------------------------------------------------------------------------------------------
                    mergemap - immediate |                 1,998 (±5.14%) |                26,582 (±4.79%) |          13.31x |        1,230.6%
                                mergemap |                   583 (±5.49%) |                 6,060 (±2.12%) |          10.39x |          939.2%
---------------------------------------------------------------------------------------------------------------------------------------------------
```
