### PR TITLE
Creation method moves

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "watch": "Watch codebase, trigger compile when source code changes"
   },
   "scripts": {
+    "install": "typings install",
     "info": "npm-scripts-info",
     "build_all": "npm-run-all build_es6 build_amd build_cjs build_global generate_packages",
     "build_amd": "npm-run-all clean_dist_amd copy_src_amd compile_dist_amd",

--- a/src/add/observable/bindCallback.ts
+++ b/src/add/observable/bindCallback.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {BoundCallbackObservable} from '../../observable/BoundCallbackObservable';
+import {bindCallback as staticBindCallback} from '../../observable/bindCallback';
 
-Observable.bindCallback = BoundCallbackObservable.create;
+Observable.bindCallback = staticBindCallback;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let bindCallback: typeof BoundCallbackObservable.create;
+    export let bindCallback: typeof staticBindCallback;
   }
 }

--- a/src/add/observable/bindNodeCallback.ts
+++ b/src/add/observable/bindNodeCallback.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {BoundNodeCallbackObservable} from '../../observable/BoundNodeCallbackObservable';
+import {bindNodeCallback as staticBindNodeCallback} from '../../observable/bindNodeCallback';
 
-Observable.bindNodeCallback = BoundNodeCallbackObservable.create;
+Observable.bindNodeCallback = staticBindNodeCallback;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let bindNodeCallback: typeof BoundNodeCallbackObservable.create;
+    export let bindNodeCallback: typeof staticBindNodeCallback;
   }
 }

--- a/src/add/observable/concat.ts
+++ b/src/add/observable/concat.ts
@@ -1,5 +1,5 @@
 import {Observable} from '../../Observable';
-import {concatStatic} from '../../operator/concat';
+import {concat as concatStatic} from '../../observable/concat';
 
 Observable.concat = concatStatic;
 

--- a/src/add/observable/defer.ts
+++ b/src/add/observable/defer.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {DeferObservable} from '../../observable/DeferObservable';
+import {defer as staticDefer} from '../../observable/defer';
 
-Observable.defer = DeferObservable.create;
+Observable.defer = staticDefer;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let defer: typeof DeferObservable.create;
+    export let defer: typeof staticDefer;
   }
 }

--- a/src/add/observable/dom/ajax.ts
+++ b/src/add/observable/dom/ajax.ts
@@ -1,10 +1,11 @@
 import {Observable} from '../../../Observable';
-import {AjaxObservable} from '../../../observable/dom/AjaxObservable';
+import {ajax as staticAjax} from '../../../observable/dom/ajax';
+import {AjaxCreationMethod} from '../../../observable/dom/AjaxObservable';
 
-Observable.ajax = AjaxObservable.create;
+Observable.ajax = staticAjax;
 
 declare module '../../../Observable' {
   namespace Observable {
-    export let ajax: typeof AjaxObservable.create;
+    export let ajax: AjaxCreationMethod;
   }
 }

--- a/src/add/observable/dom/webSocket.ts
+++ b/src/add/observable/dom/webSocket.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../../Observable';
-import {WebSocketSubject} from '../../../observable/dom/WebSocketSubject';
+import {webSocket as staticWebSocket} from '../../../observable/dom/webSocket';
 
-Observable.webSocket = WebSocketSubject.create;
+Observable.webSocket = staticWebSocket;
 
 declare module '../../../Observable' {
   namespace Observable {
-    export let webSocket: typeof WebSocketSubject.create;
+    export let webSocket: typeof staticWebSocket;
   }
 }

--- a/src/add/observable/empty.ts
+++ b/src/add/observable/empty.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {EmptyObservable} from '../../observable/EmptyObservable';
+import {empty as staticEmpty} from '../../observable/empty';
 
-Observable.empty = EmptyObservable.create;
+Observable.empty = staticEmpty;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let empty: typeof EmptyObservable.create;
+    export let empty: typeof staticEmpty;
   }
 }

--- a/src/add/observable/forkJoin.ts
+++ b/src/add/observable/forkJoin.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {ForkJoinObservable} from '../../observable/ForkJoinObservable';
+import {forkJoin as staticForkJoin} from '../../observable/forkJoin';
 
-Observable.forkJoin = ForkJoinObservable.create;
+Observable.forkJoin = staticForkJoin;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let forkJoin: typeof ForkJoinObservable.create;
+    export let forkJoin: typeof staticForkJoin;
   }
 }

--- a/src/add/observable/from.ts
+++ b/src/add/observable/from.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {FromObservable} from '../../observable/FromObservable';
+import {from as staticFrom} from '../../observable/from';
 
-Observable.from = FromObservable.create;
+Observable.from = staticFrom;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let from: typeof FromObservable.create;
+    export let from: typeof staticFrom;
   }
 }

--- a/src/add/observable/fromEvent.ts
+++ b/src/add/observable/fromEvent.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {FromEventObservable} from '../../observable/FromEventObservable';
+import {fromEvent as staticFromEvent} from '../../observable/fromEvent';
 
-Observable.fromEvent = FromEventObservable.create;
+Observable.fromEvent = staticFromEvent;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let fromEvent: typeof FromEventObservable.create;
+    export let fromEvent: typeof staticFromEvent;
   }
 }

