### PR TITLE
chore(test): enable source map for test stack trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,6 +183,7 @@
     "rx": "latest",
     "sinon": "^1.17.3",
     "sinon-chai": "^2.8.0",
+    "source-map-support": "^0.4.0",
     "systemjs": "^0.19.24",
     "systemjs-builder": "^0.10.6",
     "tslint": "^3.5.0",

--- a/spec/support/default.opts
+++ b/spec/support/default.opts
@@ -1,3 +1,4 @@
+--require source-map-support/register
 --require spec-js/helpers/test-helper.js
 --require spec-js/helpers/ajax-helper.js
 --ui spec-js/helpers/testScheduler-ui.js


### PR DESCRIPTION
**Description:**
This PR adds small ergonomics into test runner to enable source map of stack trace

before:
<img width="625" alt="before" src="https://cloud.githubusercontent.com/assets/1210596/14325681/3e8ff4fc-fbdf-11e5-921a-d29f7fece388.png">

after:
<img width="639" alt="after" src="https://cloud.githubusercontent.com/assets/1210596/14325686/420eecdc-fbdf-11e5-9bae-188b5206cbab.png">

It doesn't give clarity for test cases using testscheduler.flush() much though, gives small convenience over general failures.

**Related issue (if exists):**
