### PR TITLE
chore(MAINTAINERS): update maintainers username

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,5 +1,5 @@
-Ben Lesh <blesh@netflix.com>
-OJ Kwon <kwon.ohjoong@gmail.com>
-Andre Staltz <andre@staltz.com>
-Paul Taylor <paul.e.taylor@me.com>
-Matthew Podwysocki <matthewp@microsoft.com>
+Ben Lesh <blesh@netflix.com> (@blesh)
+OJ Kwon <kwon.ohjoong@gmail.com> (@kwonoj)
+Andre Staltz <andre@staltz.com> (@staltz)
+Paul Taylor <paul.e.taylor@me.com> (@trxcllnt)
+Matthew Podwysocki <matthewp@microsoft.com> (@mattpodwysocki)


### PR DESCRIPTION
**Description:**

This PR updates `MAINTAINERS` file to include each username - per documentation (https://lgtm.co/docs/maintainers/) username is necessary to enable LGTM correctly.

Note: it's kind of chicken-and-egg, LGTM might block this PR as well.

**Related issue (if exists):**

