### PR TITLE
chore(MAINTAINERS): add MAINTAINERS file for lgtm.co

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,0 +1,5 @@
+Ben Lesh <blesh@netflix.com>
+OJ Kwon <kwon.ohjoong@gmail.com>
+Andre Staltz <andre@staltz.com>
+Paul Taylor <paul.e.taylor@me.com>
+Matthew Podwysocki <matthewp@microsoft.com>


### PR DESCRIPTION
**Description:**
If we want to use https://lgtm.co/, there are two steps required:

- Add a MAINTAINERS file (this PR)
- Enable the service by logging in at https://lgtm.co/ (@blesh **needs to do this with access rights to reactivex org**)

