### PR TITLE
fix(Subject): do not expose static create method to inherited

### DIFF
--- a/spec/subjects/AsyncSubject-spec.ts
+++ b/spec/subjects/AsyncSubject-spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
+import {SubjectBase} from '../../dist/cjs/Subject';
 
 const AsyncSubject = Rx.AsyncSubject;
 
@@ -21,6 +22,11 @@ class TestObserver implements Rx.Observer<number> {
 
 /** @test {AsyncSubject} */
 describe('AsyncSubject', () => {
+  it('should extend SubjectBase', () => {
+    const subject = new AsyncSubject();
+    expect(subject).to.instanceOf(SubjectBase);
+  });
+
   it('should emit the last value when complete', () => {
     const subject = new AsyncSubject();
     const observer = new TestObserver();

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
+import {SubjectBase} from '../../dist/cjs/Subject';
 declare const {hot, expectObservable};
 
 const BehaviorSubject = Rx.BehaviorSubject;
@@ -8,10 +9,9 @@ const ObjectUnsubscribedError = Rx.ObjectUnsubscribedError;
 
 /** @test {BehaviorSubject} */
 describe('BehaviorSubject', () => {
-  it('should extend Subject', (done: MochaDone) => {
+  it('should extend SubjectBase', () => {
     const subject = new BehaviorSubject(null);
-    expect(subject instanceof Rx.Subject).to.be.true;
-    done();
+    expect(subject).to.instanceOf(SubjectBase);
   });
 
   it('should throw if it has received an error and getValue() is called', () => {

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -1,6 +1,7 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import {TestScheduler} from '../../dist/cjs/testing/TestScheduler';
+import {SubjectBase} from '../../dist/cjs/Subject';
 declare const {hot, expectObservable};
 
 declare const rxTestScheduler: TestScheduler;
@@ -10,10 +11,9 @@ const Observable = Rx.Observable;
 
 /** @test {ReplaySubject} */
 describe('ReplaySubject', () => {
-  it('should extend Subject', (done: MochaDone) => {
+  it('should extend SubjectBase', () => {
     const subject = new ReplaySubject();
-    expect(subject instanceof Rx.Subject).to.be.true;
-    done();
+    expect(subject).to.instanceOf(SubjectBase);
   });
 
   it('should replay values upon subscription', (done: MochaDone) => {

--- a/src/AsyncSubject.ts
+++ b/src/AsyncSubject.ts
@@ -1,11 +1,11 @@
-import {Subject} from './Subject';
+import {SubjectBase} from './Subject';
 import {Subscriber} from './Subscriber';
 import {Subscription} from './Subscription';
 
 /**
  * @class AsyncSubject<T>
  */
-export class AsyncSubject<T> extends Subject<T> {
+export class AsyncSubject<T> extends SubjectBase<T> {
   private value: T = null;
   private hasNext: boolean = false;
   private hasCompleted: boolean = false;

--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -1,4 +1,4 @@
-import {Subject} from './Subject';
+import {SubjectBase} from './Subject';
 import {Subscriber} from './Subscriber';
 import {Subscription, ISubscription} from './Subscription';
 import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
@@ -6,7 +6,7 @@ import {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
 /**
  * @class BehaviorSubject<T>
  */
-export class BehaviorSubject<T> extends Subject<T> {
+export class BehaviorSubject<T> extends SubjectBase<T> {
 
   constructor(private _value: T) {
     super();

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -1,4 +1,4 @@
-import {Subject} from './Subject';
+import {SubjectBase} from './Subject';
 import {Scheduler} from './Scheduler';
 import {queue} from './scheduler/queue';
 import {Subscriber} from './Subscriber';
@@ -8,7 +8,7 @@ import {ObserveOnSubscriber} from './operator/observeOn';
 /**
  * @class ReplaySubject<T>
  */
-export class ReplaySubject<T> extends Subject<T> {
+export class ReplaySubject<T> extends SubjectBase<T> {
   private _events: ReplayEvent<T>[] = [];
   private _bufferSize: number;
   private _windowTime: number;


### PR DESCRIPTION
**Description:**
This PR aligns interface of classes inherited from `Subject<T>`, do not expose static creation method by introducing abstract class `SubjectBase<T>`.

**Related issue (if exists):**

closes #1890