### PR TITLE
docs(Observable): fix typos

### DIFF
--- a/doc/observable.md
+++ b/doc/observable.md
@@ -296,7 +296,7 @@ observable.subscribe(x => console.log(x));
 
 It is not a coincidence that `observable.subscribe` and `subscribe` in `Observable.create(function subscribe(observer) {...})` have the same name. In the library, they are different, but for practical purposes you can consider them conceptually equal.
 
-This shows how a `subscribe` calls are not at all shared among multiple Observers of the same Observable. When calling `observable.subscribe` with an Observer, the function `subscribe` in `Observable.create(function subscribe(observer) {...})` is run for that given Observer. Each call to `observable.subscribe` triggers its own independent for that given Observer.
+This shows how `subscribe` calls are not shared among multiple Observers of the same Observable. When calling `observable.subscribe` with an Observer, the function `subscribe` in `Observable.create(function subscribe(observer) {...})` is run for that given Observer. Each call to `observable.subscribe` triggers its own independent setup for that given Observer.
 
 <span class="informal">Subscribing to an Observable is like calling a function, providing callbacks where the data will be delivered to.</span>
 


### PR DESCRIPTION
I'm not sure I made correct changes, but it definitely feels like something is missing in current docs here:
> Each call to observable.subscribe triggers its own **independent for** that given Observer.

It seems like a word belongs after "independent", but I'm not sure what, so I just suggested "setup".

And for this one:
> This shows how **a subscribe calls are** not at all shared among multiple Observers of the same Observable.

My removal of "a" is fixing a typo, but my removal of "at all" is just simplification. I see why you might want to keep it for emphasis.