### PR TITLE
test(helper): enable global leak check for test cases

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -64,6 +64,7 @@ describe('Observable', () => {
         expect(x).to.equal(42);
       }).then(() => {
         expect(wasCalled).to.be.true;
+        delete __root__.Rx;
         done();
       });
     });

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -34,6 +34,8 @@ describe('Observable.prototype.toPromise', () => {
     Observable.of(42).toPromise().then((x: number) => {
       expect(wasCalled).to.be.true;
       expect(x).to.equal(42);
+
+      delete __root__.Rx;
       done();
     });
   });

--- a/spec/support/default.opts
+++ b/spec/support/default.opts
@@ -5,6 +5,8 @@
 --reporter dot
 --bail
 --full-trace
+--check-leaks
+--globals WebSocket,FormData
 
 --recursive
 --timeout 5000


### PR DESCRIPTION
**Description:**

This PR enables global leak check in mocha test runner, to ensure if any global patching in test case to be cleared. Seems this is somewhat inaccurate such as some teardown in test hook is not detected, those are marked as ignored.

**Related issue (if exists):**

