### PR TITLE
added ajax tests for 204 No Content

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -440,6 +440,33 @@ describe('Observable.ajax', () => {
       expect(complete).to.be.true;
     });
 
+    it('should succeed on 204 No Content', () => {
+      const expected = null;
+      let result;
+      let complete = false;
+
+      Rx.Observable
+        .ajax.get('/flibbertyJibbet')
+        .subscribe(x => {
+          result = x.response;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.url).to.equal('/flibbertyJibbet');
+
+      request.respondWith({
+        'status': 204,
+        'contentType': 'application/json',
+        'responseText': expected
+      });
+
+      expect(result).to.deep.equal(expected);
+      expect(complete).to.be.true;
+    });
+
     it('should able to select json response via getJSON', () => {
       const expected = { foo: 'bar' };
       let result;
@@ -469,6 +496,7 @@ describe('Observable.ajax', () => {
   });
 
   describe('ajax.post', () => {
+
     it('should succeed on 200', () => {
       const expected = { foo: 'bar', hi: 'there you' };
       let result: Rx.AjaxResponse;
@@ -501,5 +529,38 @@ describe('Observable.ajax', () => {
       expect(result.response).to.deep.equal(expected);
       expect(complete).to.be.true;
     });
+
+    it('should succeed on 204 No Content', () => {
+      const expected = null;
+      let result: Rx.AjaxResponse;
+      let complete = false;
+
+      Rx.Observable
+        .ajax.post('/flibbertyJibbet', expected)
+        .subscribe(x => {
+          result = x;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('/flibbertyJibbet');
+      expect(request.requestHeaders).to.deep.equal({
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      });
+
+      request.respondWith({
+        'status': 204,
+        'contentType': 'application/json',
+        'responseText': expected
+      });
+
+      expect(result.response).to.deep.equal(expected);
+      expect(complete).to.be.true;
+    });
+
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**

