### PR TITLE
fix(catch): removed unneeded overload for catch

### DIFF
--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -22,7 +22,6 @@ export function _catch<T, R>(selector: (err: any, caught: Observable<T>) => Obse
 }
 
 export interface CatchSignature<T> {
-  (selector: (err: any, caught: Observable<T>) => ObservableInput<T>): Observable<T>;
   <R>(selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<R>;
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This is a really strange issue that I've been fighting with today.   When returning an `Observable<T>` to `mergeMap` I was having the resulting value come out as `Observable<any>` and I couldn't figure out why.  If I returned a `Promise<T>` or returned `T[]` everything was working correctly.

I used `git bisect` to determine that the issue originated with [`e55c62df9`](https://github.com/ReactiveX/rxjs/commit/e55c62df92228c0e71dbea587d6d68c28988829b).  After playing with the commit a little bit I able to reduce the problem down to.

What the full problem comes down to is using `TypeScript 2.0+` and `rxjs beta11`.  With TS1.8 this is not a problem.  The test added in this case only fails in TypeScript 2.0.

```ts
export interface CatchSignature<T> {
  (selector: (err: any, caught: Observable<T>) => ObservableInput<T>): Observable<T>;
  <R>(selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<R>;
}
```

Changing it to the following, solved the problem.

```ts
export interface CatchSignature<T> {
  <R>(selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<R>;
  (selector: (err: any, caught: Observable<T>) => ObservableInput<T>): Observable<T>;
}
```

This is a huge issue for anyone that's currently using TS2.0 with the current RxJS code base, it caused a bunch of my code to suddenly break for no reason.  Would be great if we could another release for this one. :smiling_imp: 