### PR TITLE
style(scan): updated signatures for scan and reduce

### DIFF
--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -1,5 +1,5 @@
 import * as Rx from '../../dist/cjs/Rx';
-declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions};
+declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions, type};
 
 const Observable = Rx.Observable;
 
@@ -230,5 +230,34 @@ describe('Observable.prototype.reduce', () => {
 
     expectObservable(e1.reduce(reduceFunction)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should accept array typed reducers', () => {
+    type(() => {
+      let a: Rx.Observable<{ a: number; b: string }>;
+      a.reduce((acc, value) => acc.concat(value), []);
+    });
+  });
+
+  it('should accept T typed reducers', () => {
+    type(() => {
+      let a: Rx.Observable<{ a?: number; b?: string }>;
+      a.reduce((acc, value) => {
+        value.a = acc.a;
+        value.b = acc.b;
+        return acc;
+      }, {});
+    });
+  });
+
+  it('should accept R typed reducers', () => {
+    type(() => {
+      let a: Rx.Observable<{ a: number; b: string }>;
+      a.reduce<{ a?: number; b?: string }>((acc, value) => {
+        value.a = acc.a;
+        value.b = acc.b;
+        return acc;
+      }, {});
+    });
   });
 });

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -1,6 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
-declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions};
+declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions, type};
 
 const Observable = Rx.Observable;
 
@@ -200,5 +200,34 @@ describe('Observable.prototype.scan', () => {
 
     expectObservable(scan).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should accept array typed reducers', () => {
+    type(() => {
+      let a: Rx.Observable<{ a: number; b: string }>;
+      a.reduce((acc, value) => acc.concat(value), []);
+    });
+  });
+
+  it('should accept T typed reducers', () => {
+    type(() => {
+      let a: Rx.Observable<{ a?: number; b?: string }>;
+      a.reduce((acc, value) => {
+        value.a = acc.a;
+        value.b = acc.b;
+        return acc;
+      }, {});
+    });
+  });
+
+  it('should accept R typed reducers', () => {
+    type(() => {
+      let a: Rx.Observable<{ a: number; b: string }>;
+      a.reduce<{ a?: number; b?: string }>((acc, value) => {
+        value.a = acc.a;
+        value.b = acc.b;
+        return acc;
+      }, {});
+    });
   });
 });

--- a/src/add/operator/scan.ts
+++ b/src/add/operator/scan.ts
@@ -1,11 +1,12 @@
 
 import {Observable} from '../../Observable';
-import {scan, ScanSignature} from '../../operator/scan';
+import {ReduceSignature} from '../../operator/reduce';
+import {scan} from '../../operator/scan';
 
 Observable.prototype.scan = scan;
 
 declare module '../../Observable' {
   interface Observable<T> {
-    scan: ScanSignature<T>;
+    scan: ReduceSignature<T>;
   }
 }

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -52,7 +52,9 @@ export function reduce<T, R>(accumulator: (acc: R, value: T) => R, seed?: R): Ob
 }
 
 export interface ReduceSignature<T> {
-  <R>(accumulator: (acc: R, value: T) => R, seed?: R): Observable<R>;
+  (accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
+  (accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): Observable<T[]>;
+  <R>(accumulator: (acc: R, value: T, index: number) => R, seed?: R): Observable<R>;
 }
 
 export class ReduceOperator<T, R> implements Operator<T, R> {

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -43,10 +43,6 @@ export function scan<T, R>(accumulator: (acc: R, value: T, index: number) => R, 
   return this.lift(new ScanOperator(accumulator, seed));
 }
 
-export interface ScanSignature<T> {
-  <R>(accumulator: (acc: R, value: T, index: number) => R, seed?: T | R): Observable<R>;
-}
-
 class ScanOperator<T, R> implements Operator<T, R> {
   constructor(private accumulator: (acc: R, value: T, index: number) => R, private seed?: T | R) {
   }
@@ -75,7 +71,7 @@ class ScanSubscriber<T, R> extends Subscriber<T> {
     this._seed = value;
   }
 
-  constructor(destination: Subscriber<R>, private accumulator: (acc: R, value: T, index: number) => R, seed?: T|R) {
+  constructor(destination: Subscriber<R>, private accumulator: (acc: R, value: T, index: number) => R, seed?: T | R) {
     super(destination);
     this.seed = seed;
     this.accumulatorSet = typeof seed !== 'undefined';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This change makes working with scan/reduce a little easier in TypeScript based applications.

**Related issue (if exists):**
None that I'm aware of.

This change makes working with scan and reduce a little easier without having to cast the types.