### PR TITLE
Matching es-observable proposal `of` async emission

### DIFF
--- a/perf/micro/immediate-scheduler/observable/of-plain-calls.js
+++ b/perf/micro/immediate-scheduler/observable/of-plain-calls.js
@@ -1,0 +1,34 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function of(suite) {
+  var args = [];
+  for (var i = 0; i < 25; i++) {
+    args.push(i);
+  }
+
+  var oldOfWithImmediateScheduler = RxOld.Observable.of.apply(null, args);
+  var newOfWithImmediateScheduler = RxNew.Observable.of.apply(null, args);
+
+  function _next(x) { }
+  function _error(e) { }
+
+  // add tests
+  return suite
+    .add('old of called plain', {
+      defer: true,
+      fn: function (deferred) {
+        oldOfWithImmediateScheduler.subscribe(_next, _error, function () {
+          deferred.resolve();
+        });
+      }
+    })
+    .add('new of called plain', {
+      defer: true,
+      fn: function (deferred) {
+        newOfWithImmediateScheduler.subscribe(_next, _error, function () {
+          deferred.resolve();
+        });
+      }
+    });
+};

--- a/perf/micro/immediate-scheduler/observable/of.js
+++ b/perf/micro/immediate-scheduler/observable/of.js
@@ -8,7 +8,7 @@ module.exports = function of(suite) {
   }
 
   var oldOfWithImmediateScheduler = RxOld.Observable.of.apply(null, args.concat(RxOld.Scheduler.immediate));
