### PR TITLE
refactor(*): rename isUnsubscribed to closed

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -13,7 +13,7 @@ function expectFullObserver(val) {
   expect(val.next).to.be.a('function');
   expect(val.error).to.be.a('function');
   expect(val.complete).to.be.a('function');
-  expect(val.isUnsubscribed).to.be.a('boolean');
+  expect(val.closed).to.be.a('boolean');
 }
 
 /** @test {Observable} */
@@ -260,7 +260,7 @@ describe('Observable', () => {
       }
 
       expect(sub).to.be.a('undefined');
-      expect(subscriber.isUnsubscribed).to.be.true;
+      expect(subscriber.closed).to.be.true;
       expect(unsubscribeCalled).to.be.true;
       expect(messageError).to.be.true;
       expect(messageErrorValue).to.equal('boo!');

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -315,17 +315,17 @@ describe('Subject', () => {
     let outputComplete = false;
 
     const destination = {
-      isUnsubscribed: false,
+      closed: false,
       next: function (x) {
         nexts.push(x);
       },
       error: function (err) {
         error = err;
-        this.isUnsubscribed = true;
+        this.closed = true;
       },
       complete: () => {
         complete = true;
-        this.isUnsubscribed = true;
+        this.closed = true;
       }
     };
 
@@ -361,17 +361,17 @@ describe('Subject', () => {
     let outputComplete = false;
 
     const destination = {
-      isUnsubscribed: false,
+      closed: false,
       next: function (x) {
         nexts.push(x);
       },
       error: function (err) {
         error = err;
-        this.isUnsubscribed = true;
+        this.closed = true;
       },
       complete: () => {
         complete = true;
-        this.isUnsubscribed = true;
+        this.closed = true;
       }
     };
 

--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -55,7 +55,7 @@ describe('Subscription', () => {
         tearDowns.push(2);
         sub.add(<any>({
           unsubscribe: () => {
-            expect(sub.isUnsubscribed).to.be.true;
+            expect(sub.closed).to.be.true;
             throw new Error('Who is your daddy, and what does he do?');
           }
         }));

--- a/spec/observables/ScalarObservable-spec.ts
+++ b/spec/observables/ScalarObservable-spec.ts
@@ -21,7 +21,7 @@ describe('ScalarObservable', () => {
     const s = new ScalarObservable(1, rxTestScheduler);
     const subscriber = new Rx.Subscriber();
     s.subscribe(subscriber);
-    subscriber.isUnsubscribed = true;
+    subscriber.closed = true;
     rxTestScheduler.flush();
   });
 

--- a/spec/operators/skipUntil-spec.ts
+++ b/spec/operators/skipUntil-spec.ts
@@ -224,7 +224,7 @@ describe('Observable.prototype.skipUntil', () => {
     const expected =  '-';
 
     e1.subscribe((x: string) => {
-      if (x === 'd' && !skip.isUnsubscribed) {
+      if (x === 'd' && !skip.closed) {
         skip.next('x');
       }
 

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -128,9 +128,9 @@ describe('Observable.prototype.take', () => {
 
   it('should unsubscribe from the source when it reaches the limit', () => {
     const source = Observable.create(observer => {
-      expect(observer.isUnsubscribed).to.be.false;
+      expect(observer.closed).to.be.false;
       observer.next(42);
-      expect(observer.isUnsubscribed).to.be.true;
+      expect(observer.closed).to.be.true;
     }).take(1);
 
     source.subscribe();

--- a/spec/schedulers/QueueScheduler-spec.ts
+++ b/spec/schedulers/QueueScheduler-spec.ts
@@ -47,7 +47,7 @@ describe('Scheduler.queue', () => {
     } catch (e) {
       errorValue = e;
     }
-    expect(actions.every((action) => action.isUnsubscribed)).to.be.true;
+    expect(actions.every((action) => action.closed)).to.be.true;
     expect(action2Exec).to.be.false;
     expect(action3Exec).to.be.false;
     expect(errorValue).exist;

--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -18,7 +18,7 @@ export class BehaviorSubject<T> extends Subject<T> {
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
     const subscription = super._subscribe(subscriber);
-    if (subscription && !(<ISubscription>subscription).isUnsubscribed) {
+    if (subscription && !(<ISubscription>subscription).closed) {
       subscriber.next(this._value);
     }
     return subscription;
@@ -27,7 +27,7 @@ export class BehaviorSubject<T> extends Subject<T> {
   getValue(): T {
     if (this.hasError) {
       throw this.thrownError;
-    } else if (this.isUnsubscribed) {
+    } else if (this.closed) {
       throw new ObjectUnsubscribedError();
     } else {
       return this._value;

--- a/src/MiscJSDoc.ts
+++ b/src/MiscJSDoc.ts
@@ -74,7 +74,7 @@ export class ObservableDoc {
  *
  * ```ts
  * interface Observer<T> {
- *   isUnsubscribed?: boolean;
+ *   closed?: boolean;
  *   next: (value: T) => void;
  *   error: (err: any) => void;
  *   complete: () => void;
@@ -98,7 +98,7 @@ export class ObserverDoc<T> {
    * subscriber, has already been unsubscribed from its Observable.
    * @type {boolean}
    */
-  isUnsubscribed: boolean = false;
+  closed: boolean = false;
   /**
    * The callback to receive notifications of type `next` from the Observable,
    * with a value. The Observable may call this method 0 or more times.

--- a/src/Observer.ts
+++ b/src/Observer.ts
@@ -1,19 +1,19 @@
 export interface NextObserver<T> {
-  isUnsubscribed?: boolean;
+  closed?: boolean;
   next: (value: T) => void;
   error?: (err: any) => void;
   complete?: () => void;
 }
 
 export interface ErrorObserver<T> {
-  isUnsubscribed?: boolean;
+  closed?: boolean;
   next?: (value: T) => void;
   error: (err: any) => void;
   complete?: () => void;
 }
 
 export interface CompletionObserver<T> {
-  isUnsubscribed?: boolean;
+  closed?: boolean;
   next?: (value: T) => void;
   error?: (err: any) => void;
   complete: () => void;
@@ -22,14 +22,14 @@ export interface CompletionObserver<T> {
 export type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
 export interface Observer<T> {
-  isUnsubscribed?: boolean;
+  closed?: boolean;
   next: (value: T) => void;
   error: (err: any) => void;
   complete: () => void;
 }
 
 export const empty: Observer<any> = {
-  isUnsubscribed: true,
+  closed: true,
   next(value: any): void { /* noop */},
   error(err: any): void { throw err; },
   complete(): void { /*noop*/ }

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -37,7 +37,7 @@ export class ReplaySubject<T> extends Subject<T> {
     }
 
     const len = _events.length;
-    for (let i = 0; i < len && !subscriber.isUnsubscribed; i++) {
+    for (let i = 0; i < len && !subscriber.closed; i++) {
       subscriber.next(_events[i].value);
     }
 

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -27,7 +27,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   observers: Observer<T>[] = [];
 
-  isUnsubscribed = false;
+  closed = false;
 
   isStopped = false;
 
@@ -50,7 +50,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
   }
 
   next(value?: T) {
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       throw new ObjectUnsubscribedError();
     }
     if (!this.isStopped) {
@@ -64,7 +64,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
   }
 
   error(err: any) {
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       throw new ObjectUnsubscribedError();
     }
     this.hasError = true;
@@ -80,7 +80,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
   }
 
   complete() {
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       throw new ObjectUnsubscribedError();
     }
     this.isStopped = true;
@@ -95,12 +95,12 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   unsubscribe() {
     this.isStopped = true;
-    this.isUnsubscribed = true;
+    this.closed = true;
     this.observers = null;
   }
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       throw new ObjectUnsubscribedError();
     } else if (this.hasError) {
       subscriber.error(this.thrownError);

--- a/src/SubjectSubscription.ts
+++ b/src/SubjectSubscription.ts
@@ -8,25 +8,25 @@ import {Subscription} from './Subscription';
  * @extends {Ignored}
  */
 export class SubjectSubscription<T> extends Subscription {
-  isUnsubscribed: boolean = false;
+  closed: boolean = false;
 
   constructor(public subject: Subject<T>, public subscriber: Observer<T>) {
     super();
   }
 
   unsubscribe() {
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       return;
     }
 
-    this.isUnsubscribed = true;
+    this.closed = true;
 
     const subject = this.subject;
     const observers = subject.observers;
 
     this.subject = null;
 
-    if (!observers || observers.length === 0 || subject.isStopped || subject.isUnsubscribed) {
+    if (!observers || observers.length === 0 || subject.isStopped || subject.closed) {
       return;
     }
 

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -124,7 +124,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   }
 
   unsubscribe(): void {
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       return;
     }
     this.isStopped = true;

--- a/src/observable/ArrayLikeObservable.ts
+++ b/src/observable/ArrayLikeObservable.ts
@@ -28,7 +28,7 @@ export class ArrayLikeObservable<T> extends Observable<T> {
   static dispatch(state: any) {
     const { arrayLike, index, length, mapFn, subscriber } = state;
 
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
 
@@ -69,7 +69,7 @@ export class ArrayLikeObservable<T> extends Observable<T> {
         arrayLike, index, length, mapFn, subscriber
       });
     } else {
-      for (let i = 0; i < length && !subscriber.isUnsubscribed; i++) {
+      for (let i = 0; i < length && !subscriber.closed; i++) {
         const result = mapFn ? mapFn(arrayLike[i], i) : arrayLike[i];
         subscriber.next(result);
       }

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -89,7 +89,7 @@ export class ArrayObservable<T> extends Observable<T> {
 
     subscriber.next(array[index]);
 
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
 
@@ -120,7 +120,7 @@ export class ArrayObservable<T> extends Observable<T> {
         array, index, count, subscriber
       });
     } else {
-      for (let i = 0; i < count && !subscriber.isUnsubscribed; i++) {
+      for (let i = 0; i < count && !subscriber.closed; i++) {
         subscriber.next(array[i]);
       }
       subscriber.complete();

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -36,7 +36,7 @@ export class ConnectableObservable<T> extends Observable<T> {
       connection = this._connection = new Subscription();
       connection.add(this.source
         .subscribe(new ConnectableSubscriber(this.getSubject(), this)));
-      if (connection.isUnsubscribed) {
+      if (connection.closed) {
         this._connection = null;
         connection = Subscription.EMPTY;
       } else {
@@ -90,7 +90,7 @@ class RefCountOperator<T> implements Operator<T, T> {
     const refCounter = new RefCountSubscriber(subscriber, connectable);
     const subscription = source._subscribe(refCounter);
 
-    if (!refCounter.isUnsubscribed) {
+    if (!refCounter.closed) {
       (<any> refCounter).connection = connectable.connect();
     }
 

--- a/src/observable/GenerateObservable.ts
+++ b/src/observable/GenerateObservable.ts
@@ -233,7 +233,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
         return;
       }
       subscriber.next(value);
-      if (subscriber.isUnsubscribed) {
+      if (subscriber.closed) {
         break;
       }
       try {
@@ -247,7 +247,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
 
   private static dispatch<T, S>(state: SchedulerState<T, S>): Subscription | void {
     const { subscriber, condition } = state;
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
     if (state.needIterate) {
@@ -272,7 +272,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
         subscriber.complete();
         return;
       }
-      if (subscriber.isUnsubscribed) {
+      if (subscriber.closed) {
         return;
       }
     }
@@ -283,11 +283,11 @@ export class GenerateObservable<T, S> extends Observable<T> {
       subscriber.error(err);
       return;
     }
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
     subscriber.next(value);
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
     return (<Action<SchedulerState<T, S>>><any>this).schedule(state);

--- a/src/observable/IntervalObservable.ts
+++ b/src/observable/IntervalObservable.ts
@@ -53,7 +53,7 @@ export class IntervalObservable extends Observable<number> {
 
     subscriber.next(index);
 
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
 

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -54,7 +54,7 @@ export class IteratorObservable<T> extends Observable<T> {
       state.index = index + 1;
     }
 
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
 
@@ -114,7 +114,7 @@ export class IteratorObservable<T> extends Observable<T> {
         } else {
           subscriber.next(result.value);
         }
-        if (subscriber.isUnsubscribed) {
+        if (subscriber.closed) {
           break;
         }
       } while (true);

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -53,7 +53,7 @@ export class PromiseObservable<T> extends Observable<T> {
 
     if (scheduler == null) {
       if (this._isScalar) {
-        if (!subscriber.isUnsubscribed) {
+        if (!subscriber.closed) {
           subscriber.next(this.value);
           subscriber.complete();
         }
@@ -62,13 +62,13 @@ export class PromiseObservable<T> extends Observable<T> {
           (value) => {
             this.value = value;
             this._isScalar = true;
-            if (!subscriber.isUnsubscribed) {
+            if (!subscriber.closed) {
               subscriber.next(value);
               subscriber.complete();
             }
           },
           (err) => {
-            if (!subscriber.isUnsubscribed) {
+            if (!subscriber.closed) {
               subscriber.error(err);
             }
           }
@@ -80,7 +80,7 @@ export class PromiseObservable<T> extends Observable<T> {
       }
     } else {
       if (this._isScalar) {
-        if (!subscriber.isUnsubscribed) {
+        if (!subscriber.closed) {
           return scheduler.schedule(dispatchNext, 0, { value: this.value, subscriber });
         }
       } else {
@@ -88,12 +88,12 @@ export class PromiseObservable<T> extends Observable<T> {
           (value) => {
             this.value = value;
             this._isScalar = true;
-            if (!subscriber.isUnsubscribed) {
+            if (!subscriber.closed) {
               subscriber.add(scheduler.schedule(dispatchNext, 0, { value, subscriber }));
             }
           },
           (err) => {
-            if (!subscriber.isUnsubscribed) {
+            if (!subscriber.closed) {
               subscriber.add(scheduler.schedule(dispatchError, 0, { err, subscriber }));
             }
           })
@@ -112,7 +112,7 @@ interface DispatchNextArg<T> {
 }
 function dispatchNext<T>(arg: DispatchNextArg<T>) {
   const { value, subscriber } = arg;
-  if (!subscriber.isUnsubscribed) {
+  if (!subscriber.closed) {
     subscriber.next(value);
     subscriber.complete();
   }
@@ -124,7 +124,7 @@ interface DispatchErrorArg<T> {
 }
 function dispatchError<T>(arg: DispatchErrorArg<T>) {
   const { err, subscriber } = arg;
-  if (!subscriber.isUnsubscribed) {
+  if (!subscriber.closed) {
     subscriber.error(err);
   }
 }

--- a/src/observable/RangeObservable.ts
+++ b/src/observable/RangeObservable.ts
@@ -57,7 +57,7 @@ export class RangeObservable extends Observable<number> {
 
     subscriber.next(start);
 
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
 
@@ -97,7 +97,7 @@ export class RangeObservable extends Observable<number> {
           break;
         }
         subscriber.next(start++);
-        if (subscriber.isUnsubscribed) {
+        if (subscriber.closed) {
           break;
         }
       } while (true);

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -22,7 +22,7 @@ export class ScalarObservable<T> extends Observable<T> {
     }
 
     subscriber.next(value);
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     }
 
@@ -49,7 +49,7 @@ export class ScalarObservable<T> extends Observable<T> {
       });
     } else {
       subscriber.next(value);
-      if (!subscriber.isUnsubscribed) {
+      if (!subscriber.closed) {
         subscriber.complete();
       }
     }

--- a/src/observable/TimerObservable.ts
+++ b/src/observable/TimerObservable.ts
@@ -69,7 +69,7 @@ export class TimerObservable extends Observable<number> {
 
     subscriber.next(index);
 
-    if (subscriber.isUnsubscribed) {
+    if (subscriber.closed) {
       return;
     } else if (period === -1) {
       return subscriber.complete();

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -207,7 +207,7 @@ function dispatchBufferTimeSpanOnly(state: any) {
     subscriber.closeContext(prevContext);
   }
 
-  if (!subscriber.isUnsubscribed) {
+  if (!subscriber.closed) {
     state.context = subscriber.openContext();
     state.context.closeAction = (<any>this).schedule(state, state.bufferTimeSpan);
   }
@@ -222,7 +222,7 @@ function dispatchBufferCreation<T>(state: CreationState<T>) {
   const { bufferCreationInterval, bufferTimeSpan, subscriber, scheduler } = state;
   const context = subscriber.openContext();
   const action = <Action<CreationState<T>>>this;
-  if (!subscriber.isUnsubscribed) {
+  if (!subscriber.closed) {
     subscriber.add(context.closeAction = scheduler.schedule<DispatchArg<T>>(dispatchBufferClose, bufferTimeSpan, { subscriber, context }));
     action.schedule(state, bufferCreationInterval);
   }

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -162,7 +162,7 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
 
     const innerSubscription = subscribeToResult(this, closingNotifier, <any>context);
 
-    if (!innerSubscription || innerSubscription.isUnsubscribed) {
+    if (!innerSubscription || innerSubscription.closed) {
       this.closeBuffer(context);
     } else {
       (<any> innerSubscription).context = context;

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -108,7 +108,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
 
     subscription = subscribeToResult(this, duration);
-    if (!subscription.isUnsubscribed) {
+    if (!subscription.closed) {
       this.add(this.durationSubscription = subscription);
     }
   }

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -114,7 +114,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   protected _next(value: any): void {
     const destination = this.destination;
 
-    if (destination.isUnsubscribed) {
+    if (destination.closed) {
       this._complete();
       return;
     }

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -62,7 +62,7 @@ class RepeatSubscriber<T> extends Subscriber<T> {
       }
       this.unsubscribe();
       this.isStopped = false;
-      this.isUnsubscribed = false;
+      this.closed = false;
       source.subscribe(this);
     }
   }

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -59,7 +59,7 @@ class RetrySubscriber<T> extends Subscriber<T> {
       }
       this.unsubscribe();
       this.isStopped = false;
-      this.isUnsubscribed = false;
+      this.closed = false;
       source.subscribe(this);
     }
   }

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -81,7 +81,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
       }
 
       this.unsubscribe();
-      this.isUnsubscribed = false;
+      this.closed = false;
 
       this.errors = errors;
       this.retries = retries;
@@ -115,7 +115,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
     this.unsubscribe();
     this.isStopped = false;
-    this.isUnsubscribed = false;
+    this.closed = false;
 
     this.errors = errors;
     this.retries = retries;

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -111,7 +111,7 @@ class SwitchMapSubscriber<T, I, R> extends OuterSubscriber<T, I> {
 
   protected _complete(): void {
     const {innerSubscription} = this;
-    if (!innerSubscription || innerSubscription.isUnsubscribed) {
+    if (!innerSubscription || innerSubscription.closed) {
       super._complete();
     }
   }

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -99,7 +99,7 @@ class SwitchMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
 
   protected _complete() {
     const {innerSubscription} = this;
-    if (!innerSubscription || innerSubscription.isUnsubscribed) {
+    if (!innerSubscription || innerSubscription.closed) {
       super._complete();
     }
   }

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -104,7 +104,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   handleTimeout(): void {
-    if (!this.isUnsubscribed) {
+    if (!this.closed) {
       const withObservable = this.withObservable;
       this.unsubscribe();
       this.destination.add(this.timeoutSubscription = subscribeToResult(this, withObservable));

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -59,7 +59,7 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
   call(subscriber: Subscriber<Observable<T>>, source: any): any {
     const windowSubscriber = new WindowSubscriber(subscriber);
     const sourceSubscription = source._subscribe(windowSubscriber);
-    if (!sourceSubscription.isUnsubscribed) {
+    if (!sourceSubscription.closed) {
       windowSubscriber.add(subscribeToResult(windowSubscriber, this.windowBoundaries));
     }
     return sourceSubscription;

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -94,14 +94,14 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     const windows = this.windows;
     const len = windows.length;
 
-    for (let i = 0; i < len && !this.isUnsubscribed; i++) {
+    for (let i = 0; i < len && !this.closed; i++) {
       windows[i].next(value);
     }
     const c = this.count - windowSize + 1;
-    if (c >= 0 && c % startWindowEvery === 0 && !this.isUnsubscribed) {
+    if (c >= 0 && c % startWindowEvery === 0 && !this.closed) {
       windows.shift().complete();
     }
-    if (++this.count % startWindowEvery === 0 && !this.isUnsubscribed) {
+    if (++this.count % startWindowEvery === 0 && !this.closed) {
       const window = new Subject<T>();
       windows.push(window);
       destination.next(window);
@@ -111,7 +111,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
   protected _error(err: any) {
     const windows = this.windows;
     if (windows) {
-      while (windows.length > 0 && !this.isUnsubscribed) {
+      while (windows.length > 0 && !this.closed) {
         windows.shift().error(err);
       }
     }
@@ -121,7 +121,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
   protected _complete() {
     const windows = this.windows;
     if (windows) {
-      while (windows.length > 0 && !this.isUnsubscribed) {
+      while (windows.length > 0 && !this.closed) {
         windows.shift().complete();
       }
     }

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -118,7 +118,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     const len = windows.length;
     for (let i = 0; i < len; i++) {
       const window = windows[i];
-      if (!window.isUnsubscribed) {
+      if (!window.closed) {
         window.next(value);
       }
     }
@@ -136,7 +136,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     const windows = this.windows;
     while (windows.length > 0) {
       const window = windows.shift();
-      if (!window.isUnsubscribed) {
+      if (!window.closed) {
         window.complete();
       }
     }

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -171,7 +171,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
         this.contexts.push(context);
         const innerSubscription = subscribeToResult(this, closingNotifier, context);
 
-        if (innerSubscription.isUnsubscribed) {
+        if (innerSubscription.closed) {
           this.closeWindow(this.contexts.length - 1);
         } else {
           (<any> innerSubscription).context = context;

--- a/src/scheduler/AsyncAction.ts
+++ b/src/scheduler/AsyncAction.ts
@@ -22,7 +22,7 @@ export class AsyncAction<T> extends Action<T> {
 
   public schedule(state?: T, delay: number = 0): Subscription {
 
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       return this;
      }
 
@@ -88,7 +88,7 @@ export class AsyncAction<T> extends Action<T> {
    */
   public execute(state: T, delay: number): any {
 
-    if (this.isUnsubscribed) {
+    if (this.closed) {
       return new Error('executing a cancelled action');
     }
 

--- a/src/scheduler/QueueAction.ts
+++ b/src/scheduler/QueueAction.ts
@@ -25,7 +25,7 @@ export class QueueAction<T> extends AsyncAction<T> {
   }
 
   public execute(state: T, delay: number): any {
-    return (delay > 0 || this.isUnsubscribed) ?
+    return (delay > 0 || this.closed) ?
       super.execute(state, delay) :
       this._execute(state, delay) ;
   }

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -19,7 +19,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
                                      outerIndex?: number): Subscription {
   let destination: Subscriber<any> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex);
 
-  if (destination.isUnsubscribed) {
+  if (destination.closed) {
     return null;
   }
 
@@ -34,16 +34,16 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
   }
 
   if (isArray(result)) {
-    for (let i = 0, len = result.length; i < len && !destination.isUnsubscribed; i++) {
+    for (let i = 0, len = result.length; i < len && !destination.closed; i++) {
       destination.next(result[i]);
     }
-    if (!destination.isUnsubscribed) {
+    if (!destination.closed) {
       destination.complete();
     }
   } else if (isPromise(result)) {
     result.then(
       (value) => {
-        if (!destination.isUnsubscribed) {
+        if (!destination.closed) {
           destination.next(<any>value);
           destination.complete();
         }
@@ -58,11 +58,11 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
   } else if (typeof result[$$iterator] === 'function') {
     for (let item of <any>result) {
       destination.next(<any>item);
-      if (destination.isUnsubscribed) {
+      if (destination.closed) {
         break;
       }
     }
-    if (!destination.isUnsubscribed) {
+    if (!destination.closed) {
       destination.complete();
     }
   } else if (typeof result[$$observable] === 'function') {


### PR DESCRIPTION
As per discussions in https://github.com/ReactiveX/rxjs/issues/1798

Renames every instance of `isUnsubscribed` to `closed` to correctly implement the observable spec (see this issue for context: https://github.com/zenparsing/es-observable/issues/90).

The original commit for this PR represents the most basic implementation of the discussions in https://github.com/ReactiveX/rxjs/issues/1798. This is a breaking change, however since RxJS 5 is still in beta maybe that won’t matter? If you’d like me to add backward compatibility for `isUnsubscribed`, let me know.