### PR TITLE
Improve finally tests

### DIFF
--- a/spec/operators/finally-spec.ts
+++ b/spec/operators/finally-spec.ts
@@ -83,7 +83,7 @@ describe('Observable.prototype.finally', () => {
     expectObservable(result).toBe(expected);
     // manually flush so `finally()` has chance to execute before the test is over.
     rxTestScheduler.flush();
-    expect(executed).to.equal(true);
+    expect(executed).to.be.true;
   });
 
   it('should handle never', () => {
@@ -94,7 +94,7 @@ describe('Observable.prototype.finally', () => {
     expectObservable(result).toBe(expected);
     // manually flush so `finally()` has chance to execute before the test is over.
     rxTestScheduler.flush();
-    expect(executed).to.equal(false);
+    expect(executed).to.be.false;
   });
 
   it('should handle throw', () => {
@@ -105,7 +105,7 @@ describe('Observable.prototype.finally', () => {
     expectObservable(result).toBe(expected);
     // manually flush so `finally()` has chance to execute before the test is over.
     rxTestScheduler.flush();
-    expect(executed).to.equal(true);
+    expect(executed).to.be.true;
   });
 
   it('should handle basic hot observable', () => {
@@ -118,7 +118,7 @@ describe('Observable.prototype.finally', () => {
     expectSubscriptions(s1.subscriptions).toBe(subs);
     // manually flush so `finally()` has chance to execute before the test is over.
     rxTestScheduler.flush();
-    expect(executed).to.equal(true);
+    expect(executed).to.be.true;
   });
 
   it('should handle basic cold observable', () => {
@@ -131,7 +131,7 @@ describe('Observable.prototype.finally', () => {
     expectSubscriptions(s1.subscriptions).toBe(subs);
     // manually flush so `finally()` has chance to execute before the test is over.
     rxTestScheduler.flush();
-    expect(executed).to.equal(true);
+    expect(executed).to.be.true;
   });
 
   it('should handle basic error', () => {
@@ -144,7 +144,7 @@ describe('Observable.prototype.finally', () => {
     expectSubscriptions(s1.subscriptions).toBe(subs);
     // manually flush so `finally()` has chance to execute before the test is over.
     rxTestScheduler.flush();
-    expect(executed).to.equal(true);
+    expect(executed).to.be.true;
   });
 
   it('should handle unsubscription', () => {
@@ -158,6 +158,6 @@ describe('Observable.prototype.finally', () => {
     expectSubscriptions(s1.subscriptions).toBe(subs);
     // manually flush so `finally()` has chance to execute before the test is over.
     rxTestScheduler.flush();
-    expect(executed).to.equal(true);
+    expect(executed).to.be.true;
   });
 });

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -6,25 +6,25 @@ import {Observable} from '../Observable';
 /**
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
  * the source terminates on complete or error.
- * @param {function} finallySelector function to be called when source terminates.
+ * @param {function} callback function to be called when source terminates.
  * @return {Observable} an Observable that mirrors the source, but will call the specified function on termination.
  * @method finally
  * @owner Observable
  */
-export function _finally<T>(finallySelector: () => void): Observable<T> {
-  return this.lift(new FinallyOperator(finallySelector));
+export function _finally<T>(callback: () => void): Observable<T> {
+  return this.lift(new FinallyOperator(callback));
 }
 
 export interface FinallySignature<T> {
-  <T>(finallySelector: () => void): Observable<T>;
+  <T>(callback: () => void): Observable<T>;
 }
 
 class FinallyOperator<T> implements Operator<T, T> {
-  constructor(private finallySelector: () => void) {
+  constructor(private callback: () => void) {
   }
 
   call(subscriber: Subscriber<T>, source: any): any {
-    return source._subscribe(new FinallySubscriber(subscriber, this.finallySelector));
+    return source._subscribe(new FinallySubscriber(subscriber, this.callback));
   }
 }
 
@@ -34,8 +34,8 @@ class FinallyOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class FinallySubscriber<T> extends Subscriber<T> {
-  constructor(destination: Subscriber<T>, finallySelector: () => void) {
+  constructor(destination: Subscriber<T>, callback: () => void) {
     super(destination);
-    this.add(new Subscription(finallySelector));
+    this.add(new Subscription(callback));
   }
 }


### PR DESCRIPTION
- Adds additional, virtually scheduled tests to the finally battery of tests. Covers basic usage.
- Renames `finallySelector` as just `callback`, because it doesn't really "select" anything.