### PR TITLE
fix(WebSocketSubject): WebSocketSubject will now chain operators prop…

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -52,6 +52,29 @@ describe('Observable.webSocket', () => {
     subject.unsubscribe();
   });
 
+  it('should allow the user to chain operators', () => {
+    let messageReceived = false;
+    const subject = Observable.webSocket('ws://mysocket');
+
+    subject
+      .map(x => x + '?')
+      .map(x => x + '!')
+      .map(x => x + '!')
+      .subscribe((x: string) => {
+        expect(x).to.equal('pong?!!');
+        messageReceived = true;
+      });
+
+    const socket = MockWebSocket.lastSocket;
+
+    socket.open();
+
+    socket.triggerMessage(JSON.stringify('pong'));
+    expect(messageReceived).to.be.true;
+
+    subject.unsubscribe();
+  });
+
   it('receive multiple messages', () => {
     const expected = ['what', 'do', 'you', 'do', 'with', 'a', 'drunken', 'sailor?'];
     const results = [];

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -1,7 +1,6 @@
 import {Subject, AnonymousSubject} from '../../Subject';
 import {Subscriber} from '../../Subscriber';
 import {Observable} from '../../Observable';
-import {Operator} from '../../Operator';
 import {Subscription} from '../../Subscription';
 import {root} from '../../util/root';
 import {ReplaySubject} from '../../ReplaySubject';
@@ -66,12 +65,6 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     }
 
     this.destination = new ReplaySubject();
-  }
-
-  lift<R>(operator: Operator<T, R>) {
-    const sock: WebSocketSubject<T> = new WebSocketSubject(this, this.destination);
-    sock.operator = <any>operator;
-    return sock;
   }
 
   // TODO: factor this out to be a proper Operator/Subscriber implementation and eliminate closures


### PR DESCRIPTION
Removed the custom `lift` method from WebSocketSubject. This is the quick and dirty fix for #1745. I think this class needs to be refactored again so it no longer overwrites it's own `destination`.