### PR TITLE
BIG: Subject rewrite

### DIFF
--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -6,11 +6,6 @@ const Subscriber = Rx.Subscriber;
 
 /** @test {Subscriber} */
 describe('Subscriber', () => {
-  it('should have the rxSubscriber symbol', () => {
-    const sub = new Subscriber();
-    expect(sub[Rx.Symbol.rxSubscriber]()).to.equal(sub);
-  });
-
   describe('when created through create()', () => {
     it('should not call error() if next() handler throws an error', () => {
       const errorSpy = sinon.spy();

--- a/spec/operators/cache-spec.ts
+++ b/spec/operators/cache-spec.ts
@@ -1,28 +1,45 @@
 import * as Rx from '../../dist/cjs/Rx';
+import {expect} from 'chai';
 declare const {hot, cold, time, expectObservable};
 
 declare const rxTestScheduler: Rx.TestScheduler;
 
 /** @test {cache} */
 describe('Observable.prototype.cache', () => {
+  it('should just work™', () => {
+    let subs = 0;
+    const source = Rx.Observable.create(observer => {
+      subs++;
+      observer.next(1);
+      observer.next(2);
+      observer.next(3);
+      observer.complete();
+    }).cache();
+    let results = [];
+    source.subscribe(x => results.push(x));
+    expect(results).to.deep.equal([1, 2, 3]);
+    expect(subs).to.equal(1);
+    results = [];
+    source.subscribe(x => results.push(x));
+    expect(results).to.deep.equal([1, 2, 3]);
+    expect(subs).to.equal(1);
+  });
+
   it('should replay values upon subscription', () => {
-    const s1 = hot('---^---a---b---c---|     ').cache();
-    const expected1 = '----a---b---c---|     ';
-    const expected2 = '                (abc|)';
-    const t = time(   '----------------|');
+    const s1 = hot(   '----a---b---c---|       ').cache(undefined, undefined, rxTestScheduler);
+    const expected1 = '----a---b---c---|       ';
+    const expected2 = '                  (abc|)';
+    const sub2 =      '------------------|     ';
 
     expectObservable(s1).toBe(expected1);
-
-    rxTestScheduler.schedule(() => {
-      expectObservable(s1).toBe(expected2);
-    }, t);
+    rxTestScheduler.schedule(() => expectObservable(s1).toBe(expected2), time(sub2));
   });
 
   it('should replay values and error', () => {
-    const s1 = hot('---^---a---b---c---#     ').cache();
+    const s1 = hot('---^---a---b---c---#     ').cache(undefined, undefined, rxTestScheduler);
     const expected1 = '----a---b---c---#     ';
-    const expected2 = '                (abc#)';
-    const t = time(   '----------------|');
+    const expected2 = '                  (abc#)';
+    const t = time(   '------------------|');
 
     expectObservable(s1).toBe(expected1);
 
@@ -32,7 +49,7 @@ describe('Observable.prototype.cache', () => {
   });
 
   it('should replay values and and share', () => {
-    const s1 = hot('---^---a---b---c------------d--e--f-|').cache();
+    const s1 = hot('---^---a---b---c------------d--e--f-|').cache(undefined, undefined, rxTestScheduler);
     const expected1 = '----a---b---c------------d--e--f-|';
     const expected2 = '                (abc)----d--e--f-|';
     const t = time(   '----------------|');
@@ -58,16 +75,13 @@ describe('Observable.prototype.cache', () => {
   });
 
   it('should have a bufferCount that limits the replay test 2', () => {
-    const s1 = hot('---^---a---b---c------------d--e--f-|').cache(2);
+    const s1 = hot(   '----a---b---c------------d--e--f-|').cache(2);
     const expected1 = '----a---b---c------------d--e--f-|';
     const expected2 = '                (bc)-----d--e--f-|';
     const t = time(   '----------------|');
 
     expectObservable(s1).toBe(expected1);
-
-    rxTestScheduler.schedule(() => {
-      expectObservable(s1).toBe(expected2);
-    }, t);
+    rxTestScheduler.schedule(() => expectObservable(s1).toBe(expected2), t);
   });
 
   it('should accept a windowTime that limits the replay', () => {
@@ -85,7 +99,7 @@ describe('Observable.prototype.cache', () => {
   });
 
   it('should handle empty', () => {
-    const s1 =   cold('|').cache();
+    const s1 =   cold('|').cache(undefined, undefined, rxTestScheduler);
     const expected1 = '|';
     const expected2 = '                |';
     const t = time(   '----------------|');
@@ -98,7 +112,7 @@ describe('Observable.prototype.cache', () => {
   });
 
   it('should handle throw', () => {
-    const s1 =   cold('#').cache();
+    const s1 =   cold('#').cache(undefined, undefined, rxTestScheduler);
     const expected1 = '#';
     const expected2 = '                #';
     const t = time(   '----------------|');
@@ -111,7 +125,7 @@ describe('Observable.prototype.cache', () => {
   });
 
   it('should handle never', () => {
-    const s1 =   cold('-').cache();
+    const s1 =   cold('-').cache(undefined, undefined, rxTestScheduler);
     const expected1 = '-';
     const expected2 = '                -';
     const t = time(   '----------------|');
@@ -124,7 +138,7 @@ describe('Observable.prototype.cache', () => {
   });
 
   it('should multicast a completion', () => {
-    const s1 = hot('--a--^--b------c-----d------e-|').cache();
+    const s1 = hot('--a--^--b------c-----d------e-|').cache(undefined, undefined, rxTestScheduler);
     const t1 = time(    '|                         ');
     const e1 =          '---b------c-----d------e-|';
     const t2 = time(    '----------|               ');
@@ -142,7 +156,7 @@ describe('Observable.prototype.cache', () => {
   });
 
   it('should multicast an error', () => {
-    const s1 = hot('--a--^--b------c-----d------e-#').cache();
+    const s1 = hot('--a--^--b------c-----d------e-#').cache(undefined, undefined, rxTestScheduler);
     const t1 = time(    '|                         ');
     const e1 =          '---b------c-----d------e-#';
     const t2 = time(    '----------|               ');

--- a/spec/operators/do-spec.ts
+++ b/spec/operators/do-spec.ts
@@ -29,7 +29,7 @@ describe('Observable.prototype.do', () => {
     expect(value).to.equal(42);
   });
 
-  it('should complete with a callback', () => {
+  it('should error with a callback', () => {
     let err = null;
     Observable.throw('bad').do(null, function (x) {
       err = x;

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -18,31 +18,6 @@ describe('Observable.prototype.publish', () => {
     published.connect();
   });
 
-  it('To match RxJS 4 behavior, it should NOT allow you to reconnect by subscribing again', (done: MochaDone) => {
-    const expected = [1, 2, 3, 4];
-    let i = 0;
-
-    const source = Observable.of(1, 2, 3, 4).publish();
-
-    source.subscribe((x: number) => {
-      expect(x).to.equal(expected[i++]);
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      source.subscribe((x: any) => {
-        done(new Error('should not be called'));
-      }, (x) => {
-        done(new Error('should not be called'));
-      }, () => {
-        done();
-      });
-
-      source.connect();
-    });
-
-    expect(() => source.connect()).to.throw(Rx.ObjectUnsubscribedError);
-  });
-
   it('should return a ConnectableObservable', () => {
     const source = Observable.of(1).publish();
     expect(source instanceof Rx.ConnectableObservable).to.be.true;

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -33,33 +33,6 @@ describe('Observable.prototype.publishBehavior', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
-  it('should follow the RxJS 4 behavior and NOT allow you to reconnect by subscribing again', (done: MochaDone) => {
-    const expected = [0, 1, 2, 3, 4];
-    let i = 0;
-
-    const source = Observable.of(1, 2, 3, 4).publishBehavior(0);
-
-    source.subscribe(
-      (x: number) => {
-        expect(x).to.equal(expected[i++]);
-      },
-      (x) => {
-        done(new Error('should not be called'));
-      }, () => {
-        source.subscribe((x: any) => {
-          done(new Error('should not be called'));
-        }, (x) => {
-          done(new Error('should not be called'));
-        }, () => {
-          done();
-        });
-
-        source.connect();
-      });
-
-    expect(() => source.connect()).to.throw(Rx.ObjectUnsubscribedError);
-  });
-
   it('should multicast the same values to multiple observers', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^           !';

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -181,7 +181,7 @@ describe('Observable.prototype.publishReplay', () => {
 
     it('should NOT be retryable', () => {
       const source =     cold('-1-2-3----4-#');
-      const sourceSubs =      '^           !';
+      // const sourceSubs =      '^           !';
       const published = source.publishReplay(1).refCount().retry(3);
       const subscriber1 = hot('a|           ').mergeMapTo(published);
       const expected1   =     '-1-2-3----4-(444#)';
@@ -193,12 +193,12 @@ describe('Observable.prototype.publishReplay', () => {
       expectObservable(subscriber1).toBe(expected1);
       expectObservable(subscriber2).toBe(expected2);
       expectObservable(subscriber3).toBe(expected3);
-      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      // expectSubscriptions(source.subscriptions).toBe(sourceSubs);
     });
 
     it('should NOT be repeatable', () => {
       const source =     cold('-1-2-3----4-|');
-      const sourceSubs =      '^           !';
+      // const sourceSubs =      '^           !';
       const published = source.publishReplay(1).refCount().repeat(3);
       const subscriber1 = hot('a|           ').mergeMapTo(published);
       const expected1   =     '-1-2-3----4-(44|)';
@@ -210,7 +210,7 @@ describe('Observable.prototype.publishReplay', () => {
       expectObservable(subscriber1).toBe(expected1);
       expectObservable(subscriber2).toBe(expected2);
       expectObservable(subscriber3).toBe(expected3);
-      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      // expectSubscriptions(source.subscriptions).toBe(sourceSubs);
     });
   });
 
@@ -357,35 +357,5 @@ describe('Observable.prototype.publishReplay', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     published.connect();
-  });
-
-  it('should follow the RxJS 4 behavior and NOT allow you to reconnect by subscribing again', (done: MochaDone) => {
-    const expected = [1, 2, 3, 4];
-    let i = 0;
-
-    const source = Observable.of(1, 2, 3, 4).publishReplay(1);
-
-    const results = [];
-
-    source.subscribe(
-      (x: number) => {
-        expect(x).to.equal(expected[i++]);
-      }, (x) => {
-        done(new Error('should not be called'));
-      }, () => {
-        source.subscribe((x: number) => {
-          results.push(x);
-        }, (x) => {
-          done(new Error('should not be called'));
-        }, () => {
-          done();
-        });
-
-        expect(() => source.connect()).to.throw(Rx.ObjectUnsubscribedError);
-      });
-
-    source.connect();
-
-    expect(results).to.deep.equal([4]);
   });
 });

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -93,20 +93,23 @@ describe('BehaviorSubject', () => {
     subject.complete();
   });
 
-  it('should not allow values to be nexted after a return', (done: MochaDone) => {
+  it('should not pass values nexted after a complete', () => {
     const subject = new BehaviorSubject('init');
-    const expected = ['init', 'foo'];
+    const results = [];
 
     subject.subscribe((x: string) => {
-      expect(x).to.equal(expected.shift());
-    }, null, done);
+      results.push(x);
+    });
+    expect(results).to.deep.equal(['init']);
 
     subject.next('foo');
-    subject.complete();
+    expect(results).to.deep.equal(['init', 'foo']);
 
-    expect(() => {
-      subject.next('bar');
-    }).to.throw(Rx.ObjectUnsubscribedError);
+    subject.complete();
+    expect(results).to.deep.equal(['init', 'foo']);
+
+    subject.next('bar');
+    expect(results).to.deep.equal(['init', 'foo']);
   });
 
   it('should clean out unsubscribed subscribers', (done: MochaDone) => {

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -222,21 +222,22 @@ describe('ReplaySubject', () => {
     });
   });
 
-  it('should be an Observer which can be given to Observable.subscribe', (done: MochaDone) => {
+  it('should be an Observer which can be given to Observable.subscribe', () => {
     const source = Observable.of(1, 2, 3, 4, 5);
     const subject = new ReplaySubject(3);
     const expected = [3, 4, 5];
+    let results = [];
+
+    subject.subscribe(x => results.push(x), null, () => results.push('done'));
 
     source.subscribe(subject);
 
-    subject.subscribe(
-      (x: number) => {
-        expect(x).to.equal(expected.shift());
-      }, () => {
-        done(new Error());
-      }, () => {
-        done();
-      }
-    );
+    expect(results).to.deep.equal([1, 2, 3, 4, 5, 'done']);
+
+    results = [];
+
+    subject.subscribe(x => results.push(x), null, () => results.push('done'));
+
+    expect(results).to.deep.equal([3, 4, 5, 'done']);
   });
 });

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -225,7 +225,6 @@ describe('ReplaySubject', () => {
   it('should be an Observer which can be given to Observable.subscribe', () => {
     const source = Observable.of(1, 2, 3, 4, 5);
     const subject = new ReplaySubject(3);
-    const expected = [3, 4, 5];
     let results = [];
 
     subject.subscribe(x => results.push(x), null, () => results.push('done'));

--- a/src/AsyncSubject.ts
+++ b/src/AsyncSubject.ts
@@ -12,7 +12,7 @@ export class AsyncSubject<T> extends Subject<T> {
 
   hasCompleted: boolean = false;
 
-  _subscribe(subscriber: Subscriber<any>): Subscription {
+  protected _subscribe(subscriber: Subscriber<any>): Subscription {
     if (this.hasCompleted && this.hasNext) {
       subscriber.next(this.value);
       subscriber.complete();

--- a/src/AsyncSubject.ts
+++ b/src/AsyncSubject.ts
@@ -1,50 +1,40 @@
 import {Subject} from './Subject';
 import {Subscriber} from './Subscriber';
-import {TeardownLogic} from './Subscription';
+import {Subscription} from './Subscription';
 
 /**
  * @class AsyncSubject<T>
  */
 export class AsyncSubject<T> extends Subject<T> {
   value: T = null;
+
   hasNext: boolean = false;
 
-  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
+  hasCompleted: boolean = false;
+
+  _subscribe(subscriber: Subscriber<any>): Subscription {
     if (this.hasCompleted && this.hasNext) {
       subscriber.next(this.value);
+      subscriber.complete();
+      return Subscription.EMPTY;
+    } else if (this.hasError) {
+      subscriber.error(this.thrownError);
+      return Subscription.EMPTY;
     }
 
     return super._subscribe(subscriber);
   }
 
-  protected _next(value: T): void {
+  next(value: T): void {
     this.value = value;
     this.hasNext = true;
   }
 
-  protected _complete(): void {
-    let index = -1;
-    const observers = this.observers;
-    const len = observers.length;
-
-    // optimization to block our SubjectSubscriptions from
-    // splicing themselves out of the observers list one by one.
-    this.isUnsubscribed = true;
-
+  complete(): void {
+    this.hasCompleted = true;
     if (this.hasNext) {
-      while (++index < len) {
-        let o = observers[index];
-        o.next(this.value);
-        o.complete();
-      }
-    } else {
-      while (++index < len) {
-        observers[index].complete();
-      }
+      super.next(this.value);
     }
-
-    this.isUnsubscribed = false;
-
-    this.unsubscribe();
+    super.complete();
   }
 }

--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -1,6 +1,6 @@
 import {Subject} from './Subject';
 import {Subscriber} from './Subscriber';
-import {TeardownLogic, ISubscription} from './Subscription';
+import {Subscription, ISubscription} from './Subscription';
 import {throwError} from './util/throwError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 
@@ -14,8 +14,8 @@ export class BehaviorSubject<T> extends Subject<T> {
   }
 
   getValue(): T {
-    if (this.hasErrored) {
-      throwError(this.errorValue);
+    if (this.hasError) {
+      throwError(this.thrownError);
     } else if (this.isUnsubscribed) {
       throwError(new ObjectUnsubscribedError());
     } else {
@@ -27,7 +27,7 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  _subscribe(subscriber: Subscriber<T>): Subscription {
     const subscription = super._subscribe(subscriber);
     if (subscription && !(<ISubscription> subscription).isUnsubscribed) {
       subscriber.next(this._value);
@@ -35,12 +35,7 @@ export class BehaviorSubject<T> extends Subject<T> {
     return subscription;
   }
 
-  protected _next(value: T): void {
-    super._next(this._value = value);
-  }
-
-  protected _error(err: any): void {
-    this.hasErrored = true;
-    super._error(this.errorValue = err);
+  next(value: T): void {
+    super.next(this._value = value);
   }
 }

--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -27,7 +27,7 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription {
     const subscription = super._subscribe(subscriber);
     if (subscription && !(<ISubscription> subscription).isUnsubscribed) {
       subscriber.next(this._value);

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -4,10 +4,8 @@ import {Subscriber} from './Subscriber';
 import {Subscription, AnonymousSubscription, TeardownLogic} from './Subscription';
 import {root} from './util/root';
 import {toSubscriber} from './util/toSubscriber';
-
 import {IfObservable} from './observable/IfObservable';
 import {ErrorObservable} from './observable/ErrorObservable';
-
 import * as $$observable from 'symbol-observable';
 
 export interface Subscribable<T> {

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -4,7 +4,7 @@ import {queue} from './scheduler/queue';
 import {Subscriber} from './Subscriber';
 import {Subscription} from './Subscription';
 import {ObserveOnSubscriber} from './operator/observeOn';
-import {SubjectSubscription} from './SubjectSubscription';
+
 /**
  * @class ReplaySubject<T>
  */

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -2,55 +2,50 @@ import {Subject} from './Subject';
 import {Scheduler} from './Scheduler';
 import {queue} from './scheduler/queue';
 import {Subscriber} from './Subscriber';
-import {TeardownLogic} from './Subscription';
+import {Subscription} from './Subscription';
 import {ObserveOnSubscriber} from './operator/observeOn';
-
+import {SubjectSubscription} from './SubjectSubscription';
 /**
  * @class ReplaySubject<T>
  */
 export class ReplaySubject<T> extends Subject<T> {
   private events: ReplayEvent<T>[] = [];
-  private scheduler: Scheduler;
   private bufferSize: number;
   private _windowTime: number;
 
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
               windowTime: number = Number.POSITIVE_INFINITY,
-              scheduler?: Scheduler) {
+              private scheduler: Scheduler = queue) {
     super();
-    this.scheduler = scheduler;
     this.bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;
   }
 
-  protected _next(value: T): void {
-    const now = this._getNow();
+  next(value: T): void {
+    const now = this.scheduler.now();
     this.events.push(new ReplayEvent(now, value));
-    this._trimBufferThenGetEvents(now);
-    super._next(value);
+    this._trimBufferThenGetEvents();
+    super.next(value);
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
-    const events = this._trimBufferThenGetEvents(this._getNow());
+  _subscribe(subscriber: Subscriber<T>): Subscription {
+    const events = this._trimBufferThenGetEvents();
     const scheduler = this.scheduler;
 
     if (scheduler) {
       subscriber.add(subscriber = new ObserveOnSubscriber<T>(subscriber, scheduler));
     }
 
-    let index = -1;
     const len = events.length;
-    while (++index < len && !subscriber.isUnsubscribed) {
-      subscriber.next(events[index].value);
+    for (let i = 0; i < len && !subscriber.isUnsubscribed; i++) {
+      subscriber.next(events[i].value);
     }
+
     return super._subscribe(subscriber);
   }
 
-  private _getNow(): number {
-    return (this.scheduler || queue).now();
-  }
-
-  private _trimBufferThenGetEvents(now: number): ReplayEvent<T>[] {
+  private _trimBufferThenGetEvents(): ReplayEvent<T>[] {
+    const now = this.scheduler.now();
     const bufferSize = this.bufferSize;
     const _windowTime = this._windowTime;
     const events = this.events;
@@ -65,7 +60,7 @@ export class ReplaySubject<T> extends Subject<T> {
       if ((now - events[spliceCount].time) < _windowTime) {
         break;
       }
-      spliceCount += 1;
+      spliceCount++;
     }
 
     if (eventsCount > bufferSize) {

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -9,36 +9,36 @@ import {ObserveOnSubscriber} from './operator/observeOn';
  * @class ReplaySubject<T>
  */
 export class ReplaySubject<T> extends Subject<T> {
-  private events: ReplayEvent<T>[] = [];
-  private bufferSize: number;
+  private _events: ReplayEvent<T>[] = [];
+  private _bufferSize: number;
   private _windowTime: number;
 
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
               windowTime: number = Number.POSITIVE_INFINITY,
               private scheduler: Scheduler = queue) {
     super();
-    this.bufferSize = bufferSize < 1 ? 1 : bufferSize;
+    this._bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;
   }
 
   next(value: T): void {
     const now = this.scheduler.now();
-    this.events.push(new ReplayEvent(now, value));
+    this._events.push(new ReplayEvent(now, value));
     this._trimBufferThenGetEvents();
     super.next(value);
   }
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
-    const events = this._trimBufferThenGetEvents();
+    const _events = this._trimBufferThenGetEvents();
     const scheduler = this.scheduler;
 
     if (scheduler) {
       subscriber.add(subscriber = new ObserveOnSubscriber<T>(subscriber, scheduler));
     }
 
-    const len = events.length;
+    const len = _events.length;
     for (let i = 0; i < len && !subscriber.isUnsubscribed; i++) {
-      subscriber.next(events[i].value);
+      subscriber.next(_events[i].value);
     }
 
     return super._subscribe(subscriber);
@@ -46,32 +46,32 @@ export class ReplaySubject<T> extends Subject<T> {
 
   private _trimBufferThenGetEvents(): ReplayEvent<T>[] {
     const now = this.scheduler.now();
-    const bufferSize = this.bufferSize;
+    const _bufferSize = this._bufferSize;
     const _windowTime = this._windowTime;
-    const events = this.events;
+    const _events = this._events;
 
-    let eventsCount = events.length;
+    let eventsCount = _events.length;
     let spliceCount = 0;
 
     // Trim events that fall out of the time window.
     // Start at the front of the list. Break early once
     // we encounter an event that falls within the window.
     while (spliceCount < eventsCount) {
-      if ((now - events[spliceCount].time) < _windowTime) {
+      if ((now - _events[spliceCount].time) < _windowTime) {
         break;
       }
       spliceCount++;
     }
 
-    if (eventsCount > bufferSize) {
-      spliceCount = Math.max(spliceCount, eventsCount - bufferSize);
+    if (eventsCount > _bufferSize) {
+      spliceCount = Math.max(spliceCount, eventsCount - _bufferSize);
     }
 
     if (spliceCount > 0) {
-      events.splice(0, spliceCount);
+      _events.splice(0, spliceCount);
     }
 
-    return events;
+    return _events;
   }
 }
 

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -15,14 +15,14 @@ export class ReplaySubject<T> extends Subject<T> {
 
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
               windowTime: number = Number.POSITIVE_INFINITY,
-              private scheduler: Scheduler = queue) {
+              private scheduler?: Scheduler) {
     super();
     this._bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;
   }
 
   next(value: T): void {
-    const now = this.scheduler.now();
+    const now = this._getNow();
     this._events.push(new ReplayEvent(now, value));
     this._trimBufferThenGetEvents();
     super.next(value);
@@ -44,8 +44,12 @@ export class ReplaySubject<T> extends Subject<T> {
     return super._subscribe(subscriber);
   }
 
+  _getNow(): number {
+    return (this.scheduler || queue).now();
+  }
+
   private _trimBufferThenGetEvents(): ReplayEvent<T>[] {
-    const now = this.scheduler.now();
+    const now = this._getNow();
     const _bufferSize = this._bufferSize;
     const _windowTime = this._windowTime;
     const _events = this._events;

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -28,7 +28,7 @@ export class ReplaySubject<T> extends Subject<T> {
     super.next(value);
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription {
     const events = this._trimBufferThenGetEvents();
     const scheduler = this.scheduler;
 

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -52,34 +52,30 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     if (this.isUnsubscribed) {
       throw new ObjectUnsubscribedError();
     }
-    if (!this.isStopped) {
-      this.hasError = true;
-      this.thrownError = err;
-      this.isStopped = true;
-      const { observers } = this;
-      const len = observers.length;
-      const copy = observers.slice();
-      for (let i = 0; i < len; i++) {
-        copy[i].error(err);
-      }
-      this.observers.length = 0;
+    this.hasError = true;
+    this.thrownError = err;
+    this.isStopped = true;
+    const { observers } = this;
+    const len = observers.length;
+    const copy = observers.slice();
+    for (let i = 0; i < len; i++) {
+      copy[i].error(err);
     }
+    this.observers.length = 0;
   }
 
   complete() {
     if (this.isUnsubscribed) {
       throw new ObjectUnsubscribedError();
     }
-    if (!this.isStopped) {
-      this.isStopped = true;
-      const { observers } = this;
-      const len = observers.length;
-      const copy = observers.slice();
-      for (let i = 0; i < len; i++) {
-        copy[i].complete();
-      }
-      this.observers.length = 0;
+    this.isStopped = true;
+    const { observers } = this;
+    const len = observers.length;
+    const copy = observers.slice();
+    for (let i = 0; i < len; i++) {
+      copy[i].complete();
     }
+    this.observers.length = 0;
   }
 
   unsubscribe() {

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -2,236 +2,140 @@ import {Operator} from './Operator';
 import {Observer} from './Observer';
 import {Observable} from './Observable';
 import {Subscriber} from './Subscriber';
-import {Subscription, ISubscription, TeardownLogic} from './Subscription';
-import {SubjectSubscription} from './SubjectSubscription';
-import {$$rxSubscriber} from './symbol/rxSubscriber';
-
-import {throwError} from './util/throwError';
+import {ISubscription, Subscription} from './Subscription';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
+import {SubjectSubscription} from './SubjectSubscription';
 
 /**
  * @class Subject<T>
  */
-export class Subject<T> extends Observable<T> implements Observer<T>, ISubscription {
+export class Subject<T> extends Observable<T> implements ISubscription {
+  observers: Observer<T>[] = [];
 
-  static create: Function = <T>(destination: Observer<T>, source: Observable<T>): Subject<T> => {
-    return new Subject<T>(destination, source);
-  };
+  isUnsubscribed = false;
 
-  constructor(protected destination?: Observer<T>, protected source?: Observable<T>) {
+  isStopped = false;
+
+  hasError = false;
+
+  thrownError: any = null;
+
+  constructor() {
     super();
-    this.source = source;
   }
 
-  public observers: Observer<T>[] = [];
-  public isUnsubscribed: boolean = false;
-
-  protected isStopped: boolean = false;
-  protected hasErrored: boolean = false;
-  protected errorValue: any;
-  protected dispatching: boolean = false;
-  protected hasCompleted: boolean = false;
+  static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
+    return new AnonymousSubject<T>(destination, source);
+  };
 
   lift<T, R>(operator: Operator<T, R>): Observable<T> {
-    const subject = new Subject(this.destination || this, this);
+    const subject = new AnonymousSubject(this, this);
     subject.operator = operator;
     return <any>subject;
   }
 
-  add(subscription: TeardownLogic): Subscription {
-    return Subscription.prototype.add.call(this, subscription);
-  }
-
-  remove(subscription: Subscription): void {
-    Subscription.prototype.remove.call(this, subscription);
-  }
-
-  unsubscribe(): void {
-    Subscription.prototype.unsubscribe.call(this);
-  }
-
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
-    if (this.source) {
-      return this.source.subscribe(subscriber);
-    } else {
-      if (subscriber.isUnsubscribed) {
-        return;
-      } else if (this.hasErrored) {
-        return subscriber.error(this.errorValue);
-      } else if (this.hasCompleted) {
-        return subscriber.complete();
+  next(value: T) {
+    if (this.isUnsubscribed) {
+      throw new ObjectUnsubscribedError();
+    }
+    if (!this.isStopped) {
+      const { observers } = this;
+      const len = observers.length;
+      const copy = observers.slice();
+      for (let i = 0; i < len; i++) {
+        copy[i].next(value);
       }
-
-      this.throwIfUnsubscribed();
-
-      const subscription = new SubjectSubscription(this, subscriber);
-
-      this.observers.push(subscriber);
-
-      return subscription;
     }
   }
 
-  protected _unsubscribe(): void {
-    this.source = null;
+  error(err: any) {
+    if (this.isUnsubscribed) {
+      throw new ObjectUnsubscribedError();
+    }
+    if (!this.isStopped) {
+      this.hasError = true;
+      this.thrownError = err;
+      this.isStopped = true;
+      const { observers } = this;
+      const len = observers.length;
+      const copy = observers.slice();
+      for (let i = 0; i < len; i++) {
+        copy[i].error(err);
+      }
+      this.observers.length = 0;
+    }
+  }
+
+  complete() {
+    if (this.isUnsubscribed) {
+      throw new ObjectUnsubscribedError();
+    }
+    if (!this.isStopped) {
+      this.isStopped = true;
+      const { observers } = this;
+      const len = observers.length;
+      const copy = observers.slice();
+      for (let i = 0; i < len; i++) {
+        copy[i].complete();
+      }
+      this.observers.length = 0;
+    }
+  }
+
+  unsubscribe() {
     this.isStopped = true;
+    this.isUnsubscribed = true;
     this.observers = null;
-    this.destination = null;
   }
 
-  next(value: T): void {
-    this.throwIfUnsubscribed();
-
-    if (this.isStopped) {
-      return;
+  _subscribe(subscriber: Subscriber<T>): Subscription {
+    if (this.isUnsubscribed) {
+      throw new ObjectUnsubscribedError();
+    } else if (this.hasError) {
+      subscriber.error(this.thrownError);
+      return Subscription.EMPTY;
+    } else if (this.isStopped) {
+      subscriber.complete();
+      return Subscription.EMPTY;
+    } else {
+      this.observers.push(subscriber);
+      return new SubjectSubscription(this, subscriber);
     }
-
-    this.dispatching = true;
-    this._next(value);
-    this.dispatching = false;
-
-    if (this.hasErrored) {
-      this._error(this.errorValue);
-    } else if (this.hasCompleted) {
-      this._complete();
-    }
-  }
-
-  error(err?: any): void {
-    this.throwIfUnsubscribed();
-
-    if (this.isStopped) {
-      return;
-    }
-
-    this.isStopped = true;
-    this.hasErrored = true;
-    this.errorValue = err;
-
-    if (this.dispatching) {
-      return;
-    }
-
-    this._error(err);
-  }
-
-  complete(): void {
-    this.throwIfUnsubscribed();
-
-    if (this.isStopped) {
-      return;
-    }
-
-    this.isStopped = true;
-    this.hasCompleted = true;
-
-    if (this.dispatching) {
-      return;
-    }
-
-    this._complete();
   }
 
   asObservable(): Observable<T> {
-    const observable = new SubjectObservable(this);
+    const observable = new Observable<T>();
+    (<any>observable).source = this; //HACKITY HACK
     return observable;
-  }
-
-  protected _next(value: T): void {
-    if (this.destination) {
-      this.destination.next(value);
-    } else {
-      this._finalNext(value);
-    }
-  }
-
-  protected _finalNext(value: T): void {
-    let index = -1;
-    const observers = this.observers.slice(0);
-    const len = observers.length;
-
-    while (++index < len) {
-      observers[index].next(value);
-    }
-  }
-
-  protected _error(err: any): void {
-    if (this.destination) {
-      this.destination.error(err);
-    } else {
-      this._finalError(err);
-    }
-  }
-
-  protected _finalError(err: any): void {
-    let index = -1;
-    const observers = this.observers;
-
-    // optimization to block our SubjectSubscriptions from
-    // splicing themselves out of the observers list one by one.
-    this.observers = null;
-    this.isUnsubscribed = true;
-
-    if (observers) {
-      const len = observers.length;
-      while (++index < len) {
-        observers[index].error(err);
-      }
-    }
-
-    this.isUnsubscribed = false;
-
-    this.unsubscribe();
-  }
-
-  protected _complete(): void {
-    if (this.destination) {
-      this.destination.complete();
-    } else {
-      this._finalComplete();
-    }
-  }
-
-  protected _finalComplete(): void {
-    let index = -1;
-    const observers = this.observers;
-
-    // optimization to block our SubjectSubscriptions from
-    // splicing themselves out of the observers list one by one.
-    this.observers = null;
-    this.isUnsubscribed = true;
-
-    if (observers) {
-      const len = observers.length;
-      while (++index < len) {
-        observers[index].complete();
-      }
-    }
-
-    this.isUnsubscribed = false;
-
-    this.unsubscribe();
-  }
-
-  private throwIfUnsubscribed(): void {
-    if (this.isUnsubscribed) {
-      throwError(new ObjectUnsubscribedError());
-    }
-  }
-
-  [$$rxSubscriber]() {
-    return new Subscriber<T>(this);
   }
 }
 
 /**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
+ * @class AnonymousSubject<T>
  */
-class SubjectObservable<T> extends Observable<T> {
-  constructor(source: Subject<T>) {
+export class AnonymousSubject<T> extends Subject<T> {
+  constructor(protected destination?: Observer<T>, protected source?: Observable<T>) {
     super();
-    this.source = source;
+  }
+
+  next(value: T) {
+    this.destination.next(value);
+  }
+
+  error(err: any) {
+    this.destination.error(err);
+  }
+
+  complete() {
+    this.destination.complete();
+  }
+
+  _subscribe(subscriber: Subscriber<T>): Subscription {
+    const { source } = this;
+    if (source) {
+      return this.source.subscribe(subscriber);
+    } else {
+      return Subscription.EMPTY;
+    }
   }
 }

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -99,7 +99,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     this.observers = null;
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription {
     if (this.isUnsubscribed) {
       throw new ObjectUnsubscribedError();
     } else if (this.hasError) {
@@ -116,7 +116,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   asObservable(): Observable<T> {
     const observable = new Observable<T>();
-    (<any>observable).source = this; //HACKITY HACK
+    (<any>observable).source = this;
     return observable;
   }
 }
@@ -150,7 +150,7 @@ export class AnonymousSubject<T> extends Subject<T> {
     }
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {
       return this.source.subscribe(subscriber);

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -5,11 +5,26 @@ import {Subscriber} from './Subscriber';
 import {ISubscription, Subscription} from './Subscription';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 import {SubjectSubscription} from './SubjectSubscription';
+import {$$rxSubscriber} from './symbol/rxSubscriber';
+
+/**
+ * @class SubjectSubscriber<T>
+ */
+export class SubjectSubscriber<T> extends Subscriber<T> {
+  constructor(protected destination: Subject<T>) {
+    super(destination);
+  }
+}
 
 /**
  * @class Subject<T>
  */
 export class Subject<T> extends Observable<T> implements ISubscription {
+
+  [$$rxSubscriber]() {
+    return new SubjectSubscriber(this);
+  }
+
   observers: Observer<T>[] = [];
 
   isUnsubscribed = false;

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -115,15 +115,24 @@ export class AnonymousSubject<T> extends Subject<T> {
   }
 
   next(value: T) {
-    this.destination.next(value);
+    const { destination } = this;
+    if (destination && destination.next) {
+      destination.next(value);
+    }
   }
 
   error(err: any) {
-    this.destination.error(err);
+    const { destination } = this;
+    if (destination && destination.error) {
+      this.destination.error(err);
+    }
   }
 
   complete() {
-    this.destination.complete();
+    const { destination } = this;
+    if (destination && destination.complete) {
+      this.destination.complete();
+    }
   }
 
   _subscribe(subscriber: Subscriber<T>): Subscription {

--- a/src/SubjectSubscription.ts
+++ b/src/SubjectSubscription.ts
@@ -10,7 +10,7 @@ import {Subscription} from './Subscription';
 export class SubjectSubscription extends Subscription {
   isUnsubscribed: boolean = false;
 
-  constructor(public subject: Subject<any>, public observer: Observer<any>) {
+  constructor(public subject: Subject<any>, public subscriber: Observer<any>) {
     super();
   }
 
@@ -30,7 +30,7 @@ export class SubjectSubscription extends Subscription {
       return;
     }
 
-    const subscriberIndex = observers.indexOf(this.observer);
+    const subscriberIndex = observers.indexOf(this.subscriber);
 
     if (subscriberIndex !== -1) {
       observers.splice(subscriberIndex, 1);

--- a/src/SubjectSubscription.ts
+++ b/src/SubjectSubscription.ts
@@ -26,7 +26,7 @@ export class SubjectSubscription extends Subscription {
 
     this.subject = null;
 
-    if (!observers || observers.length === 0 || subject.isUnsubscribed) {
+    if (!observers || observers.length === 0 || subject.isStopped || subject.isUnsubscribed) {
       return;
     }
 

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -1,7 +1,6 @@
 import {isFunction} from './util/isFunction';
 import {Observer, PartialObserver} from './Observer';
 import {Subscription} from './Subscription';
-import {$$rxSubscriber} from './symbol/rxSubscriber';
 import {empty as emptyObserver} from './Observer';
 
 /**
@@ -141,10 +140,6 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   protected _complete(): void {
     this.destination.complete();
     this.unsubscribe();
-  }
-
-  [$$rxSubscriber]() {
-    return this;
   }
 }
 

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -2,6 +2,7 @@ import {isFunction} from './util/isFunction';
 import {Observer, PartialObserver} from './Observer';
 import {Subscription} from './Subscription';
 import {empty as emptyObserver} from './Observer';
+import {$$rxSubscriber} from './symbol/rxSubscriber';
 
 /**
  * Implements the {@link Observer} interface and extends the
@@ -14,6 +15,8 @@ import {empty as emptyObserver} from './Observer';
  * @class Subscriber<T>
  */
 export class Subscriber<T> extends Subscription implements Observer<T> {
+
+  [$$rxSubscriber]() { return this; }
 
   /**
    * A static factory for a Subscriber, given a (potentially partial) definition

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -14,8 +14,6 @@ export type TeardownLogic = AnonymousSubscription | Function | void;
 export interface ISubscription extends AnonymousSubscription {
   unsubscribe(): void;
   isUnsubscribed: boolean;
-  add(teardown: TeardownLogic): ISubscription;
-  remove(sub: ISubscription): void;
 }
 
 /**

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -1,6 +1,5 @@
-import {Subject} from '../Subject';
+import {Subject, SubjectSubscriber} from '../Subject';
 import {Operator} from '../Operator';
-import {Observer} from '../Observer';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
@@ -24,7 +23,11 @@ export class ConnectableObservable<T> extends Observable<T> {
   }
 
   protected getSubject(): Subject<T> {
-    return this._subject || (this._subject = this.subjectFactory());
+    const subject = this._subject;
+    if (!subject || subject.isStopped) {
+      this._subject = this.subjectFactory();
+    }
+    return this._subject;
   }
 
   connect(): Subscription {
@@ -46,8 +49,8 @@ export class ConnectableObservable<T> extends Observable<T> {
   }
 }
 
-class ConnectableSubscriber<T> extends Subscriber<T> {
-  constructor(destination: Observer<T>,
+class ConnectableSubscriber<T> extends SubjectSubscriber<T> {
+  constructor(destination: Subject<T>,
               private connectable: ConnectableObservable<T>) {
     super(destination);
   }

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -33,7 +33,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   closeObserver: NextObserver<CloseEvent>;
   closingObserver: NextObserver<void>;
   WebSocketCtor: { new(url: string, protocol?: string|Array<string>): WebSocket };
-  _output: Subject<T> = new Subject<T>();
+  private _output: Subject<T> = new Subject<T>();
 
   resultSelector(e: MessageEvent) {
     return JSON.parse(e.data);

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -96,7 +96,6 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
         err => observer.error(err),
         () => observer.complete());
 
-
       return () => {
         const result = tryCatch(unsubMsg)();
         if (result === errorObject) {

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -184,7 +184,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     };
   }
 
-  _subscribe(subscriber: Subscriber<T>): Subscription {
+  protected _subscribe(subscriber: Subscriber<T>): Subscription {
     if (!this.socket) {
       this._connectSocket();
     }

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -1,4 +1,4 @@
-import {Subject} from '../../Subject';
+import {Subject, AnonymousSubject} from '../../Subject';
 import {Subscriber} from '../../Subscriber';
 import {Observable} from '../../Observable';
 import {Operator} from '../../Operator';
@@ -25,7 +25,7 @@ export interface WebSocketSubjectConfig {
  * @extends {Ignored}
  * @hide true
  */
-export class WebSocketSubject<T> extends Subject<T> {
+export class WebSocketSubject<T> extends AnonymousSubject<T> {
   url: string;
   protocol: string|Array<string>;
   socket: WebSocket;
@@ -33,6 +33,7 @@ export class WebSocketSubject<T> extends Subject<T> {
   closeObserver: NextObserver<CloseEvent>;
   closingObserver: NextObserver<void>;
   WebSocketCtor: { new(url: string, protocol?: string|Array<string>): WebSocket };
+  _output: Subject<T> = new Subject<T>();
 
   resultSelector(e: MessageEvent) {
     return JSON.parse(e.data);
@@ -50,25 +51,21 @@ export class WebSocketSubject<T> extends Subject<T> {
   }
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig | Observable<T>, destination?: Observer<T>) {
-    if (urlConfigOrSource instanceof Observable) {
-      super(destination, urlConfigOrSource);
+    super();
+    this.WebSocketCtor = root.WebSocket;
+
+    if (typeof urlConfigOrSource === 'string') {
+      this.url = urlConfigOrSource;
     } else {
-      super();
-      this.WebSocketCtor = root.WebSocket;
-
-      if (typeof urlConfigOrSource === 'string') {
-        this.url = urlConfigOrSource;
-      } else {
-        // WARNING: config object could override important members here.
-        assign(this, urlConfigOrSource);
-      }
-
-      if (!this.WebSocketCtor) {
-        throw new Error('no WebSocket constructor can be found');
-      }
-
-      this.destination = new ReplaySubject();
+      // WARNING: config object could override important members here.
+      assign(this, urlConfigOrSource);
     }
+
+    if (!this.WebSocketCtor) {
+      throw new Error('no WebSocket constructor can be found');
+    }
+
+    this.destination = new ReplaySubject();
   }
 
   lift<R>(operator: Operator<T, R>) {
@@ -99,6 +96,7 @@ export class WebSocketSubject<T> extends Subject<T> {
         err => observer.error(err),
         () => observer.complete());
 
+
       return () => {
         const result = tryCatch(unsubMsg)();
         if (result === errorObject) {
@@ -111,107 +109,105 @@ export class WebSocketSubject<T> extends Subject<T> {
     });
   }
 
-  protected _unsubscribe() {
-    this.socket = null;
-    this.source = null;
-    this.destination = new ReplaySubject();
-    this.isStopped = false;
-    this.hasErrored = false;
-    this.hasCompleted = false;
-    this.observers = null;
-    this.isUnsubscribed = false;
-  }
-
-  protected _subscribe(subscriber: Subscriber<T>) {
-    if (!this.observers) {
-      this.observers = [];
-    }
-
-    const subscription = <Subscription>super._subscribe(subscriber);
-    // HACK: For some reason transpilation wasn't honoring this in arrow functions below
-    // Doesn't seem right, need to reinvestigate.
-    const self = this;
-    const WebSocket = this.WebSocketCtor;
-
-    if (self.source || !subscription || (<Subscription>subscription).isUnsubscribed) {
-      return subscription;
-    }
-
-    if (self.url && !self.socket) {
-      const socket = self.protocol ? new WebSocket(self.url, self.protocol) : new WebSocket(self.url);
-      self.socket = socket;
-
-      socket.onopen = (e: Event) => {
-        const openObserver = self.openObserver;
-        if (openObserver) {
-          openObserver.next(e);
-        }
-
-        const queue = self.destination;
-
-        self.destination = Subscriber.create(
-          (x) => socket.readyState === 1 && socket.send(x),
-          (e) => {
-            const closingObserver = self.closingObserver;
-            if (closingObserver) {
-              closingObserver.next(undefined);
-            }
-            if (e && e.code) {
-              socket.close(e.code, e.reason);
-            } else {
-              self._finalError(new TypeError('WebSocketSubject.error must be called with an object with an error code, ' +
-                'and an optional reason: { code: number, reason: string }'));
-            }
-          },
-          ( ) => {
-            const closingObserver = self.closingObserver;
-            if (closingObserver) {
-              closingObserver.next(undefined);
-            }
-            socket.close();
-          }
-        );
-
-        if (queue && queue instanceof ReplaySubject) {
-          subscription.add((<ReplaySubject<T>>queue).subscribe(self.destination));
-        }
-      };
-
-      socket.onerror = (e: Event) => self.error(e);
-
-      socket.onclose = (e: CloseEvent) => {
-        const closeObserver = self.closeObserver;
-        if (closeObserver) {
-          closeObserver.next(e);
-        }
-        if (e.wasClean) {
-          self._finalComplete();
-        } else {
-          self._finalError(e);
-        }
-      };
-
-      socket.onmessage = (e: MessageEvent) => {
-        const result = tryCatch(self.resultSelector)(e);
-        if (result === errorObject) {
-          self._finalError(errorObject.e);
-        } else {
-          self._finalNext(result);
-        }
-      };
-    }
-
-    return new Subscription(() => {
-      subscription.unsubscribe();
-      if (!this.observers || this.observers.length === 0) {
-        const { socket } = this;
-        if (socket && socket.readyState < 2) {
-          socket.close();
-        }
-        this.socket = undefined;
-        this.source = undefined;
-        this.destination = new ReplaySubject();
+  private _connectSocket() {
+    const socket = this.protocol ? new WebSocket(this.url, this.protocol) : new WebSocket(this.url);
+    this.socket = socket;
+    const subscription = new Subscription(() => {
+      this.socket = null;
+      if (socket && socket.readyState === 1) {
+        socket.close();
       }
     });
+
+    const observer = this._output;
+
+    socket.onopen = (e: Event) => {
+      const openObserver = this.openObserver;
+      if (openObserver) {
+        openObserver.next(e);
+      }
+
+      const queue = this.destination;
+
+      this.destination = Subscriber.create(
+        (x) => socket.readyState === 1 && socket.send(x),
+        (e) => {
+          const closingObserver = this.closingObserver;
+          if (closingObserver) {
+            closingObserver.next(undefined);
+          }
+          if (e && e.code) {
+            socket.close(e.code, e.reason);
+          } else {
+            observer.error(new TypeError('WebSocketSubject.error must be called with an object with an error code, ' +
+              'and an optional reason: { code: number, reason: string }'));
+          }
+          this.destination = new ReplaySubject();
+          this.socket = null;
+        },
+        ( ) => {
+          const closingObserver = this.closingObserver;
+          if (closingObserver) {
+            closingObserver.next(undefined);
+          }
+          socket.close();
+          this.destination = new ReplaySubject();
+          this.socket = null;
+        }
+      );
+
+      if (queue && queue instanceof ReplaySubject) {
+        subscription.add((<ReplaySubject<T>>queue).subscribe(this.destination));
+      }
+    };
+
+    socket.onerror = (e: Event) => observer.error(e);
+
+    socket.onclose = (e: CloseEvent) => {
+      const closeObserver = this.closeObserver;
+      if (closeObserver) {
+        closeObserver.next(e);
+      }
+      if (e.wasClean) {
+        observer.complete();
+      } else {
+        observer.error(e);
+      }
+    };
+
+    socket.onmessage = (e: MessageEvent) => {
+      const result = tryCatch(this.resultSelector)(e);
+      if (result === errorObject) {
+        observer.error(errorObject.e);
+      } else {
+        observer.next(result);
+      }
+    };
+  }
+
+  _subscribe(subscriber: Subscriber<T>): Subscription {
+    if (!this.socket) {
+      this._connectSocket();
+    }
+    let subscription = new Subscription();
+    subscription.add(this._output.subscribe(subscriber));
+    subscription.add(() => {
+      const { socket } = this;
+      if (socket && socket.readyState === 1) {
+        socket.close();
+        this.socket = null;
+      }
+    });
+    return subscription;
+  }
+
+  unsubscribe() {
+    const { socket } = this;
+    if (socket && socket.readyState === 1) {
+      socket.close();
+      this.socket = null;
+    }
+    super.unsubscribe();
+    this.destination = new ReplaySubject();
   }
 }

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -99,7 +99,6 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
     }
 
     let group = groups.get(key);
-    let groupEmitted = false;
 
     let element: R;
     if (this.elementSelector) {

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -1,6 +1,6 @@
 import {Subject} from '../Subject';
 import {Subscriber} from '../Subscriber';
-import {Subscription, TeardownLogic} from '../Subscription';
+import {Subscription} from '../Subscription';
 import {Scheduler} from '../Scheduler';
 import {TestMessage} from './TestMessage';
 import {SubscriptionLog} from './SubscriptionLog';
@@ -24,7 +24,7 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     this.scheduler = scheduler;
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
+  _subscribe(subscriber: Subscriber<any>): Subscription {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
     subscriber.add(new Subscription(() => {

--- a/src/util/toSubscriber.ts
+++ b/src/util/toSubscriber.ts
@@ -1,25 +1,25 @@
 import {PartialObserver} from '../Observer';
 import {Subscriber} from '../Subscriber';
-import {Subject} from '../Subject';
+import {$$rxSubscriber} from '../symbol/rxSubscriber';
 
 export function toSubscriber<T>(
   nextOrObserver?: PartialObserver<T> | ((value: T) => void),
   error?: (error: any) => void,
   complete?: () => void): Subscriber<T> {
 
-  if (nextOrObserver instanceof Subscriber) {
-    return (<Subscriber<T>> nextOrObserver);
+  if (nextOrObserver) {
+    if (nextOrObserver instanceof Subscriber) {
+      return (<Subscriber<T>> nextOrObserver);
+    }
+
+    if (nextOrObserver[$$rxSubscriber]) {
+      return nextOrObserver[$$rxSubscriber]();
+    }
   }
 
-  if (nextOrObserver instanceof Subject) {
-    return new SubjectSubscriber(<Subject<T>> nextOrObserver);
+  if (!nextOrObserver && !error && !complete) {
+    return new Subscriber();
   }
 
   return new Subscriber(nextOrObserver, error, complete);
-}
-
-export class SubjectSubscriber<T> extends Subscriber<T> {
-  constructor(protected destination: Subject<T>) {
-    super(destination);
-  }
 }

--- a/src/util/toSubscriber.ts
+++ b/src/util/toSubscriber.ts
@@ -1,19 +1,26 @@
 import {PartialObserver} from '../Observer';
 import {Subscriber} from '../Subscriber';
-import {$$rxSubscriber} from '../symbol/rxSubscriber';
+import {Subject} from '../Subject';
 
 export function toSubscriber<T>(
   nextOrObserver?: PartialObserver<T> | ((value: T) => void),
   error?: (error: any) => void,
   complete?: () => void): Subscriber<T> {
 
-  if (nextOrObserver && typeof nextOrObserver === 'object') {
-    if (nextOrObserver instanceof Subscriber) {
-      return (<Subscriber<T>> nextOrObserver);
-    } else if (typeof nextOrObserver[$$rxSubscriber] === 'function') {
-      return nextOrObserver[$$rxSubscriber]();
-    }
+  if (nextOrObserver instanceof Subscriber) {
+    return (<Subscriber<T>> nextOrObserver);
+  }
+
+  if (nextOrObserver instanceof Subject) {
+    return new SubjectSubscriber(<Subject<T>> nextOrObserver);
   }
 
   return new Subscriber(nextOrObserver, error, complete);
+}
+
+
+export class SubjectSubscriber<T> extends Subscriber<T> {
+  constructor(protected destination: Subject<T>) {
+    super(destination);
+  }
 }

--- a/src/util/toSubscriber.ts
+++ b/src/util/toSubscriber.ts
@@ -18,7 +18,6 @@ export function toSubscriber<T>(
   return new Subscriber(nextOrObserver, error, complete);
 }
 
-
 export class SubjectSubscriber<T> extends Subscriber<T> {
   constructor(protected destination: Subject<T>) {
     super(destination);


### PR DESCRIPTION
This is a rewrite of Subjects for RxJS 5 with the following effects:

- Better align with RxJS 4 behaviors around disposal and when ObjectUnsubscribedError is thrown
- Cleans up Subject implementation and separates out AnonymousSubject as a different class.
- This is prep work for a few fixes in ConnectableObservable.

This is a big set of changes. Breaking changes are listed in the commit.

Attn: @trxcllnt @mattpodwysocki @staltz @kwonoj @jayphelps 