### PR TITLE
fix(ConnectableObservable): fix race conditions in ConnectableObservable and refCount.

### DIFF
--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -1,4 +1,6 @@
 import {Subject} from '../Subject';
+import {Operator} from '../Operator';
+import {Observer} from '../Observer';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
@@ -8,8 +10,9 @@ import {Subscription} from '../Subscription';
  */
 export class ConnectableObservable<T> extends Observable<T> {
 
-  protected subject: Subject<T>;
-  protected subscription: Subscription;
+  protected _subject: Subject<T>;
+  protected _refCount: number = 0;
+  protected _connection: Subscription;
 
   constructor(protected source: Observable<T>,
               protected subjectFactory: () => Subject<T>) {
@@ -20,133 +23,106 @@ export class ConnectableObservable<T> extends Observable<T> {
     return this.getSubject().subscribe(subscriber);
   }
 
-  protected getSubject() {
-    const subject = this.subject;
-    if (subject && !subject.isUnsubscribed) {
-      return subject;
-    }
-    return (this.subject = this.subjectFactory());
+  protected getSubject(): Subject<T> {
+    return this._subject || (this._subject = this.subjectFactory());
   }
 
   connect(): Subscription {
-    const source = this.source;
-    let subscription = this.subscription;
-    if (subscription && !subscription.isUnsubscribed) {
-      return subscription;
+    let connection = this._connection;
+    if (!connection) {
+      connection = this.source.subscribe(new ConnectableSubscriber(this.getSubject(), this));
+      if (connection.isUnsubscribed) {
+        this._connection = null;
+        connection = Subscription.EMPTY;
+      } else {
+        this._connection = connection;
+      }
     }
-    subscription = source.subscribe(this.getSubject());
-    subscription.add(new ConnectableSubscription(this));
-    return (this.subscription = subscription);
+    return connection;
   }
 
   refCount(): Observable<T> {
-    return new RefCountObservable(this);
-  }
-
-  /**
-   * This method is opened for `ConnectableSubscription`.
-   * Not to call from others.
-   */
-  _closeSubscription(): void {
-    this.subject = null;
-    this.subscription = null;
+    return this.lift(new RefCountOperator<T>(this));
   }
 }
 
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class ConnectableSubscription extends Subscription {
-  constructor(protected connectable: ConnectableObservable<any>) {
-    super();
+class ConnectableSubscriber<T> extends Subscriber<T> {
+  constructor(destination: Observer<T>,
+              private connectable: ConnectableObservable<T>) {
+    super(destination);
   }
-
+  protected _error(err: any): void {
+    this._unsubscribe();
+    super._error(err);
+  }
+  protected _complete(): void {
+    this._unsubscribe();
+    super._complete();
+  }
   protected _unsubscribe() {
-    const connectable = this.connectable;
-    connectable._closeSubscription();
-    this.connectable = null;
+    const { connectable } = this;
+    if (connectable) {
+      this.connectable = null;
+      (<any> connectable)._refCount = 0;
+      (<any> connectable)._subject = null;
+      (<any> connectable)._connection = null;
+    }
   }
 }
 
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class RefCountObservable<T> extends Observable<T> {
-  connection: Subscription;
-
-  constructor(protected connectable: ConnectableObservable<T>,
-              public refCount: number = 0) {
-    super();
+class RefCountOperator<T> implements Operator<T, T> {
+  constructor(private connectable: ConnectableObservable<T>) {
   }
+  call(subscriber: Subscriber<T>, source: any): any {
 
-  protected _subscribe(subscriber: Subscriber<T>) {
-    const connectable = this.connectable;
-    const refCountSubscriber: RefCountSubscriber<T> = new RefCountSubscriber(subscriber, this);
-    const subscription = connectable.subscribe(refCountSubscriber);
-    if (!subscription.isUnsubscribed && ++this.refCount === 1) {
-      refCountSubscriber.connection = this.connection = connectable.connect();
+    const { connectable } = this;
+    (<any> connectable)._refCount++;
+
+    const refCounter = new RefCountSubscriber(subscriber, connectable);
+    const subscription = source._subscribe(refCounter);
+
+    if (!refCounter.isUnsubscribed) {
+      (<any> refCounter).connection = connectable.connect();
     }
+
     return subscription;
   }
 }
 
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
 class RefCountSubscriber<T> extends Subscriber<T> {
-  connection: Subscription;
 
-  constructor(public destination: Subscriber<T>,
-              private refCountObservable: RefCountObservable<T>) {
-    super(null);
-    this.connection = refCountObservable.connection;
-    destination.add(this);
-  }
+  private connection: Subscription;
 
-  protected _next(value: T) {
-    this.destination.next(value);
-  }
-
-  protected _error(err: any) {
-    this._resetConnectable();
-    this.destination.error(err);
-  }
-
-  protected _complete() {
-    this._resetConnectable();
-    this.destination.complete();
-  }
-
-  private _resetConnectable() {
-    const observable = this.refCountObservable;
-    const obsConnection = observable.connection;
-    const subConnection = this.connection;
-    if (subConnection && subConnection === obsConnection) {
-      observable.refCount = 0;
-      obsConnection.unsubscribe();
-      observable.connection = null;
-      this.unsubscribe();
-    }
+  constructor(destination: Subscriber<T>,
+              private connectable: ConnectableObservable<T>) {
+    super(destination);
   }
 
   protected _unsubscribe() {
-    const observable = this.refCountObservable;
-    if (observable.refCount === 0) {
+
+    const { connectable } = this;
+    if (!connectable) {
+      this.connection = null;
       return;
     }
-    if (--observable.refCount === 0) {
-      const obsConnection = observable.connection;
-      const subConnection = this.connection;
-      if (subConnection && subConnection === obsConnection) {
-        obsConnection.unsubscribe();
-        observable.connection = null;
-      }
+
+    this.connectable = null;
+    const refCount = (<any> connectable)._refCount;
+    if (refCount <= 0) {
+      this.connection = null;
+      return;
+    }
+
+    (<any> connectable)._refCount = refCount - 1;
+    if (refCount > 1) {
+      this.connection = null;
+      return;
+    }
+
+    const { connection } = this;
+    if (connection) {
+      this.connection = null;
+      connection.unsubscribe();
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Moves the refCount state to `ConnectableObservable`. Introduces a `Subscriber` between the source and the `Subject`, which can intercept `error` and `complete` calls before they go to the `Subject` and reset the state of the `ConnectableObservable`.

**Related issue (if exists):**
#1669 and possibly #1628