### PR TITLE
Test for issues 1466

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -394,35 +394,24 @@ describe('Observable.webSocket', () => {
 
     it('should work in combination with retry (issue #1466)', () => {
       const error = { wasClean: false};
-
-      var subCounter = 0;
-      var unsubCounter = 0;
+      const results = [];
 
       const subject = Observable.webSocket(<any>{url: 'ws://mysocket'})
-      .multiplex(
-        () => subCounter++,
-        () => unsubCounter++,
-        () => true)
-      .retry(1);
+        .multiplex(
+          () => results.push('sub'),
+          () => results.push('unsub'),
+          () => true)
+        .retry(1);
 
-      var nextCalled = false;
-      var failed = null;
-      var completed = false;
       subject.subscribe(
-        () => nextCalled = true,
-        (e) => failed = e,
-        () => completed = true);
+        () => results.push('next'),
+        (e) => results.push(e));
 
       let socket = MockWebSocket.lastSocket;
 
       socket.triggerClose(error);
 
-      expect(subCounter).to.equal(2);
-      expect(unsubCounter).to.equal(2);
-
-      expect(nextCalled).to.be.false;
-      expect(failed).to.equal(error);
-      expect(completed).to.be.false;
+      expect(results).to.deep.equal(['sub', 'unsub', 'sub', error, 'unsub']);
     });
   });
 });

--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -391,5 +391,38 @@ describe('Observable.webSocket', () => {
       expect(socket.close).have.been.called;
       (<any>socket.close).restore();
     });
+
+    it('should work in combination with retry (issue #1466)', () => {
+      const error = { wasClean: false};
+
+      var subCounter = 0;
+      var unsubCounter = 0;
+
+      const subject = Observable.webSocket(<any>{url: 'ws://mysocket'})
+      .multiplex(
+        () => subCounter++,
+        () => unsubCounter++,
+        () => true)
+      .retry(1);
+
+      var nextCalled = false;
+      var failed = null;
+      var completed = false;
+      subject.subscribe(
+        () => nextCalled = true,
+        (e) => failed = e,
+        () => completed = true);
+
+      let socket = MockWebSocket.lastSocket;
+
+      socket.triggerClose(error);
+
+      expect(subCounter).to.equal(2);
+      expect(unsubCounter).to.equal(2);
+
+      expect(nextCalled).to.be.false;
+      expect(failed).to.equal(error);
+      expect(completed).to.be.false;
+    });
   });
 });


### PR DESCRIPTION
Hello

This PR contains a test for the issue #1466 - WebSocketSubject cannot be retried. It looks, that the issue does no longer exists since beta 8. Because I want to fix it and I started my work with a test, I'm able to submit the test with this PR ;-)

On branch 5.0.0-beta.6 and 5.0.0-beta.7 the test fails with an "ObjectUnsubscribedError".

If something needs to be changed, let me know.

Finally I have to say thanks for the great work - its damn impressive!