### PR TITLE
chore(test): format test failure output for expectObservable

### DIFF
--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -31,19 +31,4 @@ export function lowerCaseO<T>(...args): Rx.Observable<T> {
   return <any>o;
 };
 
-//overrides JSON.toStringfy to serialize error object
-Object.defineProperty(Error.prototype, 'toJSON', {
-  value: function () {
-    const alt = {};
-
-    Object.getOwnPropertyNames(this).forEach(function (key) {
-      if (key !== 'stack') {
-        alt[key] = this[key];
-      }
-    }, this);
-    return alt;
-  },
-  configurable: true
-});
-
 global.__root__ = root;


### PR DESCRIPTION
**Description:**

While migration, `testScheduler` accepts built in assertion `assert.deepEqual` from chai, but it doesn't provide readable output for marble testing. Reintroduced previous custom matcher amended following chai's assertion manner.


*Before
<img width="773" alt="screenshot_1" src="https://cloud.githubusercontent.com/assets/1210596/14126347/201cb21e-f5c5-11e5-93a7-be53b7cd435f.png">

*After
<img width="764" alt="screenshot_2" src="https://cloud.githubusercontent.com/assets/1210596/14126352/2623695a-f5c5-11e5-9445-d4e6d3ca36b3.png">