--- a/src/add/observable/fromEventPattern.ts
+++ b/src/add/observable/fromEventPattern.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {FromEventPatternObservable} from '../../observable/FromEventPatternObservable';
+import {fromEventPattern as staticFromEventPattern} from '../../observable/fromEventPattern';
 
-Observable.fromEventPattern = FromEventPatternObservable.create;
+Observable.fromEventPattern = staticFromEventPattern;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let fromEventPattern: typeof FromEventPatternObservable.create;
+    export let fromEventPattern: typeof staticFromEventPattern;
   }
 }

--- a/src/add/observable/fromPromise.ts
+++ b/src/add/observable/fromPromise.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {PromiseObservable} from '../../observable/PromiseObservable';
+import {fromPromise as staticFromPromise} from '../../observable/fromPromise';
 
-Observable.fromPromise = PromiseObservable.create;
+Observable.fromPromise = staticFromPromise;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let fromPromise: typeof PromiseObservable.create;
+    export let fromPromise: typeof staticFromPromise;
   }
 }

--- a/src/add/observable/if.ts
+++ b/src/add/observable/if.ts
@@ -1,4 +1,4 @@
 import {Observable} from '../../Observable';
-import {IfObservable} from '../../observable/IfObservable';
+import {_if} from '../../observable/if';
 
-Observable.if = IfObservable.create;
+Observable.if = _if;

--- a/src/add/observable/interval.ts
+++ b/src/add/observable/interval.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {IntervalObservable} from '../../observable/IntervalObservable';
+import {interval as staticInterval} from '../../observable/interval';
 
-Observable.interval = IntervalObservable.create;
+Observable.interval = staticInterval;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let interval: typeof IntervalObservable.create;
+    export let interval: typeof staticInterval;
   }
 }

--- a/src/add/observable/merge.ts
+++ b/src/add/observable/merge.ts
@@ -1,5 +1,5 @@
 import {Observable} from '../../Observable';
-import {mergeStatic} from '../../operator/merge';
+import {merge as mergeStatic} from '../../observable/merge';
 
 Observable.merge = mergeStatic;
 

--- a/src/add/observable/never.ts
+++ b/src/add/observable/never.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {NeverObservable} from '../../observable/NeverObservable';
+import {never as staticNever} from '../../observable/never';
 
-Observable.never = NeverObservable.create;
+Observable.never = staticNever;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let never: typeof NeverObservable.create;
+    export let never: typeof staticNever;
   }
 }

--- a/src/add/observable/of.ts
+++ b/src/add/observable/of.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {ArrayObservable} from '../../observable/ArrayObservable';
+import {of as staticOf} from '../../observable/of';
 
-Observable.of = ArrayObservable.of;
+Observable.of = staticOf;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let of: typeof ArrayObservable.of;
+    export let of: typeof staticOf; //formOf an iceberg!
   }
 }

--- a/src/add/observable/range.ts
+++ b/src/add/observable/range.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {RangeObservable} from '../../observable/RangeObservable';
+import {range as staticRange} from '../../observable/range';
 
-Observable.range = RangeObservable.create;
+Observable.range = staticRange;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let range: typeof RangeObservable.create;
+    export let range: typeof staticRange;
   }
 }

--- a/src/add/observable/throw.ts
+++ b/src/add/observable/throw.ts
@@ -1,4 +1,4 @@
 import {Observable} from '../../Observable';
-import {ErrorObservable} from '../../observable/ErrorObservable';
+import {_throw} from '../../observable/throw';
 
-Observable.throw = ErrorObservable.create;
+Observable.throw = _throw;

--- a/src/add/observable/timer.ts
+++ b/src/add/observable/timer.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {TimerObservable} from '../../observable/TimerObservable';
+import {timer as staticTimer} from '../../observable/timer';
 
-Observable.timer = TimerObservable.create;
+Observable.timer = staticTimer;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let timer: typeof TimerObservable.create;
+    export let timer: typeof staticTimer;
   }
 }

--- a/src/add/observable/using.ts
+++ b/src/add/observable/using.ts
@@ -1,10 +1,10 @@
 import {Observable} from '../../Observable';
-import {UsingObservable} from '../../observable/UsingObservable';
+import {using as staticUsing} from '../../observable/using';
 
-Observable.using = UsingObservable.create;
+Observable.using = staticUsing;
 
 declare module '../../Observable' {
   namespace Observable {
-    export let using: typeof UsingObservable.create;
+    export let using: typeof staticUsing;
   }
 }

--- a/src/add/observable/zip.ts
+++ b/src/add/observable/zip.ts
@@ -1,5 +1,5 @@
 import {Observable} from '../../Observable';
-import {zipStatic} from '../../operator/zip';
+import {zip as zipStatic} from '../../observable/zip';
 
 Observable.zip = zipStatic;
 

--- a/src/observable/bindCallback.ts
+++ b/src/observable/bindCallback.ts
@@ -1,0 +1,3 @@
+import { BoundCallbackObservable } from './BoundCallbackObservable';
+
+export const bindCallback = BoundCallbackObservable.create;

