### PR TITLE
Fix a few tests

### DIFF
--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -40,10 +40,11 @@ function assertAction(done: DoneSignature, assertion: (done?: DoneSignature) => 
     errorHappened = true;
     error = e;
   } finally {
+    global.rxTestScheduler = null;
     if (errorHappened) {
-      setTimeout(function () { done.fail(error); });
+      done.fail(error);
     } else {
-      setTimeout(function () { done(); });
+      done();
     }
   }
 }

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -40,7 +40,7 @@ describe('Observable.prototype.publish', () => {
       source.connect();
     });
 
-    source.connect();
+    expect(() => source.connect()).toThrow(new Rx.ObjectUnsubscribedError());
   });
 
   it('should return a ConnectableObservable', () => {


### PR DESCRIPTION
We had a couple of tests that *should* have been erroring for months. This a disturbing part of Jasmine, but when you added an arbitrary number of tests to our testing suite, then suddenly some of our tests would fail with `ObjectUnsubscribedError`. 

Work done:

1. Added about 100 tests that were just `expect(1).toBe(1)` inside of them until I saw the errors happening.
2. Verified, empirically, that there were no timing errors where the global `rxTestScheduler` was being used/trampled by multiple tests.
3. Removed unnecessary `setTimeout` calls from test helpers and added an additional assurance that `rxTestScheduler` was being cleared at the end of the test.
4. Fixed two tests that *should* have been throwing errors this entire time, to assert the expected errors rather than just throw.
5. Removed the 100 superfluous tests.