### PR TITLE
docs(README): fix Travis CI link broken

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Build Status](https://travis-ci.org/ReactiveX/RxJS.svg?branch=master)](https://travis-ci.org/ReactiveX/RxJS)
+[![Build Status](https://travis-ci.org/ReactiveX/rxjs.svg?branch=master)](https://travis-ci.org/ReactiveX/rxjs)
 [![Coverage Status](https://coveralls.io/repos/ReactiveX/RxJS/badge.svg?branch=master&service=github)](https://coveralls.io/github/ReactiveX/RxJS?branch=master)
 [![npm version](https://badge.fury.io/js/%40reactivex%2Frxjs.svg)](http://badge.fury.io/js/%40reactivex%2Frxjs)
 [![Join the chat at https://gitter.im/Reactive-Extensions/RxJS](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/Reactive-Extensions/RxJS?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)


### PR DESCRIPTION
**Description:**
in README.md, Travis CI link is broken.

![reactivex_rxjs__a_reactive_programming_library_for_javascript](https://cloud.githubusercontent.com/assets/125332/13980076/bd3fd3a0-f11f-11e5-831c-1bf9cb7caf94.png)

![travis_ci_-_test_and_deploy_your_code_with_confidence](https://cloud.githubusercontent.com/assets/125332/13980086/dd697da2-f11f-11e5-94a2-8d928db6d348.png)

https://travis-ci.org/ReactiveX/rxjs.svg?branch=master
[![Build Status](https://travis-ci.org/ReactiveX/rxjs.svg?branch=master)](https://travis-ci.org/ReactiveX/rxjs)

**Related issue (if exists):**

None