-  var newOfWithImmediateScheduler = RxNew.Observable.of.apply(null, args);
+  var newOfWithImmediateScheduler = RxNew.Observable.of.apply(null, args.concat(RxNew.Scheduler.none));
 
   function _next(x) { }
   function _error(e) { }

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -386,7 +386,7 @@ describe('Subject', () => {
 
   it('should have a static create function that works', () => {
     expect(Subject.create).to.be.a('function');
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = Observable.of(1, 2, 3, 4, 5, Rx.Scheduler.none);
     const nexts = [];
     const output = [];
 
@@ -432,7 +432,7 @@ describe('Subject', () => {
 
   it('should have a static create function that works also to raise errors', () => {
     expect(Subject.create).to.be.a('function');
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = Observable.of(1, 2, 3, 4, 5, Rx.Scheduler.none);
     const nexts = [];
     const output = [];
 
@@ -477,7 +477,7 @@ describe('Subject', () => {
   });
 
   it('should be an Observer which can be given to Observable.subscribe', (done: MochaDone) => {
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = Observable.of(1, 2, 3, 4, 5, Rx.Scheduler.none);
     const subject = new Subject();
     const expected = [1, 2, 3, 4, 5];
 
@@ -494,7 +494,7 @@ describe('Subject', () => {
   });
 
   it('should be usable as an Observer of a finite delayed Observable', (done: MochaDone) => {
-    const source = Rx.Observable.of(1, 2, 3).delay(50);
+    const source = Rx.Observable.of(1, 2, 3, Rx.Scheduler.none).delay(50);
     const subject = new Rx.Subject();
 
     const expected = [1, 2, 3];
@@ -626,7 +626,7 @@ describe('Subject', () => {
 
       const subject = new Rx.Subject(null, new Rx.Observable((observer: Rx.Observer<any>) => {
         subscribed = true;
-        const subscription = Rx.Observable.of('x').subscribe(observer);
+        const subscription = Rx.Observable.of('x', Rx.Scheduler.none).subscribe(observer);
         return () => {
           subscription.unsubscribe();
         };

--- a/spec/observables/defer-spec.ts
+++ b/spec/observables/defer-spec.ts
@@ -103,8 +103,8 @@ describe('Observable.defer', () => {
     const expected =   '--a--b-     ';
     const unsub =      '      !     ';
 
-    const e1 = Observable.defer(() => source.mergeMap((x: string) => Observable.of(x)))
-      .mergeMap((x: string) => Observable.of(x));
+    const e1 = Observable.defer(() => source.mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none)))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(e1, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -12,7 +12,7 @@ describe('Observable.from', () => {
   ('should create an observable from an array', () => {
     const e1 = Observable.from([10, 20, 30])
       // for the purpose of making a nice diagram, spread out the synchronous emissions
-      .concatMap((x, i) => Observable.of(x).delay(i === 0 ? 0 : 20, rxTestScheduler));
+      .concatMap((x, i) => Observable.of(x, Rx.Scheduler.none).delay(i === 0 ? 0 : 20, rxTestScheduler));
     const expected = 'x-y-(z|)';
     expectObservable(e1).toBe(expected, {x: 10, y: 20, z: 30});
   });
@@ -213,7 +213,7 @@ describe('Observable.from', () => {
   it('should handle object has observable symbol', (done: MochaDone) => {
     const value = 'x';
 
-    Observable.from(Observable.of(value)).subscribe((x: string) =>  {
+    Observable.from(Observable.of(value, Rx.Scheduler.none)).subscribe((x: string) =>  {
       expect(x).to.equal(value);
     }, (err: any) => {
       done(new Error('should not be called'));

--- a/spec/observables/if-spec.ts
+++ b/spec/observables/if-spec.ts
@@ -5,21 +5,21 @@ const Observable = Rx.Observable;
 
 describe('Observable.if', () => {
   it('should subscribe to thenSource when the conditional returns true', () => {
-    const e1 = Observable.if(() => true, Observable.of('a'));
+    const e1 = Observable.if(() => true, Observable.of('a', Rx.Scheduler.none));
     const expected = '(a|)';
 
     expectObservable(e1).toBe(expected);
   });
 
   it('should subscribe to elseSource when the conditional returns false', () => {
-    const e1 = Observable.if(() => false, Observable.of('a'), Observable.of('b'));
+    const e1 = Observable.if(() => false, Observable.of('a', Rx.Scheduler.none), Observable.of('b', Rx.Scheduler.none));
     const expected = '(b|)';
 
     expectObservable(e1).toBe(expected);
   });
 
   it('should complete without an elseSource when the conditional returns false', () => {
-    const e1 = Observable.if(() => false, Observable.of('a'));
+    const e1 = Observable.if(() => false, Observable.of('a', Rx.Scheduler.none));
     const expected = '|';
 
     expectObservable(e1).toBe(expected);
@@ -28,7 +28,7 @@ describe('Observable.if', () => {
   it('should raise error when conditional throws', () => {
     const e1 = Observable.if(<any>(() => {
       throw 'error';
-    }), Observable.of('a'));
+    }), Observable.of('a', Rx.Scheduler.none));
 
     const expected = '#';
 
@@ -51,7 +51,7 @@ describe('Observable.if', () => {
   it('should accept resolved promise as elseSource', (done: MochaDone) => {
     const expected = 42;
     const e1 = Observable.if(() => false,
-      Observable.of('a'),
+      Observable.of('a', Rx.Scheduler.none),
       new Promise((resolve: any) => { resolve(expected); }));
 
     e1.subscribe(x => {
@@ -66,7 +66,7 @@ describe('Observable.if', () => {
   it('should accept rejected promise as elseSource', (done: MochaDone) => {
     const expected = 42;
     const e1 = Observable.if(() => false,
-      Observable.of('a'),
+      Observable.of('a', Rx.Scheduler.none),
       new Promise((resolve: any, reject: any) => { reject(expected); }));
 
     e1.subscribe(x => {

--- a/spec/observables/merge-spec.ts
+++ b/spec/observables/merge-spec.ts
@@ -22,7 +22,7 @@ describe('Observable.merge(...observables)', () => {
   });
 
   it('should return itself when try to merge single observable', () => {
-    const e1 = Observable.of('a');
+    const e1 = Observable.of('a', Rx.Scheduler.none);
     const result = Observable.merge(e1);
 
     expect(e1).to.equal(result);
@@ -217,8 +217,8 @@ describe('Observable.merge(...observables, Scheduler, number)', () => {
   });
 
   it('should handle scheduler', () => {
-    const e1 =  Observable.of('a');
-    const e2 =  Observable.of('b').delay(20, rxTestScheduler);
+    const e1 =  Observable.of('a', Rx.Scheduler.none);
+    const e2 =  Observable.of('b', Rx.Scheduler.none).delay(20, rxTestScheduler);
     const expected = 'a-(b|)';
 
     expectObservable(Observable.merge(e1, e2, rxTestScheduler)).toBe(expected);

--- a/spec/observables/race-spec.ts
+++ b/spec/observables/race-spec.ts
@@ -110,9 +110,9 @@ describe('Observable.race', () => {
     const unsub =         '         !    ';
 
     const result = Observable.race(
-        e1.mergeMap((x: string) => Observable.of(x)),
-        e2.mergeMap((x: string) => Observable.of(x))
-    ).mergeMap((x: any) => Observable.of(x));
+        e1.mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none)),
+        e2.mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
+    ).mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/observables/range-spec.ts
+++ b/spec/observables/range-spec.ts
@@ -13,7 +13,7 @@ describe('Observable.range', () => {
   asDiagram('range(1, 10)')('should create an observable with numbers 1 to 10', () => {
     const e1 = Observable.range(1, 10)
       // for the purpose of making a nice diagram, spread out the synchronous emissions
-      .concatMap((x, i) => Observable.of(x).delay(i === 0 ? 0 : 20, rxTestScheduler));
+      .concatMap((x, i) => Observable.of(x, Rx.Scheduler.none).delay(i === 0 ? 0 : 20, rxTestScheduler));
     const expected = 'a-b-c-d-e-f-g-h-i-(j|)';
     const values = {
       a: 1,

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -114,7 +114,7 @@ describe('Observable.zip', () => {
         return this;
       };
 
-      Observable.zip(Observable.of(1, 2, 3), myIterator)
+      Observable.zip(Observable.of(1, 2, 3, Rx.Scheduler.none), myIterator)
         .subscribe();
 
       // since zip will call `next()` in advance, total calls when

--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -82,9 +82,9 @@ describe('Observable.prototype.audit', () => {
     const unsub =    '              !               ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .audit(() => e2)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/auditTime-spec.ts
+++ b/spec/operators/auditTime-spec.ts
@@ -122,9 +122,9 @@ describe('Observable.prototype.auditTime', () => {
     const unsub =    '                               !';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .auditTime(50, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);

--- a/spec/operators/buffer-spec.ts
+++ b/spec/operators/buffer-spec.ts
@@ -145,9 +145,9 @@ describe('Observable.prototype.buffer', () => {
     };
 
     const result = a
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .buffer(b)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, expectedValues);
     expectSubscriptions(a.subscriptions).toBe(subs);

--- a/spec/operators/bufferCount-spec.ts
+++ b/spec/operators/bufferCount-spec.ts
@@ -72,9 +72,9 @@ describe('Observable.prototype.bufferCount', () => {
     const unsub =    '                  !           ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .bufferCount(3, 2)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(subs);

--- a/spec/operators/bufferTime-spec.ts
+++ b/spec/operators/bufferTime-spec.ts
@@ -149,9 +149,9 @@ describe('Observable.prototype.bufferTime', () => {
     };
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .bufferTime(t, interval, rxTestScheduler)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(subs);

--- a/spec/operators/bufferToggle-spec.ts
+++ b/spec/operators/bufferToggle-spec.ts
@@ -163,9 +163,9 @@ describe('Observable.prototype.bufferToggle', () => {
 
     let i = 0;
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .bufferToggle(e2, () => closings[i++])
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -365,7 +365,7 @@ describe('Observable.prototype.bufferToggle', () => {
   });
 
   it('should accept openings rejected promise', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
+    const e1 = Observable.concat(Observable.of(1, Rx.Scheduler.none),
       Observable.timer(10).mapTo(2),
       Observable.timer(10).mapTo(3),
       Observable.timer(100).mapTo(4)
@@ -386,14 +386,14 @@ describe('Observable.prototype.bufferToggle', () => {
   });
 
   it('should accept closing selector that returns a resolved promise', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
+    const e1 = Observable.concat(Observable.of(1, Rx.Scheduler.none),
       Observable.timer(10).mapTo(2),
       Observable.timer(10).mapTo(3),
       Observable.timer(100).mapTo(4)
       );
     const expected = [[1]];
 
-    e1.bufferToggle(Observable.of(10), () => new Promise((resolve: any) => { resolve(42); }))
+    e1.bufferToggle(Observable.of(10, Rx.Scheduler.none), () => new Promise((resolve: any) => { resolve(42); }))
       .subscribe((x) => {
         expect(x).to.deep.equal(expected.shift());
       }, () => {
@@ -405,7 +405,7 @@ describe('Observable.prototype.bufferToggle', () => {
   });
 
   it('should accept closing selector that returns a rejected promise', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
+    const e1 = Observable.concat(Observable.of(1, Rx.Scheduler.none),
       Observable.timer(10).mapTo(2),
       Observable.timer(10).mapTo(3),
       Observable.timer(100).mapTo(4)
@@ -413,7 +413,7 @@ describe('Observable.prototype.bufferToggle', () => {
 
     const expected = 42;
 
-    e1.bufferToggle(Observable.of(10), () => new Promise((resolve: any, reject: any) => { reject(expected); }))
+    e1.bufferToggle(Observable.of(10, Rx.Scheduler.none), () => new Promise((resolve: any, reject: any) => { reject(expected); }))
       .subscribe((x) => {
         done(new Error('should not be called'));
       }, (x) => {

--- a/spec/operators/bufferWhen-spec.ts
+++ b/spec/operators/bufferWhen-spec.ts
@@ -137,9 +137,9 @@ describe('Observable.prototype.bufferWhen', () => {
 
     let i = 0;
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .bufferWhen(() => closings[i++])
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -298,7 +298,7 @@ describe('Observable.prototype.bufferWhen', () => {
   // buffer in a synchronous infinite loop until the stack overflows. This also
   // happens with buffer in RxJS 4.
   it('should NOT handle hot inner empty', (done: MochaDone) => {
-    const source = Observable.of(1, 2, 3, 4, 5, 6, 7, 8, 9);
+    const source = Observable.of<number>(1, 2, 3, 4, 5, 6, 7, 8, 9, Rx.Scheduler.none);
     const closing = Observable.empty();
     const TOO_MANY_INVOCATIONS = 30;
 

--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -30,7 +30,7 @@ describe('Observable.prototype.catch', () => {
         return n;
       })
       .catch((err: any) => {
-        return Observable.of('X', 'Y', 'Z');
+        return Observable.of('X', 'Y', 'Z', Rx.Scheduler.none);
       });
 
     expectObservable(result).toBe(expected);
@@ -58,7 +58,7 @@ describe('Observable.prototype.catch', () => {
     const unsub =    '       !         ';
 
     const result = e1.catch(() => {
-      return Observable.of('X', 'Y', 'Z');
+      return Observable.of('X', 'Y', 'Z', Rx.Scheduler.none);
     });
 
     expectObservable(result, unsub).toBe(expected);
@@ -74,9 +74,9 @@ describe('Observable.prototype.catch', () => {
     const result = e1
       .mergeMap((x: any) => Observable.of(x))
       .catch(() => {
-        return Observable.of('X', 'Y', 'Z');
+        return Observable.of('X', 'Y', 'Z', Rx.Scheduler.none);
       })
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -154,7 +154,7 @@ describe('Observable.prototype.catch', () => {
     const subs =     '(^!)';
     const expected = '(abc|)';
 
-    const result = e1.catch((err: any) => Observable.of('a', 'b', 'c'));
+    const result = e1.catch((err: any) => Observable.of('a', 'b', 'c', Rx.Scheduler.none));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -165,7 +165,7 @@ describe('Observable.prototype.catch', () => {
     const subs =     '^          !';
     const expected = '--a--b--c--|';
 
-    const result = e1.catch((err: any) => Observable.of('x', 'y', 'z'));
+    const result = e1.catch((err: any) => Observable.of('x', 'y', 'z', Rx.Scheduler.none));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);

--- a/spec/operators/combineAll-spec.ts
+++ b/spec/operators/combineAll-spec.ts
@@ -25,7 +25,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -39,7 +39,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '(^!)';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -53,7 +53,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -67,7 +67,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =  '(^!)';
     const expected = '|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -81,7 +81,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -95,7 +95,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.of(e2, e1).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e2, e1, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -109,7 +109,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^  ';
     const expected =         '-'; //never
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -123,7 +123,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '-----'; //never
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -137,7 +137,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =        '^         !';
     const expected =      '----x-yz--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -153,7 +153,7 @@ describe('Observable.prototype.combineAll', () => {
     const unsub =         '         !    ';
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -169,10 +169,10 @@ describe('Observable.prototype.combineAll', () => {
     const unsub =         '         !    ';
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-    const result = Observable.of(e1, e2)
-      .mergeMap((x: any) => Observable.of(x))
+    const result = Observable.of(e1, e2, Rx.Scheduler.none)
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .combineAll((x: any, y: any) => x + y)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -188,7 +188,7 @@ describe('Observable.prototype.combineAll', () => {
     const e3subs =        '^         !';
     const expected =      '-----wxyz-|';
 
-    const result = Observable.of(e1, e2, e3).combineAll((x: string, y: string, z: string) => x + y + z);
+    const result = Observable.of(e1, e2, e3, Rx.Scheduler.none).combineAll((x: string, y: string, z: string) => x + y + z);
 
     expectObservable(result).toBe(expected, { w: 'bfi', x: 'cfi', y: 'cgi', z: 'cgj' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -203,7 +203,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^     !';
     const expected = '------#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'shazbot!');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -217,7 +217,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =     '^   !';
     const expected =   '----#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'too bad, honk');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -231,7 +231,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -245,7 +245,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -259,7 +259,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -273,7 +273,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -287,7 +287,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -301,7 +301,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^     !';
     const expected =     '------#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -315,7 +315,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^    !';
     const expected =     '-----#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -329,7 +329,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, { a: 1, b: 2}, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -343,7 +343,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -357,7 +357,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -371,7 +371,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =       '^      !';
     const expected =        '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -385,7 +385,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =     '^           !';
     const expected =   '-----x-y-z--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'be', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -399,7 +399,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =      '^                   !';
     const expected =    '-----------x--y--z--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -413,7 +413,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, null, 'jenga');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -427,7 +427,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^                   !';
     const expected =       '-----------x--y--z--#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right, Rx.Scheduler.none).combineAll((x: any, y: any) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' }, 'dun dun dun');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -441,7 +441,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =      '^  !';
     const expected =    '---#';
 
-    const result = Observable.of(e1, e2).combineAll(<any>((x: string, y: string) => { throw 'ha ha ' + x + ', ' + y; }));
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).combineAll(<any>((x: string, y: string) => { throw 'ha ha ' + x + ', ' + y; }));
 
     expectObservable(result).toBe(expected, null, 'ha ha b, d');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -449,10 +449,10 @@ describe('Observable.prototype.combineAll', () => {
   });
 
   it('should combine two observables', (done: MochaDone) => {
-    const a = Observable.of(1, 2, 3);
-    const b = Observable.of(4, 5, 6, 7, 8);
+    const a = Observable.of(1, 2, 3, Rx.Scheduler.none);
+    const b = Observable.of(4, 5, 6, 7, 8, Rx.Scheduler.none);
     const expected = [[3, 4], [3, 5], [3, 6], [3, 7], [3, 8]];
-    Observable.of(a, b).combineAll().subscribe((vals: any) => {
+    Observable.of(a, b, Rx.Scheduler.none).combineAll().subscribe((vals: any) => {
       expect(vals).to.deep.equal(expected.shift());
     }, null, () => {
       expect(expected.length).to.equal(0);

--- a/spec/operators/combineLatest-spec.ts
+++ b/spec/operators/combineLatest-spec.ts
@@ -453,9 +453,9 @@ describe('Observable.prototype.combineLatest', () => {
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .combineLatest(e2, (x: any, y: any) => x + y)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/concat-spec.ts
+++ b/spec/operators/concat-spec.ts
@@ -206,9 +206,9 @@ describe('Observable.prototype.concat', () => {
     const unsub =     '                 !    ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .concat(e2)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -61,9 +61,9 @@ describe('Observable.prototype.concatAll', () => {
 
   it('should concat all observables in an observable', () => {
     const e1 = Rx.Observable.from([
-      Rx.Observable.of('a'),
-      Rx.Observable.of('b'),
-      Rx.Observable.of('c')
+      Rx.Observable.of('a', Rx.Scheduler.none),
+      Rx.Observable.of('b', Rx.Scheduler.none),
+      Rx.Observable.of('c', Rx.Scheduler.none)
     ]).take(10);
     const expected = '(abc|)';
 
@@ -72,9 +72,9 @@ describe('Observable.prototype.concatAll', () => {
 
   it('should throw if any child observable throws', () => {
     const e1 = Rx.Observable.from([
-      Rx.Observable.of('a'),
+      Rx.Observable.of('a', Rx.Scheduler.none),
       Rx.Observable.throw('error'),
-      Rx.Observable.of('c')
+      Rx.Observable.of('c', Rx.Scheduler.none)
     ]).take(10);
     const expected = '(a#)';
 
@@ -124,7 +124,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '  ^   !';
     const expected =  '------|';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -138,7 +138,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs = [];
     const expected =  '-';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -152,7 +152,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '  ^';
     const expected =  '---';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -166,7 +166,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs = [];
     const expected =  '-';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -180,7 +180,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '  ^   !';
     const expected =  '------#';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -194,7 +194,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs = [];
     const expected =  '---#';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -208,7 +208,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs = [];
     const expected =  '---#';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -222,7 +222,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '     ^       !';
     const expected =  '--a----------|';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -236,7 +236,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '  ^    !';
     const expected =  '----a--|';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -251,7 +251,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '     ^';
     const expected =  '--a---';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -265,7 +265,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs = [];
     const expected =  '-';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -279,7 +279,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '    ^       !';
     const expected =  '---a-----b--|';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -294,7 +294,7 @@ describe('Observable.prototype.concatAll', () => {
     const unsub =     '                 !    ';
     const expected =  '---a-a--a-----b-b     ';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -309,10 +309,10 @@ describe('Observable.prototype.concatAll', () => {
     const expected =  '---a-a--a-----b-b-    ';
     const unsub =     '                 !    ';
 
-    const result = Observable.of(e1, e2)
-      .mergeMap((x: any) => Observable.of(x))
+    const result = Observable.of(e1, e2, Rx.Scheduler.none)
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .concatAll()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -326,7 +326,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs = [];
     const expected =  '--#';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -340,7 +340,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =    '     ^      !';
     const expected =  '--a---------#';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -355,7 +355,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =   '       ^      !';
     const expected = '--a--b--x--y--|';
 
-    const result = Observable.of(e1, e2).concatAll();
+    const result = Observable.of(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -370,7 +370,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =   '            ^      !';
     const expected = '--a--b--c----x-y-z-|';
 
-    const result = Observable.of<Rx.Observable<string>>(e1, e2).concatAll();
+    const result = Observable.of<Rx.Observable<string>>(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -384,7 +384,7 @@ describe('Observable.prototype.concatAll', () => {
     const e2subs =   '           ^     !';
     const expected = '--a--b--c--y--z--|';
 
-    const result = Observable.of<Rx.Observable<string>>(e1, e2).concatAll();
+    const result = Observable.of<Rx.Observable<string>>(e1, e2, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -413,7 +413,7 @@ describe('Observable.prototype.concatAll', () => {
     const e1subs =    '^    !';
     const expected =  '---a-|';
 
-    const result = Observable.of(e1).concatAll();
+    const result = Observable.of(e1, Rx.Scheduler.none).concatAll();
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -466,9 +466,9 @@ describe('Observable.prototype.concatMap', () => {
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .concatMap((value: any) => observableLookup[value])
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -171,9 +171,9 @@ describe('Observable.prototype.concatMapTo', () => {
     const unsub =      '                  !';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .concatMapTo(inner)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/count-spec.ts
+++ b/spec/operators/count-spec.ts
@@ -187,9 +187,9 @@ describe('Observable.prototype.count', () => {
     const unsub =     '      !    ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .count((value: string) => parseInt(value) < 10)
-      .mergeMap((x: number) => Observable.of(x));
+      .mergeMap((x: number) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, { w: 3 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -94,9 +94,9 @@ describe('Observable.prototype.debounce', () => {
     const unsub =    '       !       ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .debounce(getTimerSelector(20))
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -349,7 +349,7 @@ describe('Observable.prototype.debounce', () => {
   });
 
   it('should delay by promise resolves', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
+    const e1 = Observable.concat(Observable.of(1, Rx.Scheduler.none),
       Observable.timer(10).mapTo(2),
       Observable.timer(10).mapTo(3),
       Observable.timer(100).mapTo(4)
@@ -370,7 +370,7 @@ describe('Observable.prototype.debounce', () => {
   });
 
   it('should raises error when promise rejects', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
+    const e1 = Observable.concat(Observable.of(1, Rx.Scheduler.none),
       Observable.timer(10).mapTo(2),
       Observable.timer(10).mapTo(3),
       Observable.timer(100).mapTo(4)

--- a/spec/operators/debounceTime-spec.ts
+++ b/spec/operators/debounceTime-spec.ts
@@ -86,9 +86,9 @@ describe('Observable.prototype.debounceTime', () => {
     const unsub =    '       !       ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .debounceTime(20, rxTestScheduler)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/defaultIfEmpty-spec.ts
+++ b/spec/operators/defaultIfEmpty-spec.ts
@@ -67,9 +67,9 @@ describe('Observable.prototype.defaultIfEmpty', () => {
     const unsub =    '    !    ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .defaultIfEmpty('x')
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -125,9 +125,9 @@ describe('Observable.prototype.delay', () => {
     const unsub =    '        !   ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .delay(t, rxTestScheduler)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/dematerialize-spec.ts
+++ b/spec/operators/dematerialize-spec.ts
@@ -135,9 +135,9 @@ describe('Observable.prototype.dematerialize', () => {
     const unsub =    '       !       ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .dematerialize()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/distinct-spec.ts
+++ b/spec/operators/distinct-spec.ts
@@ -69,7 +69,7 @@ describe('Observable.prototype.distinct', () => {
   });
 
   it('should emit if source is scalar', () => {
-    const e1 = Observable.of('a');
+    const e1 = Observable.of('a', Rx.Scheduler.none);
     const expected = '(a|)';
 
     expectObservable((<any>e1).distinct()).toBe(expected);
@@ -121,9 +121,9 @@ describe('Observable.prototype.distinct', () => {
     const unsub =    '          !          ';
 
     const result = (<any>e1
-      .mergeMap((x: any) => Observable.of(x)))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none)))
       .distinct()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/distinctKey-spec.ts
+++ b/spec/operators/distinctKey-spec.ts
@@ -103,7 +103,7 @@ describe('Observable.prototype.distinctKey', () => {
 
   it('should emit if source is scalar', () => {
     const values = {a: {val: 1}};
-    const e1 = Observable.of(values.a);
+    const e1 = Observable.of(values.a, Rx.Scheduler.none);
     const expected = '(a|)';
 
     expectObservable((<any>e1).distinctKey('val')).toBe(expected, values);
@@ -159,9 +159,9 @@ describe('Observable.prototype.distinctKey', () => {
     const unsub =    '          !          ';
 
     const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .distinctKey('val')
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/distinctUntilChanged-spec.ts
+++ b/spec/operators/distinctUntilChanged-spec.ts
@@ -76,7 +76,7 @@ describe('Observable.prototype.distinctUntilChanged', () => {
   });
 
   it('should emit if source is scalar', () => {
-    const e1 = Observable.of('a');
+    const e1 = Observable.of('a', Rx.Scheduler.none);
     const expected = '(a|)';
 
     expectObservable(e1.distinctUntilChanged()).toBe(expected);
@@ -128,9 +128,9 @@ describe('Observable.prototype.distinctUntilChanged', () => {
     const unsub =    '          !          ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .distinctUntilChanged()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/distinctUntilKeyChanged-spec.ts
+++ b/spec/operators/distinctUntilKeyChanged-spec.ts
@@ -101,7 +101,7 @@ describe('Observable.prototype.distinctUntilKeyChanged', () => {
 
   it('should emit if source is scalar', () => {
     const values = {a: {val: 1}};
-    const e1 = Rx.Observable.of(values.a);
+    const e1 = Rx.Observable.of(values.a, Rx.Scheduler.none);
     const expected = '(a|)';
 
     expectObservable((<any>e1).distinctUntilKeyChanged('val')).toBe(expected, values);
@@ -157,9 +157,9 @@ describe('Observable.prototype.distinctUntilKeyChanged', () => {
     const unsub =    '          !          ';
 
     const result = (<any>e1)
-      .mergeMap((x: any) => Rx.Observable.of(x))
+      .mergeMap((x: any) => Rx.Observable.of(x, Rx.Scheduler.none))
       .distinctUntilKeyChanged('val')
-      .mergeMap((x: any) => Rx.Observable.of(x));
+      .mergeMap((x: any) => Rx.Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/do-spec.ts
+++ b/spec/operators/do-spec.ts
@@ -21,7 +21,7 @@ describe('Observable.prototype.do', () => {
 
   it('should next with a callback', () => {
     let value = null;
-    Observable.of(42).do(function (x) {
+    Observable.of(42, Rx.Scheduler.none).do(function (x) {
       value = x;
     })
     .subscribe();
@@ -45,7 +45,7 @@ describe('Observable.prototype.do', () => {
     const expected = [1, 2, 3];
     const results = [];
 
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .do(<Rx.Observer<number>>{
         next: (x: number) => {
           results.push(x);
@@ -78,7 +78,7 @@ describe('Observable.prototype.do', () => {
       }
     });
 
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .do(<Rx.Observer<number>>subject)
       .subscribe();
   });
@@ -124,7 +124,7 @@ describe('Observable.prototype.do', () => {
   it('should handle next with observer', () => {
     let value = null;
 
-    Observable.of('hi').do(<any>{
+    Observable.of('hi', Rx.Scheduler.none).do(<any>{
       next: (x: string) => {
         value = x;
       }
@@ -134,7 +134,7 @@ describe('Observable.prototype.do', () => {
   });
 
   it('should raise error if next handler raises error', () => {
-    Observable.of('hi').do(<any>{
+    Observable.of('hi', Rx.Scheduler.none).do(<any>{
       next: (x: string) => {
         throw new Error('bad');
       }
@@ -183,11 +183,11 @@ describe('Observable.prototype.do', () => {
     const unsub =    '       !    ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .do(() => {
         //noop
       })
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/elementAt-spec.ts
+++ b/spec/operators/elementAt-spec.ts
@@ -88,9 +88,9 @@ describe('Observable.prototype.elementAt', () => {
     const unsub =      '      !     ';
 
     const result = (<any>source)
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .elementAt(2)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/every-spec.ts
+++ b/spec/operators/every-spec.ts
@@ -26,7 +26,7 @@ describe('Observable.prototype.every', () => {
   it('should accept thisArg with scalar observables', () => {
     const thisArg = {};
 
-    Observable.of(1).every(function (value: number, index: number) {
+    Observable.of(1, Rx.Scheduler.none).every(function (value: number, index: number) {
       expect(this).to.deep.equal(thisArg);
       return true;
     }, thisArg).subscribe();
@@ -36,7 +36,7 @@ describe('Observable.prototype.every', () => {
   it('should accept thisArg with array observables', () => {
     const thisArg = {};
 
-    Observable.of(1, 2, 3, 4).every(function (value: number, index: number) {
+    Observable.of(1, 2, 3, 4, Rx.Scheduler.none).every(function (value: number, index: number) {
       expect(this).to.deep.equal(thisArg);
       return true;
     }, thisArg).subscribe();
@@ -109,9 +109,9 @@ describe('Observable.prototype.every', () => {
     const unsub =      '       !          ';
 
     const result = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .every(predicate)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -144,21 +144,21 @@ describe('Observable.prototype.every', () => {
   });
 
   it('should emit true if Scalar source matches with predicate', () => {
-    const source = Observable.of(5);
+    const source = Observable.of(5, Rx.Scheduler.none);
     const expected = '(T|)';
 
     expectObservable(source.every(predicate)).toBe(expected, {T: true});
   });
 
   it('should emit false if Scalar source does not match with predicate', () => {
-    const source = Observable.of(3);
+    const source = Observable.of(3, Rx.Scheduler.none);
     const expected = '(F|)';
 
     expectObservable(source.every(predicate)).toBe(expected, {F: false});
   });
 
   it('should propagate error if predicate throws on Scalar source', () => {
-    const source = Observable.of(3);
+    const source = Observable.of(3, Rx.Scheduler.none);
     const expected = '#';
 
     function faultyPredicate(x) {
@@ -169,21 +169,21 @@ describe('Observable.prototype.every', () => {
   });
 
   it('should emit true if Array source matches with predicate', () => {
-    const source = Observable.of(5, 10, 15, 20);
+    const source = Observable.of(5, 10, 15, 20, Rx.Scheduler.none);
     const expected = '(T|)';
 
     expectObservable(source.every(predicate)).toBe(expected, {T: true});
   });
 
   it('should emit false if Array source does not match with predicate', () => {
-    const source = Observable.of(5, 9, 15, 20);
+    const source = Observable.of(5, 9, 15, 20, Rx.Scheduler.none);
     const expected = '(F|)';
 
     expectObservable(source.every(predicate)).toBe(expected, {F: false});
   });
 
   it('should propagate error if predicate eventually throws on Array source', () => {
-    const source = Observable.of(5, 10, 15, 20);
+    const source = Observable.of(5, 10, 15, 20, Rx.Scheduler.none);
     const expected = '#';
 
     function faultyPredicate(x) {

--- a/spec/operators/exhaust-spec.ts
+++ b/spec/operators/exhaust-spec.ts
@@ -23,7 +23,7 @@ describe('Observable.prototype.exhaust', () => {
     const e2subs = [];
     const expected = '(ab|)';
 
-    expectObservable((<any>Observable.of(e1, e2)).exhaust()).toBe(expected);
+    expectObservable((<any>Observable.of(e1, e2, Rx.Scheduler.none)).exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -95,9 +95,9 @@ describe('Observable.prototype.exhaust', () => {
     const expected = '--------a---b----            ';
 
     const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .exhaust()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -190,7 +190,7 @@ describe('Observable.prototype.exhaust', () => {
   it('should handle an observable of promises', (done: MochaDone) => {
     const expected = [1];
 
-    (<any>Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)))
+    (<any>Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3), Rx.Scheduler.none))
       .exhaust()
       .subscribe((x: number) => {
         expect(x).to.equal(expected.shift());

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -150,9 +150,9 @@ describe('Observable.prototype.exhaustMap', () => {
     const observableLookup = { x: x, y: y, z: z };
 
     const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .exhaustMap((value: any) => observableLookup[value])
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -134,14 +134,14 @@ describe('Observable.prototype.expand', () => {
     const unsub =    '       !  ';
 
     const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .expand((x: number): Rx.Observable<any> => {
         if (x === 16) {
           return Observable.empty();
         }
         return cold(e2shape, { z: x + x });
       })
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -288,7 +288,7 @@ describe('Observable.prototype.expand', () => {
       if (x === 16) {
         return Observable.empty();
       }
-      return Observable.of(x + x); // scalar
+      return Observable.of(x + x, Rx.Scheduler.none); // scalar
     });
 
     expectObservable(result).toBe(expected, values);
@@ -297,7 +297,7 @@ describe('Observable.prototype.expand', () => {
 
   it('should recursively flatten promises', (done: MochaDone) => {
     const expected = [1, 2, 4, 8, 16];
-    (<any>Observable.of(1))
+    (<any>Observable.of(1, Rx.Scheduler.none))
       .expand((x: number): any => {
         if (x === 16) {
           return Observable.empty();
@@ -314,7 +314,7 @@ describe('Observable.prototype.expand', () => {
 
   it('should recursively flatten Arrays', (done: MochaDone) => {
     const expected = [1, 2, 4, 8, 16];
-    (<any>Observable).of(1)
+    (<any>Observable).of(1, Rx.Scheduler.none)
       .expand((x: number): any => {
         if (x === 16) {
           return Observable.empty();
@@ -349,7 +349,7 @@ describe('Observable.prototype.expand', () => {
       return ish;
     };
 
-    (<any>Observable.of(1))
+    (<any>Observable.of(1, Rx.Scheduler.none))
       .expand(project)
       .subscribe((x: number) => {
         expect(x).to.equal(expected.shift());

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -245,7 +245,7 @@ describe('Observable.prototype.filter', () => {
   });
 
   it('should send errors down the error path', (done: MochaDone) => {
-    Observable.of(42).filter(<any>((x: number, index: number) => {
+    Observable.of(42, Rx.Scheduler.none).filter(<any>((x: number, index: number) => {
       throw 'bad';
     }))
       .subscribe((x: number) => {
@@ -265,9 +265,9 @@ describe('Observable.prototype.filter', () => {
     const expected =          '--3---5----7-       ';
 
     const r = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .filter(isPrime)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(r, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/finally-spec.ts
+++ b/spec/operators/finally-spec.ts
@@ -7,7 +7,7 @@ const Observable = Rx.Observable;
 describe('Observable.prototype.finally', () => {
   it('should call finally after complete', (done: MochaDone) => {
     let completed = false;
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .finally(() => {
         expect(completed).to.be.true;
         done();
@@ -19,7 +19,7 @@ describe('Observable.prototype.finally', () => {
 
   it('should call finally after error', (done: MochaDone) => {
     let thrown = false;
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .map(function (x) {
         if (x === 3) {
           throw x;
@@ -65,7 +65,7 @@ describe('Observable.prototype.finally', () => {
       }
     }
 
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .finally(checkFinally)
       .finally(checkFinally)
       .share()

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -24,7 +24,7 @@ describe('Observable.prototype.find', () => {
 
   it('should throw if not provided a function', () => {
     expect(() => {
-      (<any>Observable.of('yut', 'yee', 'sam')).find('yee');
+      (<any>Observable.of('yut', 'yee', 'sam', Rx.Scheduler.none)).find('yee');
     }).to.throw(TypeError, 'predicate is not a function');
   });
 
@@ -122,9 +122,9 @@ describe('Observable.prototype.find', () => {
     const unsub =      '      !     ';
 
     const result = (<any>source)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .find((value: string) => value === 'z')
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -115,9 +115,9 @@ describe('Observable.prototype.findIndex', () => {
     const unsub =      '      !     ';
 
     const result = (<any>source)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .findIndex((value: string) => value === 'z')
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -77,9 +77,9 @@ describe('Observable.prototype.first', () => {
     const unsub =       '   !               ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .first()
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -40,7 +40,7 @@ describe('Observable.prototype.groupBy', () => {
       { key: 0, values: [2] }
     ];
 
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .groupBy((x: number) => x % 2)
       .subscribe((g: any) => {
         const expectedGroup = expectedGroups.shift();
@@ -58,7 +58,7 @@ describe('Observable.prototype.groupBy', () => {
       { key: 0, values: ['2!'] }
     ];
 
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .groupBy((x: number) => x % 2, (x: number) => x + '!')
       .subscribe((g: any) => {
         const expectedGroup = expectedGroups.shift();
@@ -78,7 +78,7 @@ describe('Observable.prototype.groupBy', () => {
       { key: 0, values: [6] }
     ];
 
-    Observable.of(1, 2, 3, 4, 5, 6)
+    Observable.of(1, 2, 3, 4, 5, 6, Rx.Scheduler.none)
       .groupBy(
         (x: number) => x % 2,
         (x: number) => x,
@@ -335,9 +335,9 @@ describe('Observable.prototype.groupBy', () => {
     const expectedValues = { w: 'foo', x: 'bar', y: 'baz' };
 
     const source = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .groupBy((x: string) => x.toLowerCase().trim())
-      .mergeMap((group: any) => Observable.of(group.key));
+      .mergeMap((group: any) => Observable.of(group.key, Rx.Scheduler.none));
 
     expectObservable(source, unsub).toBe(expected, expectedValues);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/ignoreElements-spec.ts
+++ b/spec/operators/ignoreElements-spec.ts
@@ -33,9 +33,9 @@ describe('Observable.prototype.ignoreElements', () => {
     const unsub =      '       !       ';
 
     const result = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .ignoreElements()
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/isEmpty-spec.ts
+++ b/spec/operators/isEmpty-spec.ts
@@ -65,9 +65,9 @@ describe('Observable.prototype.isEmpty', () => {
     const unsub =       '      !           ';
 
     const result = (<any>source)
-      .mergeMap((x: string) => Rx.Observable.of(x))
+      .mergeMap((x: string) => Rx.Observable.of(x, Rx.Scheduler.none))
       .isEmpty()
-      .mergeMap((x: string) => Rx.Observable.of(x));
+      .mergeMap((x: string) => Rx.Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/last-spec.ts
+++ b/spec/operators/last-spec.ts
@@ -70,9 +70,9 @@ describe('Observable.prototype.last', () => {
     const unsub =     '       !       ';
 
     const result = e1
-      .mergeMap((x: string) => Rx.Observable.of(x))
+      .mergeMap((x: string) => Rx.Observable.of(x, Rx.Scheduler.none))
       .last()
-      .mergeMap((x: string) => Rx.Observable.of(x));
+      .mergeMap((x: string) => Rx.Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/map-spec.ts
+++ b/spec/operators/map-spec.ts
@@ -35,7 +35,7 @@ describe('Observable.prototype.map', () => {
 
   it('should throw an error if not passed a function', () => {
     expect(() => {
-      Observable.of(1, 2, 3).map(<any>'potato');
+      Observable.of(1, 2, 3, Rx.Scheduler.none).map(<any>'potato');
     }).to.throw(TypeError, 'argument is not a function. Are you looking for `mapTo()`?');
   });
 
@@ -85,7 +85,7 @@ describe('Observable.prototype.map', () => {
 
   it('should propagate errors from subscribe', () => {
     const r = () => {
-      Observable.of(1)
+      Observable.of(1, Rx.Scheduler.none)
         .map(identity)
         .subscribe(throwError);
     };
@@ -247,9 +247,9 @@ describe('Observable.prototype.map', () => {
     const expected = '--x--y-     ';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .map(addDrama)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(r, unsub).toBe(expected, {x: '1!', y: '2!'});
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/mapTo-spec.ts
+++ b/spec/operators/mapTo-spec.ts
@@ -57,7 +57,7 @@ describe('Observable.prototype.mapTo', () => {
 
   it('should propagate errors from subscribe', () => {
     const r = () => {
-      Observable.of(1)
+      Observable.of(1, Rx.Scheduler.none)
         .mapTo(-1)
         .subscribe(throwError);
     };
@@ -92,9 +92,9 @@ describe('Observable.prototype.mapTo', () => {
     const expected = '--x--x-     ';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .mapTo('x')
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(r, unsub).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/materialize-spec.ts
+++ b/spec/operators/materialize-spec.ts
@@ -83,9 +83,9 @@ describe('Observable.prototype.materialize', () => {
     };
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .materialize()
-      .mergeMap((x: Rx.Notification<any>) => Observable.of(x));
+      .mergeMap((x: Rx.Notification<any>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/max-spec.ts
+++ b/spec/operators/max-spec.ts
@@ -86,9 +86,9 @@ describe('Observable.prototype.max', () => {
     const unsub =      '      !     ';
 
     const result = (<any>source)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .max()
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, { x: 42 });
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/merge-spec.ts
+++ b/spec/operators/merge-spec.ts
@@ -23,8 +23,8 @@ describe('Observable.prototype.merge', () => {
   });
 
   it('should merge a source with a second', (done: MochaDone) => {
-    const a = Observable.of(1, 2, 3);
-    const b = Observable.of(4, 5, 6, 7, 8);
+    const a = Observable.of(1, 2, 3, Rx.Scheduler.none);
+    const b = Observable.of(4, 5, 6, 7, 8, Rx.Scheduler.none);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
 
     a.merge(b).subscribe((val: number) => {
@@ -278,11 +278,11 @@ describe('Observable.prototype.merge', () => {
 
 describe('Observable.prototype.mergeAll', () => {
   it('should merge two observables', (done: MochaDone) => {
-    const a = Observable.of(1, 2, 3);
-    const b = Observable.of(4, 5, 6, 7, 8);
+    const a = Observable.of(1, 2, 3, Rx.Scheduler.none);
+    const b = Observable.of(4, 5, 6, 7, 8, Rx.Scheduler.none);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    Observable.of(a, b).mergeAll().subscribe((val: number) => {
+    Observable.of(a, b, Rx.Scheduler.none).mergeAll().subscribe((val: number) => {
       expect(val).to.equal(r.shift());
     }, null, done);
   });

--- a/spec/operators/mergeAll-spec.ts
+++ b/spec/operators/mergeAll-spec.ts
@@ -17,9 +17,9 @@ describe('Observable.prototype.mergeAll', () => {
 
   it('should merge all observables in an observable', () => {
     const e1 = Observable.from([
-      Observable.of('a'),
-      Observable.of('b'),
-      Observable.of('c')
+      Observable.of('a', Rx.Scheduler.none),
+      Observable.of('b', Rx.Scheduler.none),
+      Observable.of('c', Rx.Scheduler.none)
     ]);
     const expected = '(abc|)';
 
@@ -28,9 +28,9 @@ describe('Observable.prototype.mergeAll', () => {
 
   it('should throw if any child observable throws', () => {
     const e1 = Observable.from([
-      Observable.of('a'),
+      Observable.of('a', Rx.Scheduler.none),
       Observable.throw('error'),
-      Observable.of('c')
+      Observable.of('c', Rx.Scheduler.none)
     ]);
     const expected = '(a#)';
 
@@ -145,9 +145,9 @@ describe('Observable.prototype.mergeAll', () => {
     const unsub =     '            !     ';
 
     const result = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .mergeAll()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -729,7 +729,7 @@ describe('Observable.prototype.mergeMap', () => {
   });
 
   it('should map and flatten', () => {
-    const source = Observable.of(1, 2, 3, 4).mergeMap((x: number) => Observable.of(x + '!'));
+    const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).mergeMap((x: number) => Observable.of(x + '!', Rx.Scheduler.none));
 
     const expected = ['1!', '2!', '3!', '4!'];
     let completed = false;
@@ -745,7 +745,7 @@ describe('Observable.prototype.mergeMap', () => {
   });
 
   it('should map and flatten an Array', () => {
-    const source = Observable.of(1, 2, 3, 4).mergeMap((x: number): any => [x + '!']);
+    const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).mergeMap((x: number): any => [x + '!']);
 
     const expected = ['1!', '2!', '3!', '4!'];
     let completed = false;

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -420,7 +420,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   });
 
   it('should map and flatten', () => {
-    const source = Observable.of(1, 2, 3, 4).mergeMapTo(Observable.of('!'));
+    const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).mergeMapTo(Observable.of('!', Rx.Scheduler.none));
 
     const expected = ['!', '!', '!', '!'];
     let completed = false;
@@ -436,7 +436,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   });
 
   it('should map and flatten an Array', () => {
-    const source = Observable.of(1, 2, 3, 4).mergeMapTo(<any>['!']);
+    const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).mergeMapTo(<any>['!']);
 
     const expected = ['!', '!', '!', '!'];
     let completed = false;

--- a/spec/operators/mergeScan-spec.ts
+++ b/spec/operators/mergeScan-spec.ts
@@ -20,7 +20,7 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x), Rx.Scheduler.none), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -37,7 +37,7 @@ describe('Observable.prototype.mergeScan', () => {
       w: ['b', 'c', 'd']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x), Rx.Scheduler.none), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -58,7 +58,7 @@ describe('Observable.prototype.mergeScan', () => {
     };
 
     const source = (<any>e1).mergeScan((acc: any, x: string) =>
-      Observable.of(acc.concat(x)).delay(20, rxTestScheduler), []);
+      Observable.of(acc.concat(x), Rx.Scheduler.none).delay(20, rxTestScheduler), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -79,7 +79,7 @@ describe('Observable.prototype.mergeScan', () => {
     };
 
     const source = (<any>e1).mergeScan((acc: any, x: string) =>
-      Observable.of(acc.concat(x)).delay(50, rxTestScheduler), []);
+      Observable.of(acc.concat(x), Rx.Scheduler.none).delay(50, rxTestScheduler), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -100,7 +100,7 @@ describe('Observable.prototype.mergeScan', () => {
     };
 
     const source = (<any>e1).mergeScan((acc: any, x: string) =>
-      Observable.of(acc.concat(x)).delay(50, rxTestScheduler), []);
+      Observable.of(acc.concat(x), Rx.Scheduler.none).delay(50, rxTestScheduler), []);
 
     expectObservable(source, e1subs).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -122,10 +122,10 @@ describe('Observable.prototype.mergeScan', () => {
     };
 
     const source = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .mergeScan((acc: any, x: string) =>
-        Observable.of(acc.concat(x)).delay(50, rxTestScheduler), [])
-      .mergeMap(function (x) { return Observable.of(x); });
+        Observable.of(acc.concat(x), Rx.Scheduler.none).delay(50, rxTestScheduler), [])
+      .mergeMap(function (x) { return Observable.of(x, Rx.Scheduler.none); });
 
     expectObservable(source, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -145,7 +145,7 @@ describe('Observable.prototype.mergeScan', () => {
       if (x === 'd') {
         throw 'bad!';
       }
-      return Observable.of(acc.concat(x));
+      return Observable.of(acc.concat(x), Rx.Scheduler.none);
     }, []);
 
     expectObservable(source).toBe(expected, values, 'bad!');
@@ -198,7 +198,7 @@ describe('Observable.prototype.mergeScan', () => {
       u: []
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x), Rx.Scheduler.none), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -209,7 +209,7 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x), Rx.Scheduler.none), []);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -220,7 +220,7 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x), Rx.Scheduler.none), []);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -239,7 +239,7 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x), Rx.Scheduler.none), []);
 
     expectObservable(source, sub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(sub);

--- a/spec/operators/min-spec.ts
+++ b/spec/operators/min-spec.ts
@@ -184,9 +184,9 @@ describe('Observable.prototype.min', () => {
     };
 
     const result = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .min(predicate)
-      .mergeMap((x: number) => Observable.of(x));
+      .mergeMap((x: number) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, { w: 42 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -22,7 +22,7 @@ describe('Observable.prototype.multicast', () => {
   it('should accept Subjects', (done: MochaDone) => {
     const expected = [1, 2, 3, 4];
 
-    const connectable = Observable.of(1, 2, 3, 4).multicast(new Subject<number>());
+    const connectable = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).multicast(new Subject<number>());
 
     connectable.subscribe((x: number) => { expect(x).to.equal(expected.shift()); },
         (x) => {
@@ -37,7 +37,7 @@ describe('Observable.prototype.multicast', () => {
   it('should accept Subject factory functions', (done: MochaDone) => {
     const expected = [1, 2, 3, 4];
 
-    const connectable = Observable.of(1, 2, 3, 4).multicast(() => new Subject<number>());
+    const connectable = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).multicast(() => new Subject<number>());
 
     connectable.subscribe((x: number) => { expect(x).to.equal(expected.shift()); },
         (x) => {
@@ -128,7 +128,7 @@ describe('Observable.prototype.multicast', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const multicasted = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .multicast(() => new Subject<string>());
     const subscriber1 = hot('a|           ').mergeMapTo(multicasted);
     const expected1   =     '-1-2-3----   ';
@@ -490,7 +490,7 @@ describe('Observable.prototype.multicast', () => {
       const expected = [1, 2, 3, 4];
       let i = 0;
 
-      const source = Observable.of(1, 2, 3, 4).multicast(() => new Subject<number>());
+      const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).multicast(() => new Subject<number>());
 
       source.subscribe((x: number) => {
         expect(x).to.equal(expected[i++]);
@@ -510,13 +510,13 @@ describe('Observable.prototype.multicast', () => {
 
     it('should not throw ObjectUnsubscribedError when used in ' +
     'a switchMap', (done: MochaDone) => {
-      const source = Observable.of(1, 2, 3)
+      const source = Observable.of(1, 2, 3, Rx.Scheduler.none)
         .multicast(() => new Subject<number>())
         .refCount();
 
       const expected = ['a1', 'a2', 'a3', 'b1', 'b2', 'b3', 'c1', 'c2', 'c3'];
 
-      Observable.of('a', 'b', 'c')
+      Observable.of('a', 'b', 'c', Rx.Scheduler.none)
         .switchMap((letter: string) => source.map((n: number) => String(letter + n)))
         .subscribe((x: string) => {
           expect(x).to.equal(expected.shift());
@@ -534,7 +534,7 @@ describe('Observable.prototype.multicast', () => {
       const expected = [1, 2, 3, 4];
       let i = 0;
 
-      const source = Observable.of(1, 2, 3, 4).multicast(new Subject<number>());
+      const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).multicast(new Subject<number>());
 
       source.subscribe((x: number) => {
         expect(x).to.equal(expected[i++]);
@@ -555,13 +555,13 @@ describe('Observable.prototype.multicast', () => {
 
     it('should not throw ObjectUnsubscribedError when used in ' +
     'a switchMap', (done: MochaDone) => {
-      const source = Observable.of(1, 2, 3)
+      const source = Observable.of(1, 2, 3, Rx.Scheduler.none)
         .multicast(new Subject<number>())
         .refCount();
 
       const expected = ['a1', 'a2', 'a3'];
 
-      Observable.of('a', 'b', 'c')
+      Observable.of('a', 'b', 'c', Rx.Scheduler.none)
         .switchMap((letter: string) => source.map((n: number) => String(letter + n)))
         .subscribe((x: string) => {
           expect(x).to.equal(expected.shift());

--- a/spec/operators/observeOn-spec.ts
+++ b/spec/operators/observeOn-spec.ts
@@ -70,9 +70,9 @@ describe('Observable.prototype.observeOn', () => {
     const unsub =     '    !    ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .observeOn(rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);

--- a/spec/operators/partition-spec.ts
+++ b/spec/operators/partition-spec.ts
@@ -211,10 +211,10 @@ describe('Observable.prototype.partition', () => {
     const unsub =     '       !          ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .partition((x: string) => x === 'a')
       .map((observable: Rx.Observable<string>) =>
-        observable.mergeMap((x: string) => Observable.of(x)));
+        observable.mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none)));
 
     expectObservable(result[0], unsub).toBe(expected[0]);
     expectObservable(result[1], unsub).toBe(expected[1]);

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -85,7 +85,7 @@ describe('Observable.prototype.pluck', () => {
 
   it('should throw an error if not property is passed', () => {
     expect(() => {
-      Observable.of({prop: 1}, {prop: 2}).pluck();
+      Observable.of({prop: 1}, {prop: 2}, Rx.Scheduler.none).pluck();
     }).to.throw(Error, 'List of properties cannot be empty.');
   });
 
@@ -160,9 +160,9 @@ describe('Observable.prototype.pluck', () => {
     const expected = '--1--2-     ';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .pluck('prop')
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(r, unsub).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -22,7 +22,7 @@ describe('Observable.prototype.publish', () => {
     const expected = [1, 2, 3, 4];
     let i = 0;
 
-    const source = Observable.of(1, 2, 3, 4).publish();
+    const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).publish();
 
     source.subscribe((x: number) => {
       expect(x).to.equal(expected[i++]);
@@ -44,7 +44,7 @@ describe('Observable.prototype.publish', () => {
   });
 
   it('should return a ConnectableObservable', () => {
-    const source = Observable.of(1).publish();
+    const source = Observable.of(1, Rx.Scheduler.none).publish();
     expect(source instanceof Rx.ConnectableObservable).to.be.true;
   });
 
@@ -127,7 +127,7 @@ describe('Observable.prototype.publish', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .publish();
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '-1-2-3----   ';

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -19,7 +19,7 @@ describe('Observable.prototype.publishBehavior', () => {
   });
 
   it('should return a ConnectableObservable', () => {
-    const source = Observable.of(1).publishBehavior(1);
+    const source = Observable.of(1, Rx.Scheduler.none).publishBehavior(1);
     expect(source instanceof Rx.ConnectableObservable).to.be.true;
   });
 
@@ -37,7 +37,7 @@ describe('Observable.prototype.publishBehavior', () => {
     const expected = [0, 1, 2, 3, 4];
     let i = 0;
 
-    const source = Observable.of(1, 2, 3, 4).publishBehavior(0);
+    const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).publishBehavior(0);
 
     source.subscribe(
       (x: number) => {
@@ -129,7 +129,7 @@ describe('Observable.prototype.publishBehavior', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .publishBehavior('0');
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '01-2-3----   ';

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -19,7 +19,7 @@ describe('Observable.prototype.publishLast', () => {
   });
 
   it('should return a ConnectableObservable', () => {
-    const source = Observable.of(1).publishLast();
+    const source = Observable.of(1, Rx.Scheduler.none).publishLast();
 
     expect(source instanceof Rx.ConnectableObservable).to.be.true;
   });
@@ -103,7 +103,7 @@ describe('Observable.prototype.publishLast', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .publishLast();
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '----------   ';

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -19,7 +19,7 @@ describe('Observable.prototype.publishReplay', () => {
   });
 
   it('should return a ConnectableObservable', () => {
-    const source = Observable.of(1).publishReplay();
+    const source = Observable.of(1, Rx.Scheduler.none).publishReplay();
     expect(source instanceof Rx.ConnectableObservable).to.be.true;
   });
 
@@ -121,7 +121,7 @@ describe('Observable.prototype.publishReplay', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none))
       .publishReplay(1);
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '-1-2-3----   ';
@@ -363,7 +363,7 @@ describe('Observable.prototype.publishReplay', () => {
     const expected = [1, 2, 3, 4];
     let i = 0;
 
-    const source = Observable.of(1, 2, 3, 4).publishReplay(1);
+    const source = Observable.of(1, 2, 3, 4, Rx.Scheduler.none).publishReplay(1);
 
     const results = [];
 

--- a/spec/operators/race-spec.ts
+++ b/spec/operators/race-spec.ts
@@ -99,9 +99,9 @@ describe('Observable.prototype.race', () => {
     const unsub =         '         !    ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .race(e2)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -89,9 +89,9 @@ describe('Observable.prototype.reduce', () => {
     };
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .reduce(reduceFunction)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/repeat-spec.ts
+++ b/spec/operators/repeat-spec.ts
@@ -86,9 +86,9 @@ describe('Observable.prototype.repeat', () => {
     const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .repeat()
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -278,7 +278,7 @@ describe('Observable.prototype.repeat', () => {
   it('should repeat a synchronous source (multicasted and refCounted) multiple times', (done: MochaDone) => {
     const expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
 
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .multicast(() => new Rx.Subject<number>())
       .refCount()
       .repeat(5)

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -184,9 +184,9 @@ describe('Observable.prototype.retry', () => {
     const unsub =       '             !           ';
 
     const result = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .retry(100)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -195,7 +195,7 @@ describe('Observable.prototype.retry', () => {
   it('should retry a synchronous source (multicasted and refCounted) multiple times', (done: MochaDone) => {
     const expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
 
-    Observable.of(1, 2, 3).concat(Observable.throw('bad!'))
+    Observable.of(1, 2, 3, Rx.Scheduler.none).concat(Observable.throw('bad!'))
       .multicast(() => new Rx.Subject())
       .refCount()
       .retry(4)

--- a/spec/operators/retryWhen-spec.ts
+++ b/spec/operators/retryWhen-spec.ts
@@ -38,7 +38,7 @@ describe('Observable.prototype.retryWhen', () => {
     let retried = false;
     const expected = [1, 2, 1, 2];
     let i = 0;
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .map((n: number) => {
         if (n === 3) {
           throw 'bad';
@@ -64,7 +64,7 @@ describe('Observable.prototype.retryWhen', () => {
 
   it('should retry when notified and complete on returned completion', (done: MochaDone) => {
     const expected = [1, 2, 1, 2];
-    Observable.of(1, 2, 3)
+    Observable.of(1, 2, 3, Rx.Scheduler.none)
       .map((n: number) => {
         if (n === 3) {
           throw 'bad';
@@ -272,9 +272,9 @@ describe('Observable.prototype.retryWhen', () => {
     const unsub =        '                    !       ';
 
     const result = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .retryWhen((errors: any) => notifier)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -319,7 +319,7 @@ describe('Observable.prototype.retryWhen', () => {
             if (++invoked < 3) {
               return Observable.empty();
             } else {
-              return Observable.of('stop!');
+              return Observable.of('stop!', Rx.Scheduler.none);
             }
           })
       ));

--- a/spec/operators/sample-spec.ts
+++ b/spec/operators/sample-spec.ts
@@ -99,9 +99,9 @@ describe('Observable.prototype.sample', () => {
     const unsub =          '              !                        ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .sample(e2)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/sampleTime-spec.ts
+++ b/spec/operators/sampleTime-spec.ts
@@ -75,9 +75,9 @@ describe('Observable.prototype.sampleTime', () => {
     const unsub =          '                !            ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .sampleTime(110, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -169,9 +169,9 @@ describe('Observable.prototype.scan', () => {
     };
 
     const source = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .scan((acc: any, x: string) => [].concat(acc, x), [])
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(source, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -190,9 +190,9 @@ describe('Observable.prototype.share', () => {
     const source =     cold(   '-1-2-3----4-|');
     const sourceSubs =      '   ^        !   ';
     const shared = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .share()
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
     const subscriber1 = hot('   a|           ').mergeMapTo(shared);
     const unsub1 =          '          !     ';
     const expected1   =     '   -1-2-3--     ';

--- a/spec/operators/single-spec.ts
+++ b/spec/operators/single-spec.ts
@@ -49,9 +49,9 @@ describe('Observable.prototype.single', () => {
     const unsub =     '   !        ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .single()
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/skip-spec.ts
+++ b/spec/operators/skip-spec.ts
@@ -58,9 +58,9 @@ describe('Observable.prototype.skip', () => {
     const unsub =      '          !       ';
 
     const result = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .skip(2)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/skipUntil-spec.ts
+++ b/spec/operators/skipUntil-spec.ts
@@ -75,9 +75,9 @@ describe('Observable.prototype.skipUntil', () => {
     const unsub =      '         !          ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .skipUntil(skip)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/skipWhile-spec.ts
+++ b/spec/operators/skipWhile-spec.ts
@@ -106,9 +106,9 @@ describe('Observable.prototype.skipWhile', () => {
     };
 
     const result = source
-      .mergeMap(function (x) { return Observable.of(x); })
+      .mergeMap(function (x) { return Observable.of(x, Rx.Scheduler.none); })
       .skipWhile(predicate)
-      .mergeMap(function (x) { return Observable.of(x); });
+      .mergeMap(function (x) { return Observable.of(x, Rx.Scheduler.none); });
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);

--- a/spec/operators/startWith-spec.ts
+++ b/spec/operators/startWith-spec.ts
@@ -119,9 +119,9 @@ describe('Observable.prototype.startWith', () => {
     const values = { s: 's', a: 'a', b: 'b' };
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .startWith('s', rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/subscribeOn-spec.ts
+++ b/spec/operators/subscribeOn-spec.ts
@@ -70,9 +70,9 @@ describe('Observable.prototype.subscribeOn', () => {
     const unsub =     '    !    ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .subscribeOn(rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);

--- a/spec/operators/switch-spec.ts
+++ b/spec/operators/switch-spec.ts
@@ -31,7 +31,7 @@ describe('Observable.prototype.switch', () => {
   it('should unsub inner observables', () => {
     const unsubbed = [];
 
-    Observable.of('a', 'b').map((x: string) =>
+    Observable.of('a', 'b', Rx.Scheduler.none).map((x: string) =>
       Observable.create((subscriber: Rx.Subscriber<string>) => {
         subscriber.complete();
         return () => {
@@ -45,11 +45,11 @@ describe('Observable.prototype.switch', () => {
   });
 
   it('should switch to each inner Observable', (done: MochaDone) => {
-    const a = Observable.of(1, 2, 3);
-    const b = Observable.of(4, 5, 6);
+    const a = Observable.of(1, 2, 3, Rx.Scheduler.none);
+    const b = Observable.of(4, 5, 6, Rx.Scheduler.none);
     const r = [1, 2, 3, 4, 5, 6];
     let i = 0;
-    Observable.of(a, b).switch().subscribe((x: number) => {
+    Observable.of(a, b, Rx.Scheduler.none).switch().subscribe((x: number) => {
       expect(x).to.equal(r[i++]);
     }, null, done);
   });
@@ -89,9 +89,9 @@ describe('Observable.prototype.switch', () => {
     const unsub =    '                !            ';
 
     const result = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .switch()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -179,7 +179,7 @@ describe('Observable.prototype.switch', () => {
   it('should handle an observable of promises', (done: MochaDone) => {
     const expected = [3];
 
-    (<any>Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)))
+    (<any>Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3), Rx.Scheduler.none))
       .switch()
       .subscribe((x: number) => {
         expect(x).to.equal(expected.shift());
@@ -190,7 +190,7 @@ describe('Observable.prototype.switch', () => {
   });
 
   it('should handle an observable of promises, where last rejects', (done: MochaDone) => {
-    Observable.of<any>(Promise.resolve(1), Promise.resolve(2), Promise.reject(3))
+    Observable.of<any>(Promise.resolve(1), Promise.resolve(2), Promise.reject(3), Rx.Scheduler.none)
       .switch()
       .subscribe(() => {
         done(new Error('should not be called'));
@@ -206,7 +206,7 @@ describe('Observable.prototype.switch', () => {
     const expected = [1, 2, 3, 4];
     let completed = false;
 
-    Observable.of<any>(Observable.never(), Observable.never(), [1, 2, 3, 4])
+    Observable.of<any>(Observable.never(), Observable.never(), [1, 2, 3, 4], Rx.Scheduler.none)
       .switch()
       .subscribe((x: number) => {
         expect(x).to.equal(expected.shift());

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -21,9 +21,9 @@ describe('Observable.prototype.switchMap', () => {
   });
 
   it('should switch with a selector function', (done: MochaDone) => {
-    const a = Observable.of(1, 2, 3);
+    const a = Observable.of(1, 2, 3, Rx.Scheduler.none);
     const expected = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'a3', 'b3', 'c3'];
-    a.switchMap((x: number) => Observable.of('a' + x, 'b' + x, 'c' + x))
+    a.switchMap((x: number) => Observable.of('a' + x, 'b' + x, 'c' + x, Rx.Scheduler.none))
       .subscribe((x: string) => {
         expect(x).to.equal(expected.shift());
       }, null, done);
@@ -32,7 +32,7 @@ describe('Observable.prototype.switchMap', () => {
   it('should unsub inner observables', () => {
     const unsubbed = [];
 
-    Observable.of('a', 'b').switchMap((x: string) =>
+    Observable.of('a', 'b', Rx.Scheduler.none).switchMap((x: string) =>
       Observable.create((subscriber: Rx.Subscriber<string>) => {
         subscriber.complete();
         return () => {
@@ -125,9 +125,9 @@ describe('Observable.prototype.switchMap', () => {
     const observableLookup = { x: x, y: y };
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .switchMap((value: string) => observableLookup[value])
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -311,7 +311,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    const result = e1.switchMap((value: any) => Observable.of(value));
+    const result = e1.switchMap((value: any) => Observable.of(value, Rx.Scheduler.none));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -322,7 +322,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const result = e1.switchMap((value: any) => Observable.of(value));
+    const result = e1.switchMap((value: any) => Observable.of(value, Rx.Scheduler.none));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -333,7 +333,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const result = e1.switchMap((value: any) => Observable.of(value));
+    const result = e1.switchMap((value: any) => Observable.of(value, Rx.Scheduler.none));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -21,9 +21,9 @@ describe('Observable.prototype.switchMapTo', () => {
   });
 
   it('should switch a synchronous many outer to a synchronous many inner', (done: MochaDone) => {
-    const a = Observable.of(1, 2, 3);
+    const a = Observable.of(1, 2, 3, Rx.Scheduler.none);
     const expected = ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
-    a.switchMapTo(Observable.of('a', 'b', 'c')).subscribe((x: string) => {
+    a.switchMapTo(Observable.of('a', 'b', 'c', Rx.Scheduler.none)).subscribe((x: string) => {
       expect(x).to.equal(expected.shift());
     }, null, done);
   });
@@ -31,7 +31,7 @@ describe('Observable.prototype.switchMapTo', () => {
   it('should unsub inner observables', () => {
     let unsubbed = 0;
 
-    Observable.of('a', 'b').switchMapTo(
+    Observable.of('a', 'b', Rx.Scheduler.none).switchMapTo(
       Observable.create((subscriber: Rx.Subscriber<string>) => {
         subscriber.complete();
         return () => {
@@ -95,9 +95,9 @@ describe('Observable.prototype.switchMapTo', () => {
     const unsub =    '                      !       ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .switchMapTo(x)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -199,7 +199,7 @@ describe('Observable.prototype.switchMapTo', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable(e1.switchMapTo(Observable.of('foo'))).toBe(expected);
+    expectObservable(e1.switchMapTo(Observable.of('foo', Rx.Scheduler.none))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -208,7 +208,7 @@ describe('Observable.prototype.switchMapTo', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.switchMapTo(Observable.of('foo'))).toBe(expected);
+    expectObservable(e1.switchMapTo(Observable.of('foo', Rx.Scheduler.none))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -217,7 +217,7 @@ describe('Observable.prototype.switchMapTo', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.switchMapTo(Observable.of('foo'))).toBe(expected);
+    expectObservable(e1.switchMapTo(Observable.of('foo', Rx.Scheduler.none))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -118,9 +118,9 @@ describe('Observable.prototype.take', () => {
     const expected =  '---a--b---            ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .take(42)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/takeLast-spec.ts
+++ b/spec/operators/takeLast-spec.ts
@@ -152,9 +152,9 @@ describe('Observable.prototype.takeLast', () => {
     const expected =  '----------            ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .takeLast(42)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/takeUntil-spec.ts
+++ b/spec/operators/takeUntil-spec.ts
@@ -183,9 +183,9 @@ describe('Observable.prototype.takeUntil', () => {
     const expected =   '--a--b--                ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .takeUntil(e2)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/takeWhile-spec.ts
+++ b/spec/operators/takeWhile-spec.ts
@@ -192,9 +192,9 @@ describe('Observable.prototype.takeWhile', () => {
     }
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .takeWhile(predicate)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -78,9 +78,9 @@ describe('Observable.prototype.throttle', () =>  {
     const unsub =    '              !               ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .throttle(() =>  e2)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -281,7 +281,7 @@ describe('Observable.prototype.throttle', () =>  {
   });
 
   it('should throttle by promise resolves', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
+    const e1 = Observable.concat(Observable.of(1, Rx.Scheduler.none),
       Observable.timer(10).mapTo(2),
       Observable.timer(10).mapTo(3),
       Observable.timer(50).mapTo(4)
@@ -304,7 +304,7 @@ describe('Observable.prototype.throttle', () =>  {
   });
 
   it('should raise error when promise rejects', (done: MochaDone) => {
-    const e1 = Observable.concat(Observable.of(1),
+    const e1 = Observable.concat(Observable.of(1, Rx.Scheduler.none),
       Observable.timer(10).mapTo(2),
       Observable.timer(10).mapTo(3),
       Observable.timer(50).mapTo(4)

--- a/spec/operators/throttleTime-spec.ts
+++ b/spec/operators/throttleTime-spec.ts
@@ -19,7 +19,7 @@ describe('Observable.prototype.throttleTime', () => {
   });
 
   it('should throttle events by 50 time units', (done: MochaDone) => {
-    Observable.of(1, 2, 3).throttleTime(50)
+    Observable.of(1, 2, 3, Rx.Scheduler.none).throttleTime(50)
       .subscribe((x: number) => {
         expect(x).to.equal(1);
       }, null, done);
@@ -119,9 +119,9 @@ describe('Observable.prototype.throttleTime', () => {
     const unsub =    '                               !';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .throttleTime(50, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(subs);

--- a/spec/operators/timeInterval-spec.ts
+++ b/spec/operators/timeInterval-spec.ts
@@ -96,9 +96,9 @@ describe('Observable.prototype.timeInterval', () => {
     };
 
     const result = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .timeInterval(rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -70,9 +70,9 @@ describe('Observable.prototype.timeout', () => {
     const unsub =    '          !        ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .timeout(50, null, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/timeoutWith-spec.ts
+++ b/spec/operators/timeoutWith-spec.ts
@@ -73,9 +73,9 @@ describe('Observable.prototype.timeoutWith', () => {
     const unsub =      '              !    ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .timeoutWith(40, e2, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -91,9 +91,9 @@ describe('Observable.prototype.timeoutWith', () => {
     const unsub =    '     !           ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .timeoutWith(50, e2, rxTestScheduler)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/timestamp-spec.ts
+++ b/spec/operators/timestamp-spec.ts
@@ -96,9 +96,9 @@ describe('Observable.prototype.timestamp', () => {
     };
 
     const result = e1
-      .mergeMap(x => Observable.of(x))
+      .mergeMap(x => Observable.of(x, Rx.Scheduler.none))
       .timestamp(rxTestScheduler)
-      .mergeMap(x => Observable.of(x));
+      .mergeMap(x => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, expectedValue);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -76,9 +76,9 @@ describe('Observable.prototype.toArray', () => {
     const unsub =    '        !                 ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .toArray()
-      .mergeMap((x: Array<string>) => Observable.of(x));
+      .mergeMap((x: Array<string>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -107,6 +107,6 @@ describe('Observable.prototype.toArray', () => {
       val: 3
     };
 
-    Observable.of(typeValue).toArray().subscribe(x => { x[0].val.toString(); });
+    Observable.of(typeValue, Rx.Scheduler.none).toArray().subscribe(x => { x[0].val.toString(); });
   });
 });

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -7,7 +7,7 @@ const Observable = Rx.Observable;
 /** @test {toPromise} */
 describe('Observable.prototype.toPromise', () => {
   it('should convert an Observable to a promise of its last value', (done: MochaDone) => {
-    Observable.of(1, 2, 3).toPromise(Promise).then((x: number) => {
+    Observable.of(1, 2, 3, Rx.Scheduler.none).toPromise(Promise).then((x: number) => {
       expect(x).to.equal(3);
       done();
     });
@@ -31,7 +31,7 @@ describe('Observable.prototype.toPromise', () => {
       return new Promise(callback);
     };
 
-    Observable.of(42).toPromise().then((x: number) => {
+    Observable.of(42, Rx.Scheduler.none).toPromise().then((x: number) => {
       expect(wasCalled).to.be.true;
       expect(x).to.equal(42);
 

--- a/spec/operators/window-spec.ts
+++ b/spec/operators/window-spec.ts
@@ -192,9 +192,9 @@ describe('Observable.prototype.window', () => {
     const expectedValues = { a: a, b: b };
 
     const result = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .window(closings)
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+      .mergeMap((x: Rx.Observable<string>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/windowCount-spec.ts
+++ b/spec/operators/windowCount-spec.ts
@@ -165,9 +165,9 @@ describe('Observable.prototype.windowCount', () => {
     const values = { w: w, x: x, y: y, z: z };
 
     const result = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .windowCount(2, 1)
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+      .mergeMap((x: Rx.Observable<string>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -209,9 +209,9 @@ describe('Observable.prototype.windowTime', () => {
     const values = { x: x, y: y };
 
     const result = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .windowTime(timeSpan, interval, rxTestScheduler)
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+      .mergeMap((x: Rx.Observable<string>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(sourcesubs);

--- a/spec/operators/windowToggle-spec.ts
+++ b/spec/operators/windowToggle-spec.ts
@@ -187,9 +187,9 @@ describe('Observable.prototype.windowToggle', () => {
 
     let i = 0;
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .windowToggle(e2, () => close[i++])
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+      .mergeMap((x: Rx.Observable<string>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/windowWhen-spec.ts
+++ b/spec/operators/windowWhen-spec.ts
@@ -144,9 +144,9 @@ describe('Observable.prototype.windowWhen', () => {
 
     let i = 0;
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .windowWhen(() => closings[i++])
-      .mergeMap((x: Rx.Observable<string>) => Observable.of(x));
+      .mergeMap((x: Rx.Observable<string>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/withLatestFrom-spec.ts
+++ b/spec/operators/withLatestFrom-spec.ts
@@ -104,9 +104,9 @@ describe('Observable.prototype.withLatestFrom', () => {
     const project = function (a, b, c) { return a + b + c; };
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .withLatestFrom(e2, e3, project)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -241,21 +241,21 @@ describe('Observable.prototype.withLatestFrom', () => {
   });
 
   it('should handle promises', (done: MochaDone) => {
-    Observable.of(1).delay(1).withLatestFrom(Promise.resolve(2), Promise.resolve(3))
+    Observable.of(1, Rx.Scheduler.none).delay(1).withLatestFrom(Promise.resolve(2), Promise.resolve(3))
       .subscribe((x: any) => {
         expect(x).to.deep.equal([1, 2, 3]);
       }, null, done);
   });
 
   it('should handle arrays', () => {
-    Observable.of(1).delay(1).withLatestFrom([2, 3, 4], [4, 5, 6])
+    Observable.of(1, Rx.Scheduler.none).delay(1).withLatestFrom([2, 3, 4], [4, 5, 6])
       .subscribe((x: any) => {
         expect(x).to.deep.equal([1, 4, 6]);
       });
   });
 
   it('should handle lowercase-o observables', () => {
-    Observable.of(1).delay(1).withLatestFrom(lowerCaseO(2, 3, 4), lowerCaseO(4, 5, 6))
+    Observable.of(1, Rx.Scheduler.none).delay(1).withLatestFrom(lowerCaseO(2, 3, 4), lowerCaseO(4, 5, 6))
       .subscribe((x: any) => {
         expect(x).to.deep.equal([1, 4, 6]);
       });

--- a/spec/operators/zip-spec.ts
+++ b/spec/operators/zip-spec.ts
@@ -111,7 +111,7 @@ describe('Observable.prototype.zip', () => {
       };
       myIterator[Symbol.iterator] = function () { return this; };
 
-      Observable.of(1, 2, 3).zip(myIterator)
+      Observable.of(1, 2, 3, Rx.Scheduler.none).zip(myIterator)
         .subscribe();
 
       // since zip will call `next()` in advance, total calls when
@@ -582,9 +582,9 @@ describe('Observable.prototype.zip', () => {
     const expected = '---x---y--';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .zip(b)
-      .mergeMap((x: Array<any>) => Observable.of(x));
+      .mergeMap((x: Array<any>) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(r, unsub).toBe(expected, { x: ['1', '4'], y: ['2', '5']});
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -27,7 +27,7 @@ describe('Observable.prototype.zipAll', () => {
     const expected = '---x---y---z';
     const values = { x: ['1', '4'], y: ['2', '5'], z: ['3', '6'] };
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, values);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected, values);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -36,8 +36,8 @@ describe('Observable.prototype.zipAll', () => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
     Observable.of<any>(
-      Observable.of<any>('a', 'b', 'c'),
-      Observable.of<any>(1, 2, 3)
+      Observable.of<any>('a', 'b', 'c', Rx.Scheduler.none),
+      Observable.of<any>(1, 2, 3, Rx.Scheduler.none)
     )
     .zipAll((a: any, b: any) => a + b)
     .subscribe((x: any) => {
@@ -59,7 +59,7 @@ describe('Observable.prototype.zipAll', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(Observable.of<any>(e1, e2, e3).zipAll()).toBe(expected, values);
+    expectObservable(Observable.of<any>(e1, e2, e3, Rx.Scheduler.none).zipAll()).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -80,7 +80,7 @@ describe('Observable.prototype.zipAll', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(Observable.of<any>(e1, e2, e3).zipAll()).toBe(expected, values);
+    expectObservable(Observable.of<any>(e1, e2, e3, Rx.Scheduler.none).zipAll()).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -107,7 +107,7 @@ describe('Observable.prototype.zipAll', () => {
         z: ['d', 3]
       };
 
-      expectObservable(Observable.of<any>(e1, myIterator).zipAll()).toBe(expected, values);
+      expectObservable(Observable.of<any>(e1, myIterator, Rx.Scheduler.none).zipAll()).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
 
@@ -122,7 +122,7 @@ describe('Observable.prototype.zipAll', () => {
       };
       myIterator[Symbol.iterator] = function () { return this; };
 
-      Observable.of<any>(Observable.of<any>(1, 2, 3), myIterator).zipAll()
+      Observable.of<any>(Observable.of<any>(1, 2, 3, Rx.Scheduler.none), myIterator, Rx.Scheduler.none).zipAll()
         .subscribe();
 
       // since zip will call `next()` in advance, total calls when
@@ -136,7 +136,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [];
       const expected = '-';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -146,7 +146,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [];
       const expected = '|';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -156,7 +156,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '|';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -166,7 +166,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [];
       const expected = '--------|';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -176,7 +176,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '-';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -186,7 +186,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [2];
       const expected = '-----(x|)';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, { x: ['1', 2] });
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected, { x: ['1', 2] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -196,7 +196,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [];
       const expected = '-----#';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -206,7 +206,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '-----#';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -216,7 +216,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [4, 5, 6];
       const expected = '---x--y--(z|)';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected,
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected,
         { x: ['1', 4], y: ['2', 5], z: ['3', 6] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -233,7 +233,7 @@ describe('Observable.prototype.zipAll', () => {
         } else {
           return x + y;
         }};
-      expectObservable(Observable.of<any>(a, b).zipAll(selector)).toBe(expected,
+      expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll(selector)).toBe(expected,
         { x: '14' }, new Error('too bad'));
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -246,7 +246,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((e1: string, e2: string) => e1 + e2))
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll((e1: string, e2: string) => e1 + e2))
       .toBe(expected, { x: '14', y: '25', z: '36' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -260,7 +260,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    expectObservable(Observable.of<any>(a, b, c).zipAll()).toBe(expected,
+    expectObservable(Observable.of<any>(a, b, c, Rx.Scheduler.none).zipAll()).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -274,7 +274,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = Observable.of<any>(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
+    const observable = Observable.of<any>(a, b, c, Rx.Scheduler.none).zipAll((r0, r1, r2) => [r0, r1, r2]);
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -289,7 +289,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = Observable.of<any>(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
+    const observable = Observable.of<any>(a, b, c, Rx.Scheduler.none).zipAll((r0, r1, r2) => [r0, r1, r2]);
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -303,7 +303,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((r1: string, r2: string) => r1 + r2))
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll((r1: string, r2: string) => r1 + r2))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -316,7 +316,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((r1: string, r2: string) => r1 + r2))
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll((r1: string, r2: string) => r1 + r2))
       .toBe(expected, { a: '21', b: '43', c: '65', d: '87', e: '09' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -329,7 +329,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                ! ';
     const expected =   '---a--b--c--d--e-| ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((r1: string, r2: string) => r1 + r2))
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll((r1: string, r2: string) => r1 + r2))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -348,7 +348,7 @@ describe('Observable.prototype.zipAll', () => {
       } else {
         return x + y;
       }};
-    const observable = Observable.of<any>(a, b).zipAll(selector);
+    const observable = Observable.of<any>(a, b, Rx.Scheduler.none).zipAll(selector);
     expectObservable(observable).toBe(expected,
       { x: '23' }, new Error('too bad'));
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -371,8 +371,8 @@ describe('Observable.prototype.zipAll', () => {
     const expected = ['a1', 'b2'];
     let i = 0;
     Observable.of<any>(
-      Observable.of<any>('a', 'b', 'c'),
-      Observable.of<any>(1, 2)
+      Observable.of<any>('a', 'b', 'c', Rx.Scheduler.none),
+      Observable.of<any>(1, 2, Rx.Scheduler.none)
     )
     .zipAll((a: any, b: any) => a + b)
     .subscribe((x: any) => {
@@ -463,7 +463,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -475,7 +475,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -487,7 +487,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -499,7 +499,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -511,7 +511,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -523,7 +523,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -535,7 +535,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '-';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -547,7 +547,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -559,7 +559,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(Observable.of<any>(a, b).zipAll())
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll())
       .toBe(expected, { x: ['1', '4'], y: ['2', '5'], z: ['3', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -572,7 +572,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -584,7 +584,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -596,7 +596,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !    ';
     const expected = '------#    ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -608,7 +608,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -620,7 +620,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -632,7 +632,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, null, 'too bad');
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected, null, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -644,7 +644,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, { x: [1, 2] }, 'too bad');
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected, { x: [1, 2] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -656,7 +656,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, { x: [2, 1] }, 'too bad');
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected, { x: [2, 1] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -668,7 +668,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<any>(a, b, Rx.Scheduler.none).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -688,7 +688,7 @@ describe('Observable.prototype.zipAll', () => {
 
   it('should combine a source with an immediately-scheduled source', (done: MochaDone) => {
     const a = Observable.of<any>(1, 2, 3, queueScheduler);
-    const b = Observable.of<any>(4, 5, 6, 7, 8);
+    const b = Observable.of<any>(4, 5, 6, 7, 8, Rx.Scheduler.none);
     const r = [[1, 4], [2, 5], [3, 6]];
     let i = 0;
 
@@ -708,10 +708,10 @@ describe('Observable.prototype.zipAll', () => {
     const expected = '---x---y--';
     const values = { x: ['1', '4'], y: ['2', '5']};
 
-    const r = Observable.of<any>(a, b)
-      .mergeMap((x: string) => Observable.of(x))
+    const r = Observable.of<any>(a, b, Rx.Scheduler.none)
+      .mergeMap((x: string) => Observable.of(x, Rx.Scheduler.none))
       .zipAll()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x: any) => Observable.of(x, Rx.Scheduler.none));
 
     expectObservable(r, unsub).toBe(expected, values);
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -188,7 +188,7 @@ describe('TestScheduler', () => {
       });
 
       it('should return an object with a toBe function', () => {
-        expect(expectObservable(Rx.Observable.of(1)).toBe).to.be.a('function');
+        expect(expectObservable(Rx.Observable.of(1, Rx.Scheduler.none)).toBe).to.be.a('function');
       });
 
       it('should append to flushTests array', () => {

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -169,7 +169,7 @@ describe('BehaviorSubject', () => {
   });
 
   it('should be an Observer which can be given to Observable.subscribe', (done: MochaDone) => {
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = Observable.of(1, 2, 3, 4, 5, Rx.Scheduler.none);
     const subject = new BehaviorSubject(0);
     const expected = [0, 1, 2, 3, 4, 5];
 

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -223,7 +223,7 @@ describe('ReplaySubject', () => {
   });
 
   it('should be an Observer which can be given to Observable.subscribe', (done: MochaDone) => {
-    const source = Observable.of(1, 2, 3, 4, 5);
+    const source = Observable.of(1, 2, 3, 4, 5, Rx.Scheduler.none);
     const subject = new ReplaySubject(3);
     const expected = [3, 4, 5];
 

--- a/src/Notification.ts
+++ b/src/Notification.ts
@@ -1,5 +1,8 @@
 import {PartialObserver} from './Observer';
 import {Observable} from './Observable';
+import {ScalarObservable} from './observable/ScalarObservable';
+import {ErrorObservable} from './observable/ErrorObservable';
+import {EmptyObservable} from './observable/EmptyObservable';
 
 /**
  * Represents a push-based event or value that an {@link Observable} can emit.
@@ -84,11 +87,11 @@ export class Notification<T> {
     const kind = this.kind;
     switch (kind) {
       case 'N':
-        return Observable.of(this.value);
+        return new ScalarObservable(this.value);
       case 'E':
-        return Observable.throw(this.exception);
+        return new ErrorObservable(this.exception);
       case 'C':
-        return Observable.empty<T>();
+        return new EmptyObservable<T>();
     }
   }
 

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -133,9 +133,11 @@ export {UnsubscriptionError} from './util/UnsubscriptionError';
 import {asap} from './scheduler/asap';
 import {async} from './scheduler/async';
 import {queue} from './scheduler/queue';
+import {none} from './scheduler/none';
 import {AsapScheduler} from './scheduler/AsapScheduler';
 import {AsyncScheduler} from './scheduler/AsyncScheduler';
 import {QueueScheduler} from './scheduler/QueueScheduler';
+import {RecursiveScheduler} from './scheduler/RecursiveScheduler';
 import {$$rxSubscriber as rxSubscriber} from './symbol/rxSubscriber';
 import {$$observable as observable} from './symbol/observable';
 import {$$iterator as iterator} from './symbol/iterator';
@@ -151,11 +153,16 @@ import {$$iterator as iterator} from './symbol/iterator';
  * asynchronous conversions.
  * @property {Scheduler} async Schedules work with `setInterval`. Use this for
  * time-based operations.
+ * @property {Scheduler} none this is a recursive scheduler and will call items
+ * scheduled with a delay of 0 _immediately_. A reference check is done in most operations
+ * that accept a scheduler. If the provided scheduler matches this `none` reference,
+ * then no scheduler is used at all. This is done for performance reasons.
  */
 let Scheduler = {
   asap,
   async,
-  queue
+  queue,
+  none
 };
 
 /**

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -5,6 +5,8 @@ import {EmptyObservable} from './EmptyObservable';
 import {Subscriber} from '../Subscriber';
 import {isScheduler} from '../util/isScheduler';
 import {TeardownLogic} from '../Subscription';
+import {asap} from '../scheduler/asap';
+import {isUnscheduled} from '../scheduler/none';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -65,6 +67,10 @@ export class ArrayObservable<T> extends Observable<T> {
     if (isScheduler(scheduler)) {
       array.pop();
     } else {
+      scheduler = asap;
+    }
+
+    if (isUnscheduled(scheduler)) {
       scheduler = null;
     }
 

--- a/src/scheduler/AsapScheduler.ts
+++ b/src/scheduler/AsapScheduler.ts
@@ -1,10 +1,9 @@
-import {Action} from './Action';
 import {AsapAction} from './AsapAction';
 import {Subscription} from '../Subscription';
 import {QueueScheduler} from './QueueScheduler';
 
 export class AsapScheduler extends QueueScheduler {
-  scheduleNow<T>(work: (x?: T) => Subscription, state?: T): Action<T> {
+  scheduleNow<T>(work: (x?: T) => Subscription, state?: T): Subscription {
     return new AsapAction(this, work).schedule(state);
   }
 }

--- a/src/scheduler/AsyncScheduler.ts
+++ b/src/scheduler/AsyncScheduler.ts
@@ -1,10 +1,9 @@
-import {Action} from './Action';
 import {FutureAction} from './FutureAction';
 import {Subscription} from '../Subscription';
 import {QueueScheduler} from './QueueScheduler';
 
 export class AsyncScheduler extends QueueScheduler {
-  scheduleNow<T>(work: (x?: T) => Subscription, state?: T): Action<T> {
+  scheduleNow<T>(work: (x?: T) => Subscription, state?: T): Subscription {
     return new FutureAction(this, work).schedule(state, 0);
   }
 }

--- a/src/scheduler/QueueScheduler.ts
+++ b/src/scheduler/QueueScheduler.ts
@@ -2,7 +2,6 @@ import {Scheduler} from '../Scheduler';
 import {QueueAction} from './QueueAction';
 import {Subscription} from '../Subscription';
 import {FutureAction} from './FutureAction';
-import {Action} from './Action';
 
 export class QueueScheduler implements Scheduler {
   public active: boolean = false;
@@ -36,11 +35,11 @@ export class QueueScheduler implements Scheduler {
       this.scheduleLater(work, delay, state);
   }
 
-  scheduleNow<T>(work: (x?: T) => Subscription | void, state?: T): Action<T> {
+  scheduleNow<T>(work: (x?: T) => Subscription | void, state?: T): Subscription {
     return new QueueAction(this, work).schedule(state);
   }
 
-  scheduleLater<T>(work: (x?: T) => Subscription | void, delay: number, state?: T): Action<T> {
+  scheduleLater<T>(work: (x?: T) => Subscription | void, delay: number, state?: T): Subscription {
     return new FutureAction(this, work).schedule(state, delay);
   }
 }

--- a/src/scheduler/RecursiveScheduler.ts
+++ b/src/scheduler/RecursiveScheduler.ts
@@ -1,0 +1,13 @@
+import {Subscription} from '../Subscription';
+import {QueueScheduler} from './QueueScheduler';
+
+/**
+ * WARNING: This should not be used directly. If you want to use a recursive scheduler, use the one provided in
+ * either `Rx.Scheduler.none` or the module `"rxjs/scheduler/none"`.
+ */
+export class RecursiveScheduler extends QueueScheduler {
+  scheduleNow<T>(work: (x?: T) => Subscription, state?: T): Subscription {
+    work(state);
+    return Subscription.EMPTY;
+  }
+}

--- a/src/scheduler/none.ts
+++ b/src/scheduler/none.ts
@@ -1,0 +1,16 @@
+import {RecursiveScheduler} from './RecursiveScheduler';
+
+/**
+ * A static instance of a recursive scheduler.
+ * This is THE instance. Don't new-up another RecursiveScheduler
+ * Use this to force `of` and `from` to have a  completely synchronous behavior.
+ * When used, there is a reference check done in most schedulable operations.
+ * If the scheduler reference equals this reference, then scheduling is not
+ * used at all.
+ */
+export const none = new RecursiveScheduler();
+
+/** returns whether or not scheduling should be used based on a passed scheduler */
+export function isUnscheduled(scheduler: any): boolean {
+  return !scheduler || scheduler === none;
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

1. Adds an `Rx.Scheduler.none`. This is a recursive scheduler, but in practice in our code it should never be called. Rather it should be referentially checked, then a recursive "hot path" should be taken.
2. Updates `Notification` to stop using static observable creation methods (it was using `Observable.of` internally)
3. Updates `Observable.of` to default to `asap` scheduling. This is done to match the [es-observable proposal's definition of `of`](http://github.com/zenparsing/es-observable)
4. Adds a perf test comparing the plain calls of `of` for both Rx 4 and 5

**Related issue (if exists):** ??? I'm sure it's come up, I'll have to search for one.

### Please direct hate mail regarding this design to @zenparsing, @jhusain and others at the [es-observable spec](http://github.com/zenparsing/es-observable). If you care that much, you should be more involved in the discussions on that spec.

😛

FWIW: The perf even with micro task scheduling in 5 vs trampoline scheduling in 4 is still solidly improved:

```

                     RxJS 4.1.0 |              RxJS 5.0.0-beta.6 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                55,125 (±1.39%) |               351,630 (±0.80%) |           6.38x |          537.9%
```
