### PR TITLE
docs(reference): hide irrelevant Observable subclasses

### DIFF
--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -9,6 +9,9 @@ import {rxSubscriber} from './symbol/rxSubscriber';
 import {throwError} from './util/throwError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 
+/**
+ * @class Subject<T>
+ */
 export class Subject<T> extends Observable<T> implements Observer<T>, Subscription {
 
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): Subject<T> => {
@@ -221,6 +224,11 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
   }
 }
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
 class SubjectObservable<T> extends Observable<T> {
   constructor(source: Subject<T>) {
     super();

--- a/src/observable/ArrayLikeObservable.ts
+++ b/src/observable/ArrayLikeObservable.ts
@@ -5,6 +5,11 @@ import {EmptyObservable} from './EmptyObservable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
 export class ArrayLikeObservable<T> extends Observable<T> {
 
   private mapFn: (x: T, y: number) => T;

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -7,19 +7,21 @@ import {isScheduler} from '../util/isScheduler';
 import {Subscription} from '../Subscription';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class ArrayObservable<T> extends Observable<T> {
 
   /**
    * @param array
    * @param scheduler
-   * @return {ArrayObservable}
+   * @return {Observable}
    * @static true
    * @name fromArray
    * @owner Observable
    */
-  static create<T>(array: T[], scheduler?: Scheduler) {
+  static create<T>(array: T[], scheduler?: Scheduler): Observable<T> {
     return new ArrayObservable(array, scheduler);
   }
 

--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -7,7 +7,9 @@ import {errorObject} from '../util/errorObject';
 import {AsyncSubject} from '../subject/AsyncSubject';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class BoundCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -7,7 +7,9 @@ import {errorObject} from '../util/errorObject';
 import {AsyncSubject} from '../subject/AsyncSubject';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class BoundNodeCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -3,6 +3,9 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ * @class ConnectableObservable<T>
+ */
 export class ConnectableObservable<T> extends Observable<T> {
 
   protected subject: Subject<T>;
@@ -62,6 +65,11 @@ class ConnectableSubscription extends Subscription {
   }
 }
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
 class RefCountObservable<T> extends Observable<T> {
   connection: Subscription;
 

--- a/src/observable/DeferObservable.ts
+++ b/src/observable/DeferObservable.ts
@@ -4,7 +4,9 @@ import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class DeferObservable<T> extends Observable<T> {
 

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -4,13 +4,15 @@ import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class EmptyObservable<T> extends Observable<T> {
 
   /**
    * @param scheduler
-   * @return {EmptyObservable<T>}
+   * @return {Observable<T>}
    * @static true
    * @name empty
    * @owner Observable

--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -3,7 +3,9 @@ import {Observable} from '../Observable';
 import {Subscription} from '../Subscription';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class ErrorObservable extends Observable<any> {
 

--- a/src/observable/ForkJoinObservable.ts
+++ b/src/observable/ForkJoinObservable.ts
@@ -6,7 +6,9 @@ import {isPromise} from '../util/isPromise';
 import {isArray} from '../util/isArray';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class ForkJoinObservable<T> extends Observable<T> {
   constructor(private sources: Array<Observable<any> | Promise<any>>,

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -35,7 +35,9 @@ function isEventTarget(sourceObj: any): sourceObj is EventTarget {
 export type EventTargetLike = EventTarget | NodeStyleEventEmmitter | JQueryStyleEventEmitter | NodeList | HTMLCollection;
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class FromEventObservable<T, R> extends Observable<T> {
 

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -5,7 +5,9 @@ import {errorObject} from '../util/errorObject';
 import {Subscriber} from '../Subscriber';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class FromEventPatternObservable<T, R> extends Observable<T> {
 

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -16,7 +16,9 @@ import {ObserveOnSubscriber} from '../operator/observeOn';
 const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 'number');
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class FromObservable<T> extends Observable<T> {
   constructor(private ish: ObservableInput<T>, private scheduler: Scheduler) {

--- a/src/observable/IfObservable.ts
+++ b/src/observable/IfObservable.ts
@@ -2,6 +2,11 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
 export class IfObservable<T, R> extends Observable<T> {
 
   static create<T, R>(condition: () => boolean,

--- a/src/observable/IntervalObservable.ts
+++ b/src/observable/IntervalObservable.ts
@@ -5,7 +5,9 @@ import {Observable} from '../Observable';
 import {async} from '../scheduler/async';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class IntervalObservable extends Observable<number> {
   /**

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -9,6 +9,11 @@ import {errorObject} from '../util/errorObject';
 import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
 export class IteratorObservable<T> extends Observable<T> {
   private iterator: any;
 

--- a/src/observable/NeverObservable.ts
+++ b/src/observable/NeverObservable.ts
@@ -3,7 +3,9 @@ import {Subscriber} from '../Subscriber';
 import {noop} from '../util/noop';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class NeverObservable<T> extends Observable<T> {
   /**

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -5,7 +5,9 @@ import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class PromiseObservable<T> extends Observable<T> {
 

--- a/src/observable/RangeObservable.ts
+++ b/src/observable/RangeObservable.ts
@@ -4,7 +4,9 @@ import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class RangeObservable extends Observable<number> {
 

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -3,6 +3,11 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
 export class ScalarObservable<T> extends Observable<T> {
   static create<T>(value: T, scheduler?: Scheduler): ScalarObservable<T> {
     return new ScalarObservable(value, scheduler);

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -5,6 +5,11 @@ import {Observable} from '../Observable';
 import {asap} from '../scheduler/asap';
 import {isNumeric} from '../util/isNumeric';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
 export class SubscribeOnObservable<T> extends Observable<T> {
   static create<T>(source: Observable<T>, delay: number = 0, scheduler: Scheduler = asap): Observable<T> {
     return new SubscribeOnObservable(source, delay, scheduler);

--- a/src/observable/TimerObservable.ts
+++ b/src/observable/TimerObservable.ts
@@ -8,7 +8,9 @@ import {Subscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class TimerObservable extends Observable<number> {
 

--- a/src/observable/UsingObservable.ts
+++ b/src/observable/UsingObservable.ts
@@ -2,6 +2,11 @@ import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
 export class UsingObservable<T> extends Observable<T> {
 
   static create<T>(resourceFactory: () => Subscription,

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -71,28 +71,41 @@ export function ajaxGetJSON<T, R>(url: string, resultSelector?: (data: T) => R, 
   const finalResultSelector = resultSelector ? (res: AjaxResponse) => resultSelector(res.response) : (res: AjaxResponse) => res.response;
   return new AjaxObservable<R>({ method: 'GET', url, responseType: 'json', resultSelector: finalResultSelector, headers });
 };
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
+export class AjaxObservable<T> extends Observable<T> {
   /**
-   * Creates an observable for an Ajax request with either a request object with url, headers, etc or a string for a URL.
+   * Creates an observable for an Ajax request with either a request object with
+   * url, headers, etc or a string for a URL.
    *
    * @example
-   *   source = Rx.Observable.ajax('/products');
-   *   source = Rx.Observable.ajax( url: 'products', method: 'GET' });
+   * source = Rx.Observable.ajax('/products');
+   * source = Rx.Observable.ajax( url: 'products', method: 'GET' });
    *
-   * @param {Object} request Can be one of the following:
-   *
-   *  A string of the URL to make the Ajax call.
-   *  An object with the following properties
+   * @param {string|Object} request Can be one of the following:
+   *   A string of the URL to make the Ajax call.
+   *   An object with the following properties
    *   - url: URL of the request
    *   - body: The body of the request
    *   - method: Method of the request, such as GET, POST, PUT, PATCH, DELETE
    *   - async: Whether the request is async
    *   - headers: Optional headers
    *   - crossDomain: true if a cross domain request, else false
-   *   - createXHR: a function to override if you need to use an alternate XMLHttpRequest implementation.
-   *   - resultSelector: a function to use to alter the output value type of the Observable. Gets {AjaxResponse} as an argument
+   *   - createXHR: a function to override if you need to use an alternate
+   *   XMLHttpRequest implementation.
+   *   - resultSelector: a function to use to alter the output value type of
+   *   the Observable. Gets {@link AjaxResponse} as an argument.
    * @return {Observable} An observable sequence containing the XMLHttpRequest.
+   * @static true
+   * @name ajax
+   * @owner Observable
   */
-export class AjaxObservable<T> extends Observable<T> {
+  static _create_stub(): void { return null; }
+
   static create: AjaxCreationMethod = (() => {
     const create: any = (urlOrRequest: string | AjaxRequest) => {
       return new AjaxObservable(urlOrRequest);

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -21,7 +21,9 @@ export interface WebSocketSubjectConfig {
 }
 
 /**
- *
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
  */
 export class WebSocketSubject<T> extends Subject<T> {
   url: string;

--- a/src/operator/delayWhen.ts
+++ b/src/operator/delayWhen.ts
@@ -114,6 +114,11 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 }
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
 class SubscriptionDelayObservable<T> extends Observable<T> {
   constructor(protected source: Observable<T>, private subscriptionDelay: Observable<any>) {
     super();

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -8,15 +8,22 @@ import {FastMap} from '../util/FastMap';
 
 /**
  * Groups the items emitted by an Observable according to a specified criterion,
- * and emits these grouped items as `GroupedObservables`, one `GroupedObservable` per group.
+ * and emits these grouped items as `GroupedObservables`, one
+ * {@link GroupedObservable} per group.
  *
  * <img src="./img/groupBy.png" width="100%">
  *
- * @param {Function} keySelector - a function that extracts the key for each item
- * @param {Function} elementSelector - a function that extracts the return element for each item
- * @return {Observable} an Observable that emits GroupedObservables, each of which corresponds
- * to a unique key value and each of which emits those items from the source Observable that share
- * that key value.
+ * @param {function(value: T): K} keySelector a function that extracts the key
+ * for each item.
+ * @param {function(value: T): R} [elementSelector] a function that extracts the
+ * return element for each item.
+ * @param {function(grouped: GroupedObservable<K,R>): Observable<any>} [durationSelector]
+ * a function that returns an Observable to determine how long each group should
+ * exist.
+ * @return {Observable<GroupedObservable<K,R>>} an Observable that emits
+ * GroupedObservables, each of which corresponds to a unique key value and each
+ * of which emits those items from the source Observable that share that key
+ * value.
  * @method groupBy
  * @owner Observable
  */
@@ -211,6 +218,14 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
   }
 }
 
+/**
+ * An Observable representing values belonging to the same group represented by
+ * a common key. The values emitted by a GroupedObservable come from the source
+ * Observable. The common key is available as the field `key` on a
+ * GroupedObservable instance.
+ *
+ * @class GroupedObservable<K, T>
+ */
 export class GroupedObservable<K, T> extends Observable<T> {
   constructor(public key: K,
               private groupSubject: Subject<T>,

--- a/src/subject/AsyncSubject.ts
+++ b/src/subject/AsyncSubject.ts
@@ -2,6 +2,9 @@ import {Subject} from '../Subject';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 
+/**
+ * @class AsyncSubject<T>
+ */
 export class AsyncSubject<T> extends Subject<T> {
   value: T = null;
   hasNext: boolean = false;

--- a/src/subject/BehaviorSubject.ts
+++ b/src/subject/BehaviorSubject.ts
@@ -4,6 +4,9 @@ import {Subscription} from '../Subscription';
 import {throwError} from '../util/throwError';
 import {ObjectUnsubscribedError} from '../util/ObjectUnsubscribedError';
 
+/**
+ * @class BehaviorSubject<T>
+ */
 export class BehaviorSubject<T> extends Subject<T> {
 
   constructor(private _value: T) {

--- a/src/subject/ReplaySubject.ts
+++ b/src/subject/ReplaySubject.ts
@@ -5,6 +5,9 @@ import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
 import {ObserveOnSubscriber} from '../operator/observeOn';
 
+/**
+ * @class ReplaySubject<T>
+ */
 export class ReplaySubject<T> extends Subject<T> {
   private events: ReplayEvent<T>[] = [];
   private scheduler: Scheduler;

--- a/src/testing/ColdObservable.ts
+++ b/src/testing/ColdObservable.ts
@@ -7,6 +7,11 @@ import {SubscriptionLoggable} from './SubscriptionLoggable';
 import {applyMixins} from '../util/applyMixins';
 import {Subscriber} from '../Subscriber';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
 export class ColdObservable<T> extends Observable<T> implements SubscriptionLoggable {
   public subscriptions: SubscriptionLog[] = [];
   scheduler: Scheduler;

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -7,6 +7,11 @@ import {SubscriptionLog} from './SubscriptionLog';
 import {SubscriptionLoggable} from './SubscriptionLoggable';
 import {applyMixins} from '../util/applyMixins';
 
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
 export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable {
   public subscriptions: SubscriptionLog[] = [];
   scheduler: Scheduler;

--- a/tools/custom-esdoc-plugin.js
+++ b/tools/custom-esdoc-plugin.js
@@ -1,42 +1,48 @@
-// Fixes ESDoc structure by moving all "add-able" operator functions
-// (either prototype operator or static operator) under the Observable class.
-// Looks for the "@owner" tag, then moves the thing to that owner. "@owner" is
-// usually "Observable", but may be something else.
-exports.onHandleTag = function onHandleTag(ev) {
-  function getTagValue(tag, tagName) {
-    var unknownTags = tag.unknown;
-    if (!unknownTags) {
-      return null;
-    }
-    var unknownTagsLength = unknownTags.length;
-    for (var i = 0; i < unknownTagsLength; i++) {
-      if (unknownTags[i].tagName === tagName) {
-        return unknownTags[i].tagValue;
-      }
-    }
+function getTagValue(tag, tagName) {
+  var unknownTags = tag.unknown;
+  if (!unknownTags) {
     return null;
   }
-
-  function getLongname(name) {
-    var index = ev.data.tag.findIndex(function (t) {
-      return t.name === name;
-    });
-    if (index === -1) {
-      throw new Error('Could not find longname for unknown tag named "' + name +
-        '"');
-    } else {
-      return ev.data.tag[index].longname;
+  var unknownTagsLength = unknownTags.length;
+  for (var i = 0; i < unknownTagsLength; i++) {
+    if (unknownTags[i].tagName === tagName) {
+      return unknownTags[i].tagValue;
     }
   }
+  return null;
+}
 
+function getLongname(ev, name) {
+  var index = ev.data.tag.findIndex(function (t) {
+    return t.name === name;
+  });
+  if (index === -1) {
+    throw new Error('Could not find longname for unknown tag named "' + name +
+      '"');
+  } else {
+    return ev.data.tag[index].longname;
+  }
+}
+
+/**
+ * Fixes ESDoc structure by moving all "add-able" operator functions
+ * (either prototype operator or static operator) under the Observable class.
+ * Looks for the "@owner" tag, then moves the thing to that owner. "@owner" is
+ * usually "Observable", but may be something else.
+ */
+exports.onHandleTag = function onHandleTag(ev) {
   var tagsLen = ev.data.tag.length;
   for (var i = 0; i < tagsLen; i++) {
     var tag = ev.data.tag[i];
     var owner = getTagValue(tag, '@owner');
     var name = getTagValue(tag, '@name');
     var isStatic = getTagValue(tag, '@static');
-    if (owner) {
-      var ownerLongname = getLongname(owner);
+    var isHidden = getTagValue(tag, '@hide');
+    if (isHidden) {
+      ev.data.tag[i] = {name: '', longname: ''};
+      ev.data.tag[i]['export'] = false;
+    } else if (owner) {
+      var ownerLongname = getLongname(ev, owner);
       tag.kind = 'method';
       tag.static = false;
       tag.memberof = ownerLongname;


### PR DESCRIPTION
**Description:**
Transient Observables like ErrorObservable are made hidden by this commit. This cleans up the
documentation in Observable listing all its subclasses. Transient Observable subclasses are
irrelevant in the documentation since they cannot be directly used by the API.

## Before:

<img width="1051" alt="screen shot 2016-03-16 at 17 16 57" src="https://cloud.githubusercontent.com/assets/90512/13817458/ed3a772a-eb9a-11e5-8f1f-e697ed896260.png">

## After:

<img width="849" alt="screen shot 2016-03-16 at 17 14 08" src="https://cloud.githubusercontent.com/assets/90512/13817399/b51530f6-eb9a-11e5-9e71-9ef7aaec0bbb.png">

**Related issue (if exists):**

#1060, #1242