### PR TITLE
fix(WebSocketSubject): pass constructor errors onto observable

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -374,6 +374,23 @@ describe('Observable.webSocket', () => {
 
       subject.unsubscribe();
     });
+
+    it('should handle constructor errors', () => {
+      const subject = Observable.webSocket(<any>{
+        url: 'bad_url',
+        WebSocketCtor: (url: string, protocol?: string | string[]): WebSocket => {
+          throw new Error(`connection refused`);
+        }
+      });
+
+      subject.subscribe((x: any) => {
+        expect(x).to.equal('this should not happen');
+      }, (err: any) => {
+        expect(err).to.be.an('error', 'connection refused');
+      });
+
+      subject.unsubscribe();
+    });
   });
 
   describe('multiplex', () => {

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -114,18 +114,25 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
 
   private _connectSocket() {
     const { WebSocketCtor } = this;
-    const socket = this.protocol ?
-      new WebSocketCtor(this.url, this.protocol) :
-      new WebSocketCtor(this.url);
-    this.socket = socket;
+    const observer = this._output;
+
+    let socket: WebSocket = null;
+    try {
+      socket = this.protocol ?
+        new WebSocketCtor(this.url, this.protocol) :
+        new WebSocketCtor(this.url);
+      this.socket = socket;
+    } catch (e) {
+      observer.error(e);
+      return;
+    }
+
     const subscription = new Subscription(() => {
       this.socket = null;
       if (socket && socket.readyState === 1) {
         socket.close();
       }
     });
-
-    const observer = this._output;
 
     socket.onopen = (e: Event) => {
       const openObserver = this.openObserver;


### PR DESCRIPTION
**Description:**

Passes websocket constructor error onto the returned observable.

**Related issue (if exists):**

#1891