### PR TITLE
fix(subscriptions): fixes bug that tracked subscriber subscriptions twice.

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -91,7 +91,11 @@ export class Observable<T> implements Subscribable<T> {
     const { operator } = this;
     const sink = toSubscriber(observerOrNext, error, complete);
 
-    sink.add(operator ? operator.call(sink, this) : this._subscribe(sink));
+    if (operator) {
+      operator.call(sink, this);
+    } else {
+      sink.add(this._subscribe(sink));
+    }
 
     if (sink.syncErrorThrowable) {
       sink.syncErrorThrowable = false;

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -76,9 +76,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
               private keySelector: (value: T) => K,
               private elementSelector?: (value: T) => R,
               private durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>) {
-    super();
-    this.destination = destination;
-    this.add(destination);
+    super(destination);
   }
 
   protected _next(value: T): void {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This fixes an issue where Subscribers were being added to their destination's subscription lists twice. I don't believe there was any functional regression, but performance theoretically suffered.

**Related issue (if exists):**
none that I'm aware of.