### PR TITLE
fix(VirtualTimeScheduler): remove default maxFrame limit

### DIFF
--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -10,7 +10,7 @@ export class VirtualTimeScheduler extends AsyncScheduler {
   public index: number = -1;
 
   constructor(SchedulerAction: typeof AsyncAction = VirtualAction,
-              public maxFrames: number = 750) {
+              public maxFrames: number = Number.POSITIVE_INFINITY) {
     super(SchedulerAction, () => this.frame);
   }
 

--- a/src/testing/TestScheduler.ts
+++ b/src/testing/TestScheduler.ts
@@ -6,7 +6,9 @@ import {HotObservable} from './HotObservable';
 import {TestMessage} from './TestMessage';
 import {SubscriptionLog} from './SubscriptionLog';
 import {Subscription} from '../Subscription';
-import {VirtualTimeScheduler} from '../scheduler/VirtualTimeScheduler';
+import {VirtualTimeScheduler, VirtualAction} from '../scheduler/VirtualTimeScheduler';
+
+const defaultMaxFrame: number = 750;
 
 interface FlushableTest {
   ready: boolean;
@@ -23,7 +25,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   private flushTests: FlushableTest[] = [];
 
   constructor(public assertDeepEqual: (actual: any, expected: any) => boolean | void) {
-    super();
+    super(VirtualAction, defaultMaxFrame);
   }
 
   createTime(marbles: string): number {


### PR DESCRIPTION
**Description:**

This PR amends ctor of `virtualTimeScheduler` to not to have default maxframe values (== positive infinity) let `testScheduler` specifies it. Anyone create instance of `virtualTimeScheduler` may set maxframe value if needed.

**Related issue (if exists):**

closes #1889