### PR TITLE
test(switch): update test case to use correct operator

### DIFF
--- a/spec/operators/switch-spec.ts
+++ b/spec/operators/switch-spec.ts
@@ -38,7 +38,7 @@ describe('Observable.prototype.switch', () => {
           unsubbed.push(x);
         };
       }))
-    .mergeAll()
+    .switch()
     .subscribe();
 
     expect(unsubbed).to.deep.equal(['a', 'b']);


### PR DESCRIPTION
This test case appears to be the victim of a copy paste error, this particular test for switch was not calling switch at all. Updated to call switch and it still passes.