### PR TITLE
feat(filter): Observable<T>.filter() can take a type guard as the predicate function

### DIFF
--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -50,6 +50,7 @@ export function filter<T>(predicate: (value: T, index: number) => boolean,
 
 export interface FilterSignature<T> {
   (predicate: (value: T, index: number) => boolean, thisArg?: any): Observable<T>;
+  <S extends T>(predicate: (value: T, index: number) => value is S, thisArg?: any): Observable<S>;
 }
 
 class FilterOperator<T> implements Operator<T, T> {

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -45,6 +45,7 @@ export function find<T>(predicate: (value: T, index: number, source: Observable<
 
 export interface FindSignature<T> {
   (predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>;
+  <S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S, thisArg?: any): Observable<S>;
 }
 
 export class FindValueOperator<T> implements Operator<T, T> {

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -58,9 +58,15 @@ export function first<T, R>(predicate?: (value: T, index: number, source: Observ
   return this.lift(new FirstOperator(predicate, resultSelector, defaultValue, this));
 }
 
+// We can cast `T -> R` in it if we pass the result selector.
+// Therefore we don't provide the signature which takes both a type guard function
+// as the predicate and the result selector.
+// (see #1936)
 export interface FirstSignature<T> {
   (predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
+  <S extends T>(predicate?: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
   (predicate: (value: T, index: number, source: Observable<T>) => boolean, resultSelector: void, defaultValue?: T): Observable<T>;
+  <S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S, resultSelector: void, defaultValue?: S): Observable<S>;
   <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R,
       defaultValue?: R): Observable<R>;
 }

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -26,9 +26,15 @@ export function last<T, R>(predicate?: (value: T, index: number, source: Observa
   return this.lift(new LastOperator(predicate, resultSelector, defaultValue, this));
 }
 
+// We can cast `T -> R` in it if we pass the result selector.
+// Therefore we don't provide the signature which takes both a type guard function
+// as the predicate and the result selector.
+// (see #1936)
 export interface LastSignature<T> {
   (predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
+  <S extends T>(predicate?: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
   (predicate: (value: T, index: number, source: Observable<T>) => boolean, resultSelector: void, defaultValue?: T): Observable<T>;
+  <S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S, resultSelector: void, defaultValue?: S): Observable<S>;
   <R>(predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R,
       defaultValue?: R): Observable<R>;
 }


### PR DESCRIPTION
## Description


### Before

By the previous code base, we need to use `filter()` + `map()`

```typescript
interface SuperClass {}
interface DerivedClass extends SuperClass {}

const bar: Observable<SuperClass> = someobservable;
const derived: Observable<DerivedClass> = bar.filter((v): boolean => {
    // some type guard logic
  }).map<DerivedClass>((v) => v as DerivedClass);
```

### After

By this change, we can write this code:

```typescript
const bar: Observable<SuperClass> = someobservable;
const derived: Observable<DerivedClass> = bar.filter<DerivedClass>((v): v is DerivedClass => {
  // some type guard logic
});
```

## Related issue (if exists)

https://github.com/Microsoft/TypeScript/pull/10027