### PR TITLE
fix(AjaxObservable): support json responseType on IE

### DIFF
--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -375,11 +375,13 @@ export class AjaxResponse {
 
   constructor(public originalEvent: Event, public xhr: XMLHttpRequest, public request: AjaxRequest) {
     this.status = xhr.status;
-    this.responseType = xhr.responseType;
+    this.responseType = xhr.responseType || request.responseType;
+
     switch (this.responseType) {
       case 'json':
         if ('response' in xhr) {
-          this.response = xhr.response;
+          //IE does not support json as responseType, parse it internally
+          this.response = xhr.responseType ? xhr.response : JSON.parse(xhr.response || xhr.responseText || '');
         } else {
           this.response = JSON.parse(xhr.responseText || '');
         }


### PR DESCRIPTION
**Description:**
This PR updates internal behavior of AjaxObservable for IE specific by IE doesn't support json as response type, parse response as json object internally.

**Related issue (if exists):**

closes #1381