### PR TITLE
feat(Observable): initial IObservable interface

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -17,13 +17,19 @@ export interface Subscribable<T> {
 export type SubscribableOrPromise<T> = Subscribable<T> | Promise<T>;
 export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T>;
 
+export interface IObservable<T> extends Subscribable<T> {
+  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
+            error?: (error: any) => void,
+            complete?: () => void): Subscription;
+}
+
 /**
  * A representation of any set of values over any amount of time. This the most basic building block
  * of RxJS.
  *
  * @class Observable<T>
  */
-export class Observable<T> implements Subscribable<T> {
+export class Observable<T> implements IObservable<T> {
 
   public _isScalar: boolean = false;
 

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -140,6 +140,7 @@ import './add/operator/zip';
 import './add/operator/zipAll';
 
 /* tslint:disable:no-unused-variable */
+export {IObservable} from './Observable';
 export {Operator} from './Operator';
 export {Observer} from './Observer';
 export {Subscription} from './Subscription';

--- a/src/add/operator/catch.ts
+++ b/src/add/operator/catch.ts
@@ -5,6 +5,9 @@ import {_catch, CatchSignature} from '../../operator/catch';
 Observable.prototype.catch = _catch;
 
 declare module '../../Observable' {
+  interface IObservable<T> {
+    catch: CatchSignature<T>;
+  }
   interface Observable<T> {
     catch: CatchSignature<T>;
   }

--- a/src/add/operator/map.ts
+++ b/src/add/operator/map.ts
@@ -5,6 +5,9 @@ import {map, MapSignature} from '../../operator/map';
 Observable.prototype.map = map;
 
 declare module '../../Observable' {
+  interface IObservable<T> {
+    map: MapSignature<T>;
+  }
   interface Observable<T> {
     map: MapSignature<T>;
   }

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -1,6 +1,6 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {Observable} from '../Observable';
+import {IObservable} from '../Observable';
 
 /**
  * Catches errors on the observable to be handled by returning a new observable or throwing an error.
@@ -12,21 +12,21 @@ import {Observable} from '../Observable';
  * @method catch
  * @owner Observable
  */
-export function _catch<T, R>(selector: (err: any, caught: Observable<T>) => Observable<R>): Observable<R> {
+export function _catch<T, R>(selector: (err: any, caught: IObservable<T>) => IObservable<R>): IObservable<R> {
   const operator = new CatchOperator(selector);
   const caught = this.lift(operator);
   return (operator.caught = caught);
 }
 
 export interface CatchSignature<T> {
-  (selector: (err: any, caught: Observable<T>) => Observable<T>): Observable<T>;
-  <R>(selector: (err: any, caught: Observable<T>) => Observable<R>): Observable<R>;
+  (selector: (err: any, caught: IObservable<T>) => IObservable<T>): IObservable<T>;
+  <R>(selector: (err: any, caught: IObservable<T>) => IObservable<R>): IObservable<R>;
 }
 
 class CatchOperator<T, R> implements Operator<T, R> {
-  caught: Observable<any>;
+  caught: IObservable<any>;
 
-  constructor(private selector: (err: any, caught: Observable<any>) => Observable<any>) {
+  constructor(private selector: (err: any, caught: IObservable<any>) => IObservable<any>) {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
@@ -42,8 +42,8 @@ class CatchOperator<T, R> implements Operator<T, R> {
 class CatchSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<any>,
-              private selector: (err: any, caught: Observable<any>) => Observable<any>,
-              private caught: Observable<any>) {
+              private selector: (err: any, caught: IObservable<any>) => IObservable<any>,
+              private caught: IObservable<any>) {
     super(destination);
   }
 
@@ -64,7 +64,7 @@ class CatchSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  private _innerSub(result: Observable<any>) {
+  private _innerSub(result: IObservable<any>) {
     this.unsubscribe();
     (<any>this.destination).remove(this);
     result.subscribe(this.destination);

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -1,6 +1,6 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {Observable} from '../Observable';
+import {IObservable} from '../Observable';
 
 /**
  * Applies a given `project` function to each value emitted by the source
@@ -35,7 +35,7 @@ import {Observable} from '../Observable';
  * @method map
  * @owner Observable
  */
-export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): Observable<R> {
+export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): IObservable<R> {
   if (typeof project !== 'function') {
     throw new TypeError('argument is not a function. Are you looking for `mapTo()`?');
   }
@@ -43,7 +43,7 @@ export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any
 }
 
 export interface MapSignature<T> {
-  <R>(project: (value: T, index: number) => R, thisArg?: any): Observable<R>;
+  <R>(project: (value: T, index: number) => R, thisArg?: any): IObservable<R>;
 }
 
 class MapOperator<T, R> implements Operator<T, R> {


### PR DESCRIPTION
This PR is not meant to be merged, but to gauge for your opinion on this.
If approved, I can make the changes for the other operators and methods as well.

**Description:**

An interface for Observables.

This fixes a problem we were having when npm linking a library exposing methods that return Observables.

For example, when you `npm link ng2-example-library` ([ng2-example-library](https://github.com/vankeer/ng2-example-library)) in [ng2-example-consumer](https://github.com/vankeer/ng2-example-consumer), you get this:

> src\app\repository\repository.service.ts(14,10): error TS2322: Type 'Observable<any[]>' is not assignable to type 'Observable<any[]>'.
>   Property 'source' is protected but type 'Observable<T>' is not a class derived from 'Observable<T>'.

**Impact:**

Quite a lot of operator signatures would have to be adapted to accommodate this change, as well as changes by the user would be required (Observable > IObservable). We could avoid the latter by renaming the interface to Observable and the class to something else.