### PR TITLE
chore(typings): update type definition for concatAll

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -1,4 +1,4 @@
-import {PartialObserver, Observer} from './Observer';
+import {PartialObserver} from './Observer';
 import {Operator} from './Operator';
 import {Subscriber} from './Subscriber';
 import {Subscription, AnonymousSubscription, TeardownLogic} from './Subscription';
@@ -10,7 +10,9 @@ import {IfObservable} from './observable/IfObservable';
 import {ErrorObservable} from './observable/ErrorObservable';
 
 export interface Subscribable<T> {
-  subscribe(observer: Observer<T>): AnonymousSubscription;
+  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
+            error?: (error: any) => void,
+            complete?: () => void): AnonymousSubscription;
 }
 
 export type SubscribableOrPromise<T> = Subscribable<T> | Promise<T>;

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -1,3 +1,4 @@
+import {Subscribable} from '../Observable';
 import {MergeAllOperator} from './mergeAll';
 
 /**
@@ -48,4 +49,5 @@ export function concatAll<T>(): T {
 
 export interface ConcatAllSignature<T> {
   (): T;
+  <R>(): Subscribable<R>;
 }


### PR DESCRIPTION
**Description:**
This PR amends type definition of `concatAll` to allow explicit casting to inner type `T` when it's non-observable subscribable (i.e, Promise). 

Also this PR loosen type requirement of `Subscribable:Subscribe` to allow partial observer type as same as current `Observable:Subscribe` does. May debatable, opening PR for discussion. 

**Related issue (if exists):**

closes #1436