### PR TITLE
fix(root): find global context (window/self/global) in a more safe way

### DIFF
--- a/spec/util/root-spec.ts
+++ b/spec/util/root-spec.ts
@@ -1,0 +1,9 @@
+import { expect } from 'chai';
+import { root } from '../../dist/cjs/util/root';
+
+/** @test {root} */
+describe('root', () => {
+  it('should exist', () => {
+    expect(typeof root).to.equal('object');
+  });
+});

--- a/src/util/root.ts
+++ b/src/util/root.ts
@@ -1,12 +1,3 @@
-let objectTypes = {
-  'boolean': false,
-  'function': true,
-  'object': true,
-  'number': false,
-  'string': false,
-  'undefined': false
-};
-
 declare let global: NodeJS.Global;
 declare let module: any;
 declare let exports: any;
@@ -18,9 +9,17 @@ declare module NodeJS {
   }
 }
 
-export let root: any = (objectTypes[typeof self] && self) || (objectTypes[typeof window] && window);
+/**
+ * window: browser in DOM main thread
+ * self: browser in WebWorker
+ * global: Node.js/other
+ */
+export const root: any = (
+     typeof window == 'object' && window.window === window && window
+  || typeof self == 'object' && self.self === self && self
+  || typeof global == 'object' && global.global === global && global
+);
 
-let freeGlobal = objectTypes[typeof global] && global;
-if (freeGlobal && (freeGlobal.global === freeGlobal || freeGlobal.window === freeGlobal)) {
-  root = freeGlobal;
+if (!root) {
+  throw new Error('RxJS could not find any global context (window, self, global)');
 }


### PR DESCRIPTION
Fixes #1930

Unfortunately this isn't something we can really unit test AFAIK. It's pretty meta.

The `objectTypes` stuffs appeared to be a left over from earlier refactors cause none of these should ever be a function.