### PR TITLE
fix(AsyncSubject): do not allow change value after complete

### DIFF
--- a/spec/subjects/AsyncSubject-spec.ts
+++ b/spec/subjects/AsyncSubject-spec.ts
@@ -79,6 +79,21 @@ describe('AsyncSubject', () => {
     expect(observer.results).to.deep.equal([2, 'done']);
   });
 
+  it('should not allow change value after complete', () => {
+    const subject = new AsyncSubject();
+    const observer = new TestObserver();
+    const otherObserver = new TestObserver();
+    subject.subscribe(observer);
+
+    subject.next(1);
+    expect(observer.results).to.deep.equal([]);
+    subject.complete();
+    expect(observer.results).to.deep.equal([1, 'done']);
+    subject.next(2);
+    subject.subscribe(otherObserver);
+    expect(otherObserver.results).to.deep.equal([1, 'done']);
+  });
+
   it('should not emit values if unsubscribed before complete', () => {
     const subject = new AsyncSubject();
     const observer = new TestObserver();

--- a/src/AsyncSubject.ts
+++ b/src/AsyncSubject.ts
@@ -6,11 +6,9 @@ import {Subscription} from './Subscription';
  * @class AsyncSubject<T>
  */
 export class AsyncSubject<T> extends Subject<T> {
-  value: T = null;
-
-  hasNext: boolean = false;
-
-  hasCompleted: boolean = false;
+  private value: T = null;
+  private hasNext: boolean = false;
+  private hasCompleted: boolean = false;
 
   protected _subscribe(subscriber: Subscriber<any>): Subscription {
     if (this.hasCompleted && this.hasNext) {
@@ -26,8 +24,10 @@ export class AsyncSubject<T> extends Subject<T> {
   }
 
   next(value: T): void {
-    this.value = value;
-    this.hasNext = true;
+    if (!this.hasCompleted) {
+      this.value = value;
+      this.hasNext = true;
+    }
   }
 
   complete(): void {


### PR DESCRIPTION
**Description:**
This PR updates `AsyncSubject::next` adds guard to now allow to change value if it's already completed.

**Related issue (if exists):**

closes #1800