### PR TITLE
chore(typings): fixed compiler errors when using @next version of typescript

### DIFF
--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -98,14 +98,17 @@ export class FromEventObservable<T, R> extends Observable<T> {
         FromEventObservable.setupSubscription(sourceObj[i], eventName, handler, subscriber);
       }
     } else if (isEventTarget(sourceObj)) {
+      const source = sourceObj;
       sourceObj.addEventListener(eventName, <EventListener>handler);
-      unsubscribe = () => sourceObj.removeEventListener(eventName, <EventListener>handler);
+      unsubscribe = () => source.removeEventListener(eventName, <EventListener>handler);
     } else if (isJQueryStyleEventEmitter(sourceObj)) {
+      const source = sourceObj;
       sourceObj.on(eventName, handler);
-      unsubscribe = () => sourceObj.off(eventName, handler);
+      unsubscribe = () => source.off(eventName, handler);
     } else if (isNodeStyleEventEmmitter(sourceObj)) {
+      const source = sourceObj;
       sourceObj.addListener(eventName, handler);
-      unsubscribe = () => sourceObj.removeListener(eventName, handler);
+      unsubscribe = () => source.removeListener(eventName, handler);
     }
 
     subscriber.add(new Subscription(unsubscribe));

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -239,7 +239,7 @@ class StaticArrayIterator<T> implements LookAheadIterator<T> {
   next(value?: any): IteratorResult<T> {
     const i = this.index++;
     const array = this.array;
-    return i < this.length ? { value: array[i], done: false } : { done: true };
+    return i < this.length ? { value: array[i], done: false } : { value: null, done: true };
   }
 
   hasValue() {
@@ -277,7 +277,7 @@ class ZipBufferIterator<T, R> extends OuterSubscriber<T, R> implements LookAhead
   next(): IteratorResult<T> {
     const buffer = this.buffer;
     if (buffer.length === 0 && this.isComplete) {
-      return { done: true };
+      return { value: null, done: true };
     } else {
       return { value: buffer.shift(), done: false };
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This fixes two of the compiler errors that are issues with the `vNext` version of TypeScript (currently named 1.9, soon to be 2.0 I believe).

The third error is a compiler issue, so I have made no changes to `FromEventObservable`.

**Related issue (if exists):**
#1697
