### PR TITLE
refactor(Operator): replace operator<T, R> to interface

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -571,9 +571,8 @@ describe('Observable.lift', () => {
     }
 
     // The custom Operator
-    class LogOperator<T, R> extends Rx.Operator<T, R> {
+    class LogOperator<T, R> implements Rx.Operator<T, R> {
       constructor(private childOperator: Rx.Operator<T, R>) {
-        super();
       }
 
       call(subscriber: Rx.Subscriber<R>, source: any): TeardownLogic {

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -1,8 +1,6 @@
 import {Subscriber} from './Subscriber';
 import {TeardownLogic} from './Subscription';
 
-export class Operator<T, R> {
-  call(subscriber: Subscriber<R>, source: any): TeardownLogic {
-    return source._subscribe(new Subscriber<T>(subscriber));
-  }
+export interface Operator<T, R> {
+  call(subscriber: Subscriber<R>, source: any): TeardownLogic;
 }


### PR DESCRIPTION
**Description:**

This PR replaces implementation `Operator<T, R>`  into `interface` by base implementation `Operator::call` is not necessarily needed, since creating new operator requires to override it any time. Instead, this PR makes operator as contract interface only.