### PR TITLE
fix(min/max): do not return comparer values (#1892)

### DIFF
--- a/spec/operators/max-spec.ts
+++ b/spec/operators/max-spec.ts
@@ -184,26 +184,13 @@ describe('Observable.prototype.max', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should handle a constant predicate on observable with many values', () => {
-    const e1 = hot('-x-^-a-b-c-d-e-f-g-|');
-    const e1subs =    '^               !';
-    const expected =  '----------------(w|)';
-
-    const predicate = () => {
-      return 42;
-    };
-
-    expectObservable((<any>e1).max(predicate)).toBe(expected, { w: 42 });
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should handle a predicate on observable with many values', () => {
+  it('should handle a reverse predicate on observable with many values', () => {
     const e1 = hot('-a-^-b--c--d-|', { a: 42, b: -1, c: 0, d: 666 });
     const e1subs =    '^         !';
     const expected =  '----------(w|)';
 
     const predicate = function (x, y) {
-      return Math.min(x, y);
+      return x > y ? -1 : 1;
     };
 
     expectObservable((<any>e1).max(predicate)).toBe(expected, { w: -1 });
@@ -211,15 +198,15 @@ describe('Observable.prototype.max', () => {
   });
 
   it('should handle a predicate for string on observable with many values', () => {
-    const e1 = hot('-1-^-2--3--4-|');
+    const e1 = hot('-a-^-b--c--d-|');
     const e1subs =    '^         !';
     const expected =  '----------(w|)';
 
     const predicate = function (x, y) {
-      return x > y ? x : y;
+      return x > y ? -1 : 1;
     };
 
-    expectObservable((<any>e1).max(predicate)).toBe(expected, { w: '4' });
+    expectObservable((<any>e1).max(predicate)).toBe(expected, { w: 'b' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/spec/operators/min-spec.ts
+++ b/spec/operators/min-spec.ts
@@ -169,7 +169,7 @@ describe('Observable.prototype.min', () => {
       return 42;
     };
 
-    expectObservable((<any>e1).min(predicate), unsub).toBe(expected, { w: 42 });
+    expectObservable((<any>e1).min(predicate), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -188,30 +188,17 @@ describe('Observable.prototype.min', () => {
       .min(predicate)
       .mergeMap((x: number) => Observable.of(x));
 
-    expectObservable(result, unsub).toBe(expected, { w: 42 });
+    expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should handle a constant predicate on observable with many values', () => {
-    const e1 = hot('-x-^-a-b-c-d-e-f-g-|');
-    const e1subs =    '^               !';
-    const expected =  '----------------(w|)';
-
-    const predicate = () => {
-      return 42;
-    };
-
-    expectObservable((<any>e1).min(predicate)).toBe(expected, { w: 42 });
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should handle a predicate on observable with many values', () => {
+  it('should handle a reverse predicate on observable with many values', () => {
     const e1 = hot('-a-^-b--c--d-|', { a: 42, b: -1, c: 0, d: 666 });
     const e1subs =    '^         !';
     const expected =  '----------(w|)';
 
     const predicate = function (x, y) {
-      return Math.max(x, y);
+      return x > y ? -1 : 1;
     };
 
     expectObservable((<any>e1).min(predicate)).toBe(expected, { w: 666 });
@@ -219,15 +206,15 @@ describe('Observable.prototype.min', () => {
   });
 
   it('should handle a predicate for string on observable with many values', () => {
-    const e1 = hot('-1-^-2--3--4-|');
+    const e1 = hot('-a-^-b--c--d-|');
     const e1subs =    '^         !';
     const expected =  '----------(w|)';
 
     const predicate = function (x, y) {
-      return x < y ? x : y;
+      return x > y ? -1 : 1;
     };
 
-    expectObservable((<any>e1).min(predicate)).toBe(expected, { w: '2' });
+    expectObservable((<any>e1).min(predicate)).toBe(expected, { w: 'd' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/src/operator/max.ts
+++ b/src/operator/max.ts
@@ -13,13 +13,13 @@ import { ReduceOperator } from './reduce';
  * @method max
  * @owner Observable
  */
-export function max<T>(comparer?: (x: T, y: T) => T): Observable<T> {
-  const max: typeof comparer = (typeof comparer === 'function')
-    ? comparer
+export function max<T>(comparer?: (x: T, y: T) => number): Observable<T> {
+  const max: (x: T, y: T) => T = (typeof comparer === 'function')
+    ? (x, y) => comparer(x, y) > 0 ? x : y
     : (x, y) => x > y ? x : y;
   return this.lift(new ReduceOperator(max));
 }
 
 export interface MaxSignature<T> {
-  (comparer?: (x: T, y: T) => T): Observable<T>;
+  (comparer?: (x: T, y: T) => number): Observable<T>;
 }

--- a/src/operator/min.ts
+++ b/src/operator/min.ts
@@ -12,13 +12,13 @@ import { ReduceOperator } from './reduce';
  * @method min
  * @owner Observable
  */
-export function min<T>(comparer?: (x: T, y: T) => T): Observable<T> {
-  const min: typeof comparer = (typeof comparer === 'function')
-    ? comparer
+export function min<T>(comparer?: (x: T, y: T) => number): Observable<T> {
+  const min: (x: T, y: T) => T = (typeof comparer === 'function')
+    ? (x, y) => comparer(x, y) < 0 ? x : y
     : (x, y) => x < y ? x : y;
   return this.lift(new ReduceOperator(min));
 }
 
 export interface MinSignature<T> {
-  (comparer?: (x: T, y: T) => T): Observable<T>;
+  (comparer?: (x: T, y: T) => number): Observable<T>;
 }


### PR DESCRIPTION
**Description:**

min (&max) operators have now the expected behavior when used with a comparer:
- previously they were behaving like _reduce_ and emitting (last) comparer return value
- they now emit original observable min/max value by comparing the comparer return value to 0

method signatures were changed to have comparer return a number instead of T
unit tests have been updated, the ones relying on a constant comparer have been removed when their outcome should be undefined (more than 1 value in stream and no error/unsub) and replaced by ones with either a basic or reverse comparer.

I can split the PR in 2 commits (one for min and one for max) if you think that'd help on the release notes.

**Related issue :**

#1892 