### PR TITLE
fix(toPromise): do not resolve when does not emit values

### DIFF
--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -22,6 +22,15 @@ describe('Observable.prototype.toPromise', () => {
     });
   });
 
+  it('should not resolve if does not emit any value', (done: MochaDone) => {
+    Observable.empty().toPromise(Promise).then(() => {
+      done(new Error('should not be called'));
+    }, (err: any) => {
+      expect(err).to.equal('no values emitted');
+      done();
+    });
+  });
+
   it('should allow for global config via Rx.config.Promise', (done: MochaDone) => {
     let wasCalled = false;
     __root__.Rx = {};

--- a/src/operator/toPromise.ts
+++ b/src/operator/toPromise.ts
@@ -21,7 +21,14 @@ export function toPromise<T>(PromiseCtor?: typeof Promise): Promise<T> {
 
   return new PromiseCtor((resolve, reject) => {
     let value: any;
-    this.subscribe((x: T) => value = x, (err: any) => reject(err), () => resolve(value));
+    let hasValue: boolean = false;
+
+    this.subscribe((x: T) => {
+      value = x;
+      hasValue = true;
+    },
+    (err: any) => reject(err),
+    () => hasValue ? resolve(value) : reject('no values emitted'));
   });
 }
 


### PR DESCRIPTION
**Description:**
This PR updates behavior of `toPromise`, let it explicitly resolve only if observable emits any value. If there isn't value emitted, promise will be rejected instead.

/cc @staltz also for review.

**Related issue (if exists):**

closes #1736