### PR TITLE
style(typings): updated ObservableInput<T> to use PromiseLike<T> instead of Promise<T>

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -14,7 +14,7 @@ export interface Subscribable<T> {
             complete?: () => void): AnonymousSubscription;
 }
 
-export type SubscribableOrPromise<T> = Subscribable<T> | Promise<T>;
+export type SubscribableOrPromise<T> = Subscribable<T> | PromiseLike<T>;
 export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T>;
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
It appears that there are still some typing issues related to `catch` on both `Promise<T>` and `Observable<T>`.

This change simply reduces what we consider a `Promise<T>` just the thenable interface.  I double checked our code and our promise handling code only requires `then` and does not require `catch`.  This change will also make it easier for TypeScript consumers to return promise like items, instead of true promises.

Much like with the catch issue before I don't really have a valid test case, because all the unit tests do not use the `...Signature<T>` interfaces, and instead just the methods.

Once we move to TS2.0 that will change, as we remove the signature interfaces and move them to the methods themselves.

**Related issue (if exists):**

