### PR TITLE
fix(windowToggle): handle closingSelector completes immediately

### DIFF
--- a/spec/operators/windowToggle-spec.ts
+++ b/spec/operators/windowToggle-spec.ts
@@ -407,4 +407,22 @@ describe('Observable.prototype.windowToggle', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
+
+  it ('should handle empty closing observable', () => {
+    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+    const e1subs =      '^                                  !';
+    const e2 = cold(    '---o---------------o-----------|    ');
+    const e2subs =      '^                              !    ';
+    const e3 =  Observable.empty();
+    const expected =    '---x---------------y---------------|';
+    const x = cold(        '|');
+    const y = cold(                        '|');
+    const values = { x: x, y: y };
+
+    const result = e1.windowToggle(e2, () => e3);
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
 });

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -131,10 +131,16 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
         const context = { window, subscription };
         this.contexts.push(context);
         const innerSubscription = subscribeToResult(this, closingNotifier, context);
-        (<any> innerSubscription).context = context;
-        subscription.add(innerSubscription);
+
+        if (innerSubscription.isUnsubscribed) {
+          this.closeWindow(this.contexts.length - 1);
+        } else {
+          (<any> innerSubscription).context = context;
+          subscription.add(innerSubscription);
+        }
 
         this.destination.next(window);
+
       }
     } else {
       this.closeWindow(this.contexts.indexOf(outerValue));
@@ -151,7 +157,11 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
     }
   }
 
-  closeWindow(index: number) {
+  private closeWindow(index: number): void {
+    if (index === -1) {
+      return;
+    }
+
     const { contexts } = this;
     const context = contexts[index];
     const { window, subscription } = context;


### PR DESCRIPTION
**Description:**

This PR handles cases where `closingSelector` returns immediately completing observables (i.e `emptyObservable`) which invokes `notifyComplete` synchronously, not able to close constructed window by not having its context. 

**Related issue (if exists):**

closes #1487

This may not be ideal fixes for issue, any suggestion would be appreciated. /cc @staltz also for visibility & review.