### PR TITLE
docs(instructions): write instructions for not reading doc/ directory

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -1,0 +1,3 @@
+# RxJS official docs at http://reactivex.io/rxjs/
+
+These files are not meant for reading directly in GitHub, they are just source code for generating the official page. You should find the docs at http://reactivex.io/rxjs/, containing all the documentation.


### PR DESCRIPTION
**Description:**
People have been mislead to look for docs by browsing through the doc/ directory through GitHub,
like they did with RxJS 4. This directory is not meant for content to be consumed directly through
GitHub, so this README will instruct people to look at reactivex.io/rxjs instead.

**Related issue (if exists):**
#1602