### PR TITLE
fix(ajaxObservable): remove implicit dependency to map operator patch

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -440,39 +440,66 @@ describe('Observable.ajax', () => {
       expect(complete).to.be.true;
     });
 
-    describe('ajax.post', () => {
-      it('should succeed on 200', () => {
-        const expected = { foo: 'bar', hi: 'there you' };
-        let result: Rx.AjaxResponse;
-        let complete = false;
+    it('should able to select json response via getJSON', () => {
+      const expected = { foo: 'bar' };
+      let result;
+      let complete = false;
 
-        Rx.Observable
-          .ajax.post('/flibbertyJibbet', expected)
-          .subscribe(x => {
-            result = x;
-          }, null, () => {
-            complete = true;
-          });
-
-        const request = MockXMLHttpRequest.mostRecent;
-
-        expect(request.method).to.equal('POST');
-        expect(request.url).to.equal('/flibbertyJibbet');
-        expect(request.requestHeaders).to.deep.equal({
-          'X-Requested-With': 'XMLHttpRequest',
-          'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      Rx.Observable
+        .ajax.getJSON('/flibbertyJibbet')
+        .subscribe(x => {
+          result = x;
+        }, null, () => {
+          complete = true;
         });
 
-        request.respondWith({
-          'status': 200,
-          'contentType': 'application/json',
-          'responseText': JSON.stringify(expected)
-        });
+      const request = MockXMLHttpRequest.mostRecent;
 
-        expect(request.data).to.equal('foo=bar&hi=there%20you');
-        expect(result.response).to.deep.equal(expected);
-        expect(complete).to.be.true;
+      expect(request.url).to.equal('/flibbertyJibbet');
+
+      request.respondWith({
+        'status': 200,
+        'contentType': 'application/json',
+        'responseText': JSON.stringify(expected)
       });
+
+      expect(result).to.deep.equal(expected);
+      expect(complete).to.be.true;
+    });
+  });
+
+  describe('ajax.post', () => {
+    it('should succeed on 200', () => {
+      const expected = { foo: 'bar', hi: 'there you' };
+      let result: Rx.AjaxResponse;
+      let complete = false;
+
+      Rx.Observable
+        .ajax.post('/flibbertyJibbet', expected)
+        .subscribe(x => {
+          result = x;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('/flibbertyJibbet');
+      expect(request.requestHeaders).to.deep.equal({
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      });
+
+      request.respondWith({
+        'status': 200,
+        'contentType': 'application/json',
+        'responseText': JSON.stringify(expected)
+      });
+
+      expect(request.data).to.equal('foo=bar&hi=there%20you');
+      expect(result.response).to.deep.equal(expected);
+      expect(complete).to.be.true;
     });
   });
 });

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -4,6 +4,7 @@ import {errorObject} from '../../util/errorObject';
 import {Observable} from '../../Observable';
 import {Subscriber} from '../../Subscriber';
 import {TeardownLogic} from '../../Subscription';
+import {MapOperator} from '../../operator/map';
 
 export interface AjaxRequest {
   url?: string;
@@ -66,7 +67,7 @@ export interface AjaxCreationMethod {
   post(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
   put(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
   delete(url: string, headers?: Object): Observable<AjaxResponse>;
-  getJSON<T, R>(url: string, resultSelector?: (data: T) => R, headers?: Object): Observable<R>;
+  getJSON<T, R>(url: string, headers?: Object): Observable<R>;
 }
 
 export function ajaxGet(url: string, headers: Object = null) {
@@ -86,7 +87,8 @@ export function ajaxPut(url: string, body?: any, headers?: Object): Observable<A
 };
 
 export function ajaxGetJSON<T>(url: string, headers?: Object): Observable<T> {
-  return new AjaxObservable<AjaxResponse>({ method: 'GET', url, responseType: 'json', headers }).map(x => x.response);
+  return new AjaxObservable<AjaxResponse>({ method: 'GET', url, responseType: 'json', headers })
+    .lift<T>(new MapOperator<AjaxResponse, T>((x: AjaxResponse, index: number): T => x.response, null));
 };
 
 /**

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -46,7 +46,7 @@ export interface MapSignature<T> {
   <R>(project: (value: T, index: number) => R, thisArg?: any): Observable<R>;
 }
 
-class MapOperator<T, R> implements Operator<T, R> {
+export class MapOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => R, private thisArg: any) {
   }
 


### PR DESCRIPTION
**Description:**
This PR updates behavior of `ajax.getJSON`, internally relies on observable to have `map` operator patched to select response, which causes failure if consumer imports observable without operator patched. Instead, explicitly imports map operator.

**Related issue (if exists):**

closes #1874