### PR TITLE
fix(Observable.from): use scheduler if supplied

### DIFF
--- a/spec/observables/IteratorObservable-spec.ts
+++ b/spec/observables/IteratorObservable-spec.ts
@@ -32,12 +32,6 @@ describe('IteratorObservable', () => {
     }).to.throw(Error, 'object is not iterable');
   });
 
-  it('should not accept non-function project', () => {
-    expect(() => {
-      IteratorObservable.create([], 42);
-    }).to.throw(Error, 'when provided, `project` must be a function.');
-  });
-
   it('should emit members of an array iterator', (done: MochaDone) => {
     const expected = [10, 20, 30, 40];
     IteratorObservable.create([10, 20, 30, 40])
@@ -55,8 +49,6 @@ describe('IteratorObservable', () => {
   it('should emit members of an array iterator on a particular scheduler', () => {
     const source = IteratorObservable.create(
       [10, 20, 30, 40],
-      (x: number) => x,
-      null,
       rxTestScheduler
     );
 
@@ -65,32 +57,12 @@ describe('IteratorObservable', () => {
     expectObservable(source).toBe('(abcd|)', values);
   });
 
-  it('should emit members of an array iterator on a particular scheduler, project throws', () => {
-    const source = IteratorObservable.create(
-      [10, 20, 30, 40],
-      (x: number) => {
-        if (x === 30) {
-          throw 'error';
-        }
-        return x * x;
-      },
-      null,
-      rxTestScheduler
-    );
-
-    const values = { a: 100, b: 400 };
-
-    expectObservable(source).toBe('(ab#)', values);
-  });
-
   it('should emit members of an array iterator on a particular scheduler, ' +
   'but is unsubscribed early', (done: MochaDone) => {
     const expected = [10, 20, 30, 40];
 
     const source = IteratorObservable.create(
       [10, 20, 30, 40],
-      (x: number) => x,
-      null,
       Rx.Scheduler.queue
     );
 
@@ -110,62 +82,11 @@ describe('IteratorObservable', () => {
     source.subscribe(subscriber);
   });
 
-  it('should emit members of an array iterator, and project them', (done: MochaDone) => {
-    const expected = [100, 400, 900, 1600];
-    IteratorObservable.create([10, 20, 30, 40], (x: number) => x * x)
-      .subscribe(
-        (x: number) => { expect(x).to.equal(expected.shift()); },
-        (x) => {
-          done(new Error('should not be called'));
-        }, () => {
-          expect(expected.length).to.equal(0);
-          done();
-        }
-      );
-  });
-
-  it('should emit members of an array iterator, and project but raise an error', (done: MochaDone) => {
-    const expected = [100, 400];
-    function project(x) {
-      if (x === 30) {
-        throw new Error('boom');
-      } else {
-        return x * x;
-      }
-    }
-    IteratorObservable.create([10, 20, 30, 40], project)
-      .subscribe(
-        (x: number) => {
-          expect(x).to.equal(expected.shift());
-        },
-        (err: any) => {
-          expect(expected.length).to.equal(0);
-          expect(err.message).to.equal('boom');
-          done();
-        }, () => {
-          done(new Error('should not be called'));
-        });
-  });
-
   it('should emit characters of a string iterator', (done: MochaDone) => {
     const expected = ['f', 'o', 'o'];
     IteratorObservable.create('foo')
       .subscribe(
         (x: number) => { expect(x).to.equal(expected.shift()); },
-        (x) => {
-          done(new Error('should not be called'));
-        }, () => {
-          expect(expected.length).to.equal(0);
-          done();
-        }
-      );
-  });
-
-  it('should emit characters of a string iterator, and project them', (done: MochaDone) => {
-    const expected = ['F', 'O', 'O'];
-    IteratorObservable.create('foo', (x: string) => x.toUpperCase())
-      .subscribe(
-        (x: string) => { expect(x).to.equal(expected.shift()); },
         (x) => {
           done(new Error('should not be called'));
         }, () => {

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
-import {$$iterator} from '../../dist/cjs/symbol/iterator';
 
 declare const {asDiagram, expectObservable, Symbol, type};
 declare const rxTestScheduler: Rx.TestScheduler;
@@ -17,209 +16,12 @@ describe('Observable.from', () => {
     expectObservable(e1).toBe(expected, {x: 10, y: 20, z: 30});
   });
 
-  it('should enumerate an Array', function (done: MochaDone) {
-    this.timeout(300);
-
-    const expected = [1, 2, 3];
-    let i = 0;
-
-    Observable.from(expected).subscribe((x: number) => {
-      expect(x).to.equal(expected[i++]);
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
-  it('should handle an ArrayLike', function (done: MochaDone) {
-    this.timeout(300);
-
-    const arrayLike: ArrayLike<number> = {
-      length: 3,
-      0: 1,
-      1: 2,
-      2: 3
-    };
-    const expected = [1, 2, 3];
-
-    Observable.from(arrayLike).subscribe((x: number) =>  {
-      expect(x).to.equal(expected.shift());
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
-  it('should handle an ArrayLike from arguments', function (done: MochaDone) {
-    this.timeout(300);
-
-    function makeArrayLike(...args) {
-      const expected = [1, 2, 3];
-
-      Observable.from(arguments).subscribe((x: number) => {
-        expect(x).to.equal(expected.shift());
-      }, (x) => {
-        done(new Error('should not be called'));
-      }, () => {
-        done();
-      });
-    }
-
-    makeArrayLike(1, 2, 3);
-  });
-
-  it('should handle an ArrayLike with a mapFn', function (done: MochaDone) {
-    this.timeout(300);
-
-    const arrayLike: ArrayLike<number> = {
-      length: 3,
-      0: 1,
-      1: 2,
-      2: 3
-    };
-    const expected = [1, 1, 1];
-    const mapFn = (v, k) => v - k;
-
-    Observable.from(arrayLike, mapFn).subscribe((x: number) =>  {
-      expect(x).to.equal(expected.shift());
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
-  it('should handle an ArrayLike with a thisArg', (done: MochaDone) => {
-    const arrayLike: ArrayLike<number> = {
-      length: 3,
-      0: 1,
-      1: 2,
-      2: 3
-    };
-    const expected = [123, 123, 123];
-    const mapFn = function (x, y) {
-      return this.thing;
-    };
-
-    Observable.from(arrayLike, mapFn, {thing: 123}).subscribe((x: number) =>  {
-      expect(x).to.equal(expected.shift());
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
-  it('should handle a promise', (done: MochaDone) => {
-    const promise = Promise.resolve('pinky swear');
-
-    Observable.from(promise).subscribe((x: string) =>  {
-      expect(x).to.equal('pinky swear');
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
-  it('should handle an "observableque" object', (done: MochaDone) => {
-    const observablesque = <any>{};
-
-    observablesque[Symbol.observable] = () => {
-      return {
-        subscribe: (observer: Rx.Observer<string>) => {
-          observer.next('test');
-          observer.complete();
-        }
-      };
-    };
-
-    Observable.from(observablesque).subscribe((x: string) =>  {
-      expect(x).to.equal('test');
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
-  it('should accept scheduler for observableque object', () => {
-    const observablesque = <any>{};
-
-    observablesque[Symbol.observable] = () => {
-      return {
-        subscribe: (observer: Rx.Observer<string>) => {
-          observer.next('x');
-          observer.complete();
-        }
-      };
-    };
-
-    const e1 = Observable.from(observablesque, rxTestScheduler);
-    const expected = '(x|)';
-
-    expectObservable(e1).toBe(expected);
-  });
-
-  it('should handle a string', (done: MochaDone) => {
-    const expected = ['a', 'b', 'c'];
-    Observable.from('abc').subscribe((x: string) =>  {
-      expect(x).to.equal(expected.shift());
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
-  it('should handle any iterable thing', (done: MochaDone) => {
-    const iterable = <any>{};
-    const iteratorResults = [
-      { value: 'one', done: false },
-      { value: 'two', done: false },
-      { done: true }
-    ];
-    const expected = ['one', 'two'];
-
-    expect($$iterator).to.equal(Symbol.iterator);
-
-    iterable[Symbol.iterator] = () => {
-      return {
-        next: () => {
-          return iteratorResults.shift();
-        }
-      };
-    };
-
-    Observable.from(iterable).subscribe((x: string) =>  {
-      expect(x).to.equal(expected.shift());
-    }, (x) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
-  });
-
   it('should throw for non observable object', () => {
     const r = () => {
       Observable.from(<any>{}).subscribe();
     };
 
     expect(r).to.throw();
-  });
-
-  it('should handle object has observable symbol', (done: MochaDone) => {
-    const value = 'x';
-
-    Observable.from(Observable.of(value)).subscribe((x: string) =>  {
-      expect(x).to.equal(value);
-    }, (err: any) => {
-      done(new Error('should not be called'));
-    }, () => {
-      done();
-    });
   });
 
   it('should return T for ObservableLike objects', () => {
@@ -239,4 +41,142 @@ describe('Observable.from', () => {
       /* tslint:enable:no-unused-variable */
     });
   });
+
+  const fakerator = (...values) => ({
+    [<symbol>Symbol.iterator]: () => {
+      const clone = [...values];
+      return {
+        next: () => ({
+          done: clone.length <= 0,
+          value: clone.shift()
+        })
+      };
+    }
+  });
+
+  const sources: { name: string, value: any }[] = [
+    { name: 'observable', value: Observable.of('x') },
+    { name: 'array', value: ['x'] },
+    { name: 'promise', value: Promise.resolve('x') },
+    { name: 'iterator', value: fakerator('x') },
+    { name: 'array-like', value: { [0]: 'x', length: 1 }},
+    { name: 'string', value: 'x'},
+    { name: 'arguments', value: function(x) { return arguments; }('x') },
+  ];
+
+  for (const source of sources) {
+    it(`should accept ${source.name}`, (done: MochaDone) => {
+      let nextInvoked = false;
+      Observable.from(source.value)
+        .subscribe(
+          (x: string) => {
+            nextInvoked = true;
+            expect(x).to.equal('x');
+          },
+          (x) => {
+            done(new Error('should not be called'));
+          },
+          () => {
+            expect(nextInvoked).to.equal(true);
+            done();
+          }
+        );
+    });
+    it(`should accept ${source.name} and scheduler`, (done: MochaDone) => {
+      let nextInvoked = false;
+      Observable.from(source.value, Rx.Scheduler.async)
+        .subscribe(
+          (x: string) => {
+            nextInvoked = true;
+            expect(x).to.equal('x');
+          },
+          (x) => {
+            done(new Error('should not be called'));
+          },
+          () => {
+            expect(nextInvoked).to.equal(true);
+            done();
+          }
+        );
+      expect(nextInvoked).to.equal(false);
+    });
+    it(`should accept ${source.name} and projection`, (done: MochaDone) => {
+      let nextInvoked = false;
+      Observable.from(source.value, x => x + 'x')
+        .subscribe(
+          (x: string) => {
+            nextInvoked = true;
+            expect(x).to.equal('xx');
+          },
+          (x) => {
+            done(new Error('should not be called'));
+          },
+          () => {
+            expect(nextInvoked).to.equal(true);
+            done();
+          }
+        );
+    });
+    it(`should accept ${source.name}, projection and scheduler`, (done: MochaDone) => {
+      let nextInvoked = false;
+      Observable.from(source.value, x => x + 'x', Rx.Scheduler.async)
+        .subscribe(
+          (x: string) => {
+            nextInvoked = true;
+            expect(x).to.equal('xx');
+          },
+          (x) => {
+            done(new Error('should not be called'));
+          },
+          () => {
+            expect(nextInvoked).to.equal(true);
+            done();
+          }
+        );
+      expect(nextInvoked).to.equal(false);
+    });
+    it(`should accept ${source.name}, projection and context`, (done: MochaDone) => {
+      const projection = function(x) {
+        expect(this.foo).to.equal('bar');
+        return x + 'x';
+      };
+      let nextInvoked = false;
+      Observable.from(source.value, projection, { foo: 'bar' })
+        .subscribe(
+          (x: string) => {
+            nextInvoked = true;
+            expect(x).to.equal('xx');
+          },
+          (x) => {
+            done(new Error('should not be called'));
+          },
+          () => {
+            expect(nextInvoked).to.equal(true);
+            done();
+          }
+        );
+    });
+    it(`should accept ${source.name}, projection, context and scheduler`, (done: MochaDone) => {
+      const projection = function(x) {
+        expect(this.foo).to.equal('bar');
+        return x + 'x';
+      };
+      let nextInvoked = false;
+      Observable.from(source.value, projection, { foo: 'bar' }, Rx.Scheduler.async)
+        .subscribe(
+          (x: string) => {
+            nextInvoked = true;
+            expect(x).to.equal('xx');
+          },
+          (x) => {
+            done(new Error('should not be called'));
+          },
+          () => {
+            expect(nextInvoked).to.equal(true);
+            done();
+          }
+        );
+      expect(nextInvoked).to.equal(false);
+    });
+  }
 });

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -34,10 +34,10 @@ describe('Observable.from', () => {
     });
   });
 
-  it('should return T and map for arrays', () => {
+  it('should return T for arrays', () => {
     type(() => {
       /* tslint:disable:no-unused-variable */
-      let o1: Rx.Observable<number> = Observable.from(<number[]>[], x => x.toString(), null, Rx.Scheduler.asap);
+      let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
       /* tslint:enable:no-unused-variable */
     });
   });
@@ -89,84 +89,6 @@ describe('Observable.from', () => {
           (x: string) => {
             nextInvoked = true;
             expect(x).to.equal('x');
-          },
-          (x) => {
-            done(new Error('should not be called'));
-          },
-          () => {
-            expect(nextInvoked).to.equal(true);
-            done();
-          }
-        );
-      expect(nextInvoked).to.equal(false);
-    });
-    it(`should accept ${source.name} and projection`, (done: MochaDone) => {
-      let nextInvoked = false;
-      Observable.from(source.value, x => x + 'x')
-        .subscribe(
-          (x: string) => {
-            nextInvoked = true;
-            expect(x).to.equal('xx');
-          },
-          (x) => {
-            done(new Error('should not be called'));
-          },
-          () => {
-            expect(nextInvoked).to.equal(true);
-            done();
-          }
-        );
-    });
-    it(`should accept ${source.name}, projection and scheduler`, (done: MochaDone) => {
-      let nextInvoked = false;
-      Observable.from(source.value, x => x + 'x', Rx.Scheduler.async)
-        .subscribe(
-          (x: string) => {
-            nextInvoked = true;
-            expect(x).to.equal('xx');
-          },
-          (x) => {
-            done(new Error('should not be called'));
-          },
-          () => {
-            expect(nextInvoked).to.equal(true);
-            done();
-          }
-        );
-      expect(nextInvoked).to.equal(false);
-    });
-    it(`should accept ${source.name}, projection and context`, (done: MochaDone) => {
-      const projection = function(x) {
-        expect(this.foo).to.equal('bar');
-        return x + 'x';
-      };
-      let nextInvoked = false;
-      Observable.from(source.value, projection, { foo: 'bar' })
-        .subscribe(
-          (x: string) => {
-            nextInvoked = true;
-            expect(x).to.equal('xx');
-          },
-          (x) => {
-            done(new Error('should not be called'));
-          },
-          () => {
-            expect(nextInvoked).to.equal(true);
-            done();
-          }
-        );
-    });
-    it(`should accept ${source.name}, projection, context and scheduler`, (done: MochaDone) => {
-      const projection = function(x) {
-        expect(this.foo).to.equal('bar');
-        return x + 'x';
-      };
-      let nextInvoked = false;
-      Observable.from(source.value, projection, { foo: 'bar' }, Rx.Scheduler.async)
-        .subscribe(
-          (x: string) => {
-            nextInvoked = true;
-            expect(x).to.equal('xx');
           },
           (x) => {
             done(new Error('should not be called'));

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -42,6 +42,17 @@ describe('Observable.from', () => {
     });
   });
 
+  const fakervable = (...values) => ({
+    [<symbol>Symbol.observable]: () => ({
+      subscribe: (observer: Rx.Observer<string>) => {
+        for (const value of values) {
+          observer.next(value);
+        }
+        observer.complete();
+      }
+    })
+  });
+
   const fakerator = (...values) => ({
     [<symbol>Symbol.iterator]: () => {
       const clone = [...values];
@@ -56,6 +67,7 @@ describe('Observable.from', () => {
 
   const sources: { name: string, value: any }[] = [
     { name: 'observable', value: Observable.of('x') },
+    { name: 'observable-like', value: fakervable('x') },
     { name: 'array', value: ['x'] },
     { name: 'promise', value: Promise.resolve('x') },
     { name: 'iterator', value: fakerator('x') },

--- a/spec/support/default.opts
+++ b/spec/support/default.opts
@@ -5,7 +5,7 @@
 --ui spec-js/helpers/testScheduler-ui.js
 
 --reporter dot
---bail
+
 --full-trace
 --check-leaks
 --globals WebSocket,FormData,XDomainRequest,ActiveXObject

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -101,7 +101,7 @@ export class ArrayObservable<T> extends Observable<T> {
   // value used if Array has one value and _isScalar
   value: any;
 
-  constructor(public array: T[], public scheduler?: Scheduler) {
+  constructor(private array: T[], private scheduler?: Scheduler) {
     super();
     if (!scheduler && array.length === 1) {
       this._isScalar = true;

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -1,7 +1,5 @@
 import {isArray} from '../util/isArray';
-import {isFunction} from '../util/isFunction';
 import {isPromise} from '../util/isPromise';
-import {isScheduler} from '../util/isScheduler';
 import {PromiseObservable} from './PromiseObservable';
 import {IteratorObservable} from'./IteratorObservable';
 import {ArrayObservable} from './ArrayObservable';
@@ -22,12 +20,12 @@ const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 
  * @hide true
  */
 export class FromObservable<T> extends Observable<T> {
-  constructor(private ish: ObservableInput<T>, private scheduler: Scheduler) {
+  constructor(private ish: ObservableInput<T>, private scheduler?: Scheduler) {
     super(null);
   }
 
   static create<T>(ish: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;
-  static create<T, R>(ish: ArrayLike<T>, mapFn: (x: any, y: number) => R, thisArg?: any, scheduler?: Scheduler): Observable<R>;
+  static create<T, R>(ish: ArrayLike<T>, scheduler?: Scheduler): Observable<R>;
 
   /**
    * Creates an Observable from an Array, an array-like object, a Promise, an
@@ -71,11 +69,6 @@ export class FromObservable<T> extends Observable<T> {
    * @param {ObservableInput<T>} ish A subscribable object, a Promise, an
    * Observable-like, an Array, an iterable or an array-like object to be
    * converted.
-   * @param {function(x: any, i: number): T} [mapFn] A "map" function to call
-   * when converting array-like objects, where `x` is a value from the
-   * array-like and `i` is the index of that value in the sequence.
-   * @param {any} [thisArg] The context object to use when calling the `mapFn`,
-   * if provided.
    * @param {Scheduler} [scheduler] The scheduler on which to schedule the
    * emissions of values.
    * @return {Observable<T>} The Observable whose values are originally from the
@@ -84,19 +77,7 @@ export class FromObservable<T> extends Observable<T> {
    * @name from
    * @owner Observable
    */
-  static create<T>(ish: ObservableInput<T>,
-                   mapFnOrScheduler?: Scheduler | ((x: any, y: number) => T),
-                   thisArg?: any,
-                   lastScheduler?: Scheduler): Observable<T> {
-    let scheduler: Scheduler = null;
-    let mapFn: (x: any, i: number) => T = null;
-    if (isFunction(mapFnOrScheduler)) {
-      scheduler = lastScheduler || null;
-      mapFn = <(x: any, i: number) => T> mapFnOrScheduler;
-    } else if (isScheduler(scheduler)) {
-      scheduler = <Scheduler> mapFnOrScheduler;
-    }
-
+  static create<T>(ish: ObservableInput<T>, scheduler?: Scheduler): Observable<T> {
     if (ish != null) {
       if (typeof ish[$$observable] === 'function') {
         if (ish instanceof Observable && !scheduler) {
@@ -108,9 +89,9 @@ export class FromObservable<T> extends Observable<T> {
       } else if (isPromise(ish)) {
         return new PromiseObservable<T>(ish, scheduler);
       } else if (typeof ish[$$iterator] === 'function' || typeof ish === 'string') {
-        return new IteratorObservable<T>(<any>ish, null, null, scheduler);
+        return new IteratorObservable<T>(ish, scheduler);
       } else if (isArrayLike(ish)) {
-        return new ArrayLikeObservable(ish, mapFn, thisArg, scheduler);
+        return new ArrayLikeObservable(ish, scheduler);
       }
     }
 

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -39,11 +39,11 @@ export class PromiseObservable<T> extends Observable<T> {
    * @name fromPromise
    * @owner Observable
    */
-  static create<T>(promise: Promise<T>, scheduler: Scheduler = null): Observable<T> {
+  static create<T>(promise: Promise<T>, scheduler?: Scheduler): Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }
 
-  constructor(private promise: Promise<T>, public scheduler: Scheduler = null) {
+  constructor(private promise: Promise<T>, private scheduler?: Scheduler) {
     super();
   }
 


### PR DESCRIPTION
**Description:**

Arguments supplied to `Observable.from` are not being propagated correctly. I've chased this a couple of levels down the rabbit hole and whilst this patch fixes some issues, I'm starting to think that Iterators and Schedulers just don't work together. I supply this patch only because the code is so obviously wrong.

N.B. I tried adding tests but I don't understand enough about your testing primitives and their behavior to get the results I would expect. However, I believe the code is currently so obviously wrong that the tests are unnecessary to prove correctness, only to prevent regression.