### PR TITLE
fix(typings): make an exported function's destructuring signature explicitly

### DIFF
--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -138,11 +138,21 @@ function dispatch<T>(state: { source: BoundCallbackObservable<T>, subscriber: Su
   self.add(subject.subscribe(subscriber));
 }
 
-function dispatchNext({ value, subject }) {
+interface DispatchNextArg<T> {
+  subject: AsyncSubject<T>;
+  value: T;
+}
+function dispatchNext<T>(arg: DispatchNextArg<T>) {
+  const { value, subject } = arg;
   subject.next(value);
   subject.complete();
 }
 
-function dispatchError({ err, subject }) {
+interface DispatchErrorArg<T> {
+  subject: AsyncSubject<T>;
+  err: any;
+}
+function dispatchError<T>(arg: DispatchErrorArg<T>) {
+  const { err, subject } = arg;
   subject.error(err);
 }

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -135,11 +135,21 @@ function dispatch<T>(state: { source: BoundNodeCallbackObservable<T>, subscriber
   self.add(subject.subscribe(subscriber));
 }
 
-function dispatchNext({ value, subject }) {
+interface DispatchNextArg<T> {
+  subject: AsyncSubject<T>;
+  value: T;
+}
+function dispatchNext<T>(arg: DispatchNextArg<T>) {
+  const { value, subject } = arg;
   subject.next(value);
   subject.complete();
 }
 
-function dispatchError({ err, subject }) {
+interface DispatchErrorArg<T> {
+  subject: AsyncSubject<T>;
+  err: any;
+}
+function dispatchError<T>(arg: DispatchErrorArg<T>) {
+  const { err, subject } = arg;
   subject.error(err);
 }

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -3,6 +3,10 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {TeardownLogic} from '../Subscription';
 
+export interface DispatchArg<T> {
+  subscriber: Subscriber<T>;
+}
+
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @extends {Ignored}
@@ -51,7 +55,8 @@ export class EmptyObservable<T> extends Observable<T> {
     return new EmptyObservable<T>(scheduler);
   }
 
-  static dispatch({ subscriber }) {
+  static dispatch<T>(arg: DispatchArg<T>) {
+    const { subscriber } = arg;
     subscriber.complete();
   }
 

--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -2,6 +2,11 @@ import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
 import {TeardownLogic} from '../Subscription';
 
+export interface DispatchArg {
+  error: any;
+  subscriber: any;
+}
+
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @extends {Ignored}
@@ -53,7 +58,8 @@ export class ErrorObservable extends Observable<any> {
     return new ErrorObservable(error, scheduler);
   }
 
-  static dispatch({ error, subscriber }) {
+  static dispatch(arg: DispatchArg) {
+    const { error, subscriber } = arg;
     subscriber.error(error);
   }
 

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -88,14 +88,24 @@ export class PromiseObservable<T> extends Observable<T> {
   }
 }
 
-function dispatchNext({ value, subscriber }) {
+interface DispatchNextArg<T> {
+  subscriber: Subscriber<T>;
+  value: T;
+}
+function dispatchNext<T>(arg: DispatchNextArg<T>) {
+  const { value, subscriber } = arg;
   if (!subscriber.isUnsubscribed) {
     subscriber.next(value);
     subscriber.complete();
   }
 }
 
-function dispatchError({ err, subscriber }) {
+interface DispatchErrorArg<T> {
+  subscriber: Subscriber<T>;
+  err: any;
+}
+function dispatchError<T>(arg: DispatchErrorArg<T>) {
+  const { err, subscriber } = arg;
   if (!subscriber.isUnsubscribed) {
     subscriber.error(err);
   }

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -5,6 +5,11 @@ import {Observable} from '../Observable';
 import {asap} from '../scheduler/asap';
 import {isNumeric} from '../util/isNumeric';
 
+export interface DispatchArg<T> {
+  source: Observable<T>;
+  subscriber: Subscriber<T>;
+}
+
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @extends {Ignored}
@@ -15,7 +20,8 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     return new SubscribeOnObservable(source, delay, scheduler);
   }
 
-  static dispatch<T>({ source, subscriber }): Subscription {
+  static dispatch<T>(arg: DispatchArg<T>): Subscription {
+    const { source, subscriber } = arg;
     return source.subscribe(subscriber);
   }
 

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -152,16 +152,22 @@ function dispatchBufferTimeSpanOnly(state: any) {
   }
 }
 
+interface DispatchArg<T> {
+  subscriber: BufferTimeSubscriber<T>;
+  buffer: Array<T>;
+}
+
 function dispatchBufferCreation<T>(state: CreationState<T>) {
   const { bufferCreationInterval, bufferTimeSpan, subscriber, scheduler } = state;
   const buffer = subscriber.openBuffer();
   const action = <Action<CreationState<T>>>this;
   if (!subscriber.isUnsubscribed) {
-    action.add(scheduler.schedule(dispatchBufferClose, bufferTimeSpan, { subscriber, buffer }));
+    action.add(scheduler.schedule<DispatchArg<T>>(dispatchBufferClose, bufferTimeSpan, { subscriber, buffer }));
     action.schedule(state, bufferCreationInterval);
   }
 }
 
-function dispatchBufferClose({ subscriber, buffer }) {
+function dispatchBufferClose<T>(arg: DispatchArg<T>) {
+  const { subscriber, buffer } = arg;
   subscriber.closeBuffer(buffer);
 }

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -43,6 +43,13 @@ export class ExpandOperator<T, R> implements Operator<T, R> {
   }
 }
 
+interface DispatchArg<T, R> {
+  subscriber: ExpandSubscriber<T, R>;
+  result: Observable<R>;
+  value: any;
+  index: number;
+}
+
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @ignore
@@ -64,7 +71,8 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  private static dispatch({subscriber, result, value, index}): void {
+  private static dispatch<T, R>(arg: DispatchArg<T, R>): void {
+    const {subscriber, result, value, index} = arg;
     subscriber.subscribeToProjection(result, value, index);
   }
 
@@ -85,7 +93,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
       } else if (!this.scheduler) {
         this.subscribeToProjection(result, value, index);
       } else {
-        const state = { subscriber: this, result, value, index };
+        const state: DispatchArg<T, R> = { subscriber: this, result, value, index };
         this.add(this.scheduler.schedule(ExpandSubscriber.dispatch, 0, state));
       }
     } else {

--- a/src/operator/observeOn.ts
+++ b/src/operator/observeOn.ts
@@ -37,7 +37,8 @@ export class ObserveOnOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 export class ObserveOnSubscriber<T> extends Subscriber<T> {
-  static dispatch({ notification, destination }) {
+  static dispatch(arg: ObserveOnMessage) {
+    const { notification, destination } = arg;
     notification.observe(destination);
   }
 
@@ -66,7 +67,7 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
   }
 }
 
-class ObserveOnMessage {
+export class ObserveOnMessage {
   constructor(public notification: Notification<any>,
               public destination: PartialObserver<any>) {
   }

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -60,6 +60,11 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
   }
 }
 
-function dispatchNext<T>({ subscriber }) {
+interface DispatchArg<T> {
+  subscriber: ThrottleTimeSubscriber<T>;
+}
+
+function dispatchNext<T>(arg: DispatchArg<T>) {
+  const { subscriber } = arg;
   subscriber.clearThrottle();
 }


### PR DESCRIPTION
* This decrease cases which uses `any` type implicitly.

