### PR TITLE
refactor(symbol-observable): upgrade symbol-observable to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,6 +199,6 @@
   },
   "typings": "./dist/cjs/Rx.d.ts",
   "dependencies": {
-    "symbol-observable": "^0.2.4"
+    "symbol-observable": "^1.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -199,6 +199,6 @@
   },
   "typings": "./dist/cjs/Rx.d.ts",
   "dependencies": {
-    "symbol-observable": "^1.0.0"
+    "symbol-observable": "^1.0.1"
   }
 }

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -6,7 +6,7 @@ import {root} from './util/root';
 import {toSubscriber} from './util/toSubscriber';
 import {IfObservable} from './observable/IfObservable';
 import {ErrorObservable} from './observable/ErrorObservable';
-import * as $$observable from 'symbol-observable';
+import $$observable from 'symbol-observable';
 
 export interface Subscribable<T> {
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -170,7 +170,7 @@ import {QueueScheduler} from './scheduler/QueueScheduler';
 import {AnimationFrameScheduler} from './scheduler/AnimationFrameScheduler';
 import {$$rxSubscriber as rxSubscriber} from './symbol/rxSubscriber';
 import {$$iterator as iterator} from './symbol/iterator';
-import * as observable from 'symbol-observable';
+import observable from 'symbol-observable';
 
 /* tslint:enable:no-unused-variable */
 

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -13,7 +13,7 @@ import {Observable, ObservableInput} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {ObserveOnSubscriber} from '../operator/observeOn';
 
-import * as $$observable from 'symbol-observable';
+import $$observable from 'symbol-observable';
 
 const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 'number');
 

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -8,7 +8,7 @@ import {Subscription} from '../Subscription';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {OuterSubscriber} from '../OuterSubscriber';
 
-import * as $$observable from 'symbol-observable';
+import $$observable from 'symbol-observable';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,


### PR DESCRIPTION
The breaking change in `symbol-observable` is that it now exports in a standard es module format. So it can be consumed as `require('symbol-observable').default` or with just `import whatever from 'symbol-observable';`
