### PR TITLE
Improve readability of UnsubscriptionError

### DIFF
--- a/spec/util/UnsubscriptionError-spec.ts
+++ b/spec/util/UnsubscriptionError-spec.ts
@@ -1,0 +1,28 @@
+import {expect} from 'chai';
+import * as Rx from '../../dist/cjs/Rx';
+
+const { Observable, UnsubscriptionError } = Rx;
+
+/** @test {UnsubscriptionError} */
+describe('UnsubscriptionError', () => {
+  it('should create a message that is a clear indication of its internal errors', () => {
+    const err1 = new Error('Swiss cheese tastes amazing but smells like socks');
+    const err2 = new Error('User too big to fit in tiny European elevator');
+    const source1 = Observable.create(() => () => { throw err1; });
+    const source2 = Observable.timer(1000);
+    const source3 = Observable.create(() => () => { throw err2; });
+    const source = source1.merge(source2, source3);
+
+    const subscription = source.subscribe();
+
+    try {
+      subscription.unsubscribe();
+    } catch (err) {
+      expect(err instanceof UnsubscriptionError).to.equal(true);
+      expect(err.message).to.equal(`2 errors occurred during unsubscription:
+1) ${err1}
+2) ${err2}`);
+      expect(err.name).to.equal('UnsubscriptionError');
+    }
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -118,7 +118,7 @@ import './add/operator/zipAll';
 /* tslint:disable:no-unused-variable */
 export {Operator} from './Operator';
 export {Observer} from './Observer';
-export {Subscription, UnsubscriptionError} from './Subscription';
+export {Subscription} from './Subscription';
 export {Subscriber} from './Subscriber';
 export {AsyncSubject} from './AsyncSubject';
 export {ReplaySubject} from './ReplaySubject';
@@ -128,6 +128,7 @@ export {Notification} from './Notification';
 export {EmptyError} from './util/EmptyError';
 export {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 export {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
+export {UnsubscriptionError} from './util/UnsubscriptionError';
 
 import {asap} from './scheduler/asap';
 import {async} from './scheduler/async';

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -3,6 +3,7 @@ import {isObject} from './util/isObject';
 import {isFunction} from './util/isFunction';
 import {tryCatch} from './util/tryCatch';
 import {errorObject} from './util/errorObject';
+import {UnsubscriptionError} from './util/UnsubscriptionError';
 
 export interface AnonymousSubscription {
   unsubscribe(): void;
@@ -176,16 +177,5 @@ export class Subscription implements ISubscription {
         subscriptions.splice(subscriptionIndex, 1);
       }
     }
-  }
-}
-
-/**
- * An error thrown when one or more errors have occurred during the
- * `unsubscribe` of a {@link Subscription}.
- */
-export class UnsubscriptionError extends Error {
-  constructor(public errors: any[]) {
-    super('unsubscriptoin error(s)');
-    this.name = 'UnsubscriptionError';
   }
 }

--- a/src/util/UnsubscriptionError.ts
+++ b/src/util/UnsubscriptionError.ts
@@ -4,7 +4,9 @@
  */
 export class UnsubscriptionError extends Error {
   constructor(public errors: any[]) {
-    super('unsubscriptoin error(s)');
+    super();
     this.name = 'UnsubscriptionError';
+    this.message = errors ? `${errors.length} errors occurred during unsubscription:
+${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n')}` : '';
   }
 }

--- a/src/util/UnsubscriptionError.ts
+++ b/src/util/UnsubscriptionError.ts
@@ -1,0 +1,10 @@
+/**
+ * An error thrown when one or more errors have occurred during the
+ * `unsubscribe` of a {@link Subscription}.
+ */
+export class UnsubscriptionError extends Error {
+  constructor(public errors: any[]) {
+    super('unsubscriptoin error(s)');
+    this.name = 'UnsubscriptionError';
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Makes the logged error message from `UnsubscriptionError` more readable by adding the messages from it's inner errors.

Also refactors UnsubscriptionError to be in it's own module.

**Related issue (if exists):**
#1590 