### PR TITLE
feature(WebSocketSubject) unsubMsg undefined

### DIFF
--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -104,7 +104,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
         const result = tryCatch(unsubMsg)();
         if (result === errorObject) {
           observer.error(errorObject.e);
-        } else {
+        } else if (result !== undefined) {
           self.next(result);
         }
         subscription.unsubscribe();


### PR DESCRIPTION
**Description:**

When reconnecting a WebSocket, it's sometimes the case that a bunch of unsubscription messages are queued up before the socket was closed. Right now, they'll be unconditionally sent when the socket is reconnected. It's useful to be able to prevent sending them if they're undefined (which will just be serialized as the json string "undefined" anyway, unlikely to be what was expected)

If this makes sense, I'll add some tests