### PR TITLE
fix(window): don't track internal window subjects as subscriptions.

### DIFF
--- a/spec/operators/window-spec.ts
+++ b/spec/operators/window-spec.ts
@@ -1,4 +1,3 @@
-import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 declare const {hot, cold, asDiagram, time, expectObservable, expectSubscriptions};
 
@@ -55,6 +54,20 @@ describe('Observable.prototype.window', () => {
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
     expectSubscriptions(closings.subscriptions).toBe(closingSubs);
+  });
+
+  it('should return a single empty window if source is sync empty and closing is sync empty', () => {
+    const source =   cold('(|)');
+    const sourceSubs =    '(^!)';
+    const expected =      '(w|)';
+    const w =        cold('|');
+    const expectedValues = { w: w };
+
+    const result = source.window(Observable.empty());
+
+    expectObservable(result).toBe(expected, expectedValues);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    // expectSubscriptions(closings.subscriptions).toBe(closingSubs);
   });
 
   it('should split a Just source into a single window identical to source, using a Never closing',
@@ -199,28 +212,6 @@ describe('Observable.prototype.window', () => {
     expectObservable(result, unsub).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
     expectSubscriptions(closings.subscriptions).toBe(closingSubs);
-  });
-
-  it('should dispose window Subjects if the outer is unsubscribed early', () => {
-    const source = hot('--a--b--c--d--e--f--g--h--|');
-    const sourceSubs = '^        !                 ';
-    const expected =   'x---------                 ';
-    const x = cold(    '--a--b--c-                 ');
-    const unsub =      '         !                 ';
-    const late =  time('---------------|           ');
-    const values = { x: x };
-
-    let window;
-    const result = source.window(Observable.never())
-      .do((w: any) => { window = w; });
-
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-    rxTestScheduler.schedule(() => {
-      expect(() => {
-        window.subscribe();
-      }).to.throw(Rx.ObjectUnsubscribedError);
-    }, late);
   });
 
   it('should make outer emit error when closing throws', () => {

--- a/spec/operators/windowCount-spec.ts
+++ b/spec/operators/windowCount-spec.ts
@@ -1,4 +1,3 @@
-import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 declare const {hot, cold, asDiagram, time, expectObservable, expectSubscriptions};
 
@@ -129,28 +128,6 @@ describe('Observable.prototype.windowCount', () => {
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
-  });
-
-  it('should dispose window Subjects if the outer is unsubscribed early', () => {
-    const source = hot('--a--b--c--d--e--f--g--h--|');
-    const sourceSubs = '^        !                 ';
-    const expected =   'x---------                 ';
-    const x = cold(    '--a--b--c-                 ');
-    const unsub =      '         !                 ';
-    const late =  time('---------------|           ');
-    const values = { x: x };
-
-    let window;
-    const result = source.windowCount(10, 10)
-      .do((w: any) => { window = w; });
-
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-    rxTestScheduler.schedule(() => {
-      expect(() => {
-        window.subscribe();
-      }).to.throw(Rx.ObjectUnsubscribedError);
-    }, late);
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {

--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -1,4 +1,3 @@
-import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 declare const {hot, cold, asDiagram, time, expectObservable, expectSubscriptions};
 
@@ -170,27 +169,6 @@ describe('Observable.prototype.windowTime', () => {
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
-  });
-
-  it('should dispose window Subjects if the outer is unsubscribed early', () => {
-    const source = hot('--a--b--c--d--e--f--g--h--|');
-    const sourceSubs = '^        !                 ';
-    const expected =   'x---------                 ';
-    const x = cold(    '--a--b--c-                 ');
-    const unsub =      '         !                 ';
-    const values = { x: x };
-
-    let window;
-    const result = source.windowTime(1000, 1000, rxTestScheduler)
-      .do((w: any) => { window = w; });
-
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-    rxTestScheduler.schedule(() => {
-      expect(() => {
-        window.subscribe();
-      }).to.throw(Rx.ObjectUnsubscribedError);
-    }, 150);
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {

--- a/spec/operators/windowWhen-spec.ts
+++ b/spec/operators/windowWhen-spec.ts
@@ -1,4 +1,3 @@
-import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 declare const {hot, cold, asDiagram, time, expectObservable, expectSubscriptions};
 
@@ -152,29 +151,6 @@ describe('Observable.prototype.windowWhen', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
     expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
-  });
-
-  it('should dispose window Subjects if the outer is unsubscribed early', () => {
-    const source = hot('--a--b--c--d--e--f--g--h--|');
-    const sourceSubs = '^        !                 ';
-    const expected =   'x---------                 ';
-    const x = cold(    '--a--b--c-                 ');
-    const unsub =      '         !                 ';
-    const late =  time('---------------|           ');
-    const values = { x: x };
-
-    let window;
-    const result = source
-      .windowWhen(() => Observable.never())
-      .do((w: any) => { window = w; });
-
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-    rxTestScheduler.schedule(() => {
-      expect(() => {
-        window.subscribe();
-      }).to.throw(Rx.ObjectUnsubscribedError);
-    }, late);
   });
 
   it('should propagate error thrown from closingSelector', () => {

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -147,7 +147,6 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     const window = new Subject<T>();
     this.windows.push(window);
     const destination = this.destination;
-    destination.add(window);
     destination.next(window);
     return window;
   }

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -138,7 +138,6 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
       this.window.error(err);
     } else {
       this.add(this.closingNotification = subscribeToResult(this, closingNotifier));
-      this.add(window);
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR removes behavior in the window operators that tracked the window Subjects as Subscriptions. This could lead to race conditions where the Subscriber unsubscribes while the window operator is still active and attempting to send messages to the windows.

**Related issue (if exists):**
#1698
