### PR TITLE
fix(Schedulers): ensure schedulers can be reused after error in execu…

### DIFF
--- a/spec/Scheduler-spec.ts
+++ b/spec/Scheduler-spec.ts
@@ -34,4 +34,25 @@ describe('Scheduler.queue', () => {
       done();
     }, 70);
   });
+
+  it('should be reusable after an error is thrown during execution', (done: DoneSignature) => {
+    const results = [];
+
+    expect(() => {
+      Scheduler.queue.schedule(() => {
+        results.push(1);
+      });
+
+      Scheduler.queue.schedule(() => {
+        throw new Error('bad');
+      });
+    }).toThrow(new Error('bad'));
+
+    setTimeout(() => {
+      Scheduler.queue.schedule(() => {
+        results.push(2);
+        done();
+      });
+    }, 0);
+  });
 });

--- a/src/scheduler/Action.ts
+++ b/src/scheduler/Action.ts
@@ -8,4 +8,5 @@ export interface Action extends Subscription {
   schedule(state?: any, delay?: number): void;
   execute(): void;
   scheduler: Scheduler;
+  error: any;
 }

--- a/src/scheduler/FutureAction.ts
+++ b/src/scheduler/FutureAction.ts
@@ -8,6 +8,8 @@ export class FutureAction<T> extends Subscription implements Action {
   public id: number;
   public state: T;
   public delay: number;
+  public error: any;
+
   private pending: boolean = false;
 
   constructor(public scheduler: Scheduler,
@@ -17,13 +19,13 @@ export class FutureAction<T> extends Subscription implements Action {
 
   execute() {
     if (this.isUnsubscribed) {
-      throw new Error('How did did we execute a canceled Action?');
+      this.error = new Error('executing a cancelled action');
     } else {
       try {
         this.work(this.state);
       } catch (e) {
         this.unsubscribe();
-        throw e;
+        this.error = e;
       }
     }
   }

--- a/src/scheduler/QueueScheduler.ts
+++ b/src/scheduler/QueueScheduler.ts
@@ -21,6 +21,10 @@ export class QueueScheduler implements Scheduler {
     const actions = this.actions;
     for (let action: QueueAction<any>; action = actions.shift(); ) {
       action.execute();
+      if (action.error) {
+        this.active = false;
+        throw action.error;
+      }
     }
     this.active = false;
   }

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -25,6 +25,11 @@ export class VirtualTimeScheduler implements Scheduler {
       this.frame = action.delay;
       if (this.frame <= maxFrames) {
         action.execute();
+        if (action.error) {
+          actions.length = 0;
+          this.frame = 0;
+          throw action.error;
+        }
       } else {
         break;
       }
@@ -65,6 +70,7 @@ class VirtualAction<T> extends Subscription implements Action {
   state: T;
   delay: number;
   calls = 0;
+  error: any;
 
   constructor(public scheduler: VirtualTimeScheduler,
               public work: (x?: T) => Subscription | void,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adds a property to all Actions of `error` that is set if executing the action results in an error. That property is then checked after execution in `flush` methods of schedulers. This is an alternative to #1468 

**Related issue (if exists):**

#1464 

cc/ @trxcllnt 