### PR TITLE
chore(typings): update type definition for finally

### DIFF
--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -16,7 +16,7 @@ export function _finally<T>(callback: () => void): Observable<T> {
 }
 
 export interface FinallySignature<T> {
-  <T>(callback: () => void): Observable<T>;
+  (callback: () => void): Observable<T>;
 }
 
 class FinallyOperator<T> implements Operator<T, T> {


### PR DESCRIPTION
**Description:**

This PR updates interface definition for `finally` to properly pass source observable's type.

**Related issue (if exists):**

- pass type of source observable

closes #1672