### PR TITLE
Return null value from JSON.Parse

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import * as sinon from 'sinon';
 import * as Rx from '../../../dist/cjs/Rx';
 import {root} from '../../../dist/cjs/util/root';
-import {MockXMLHttpRequest} from '../../helpers/ajax-helper';
+import {MockXMLHttpRequest, MockXMLHttpRequestInternetExplorer} from '../../helpers/ajax-helper';
 
 declare const global: any;
 
@@ -440,6 +440,33 @@ describe('Observable.ajax', () => {
       expect(complete).to.be.true;
     });
 
+    it('should succeed on 204 No Content', () => {
+      const expected = null;
+      let result;
+      let complete = false;
+
+      Rx.Observable
+        .ajax.get('/flibbertyJibbet')
+        .subscribe(x => {
+          result = x.response;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.url).to.equal('/flibbertyJibbet');
+
+      request.respondWith({
+        'status': 204,
+        'contentType': 'application/json',
+        'responseText': expected
+      });
+
+      expect(result).to.deep.equal(expected);
+      expect(complete).to.be.true;
+    });
+
     it('should able to select json response via getJSON', () => {
       const expected = { foo: 'bar' };
       let result;
@@ -469,6 +496,7 @@ describe('Observable.ajax', () => {
   });
 
   describe('ajax.post', () => {
+
     it('should succeed on 200', () => {
       const expected = { foo: 'bar', hi: 'there you' };
       let result: Rx.AjaxResponse;
@@ -501,5 +529,73 @@ describe('Observable.ajax', () => {
       expect(result.response).to.deep.equal(expected);
       expect(complete).to.be.true;
     });
+
+    it('should succeed on 204 No Content', () => {
+      const expected = null;
+      let result: Rx.AjaxResponse;
+      let complete = false;
+
+      Rx.Observable
+        .ajax.post('/flibbertyJibbet', expected)
+        .subscribe(x => {
+          result = x;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('/flibbertyJibbet');
+      expect(request.requestHeaders).to.deep.equal({
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      });
+
+      request.respondWith({
+        'status': 204,
+        'contentType': 'application/json',
+        'responseType': 'json',
+        'responseText': expected
+      });
+
+      expect(result.response).to.equal(expected);
+      expect(complete).to.be.true;
+    });
+
+    it('should succeed in IE on 204 No Content', () => {
+      const expected = null;
+      let result: Rx.AjaxResponse;
+      let complete = false;
+
+      root.XMLHttpRequest = MockXMLHttpRequestInternetExplorer;
+
+      Rx.Observable
+        .ajax.post('/flibbertyJibbet', expected)
+        .subscribe(x => {
+          result = x;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('/flibbertyJibbet');
+      expect(request.requestHeaders).to.deep.equal({
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      });
+
+      //IE behavior: IE does not provide the a responseText property, so also exercise the code which handles this.
+      request.respondWith({
+          'status': 204,
+          'contentType': 'application/json'
+      });
+
+      expect(result.response).to.equal(expected);
+      expect(complete).to.be.true;
+    });
+
   });
 });

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -396,9 +396,9 @@ export class AjaxResponse {
       case 'json':
         if ('response' in xhr) {
           //IE does not support json as responseType, parse it internally
-          this.response = xhr.responseType ? xhr.response : JSON.parse(xhr.response || xhr.responseText || '');
+          this.response = xhr.responseType ? xhr.response : JSON.parse(xhr.response || xhr.responseText || 'null');
         } else {
-          this.response = JSON.parse(xhr.responseText || '');
+          this.response = JSON.parse(xhr.responseText || 'null');
         }
         break;
       case 'xml':


### PR DESCRIPTION
JSON.parse('') will throw a syntax error (in any browser). Fix is to return a null value. I saw this when my server returned HTTP 204 No Content.