### PR TITLE
fix(babel): fix an issue where babel could not compile `Scheduler.async`

### DIFF
--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -187,9 +187,9 @@ import observable from 'symbol-observable';
  */
 let Scheduler = {
   asap,
-  async,
   queue,
-  animationFrame
+  animationFrame,
+  async
 };
 
 /**


### PR DESCRIPTION
This moves the `async` property to be the last one defined, because babel will then not choke on the `,` after the property.

fixes #1806

related to https://phabricator.babeljs.io/T7479