### PR TITLE
docs(page): fix tiny CSS issue and typo

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -2,7 +2,7 @@
 
 RxJS is a library for composing asynchronous and event-based programs by using observable sequences. It provides one core type, the [Observable](./overview.html#observable), satellite types (Observer, Schedulers, Subjects) and operators inspired by [Array#extras](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/1.6) (map, filter, reduce, every, etc) to allow handling asynchronous events as collections.
 
-<span class="informal">Think of RxJS as lodash for events.</span>
+<span class="informal">Think of RxJS as Lodash for events.</span>
 
 ReactiveX combines the [Observer pattern](https://en.wikipedia.org/wiki/Observer_pattern) with the [Iterator pattern](https://en.wikipedia.org/wiki/Iterator_pattern) and [functional programming with collections](http://martinfowler.com/articles/collection-pipeline/#NestedOperatorExpressions) to fill the need for an ideal way of managing sequences of events.
 

--- a/doc/styles/main.css
+++ b/doc/styles/main.css
@@ -62,8 +62,8 @@ h1,h2,h3,h4 {
 }
 
 .layout-container > header > a.repo-url-github {
-  -webkit-filter: brightness(10);
-  filter: brightness(10);
+  -webkit-filter: brightness(20);
+  filter: brightness(20);
 }
 
 .search-input {


### PR DESCRIPTION


**Description:**

Fix CSS property of the brightness of the Github logo, to make it white,
and fix typo lodash => Lodash.

**Related issue (if exists):**
#1597 