### PR TITLE
fix(forkJoin): dispose the inner subscriptions when the outer subscription is disposed

### DIFF
--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -263,4 +263,20 @@ describe('Observable.forkJoin', () => {
 
     expectObservable(e1).toBe(expected);
   });
+
+  it('should allow unsubscribing early and explicitly', () => {
+    const e1 =   hot('--a--^--b--c---d-| ');
+    const e1subs =        '^        !    ';
+    const e2 =   hot('---e-^---f--g---h-|');
+    const e2subs =        '^        !    ';
+    const expected =      '----------    ';
+    const unsub =         '         !    ';
+
+    const result = Observable.forkJoin(e1, e2);
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
 });

--- a/src/observable/ForkJoinObservable.ts
+++ b/src/observable/ForkJoinObservable.ts
@@ -61,7 +61,8 @@ export class ForkJoinObservable<T> extends Observable<T> {
       if (isPromise(source)) {
         source = new PromiseObservable(<Promise<any>>source);
       }
-      (<Observable<any>>source).subscribe(new AllSubscriber(subscriber, i, context));
+      subscriber.add((<Observable<any>>source)
+        .subscribe(new AllSubscriber(subscriber, i, context)));
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Track forkJoin's inner subscriptions so they're unsubscribed when the outer subscription is unsubscribed.

**Related issue (if exists):**
#1392 