### PR TITLE
fix(ObservableAjax): only set default Content-Type header on non-GET

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -152,9 +152,7 @@ describe('Observable.ajax', () => {
     const request = MockXMLHttpRequest.mostRecent;
 
     expect(request.url).to.equal('/talk-to-me-goose');
-    expect(request.requestHeaders).to.deep.equal({
-      'X-Requested-With': 'XMLHttpRequest'
-    });
+    expect(request.requestHeaders).to.not.have.keys('Content-Type');
   });
 
   it('should have an optional resultSelector', () => {

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -143,7 +143,7 @@ describe('Observable.ajax', () => {
 
   it('should not set default Content-Type header on GET', () => {
     const obj: Rx.AjaxRequest = {
-      url: 'talk-to-me-goose',
+      url: '/talk-to-me-goose',
       method: 'GET'
     };
 

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -141,6 +141,22 @@ describe('Observable.ajax', () => {
     });
   });
 
+  it('should not set default Content-Type header on GET', () => {
+    const obj: Rx.AjaxRequest = {
+      url: 'talk-to-me-goose',
+      method: 'GET'
+    };
+
+    Rx.Observable.ajax(obj).subscribe();
+
+    const request = MockXMLHttpRequest.mostRecent;
+
+    expect(request.url).to.equal('/talk-to-me-goose');
+    expect(request.requestHeaders).to.deep.equal({
+      'X-Requested-With': 'XMLHttpRequest'
+    });
+  });
+
   it('should have an optional resultSelector', () => {
     const expected = 'avast ye swabs!';
     let result;

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -198,7 +198,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
     }
 
     // ensure content type is set
-    if (!('Content-Type' in headers) && !(root.FormData && request.body instanceof root.FormData)) {
+    if (!('Content-Type' in headers) && !(root.FormData && request.body instanceof root.FormData) && request.method !== 'GET') {
       headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
