### PR TITLE
test(deferObservable): add type definition test

### DIFF
--- a/spec/observables/defer-spec.ts
+++ b/spec/observables/defer-spec.ts
@@ -1,5 +1,5 @@
 import * as Rx from '../../dist/cjs/Rx';
-declare const {hot, expectObservable, expectSubscriptions};
+declare const {hot, expectObservable, expectSubscriptions, type};
 
 const Observable = Rx.Observable;
 
@@ -40,9 +40,9 @@ describe('Observable.defer', () => {
 
   it('should create an observable when factory throws', () => {
     //type definition need to be updated
-    const e1 = Observable.defer(<any>(() => {
+    const e1 = Observable.defer(() => {
       throw 'error';
-    }));
+    });
     const expected = '#';
 
     expectObservable(e1).toBe(expected);
@@ -71,5 +71,17 @@ describe('Observable.defer', () => {
 
     expectObservable(e1, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+  });
+
+  type(() => {
+    const typeValue = {
+      val: 3,
+      str: 'str'
+    };
+
+    Observable.defer(() => Observable.of(typeValue)).subscribe(x => { x.str.toString(); });
+    Observable.defer(() => {
+      throw 'error';
+    }).subscribe();
   });
 });

--- a/src/observable/DeferObservable.ts
+++ b/src/observable/DeferObservable.ts
@@ -15,11 +15,11 @@ export class DeferObservable<T> extends Observable<T> {
    * @name defer
    * @owner Observable
    */
-  static create<T>(observableFactory: () => Observable<T>): Observable<T> {
+  static create<T>(observableFactory: () => Observable<T> | void): Observable<T> {
     return new DeferObservable(observableFactory);
   }
 
-  constructor(private observableFactory: () => Observable<T>) {
+  constructor(private observableFactory: () => Observable<T> | void) {
     super();
   }
 
@@ -28,7 +28,7 @@ export class DeferObservable<T> extends Observable<T> {
     if (result === errorObject) {
       subscriber.error(errorObject.e);
     } else {
-      result.subscribe(subscriber);
+      (<Observable<T>>result).subscribe(subscriber);
     }
   }
 }


### PR DESCRIPTION
**Description:**

This PR adds type definition test for `deferObservable`, as well as amending parameter type to allow function can throw without return value.

**Related issue (if exists):**

**Additional**

Issue at Typescript (https://github.com/Microsoft/TypeScript/issues/1042) will allow non-void function can throw once it's arrived.
