### PR TITLE
feat(ajax): add FormData support in AjaxObservable and add percent encoding for parameter key in body

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -268,6 +268,101 @@ describe('Observable.ajax', () => {
     });
   });
 
+  describe('ajax request body', () => {
+    let rFormData: FormData;
+
+    beforeEach(() => {
+      rFormData = root.FormData;
+      root.FormData = root.FormData || class {};
+    });
+
+    afterEach(() => {
+      root.FormData = rFormData;
+    });
+
+    it('can take string body', () => {
+      const obj = {
+        url: '/flibbertyJibbet',
+        method: '',
+        body: 'foobar'
+      };
+
+      Rx.Observable.ajax(obj).subscribe();
+
+      expect(MockXMLHttpRequest.mostRecent.url).toBe('/flibbertyJibbet');
+      expect(MockXMLHttpRequest.mostRecent.data).toBe('foobar');
+    });
+
+    it('can take FormData body', () => {
+      const body = new root.FormData();
+      const obj = {
+        url: '/flibbertyJibbet',
+        method: '',
+        body: body
+      };
+
+      Rx.Observable.ajax(obj).subscribe();
+
+      expect(MockXMLHttpRequest.mostRecent.url).toBe('/flibbertyJibbet');
+      expect(MockXMLHttpRequest.mostRecent.data).toBe(body);
+    });
+
+    it('should not fail when FormData is undefined', () => {
+      root.FormData = void 0;
+
+      const obj = {
+        url: '/flibbertyJibbet',
+        method: '',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: { '🌟': '🚀' }
+      };
+
+      Rx.Observable.ajax(obj).subscribe();
+
+      expect(MockXMLHttpRequest.mostRecent.url).toBe('/flibbertyJibbet');
+    });
+
+    it('should send by form-urlencoded format', () => {
+      const body = {
+        '🌟': '🚀'
+      };
+      const obj = {
+        url: '/flibbertyJibbet',
+        method: '',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: body
+      };
+
+      Rx.Observable.ajax(obj).subscribe();
+
+      expect(MockXMLHttpRequest.mostRecent.url).toBe('/flibbertyJibbet');
+      expect(MockXMLHttpRequest.mostRecent.data).toBe('%F0%9F%8C%9F=%F0%9F%9A%80');
+    });
+
+    it('should send by JSON', () => {
+      const body = {
+        '🌟': '🚀'
+      };
+      const obj = {
+        url: '/flibbertyJibbet',
+        method: '',
+        headers: {
+          'Content-Type': 'application/json'
+        },
+        body: body
+      };
+
+      Rx.Observable.ajax(obj).subscribe();
+
+      expect(MockXMLHttpRequest.mostRecent.url).toBe('/flibbertyJibbet');
+      expect(MockXMLHttpRequest.mostRecent.data).toBe('{"🌟":"🚀"}');
+    });
+  });
+
   describe('ajax.get', () => {
     it('should succeed on 200', () => {
       const expected = { foo: 'bar' };

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -245,6 +245,8 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
   private serializeBody(body: any, contentType: string) {
     if (!body || typeof body === 'string') {
       return body;
+    } else if (root.FormData && body instanceof root.FormData) {
+      return body;
     }
 
     const splitIndex = contentType.indexOf(';');
@@ -254,7 +256,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
     switch (contentType) {
       case 'application/x-www-form-urlencoded':
-        return Object.keys(body).map(key => `${key}=${encodeURI(body[key])}`).join('&');
+        return Object.keys(body).map(key => `${encodeURI(key)}=${encodeURI(body[key])}`).join('&');
       case 'application/json':
         return JSON.stringify(body);
     }


### PR DESCRIPTION
**Description:**

add FormData support in AjaxObservable.
I want to upload files by AjaxObservable.

https://developer.mozilla.org/en-US/docs/Web/API/FormData/Using_FormData_Objects
http://caniuse.com/#search=FormData

I can't find test for AjaxSubscriber#serializeBody.
https://github.com/ReactiveX/RxJS/blob/master/spec/observables/dom/ajax-spec.ts

**Related issue (if exists):**

None.
