### PR TITLE
fix(QueueScheduler): reset active flag when action throws

### DIFF
--- a/src/scheduler/QueueScheduler.ts
+++ b/src/scheduler/QueueScheduler.ts
@@ -19,13 +19,16 @@ export class QueueScheduler implements Scheduler {
     }
     this.active = true;
     const actions = this.actions;
-    for (let action: QueueAction<any>; action = actions.shift(); ) {
-      action.execute();
+    try {
+      for (let action: QueueAction<any>; action = actions.shift(); ) {
+        action.execute();
+      }
+    } finally {
+      this.active = false;
     }
-    this.active = false;
   }
 
-  schedule<T>(work: (x?: T) => Subscription | void, delay: number = 0, state?: T): Subscription {
+  schedule<T> (work: (x?: T) => Subscription | void, delay: number = 0, state?: T): Subscription {
     return (delay <= 0) ?
       this.scheduleNow(work, state) :
       this.scheduleLater(work, delay, state);


### PR DESCRIPTION
**Description:**

This PR amends flush behavior in `QueueScheduler`, reset active status even if queued action throws, so further queued action can be executed.

**Related issue (if exists):**

closes #1464

* Little bit unsure if this change's legit, or might be better recommended way. Will wait for comment.