### PR TITLE
feat(operator): Add repeatWhen operator

### DIFF
--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -286,7 +286,12 @@ children:
       children:
       - label: I want to re-subscribe
         children:
-        - label: repeat
+          - label: immediately
+            children:
+            - label: repeat
+          - label: when another Observable emits
+            children:
+            - label: repeatWhen
       - label: I want to start a new Observable
         children:
         - label: concat

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -125,6 +125,7 @@ There are operators for different purposes, and they may be categorized as: crea
 - [`never`](../class/es6/Observable.js~Observable.html#static-method-never)
 - [`of`](../class/es6/Observable.js~Observable.html#static-method-of)
 - `repeat`
+- `repeatWhen`
 - [`range`](../class/es6/Observable.js~Observable.html#static-method-range)
 - [`throw`](../class/es6/Observable.js~Observable.html#static-method-throw)
 - [`timer`](../class/es6/Observable.js~Observable.html#static-method-timer)

--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -1,0 +1,323 @@
+import {expect} from 'chai';
+import * as Rx from '../../dist/cjs/Rx';
+declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions};
+
+const Observable = Rx.Observable;
+
+/** @test {repeatWhen} */
+describe('Observable.prototype.repeatWhen', () => {
+  asDiagram('repeatWhen')('should handle a source with eventual complete using a hot notifier', () => {
+    const source =  cold('-1--2--|');
+    const subs =        ['^      !                     ',
+                       '             ^      !        ',
+                       '                          ^ !'];
+    const notifier = hot('-------------r------------r-|');
+    const expected =     '-1--2---------1--2---------1|';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should handle a source with eventual complete using a hot notifier that raises error', () => {
+    const source = cold( '-1--2--|');
+    const subs =        ['^      !                    ',
+                       '           ^      !           ',
+                       '                   ^      !   '];
+    const notifier = hot('-----------r-------r---------#');
+    const expected =     '-1--2-------1--2----1--2-----#';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should retry when notified via returned notifier on complete', (done: MochaDone) => {
+    let retried = false;
+    const expected = [1, 2, 1, 2];
+    let i = 0;
+    Observable.of(1, 2)
+      .map((n: number) => {
+        return n;
+      })
+      .repeatWhen((notifications: any) => notifications.map((x: any) => {
+          if (retried) {
+            throw new Error('done');
+          }
+          retried = true;
+          return x;
+      }))
+      .subscribe((x: any) => {
+        expect(x).to.equal(expected[i++]);
+      },
+      (err: any) => {
+        expect(err).to.be.an('error', 'done');
+        done();
+      });
+  });
+
+  it('should retry when notified and complete on returned completion', (done: MochaDone) => {
+    const expected = [1, 2, 1, 2];
+    Observable.of(1, 2)
+      .map((n: number) => {
+        return n;
+      })
+      .repeatWhen((notifications: any) => Observable.empty())
+      .subscribe((n: number) => {
+        expect(n).to.equal(expected.shift());
+      }, (err: any) => {
+        done(new Error('should not be called'));
+      }, () => {
+        done();
+      });
+  });
+
+  it('should apply an empty notifier on an empty source', () => {
+    const source = cold(  '|');
+    const subs =          '(^!)';
+    const notifier = cold('|');
+    const expected =      '|';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should apply a never notifier on an empty source', () => {
+    const source = cold(  '|');
+    const subs =          '(^!)';
+    const notifier = cold('-');
+    const expected =      '-';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should apply an empty notifier on a never source', () => {
+    const source = cold(  '-');
+    const unsub =         '                                         !';
+    const subs =          '^                                        !';
+    const notifier = cold('|');
+    const expected =      '-';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should apply a never notifier on a never source', () => {
+    const source = cold(  '-');
+    const unsub =         '                                         !';
+    const subs =          '^                                        !';
+    const notifier = cold('-');
+    const expected =      '-';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should return an empty observable given a just-throw source and empty notifier', () => {
+    const source = cold(  '#');
+    const notifier = cold('|');
+    const expected =      '#';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+  });
+
+  it('should return a error observable given a just-throw source and never notifier', () => {
+    const source = cold(  '#');
+    const notifier = cold('-');
+    const expected =      '#';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+  });
+
+  xit('should hide errors using a never notifier on a source with eventual error', () => {
+    const source = cold(  '--a--b--c--#');
+    const subs =          '^          !';
+    const notifier = cold(           '-');
+    const expected =      '--a--b--c---------------------------------';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  xit('should propagate error thrown from notifierSelector function', () => {
+    const source = cold('--a--b--c--|');
+    const subs =        '^          !';
+    const expected =    '--a--b--c--#';
+
+    const result = source.repeatWhen(<any>(() => { throw 'bad!'; }));
+
+    expectObservable(result).toBe(expected, undefined, 'bad!');
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  xit('should replace error with complete using an empty notifier on a source ' +
+  'with eventual error', () => {
+    const source = cold(  '--a--b--c--#');
+    const subs =          '^          !';
+    const notifier = cold(           '|');
+    const expected =      '--a--b--c--|';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should mirror a basic cold source with complete, given a never notifier', () => {
+    const source = cold(  '--a--b--c--|');
+    const subs =          '^          !';
+    const notifier = cold(           '|');
+    const expected =      '--a--b--c--|';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should mirror a basic cold source with no termination, given a never notifier', () => {
+    const source = cold(  '--a--b--c---');
+    const subs =          '^           ';
+    const notifier = cold(           '|');
+    const expected =      '--a--b--c---';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should mirror a basic hot source with complete, given a never notifier', () => {
+    const source = hot('-a-^--b--c--|');
+    const subs =          '^        !';
+    const notifier = cold(         '|');
+    const expected =      '---b--c--|';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  xit('should handle a hot source that raises error but eventually completes', () => {
+    const source =   hot('-1--2--3----4--5---|');
+    const ssubs =       ['^      !            ',
+                       '              ^    !'];
+    const notifier = hot('--------------r--------r---r--r--r---|');
+    const nsubs =        '       ^           !';
+    const expected =     '-1--2---      -5---|';
+
+    const result = source
+      .map((x: string) => {
+        if (x === '3') {
+          throw 'error';
+        }
+        return x;
+      }).repeatWhen(() => notifier);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(ssubs);
+    expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+  });
+
+  it('should tear down resources when result is unsubscribed early', () => {
+    const source = cold( '-1--2--|');
+    const unsub =        '                    !       ';
+    const subs =        ['^      !                    ',
+                       '         ^      !           ',
+                       '                 ^  !       '];
+    const notifier = hot('---------r-------r---------#');
+    const nsubs =        '       ^            !       ';
+    const expected =     '-1--2-----1--2----1--       ';
+
+    const result = source.repeatWhen((notifications: any) => notifier);
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+  });
+
+  it('should not break unsubscription chains when unsubscribed explicitly', () => {
+    const source = cold( '-1--2--|');
+    const subs =        ['^      !                    ',
+                       '         ^      !           ',
+                       '                 ^  !       '];
+    const notifier = hot('---------r-------r-------r-#');
+    const nsubs =        '       ^            !       ';
+    const expected =     '-1--2-----1--2----1--       ';
+    const unsub =        '                    !       ';
+
+    const result = source
+      .mergeMap((x: string) => Observable.of(x))
+      .repeatWhen((notifications: any) => notifier)
+      .mergeMap((x: string) => Observable.of(x));
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+  });
+
+  it('should handle a source with eventual error using a dynamic notifier ' +
+  'selector which eventually throws', () => {
+    const source = cold('-1--2--|');
+    const subs =       ['^      !              ',
+                      '       ^      !       ',
+                      '              ^      !'];
+    const expected =    '-1--2---1--2---1--2--#';
+
+    let invoked = 0;
+    const result = source.repeatWhen((notifications: any) =>
+      notifications.map((err: any) => {
+        if (++invoked === 3) {
+          throw 'error';
+        } else {
+          return 'x';
+        }
+      }));
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should handle a source with eventual error using a dynamic notifier ' +
+  'selector which eventually completes', () => {
+    const source = cold('-1--2--|');
+    const subs =       ['^      !              ',
+                      '       ^      !       ',
+                      '              ^      !'];
+    const expected =    '-1--2---1--2---1--2--|';
+
+    let invoked = 0;
+    const result = source.repeatWhen((notifications: any) => notifications
+        .map(() => 'x')
+        .takeUntil(
+          notifications.flatMap(() => {
+            if (++invoked < 3) {
+              return Observable.empty();
+            } else {
+              return Observable.of('stop!');
+            }
+          })
+      ));
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -104,6 +104,7 @@ import './add/operator/publishLast';
 import './add/operator/race';
 import './add/operator/reduce';
 import './add/operator/repeat';
+import './add/operator/repeatWhen';
 import './add/operator/retry';
 import './add/operator/retryWhen';
 import './add/operator/sample';

--- a/src/add/operator/repeatWhen.ts
+++ b/src/add/operator/repeatWhen.ts
@@ -1,0 +1,11 @@
+
+import { Observable } from '../../Observable';
+import { repeatWhen, RepeatWhenSignature } from '../../operator/repeatWhen';
+
+Observable.prototype.repeatWhen = repeatWhen;
+
+declare module '../../Observable' {
+  interface Observable<T> {
+    repeatWhen: RepeatWhenSignature<T>;
+  }
+}

--- a/src/operator/repeatWhen.ts
+++ b/src/operator/repeatWhen.ts
@@ -1,0 +1,126 @@
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Observable } from '../Observable';
+import { Subject } from '../Subject';
+import { Subscription, TeardownLogic } from '../Subscription';
+import { tryCatch } from '../util/tryCatch';
+import { errorObject } from '../util/errorObject';
+
+import { OuterSubscriber } from '../OuterSubscriber';
+import { InnerSubscriber } from '../InnerSubscriber';
+import { subscribeToResult } from '../util/subscribeToResult';
+
+/**
+ * Returns an Observable that emits the same values as the source observable with the exception of a `complete`.
+ * A `complete` will cause the emission of the Throwable that cause the complete to the Observable returned from
+ * notificationHandler. If that Observable calls onComplete or `complete` then retry will call `complete` or `error`
+ * on the child subscription. Otherwise, this Observable will resubscribe to the source observable, on a particular
+ * Scheduler.
+ *
+ * <img src="./img/repeatWhen.png" width="100%">
+ *
+ * @param {notificationHandler} receives an Observable of notifications with which a user can `complete` or `error`,
+ * aborting the retry.
+ * @param {scheduler} the Scheduler on which to subscribe to the source Observable.
+ * @return {Observable} the source Observable modified with retry logic.
+ * @method repeatWhen
+ * @owner Observable
+ */
+export function repeatWhen<T>(notifier: (notifications: Observable<any>) => Observable<any>): Observable<T> {
+  return this.lift(new RepeatWhenOperator(notifier, this));
+}
+
+export interface RepeatWhenSignature<T> {
+  (notifier: (notifications: Observable<any>) => Observable<any>): Observable<T>;
+}
+
+class RepeatWhenOperator<T> implements Operator<T, T> {
+  constructor(protected notifier: (notifications: Observable<any>) => Observable<any>,
+              protected source: Observable<T>) {
+  }
+
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+    return source._subscribe(new RepeatWhenSubscriber(subscriber, this.notifier, this.source));
+  }
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
+class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
+
+  private notifications: Subject<any>;
+  private retries: Observable<any>;
+  private retriesSubscription: Subscription;
+
+  constructor(destination: Subscriber<R>,
+              private notifier: (notifications: Observable<any>) => Observable<any>,
+              private source: Observable<T>) {
+    super(destination);
+  }
+
+  complete() {
+    if (!this.isStopped) {
+
+      let notifications = this.notifications;
+      let retries: any = this.retries;
+      let retriesSubscription = this.retriesSubscription;
+
+      if (!retries) {
+        notifications = new Subject();
+        retries = tryCatch(this.notifier)(notifications);
+        if (retries === errorObject) {
+          return super.complete();
+        }
+        retriesSubscription = subscribeToResult(this, retries);
+      } else {
+        this.notifications = null;
+        this.retriesSubscription = null;
+      }
+
+      this.unsubscribe();
+      this.closed = false;
+
+      this.notifications = notifications;
+      this.retries = retries;
+      this.retriesSubscription = retriesSubscription;
+
+      notifications.next();
+    }
+  }
+
+  protected _unsubscribe() {
+    const { notifications, retriesSubscription } = this;
+    if (notifications) {
+      notifications.unsubscribe();
+      this.notifications = null;
+    }
+    if (retriesSubscription) {
+      retriesSubscription.unsubscribe();
+      this.retriesSubscription = null;
+    }
+    this.retries = null;
+  }
+
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
+
+    const { notifications, retries, retriesSubscription } = this;
+    this.notifications = null;
+    this.retries = null;
+    this.retriesSubscription = null;
+
+    this.unsubscribe();
+    this.isStopped = false;
+    this.closed = false;
+
+    this.notifications = notifications;
+    this.retries = retries;
+    this.retriesSubscription = retriesSubscription;
+
+    this.source.subscribe(this);
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [x] Add the operator to Rx
- [x] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [x] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [x] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [x] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [x] The operator should be listed in `doc/operators.md` in a category of operators
- [x] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [x] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
It still has four test from retryWhen, that are disabled as they don't make sense for repeatWhen. Maybe there are some alternative tests that should be included instead. 

**Related issue (if exists):**

