### PR TITLE
chore(typings): increase combineLatest's signature compatibility with v4

### DIFF
--- a/src/observable/combineLatest.ts
+++ b/src/observable/combineLatest.ts
@@ -11,17 +11,20 @@ export function combineLatest<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableI
 export function combineLatest<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<[T, T2, T3, T4]>;
 export function combineLatest<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<[T, T2, T3, T4, T5]>;
 export function combineLatest<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<[T, T2, T3, T4, T5, T6]>;
+
+export function combineLatest<T, R>(v1: ObservableInput<T>, project: (v1: T) => R, scheduler?: Scheduler): Observable<R>;
 export function combineLatest<T, T2, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R, scheduler?: Scheduler): Observable<R>;
 export function combineLatest<T, T2, T3, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R, scheduler?: Scheduler): Observable<R>;
 export function combineLatest<T, T2, T3, T4, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R, scheduler?: Scheduler): Observable<R>;
 export function combineLatest<T, T2, T3, T4, T5, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R, scheduler?: Scheduler): Observable<R>;
 export function combineLatest<T, T2, T3, T4, T5, T6, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R, scheduler?: Scheduler): Observable<R>;
+
 export function combineLatest<T>(array: ObservableInput<T>[], scheduler?: Scheduler): Observable<T[]>;
 export function combineLatest<R>(array: ObservableInput<any>[], scheduler?: Scheduler): Observable<R>;
 export function combineLatest<T, R>(array: ObservableInput<T>[], project: (...values: Array<T>) => R, scheduler?: Scheduler): Observable<R>;
 export function combineLatest<R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R, scheduler?: Scheduler): Observable<R>;
 export function combineLatest<T>(...observables: Array<ObservableInput<T> | Scheduler>): Observable<T[]>;
-export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<any>) => R) | Scheduler>): Observable<R>;
+export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R) | Scheduler>): Observable<R>;
 export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | Scheduler>): Observable<R>;
 /* tslint:enable:max-line-length */
 

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -80,9 +80,9 @@ export interface CombineLatestSignature<T> {
   <T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<[T, T2, T3, T4, T5]>;
   <T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<[T, T2, T3, T4, T5, T6]>;
 
-  <R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
-  <R>(array: ObservableInput<any>[]): Observable<R>;
-  <R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R): Observable<R>;
+  <R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): Observable<R>;
+  <R>(array: ObservableInput<T>[]): Observable<Array<T>>;
+  <TOther, R>(array: ObservableInput<TOther>[], project: (v1: T, ...values: Array<TOther>) => R): Observable<R>;
 }
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
- retry #1626
- Add the case for ~`T9` type parameters which are defined in v4
  - https://github.com/Reactive-Extensions/RxJS/blob/9d6ea94244c2f40a29373f9ed6b12d951d3f2238/ts/core/linq/observable/combinelatestproto.ts
  - https://github.com/Reactive-Extensions/RxJS/blob/9d6ea94244c2f40a29373f9ed6b12d951d3f2238/ts/core/linq/observable/combinelatest.ts
- Restrict cases which accepts arrays as the 1st argument of `combineLatest()`
  - From `any` to `T`.
  - As my thought, It would be rare case to pass multiple types with stuffing into an array.