### PR TITLE
chore(typings): fix compiler errors when using tsc v2.0

### DIFF
--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -125,8 +125,9 @@ export class Subject<T> extends Observable<T> implements ISubscription {
  * @class AnonymousSubject<T>
  */
 export class AnonymousSubject<T> extends Subject<T> {
-  constructor(protected destination?: Observer<T>, protected source?: Observable<T>) {
+  constructor(protected destination?: Observer<T>, source?: Observable<T>) {
     super();
+    this.source = source;
   }
 
   next(value: T) {

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -127,7 +127,8 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
 function dispatch<T>(state: { source: BoundNodeCallbackObservable<T>, subscriber: Subscriber<T> }) {
   const self = (<Subscription> this);
   const { source, subscriber } = state;
-  const { callbackFunc, args, scheduler } = source;
+  // XXX: cast to `any` to access to the private field in `source`.
+  const { callbackFunc, args, scheduler } = source as any;
   let subject = source.subject;
 
   if (!subject) {

--- a/src/observable/GenerateObservable.ts
+++ b/src/observable/GenerateObservable.ts
@@ -245,7 +245,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
     } while (true);
   }
 
-  private static dispatch<T, S>(state: SchedulerState<T, S>) {
+  private static dispatch<T, S>(state: SchedulerState<T, S>): Subscription | void {
     const { subscriber, condition } = state;
     if (subscriber.isUnsubscribed) {
       return;


### PR DESCRIPTION
- This just for enhancement to fix the errors when using tsc v2.0.
  - ...and intend to decrease our effort when we upgrade our typescript compiler.