### PR TITLE
Fixes 1921

### DIFF
--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -361,7 +361,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
   unsubscribe() {
     const { done, xhr } = this;
-    if (!done && xhr && xhr.readyState !== 4) {
+    if (!done && xhr && xhr.readyState !== 4 && typeof xhr.abort === 'function') {
       xhr.abort();
     }
     super.unsubscribe();

--- a/src/util/toSubscriber.ts
+++ b/src/util/toSubscriber.ts
@@ -1,6 +1,6 @@
-import { PartialObserver } from '../Observer';
 import { Subscriber } from '../Subscriber';
 import { $$rxSubscriber } from '../symbol/rxSubscriber';
+import { PartialObserver, empty as emptyObserver } from '../Observer';
 
 export function toSubscriber<T>(
   nextOrObserver?: PartialObserver<T> | ((value: T) => void),
@@ -18,7 +18,7 @@ export function toSubscriber<T>(
   }
 
   if (!nextOrObserver && !error && !complete) {
-    return new Subscriber();
+    return new Subscriber(emptyObserver);
   }
 
   return new Subscriber(nextOrObserver, error, complete);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Supply the Subscriber constructor the empty observer destination if `Observable.subscribe` is called with no arguments. This ensures the Subscriber wraps the empty Observer in a `SafeSubscriber` which will catch `error` messages and dispose of the subscription.

**Related issue (if exists):**
#1921