### PR TITLE
fix(Symbol): $$observable is not defined

### DIFF
--- a/src/symbol/observable.ts
+++ b/src/symbol/observable.ts
@@ -5,7 +5,9 @@ const Symbol: any = root.Symbol;
 export let $$observable: any;
 
 if (typeof Symbol === 'function') {
-  if (!Symbol.observable) {
+  if (Symbol.observable) {
+    $$observable = Symbol.observable;
+  } else {
     if (typeof Symbol.for === 'function') {
       $$observable = Symbol.for('observable');
     } else {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

`$$observable` is not defined if `Symbol.observable` is defined.

rxjs@5.0.0-beta.2 & is-observalbe@0.1.0

```
var isObservable = require('is-observable');
var Observable = require('rxjs').Observable;

console.log(isObservable(Observable.empty())); // true
```

```
var Observable = require('rxjs').Observable;
var isObservable = require('is-observable');

console.log(isObservable(Observable.empty())); // true
```


rxjs@5.0.0-beta.3 & is-observalbe@0.1.0

```
var isObservable = require('is-observable'); // Symbol.observable is defined
var Observable = require('rxjs').Observable;

console.log(isObservable(Observable.empty())); // false
```

```
var Observable = require('rxjs').Observable;
var isObservable = require('is-observable');

console.log(isObservable(Observable.empty())); // true
```

**Related issue (if exists):**
