### PR TITLE
refactor(throwError): remove utility throwError() function

### DIFF
--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -1,7 +1,6 @@
 import {Subject} from './Subject';
 import {Subscriber} from './Subscriber';
 import {Subscription, ISubscription} from './Subscription';
-import {throwError} from './util/throwError';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 
 /**
@@ -13,26 +12,26 @@ export class BehaviorSubject<T> extends Subject<T> {
     super();
   }
 
-  getValue(): T {
-    if (this.hasError) {
-      throwError(this.thrownError);
-    } else if (this.isUnsubscribed) {
-      throwError(new ObjectUnsubscribedError());
-    } else {
-      return this._value;
-    }
-  }
-
   get value(): T {
     return this.getValue();
   }
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
     const subscription = super._subscribe(subscriber);
-    if (subscription && !(<ISubscription> subscription).isUnsubscribed) {
+    if (subscription && !(<ISubscription>subscription).isUnsubscribed) {
       subscriber.next(this._value);
     }
     return subscription;
+  }
+
+  getValue(): T {
+    if (this.hasError) {
+      throw this.thrownError;
+    } else if (this.isUnsubscribed) {
+      throw new ObjectUnsubscribedError();
+    } else {
+      return this._value;
+    }
   }
 
   next(value: T): void {

--- a/src/util/throwError.ts
+++ b/src/util/throwError.ts
@@ -1,1 +1,0 @@
-export function throwError(e: any) { throw e; }


### PR DESCRIPTION
**Description:**

This PR removes utility function `throwError`, which simply wraps `throw` and only being used in single place. Error can be thrown directly.

**Related issue (if exists):**

