### PR TITLE
fix(Schedulers): ensure schedulers can be reused after error in execu…

### DIFF
--- a/spec/Scheduler-spec.ts
+++ b/spec/Scheduler-spec.ts
@@ -34,4 +34,25 @@ describe('Scheduler.queue', () => {
       done();
     }, 70);
   });
+
+  it('should be reusable after an error is thrown during execution', (done: DoneSignature) => {
+    const results = [];
+
+    expect(() => {
+      Scheduler.queue.schedule(() => {
+        results.push(1);
+      });
+
+      Scheduler.queue.schedule(() => {
+        throw new Error('bad');
+      });
+    }).toThrow(new Error('bad'));
+
+    setTimeout(() => {
+      Scheduler.queue.schedule(() => {
+        results.push(2);
+        done();
+      });
+    }, 0);
+  });
 });

--- a/src/scheduler/Action.ts
+++ b/src/scheduler/Action.ts
@@ -6,6 +6,6 @@ export interface Action extends Subscription {
   state?: any;
   delay?: number;
   schedule(state?: any, delay?: number): void;
-  execute(): void;
+  execute(errorHandler: (error: any) => void): void;
   scheduler: Scheduler;
 }

--- a/src/scheduler/FutureAction.ts
+++ b/src/scheduler/FutureAction.ts
@@ -15,15 +15,15 @@ export class FutureAction<T> extends Subscription implements Action {
     super();
   }
 
-  execute() {
+  execute(errorHandler: (err: any) => void) {
     if (this.isUnsubscribed) {
-      throw new Error('How did did we execute a canceled Action?');
+      errorHandler(new Error('Tried to execute a cancelled action'));
     } else {
       try {
         this.work(this.state);
       } catch (e) {
         this.unsubscribe();
-        throw e;
+        errorHandler(e);
       }
     }
   }

--- a/src/scheduler/QueueScheduler.ts
+++ b/src/scheduler/QueueScheduler.ts
@@ -19,8 +19,14 @@ export class QueueScheduler implements Scheduler {
     }
     this.active = true;
     const actions = this.actions;
+    const errorHandler: any = function flushError(err: any) {
+      (<any>flushError).scheduler.active = false;
+      throw err;
+    };
+    errorHandler.scheduler = this;
+
     for (let action: QueueAction<any>; action = actions.shift(); ) {
-      action.execute();
+      action.execute(errorHandler);
     }
     this.active = false;
   }

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -20,11 +20,19 @@ export class VirtualTimeScheduler implements Scheduler {
   flush() {
     const actions = this.actions;
     const maxFrames = this.maxFrames;
+    const errorHandler: any = function flushError(err: any) {
+      const { scheduler } = <any>flushError;
+      scheduler.actions.length = 0;
+      scheduler.frame = 0;
+      throw err;
+    };
+    errorHandler.scheduler = this;
+
     while (actions.length > 0) {
       let action = actions.shift();
       this.frame = action.delay;
       if (this.frame <= maxFrames) {
-        action.execute();
+        action.execute(errorHandler);
       } else {
         break;
       }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
Relates to #1464 

This is *one of two* possible fix PRs for this. This particular one adds an `errorHandler` argument to the `Action.prototype.execute` method to enable error handling and reseting the `active` flag without deoptimizing Scheduler `flush`.

/cc @trxcllnt 
