### PR TITLE
refactor(Subscription): split 'Subscription' class into class and interface

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -189,7 +189,7 @@ describe('Observable', () => {
       const sub = source.subscribe(() => {
         //noop
        });
-      expect(sub instanceof Rx.Subscription).toBe(true);
+      expect(sub instanceof Rx.CompositeSubscription).toBe(true);
       expect(unsubscribeCalled).toBe(false);
       expect(typeof sub.unsubscribe).toBe('function');
 

--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -2,7 +2,7 @@ import * as Rx from '../dist/cjs/Rx';
 import {DoneSignature} from './helpers/test-helper';
 
 const Observable = Rx.Observable;
-const Subscription = Rx.Subscription;
+const Subscription = Rx.CompositeSubscription;
 
 /** @test {Subscription} */
 describe('Subscription', () => {

--- a/spec/observables/using-spec.ts
+++ b/spec/observables/using-spec.ts
@@ -2,7 +2,7 @@ import * as Rx from '../../dist/cjs/Rx.KitchenSink';
 import {it} from '../helpers/test-helper';
 
 const Observable = Rx.Observable;
-const Subscription = Rx.Subscription;
+const Subscription = Rx.CompositeSubscription;
 
 describe('Observable.using', () => {
   it('should dispose of the resource when the subscription is disposed', (done) => {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,7 +1,7 @@
 import {PartialObserver, Observer} from './Observer';
 import {Operator} from './Operator';
 import {Subscriber} from './Subscriber';
-import {Subscription} from './Subscription';
+import {Subscription, SubscriptionList} from './Subscription';
 import {root} from './util/root';
 import {$$observable} from './symbol/observable';
 import {toSubscriber} from './util/toSubscriber';
@@ -84,7 +84,7 @@ export class Observable<T> implements Subscribable<T> {
    */
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
             error?: (error: any) => void,
-            complete?: () => void): Subscription {
+            complete?: () => void): SubscriptionList {
 
     const { operator } = this;
     const subscriber = toSubscriber(observerOrNext, error, complete);

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -119,7 +119,7 @@ import './add/operator/zipAll';
 /* tslint:disable:no-unused-variable */
 export {Operator} from './Operator';
 export {Observer} from './Observer';
-export {Subscription, UnsubscriptionError} from './Subscription';
+export {CompositeSubscription, Subscription, UnsubscriptionError} from './Subscription';
 export {Subscriber} from './Subscriber';
 export {AsyncSubject} from './subject/AsyncSubject';
 export {ReplaySubject} from './subject/ReplaySubject';

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -2,7 +2,7 @@ import {Operator} from './Operator';
 import {Observer} from './Observer';
 import {Observable} from './Observable';
 import {Subscriber} from './Subscriber';
-import {Subscription} from './Subscription';
+import {CompositeSubscription, Subscription} from './Subscription';
 import {SubjectSubscription} from './subject/SubjectSubscription';
 import {$$rxSubscriber} from './symbol/rxSubscriber';
 
@@ -39,15 +39,15 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
   }
 
   add(subscription: Subscription|Function|void): void {
-    Subscription.prototype.add.call(this, subscription);
+    CompositeSubscription.prototype.add.call(this, subscription);
   }
 
   remove(subscription: Subscription): void {
-    Subscription.prototype.remove.call(this, subscription);
+    CompositeSubscription.prototype.remove.call(this, subscription);
   }
 
   unsubscribe(): void {
-    Subscription.prototype.unsubscribe.call(this);
+    CompositeSubscription.prototype.unsubscribe.call(this);
   }
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -1,10 +1,10 @@
 import {isFunction} from './util/isFunction';
 import {Observer, PartialObserver} from './Observer';
-import {Subscription} from './Subscription';
+import {CompositeSubscription} from './Subscription';
 import {$$rxSubscriber} from './symbol/rxSubscriber';
 import {empty as emptyObserver} from './Observer';
 
-export class Subscriber<T> extends Subscription implements Observer<T> {
+export class Subscriber<T> extends CompositeSubscription implements Observer<T> {
 
   static create<T>(next?: (x?: T) => void,
                    error?: (e?: any) => void,

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -7,11 +7,14 @@ import {errorObject} from './util/errorObject';
 export interface Subscription {
   isUnsubscribed: boolean;
   unsubscribe(): void;
+}
+
+export interface SubscriptionList extends Subscription {
   add(subscription: Subscription | Function | void): void;
   remove(subscription: Subscription): void;
 }
 
-export class CompositeSubscription implements Subscription {
+export class CompositeSubscription implements SubscriptionList {
   public static EMPTY: Subscription = (function(empty: any){
     empty.isUnsubscribed = true;
     return empty;

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -4,11 +4,18 @@ import {isFunction} from './util/isFunction';
 import {tryCatch} from './util/tryCatch';
 import {errorObject} from './util/errorObject';
 
-export class Subscription {
+export interface Subscription {
+  isUnsubscribed: boolean;
+  unsubscribe(): void;
+  add(subscription: Subscription | Function | void): void;
+  remove(subscription: Subscription): void;
+}
+
+export class CompositeSubscription implements Subscription {
   public static EMPTY: Subscription = (function(empty: any){
     empty.isUnsubscribed = true;
     return empty;
-  }(new Subscription()));
+  }(new CompositeSubscription()));
 
   public isUnsubscribed: boolean = false;
 
@@ -75,7 +82,7 @@ export class Subscription {
     //  3. we're attempting to add the static `empty` Subscription
     if (!subscription || (
         subscription === this) || (
-        subscription === Subscription.EMPTY)) {
+        subscription === CompositeSubscription.EMPTY)) {
       return;
     }
 
@@ -83,7 +90,7 @@ export class Subscription {
 
     switch (typeof subscription) {
       case 'function':
-        sub = new Subscription(<(() => void) > subscription);
+        sub = new CompositeSubscription(<(() => void) > subscription);
       case 'object':
         if (sub.isUnsubscribed || typeof sub.unsubscribe !== 'function') {
           break;
@@ -106,7 +113,7 @@ export class Subscription {
     //  3. we're attempting to remove the static `empty` Subscription
     if (subscription == null   || (
         subscription === this) || (
-        subscription === Subscription.EMPTY)) {
+        subscription === CompositeSubscription.EMPTY)) {
       return;
     }
 

--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -1,6 +1,6 @@
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, SubscriptionList} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
@@ -103,7 +103,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
 }
 
 function dispatch<T>(state: { source: BoundCallbackObservable<T>, subscriber: Subscriber<T> }) {
-  const self = (<Subscription> this);
+  const self = (<SubscriptionList> this);
   const { source, subscriber } = state;
   const { callbackFunc, args, scheduler } = source;
   let subject = source.subject;

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -1,6 +1,6 @@
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, SubscriptionList} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
@@ -96,7 +96,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
 }
 
 function dispatch<T>(state: { source: BoundNodeCallbackObservable<T>, subscriber: Subscriber<T> }) {
-  const self = (<Subscription> this);
+  const self = (<SubscriptionList> this);
   const { source, subscriber } = state;
   const { callbackFunc, args, scheduler } = source;
   let subject = source.subject;

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -1,7 +1,7 @@
 import {Subject} from '../Subject';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription} from '../Subscription';
 
 /**
  * @class ConnectableObservable<T>
@@ -53,7 +53,7 @@ export class ConnectableObservable<T> extends Observable<T> {
   }
 }
 
-class ConnectableSubscription extends Subscription {
+class ConnectableSubscription extends CompositeSubscription {
   constructor(protected connectable: ConnectableObservable<any>) {
     super();
   }

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -1,7 +1,7 @@
 import {Subject} from '../Subject';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {CompositeSubscription, Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription, SubscriptionList} from '../Subscription';
 
 /**
  * @class ConnectableObservable<T>
@@ -9,7 +9,7 @@ import {CompositeSubscription, Subscription} from '../Subscription';
 export class ConnectableObservable<T> extends Observable<T> {
 
   protected subject: Subject<T>;
-  protected subscription: Subscription;
+  protected subscription: SubscriptionList;
 
   constructor(protected source: Observable<T>,
               protected subjectFactory: () => Subject<T>) {

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -1,7 +1,7 @@
 import {Observable} from '../Observable';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
 export type NodeStyleEventEmmitter = {
@@ -75,7 +75,7 @@ export class FromEventObservable<T, R> extends Observable<T> {
       unsubscribe = () => sourceObj.removeListener(eventName, handler);
     }
 
-    subscriber.add(new Subscription(unsubscribe));
+    subscriber.add(new CompositeSubscription(unsubscribe));
   }
 
   protected _subscribe(subscriber: Subscriber<T>) {

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -1,5 +1,5 @@
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {Subscriber} from '../Subscriber';
@@ -50,7 +50,7 @@ export class FromEventPatternObservable<T, R> extends Observable<T> {
     if (result === errorObject) {
       subscriber.error(result.e);
     }
-    subscriber.add(new Subscription(() => {
+    subscriber.add(new CompositeSubscription(() => {
       //TODO: determine whether or not to forward to error handler
       removeHandler(handler);
     }));

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -2,7 +2,7 @@ import {Subject} from '../../Subject';
 import {Subscriber} from '../../Subscriber';
 import {Observable} from '../../Observable';
 import {Operator} from '../../Operator';
-import {CompositeSubscription, Subscription} from '../../Subscription';
+import {CompositeSubscription, Subscription, SubscriptionList} from '../../Subscription';
 import {root} from '../../util/root';
 import {ReplaySubject} from '../../subject/ReplaySubject';
 import {Observer} from '../../Observer';
@@ -127,7 +127,7 @@ export class WebSocketSubject<T> extends Subject<T> {
       this.observers = [];
     }
 
-    const subscription = <Subscription>super._subscribe(subscriber);
+    const subscription = <SubscriptionList>super._subscribe(subscriber);
     // HACK: For some reason transpilation wasn't honoring this in arrow functions below
     // Doesn't seem right, need to reinvestigate.
     const self = this;

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -2,7 +2,7 @@ import {Subject} from '../../Subject';
 import {Subscriber} from '../../Subscriber';
 import {Observable} from '../../Observable';
 import {Operator} from '../../Operator';
-import {Subscription} from '../../Subscription';
+import {CompositeSubscription, Subscription} from '../../Subscription';
 import {root} from '../../util/root';
 import {ReplaySubject} from '../../subject/ReplaySubject';
 import {Observer} from '../../Observer';
@@ -201,7 +201,7 @@ export class WebSocketSubject<T> extends Subject<T> {
       };
     }
 
-    return new Subscription(() => {
+    return new CompositeSubscription(() => {
       subscription.unsubscribe();
       if (!this.observers || this.observers.length === 0) {
         const { socket } = this;

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
@@ -121,7 +121,7 @@ class BufferToggleSubscriber<T, O> extends Subscriber<T> {
     } else {
       let context = {
         buffer: <T[]>[],
-        subscription: new Subscription()
+        subscription: new CompositeSubscription()
       };
       contexts.push(context);
       const subscriber = new BufferToggleClosingsSubscriber<T>(this, context);

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
@@ -122,7 +122,7 @@ class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
     if (closingNotifier === errorObject) {
       this.error(errorObject.e);
     } else {
-      closingSubscription = new Subscription();
+      closingSubscription = new CompositeSubscription();
       this.closingSubscription = closingSubscription;
       this.add(closingSubscription);
       this.subscribing = true;

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
-import {CompositeSubscription, Subscription} from '../Subscription';
+import {CompositeSubscription, SubscriptionList} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
@@ -63,7 +63,7 @@ class BufferWhenOperator<T> implements Operator<T, T[]> {
 class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
   private buffer: T[];
   private subscribing: boolean = false;
-  private closingSubscription: Subscription;
+  private closingSubscription: SubscriptionList;
 
   constructor(destination: Subscriber<T[]>, private closingSelector: () => Observable<any>) {
     super(destination);

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -1,6 +1,6 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription} from '../Subscription';
 import {Observable} from '../Observable';
 
 /**
@@ -31,6 +31,6 @@ class FinallyOperator<T> implements Operator<T, T> {
 class FinallySubscriber<T> extends Subscriber<T> {
   constructor(destination: Subscriber<T>, finallySelector: () => void) {
     super(destination);
-    this.add(new Subscription(finallySelector));
+    this.add(new CompositeSubscription(finallySelector));
   }
 }

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -1,5 +1,5 @@
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription} from '../Subscription';
 import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subject} from '../Subject';
@@ -234,7 +234,7 @@ export class GroupedObservable<K, T> extends Observable<T> {
   }
 
   protected _subscribe(subscriber: Subscriber<T>) {
-    const subscription = new Subscription();
+    const subscription = new CompositeSubscription();
     const {refCountSubscription, groupSubject} = this;
     if (refCountSubscription && !refCountSubscription.isUnsubscribed) {
       subscription.add(new InnerRefCountSubscription(refCountSubscription));
@@ -244,7 +244,7 @@ export class GroupedObservable<K, T> extends Observable<T> {
   }
 }
 
-class InnerRefCountSubscription extends Subscription {
+class InnerRefCountSubscription extends CompositeSubscription {
   constructor(private parent: RefCountSubscription) {
     super();
     parent.count++;

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -2,7 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Subject} from '../Subject';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription} from '../Subscription';
 
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
@@ -127,7 +127,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
         return this.error(errorObject.e);
       } else {
         const window = new Subject<T>();
-        const subscription = new Subscription();
+        const subscription = new CompositeSubscription();
         const context = { window, subscription };
         this.contexts.push(context);
         const innerSubscription = subscribeToResult(this, closingNotifier, context);

--- a/src/scheduler/Action.ts
+++ b/src/scheduler/Action.ts
@@ -1,7 +1,7 @@
-import {Subscription} from '../Subscription';
+import {Subscription, SubscriptionList} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 
-export interface Action extends Subscription {
+export interface Action extends SubscriptionList {
   work: (state?: any) => void|Subscription;
   state?: any;
   delay?: number;

--- a/src/scheduler/FutureAction.ts
+++ b/src/scheduler/FutureAction.ts
@@ -1,9 +1,9 @@
 import {root} from '../util/root';
 import {Action} from './Action';
 import {Scheduler} from '../Scheduler';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription} from '../Subscription';
 
-export class FutureAction<T> extends Subscription implements Action {
+export class FutureAction<T> extends CompositeSubscription implements Action {
 
   public id: number;
   public state: T;

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -1,5 +1,5 @@
 import {Scheduler} from '../Scheduler';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription} from '../Subscription';
 import {Action} from './Action';
 
 export class VirtualTimeScheduler implements Scheduler {
@@ -66,7 +66,7 @@ export class VirtualTimeScheduler implements Scheduler {
   }
 }
 
-class VirtualAction<T> extends Subscription implements Action {
+class VirtualAction<T> extends CompositeSubscription implements Action {
   state: T;
   delay: number;
   calls = 0;

--- a/src/subject/SubjectSubscription.ts
+++ b/src/subject/SubjectSubscription.ts
@@ -1,8 +1,8 @@
 import {Subject} from '../Subject';
 import {Observer} from '../Observer';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription} from '../Subscription';
 
-export class SubjectSubscription extends Subscription {
+export class SubjectSubscription extends CompositeSubscription {
   isUnsubscribed: boolean = false;
 
   constructor(public subject: Subject<any>, public observer: Observer<any>) {

--- a/src/testing/ColdObservable.ts
+++ b/src/testing/ColdObservable.ts
@@ -1,5 +1,5 @@
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 import {TestMessage} from './TestMessage';
 import {SubscriptionLog} from './SubscriptionLog';
@@ -23,7 +23,7 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
     super(function (subscriber: Subscriber<any>) {
       const observable: ColdObservable<T> = this;
       const index = observable.logSubscribedFrame();
-      subscriber.add(new Subscription(() => {
+      subscriber.add(new CompositeSubscription(() => {
         observable.logUnsubscribedFrame(index);
       }));
       observable.scheduleMessages(subscriber);

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -1,6 +1,6 @@
 import {Subject} from '../Subject';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {CompositeSubscription, Subscription} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 import {TestMessage} from './TestMessage';
 import {SubscriptionLog} from './SubscriptionLog';
@@ -27,7 +27,7 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
   protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
-    subscriber.add(new Subscription(() => {
+    subscriber.add(new CompositeSubscription(() => {
       subject.logUnsubscribedFrame(index);
     }));
     return super._subscribe(subscriber);


### PR DESCRIPTION
- __This will cause BREAKING CHANGE if we accept this proposal.__
- @blesh @trxcllnt how about do you think?

-------

## Motivation

At now, [`Subscription`](https://github.com/ReactiveX/rxjs/blob/master/src/Subscription.ts) used as a implementation class or as an interface in [`Action`](https://github.com/ReactiveX/rxjs/blob/master/src/scheduler/Action.ts), [`Subject`](https://github.com/ReactiveX/rxjs/blob/master/src/Subject.ts), and others.

However, we cannot use a class which has a private member as an interface. This prevents a some refactoring internally (e.g. #1389) and It confuses us (and users) to use a class as an interface.
 

## Detailed Change

- Split `Subscription` class into `CompositeSubscription` class and `Subscription` interface.
