### PR TITLE
docs(design): Theme toggler

### DIFF
--- a/doc/scripts/theme-toggler.js
+++ b/doc/scripts/theme-toggler.js
@@ -1,0 +1,30 @@
+(function () {
+  document.addEventListener('DOMContentLoaded', function () {
+    var themes = ['dark', 'light'];
+    var themeToggler = document.createElement('div');
+    themeToggler.className = 'theme-toggler';
+
+    function setBodyClassName(theme) {
+      document.body.className = 'layout-container manual-root ' + theme + '-theme';
+    }
+
+    function createTheme(theme) {
+      var themeNode = document.createElement('span');
+      themeNode.className = 'theme-selector ' + theme;
+      themeNode.innerHTML = theme + ' theme';
+
+      themeNode.addEventListener('click', function () {
+        setBodyClassName(theme);
+        localStorage && localStorage.setItem('rxjstheme', theme);
+      });
+      themeToggler.appendChild(themeNode);
+    }
+
+    themes.forEach(createTheme);
+
+    var currentTheme = localStorage && localStorage.getItem('rxjstheme');
+    currentTheme = currentTheme || 'dark';
+    setBodyClassName(currentTheme);
+    document.querySelector('header').appendChild(themeToggler);
+  });
+})();

--- a/doc/styles/main.css
+++ b/doc/styles/main.css
@@ -33,12 +33,25 @@ h1,h2,h3,h4 {
   padding-top: 10px !important;
 }
 
+body {
+  display: none;
+}
+
+body.light-theme,
+body.dark-theme {
+  display: block;
+}
 /* Top nav bar border bottom */
 .layout-container > header {
   position: fixed;
   background-color: #333;
   box-sizing: border-box;
   border-bottom: 0;
+}
+
+body.light-theme.layout-container > header {
+  border-bottom: 1px solid #EAEAEA;
+  background-color: #EFEFEF;
 }
 
 .layout-container > header:before {
@@ -60,16 +73,28 @@ h1,h2,h3,h4 {
 .layout-container > header a:hover, .layout-container > header a:active {
   color: #FFF;
 }
+body.light-theme .layout-container > header a:hover, .layout-container > header a:active {
+  color: #EC0C8E;
+}
 
 .layout-container > header > a.repo-url-github {
   -webkit-filter: brightness(20);
   filter: brightness(20);
 }
 
+body.light-theme.layout-container > header > a.repo-url-github {
+  -webkit-filter: brightness(5);
+  filter: brightness(5);
+}
+
 .search-input {
   color: #FFF;
   font-size: 14px;
   border-color: #EC0C8E;
+}
+
+body.light-theme .search-input {
+  color: #333;
 }
 
 .search-input-edge {
@@ -79,6 +104,11 @@ h1,h2,h3,h4 {
 
 .search-result li.selected {
   color: #FFF;
+}
+
+body.light-theme .search-result li.selected {
+  background: transparent !important;
+  color: #EC0C8E;
 }
 
 .search-box img {
@@ -97,12 +127,23 @@ h1,h2,h3,h4 {
   background-color: #333;
 }
 
+body.light-theme .navigation {
+  background-color: transparent;
+    padding: 10px;
+}
+
 .navigation a {
   color: #BBB;
+}
+body.light-theme .navigation a {
+  color: #777;
 }
 
 .navigation a:hover {
   color: #FFF;
+}
+body.light-theme .navigation a:hover {
+  color: #EC0C8E;
 }
 
 .navigation .nav-dir-path {
@@ -111,6 +152,9 @@ h1,h2,h3,h4 {
 
 .navigation .manual-toc-title {
   padding: 0.5em;
+}
+body.light-theme .navigation .manual-toc-title {
+  border-radius: 3px;
 }
 
 .manual-dot {
@@ -341,4 +385,33 @@ code .typ {
 
 code .lit {
   color: #0086b3;
+}
+
+/* THEMES */
+.theme-toggler {
+  display: inline-block;
+  line-height: 30px;
+  margin: 5px;
+  color: #777;
+  border-left: 3px solid #444;
+}
+
+body.light-theme .theme-toggler {
+  border-left: 3px solid #CCC;
+}
+
+.theme-selector {
+  font-weight: normal;
+  cursor: pointer;
+  padding: 0 5px;
+}
+
+.theme-selector:first-child {
+  margin: 0 10px;
+}
+
+body.dark-theme .theme-selector.dark,
+body.light-theme .theme-selector.light {
+  font-weight: bold;
+  border-bottom: 1px solid #B7178C;
 }

--- a/esdoc.json
+++ b/esdoc.json
@@ -13,7 +13,8 @@
     "./dist/global/Rx.umd.js",
     "./doc/asset/devtools-welcome.js",
     "./doc/scripts/custom-manual-styles.js",
-    "./doc/decision-tree-widget/dist/decision-tree-widget.min.js"
+    "./doc/decision-tree-widget/dist/decision-tree-widget.min.js",
+    "./doc/scripts/theme-toggler.js"
   ],
   "index": "./doc/index.md",
   "plugins": [


### PR DESCRIPTION
Okay, referencing my GIT havoc here: https://github.com/ReactiveX/rxjs/pull/1578. This is a fresh single commit addition of the theme toggler based on latest master.

<img width="1435" alt="screen shot 2016-04-30 at 15 26 09" src="https://cloud.githubusercontent.com/assets/3956929/14936107/275b1fca-0ee8-11e6-99a8-e81a8772a07d.png">

<img width="1437" alt="screen shot 2016-04-30 at 15 26 19" src="https://cloud.githubusercontent.com/assets/3956929/14936114/4d893c90-0ee8-11e6-8aa1-bc467bbd17ad.png">

The THEME toggler will save the current theme to localStorage, if available. Dark theme is default.