### PR TITLE
fix(multicast): Fixes multicast with selector to create a new source connection per subscriber.

### DIFF
--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -54,7 +54,9 @@ describe('Observable.prototype.publish', () => {
 
   it('should accept selectors', () => {
     const source =     hot('-1-2-3----4-|');
-    const sourceSubs =     ['^           !'];
+    const sourceSubs =     ['^           !',
+                            '    ^       !',
+                            '        ^   !'];
     const published = source.publish(x => x.zip(x, (a, b) => (parseInt(a) + parseInt(b)).toString()));
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '-2-4-6----8-|';

--- a/spec/support/debug.opts
+++ b/spec/support/debug.opts
@@ -1,0 +1,14 @@
+--require source-map-support/register
+--require spec/support/mocha-setup-node.js
+--require spec-js/helpers/test-helper.js
+--require spec-js/helpers/ajax-helper.js
+--ui spec-js/helpers/testScheduler-ui.js
+
+--reporter dot
+--bail
+--full-trace
+--check-leaks
+--globals WebSocket,FormData
+
+--recursive
+--timeout 100000

--- a/src/observable/MulticastObservable.ts
+++ b/src/observable/MulticastObservable.ts
@@ -1,3 +1,4 @@
+import {Subject} from '../Subject';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Subscription} from '../Subscription';
@@ -5,14 +6,14 @@ import {ConnectableObservable} from '../observable/ConnectableObservable';
 
 export class MulticastObservable<T> extends Observable<T> {
   constructor(protected source: Observable<T>,
-              private connectable: ConnectableObservable<T>,
+              private subjectFactory: () => Subject<T>,
               private selector: (source: Observable<T>) => Observable<T>) {
     super();
   }
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
-    const {selector, connectable} = this;
-
+    const { selector, source } = this;
+    const connectable = new ConnectableObservable(source, this.subjectFactory);
     const subscription = selector(connectable).subscribe(subscriber);
     subscription.add(connectable.connect());
     return subscription;

--- a/src/operator/multicast.ts
+++ b/src/operator/multicast.ts
@@ -33,8 +33,9 @@ export function multicast<T>(subjectOrSubjectFactory: Subject<T> | (() => Subjec
     };
   }
 
-  const connectable = new ConnectableObservable(this, subjectFactory);
-  return selector ? new MulticastObservable(this, connectable, selector) : connectable;
+  return !selector ?
+    new ConnectableObservable(this, subjectFactory) :
+    new MulticastObservable(this, subjectFactory, selector);
 }
 
 export type factoryOrValue<T> = T | (() => T);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Multicast with a selector function should create a new ConnectableObservable for each subscriber to
the MulticastObservable. This ensures each subscriber creates a new connection to the source
Observable, and don't share subscription side-effects.

Multicast with selector now matches Rx4's behavior.