### PR TITLE
chore(package.json): correct RxJS 4 dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -178,7 +178,7 @@
     "promise": "^7.1.1",
     "protractor": "^3.1.1",
     "remap-istanbul": "0.5.1",
-    "rx": "^4.1.0",
+    "rx": "latest",
     "systemjs": "^0.19.24",
     "systemjs-builder": "^0.10.6",
     "tslint": "^3.5.0",


### PR DESCRIPTION
This PR's minor correction to dependency version bump, to not to use specific version of RxJS 4 but to use latest.