### PR TITLE
chore(package.json): remove redundant script

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
   },
   "scripts": {
     "info": "npm-scripts-info",
-    "postinstall": "typings install",
     "build_all": "npm-run-all build_es6 build_amd build_cjs build_global generate_packages",
     "build_amd": "npm-run-all clean_dist_amd copy_src_amd compile_dist_amd",
     "build_cjs": "npm-run-all clean_dist_cjs copy_src_cjs compile_dist_cjs",


### PR DESCRIPTION
**Description:**
This PR removes redundant `postInstall` script after https://github.com/ReactiveX/rxjs/pull/1509 is introduced.

**Related issue (if exists):**

