### PR TITLE
chore(package.json): build_test cleans up existing test cases

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "build_closure_kitchensink": "java -jar ./node_modules/google-closure-compiler/compiler.jar --js ./dist/global/Rx.KitchenSink.umd.js --language_in ECMASCRIPT5 --create_source_map ./dist/global/Rx.KitchenSink.umd.min.js.map --js_output_file ./dist/global/Rx.KitchenSink.umd.min.js",
     "build_global": "rm -rf ./dist/global && mkdirp ./dist/global && node tools/make-umd-bundle.js && node tools/make-system-bundle.js && npm-run-all build_closure_core build_closure_kitchensink",
     "build_perf": "webdriver-manager update && npm-run-all build_cjs build_global perf",
-    "build_test": "rm -rf ./dist/ && npm-run-all lint build_cjs build_spec test_jasmine",
+    "build_test": "rm -rf ./dist/ && npm-run-all lint build_cjs clean_spec build_spec test_jasmine",
     "build_cover": "rm -rf ./dist/ && npm-run-all lint build_cjs build_spec cover",
     "build_docs": "npm-run-all build_es6 build_global tests2png && esdoc -c esdoc.json",
     "build_spec": "tsc --project ./spec --pretty",


### PR DESCRIPTION
**Description:**
This PR makes `build_test` explicitly clean up existing test case build, to avoid possible confusions such as switching branches, etcs. Individual command chain (npm run build && ...) will allows to work with preserved test build.

**Related issue (if exists):**

