### PR TITLE
feat(Observable): initially create Observable.generate factory

### DIFF
--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -349,6 +349,9 @@ children:
       - label: using custom logic
         children:
         - label: Observable.create
+      - label: using a state machine similar to a for loop
+        children:
+        - label: Observable.generate
       - label: that throws an error
         children:
         - label: Observable.throw

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -120,6 +120,7 @@ There are operators for different purposes, and they may be categorized as: crea
 - [`fromEvent`](../class/es6/Observable.js~Observable.html#static-method-fromEvent)
 - [`fromEventPattern`](../class/es6/Observable.js~Observable.html#static-method-fromEventPattern)
 - [`fromPromise`](../class/es6/Observable.js~Observable.html#static-method-fromPromise)
+- [`generate`](../class/es6/Observable.js~Observable.html#static-method-generate)
 - [`interval`](../class/es6/Observable.js~Observable.html#static-method-interval)
 - [`never`](../class/es6/Observable.js~Observable.html#static-method-never)
 - [`of`](../class/es6/Observable.js~Observable.html#static-method-of)

--- a/spec/observables/generate-spec.ts
+++ b/spec/observables/generate-spec.ts
@@ -1,0 +1,168 @@
+import * as Rx from '../../dist/cjs/Rx.KitchenSink';
+import '../../dist/cjs/add/observable/generate';
+import {TestScheduler} from '../../dist/cjs/testing/TestScheduler';
+import {expect} from 'chai';
+declare const {asDiagram, expectObservable};
+declare const rxTestScheduler: TestScheduler;
+
+const Observable = Rx.Observable;
+
+function err(): any {
+  throw 'error';
+}
+
+describe('Observable.generate', () => {
+  asDiagram('generate(1, x => false, x => x + 1)')
+  ('should complete if condition does not meet', () => {
+    const source = Observable.generate(1, x => false, x => x + 1);
+    const expected = '|';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  asDiagram('generate(1, x => x == 1, x => x + 1)')
+  ('should produce first value immediately', () => {
+    const source = Observable.generate(1, x => x == 1, x => x + 1);
+    const expected = '(1|)';
+
+    expectObservable(source).toBe(expected, { '1': 1 });
+  });
+
+  asDiagram('generate(1, x => x < 3, x => x + 1)')
+  ('should produce all values synchronously', () => {
+    const source = Observable.generate(1, x => x < 3, x => x + 1);
+    const expected = '(12|)';
+
+    expectObservable(source).toBe(expected, { '1': 1, '2': 2 });
+  });
+
+  it('should use result selector', () => {
+    const source = Observable.generate(1, x => x < 3, x => x + 1, x => (x + 1).toString());
+    const expected = '(23|)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should allow omit condition', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: x => x + 1,
+      resultSelector: x => x.toString()
+    }).take(5);
+    const expected = '(12345|)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should stop producing when unsubscribed', () => {
+    const source = Observable.generate(1, x => x < 4, x => x + 1);
+    let count = 0;
+    const subscriber = new Rx.Subscriber<number>(
+      x => {
+        count++;
+        if (x == 2) {
+          subscriber.unsubscribe();
+        }
+      }
+    );
+    source.subscribe(subscriber);
+    expect(count).to.be.equal(2);
+  });
+
+  it('should accept a scheduler', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      condition: x => x < 4,
+      iterate: x => x + 1,
+      resultSelector: x => x,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(123|)';
+
+    let count = 0;
+    source.subscribe(x => count++);
+
+    expect(count).to.be.equal(0);
+    rxTestScheduler.flush();
+    expect(count).to.be.equal(3);
+
+    expectObservable(source).toBe(expected, { '1': 1, '2': 2, '3': 3 });
+  });
+
+  it('should allow minimal possible options', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: x => x * 2
+    }).take(3);
+    const expected = '(124|)';
+
+    expectObservable(source).toBe(expected, { '1': 1, '2': 2, '4': 4 });
+  });
+
+  it('should emit error if result selector throws', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: x => x * 2,
+      resultSelector: err
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should emit error if result selector throws on scheduler', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: x => x * 2,
+      resultSelector: err,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should emit error after first value if iterate function throws', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: err
+    });
+    const expected = '(1#)';
+
+    expectObservable(source).toBe(expected, { '1': 1 });
+  });
+
+  it('should emit error after first value if iterate function throws on scheduler', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: err,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(1#)';
+
+    expectObservable(source).toBe(expected, { '1': 1 });
+  });
+
+  it('should emit error if condition function throws', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: x => x + 1,
+      condition: err
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should emit error if condition function throws on scheduler', () => {
+    const source = Observable.generate({
+      initialState: 1,
+      iterate: x => x + 1,
+      condition: err,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -19,6 +19,7 @@ import './add/observable/from';
 import './add/observable/fromEvent';
 import './add/observable/fromEventPattern';
 import './add/observable/fromPromise';
+import './add/observable/generate';
 import './add/observable/interval';
 import './add/observable/merge';
 import './add/observable/race';

--- a/src/add/observable/generate.ts
+++ b/src/add/observable/generate.ts
@@ -1,0 +1,10 @@
+import {Observable} from '../../Observable';
+import {GenerateObservable} from '../../observable/GenerateObservable';
+
+Observable.generate = GenerateObservable.create;
+
+declare module '../../Observable' {
+  namespace Observable {
+    export let generate: typeof GenerateObservable.create;
+  }
+}

--- a/src/observable/GenerateObservable.ts
+++ b/src/observable/GenerateObservable.ts
@@ -1,0 +1,296 @@
+import {Observable} from '../Observable' ;
+import {Scheduler} from '../Scheduler';
+import {Subscriber} from '../Subscriber';
+import {Subscription} from '../Subscription';
+import {Action} from '../scheduler/Action';
+
+import {isScheduler} from '../util/isScheduler';
+
+const selfSelector = <T>(value: T) => value;
+
+export type ConditionFunc<S> = (state: S) => boolean;
+export type IterateFunc<S> = (state: S) => S;
+export type ResultFunc<S, T> = (state: S) => T;
+
+interface SchedulerState<T, S> {
+  needIterate?: boolean;
+  state: S;
+  subscriber: Subscriber<T>;
+  condition?: ConditionFunc<S>;
+  iterate: IterateFunc<S>;
+  resultSelector: ResultFunc<S, T>;
+}
+
+export interface GenerateBaseOptions<S> {
+  /**
+   * Inital state.
+  */
+  initialState: S;
+  /**
+   * Condition function that accepts state and returns boolean.
+   * When it returns false, the generator stops.
+   * If not specified, a generator never stops.
+  */
+  condition?: ConditionFunc<S>;
+  /**
+   * Iterate function that accepts state and returns new state.
+   */
+  iterate: IterateFunc<S>;
+  /**
+   * Scheduler to use for generation process.
+   * By default, a generator starts immediately.
+  */
+  scheduler?: Scheduler;
+}
+
+export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
+  /**
+   * Result selection function that accepts state and returns a value to emit.
+   */
+  resultSelector: ResultFunc<S, T>;
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
+export class GenerateObservable<T, S> extends Observable<T> {
+  constructor(private initialState: S,
+              private condition: ConditionFunc<S>,
+              private iterate: IterateFunc<S>,
+              private resultSelector: ResultFunc<S, T>,
+              private scheduler?: Scheduler) {
+      super();
+  }
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages.
+   *
+   * <img src="./img/generate.png" width="100%">
+   * 
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate(0, x => x < 10, x => x + 1, x => x);
+   * 
+   * @example <caption>Using asap scheduler, produces sequence of 2, 3, 5, then completes.</caption>
+   * var res = Rx.Observable.generate(1, x => x < 5, x => x * 2, x => x + 1, Rx.Scheduler.asap);
+   *
+   * @see {@link from}
+   * @see {@link create}
+   * 
+   * @param {S} initialState Initial state.
+   * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
+   * @param {function (state: S): S} iterate Iteration step function.
+   * @param {function (state: S): T} resultSelector Selector function for results produced in the sequence.
+   * @param {Scheduler} [scheduler] A {@link Scheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
+   * @returns {Observable<T>} The generated sequence.
+   */
+  static create<T, S>(initialState: S,
+                      condition: ConditionFunc<S>,
+                      iterate: IterateFunc<S>,
+                      resultSelector: ResultFunc<S, T>,
+                      scheduler?: Scheduler): Observable<T>
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages.
+   * The overload uses state as an emitted value.
+   * 
+   * <img src="./img/generate.png" width="100%">
+   *
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate(0, x => x < 10, x => x + 1);
+   * 
+   * @example <caption>Using asap scheduler, produces sequence of 1, 2, 4, then completes.</caption>
+   * var res = Rx.Observable.generate(1, x => x < 5, x => x * 2, Rx.Scheduler.asap);
+   *
+   * @see {@link from}
+   * @see {@link create}
+   *
+   * @param {S} initialState Initial state.
+   * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
+   * @param {function (state: S): S} iterate Iteration step function.
+   * @param {Scheduler} [scheduler] A {@link Scheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
+   * @returns {Observable<S>} The generated sequence.
+   */
+  static create<S>(initialState: S,
+                   condition: ConditionFunc<S>,
+                   iterate: IterateFunc<S>,
+                   scheduler?: Scheduler): Observable<S>
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages.
+   * The overload accepts options object that might contain inital state, iterate,
+   * condition and scheduler.
+   * 
+   * <img src="./img/generate.png" width="100%">
+   *
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate({
+   *   initialState: 0,
+   *   condition: x => x < 10,
+   *   iterate: x => x + 1
+   * });
+   *
+   * @see {@link from}
+   * @see {@link create}
+   *
+   * @param {GenerateBaseOptions<S>} options Object that must contain initialState, iterate and might contain condition and scheduler.
+   * @returns {Observable<S>} The generated sequence.
+   */
+  static create<S>(options: GenerateBaseOptions<S>): Observable<S>
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages.
+   * The overload accepts options object that might contain inital state, iterate,
+   * condition, result selector and scheduler.
+   * 
+   * <img src="./img/generate.png" width="100%">
+   *
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate({
+   *   initialState: 0,
+   *   condition: x => x < 10,
+   *   iterate: x => x + 1,
+   *   resultSelector: x => x
+   * });
+   *
+   * @see {@link from}
+   * @see {@link create}
+   *
+   * @param {GenerateOptions<T, S>} options Object that must contain initialState, iterate, resultSelector and might contain condition and scheduler.
+   * @returns {Observable<T>} The generated sequence.
+   */
+  static create<T, S>(options: GenerateOptions<T, S>): Observable<T>
+
+  static create<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
+                      condition?: ConditionFunc<S>,
+                      iterate?: IterateFunc<S>,
+                      resultSelectorOrObservable?: (ResultFunc<S, T>) | Scheduler,
+                      scheduler?: Scheduler): Observable<T> {
+    if (arguments.length == 1) {
+      return new GenerateObservable<T, S>(
+        (<GenerateOptions<T, S>>initialStateOrOptions).initialState,
+        (<GenerateOptions<T, S>>initialStateOrOptions).condition,
+        (<GenerateOptions<T, S>>initialStateOrOptions).iterate,
+        (<GenerateOptions<T, S>>initialStateOrOptions).resultSelector || selfSelector,
+        (<GenerateOptions<T, S>>initialStateOrOptions).scheduler);
+    }
+
+    if (resultSelectorOrObservable === undefined || isScheduler(resultSelectorOrObservable)) {
+      return new GenerateObservable<T, S>(
+        <S>initialStateOrOptions,
+        condition,
+        iterate,
+        selfSelector,
+        <Scheduler>resultSelectorOrObservable);
+    }
+
+    return new GenerateObservable<T, S>(
+      <S>initialStateOrOptions,
+      condition,
+      iterate,
+      <ResultFunc<S, T>>resultSelectorOrObservable,
+      <Scheduler>scheduler);
+  }
+
+  protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+    let state = this.initialState;
+    if (this.scheduler) {
+      return this.scheduler.schedule<SchedulerState<T, S>>(GenerateObservable.dispatch, 0, {
+        subscriber,
+        iterate: this.iterate,
+        condition: this.condition,
+        resultSelector: this.resultSelector,
+        state });
+    }
+    const { condition, resultSelector, iterate } = this;
+    do {
+      if (condition) {
+        let conditionResult: boolean;
+        try {
+          conditionResult = condition(state);
+        } catch (err) {
+          subscriber.error(err);
+          return;
+        }
+        if (!conditionResult) {
+          subscriber.complete();
+          break;
+        }
+      }
+      let value: T;
+      try {
+        value = resultSelector(state);
+      } catch (err) {
+        subscriber.error(err);
+        return;
+      }
+      subscriber.next(value);
+      if (subscriber.isUnsubscribed) {
+        break;
+      }
+      try {
+        state = iterate(state);
+      } catch (err) {
+        subscriber.error(err);
+        return;
+      }
+    } while (true);
+  }
+
+  private static dispatch<T, S>(state: SchedulerState<T, S>) {
+    const { subscriber, condition } = state;
+    if (subscriber.isUnsubscribed) {
+      return;
+    }
+    if (state.needIterate) {
+      try {
+        state.state = state.iterate(state.state);
+      } catch (err) {
+        subscriber.error(err);
+        return;
+      }
+    } else {
+      state.needIterate = true;
+    }
+    if (condition) {
+      let conditionResult: boolean;
+      try {
+        conditionResult = condition(state.state);
+      } catch (err) {
+        subscriber.error(err);
+        return;
+      }
+      if (!conditionResult) {
+        subscriber.complete();
+        return;
+      }
+      if (subscriber.isUnsubscribed) {
+        return;
+      }
+    }
+    let value: T;
+    try {
+      value = state.resultSelector(state.state);
+    } catch (err) {
+      subscriber.error(err);
+      return;
+    }
+    if (subscriber.isUnsubscribed) {
+      return;
+    }
+    subscriber.next(value);
+    if (subscriber.isUnsubscribed) {
+      return;
+    }
+    return (<Action<SchedulerState<T, S>>><any>this).schedule(state);
+  }
+}


### PR DESCRIPTION
**Description:**

The PR adds static `Observable.generate/GenerateObservable.create` method with implementation aligned with RxJS4.

The signature supports passing parameters and a single options:

```ts
  static create<T, S>(
    initialState: S,
    condition: ConditionFunc<S>,
    iterate: IterateFunc<S>,
    resultSelector: ResultFunc<S, T>,
    scheduler?: Scheduler): Observable<T>
  static create<S>(
    initialState: S,
    condition: ConditionFunc<S>,
    iterate: IterateFunc<S>,
    scheduler?: Scheduler): Observable<S>
  static create<T, S>(
    options: GenerateOptions<T, S>): Observable<T>

```

**Related issue:**

#1482 

_This is my first PR here, hi everybody_ :)
