### PR TITLE
fix: make compatible with esperanto

### DIFF
--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -22,7 +22,7 @@ export interface AjaxRequest {
   responseType?: string;
 }
 
-const createXHRDefault = (): XMLHttpRequest => {
+function createXHRDefault(): XMLHttpRequest {
   let xhr = new root.XMLHttpRequest();
   if (this.crossDomain) {
     if ('withCredentials' in xhr) {
@@ -36,7 +36,7 @@ const createXHRDefault = (): XMLHttpRequest => {
   } else {
     return xhr;
   }
-};
+}
 
 export interface AjaxCreationMethod {
   <T>(urlOrRequest: string | AjaxRequest): Observable<T>;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Esperanto complains about a [top level reference to `this` in AjaxObservable](https://github.com/ReactiveX/RxJS/blob/master/src/observable/dom/AjaxObservable.ts#L27). This PR replaces the fat arrow function with a traditional function so that `this` refers to [AjaxRequest](https://github.com/ReactiveX/RxJS/blob/master/src/observable/dom/AjaxObservable.ts#L128).

**Related issue (if exists):**