--- a/src/observable/bindNodeCallback.ts
+++ b/src/observable/bindNodeCallback.ts
@@ -1,0 +1,3 @@
+import { BoundNodeCallbackObservable } from './BoundNodeCallbackObservable';
+
+export const bindNodeCallback = BoundNodeCallbackObservable.create;

--- a/src/observable/concat.ts
+++ b/src/observable/concat.ts
@@ -1,0 +1,3 @@
+import { concatStatic } from '../operator/concat';
+
+export const concat = concatStatic;

--- a/src/observable/defer.ts
+++ b/src/observable/defer.ts
@@ -1,0 +1,3 @@
+import { DeferObservable } from './DeferObservable';
+
+export const defer = DeferObservable.create;

--- a/src/observable/dom/ajax.ts
+++ b/src/observable/dom/ajax.ts
@@ -1,0 +1,3 @@
+import { AjaxObservable, AjaxCreationMethod } from './AjaxObservable';
+
+export const ajax: AjaxCreationMethod = AjaxObservable.create;

--- a/src/observable/dom/webSocket.ts
+++ b/src/observable/dom/webSocket.ts
@@ -1,0 +1,3 @@
+import { WebSocketSubject } from './WebSocketSubject';
+
+export const webSocket = WebSocketSubject.create;

--- a/src/observable/empty.ts
+++ b/src/observable/empty.ts
@@ -1,0 +1,3 @@
+import { EmptyObservable } from './EmptyObservable';
+
+export const empty = EmptyObservable.create;

--- a/src/observable/forkJoin.ts
+++ b/src/observable/forkJoin.ts
@@ -1,0 +1,3 @@
+import { ForkJoinObservable } from './ForkJoinObservable';
+
+export const forkJoin = ForkJoinObservable.create;

--- a/src/observable/from.ts
+++ b/src/observable/from.ts
@@ -1,0 +1,3 @@
+import { FromObservable } from './FromObservable';
+
+export const from = FromObservable.create;

--- a/src/observable/fromEvent.ts
+++ b/src/observable/fromEvent.ts
@@ -1,0 +1,3 @@
+import { FromEventObservable } from './FromEventObservable';
+
+export const fromEvent = FromEventObservable.create;

--- a/src/observable/fromEventPattern.ts
+++ b/src/observable/fromEventPattern.ts
@@ -1,0 +1,3 @@
+import { FromEventPatternObservable } from './FromEventPatternObservable';
+
+export const fromEventPattern = FromEventPatternObservable.create;

--- a/src/observable/fromPromise.ts
+++ b/src/observable/fromPromise.ts
@@ -1,0 +1,3 @@
+import { PromiseObservable } from './PromiseObservable';
+
+export const fromPromise = PromiseObservable.create;

--- a/src/observable/if.ts
+++ b/src/observable/if.ts
@@ -1,0 +1,3 @@
+import { IfObservable } from './IfObservable';
+
+export const _if = IfObservable.create;

--- a/src/observable/interval.ts
+++ b/src/observable/interval.ts
@@ -1,0 +1,3 @@
+import { IntervalObservable } from './IntervalObservable';
+
+export const interval = IntervalObservable.create;

--- a/src/observable/merge.ts
+++ b/src/observable/merge.ts
@@ -1,0 +1,3 @@
+import { mergeStatic } from '../operator/merge';
+
+export const merge = mergeStatic;

--- a/src/observable/never.ts
+++ b/src/observable/never.ts
@@ -1,0 +1,3 @@
+import { NeverObservable } from './NeverObservable';
+
+export const never = NeverObservable.create;

--- a/src/observable/of.ts
+++ b/src/observable/of.ts
@@ -1,0 +1,3 @@
+import { ArrayObservable } from './ArrayObservable';
+
+export const of = ArrayObservable.of;

--- a/src/observable/range.ts
+++ b/src/observable/range.ts
@@ -1,0 +1,3 @@
+import { RangeObservable } from './RangeObservable';
+
+export const range = RangeObservable.create;

--- a/src/observable/throw.ts
+++ b/src/observable/throw.ts
@@ -1,0 +1,3 @@
+import { ErrorObservable } from './ErrorObservable';
+
+export const _throw = ErrorObservable.create;

--- a/src/observable/timer.ts
+++ b/src/observable/timer.ts
@@ -1,0 +1,3 @@
+import { TimerObservable } from './TimerObservable';
+
+export const timer = TimerObservable.create;

--- a/src/observable/using.ts
+++ b/src/observable/using.ts
@@ -1,0 +1,3 @@
+import { UsingObservable } from './UsingObservable';
+
+export const using = UsingObservable.create;

--- a/src/observable/zip.ts
+++ b/src/observable/zip.ts
@@ -1,0 +1,3 @@
+import { zipStatic } from '../operator/zip';
+
+export const zip = zipStatic;


### PR DESCRIPTION
**Description:**
Adds modules to export creation methods in a more consistent/conventional fashion.

Basically anything that was available with `Rx.Observable.nameHere` is now available from `rxjs/observable/nameHere`. At least that's the idea.

**Related issue (if exists):**
#1554 