### PR TITLE
docs(manual): update image references

### DIFF
--- a/doc/operators.md
+++ b/doc/operators.md
@@ -96,7 +96,7 @@ To explain how operators work, textual descriptions are often not enough. Many o
 
 Below you can see the anatomy of a marble diagram.
 
-<img src="./asset/marble-diagram-anatomy.svg">
+![Anatomy of marble diagrams](https://cdn.rawgit.com/ReactiveX/RxJS/master/doc/asset/marble-diagram-anatomy.svg)
 
 Throughout this documentation site, we extensively use marble diagrams to explain how operators work. They may be really useful in other contexts too, like on a whiteboard or even in our unit tests (as ASCII diagrams).
 


### PR DESCRIPTION
**Description:**

It is not clearly known, but github seems prevent to render svg content in repo as markdown content, serves as plain text directly. (http://stackoverflow.com/a/21521184 / https://github.com/isaacs/github/issues/316)
This PR updates image reference to use rawgit (https://rawgit.com/) serves correct content type.

Maybe just replace image to non-svg would be better solution? /cc @staltz 