### PR TITLE
chore(test): allow to throw non error object

### DIFF
--- a/spec/helpers/testScheduler-ui.ts
+++ b/spec/helpers/testScheduler-ui.ts
@@ -144,13 +144,13 @@ module.exports = (<any>mocha).interfaces['testscheduler-ui'] = function(suite) {
       if (fn && fn.length === 0) {
         modified = function (done: MochaDone) {
           context.rxTestScheduler = new Rx.TestScheduler(observableMatcher);
-          let error: any = null;
+          let error: Error = null;
 
           try {
             fn();
             context.rxTestScheduler.flush();
           } catch (e) {
-            error = e;
+            error = e instanceof Error ? e : new Error(e);
           } finally {
             context.rxTestScheduler = null;
             error ? done(error) : done();


### PR DESCRIPTION
**Description:**

different to jasmine, mocha's async callback requires `Error` object explicitly. This PR updates custom interface bit to allow to throw any object (i.e `throw 'bad';`) by wrap into error object.

p.s : in case of explicit call to async callback, it's still requires to deliver error object.

**Related issue (if exists):**

