### PR TITLE
fix(ScalarObservable): set _isScalar to false when initialized with a scheduler.

### DIFF
--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -34,6 +34,9 @@ export class ScalarObservable<T> extends Observable<T> {
 
   constructor(public value: T, private scheduler?: Scheduler) {
     super();
+    if (scheduler) {
+      this._isScalar = false;
+    }
   }
 
   protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
ScalarObservable's `_isScalar` flag was permanently `true`, even if initialized with a `scheduler`. This caused our internal `subscribeToResult` helper to short-circuit subscribing to the `ScalarObservable`, so the emission was never scheduled. This PR changes that.

**Related issue (if exists):**
None yet.