### PR TITLE
fix(combineLatest): emit unique arrays from the default projection

### DIFF
--- a/spec/operators/combineLatest-spec.ts
+++ b/spec/operators/combineLatest-spec.ts
@@ -461,4 +461,14 @@ describe('Observable.prototype.combineLatest', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
+
+  it('should emit unique array instances with the default projection', () => {
+    const e1 =   hot('-a--b--|');
+    const e2 =   hot('--1--2-|');
+    const expected = '-------(c|)';
+
+    const result = e1.combineLatest(e2).distinct().count();
+
+    expectObservable(result).toBe(expected, { c: 3 });
+  });
 });

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -150,7 +150,7 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
       if (this.project) {
         this._tryProject(values);
       } else {
-        this.destination.next(values);
+        this.destination.next(values.slice());
       }
     }
   }


### PR DESCRIPTION
**Description:**
Fixes `combineLatest` to emit unique array instances when using the default projection. Without this fix, the default projection emits a shared array (which causes all sorts of problems).

The included test fails against the un-patched `combineLatest` thusly:
```
combineLatest should emit unique array instances with the default projection
(expected c === 3, actual c === 1)
```

**Related issue:**
#1686 