### PR TITLE
docs(operators): write comprehensive docs on delay() and switch()

### DIFF
--- a/spec/operators/delayWhen-spec.ts
+++ b/spec/operators/delayWhen-spec.ts
@@ -5,7 +5,7 @@ declare const rxTestScheduler: Rx.TestScheduler;
 
 /** @test {delayWhen} */
 describe('Observable.prototype.delayWhen', () => {
-  asDiagram('delay(durationSelector)')('should delay by duration selector', () => {
+  asDiagram('delayWhen(durationSelector)')('should delay by duration selector', () => {
     const e1 =        hot('---a---b---c--|');
     const expected =      '-----a------c----(b|)';
     const subs =          '^                !';

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -7,11 +7,41 @@ import {Notification} from '../Notification';
 import {Observable} from '../Observable';
 
 /**
- * Returns an Observable that delays the emission of items from the source Observable
- * by a given timeout or until a given Date.
- * @param {number|Date} delay the timeout value or date until which the emission of the source items is delayed.
- * @param {Scheduler} [scheduler] the Scheduler to use for managing the timers that handle the timeout for each item.
- * @return {Observable} an Observable that delays the emissions of the source Observable by the specified timeout or Date.
+ * Delays the emission of items from the source Observable by a given timeout or
+ * until a given Date.
+ *
+ * <span class="informal">Time order shifts each item by some specified amount of
+ * milliseconds.</span>
+ *
+ * <img src="./img/delay.png" width="100%">
+ *
+ * If the delay argument is a Number, this operator time shifts the source
+ * Observable by that amount of time expressed in milliseconds. The relative
+ * time intervals between the values are preserved.
+ *
+ * If the delay argument is a Date, this operator time shifts the start of the
+ * Observable execution until the given date occurs.
+ *
+ * @example <caption>Delay each click by one second</caption>
+ * var clicks = Rx.Observable.fromEvent(document, 'click');
+ * var delayedClicks = clicks.delay(1000); // each click emitted after 1 second
+ * delayedClicks.subscribe(x => console.log(x));
+ *
+ * @example <caption>Delay all clicks until a future date happens</caption>
+ * var clicks = Rx.Observable.fromEvent(document, 'click');
+ * var date = new Date('March 15, 2050 12:00:00'); // in the future
+ * var delayedClicks = clicks.delay(date); // click emitted only after that date
+ * delayedClicks.subscribe(x => console.log(x));
+ *
+ * @see {@link debounceTime}
+ * @see {@link delayWhen}
+ *
+ * @param {number|Date} delay The delay duration in milliseconds (a `number`) or
+ * a `Date` until which the emission of the source items is delayed.
+ * @param {Scheduler} [scheduler=async] The Scheduler to use for
+ * managing the timers that handle the time-shift for each item.
+ * @return {Observable} An Observable that delays the emissions of the source
+ * Observable by the specified timeout or Date.
  * @method delay
  * @owner Observable
  */

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -6,20 +6,43 @@ import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
 /**
- * Converts an Observable that emits Observables into an Observable that emits the items emitted by the most recently
- * emitted of those Observables.
+ * Converts a higher-order Observable into a first-order Observable by only the
+ * most recently emitted of those nested Observables.
+ *
+ * <span class="informal">Flattens an Observable-of-Observables by dropping the
+ * previous nested Observable once a new one appears.</span>
  *
  * <img src="./img/switch.png" width="100%">
  *
- * Switch subscribes to an Observable that emits Observables. Each time it observes one of these emitted Observables,
- * the Observable returned by switchOnNext begins emitting the items emitted by that Observable. When a new Observable
- * is emitted, switchOnNext stops emitting items from the earlier-emitted Observable and begins emitting items from the
- * new one.
+ * `switch` subscribes to an Observable that emits Observables,
+ * also known as a higher-order Observable. Each time it observes one of these
+ * emitted nested Observables, the output Observable begins emitting the items
+ * emitted by that nested Observable. So far, it behaves like {@link mergeAll}.
+ * However, when a new nested Observable is emitted, `switch` stops emitting
+ * items from the earlier-emitted nested Observable and begins emitting items
+ * from the new one. It continues to behave like this for subsequent nested
+ * Observables.
  *
- * @param {Function} a predicate function to evaluate items emitted by the source Observable.
- * @return {Observable<T>} an Observable that emits the items emitted by the Observable most recently emitted by the
- * source Observable.
+ * @example <caption>Rerun an interval Observable on every click event</caption>
+ * var clicks = Rx.Observable.fromEvent(document, 'click');
+ * // Each click event is mapped to an Observable that ticks every second
+ * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000));
+ * var switched = higherOrder.switch();
+ * // The outcome is that `switched` is essentially a timer that restarts
+ * // on every click. The interval Observables from older clicks do not merge
+ * // with the current interval Observable.
+ * switched.subscribe(x => console.log(x));
+ *
+ * @see {@link combineAll}
+ * @see {@link concatAll}
+ * @see {@link exhaust}
+ * @see {@link mergeAll}
+ * @see {@link zipAll}
+ *
+ * @return {Observable<T>} An Observable that emits the items emitted by the
+ * Observable most recently emitted by the source Observable.
  * @method switch
+ * @name switch
  * @owner Observable
  */
 export function _switch<T>(): T {


### PR DESCRIPTION
**Description:**
I'm starting to document each operator in details and this first PR is just to demonstrate my general approach to document an operator. There are two operators documented here: `delay` and `switch`. The structure is:

1. **Short headline** describing the operator
2. **Short "informal" description** of the operator. Think of this as "the operator explained for dummies". Rx4 docs suffered from overly-technical and accurate descriptions which made it hard for normal humans to parse in their brains. I'm trying to provide both formal and informal descriptions.
3. **Marble diagram**
4. **Longer formal/technical description**
5. **Signature**: params and return
6. **Example code** that actually makes sense in the real world
7. **Link to the tests**

Here is how `delay` and `switch` look like. @blesh @trxcllnt @jhusain your feedback here is important, whether this structure is good. If it's good, I'll just go ahead and do this for all operators.

![screen shot 2016-03-15 at 17 24 34](https://cloud.githubusercontent.com/assets/90512/13783487/57f499d2-ead4-11e5-8097-138e639f20ed.png)
  
![screen shot 2016-03-15 at 17 25 55](https://cloud.githubusercontent.com/assets/90512/13783494/5e062f8e-ead4-11e5-8f61-95a4f98b2b3e.png)


**Related issue (if exists):**
#1060, #1242
