### PR TITLE
chore(typings): updated catch signature to allow T to flow through

### DIFF
--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -19,6 +19,7 @@ export function _catch<T, R>(selector: (err: any, caught: Observable<T>) => Obse
 }
 
 export interface CatchSignature<T> {
+  (selector: (err: any, caught: Observable<T>) => Observable<T>): Observable<T>;
   <R>(selector: (err: any, caught: Observable<T>) => Observable<R>): Observable<R>;
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to either Core or KitchenSink
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This allows catch to flow it's types by default, but also allows for additional casting if needed.

**Related issue (if exists):**
#1672
