### PR TITLE
Observables will not be in ES7

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ Automatically generated documentation can be found on the ReactiveX website: htt
 ## Goals
 
 - Provide better performance than preceding versions of RxJS
-- To model/follow the [ES7 Observable Spec](https://github.com/zenparsing/es-observable) to the observable.
+- To model/follow the [Observable Spec Proposal](https://github.com/zenparsing/es-observable) to the observable.
 - Provide more modular file structure in a variety of formats
 - Provide more debuggable call stacks than preceding versions of RxJS
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**

Observables did not make it into ES7 (not much did) which is feature frozen. I changed the wording to indicate proposal instead. I am glad to reword that if necessary.