### PR TITLE
chore(package.json): change typing update script execution lifecycle

### DIFF
--- a/package.json
+++ b/package.json
@@ -84,7 +84,7 @@
     "lint": "npm-run-all lint_src lint_spec lint_perf",
     "perf": "protractor protractor.conf.js",
     "perf_micro": "node ./perf/micro/index.js",
-    "prepublish": "npm run build_all",
+    "prepublish": "rm -rf ./typings && typings install && npm run build_all",
     "publish_docs": "./publish_docs.sh",
     "test_jasmine": "jasmine",
     "test_karma": "karma start karma.conf.js",


### PR DESCRIPTION
**Description:**

There isn't provided way to override `install` script itself (and strongly not recommended), have to rely on lifecycle scripts. `prepublish` is more appropriate lifecycle hook for this issue (https://docs.npmjs.com/misc/scripts) which expected to be triggered after local dev system's `install`. though name's somewhat not clear, `prepublish` is expected to chained after `npm install` (parameterless install) (https://github.com/npm/npm/issues/3059#issuecomment-12282746)

**Related issue (if exists):**

closes #1504