### PR TITLE
Updated introduction examples to use throttleTime in place of throttle

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -73,7 +73,7 @@ With RxJS:
 ```js
 var button = document.querySelector('button');
 Rx.Observable.fromEvent(button, 'click')
-  .throttle(1000)
+  .throttleTime(1000)
   .scan(count => count + 1, 0)
   .subscribe(count => console.log(`Clicked ${count} times`));
 ```
@@ -101,7 +101,7 @@ With RxJS:
 ```js
 var button = document.querySelector('button');
 Rx.Observable.fromEvent(button, 'click')
-  .throttle(1000)
+  .throttleTime(1000)
   .map(event => event.clientX)
   .scan((count, clientX) => count + clientX, 0)
   .subscribe(count => console.log(count));


### PR DESCRIPTION
**Description:**
While going through the introduction I found that the examples that used throttle threw an error due to it showing the previous usage of taking an integer to describe the interval length in milliseconds. It currently takes a function that returns an Observable, so I updated the document.