### PR TITLE
Subscription refactor: Part 1

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,7 +1,7 @@
 import {PartialObserver, Observer} from './Observer';
 import {Operator} from './Operator';
 import {Subscriber} from './Subscriber';
-import {Subscription} from './Subscription';
+import {Subscription, AnonymousSubscription, TeardownLogic} from './Subscription';
 import {root} from './util/root';
 import {$$observable} from './symbol/observable';
 import {toSubscriber} from './util/toSubscriber';
@@ -10,7 +10,7 @@ import {IfObservable} from './observable/IfObservable';
 import {ErrorObservable} from './observable/ErrorObservable';
 
 export interface Subscribable<T> {
-  subscribe(observer: Observer<T>): Subscription;
+  subscribe(observer: Observer<T>): AnonymousSubscription;
 }
 
 export type SubscribableOrPromise<T> = Subscribable<T> | Promise<T>;
@@ -37,7 +37,7 @@ export class Observable<T> implements Subscribable<T> {
    * can be `next`ed, or an `error` method can be called to raise an error, or
    * `complete` can be called to notify of a successful completion.
    */
-  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) {
+  constructor(subscribe?: <R>(subscriber: Subscriber<R>) => TeardownLogic) {
     if (subscribe) {
       this._subscribe = subscribe;
     }
@@ -53,7 +53,7 @@ export class Observable<T> implements Subscribable<T> {
    * @param {Function} subscribe? the subscriber function to be passed to the Observable constructor
    * @return {Observable} a new cold observable
    */
-  static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => Subscription | Function | void) => {
+  static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => TeardownLogic) => {
     return new Observable<T>(subscribe);
   };
 
@@ -80,7 +80,7 @@ export class Observable<T> implements Subscribable<T> {
    * @param {Function} error (optional) a handler for a terminal event resulting from an error. If no error handler is provided,
    *  the error will be thrown as unhandled
    * @param {Function} complete (optional) a handler for a terminal event resulting from successful completion.
-   * @return {Subscription} a subscription reference to the registered handlers
+   * @return {ISubscription} a subscription reference to the registered handlers
    */
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
             error?: (error: any) => void,
@@ -156,7 +156,7 @@ export class Observable<T> implements Subscribable<T> {
     });
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
     return this.source.subscribe(subscriber);
   }
 

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -2,7 +2,7 @@ import {Operator} from './Operator';
 import {Observer} from './Observer';
 import {Observable} from './Observable';
 import {Subscriber} from './Subscriber';
-import {Subscription} from './Subscription';
+import {Subscription, ISubscription, TeardownLogic} from './Subscription';
 import {SubjectSubscription} from './subject/SubjectSubscription';
 import {$$rxSubscriber} from './symbol/rxSubscriber';
 
@@ -12,7 +12,7 @@ import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 /**
  * @class Subject<T>
  */
-export class Subject<T> extends Observable<T> implements Observer<T>, Subscription {
+export class Subject<T> extends Observable<T> implements Observer<T>, ISubscription {
 
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): Subject<T> => {
     return new Subject<T>(destination, source);
@@ -38,7 +38,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, Subscripti
     return <any>subject;
   }
 
-  add(subscription: Subscription|Function|void): void {
+  add(subscription: TeardownLogic): void {
     Subscription.prototype.add.call(this, subscription);
   }
 

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -38,8 +38,8 @@ export class Subject<T> extends Observable<T> implements Observer<T>, ISubscript
     return <any>subject;
   }
 
-  add(subscription: TeardownLogic): void {
-    Subscription.prototype.add.call(this, subscription);
+  add(subscription: TeardownLogic): Subscription {
+    return Subscription.prototype.add.call(this, subscription);
   }
 
   remove(subscription: Subscription): void {

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -50,7 +50,7 @@ export class Subject<T> extends Observable<T> implements Observer<T>, ISubscript
     Subscription.prototype.unsubscribe.call(this);
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     if (this.source) {
       return this.source.subscribe(subscriber);
     } else {

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -13,7 +13,7 @@ export type TeardownLogic = AnonymousSubscription | Function | void;
 export interface ISubscription extends AnonymousSubscription {
   unsubscribe(): void;
   isUnsubscribed: boolean;
-  add(teardown: TeardownLogic): void;
+  add(teardown: TeardownLogic): ISubscription;
   remove(sub: ISubscription): void;
 }
 
@@ -92,8 +92,11 @@ export class Subscription implements ISubscription {
    * will be executed immediately
    *
    * @param {TeardownLogic} teardown the additional logic to execute on teardown.
+   * @returns {Subscription} returns the subscription used or created to be added to the inner
+   *  subscriptions list. This subscription can be used with `remove()` to remove the passed teardown
+   *  logic from the inner subscriptions list.
    */
-  add(teardown: TeardownLogic): void {
+  add(teardown: TeardownLogic): Subscription {
     if (!teardown || (
         teardown === this) || (
         teardown === Subscription.EMPTY)) {
@@ -117,6 +120,8 @@ export class Subscription implements ISubscription {
       default:
         throw new Error('Unrecognized teardown ' + teardown + ' added to Subscription.');
     }
+
+    return sub;
   }
 
   /**

--- a/src/observable/ArrayLikeObservable.ts
+++ b/src/observable/ArrayLikeObservable.ts
@@ -3,7 +3,7 @@ import {Observable} from '../Observable';
 import {ScalarObservable} from './ScalarObservable';
 import {EmptyObservable} from './EmptyObservable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -59,7 +59,7 @@ export class ArrayLikeObservable<T> extends Observable<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     let index = 0;
     const { arrayLike, mapFn, scheduler } = this;
     const length = arrayLike.length;

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -4,7 +4,7 @@ import {ScalarObservable} from './ScalarObservable';
 import {EmptyObservable} from './EmptyObservable';
 import {Subscriber} from '../Subscriber';
 import {isScheduler} from '../util/isScheduler';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -81,7 +81,7 @@ export class ArrayObservable<T> extends Observable<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     let index = 0;
     const array = this.array;
     const count = array.length;

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -1,7 +1,7 @@
 import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -29,7 +29,7 @@ export class EmptyObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
 
     const scheduler = this.scheduler;
 

--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -1,6 +1,6 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -29,7 +29,7 @@ export class ErrorObservable extends Observable<any> {
     super();
   }
 
-  protected _subscribe(subscriber: any): Subscription | Function | void {
+  protected _subscribe(subscriber: any): TeardownLogic {
     const error = this.error;
     const scheduler = this.scheduler;
 

--- a/src/observable/IfObservable.ts
+++ b/src/observable/IfObservable.ts
@@ -1,6 +1,6 @@
 import {Observable, SubscribableOrPromise} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 import {subscribeToResult} from '../util/subscribeToResult';
 import {OuterSubscriber} from '../OuterSubscriber';
@@ -23,7 +23,7 @@ export class IfObservable<T, R> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T|R>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T|R>): TeardownLogic {
     const { condition, thenSource, elseSource } = this;
 
     return new IfSubscriber(subscriber, condition, thenSource, elseSource);

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -6,7 +6,7 @@ import {Observable} from '../Observable';
 import {isFunction} from '../util/isFunction';
 import {$$iterator} from '../symbol/iterator';
 import {errorObject} from '../util/errorObject';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
 /**
@@ -89,7 +89,7 @@ export class IteratorObservable<T> extends Observable<T> {
     this.iterator = getIterator(iterator);
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
 
     let index = 0;
     const { iterator, project, thisArg, scheduler } = this;

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -2,7 +2,7 @@ import {root} from '../util/root';
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -29,7 +29,7 @@ export class PromiseObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     const promise = this.promise;
     const scheduler = this.scheduler;
 

--- a/src/observable/RangeObservable.ts
+++ b/src/observable/RangeObservable.ts
@@ -1,6 +1,6 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
 /**
@@ -55,7 +55,7 @@ export class RangeObservable extends Observable<number> {
     this.scheduler = scheduler;
   }
 
-  protected _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<number>): TeardownLogic {
     let index = 0;
     let start = this.start;
     const end = this.end;

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -1,7 +1,7 @@
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -36,7 +36,7 @@ export class ScalarObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     const value = this.value;
     const scheduler = this.scheduler;
 

--- a/src/observable/TimerObservable.ts
+++ b/src/observable/TimerObservable.ts
@@ -4,7 +4,7 @@ import {Observable} from '../Observable';
 import {async} from '../scheduler/async';
 import {isScheduler} from '../util/isScheduler';
 import {isDate} from '../util/isDate';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 import {Subscriber} from '../Subscriber';
 
 /**
@@ -69,7 +69,7 @@ export class TimerObservable extends Observable<number> {
       (<number> dueTime);
   }
 
-  protected _subscribe(subscriber: Subscriber<number>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<number>): TeardownLogic {
     const index = 0;
     const { period, dueTime, scheduler } = this;
 

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -3,7 +3,7 @@ import {tryCatch} from '../../util/tryCatch';
 import {errorObject} from '../../util/errorObject';
 import {Observable} from '../../Observable';
 import {Subscriber} from '../../Subscriber';
-import {Subscription} from '../../Subscription';
+import {TeardownLogic} from '../../Subscription';
 
 export interface AjaxRequest {
   url?: string;
@@ -148,7 +148,7 @@ export class AjaxObservable<T> extends Observable<T> {
     this.request = request;
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     return new AjaxSubscriber(subscriber, this.request);
   }
 }

--- a/src/subject/AsyncSubject.ts
+++ b/src/subject/AsyncSubject.ts
@@ -1,6 +1,6 @@
 import {Subject} from '../Subject';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * @class AsyncSubject<T>
@@ -9,7 +9,7 @@ export class AsyncSubject<T> extends Subject<T> {
   value: T = null;
   hasNext: boolean = false;
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription|Function|void {
+  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
     if (this.hasCompleted && this.hasNext) {
       subscriber.next(this.value);
     }

--- a/src/subject/BehaviorSubject.ts
+++ b/src/subject/BehaviorSubject.ts
@@ -1,6 +1,6 @@
 import {Subject} from '../Subject';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {TeardownLogic, ISubscription} from '../Subscription';
 import {throwError} from '../util/throwError';
 import {ObjectUnsubscribedError} from '../util/ObjectUnsubscribedError';
 
@@ -27,9 +27,9 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     const subscription = super._subscribe(subscriber);
-    if (subscription && !(<Subscription> subscription).isUnsubscribed) {
+    if (subscription && !(<ISubscription> subscription).isUnsubscribed) {
       subscriber.next(this._value);
     }
     return subscription;

--- a/src/subject/ReplaySubject.ts
+++ b/src/subject/ReplaySubject.ts
@@ -2,7 +2,7 @@ import {Subject} from '../Subject';
 import {Scheduler} from '../Scheduler';
 import {queue} from '../scheduler/queue';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {TeardownLogic} from '../Subscription';
 import {ObserveOnSubscriber} from '../operator/observeOn';
 
 /**
@@ -30,7 +30,7 @@ export class ReplaySubject<T> extends Subject<T> {
     super._next(value);
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     const events = this._trimBufferThenGetEvents(this._getNow());
     const scheduler = this.scheduler;
 

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -1,6 +1,6 @@
 import {Subject} from '../Subject';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 import {TestMessage} from './TestMessage';
 import {SubscriptionLog} from './SubscriptionLog';
@@ -24,7 +24,7 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     this.scheduler = scheduler;
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
     subscriber.add(new Subscription(() => {


### PR DESCRIPTION
**Description:**

- Updates the types around `Subscription`.
- Adds an `AnonymousSubscription` that will fit any duck-typed subscription
- Adds an `ISubscription` that will fit any composite-subscription (generally this was added to reduce structural surface area for type checking)
- `Subscription.prototype.add` now returns a reference to any `Subscription` it creates internally, so it can be used to `remove` the subscription.

**Related issue (if exists):**
#1532 is related, in part, because this is a step in the right direction.
This also relates to @saneyuki's PR here #1521 