### PR TITLE
fix(Subject): allow type definition to next value optionally

### DIFF
--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -49,7 +49,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     return <any>subject;
   }
 
-  next(value: T) {
+  next(value?: T) {
     if (this.isUnsubscribed) {
       throw new ObjectUnsubscribedError();
     }


### PR DESCRIPTION
**Description:**
This PR updates type definition to `Subject::next` to allow next value optionally.
This does not changes actual behavior, it was allowed to `next()` in JS already.

**Related issue (if exists):**

closes #1728