### PR TITLE
chore(travis): move coverage checker out of script step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - npm run build_spec && npm run test_jasmine && node ./node_modules/markdown-doctest/bin/cmd.js
   - npm run check_circular_dependencies
   - npm run cover
-  - cat ./coverage/coverage-remapped.lcov | ./node_modules/coveralls/bin/coveralls.js
 
 after_success:
+  - cat ./coverage/coverage-remapped.lcov | ./node_modules/coveralls/bin/coveralls.js
   - '[ "${TRAVIS_PULL_REQUEST}" = "false" ] && [ -n "${SAUCE_ACCESS_KEY}" ] && npm run test_karma || false'


### PR DESCRIPTION
**Description:**
Alternative to https://github.com/ReactiveX/rxjs/pull/1449, make code coverage checker optional.

**Related issue (if exists):**
