### PR TITLE
chore(package.json): remove override to install script

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,6 @@
     "watch": "Watch codebase, trigger compile when source code changes"
   },
   "scripts": {
-    "install": "typings install",
     "info": "npm-scripts-info",
     "build_all": "npm-run-all build_es6 build_amd build_cjs build_global generate_packages",
     "build_amd": "npm-run-all clean_dist_amd copy_src_amd compile_dist_amd",


### PR DESCRIPTION
**Description:**
This PR removes override to `npm install` script which causes implicit installation of typings on repository.

**Related issue (if exists):**

relates to #1580