### PR TITLE
chore(observable): remove hard dependency on symbol-observable

### DIFF
--- a/spec/symbol/iterator-spec.ts
+++ b/spec/symbol/iterator-spec.ts
@@ -3,7 +3,7 @@ import {expect} from 'chai';
 import {root} from '../../dist/cjs/util/root';
 import {$$iterator} from '../../dist/cjs/symbol/iterator';
 
-describe('rxSubscriber symbol', () => {
+describe('iterator symbol', () => {
   it('should exist in the proper form', () => {
     const Symbol = root.Symbol;
     if (typeof Symbol === 'function') {

--- a/spec/symbol/observable-polyfilled-spec.ts
+++ b/spec/symbol/observable-polyfilled-spec.ts
@@ -1,0 +1,10 @@
+import {expect} from 'chai';
+
+import {getSymbolObservable} from '../../dist/cjs/symbol/observable';
+
+describe('observable symbol', () => {
+  it('should exist in the proper form when Symbol does not exist', () => {
+    let $$observable = getSymbolObservable({Symbol: undefined});
+    expect($$observable).to.equal('@@observable');
+  });
+});

--- a/spec/symbol/observable-spec.ts
+++ b/spec/symbol/observable-spec.ts
@@ -1,0 +1,16 @@
+import {expect} from 'chai';
+import $$symbolObservable from 'symbol-observable';
+
+import {root} from '../../dist/cjs/util/root';
+import {getSymbolObservable} from '../../dist/cjs/symbol/observable';
+
+describe('observable symbol', () => {
+  it('should exist in the proper form', () => {
+    let $$observable = getSymbolObservable(root);
+    if (root.Symbol && root.Symbol.for) {
+      expect($$observable).to.equal($$symbolObservable);
+    } else {
+      expect($$observable).to.equal('@@observable');
+    }
+  });
+});

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -6,7 +6,7 @@ import {root} from './util/root';
 import {toSubscriber} from './util/toSubscriber';
 import {IfObservable} from './observable/IfObservable';
 import {ErrorObservable} from './observable/ErrorObservable';
-import $$observable from 'symbol-observable';
+import {$$observable} from './symbol/observable';
 
 export interface Subscribable<T> {
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -170,7 +170,7 @@ import {QueueScheduler} from './scheduler/QueueScheduler';
 import {AnimationFrameScheduler} from './scheduler/AnimationFrameScheduler';
 import {$$rxSubscriber as rxSubscriber} from './symbol/rxSubscriber';
 import {$$iterator as iterator} from './symbol/iterator';
-import observable from 'symbol-observable';
+import {$$observable as observable} from './symbol/observable';
 
 /* tslint:enable:no-unused-variable */
 

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -12,8 +12,7 @@ import {$$iterator} from '../symbol/iterator';
 import {Observable, ObservableInput} from '../Observable';
 import {Subscriber} from '../Subscriber';
 import {ObserveOnSubscriber} from '../operator/observeOn';
-
-import $$observable from 'symbol-observable';
+import {$$observable} from '../symbol/observable';
 
 const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 'number');
 

--- a/src/symbol/observable.ts
+++ b/src/symbol/observable.ts
@@ -1,0 +1,21 @@
+import {root} from '../util/root';
+
+export function getSymbolObservable(context: any) {
+  let $$observable: any;
+  let Symbol = context.Symbol;
+
+  if (typeof Symbol === 'function') {
+    if (Symbol.observable) {
+      $$observable = Symbol.observable;
+    } else {
+        $$observable = Symbol('observable');
+        Symbol.observable = $$observable;
+    }
+  } else {
+    $$observable = '@@observable';
+  }
+
+  return $$observable;
+}
+
+export const $$observable = getSymbolObservable(root);

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -7,8 +7,7 @@ import {$$iterator} from '../symbol/iterator';
 import {Subscription} from '../Subscription';
 import {InnerSubscriber} from '../InnerSubscriber';
 import {OuterSubscriber} from '../OuterSubscriber';
-
-import $$observable from 'symbol-observable';
+import {$$observable} from '../symbol/observable';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,


### PR DESCRIPTION
per discussion with @blesh, removing the hard dependency on symbol-observable to allow existing implementations (see: corejs/es7/observable) to polyfill instead of `symbol-observable`, and provide a fallback.