### PR TITLE
Remove unused source variable

### DIFF
--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -13,8 +13,7 @@ import {Subscriber} from '../Subscriber';
  */
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                          thisArg?: any): Observable<boolean> {
-  const source = this;
-  return source.lift(new EveryOperator(predicate, thisArg, source));
+  return this.lift(new EveryOperator(predicate, thisArg, this));
 }
 
 export interface EverySignature<T> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**

Introduced in an earlier commit where it makes sense,
Doesn't really make sense now. Removed and used `this`
directly.