### PR TITLE
refactor(errors): Updates custom errors to include more descriptive messages.

### DIFF
--- a/spec/helpers/testScheduler-ui.ts
+++ b/spec/helpers/testScheduler-ui.ts
@@ -104,12 +104,25 @@ module.exports = function(suite) {
       .replace(/\\n/g, '\n');
     }
 
+    function deleteErrorNotificationStack(marble) {
+      const { notification } = marble;
+      if (notification) {
+        const { kind, exception } = notification;
+        if (kind === 'E' && exception instanceof Error) {
+          exception.stack = null;
+        }
+      }
+      return marble;
+    }
+
     /**
      * custom assertion formatter for expectObservable test
      */
 
     function observableMatcher(actual, expected) {
       if (Array.isArray(actual) && Array.isArray(expected)) {
+        actual = actual.map(deleteErrorNotificationStack);
+        expected = expected.map(deleteErrorNotificationStack);
         const passed = _.isEqual(actual, expected);
         if (passed) {
           return;

--- a/spec/util/UnsubscriptionError-spec.ts
+++ b/spec/util/UnsubscriptionError-spec.ts
@@ -20,8 +20,8 @@ describe('UnsubscriptionError', () => {
     } catch (err) {
       expect(err instanceof UnsubscriptionError).to.equal(true);
       expect(err.message).to.equal(`2 errors occurred during unsubscription:
-1) ${err1}
-2) ${err2}`);
+  1) ${err1}
+  2) ${err2}`);
       expect(err.name).to.equal('UnsubscriptionError');
     }
   });

--- a/src/util/ArgumentOutOfRangeError.ts
+++ b/src/util/ArgumentOutOfRangeError.ts
@@ -10,7 +10,9 @@
  */
 export class ArgumentOutOfRangeError extends Error {
   constructor() {
-    super('argument out of range');
-    this.name = 'ArgumentOutOfRangeError';
+    const err: any = super('argument out of range');
+    (<any> this).name = err.name = 'ArgumentOutOfRangeError';
+    (<any> this).stack = err.stack;
+    (<any> this).message = err.message;
   }
 }

--- a/src/util/EmptyError.ts
+++ b/src/util/EmptyError.ts
@@ -10,7 +10,9 @@
  */
 export class EmptyError extends Error {
   constructor() {
-    super('no elements in sequence');
-    this.name = 'EmptyError';
+    const err: any = super('no elements in sequence');
+    (<any> this).name = err.name = 'EmptyError';
+    (<any> this).stack = err.stack;
+    (<any> this).message = err.message;
   }
 }

--- a/src/util/ObjectUnsubscribedError.ts
+++ b/src/util/ObjectUnsubscribedError.ts
@@ -9,7 +9,9 @@
  */
 export class ObjectUnsubscribedError extends Error {
   constructor() {
-    super('object unsubscribed');
-    this.name = 'ObjectUnsubscribedError';
+    const err: any = super('object unsubscribed');
+    (<any> this).name = err.name = 'ObjectUnsubscribedError';
+    (<any> this).stack = err.stack;
+    (<any> this).message = err.message;
   }
 }

--- a/src/util/UnsubscriptionError.ts
+++ b/src/util/UnsubscriptionError.ts
@@ -5,8 +5,11 @@
 export class UnsubscriptionError extends Error {
   constructor(public errors: any[]) {
     super();
-    this.name = 'UnsubscriptionError';
-    this.message = errors ? `${errors.length} errors occurred during unsubscription:
-${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n')}` : '';
+    const err: any = Error.call(this, errors ?
+      `${errors.length} errors occurred during unsubscription:
+  ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '');
+    (<any> this).name = err.name = 'UnsubscriptionError';
+    (<any> this).stack = err.stack;
+    (<any> this).message = err.message;
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

This PR updates our errors to include more information to make debugging easier. For example, this:

```es6
ObjectUnsubscribedError
```
will now look like this:
```es6
ObjectUnsubscribedError: object unsubscribed
    at ObjectUnsubscribedError.Error (native)
    at new ObjectUnsubscribedError (/Users/ptaylor/dev/RxJS/dist/cjs/util/ObjectUnsubscribedError.js:19:26)
    at Subject._subscribe (/Users/ptaylor/dev/RxJS/dist/cjs/Subject.js:94:19)
    at Subject.Observable.subscribe (/Users/ptaylor/dev/RxJS/dist/cjs/Observable.js:56:27)
    at repl:1:6
    at REPLServer.defaultEval (repl.js:272:27)
    at bound (domain.js:280:14)
    at REPLServer.runBound [as eval] (domain.js:293:12)
    at REPLServer.<anonymous> (repl.js:441:10)
    at emitOne (events.js:101:20)
```