### PR TITLE
fix(cache): get correct caching behavior

### DIFF
--- a/src/operator/cache.ts
+++ b/src/operator/cache.ts
@@ -1,7 +1,8 @@
 import {Observable} from '../Observable';
-import {publishReplay} from './publishReplay';
 import {Scheduler} from '../Scheduler';
-import {ConnectableObservable} from '../observable/ConnectableObservable';
+import {ReplaySubject} from '../ReplaySubject';
+import {Observer} from '../Observer';
+import {Subscription} from '../Subscription';
 
 /**
  * @param bufferSize
@@ -14,7 +15,47 @@ import {ConnectableObservable} from '../observable/ConnectableObservable';
 export function cache<T>(bufferSize: number = Number.POSITIVE_INFINITY,
                          windowTime: number = Number.POSITIVE_INFINITY,
                          scheduler?: Scheduler): Observable<T> {
-  return (<ConnectableObservable<any>>publishReplay.call(this, bufferSize, windowTime, scheduler)).refCount();
+  let subject: ReplaySubject<T>;
+  let source = this;
+  let refs = 0;
+  let outerSub: Subscription;
+
+  const getSubject = () => {
+    subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
+    return subject;
+  };
+
+  return new Observable<T>((observer: Observer<T>) => {
+    if (!subject) {
+      subject = getSubject();
+      outerSub = source.subscribe(
+        (value: T) => subject.next(value),
+        (err: any) => {
+          let s = subject;
+          subject = null;
+          s.error(err);
+        },
+        () => subject.complete()
+      );
+    }
+
+    refs++;
+
+    if (!subject) {
+      subject = getSubject();
+    }
+    let innerSub = subject.subscribe(observer);
+
+    return () => {
+      refs--;
+      if (innerSub) {
+        innerSub.unsubscribe();
+      }
+      if (refs === 0) {
+        outerSub.unsubscribe();
+      }
+    };
+  });
 }
 
 export interface CacheSignature<T> {


### PR DESCRIPTION
This is an initial pass at fixing the cache operator. There is still a lot to do, but this is merge-worthy IMO. Ideally, the cache operator would use the lift mechanism. Also this is not well optimized as it is introducing a lot of closures. But it works, and that's the point for now.

fixes #1628