### PR TITLE
docs(Manual): add external resources section

### DIFF
--- a/doc/external-references.md
+++ b/doc/external-references.md
@@ -1,0 +1,55 @@
+# External References
+
+Can't get enough RxJS? Check out these other great resources!
+
+## Tutorials
+
+- [RxJS @ Egghead.io](https://egghead.io/technologies/rx)
+- [The introduction to Reactive Programming you've been missing](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754)
+- [2 minute introduction to Rx](https://medium.com/@andrestaltz/2-minute-introduction-to-rx-24c8ca793877)
+- [Learn RxJS - @jhusain](https://github.com/jhusain/learnrx)
+- [Rx Workshop](http://rxworkshop.codeplex.com/) 
+- [Reactive Programming and MVC](http://aaronstacy.com/writings/reactive-programming-and-mvc/)
+- [RxJS Training - @andrestaltz](https://github.com/staltz/rxjs-training)
+
+
+## Books
+
+- [RxJS in Action](https://www.manning.com/books/rxjs-in-action) 
+- [RxJS](http://xgrommx.github.io/rx-book/)
+- [Intro to Rx](http://www.amazon.com/Introduction-to-Rx-ebook/dp/B008GM3YPM/)
+- [Programming Reactive Extensions and LINQ](http://www.amazon.com/Programming-Reactive-Extensions-Jesse-Liberty/dp/1430237473/)
+- [Reactive Programming with RxJS](https://pragprog.com/book/smreactjs/reactive-programming-with-rxjs)
+
+
+## Videos
+
+- [Practical Rx with Matthew Podwysocki, Bart de Smet and Jafar Husain](http://channel9.msdn.com/posts/Bart-De-Smet-Jafar-Hussain-Matthew-Podwysocki-Pragmatic-Rx)
+- [Netflix and RxJS](http://channel9.msdn.com/posts/Rx-and-Netflix)
+- [Hello RxJS - Channel 9](http://channel9.msdn.com/Blogs/Charles/Introducing-RxJS-Reactive-Extensions-for-JavaScript)
+- [MIX 2011](http://channel9.msdn.com/events/MIX/MIX11/HTM07)
+- [RxJS Today and Tomorrow - Channel 9](http://channel9.msdn.com/Blogs/Charles/Matthew-Podwysocki-and-Bart-J-F-De-Smet-RxJS-Today-and-Tomorrow)
+- [Reactive Extensions Videos on Channel 9](http://channel9.msdn.com/Tags/reactive+extensions)
+- [Asynchronous JavaScript at Netflix - Netflix JavaScript Talks - Jafar Husain](https://www.youtube.com/watch?v=XRYN2xt11Ek)
+- [Asynchronous JavaScript at Netflix - MountainWest JavaScript 2014 - Jafar Husain](https://www.youtube.com/watch?v=XE692Clb5LU)
+- [Asynchronous JavaScript at Netflix - HTML5DevConf - Jafar Husain](https://www.youtube.com/watch?v=5uxSu-F5Kj0)
+- [Adding Even More Fun to Functional Programming With RXJS - Ryan Anklam](https://www.youtube.com/watch?v=8EExNfm0gt4)
+- [Reactive Angular - Devoxx France 2014 - Martin Gontovnikas](http://parleys.com/play/53677646e4b0593229b85841/chapter0/about)
+- [Reactive Game Programming for the Discerning Hipster - JSConf 2014 - Bodil Stokke](https://www.youtube.com/watch?v=x8mmAu7ZR9Y)
+
+## Presentations
+
+
+- Don't Cross the Streams - Cascadia.js 2012 [slides/demos](http://www.slideshare.net/mattpodwysocki/cascadiajs-dont-cross-the-streams) | [video](http://www.youtube.com/watch?v=FqBq4uoiG0M)
+- Curing Your Asynchronous Blues - Strange Loop 2013 [slides/demos](https://github.com/Reactive-Extensions/StrangeLoop2013) | [video](http://www.infoq.com/presentations/rx-event-processing)
+- Streaming and event-based programming using FRP and RxJS - FutureJS 2014 [slides/demos](https://github.com/Reactive-Extensions/FutureJS) | [video](https://www.youtube.com/watch?v=zlERo_JMGCw)
+- [Tyrannosaurus Rx](http://yobriefca.se/presentations/tyrannosaurus-rx.pdf) - [James Hughes](http://twitter.com/kouphax)
+- Taming Asynchronous Workflows with Functional Reactive Programming - EuroClojure - [Leonardo Borges](https://twitter.com/leonardo_borges) [slides](http://www.slideshare.net/borgesleonardo/functional-reactive-programming-compositional-event-systems) | [video](http://www.slideshare.net/borgesleonardo/functional-reactive-programming-compositional-event-systems)
+- Reactive All the Things - ng-conf 2015 - [Martin Gontovnikas](https://twitter.com/mgonto/) & [Ben Lesh](https://twitter.com/BenLesh)
+  - [Slides](http://mgonto.github.io/reactive-all-the-things-talk/#1)
+  - [Video](https://www.youtube.com/watch?v=zbBVG8bOoXk&feature=youtu.be&app=desktop)
+- The Reactive Loop - Functional JS London 2015
+  - [Slides](http://slides.com/theefer/reactive-loop-funjs#/)
+  - [Code](https://github.com/theefer/funjs-reactive-loop)
+- Reactive Functions with RxJS - Leeds JS 2015
+  - [Slides](https://www.icloud.com/keynote/AwBWCAESEIf9pea2IykiVtOZFiXflDsaKj9lVsSLP_OtPU29v7fNpMs78DK7tvXz4bFBkb6BXFKjxqt4G5B_UlM6TwMCUCAQEEIGVYVFig5qOTdorTOd2ERMJDtn6dvDFY58zqBiVzZmtN#RxJS_talk)

--- a/esdoc.json
+++ b/esdoc.json
@@ -35,7 +35,8 @@
     ],
     "tutorial": [
       "./doc/tutorial/basics.md",
-      "./doc/tutorial/applications.md"
+      "./doc/tutorial/applications.md",
+      "./doc/external-references.md"
     ]
   }
 }


### PR DESCRIPTION
**Description:**

Add an external resources section to reactivex.io. The current docs are still a work in progress, but there are already many great resources for people interested in learning RxJS. 

Most of the links are directly copied over from the old repository and I haven't had time to go through them all. I figure that if they seemed at least somewhat relevant then they could be kept but I am open to adding or removing any that are no longer appropriate or that I missed, respectively.

<img width="1361" alt="screen shot 2016-06-01 at 11 37 38 pm" src="https://cloud.githubusercontent.com/assets/2528918/15736213/1436b3c6-2853-11e6-9d0b-b0038b134ae9.png">

<img width="1362" alt="screen shot 2016-06-01 at 11 38 06 pm" src="https://cloud.githubusercontent.com/assets/2528918/15736232/3547a020-2853-11e6-9a1c-263ae304a817.png">

**Related issue (if exists):**

closes #1666