### PR TITLE
feat(onErrorReturn): Add new Observable.prototype.onErrorReturn operator

### DIFF
--- a/spec/operators/onErrorReturn-spec.ts
+++ b/spec/operators/onErrorReturn-spec.ts
@@ -1,0 +1,111 @@
+import { expect } from 'chai';
+import * as Rx from '../../dist/cjs/Rx';
+declare const { hot, cold, asDiagram, expectObservable, expectSubscriptions };
+
+declare const rxTestSchdeuler: Rx.TestScheduler;
+const Observable = Rx.Observable;
+
+/** @test {onErrorReturn} */
+describe('Observable.prototype.onErrorReturn', () => {
+  asDiagram('onErrorReturn')('should catch error and emit single selected value', () => {
+    const e1 =   hot('--a--b--#        ');
+    const expected = '--a--b--(1|)';
+
+    const result = e1.onErrorReturn((err: any) => '1');
+
+    expectObservable(result).toBe(expected);
+  });
+
+  it('should catch error and replace it with Observable.of() that you can .switch()', () => {
+    const e1 =   hot('--a--b--c--------|');
+    const subs =     '^       !';
+    const expected = '--a--b--(XYZ|)';
+
+    const result = e1
+      .map((n: string) => {
+        if (n === 'c') {
+          throw 'bad';
+        }
+        return n;
+      })
+      .onErrorReturn((err: any) => {
+        return Observable.of('X', 'Y', 'Z');
+      })
+      .switch();
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should allow unsubscribing explicitly and early', () => {
+    const e1 =   hot('--1-2-3-4-5-6---#');
+    const e1subs =   '^      !         ';
+    const expected = '--1-2-3-         ';
+    const unsub =    '       !         ';
+
+    const result = e1.onErrorReturn(() => 'x');
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chain when unsubscribed explicitly', () => {
+    const e1 =   hot('--1-2-3-4-5-6---#');
+    const e1subs =   '^      !         ';
+    const expected = '--1-2-3-         ';
+    const unsub =    '       !         ';
+
+    const result = e1
+      .mergeMap((x: any) => Observable.of(x))
+      .onErrorReturn(() => 'x')
+      .mergeMap((x: any) => Observable.of(x));
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should mirror the source if it does not raise errors', () => {
+    const e1 =  cold('--a--b--c--|');
+    const subs =     '^          !';
+    const expected = '--a--b--c--|';
+
+    const result = e1.onErrorReturn((err: any) => 'x');
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+
+  it('should pass the error as the first argument', (done: MochaDone) => {
+    Observable.throw('bad')
+      .onErrorReturn((err: any) => {
+        expect(err).to.equal('bad');
+      })
+      .subscribe(() => {
+        //noop
+       }, (err: any) => {
+          done(new Error('should not be called'));
+        }, () => {
+          done();
+        });
+  });
+
+  it('should catch error thrown in selector and instead error with that', () => {
+    const e1 =   hot('--a--b--c--------|');
+    const subs =     '^       !';
+    const expected = '--a--b--#';
+
+    const result = e1
+      .map((n: string) => {
+        if (n === 'c') {
+          throw 'bad';
+        }
+        return n;
+      })
+      .onErrorReturn((err: any) => {
+        throw 'error';
+      });
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -94,6 +94,7 @@ import './add/operator/min';
 import './add/operator/multicast';
 import './add/operator/observeOn';
 import './add/operator/onErrorResumeNext';
+import './add/operator/onErrorReturn';
 import './add/operator/pairwise';
 import './add/operator/partition';
 import './add/operator/pluck';

--- a/src/add/operator/onErrorReturn.ts
+++ b/src/add/operator/onErrorReturn.ts
@@ -1,0 +1,10 @@
+import { Observable } from '../../Observable';
+import { onErrorReturn, OnErrorReturnSignature } from '../../operator/onErrorReturn';
+
+Observable.prototype.onErrorReturn = onErrorReturn;
+
+declare module '../../Observable' {
+  interface Observable<T> {
+    onErrorReturn: OnErrorReturnSignature<T>;
+  }
+}

--- a/src/operator/onErrorReturn.ts
+++ b/src/operator/onErrorReturn.ts
@@ -1,0 +1,66 @@
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Observable } from '../Observable';
+import { OuterSubscriber } from '../OuterSubscriber';
+
+/**
+ * Instructs an Observable to emit a particular item when it encounters an error, and then terminate normally.
+ * 
+ * You can use this to prevent errors from propagating or to supply fallback data should errors be encountered.
+ * @param {function} selector a function that takes as arguments `err`, which is the error. Whatever value
+ *  is returned by the `selector` will be emitted as the next value, just before terminating.
+ * @return {Observable} an observable that originates from the source
+ * @method onErrorReturn
+ * @owner Observable
+ */
+export function onErrorReturn<T, R>(selector: (err: any) => R): Observable<R> {
+  const operator = new OnErrorReturnOperator<T, R>(selector);
+  return this.lift(operator);
+}
+
+export interface OnErrorReturnSignature<T> {
+  <R>(selector: (err: any) => R): Observable<R>;
+}
+
+class OnErrorReturnOperator<T, R> implements Operator<T, R> {
+  constructor(private selector: (err: any) => R) {
+  }
+
+  call(subscriber: Subscriber<R>, source: any): any {
+    return source._subscribe(new OnErrorReturnSubscriber(subscriber, this.selector));
+  }
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
+class OnErrorReturnSubscriber<T, R> extends OuterSubscriber<T, R> {
+  constructor(destination: Subscriber<any>,
+              private selector: (err: any) => R) {
+    super(destination);
+  }
+
+  // NOTE: overriding `error` instead of `_error` because we don't want
+  // to have this flag this subscriber as `isStopped`.
+  error(err: any) {
+    if (!this.isStopped) {
+      const { destination } = this;
+      let result: R;
+
+      try {
+        result = this.selector(err);
+      } catch (err) {
+        this.destination.error(err);
+        return;
+      }
+
+      this.unsubscribe();
+      (<any>destination).remove(this);
+
+      destination.next(result);
+      destination.complete();
+    }
+  }
+}


### PR DESCRIPTION
Note: RxJS v4 _does **not**_ have this operator either.

Some Rx implementations contain an `onErrorReturn` operator. http://reactivex.io/documentation/operators/catch.html (scroll down and select it from RxJava list)

> instructs an Observable to emit a particular item when it encounters an error, and then terminate normally

![image](https://cloud.githubusercontent.com/assets/762949/18284626/8e5cda00-741f-11e6-8a59-346e8275203b.png)

> The `onErrorReturn` method returns an Observable that mirrors the behavior of the source Observable, unless that Observable invokes onError in which case, rather than propagating that error to the observer, onErrorReturn will instead emit a specified item and invoke the observer’s onCompleted method. [javadoc](http://reactivex.io/RxJava/javadoc/rx/Observable.html#onErrorReturn(rx.functions.Func1))

This operator is usually similar to `.catch()` but that it expects your provided selector to return a single _value_ instead of an Observable.

In practice this is exactly what people do 99% of the time in redux-observable and _maybe_ in common RxJS usage as well?


#### Using .catch()

```js
// return an Observable
.catch(error => Observable.of({
  type: FETCH_USER_REJECTED,
  payload: error.xhr.response,
  error: true
}))
```
```js
const fetchUserEpic = action$ =>
  action$.ofType(FETCH_USER)
    .mergeMap(action =>
      ajax.getJSON(`/api/users/${action.payload}`)
        .map(fetchUserFulfilled)
        .catch(error => Observable.of({
            type: FETCH_USER_REJECTED,
            payload: error.xhr.response,
            error: true
        }))
    );
```

#### Using .onErrorReturn()
```js
// Return a value
.onErrorReturn(error => ({
  type: FETCH_USER_REJECTED,
  payload: error.xhr.response,
  error: true
})
```
```js
const fetchUserEpic = action$ =>
  action$.ofType(FETCH_USER)
    .mergeMap(action =>
      ajax.getJSON(`/api/users/${action.payload}`)
        .map(fetchUserFulfilled)
        .onErrorReturn(error => ({
            type: FETCH_USER_REJECTED,
            payload: error.xhr.response,
            error: true
        })
    );
```

Or more likely with action creators:

```js
.onErrorReturn(error => fetchUserRejected(error.xhr.response))
```

We originally started to discuss this here https://github.com/redux-observable/redux-observable/issues/102

Cc/ @blesh 