### PR TITLE
refactor(Subscription): return always subscription when calling Subscription.add()

### DIFF
--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -78,4 +78,83 @@ describe('Subscription', () => {
       done();
     });
   });
+
+  describe('Subscription.add()', () => {
+    it('Should returns the self if the self is passed', () => {
+      const sub = new Subscription();
+      const ret = sub.add(sub);
+
+      expect(ret).to.equal(sub);
+    });
+
+    it('Should returns Subscription.EMPTY if it is passed', () => {
+      const sub = new Subscription();
+      const ret = sub.add(Subscription.EMPTY);
+
+      expect(ret).to.equal(Subscription.EMPTY);
+    });
+
+    it('Should returns Subscription.EMPTY if it is called with `void` value', () => {
+      const sub = new Subscription();
+      const ret = sub.add(undefined);
+      expect(ret).to.equal(Subscription.EMPTY);
+    });
+
+    it('Should returns a new Subscription created with teardown function if it is passed a function', () => {
+      const sub = new Subscription();
+
+      let isCalled = false;
+      const ret = sub.add(function() {
+        isCalled = true;
+      });
+      ret.unsubscribe();
+
+      expect(isCalled).to.equal(true);
+    });
+
+    it('Should returns the passed one if passed a unsubscribed AnonymousSubscription', () => {
+      const sub = new Subscription();
+      const arg = {
+        isUnsubscribed: true,
+        unsubscribe: () => undefined,
+      };
+      const ret = sub.add(arg);
+
+      expect(ret).to.equal(arg);
+    });
+
+    it('Should returns the passed one if passed a AnonymousSubscription having not function `unsubscribe` member', () => {
+      const sub = new Subscription();
+      const arg = {
+        isUnsubscribed: false,
+        unsubscribe: undefined as any,
+      };
+      const ret = sub.add(arg as any);
+
+      expect(ret).to.equal(arg);
+    });
+
+    it('Should returns the passed one if the self has been unsubscribed', () => {
+      const main = new Subscription();
+      main.unsubscribe();
+
+      const child = new Subscription();
+      const ret = main.add(child);
+
+      expect(ret).to.equal(child);
+    });
+
+    it('Should unsubscribe the passed one if the self has been unsubscribed', () => {
+      const main = new Subscription();
+      main.unsubscribe();
+
+      let isCalled = false;
+      const child = new Subscription(() => {
+        isCalled = true;
+      });
+      main.add(child);
+
+      expect(isCalled).to.equal(true);
+    });
+  });
 });

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -125,10 +125,12 @@ export class Subscription implements ISubscription {
    * list.
    */
   add(teardown: TeardownLogic): Subscription {
-    if (!teardown || (
-        teardown === this) || (
-        teardown === Subscription.EMPTY)) {
-      return;
+    if (!teardown || (teardown === Subscription.EMPTY)) {
+      return Subscription.EMPTY;
+    }
+
+    if (teardown === this) {
+      return this;
     }
 
     let sub = (<Subscription> teardown);


### PR DESCRIPTION
BREAKING CHANGE:

This fixes ReactiveX#1656.
This makes Subscription.add() returns always subscription.
if you checks the returned value of it. you might need to change it.