### PR TITLE
Update bufferToggle closingSelector to accept promise / empty

### DIFF
--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -35,9 +35,9 @@ import {InnerSubscriber} from '../InnerSubscriber';
  * @see {@link bufferWhen}
  * @see {@link windowToggle}
  *
- * @param {Observable<O>} openings An observable of notifications to start new
+ * @param {SubscribableOrPromise<O>} openings A Subscribable or Promise of notifications to start new
  * buffers.
- * @param {function(value: O): Observable} closingSelector A function that takes
+ * @param {function(value: O): SubscribableOrPromise} closingSelector A function that takes
  * the value emitted by the `openings` observable and returns a Subscribable or Promise,
  * which, when it emits, signals that the associated buffer should be emitted
  * and cleared.
@@ -45,19 +45,19 @@ import {InnerSubscriber} from '../InnerSubscriber';
  * @method bufferToggle
  * @owner Observable
  */
-export function bufferToggle<T, O>(openings: Observable<O>,
-                                   closingSelector: (value: O) => SubscribableOrPromise<any> | void): Observable<T[]> {
+export function bufferToggle<T, O>(openings: SubscribableOrPromise<O>,
+                                   closingSelector: (value: O) => SubscribableOrPromise<any>): Observable<T[]> {
   return this.lift(new BufferToggleOperator<T, O>(openings, closingSelector));
 }
 
 export interface BufferToggleSignature<T> {
-  <O>(openings: Observable<O>, closingSelector: (value: O) => SubscribableOrPromise<any> | void): Observable<T[]>;
+  <O>(openings: SubscribableOrPromise<O>, closingSelector: (value: O) => SubscribableOrPromise<any>): Observable<T[]>;
 }
 
 class BufferToggleOperator<T, O> implements Operator<T, T[]> {
 
-  constructor(private openings: Observable<O>,
-              private closingSelector: (value: O) => SubscribableOrPromise<any> | void) {
+  constructor(private openings: SubscribableOrPromise<O>,
+              private closingSelector: (value: O) => SubscribableOrPromise<any>) {
   }
 
   call(subscriber: Subscriber<T[]>): Subscriber<T> {
@@ -79,10 +79,10 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
   private contexts: Array<BufferContext<T>> = [];
 
   constructor(destination: Subscriber<T[]>,
-              private openings: Observable<O>,
+              private openings: SubscribableOrPromise<O>,
               private closingSelector: (value: O) => SubscribableOrPromise<any> | void) {
     super(destination);
-    this.add(this.openings.subscribe(new BufferToggleOpeningsSubscriber(this)));
+    this.add(subscribeToResult(this, openings));
   }
 
   protected _next(value: T): void {
@@ -118,7 +118,17 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
     super._complete();
   }
 
-  openBuffer(value: O): void {
+  notifyNext(outerValue: any, innerValue: O,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, O>): void {
+    outerValue ? this.closeBuffer(outerValue) : this.openBuffer(innerValue);
+  }
+
+  notifyComplete(innerSub: InnerSubscriber<T, O>): void {
+    this.closeBuffer((<any> innerSub).context);
+  }
+
+  private openBuffer(value: O): void {
     try {
       const closingSelector = this.closingSelector;
       const closingNotifier = closingSelector.call(this, value);
@@ -128,16 +138,6 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
     } catch (err) {
       this._error(err);
     }
-  }
-
-  notifyNext(outerValue: any, innerValue: O,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, O>): void {
-    this.closeBuffer(outerValue);
-  }
-
-  notifyComplete(innerSub: InnerSubscriber<T, O>): void {
-    this.closeBuffer((<any> innerSub).context);
   }
 
   private closeBuffer(context: BufferContext<T>): void {
@@ -162,36 +162,13 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
 
     const innerSubscription = subscribeToResult(this, closingNotifier, <any>context);
 
-    if (!innerSubscription.isUnsubscribed) {
+    if (!innerSubscription || innerSubscription.isUnsubscribed) {
+      this.closeBuffer(context);
+    } else {
       (<any> innerSubscription).context = context;
 
       this.add(innerSubscription);
       subscription.add(innerSubscription);
-    } else {
-      this.closeBuffer(context);
     }
-  }
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class BufferToggleOpeningsSubscriber<T, O> extends Subscriber<O> {
-  constructor(private parent: BufferToggleSubscriber<T, O>) {
-    super(null);
-  }
-
-  protected _next(value: O) {
-    this.parent.openBuffer(value);
-  }
-
-  protected _error(err: any) {
-    this.parent.error(err);
-  }
-
-  protected _complete() {
-    // noop
   }
 }

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -1,9 +1,11 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {Observable} from '../Observable';
+import {Observable, SubscribableOrPromise} from '../Observable';
 import {Subscription} from '../Subscription';
-import {tryCatch} from '../util/tryCatch';
-import {errorObject} from '../util/errorObject';
+
+import {subscribeToResult} from '../util/subscribeToResult';
+import {OuterSubscriber} from '../OuterSubscriber';
+import {InnerSubscriber} from '../InnerSubscriber';
 
 /**
  * Buffers the source Observable values starting from an emission from
@@ -17,7 +19,7 @@ import {errorObject} from '../util/errorObject';
  *
  * Buffers values from the source by opening the buffer via signals from an
  * Observable provided to `openings`, and closing and sending the buffers when
- * an Observable returned by the `closingSelector` function emits.
+ * a Subscribable or Promise returned by the `closingSelector` function emits.
  *
  * @example <caption>Every other second, emit the click events from the next 500ms</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
@@ -36,7 +38,7 @@ import {errorObject} from '../util/errorObject';
  * @param {Observable<O>} openings An observable of notifications to start new
  * buffers.
  * @param {function(value: O): Observable} closingSelector A function that takes
- * the value emitted by the `openings` observable and returns an Observable,
+ * the value emitted by the `openings` observable and returns a Subscribable or Promise,
  * which, when it emits, signals that the associated buffer should be emitted
  * and cleared.
  * @return {Observable<T[]>} An observable of arrays of buffered values.
@@ -44,18 +46,18 @@ import {errorObject} from '../util/errorObject';
  * @owner Observable
  */
 export function bufferToggle<T, O>(openings: Observable<O>,
-                                   closingSelector: (value: O) => Observable<any>): Observable<T[]> {
+                                   closingSelector: (value: O) => SubscribableOrPromise<any> | void): Observable<T[]> {
   return this.lift(new BufferToggleOperator<T, O>(openings, closingSelector));
 }
 
 export interface BufferToggleSignature<T> {
-  <O>(openings: Observable<O>, closingSelector: (value: O) => Observable<any>): Observable<T[]>;
+  <O>(openings: Observable<O>, closingSelector: (value: O) => SubscribableOrPromise<any> | void): Observable<T[]>;
 }
 
 class BufferToggleOperator<T, O> implements Operator<T, T[]> {
 
   constructor(private openings: Observable<O>,
-              private closingSelector: (value: O) => Observable<any>) {
+              private closingSelector: (value: O) => SubscribableOrPromise<any> | void) {
   }
 
   call(subscriber: Subscriber<T[]>): Subscriber<T> {
@@ -73,17 +75,17 @@ interface BufferContext<T> {
  * @ignore
  * @extends {Ignored}
  */
-class BufferToggleSubscriber<T, O> extends Subscriber<T> {
+class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
   private contexts: Array<BufferContext<T>> = [];
 
   constructor(destination: Subscriber<T[]>,
               private openings: Observable<O>,
-              private closingSelector: (value: O) => Observable<any>) {
+              private closingSelector: (value: O) => SubscribableOrPromise<any> | void) {
     super(destination);
     this.add(this.openings.subscribe(new BufferToggleOpeningsSubscriber(this)));
   }
 
-  protected _next(value: T) {
+  protected _next(value: T): void {
     const contexts = this.contexts;
     const len = contexts.length;
     for (let i = 0; i < len; i++) {
@@ -91,7 +93,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     }
   }
 
-  protected _error(err: any) {
+  protected _error(err: any): void {
     const contexts = this.contexts;
     while (contexts.length > 0) {
       const context = contexts.shift();
@@ -103,7 +105,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     super._error(err);
   }
 
-  protected _complete() {
+  protected _complete(): void {
     const contexts = this.contexts;
     while (contexts.length > 0) {
       const context = contexts.shift();
@@ -116,27 +118,29 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     super._complete();
   }
 
-  openBuffer(value: O) {
-    const closingSelector = this.closingSelector;
-    const contexts = this.contexts;
-
-    let closingNotifier = tryCatch(closingSelector)(value);
-    if (closingNotifier === errorObject) {
-      this._error(errorObject.e);
-    } else {
-      let context = {
-        buffer: <T[]>[],
-        subscription: new Subscription()
-      };
-      contexts.push(context);
-      const subscriber = new BufferToggleClosingsSubscriber<T>(this, context);
-      const subscription = closingNotifier.subscribe(subscriber);
-      context.subscription.add(subscription);
-      this.add(subscription);
+  openBuffer(value: O): void {
+    try {
+      const closingSelector = this.closingSelector;
+      const closingNotifier = closingSelector.call(this, value);
+      if (closingNotifier) {
+        this.trySubscribe(closingNotifier);
+      }
+    } catch (err) {
+      this._error(err);
     }
   }
 
-  closeBuffer(context: BufferContext<T>) {
+  notifyNext(outerValue: any, innerValue: O,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, O>): void {
+    this.closeBuffer(outerValue);
+  }
+
+  notifyComplete(innerSub: InnerSubscriber<T, O>): void {
+    this.closeBuffer((<any> innerSub).context);
+  }
+
+  private closeBuffer(context: BufferContext<T>): void {
     const contexts = this.contexts;
     if (contexts === null) {
       return;
@@ -146,6 +150,21 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     contexts.splice(contexts.indexOf(context), 1);
     this.remove(subscription);
     subscription.unsubscribe();
+  }
+
+  private trySubscribe(closingNotifier: any): void {
+    const contexts = this.contexts;
+
+    const buffer: Array<T> = [];
+    const subscription = new Subscription();
+    const context = { buffer, subscription };
+    contexts.push(context);
+
+    const innerSubscription = subscribeToResult(this, closingNotifier, <any>context);
+    (<any> innerSubscription).context = context;
+
+    this.add(innerSubscription);
+    subscription.add(innerSubscription);
   }
 }
 
@@ -169,29 +188,5 @@ class BufferToggleOpeningsSubscriber<T, O> extends Subscriber<O> {
 
   protected _complete() {
     // noop
-  }
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class BufferToggleClosingsSubscriber<T> extends Subscriber<any> {
-  constructor(private parent: BufferToggleSubscriber<T, any>,
-              private context: { subscription: any, buffer: T[] }) {
-    super(null);
-  }
-
-  protected _next() {
-    this.parent.closeBuffer(this.context);
-  }
-
-  protected _error(err: any) {
-    this.parent.error(err);
-  }
-
-  protected _complete() {
-    this.parent.closeBuffer(this.context);
   }
 }


### PR DESCRIPTION
**Description:**

This PR updates behavior of bufferToggle's `closingSelector`

- accepts closingSelector returns promise
- handle cases where closingSelector returns immediately

**Related issue (if exists):**
relates to https://github.com/ReactiveX/RxJS/issues/1487, https://github.com/ReactiveX/RxJS/issues/1246