### PR TITLE
docs(MIGRATION): onErrorResumeNext was added to v5

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -89,7 +89,6 @@ enabling "composite" subscription behavior.
 |`manySelect`|`-`|
 |`maxBy`|`-`|
 |`minBy`|`-`|
-|`onErrorResumeNext`|`-`|
 |`ofObjectChanges`|`-`|
 |`pausable`|`-`|
 |`pausableBuffered`|`-`|


### PR DESCRIPTION
Was added in #1679 but MIGRATION guide still listed it as excluded from v5.

Cc/ @kwonoj 