### PR TITLE
chore(Subscriber): add comment why Subscriber.destination is 'PartialObserver<any>'

### DIFF
--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -42,7 +42,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   public syncErrorThrowable: boolean = false;
 
   protected isStopped: boolean = false;
-  protected destination: PartialObserver<any>;
+  protected destination: PartialObserver<any>; // this `any` is the escape hatch to erase extra type param (e.g. R)
 
   /**
    * @param {Observer|function(value: T): void} [destinationOrNext] A partially


### PR DESCRIPTION
This is just for readability and explain the design.