### PR TITLE
refactor(MergeMapTo): clarify 'any' types in MergeMapToSubscriber

### DIFF
--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -1,4 +1,4 @@
-import {Observable, ObservableInput, SubscribableOrPromise} from '../Observable';
+import {Observable, ObservableInput} from '../Observable';
 import {Operator} from '../Operator';
 import {PartialObserver} from '../Observer';
 import {Subscriber} from '../Subscriber';
@@ -70,7 +70,7 @@ export interface MergeMapToSignature<T> {
 // TODO: Figure out correct signature here: an Operator<Observable<T>, R>
 //       needs to implement call(observer: Subscriber<R>): Subscriber<Observable<T>>
 export class MergeMapToOperator<T, I, R> implements Operator<Observable<T>, R> {
-  constructor(private ish: SubscribableOrPromise<I>,
+  constructor(private ish: ObservableInput<I>,
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
               private concurrent: number = Number.POSITIVE_INFINITY) {
   }
@@ -92,7 +92,7 @@ export class MergeMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
   protected index: number = 0;
 
   constructor(destination: Subscriber<R>,
-              private ish: SubscribableOrPromise<I>,
+              private ish: ObservableInput<I>,
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
               private concurrent: number = Number.POSITIVE_INFINITY) {
     super(destination);
@@ -112,7 +112,7 @@ export class MergeMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
     }
   }
 
-  private _innerSub(ish: SubscribableOrPromise<I>,
+  private _innerSub(ish: ObservableInput<I>,
                     destination: PartialObserver<I>,
                     resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
                     value: T,

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -87,7 +87,7 @@ export class MergeMapToOperator<T, I, R> implements Operator<Observable<T>, R> {
  */
 export class MergeMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
   private hasCompleted: boolean = false;
-  private buffer: Observable<any>[] = [];
+  private buffer: T[] = [];
   private active: number = 0;
   protected index: number = 0;
 
@@ -98,7 +98,7 @@ export class MergeMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
     super(destination);
   }
 
-  protected _next(value: any): void {
+  protected _next(value: T): void {
     if (this.active < this.concurrent) {
       const resultSelector = this.resultSelector;
       const index = this.index++;
@@ -112,7 +112,7 @@ export class MergeMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
     }
   }
 
-  private _innerSub(ish: any,
+  private _innerSub(ish: SubscribableOrPromise<I>,
                     destination: PartialObserver<I>,
                     resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
                     value: T,


### PR DESCRIPTION
This just intends to clarify & make strictly types.