### PR TITLE
fix(observable): ensure the subscriber chain is complete before calling this._subscribe

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -251,6 +251,76 @@ describe('Observable', () => {
       expect(messageErrorValue).toBe('boo!');
     });
 
+    it('should ignore next messages after unsubscription', () => {
+      let times = 0;
+
+      new Observable((observer: Rx.Observer<number>) => {
+        observer.next(0);
+        observer.next(0);
+        observer.next(0);
+        observer.next(0);
+      })
+      .do(() => times += 1)
+      .subscribe(
+        function() {
+          if (times === 2) {
+            this.unsubscribe();
+          }
+        }
+      );
+
+      expect(times).toBe(2);
+    });
+
+    it('should ignore error messages after unsubscription', () => {
+      let times = 0;
+      let errorCalled = false;
+
+      new Observable((observer: Rx.Observer<number>) => {
+        observer.next(0);
+        observer.next(0);
+        observer.next(0);
+        observer.error(0);
+      })
+      .do(() => times += 1)
+      .subscribe(
+        function() {
+          if (times === 2) {
+            this.unsubscribe();
+          }
+        },
+        function() { errorCalled = true; }
+      );
+
+      expect(times).toBe(2);
+      expect(errorCalled).toBe(false);
+    });
+
+    it('should ignore complete messages after unsubscription', () => {
+      let times = 0;
+      let completeCalled = false;
+
+      new Observable((observer: Rx.Observer<number>) => {
+        observer.next(0);
+        observer.next(0);
+        observer.next(0);
+        observer.complete();
+      })
+      .do(() => times += 1)
+      .subscribe(
+        function() {
+          if (times === 2) {
+            this.unsubscribe();
+          }
+        },
+        null,
+        function() { completeCalled = true; }
+      );
+
+      expect(times).toBe(2);
+      expect(completeCalled).toBe(false);
+    });
+
     describe('when called with an anonymous observer', () => {
       it('should accept an anonymous observer with just a next function and call the next function in the context' +
         ' of the anonymous observer', (done: DoneSignature) => {
@@ -299,7 +369,7 @@ describe('Observable', () => {
         }).not.toThrow();
       });
 
-      it('should not run unsubscription logic when an error is thrown sending messages synchronously to an' +
+      it('should run unsubscription logic when an error is thrown sending messages synchronously to an' +
         ' anonymous observer', () => {
         let messageError = false;
         let messageErrorValue = false;
@@ -332,6 +402,75 @@ describe('Observable', () => {
         expect(unsubscribeCalled).toBe(true);
         expect(messageError).toBe(true);
         expect(messageErrorValue).toBe('boo!');
+      });
+
+      it('should ignore next messages after unsubscription', () => {
+        let times = 0;
+
+        new Observable((observer: Rx.Observer<number>) => {
+          observer.next(0);
+          observer.next(0);
+          observer.next(0);
+          observer.next(0);
+        })
+        .do(() => times += 1)
+        .subscribe({
+          next() {
+            if (times === 2) {
+              this.unsubscribe();
+            }
+          }
+        });
+
+        expect(times).toBe(2);
+      });
+
+      it('should ignore error messages after unsubscription', () => {
+        let times = 0;
+        let errorCalled = false;
+
+        new Observable((observer: Rx.Observer<number>) => {
+          observer.next(0);
+          observer.next(0);
+          observer.next(0);
+          observer.error(0);
+        })
+        .do(() => times += 1)
+        .subscribe({
+          next() {
+            if (times === 2) {
+              this.unsubscribe();
+            }
+          },
+          error() { errorCalled = true; }
+        });
+
+        expect(times).toBe(2);
+        expect(errorCalled).toBe(false);
+      });
+
+      it('should ignore complete messages after unsubscription', () => {
+        let times = 0;
+        let completeCalled = false;
+
+        new Observable((observer: Rx.Observer<number>) => {
+          observer.next(0);
+          observer.next(0);
+          observer.next(0);
+          observer.complete();
+        })
+        .do(() => times += 1)
+        .subscribe({
+          next() {
+            if (times === 2) {
+              this.unsubscribe();
+            }
+          },
+          complete() { completeCalled = true; }
+        });
+
+        expect(times).toBe(2);
+        expect(completeCalled).toBe(false);
       });
     });
   });

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -356,11 +356,12 @@ describe('Subject', () => {
 
     subject.subscribe(function (x) {
       expect(x).toBe(expected.shift());
-    }, null, done);
+    });
 
     subject.next('foo');
     subject.complete();
-    subject.next('bar');
+    expect(() => subject.next('bar')).toThrow(new Rx.ObjectUnsubscribedError());
+    done();
   });
 
   it('should clean out unsubscribed subscribers', (done: DoneSignature) => {

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -32,4 +32,57 @@ describe('Subscriber', () => {
       expect(completeSpy).not.toHaveBeenCalled();
     });
   });
+
+  it('should ignore next messages after unsubscription', () => {
+    let times = 0;
+
+    const sub = new Subscriber({
+      next() { times += 1; }
+    });
+
+    sub.next();
+    sub.next();
+    sub.unsubscribe();
+    sub.next();
+
+    expect(times).toBe(2);
+  });
+
+  it('should ignore error messages after unsubscription', () => {
+    let times = 0;
+    let errorCalled = false;
+
+    const sub = new Subscriber({
+      next() { times += 1; },
+      error() { errorCalled = true; }
+    });
+
+    sub.next();
+    sub.next();
+    sub.unsubscribe();
+    sub.next();
+    sub.error();
+
+    expect(times).toBe(2);
+    expect(errorCalled).toBe(false);
+  });
+
+  it('should ignore complete messages after unsubscription', () => {
+    let times = 0;
+    let completeCalled = false;
+
+    const sub = new Subscriber({
+      next() { times += 1; },
+      complete() { completeCalled = true; }
+    });
+
+    sub.next();
+    sub.next();
+    sub.unsubscribe();
+    sub.next();
+    sub.complete();
+
+    expect(times).toBe(2);
+    expect(completeCalled).toBe(false);
+  });
 });

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -118,6 +118,10 @@ class SafeSubscriber<T> extends Subscriber<T> {
       next = (<PartialObserver<T>> observerOrNext).next;
       error = (<PartialObserver<T>> observerOrNext).error;
       complete = (<PartialObserver<T>> observerOrNext).complete;
+      if (isFunction(context.unsubscribe)) {
+        this.add(<() => void> context.unsubscribe.bind(context));
+      }
+      context.unsubscribe = this.unsubscribe.bind(this);
     }
 
     this._context = context;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
If an operator subscriber completed (or unsubscribed) early after receiving values from a synchronous source, the subscribers upstream weren't disposed until after returning from the source's subscribe function. When any downstream subscriber unsubscribes, the upstream subscribers should be notified immediately and unsubscribe all the way to the source subscription.

**Related issue (if exists):**
@zenparsing pointed this out in #1513

cc: @blesh 