### PR TITLE
fix(AjaxObservable): support withCredentials for CORS request

### DIFF
--- a/spec/helpers/ajax-helper.ts
+++ b/spec/helpers/ajax-helper.ts
@@ -133,6 +133,7 @@ export class MockXMLHttpRequest {
   method: any;
   data: any;
   requestHeaders: any = {};
+  withCredentials: boolean = false;
 
   constructor() {
     this.previousRequest = MockXMLHttpRequest.recentRequest;

--- a/spec/support/default.opts
+++ b/spec/support/default.opts
@@ -8,7 +8,7 @@
 --bail
 --full-trace
 --check-leaks
---globals WebSocket,FormData
+--globals WebSocket,FormData,XDomainRequest,ActiveXObject
 
 --recursive
 --timeout 5000


### PR DESCRIPTION
**Description:**

This PR updates `AjaxRequest` accepts `withCredentials` flag to be used when create CORS request by setting `crossDomain`, replicating [RXJS-DOM] (https://github.com/Reactive-Extensions/RxJS-DOM/blob/35271e7ddd7e68838d181beae3cee696b657f7f4/src/ajax/ajax.js#L214) implementation.

**Related issue (if exists):**

closes #1732, #1711