### PR TITLE
refactor(Operator): update explicit return type to call()

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../dist/cjs/Rx';
+import {TeardownLogic} from '../dist/cjs/Subscription';
 
 declare const {asDiagram, expectObservable};
 const Subscriber = Rx.Subscriber;
@@ -575,7 +576,7 @@ describe('Observable.lift', () => {
         super();
       }
 
-      call(subscriber: Rx.Subscriber<R>, source: any): Rx.Subscription | Function | void {
+      call(subscriber: Rx.Subscriber<R>, source: any): TeardownLogic {
         return this.childOperator.call(new LogSubscriber<R>(subscriber), source);
       }
     }

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -1,7 +1,8 @@
 import {Subscriber} from './Subscriber';
+import {TeardownLogic} from './Subscription';
 
 export class Operator<T, R> {
-  call(subscriber: Subscriber<R>, source: any): any {
+  call(subscriber: Subscriber<R>, source: any): TeardownLogic {
     return source._subscribe(new Subscriber<T>(subscriber));
   }
 }

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -2,7 +2,7 @@ import {Subject, SubjectSubscriber} from '../Subject';
 import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 
 /**
  * @class ConnectableObservable<T>
@@ -82,7 +82,7 @@ class ConnectableSubscriber<T> extends SubjectSubscriber<T> {
 class RefCountOperator<T> implements Operator<T, T> {
   constructor(private connectable: ConnectableObservable<T>) {
   }
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
 
     const { connectable } = this;
     (<any> connectable)._refCount++;

--- a/src/operator/audit.ts
+++ b/src/operator/audit.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable, SubscribableOrPromise} from '../Observable';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
@@ -60,7 +60,7 @@ class AuditOperator<T> implements Operator<T, T> {
   constructor(private durationSelector: (value: T) => SubscribableOrPromise<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new AuditSubscriber<T, T>(subscriber, this.durationSelector));
   }
 }

--- a/src/operator/auditTime.ts
+++ b/src/operator/auditTime.ts
@@ -3,7 +3,7 @@ import {Operator} from '../Operator';
 import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 
 /**
  * Ignores source values for `duration` milliseconds, then emits the most recent
@@ -60,7 +60,7 @@ class AuditTimeOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new AuditTimeSubscriber(subscriber, this.duration, this.scheduler));
   }
 }

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Observable, SubscribableOrPromise} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
@@ -61,7 +61,7 @@ class DebounceOperator<T> implements Operator<T, T> {
   constructor(private durationSelector: (value: T) => SubscribableOrPromise<number>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DebounceSubscriber(subscriber, this.durationSelector));
   }
 }

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -2,7 +2,7 @@ import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {async} from '../scheduler/async';
 
 /**
@@ -63,7 +63,7 @@ class DebounceTimeOperator<T> implements Operator<T, T> {
   constructor(private dueTime: number, private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DebounceTimeSubscriber(subscriber, this.dueTime, this.scheduler));
   }
 }

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -5,6 +5,7 @@ import {Scheduler} from '../Scheduler';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Delays the emission of items from the source Observable by a given timeout or
@@ -61,7 +62,7 @@ class DelayOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DelaySubscriber(subscriber, this.delay, this.scheduler));
   }
 }

--- a/src/operator/delayWhen.ts
+++ b/src/operator/delayWhen.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
@@ -69,7 +69,7 @@ class DelayWhenOperator<T> implements Operator<T, T> {
   constructor(private delayDurationSelector: (value: T) => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DelayWhenSubscriber(subscriber, this.delayDurationSelector));
   }
 }

--- a/src/operator/distinct.ts
+++ b/src/operator/distinct.ts
@@ -1,7 +1,7 @@
 import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-
+import {TeardownLogic} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
@@ -30,7 +30,7 @@ class DistinctOperator<T> implements Operator<T, T> {
   constructor(private compare: (x: T, y: T) => boolean, private flushes: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DistinctSubscriber(subscriber, this.compare, this.flushes));
   }
 }

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -3,6 +3,7 @@ import {Subscriber} from '../Subscriber';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from the previous item.
@@ -27,7 +28,7 @@ class DistinctUntilChangedOperator<T, K> implements Operator<T, T> {
               private keySelector: (x: T) => K) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DistinctUntilChangedSubscriber(subscriber, this.compare, this.keySelector));
   }
 }

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -2,6 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {PartialObserver} from '../Observer';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Perform a side effect for every emission on the source Observable, but return
@@ -62,7 +63,7 @@ class DoOperator<T> implements Operator<T, T> {
               private error?: (e: any) => void,
               private complete?: () => void) {
   }
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DoSubscriber(subscriber, this.nextOrObserver, this.error, this.complete));
   }
 }

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -2,6 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Emits the single value at the specified `index` in a sequence of emissions
@@ -56,7 +57,7 @@ class ElementAtOperator<T> implements Operator<T, T> {
     }
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ElementAtSubscriber(subscriber, this.index, this.defaultValue));
   }
 }

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 
@@ -50,7 +50,7 @@ export interface SwitchFirstSignature<T> {
 }
 
 class SwitchFirstOperator<T> implements Operator<T, T> {
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SwitchFirstSubscriber(subscriber));
   }
 }

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -1,6 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Filter items emitted by the source Observable by only emitting those that
@@ -56,7 +57,7 @@ class FilterOperator<T> implements Operator<T, T> {
               private thisArg?: any) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new FilterSubscriber(subscriber, this.predicate, this.thisArg));
   }
 }

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -1,6 +1,6 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {Observable} from '../Observable';
 
 /**
@@ -23,7 +23,7 @@ class FinallyOperator<T> implements Operator<T, T> {
   constructor(private callback: () => void) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new FinallySubscriber(subscriber, this.callback));
   }
 }

--- a/src/operator/observeOn.ts
+++ b/src/operator/observeOn.ts
@@ -4,6 +4,7 @@ import {Operator} from '../Operator';
 import {PartialObserver} from '../Observer';
 import {Subscriber} from '../Subscriber';
 import {Notification} from '../Notification';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * @see {@link Notification}
@@ -26,7 +27,7 @@ export class ObserveOnOperator<T> implements Operator<T, T> {
   constructor(private scheduler: Scheduler, private delay: number = 0) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ObserveOnSubscriber(subscriber, this.scheduler, this.delay));
   }
 }

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -3,7 +3,7 @@ import {isArray} from '../util/isArray';
 import {ArrayObservable} from '../observable/ArrayObservable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
@@ -56,7 +56,7 @@ export function raceStatic<T>(...observables: Array<Observable<any> | Array<Obse
 }
 
 export class RaceOperator<T> implements Operator<T, T> {
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RaceSubscriber(subscriber));
   }
 }

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -2,6 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {EmptyObservable} from '../observable/EmptyObservable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Returns an Observable that repeats the stream of items emitted by the source Observable at most count times,
@@ -35,7 +36,7 @@ class RepeatOperator<T> implements Operator<T, T> {
   constructor(private count: number,
               private source: Observable<T>) {
   }
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RepeatSubscriber(subscriber, this.count, this.source));
   }
 }

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -1,6 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Returns an Observable that mirrors the source Observable, resubscribing to it if it calls `error` and the
@@ -32,7 +33,7 @@ class RetryOperator<T> implements Operator<T, T> {
               private source: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RetrySubscriber(subscriber, this.count, this.source));
   }
 }

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -2,7 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 import {Subject} from '../Subject';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {tryCatch} from '../util/tryCatch';
 import {errorObject} from '../util/errorObject';
 
@@ -39,7 +39,7 @@ class RetryWhenOperator<T> implements Operator<T, T> {
               protected source: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RetryWhenSubscriber(subscriber, this.notifier, this.source));
   }
 }

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
-
+import {TeardownLogic} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
@@ -52,7 +52,7 @@ class SampleOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SampleSubscriber(subscriber, this.notifier));
   }
 }

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -3,6 +3,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {async} from '../scheduler/async';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Emits the most recently emitted value from the source Observable within
@@ -53,7 +54,7 @@ class SampleTimeOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SampleTimeSubscriber(subscriber, this.period, this.scheduler));
   }
 }

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -3,6 +3,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observer} from '../Observer';
 import {EmptyError} from '../util/EmptyError';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Returns an Observable that emits the single item emitted by the source Observable that matches a specified
@@ -33,7 +34,7 @@ class SingleOperator<T> implements Operator<T, T> {
               private source?: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SingleSubscriber(subscriber, this.predicate, this.source));
   }
 }

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -1,6 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Returns an Observable that skips `n` items emitted by an Observable.
@@ -25,7 +26,7 @@ class SkipOperator<T> implements Operator<T, T> {
   constructor(private total: number) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SkipSubscriber(subscriber, this.total));
   }
 }

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
-
+import {TeardownLogic} from '../Subscription';
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
@@ -30,7 +30,7 @@ class SkipUntilOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SkipUntilSubscriber(subscriber, this.notifier));
   }
 }

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -1,6 +1,7 @@
 import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Returns an Observable that skips all items emitted by the source Observable as long as a specified condition holds
@@ -26,7 +27,7 @@ class SkipWhileOperator<T> implements Operator<T, T> {
   constructor(private predicate: (value: T, index: number) => boolean) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SkipWhileSubscriber(subscriber, this.predicate));
   }
 }

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -3,6 +3,7 @@ import {Subscriber} from '../Subscriber';
 import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
 import {EmptyObservable} from '../observable/EmptyObservable';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Emits only the first `count` values emitted by the source Observable.
@@ -56,7 +57,7 @@ class TakeOperator<T> implements Operator<T, T> {
     }
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeSubscriber(subscriber, this.total));
   }
 }

--- a/src/operator/takeLast.ts
+++ b/src/operator/takeLast.ts
@@ -3,6 +3,7 @@ import {Subscriber} from '../Subscriber';
 import {ArgumentOutOfRangeError} from '../util/ArgumentOutOfRangeError';
 import {EmptyObservable} from '../observable/EmptyObservable';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Emits only the last `count` values emitted by the source Observable.
@@ -59,7 +60,7 @@ class TakeLastOperator<T> implements Operator<T, T> {
     }
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeLastSubscriber(subscriber, this.total));
   }
 }

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -1,6 +1,7 @@
 import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
+import {TeardownLogic} from '../Subscription';
 
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
@@ -51,7 +52,7 @@ class TakeUntilOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeUntilSubscriber(subscriber, this.notifier));
   }
 }

--- a/src/operator/takeWhile.ts
+++ b/src/operator/takeWhile.ts
@@ -1,6 +1,7 @@
 import {Operator} from '../Operator';
 import {Observable} from '../Observable';
 import {Subscriber} from '../Subscriber';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * Emits values emitted by the source Observable so long as each value satisfies
@@ -50,7 +51,7 @@ class TakeWhileOperator<T> implements Operator<T, T> {
   constructor(private predicate: (value: T, index: number) => boolean) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeWhileSubscriber(subscriber, this.predicate));
   }
 }

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Observable, SubscribableOrPromise} from '../Observable';
 import {Subscriber} from '../Subscriber';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 
 import {OuterSubscriber} from '../OuterSubscriber';
 import {InnerSubscriber} from '../InnerSubscriber';
@@ -57,7 +57,7 @@ class ThrottleOperator<T> implements Operator<T, T> {
   constructor(private durationSelector: (value: T) => SubscribableOrPromise<number>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ThrottleSubscriber(subscriber, this.durationSelector));
   }
 }

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -1,7 +1,7 @@
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {async} from '../scheduler/async';
 import {Observable} from '../Observable';
 
@@ -57,7 +57,7 @@ class ThrottleTimeOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ThrottleTimeSubscriber(subscriber, this.duration, this.scheduler));
   }
 }

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -4,6 +4,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {Observable} from '../Observable';
+import {TeardownLogic} from '../Subscription';
 
 /**
  * @param due
@@ -32,7 +33,7 @@ class TimeoutOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TimeoutSubscriber<T>(
       subscriber, this.absoluteTimeout, this.waitFor, this.errorToSend, this.scheduler
     ));

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -2,7 +2,7 @@ import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {Scheduler} from '../Scheduler';
 import {async} from '../scheduler/async';
-import {Subscription} from '../Subscription';
+import {Subscription, TeardownLogic} from '../Subscription';
 import {Observable} from '../Observable';
 import {isDate} from '../util/isDate';
 import {OuterSubscriber} from '../OuterSubscriber';
@@ -36,7 +36,7 @@ class TimeoutWithOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TimeoutWithSubscriber(
       subscriber, this.absoluteTimeout, this.waitFor, this.withObservable, this.scheduler
     ));


### PR DESCRIPTION
**Description:**

This PR updates interface of `Operator::call()` to return `TeardownLogic` explicitly. While current codebase doesn't actively using return value of `call`, it's no harm to provide strict type of it.

**Related issue (if exists):**

