### PR TITLE
feat(fromEvent): Throw if event target is invalid

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -115,6 +115,17 @@ describe('Observable.fromEvent', () => {
     expect(offHandler).to.equal(onHandler);
   });
 
+  it('should error on invalid event targets', () => {
+    const obj = {
+      addListener: () => {
+        //noop
+      }
+    };
+
+    const subscribe = () => Observable.fromEvent(<any>obj, 'click').subscribe();
+    expect(subscribe).to.throw(TypeError, 'Invalid event target');
+  });
+
   it('should pass through options to addEventListener', () => {
     let actualOptions;
     const expectedOptions = { capture: true, passive: true };

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -133,6 +133,8 @@ export class FromEventObservable<T, R> extends Observable<T> {
       const source = sourceObj;
       sourceObj.addListener(eventName, handler);
       unsubscribe = () => source.removeListener(eventName, handler);
+    } else {
+      throw new TypeError('Invalid event target');
     }
 
     subscriber.add(new Subscription(unsubscribe));


### PR DESCRIPTION
**Description:**

Throw instead of failing silently if the event target doesn't implement one of the supported protocols.

**Related issue (if exists):**
#1834
