### PR TITLE
chore(typings): removed implicit Array<T> signature for combineAll and zipAll

### DIFF
--- a/src/operator/combineAll.ts
+++ b/src/operator/combineAll.ts
@@ -46,6 +46,5 @@ export function combineAll<R>(project?: (...values: Array<any>) => R): Observabl
 }
 
 export interface CombineAllSignature<T> {
-  (): Observable<T[]>;
   <R>(project?: (...values: Array<T>) => R): Observable<R>;
 }

--- a/src/operator/zipAll.ts
+++ b/src/operator/zipAll.ts
@@ -12,6 +12,5 @@ export function zipAll<T, R>(project?: (...values: Array<any>) => R): Observable
 }
 
 export interface ZipAllSignature<T> {
-  (): Observable<T[]>;
   <R>(project?: (...values: Array<T>) => R): Observable<R>;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The implicit definition for combineAll / zipAll cannot properly infer the resulting type.  

**Related issue (if exists):**
See #1677 for more information.