### PR TITLE
refactor(Operator): `call` renamed to `connect`

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -629,8 +629,8 @@ describe('Observable.lift', () => {
       constructor(private childOperator: Rx.Operator<T, R>) {
       }
 
-      call(subscriber: Rx.Subscriber<R>, source: any): TeardownLogic {
-        return this.childOperator.call(new LogSubscriber<R>(subscriber), source);
+      connect(subscriber: Rx.Subscriber<R>, source: any): TeardownLogic {
+        return this.childOperator.connect(new LogSubscriber<R>(subscriber), source);
       }
     }
 

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -90,7 +90,7 @@ export class Observable<T> implements Subscribable<T> {
     const sink = toSubscriber(observerOrNext, error, complete);
 
     if (operator) {
-      operator.call(sink, this);
+      operator.connect(sink, this);
     } else {
       sink.add(this._subscribe(sink));
     }

--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -2,5 +2,5 @@ import { Subscriber } from './Subscriber';
 import { TeardownLogic } from './Subscription';
 
 export interface Operator<T, R> {
-  call(subscriber: Subscriber<R>, source: any): TeardownLogic;
+  connect(subscriber: Subscriber<R>, source: any): TeardownLogic;
 }

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -82,7 +82,8 @@ class ConnectableSubscriber<T> extends SubjectSubscriber<T> {
 class RefCountOperator<T> implements Operator<T, T> {
   constructor(private connectable: ConnectableObservable<T>) {
   }
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
 
     const { connectable } = this;
     (<any> connectable)._refCount++;

--- a/src/operator/audit.ts
+++ b/src/operator/audit.ts
@@ -60,7 +60,7 @@ class AuditOperator<T> implements Operator<T, T> {
   constructor(private durationSelector: (value: T) => SubscribableOrPromise<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new AuditSubscriber<T, T>(subscriber, this.durationSelector));
   }
 }

--- a/src/operator/auditTime.ts
+++ b/src/operator/auditTime.ts
@@ -60,7 +60,7 @@ class AuditTimeOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new AuditTimeSubscriber(subscriber, this.duration, this.scheduler));
   }
 }

--- a/src/operator/buffer.ts
+++ b/src/operator/buffer.ts
@@ -51,7 +51,7 @@ class BufferOperator<T> implements Operator<T, T[]> {
   constructor(private closingNotifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T[]>, source: any): any {
+  connect(subscriber: Subscriber<T[]>, source: any): any {
     return source._subscribe(new BufferSubscriber(subscriber, this.closingNotifier));
   }
 }

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -55,7 +55,7 @@ class BufferCountOperator<T> implements Operator<T, T[]> {
   constructor(private bufferSize: number, private startBufferEvery: number) {
   }
 
-  call(subscriber: Subscriber<T[]>, source: any): any {
+  connect(subscriber: Subscriber<T[]>, source: any): any {
     return source._subscribe(new BufferCountSubscriber(subscriber, this.bufferSize, this.startBufferEvery));
   }
 }

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -85,7 +85,7 @@ class BufferTimeOperator<T> implements Operator<T, T[]> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T[]>, source: any): any {
+  connect(subscriber: Subscriber<T[]>, source: any): any {
     return source._subscribe(new BufferTimeSubscriber(
       subscriber, this.bufferTimeSpan, this.bufferCreationInterval, this.maxBufferSize, this.scheduler
     ));

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -60,7 +60,7 @@ class BufferToggleOperator<T, O> implements Operator<T, T[]> {
               private closingSelector: (value: O) => SubscribableOrPromise<any>) {
   }
 
-  call(subscriber: Subscriber<T[]>, source: any): any {
+  connect(subscriber: Subscriber<T[]>, source: any): any {
     return source._subscribe(new BufferToggleSubscriber(subscriber, this.openings, this.closingSelector));
   }
 }

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -55,7 +55,7 @@ class BufferWhenOperator<T> implements Operator<T, T[]> {
   constructor(private closingSelector: () => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T[]>, source: any): any {
+  connect(subscriber: Subscriber<T[]>, source: any): any {
     return source._subscribe(new BufferWhenSubscriber(subscriber, this.closingSelector));
   }
 }

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -31,7 +31,7 @@ class CatchOperator<T, R> implements Operator<T, R> {
   constructor(private selector: (err: any, caught: Observable<T>) => ObservableInput<T | R>) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new CatchSubscriber(subscriber, this.selector, this.caught));
   }
 }

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -90,7 +90,7 @@ export class CombineLatestOperator<T, R> implements Operator<T, R> {
   constructor(private project?: (...values: Array<any>) => R) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new CombineLatestSubscriber(subscriber, this.project));
   }
 }

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -61,7 +61,7 @@ class CountOperator<T> implements Operator<T, number> {
               private source?: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<number>, source: any): any {
+  connect(subscriber: Subscriber<number>, source: any): any {
     return source._subscribe(new CountSubscriber(subscriber, this.predicate, this.source));
   }
 }

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -61,7 +61,7 @@ class DebounceOperator<T> implements Operator<T, T> {
   constructor(private durationSelector: (value: T) => SubscribableOrPromise<number>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DebounceSubscriber(subscriber, this.durationSelector));
   }
 }

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -63,7 +63,7 @@ class DebounceTimeOperator<T> implements Operator<T, T> {
   constructor(private dueTime: number, private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DebounceTimeSubscriber(subscriber, this.dueTime, this.scheduler));
   }
 }

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -46,7 +46,7 @@ class DefaultIfEmptyOperator<T, R> implements Operator<T, T | R> {
   constructor(private defaultValue: R) {
   }
 
-  call(subscriber: Subscriber<T | R>, source: any): any {
+  connect(subscriber: Subscriber<T | R>, source: any): any {
     return source._subscribe(new DefaultIfEmptySubscriber(subscriber, this.defaultValue));
   }
 }

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -62,7 +62,7 @@ class DelayOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DelaySubscriber(subscriber, this.delay, this.scheduler));
   }
 }

--- a/src/operator/delayWhen.ts
+++ b/src/operator/delayWhen.ts
@@ -69,7 +69,7 @@ class DelayWhenOperator<T> implements Operator<T, T> {
   constructor(private delayDurationSelector: (value: T) => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DelayWhenSubscriber(subscriber, this.delayDurationSelector));
   }
 }

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -47,7 +47,7 @@ export interface DematerializeSignature<T> {
 }
 
 class DeMaterializeOperator<T extends Notification<any>, R> implements Operator<T, R> {
-  call(subscriber: Subscriber<any>, source: any): any {
+  connect(subscriber: Subscriber<any>, source: any): any {
     return source._subscribe(new DeMaterializeSubscriber(subscriber));
   }
 }

--- a/src/operator/distinct.ts
+++ b/src/operator/distinct.ts
@@ -30,7 +30,7 @@ class DistinctOperator<T> implements Operator<T, T> {
   constructor(private compare: (x: T, y: T) => boolean, private flushes: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DistinctSubscriber(subscriber, this.compare, this.flushes));
   }
 }

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -28,7 +28,7 @@ class DistinctUntilChangedOperator<T, K> implements Operator<T, T> {
               private keySelector: (x: T) => K) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DistinctUntilChangedSubscriber(subscriber, this.compare, this.keySelector));
   }
 }

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -63,7 +63,7 @@ class DoOperator<T> implements Operator<T, T> {
               private error?: (e: any) => void,
               private complete?: () => void) {
   }
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new DoSubscriber(subscriber, this.nextOrObserver, this.error, this.complete));
   }
 }

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -57,7 +57,7 @@ class ElementAtOperator<T> implements Operator<T, T> {
     }
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ElementAtSubscriber(subscriber, this.index, this.defaultValue));
   }
 }

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -26,8 +26,8 @@ class EveryOperator<T> implements Operator<T, boolean> {
               private source?: Observable<T>) {
   }
 
-  call(observer: Subscriber<boolean>, source: any): any {
-    return source._subscribe(new EverySubscriber(observer, this.predicate, this.thisArg, this.source));
+  connect(subscriber: Subscriber<boolean>, source: any): any {
+    return source._subscribe(new EverySubscriber(subscriber, this.predicate, this.thisArg, this.source));
   }
 }
 

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -50,7 +50,7 @@ export interface SwitchFirstSignature<T> {
 }
 
 class SwitchFirstOperator<T> implements Operator<T, T> {
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SwitchFirstSubscriber(subscriber));
   }
 }

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -67,7 +67,7 @@ class SwitchFirstMapOperator<T, I, R> implements Operator<T, R> {
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new SwitchFirstMapSubscriber(subscriber, this.project, this.resultSelector));
   }
 }

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -73,7 +73,7 @@ export class ExpandOperator<T, R> implements Operator<T, R> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new ExpandSubscriber(subscriber, this.project, this.concurrent, this.scheduler));
   }
 }

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -57,7 +57,7 @@ class FilterOperator<T> implements Operator<T, T> {
               private thisArg?: any) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new FilterSubscriber(subscriber, this.predicate, this.thisArg));
   }
 }

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -23,7 +23,7 @@ class FinallyOperator<T> implements Operator<T, T> {
   constructor(private callback: () => void) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new FinallySubscriber(subscriber, this.callback));
   }
 }

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -54,8 +54,8 @@ export class FindValueOperator<T> implements Operator<T, T> {
               private thisArg?: any) {
   }
 
-  call(observer: Subscriber<T>, source: any): any {
-    return source._subscribe(new FindValueSubscriber(observer, this.predicate, this.source, this.yieldIndex, this.thisArg));
+  connect(subscriber: Subscriber<T>, source: any): any {
+    return source._subscribe(new FindValueSubscriber(subscriber, this.predicate, this.source, this.yieldIndex, this.thisArg));
   }
 }
 

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -72,8 +72,8 @@ class FirstOperator<T, R> implements Operator<T, R> {
               private source?: Observable<T>) {
   }
 
-  call(observer: Subscriber<R>, source: any): any {
-    return source._subscribe(new FirstSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source));
+  connect(subscriber: Subscriber<R>, source: any): any {
+    return source._subscribe(new FirstSubscriber(subscriber, this.predicate, this.resultSelector, this.defaultValue, this.source));
   }
 }
 

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -55,7 +55,7 @@ class GroupByOperator<T, K, R> implements Operator<T, GroupedObservable<K, R>> {
               private durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<GroupedObservable<K, R>>, source: any): any {
+  connect(subscriber: Subscriber<GroupedObservable<K, R>>, source: any): any {
     return source._subscribe(new GroupBySubscriber(
       subscriber, this.keySelector, this.elementSelector, this.durationSelector
     ));

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -22,7 +22,7 @@ export interface IgnoreElementsSignature<T> {
 }
 
 class IgnoreElementsOperator<T, R> implements Operator<T, R> {
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new IgnoreElementsSubscriber(subscriber));
   }
 }

--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -20,8 +20,8 @@ export interface IsEmptySignature<T> {
 }
 
 class IsEmptyOperator implements Operator<any, boolean> {
-  call (observer: Subscriber<boolean>, source: any): any {
-    return source._subscribe(new IsEmptySubscriber(observer));
+  connect(subscriber: Subscriber<boolean>, source: any): any {
+    return source._subscribe(new IsEmptySubscriber(subscriber));
   }
 }
 

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -40,8 +40,8 @@ class LastOperator<T, R> implements Operator<T, R> {
               private source?: Observable<T>) {
   }
 
-  call(observer: Subscriber<R>, source: any): any {
-    return source._subscribe(new LastSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source));
+  connect(subscriber: Subscriber<R>, source: any): any {
+    return source._subscribe(new LastSubscriber(subscriber, this.predicate, this.resultSelector, this.defaultValue, this.source));
   }
 }
 

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -50,7 +50,7 @@ export class MapOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => R, private thisArg: any) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new MapSubscriber(subscriber, this.project, this.thisArg));
   }
 }

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -44,7 +44,7 @@ class MapToOperator<T, R> implements Operator<T, R> {
     this.value = value;
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new MapToSubscriber(subscriber, this.value));
   }
 }

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -49,7 +49,7 @@ export interface MaterializeSignature<T> {
 }
 
 class MaterializeOperator<T> implements Operator<T, Notification<T>> {
-  call(subscriber: Subscriber<Notification<T>>, source: any): any {
+  connect(subscriber: Subscriber<Notification<T>>, source: any): any {
     return source._subscribe(new MaterializeSubscriber(subscriber));
   }
 }

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -4,6 +4,7 @@ import { Observer } from '../Observer';
 import { Subscription } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
+import { Subscriber } from '../Subscriber';
 
 /**
  * Converts a higher-order Observable into a first-order Observable which
@@ -61,8 +62,8 @@ export class MergeAllOperator<T> implements Operator<Observable<T>, T> {
   constructor(private concurrent: number) {
   }
 
-  call(observer: Observer<T>, source: any): any {
-    return source._subscribe(new MergeAllSubscriber(observer, this.concurrent));
+  connect(subscriber: Subscriber<T>, source: any): any {
+    return source._subscribe(new MergeAllSubscriber(subscriber, this.concurrent));
   }
 }
 

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -78,9 +78,9 @@ export class MergeMapOperator<T, I, R> implements Operator<T, I> {
               private concurrent: number = Number.POSITIVE_INFINITY) {
   }
 
-  call(observer: Subscriber<I>, source: any): any {
+  connect(subscriber: Subscriber<I>, source: any): any {
     return source._subscribe(new MergeMapSubscriber(
-      observer, this.project, this.resultSelector, this.concurrent
+      subscriber, this.project, this.resultSelector, this.concurrent
     ));
   }
 }

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -68,15 +68,15 @@ export interface MergeMapToSignature<T> {
 }
 
 // TODO: Figure out correct signature here: an Operator<Observable<T>, R>
-//       needs to implement call(observer: Subscriber<R>): Subscriber<Observable<T>>
+//       needs to implement connect(subscriber: Subscriber<R>): Subscriber<Observable<T>>
 export class MergeMapToOperator<T, I, R> implements Operator<Observable<T>, R> {
   constructor(private ish: ObservableInput<I>,
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
               private concurrent: number = Number.POSITIVE_INFINITY) {
   }
 
-  call(observer: Subscriber<R>, source: any): any {
-    return source._subscribe(new MergeMapToSubscriber(observer, this.ish, this.resultSelector, this.concurrent));
+  connect(subscriber: Subscriber<R>, source: any): any {
+    return source._subscribe(new MergeMapToSubscriber(subscriber, this.ish, this.resultSelector, this.concurrent));
   }
 }
 

--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -32,7 +32,7 @@ export class MergeScanOperator<T, R> implements Operator<T, R> {
               private concurrent: number) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new MergeScanSubscriber(
       subscriber, this.project, this.seed, this.concurrent
     ));

--- a/src/operator/observeOn.ts
+++ b/src/operator/observeOn.ts
@@ -27,7 +27,7 @@ export class ObserveOnOperator<T> implements Operator<T, T> {
   constructor(private scheduler: Scheduler, private delay: number = 0) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ObserveOnSubscriber(subscriber, this.scheduler, this.delay));
   }
 }

--- a/src/operator/onErrorResumeNext.ts
+++ b/src/operator/onErrorResumeNext.ts
@@ -58,7 +58,7 @@ class OnErrorResumeNextOperator<T, R> implements Operator<T, R> {
   constructor(private nextSources: Array<ObservableInput<any>>) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new OnErrorResumeNextSubscriber(subscriber, this.nextSources));
   }
 }

--- a/src/operator/pairwise.ts
+++ b/src/operator/pairwise.ts
@@ -46,7 +46,7 @@ export interface PairwiseSignature<T> {
 }
 
 class PairwiseOperator<T> implements Operator<T, [T, T]> {
-  call(subscriber: Subscriber<[T, T]>, source: any): any {
+  connect(subscriber: Subscriber<[T, T]>, source: any): any {
     return source._subscribe(new PairwiseSubscriber(subscriber));
   }
 }

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -56,7 +56,7 @@ export function raceStatic<T>(...observables: Array<Observable<any> | Array<Obse
 }
 
 export class RaceOperator<T> implements Operator<T, T> {
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RaceSubscriber(subscriber));
   }
 }

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -62,7 +62,7 @@ export class ReduceOperator<T, R> implements Operator<T, R> {
   constructor(private accumulator: (acc: R, value: T) => R, private seed?: R) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new ReduceSubscriber(subscriber, this.accumulator, this.seed));
   }
 }

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -36,7 +36,7 @@ class RepeatOperator<T> implements Operator<T, T> {
   constructor(private count: number,
               private source: Observable<T>) {
   }
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RepeatSubscriber(subscriber, this.count, this.source));
   }
 }

--- a/src/operator/repeatWhen.ts
+++ b/src/operator/repeatWhen.ts
@@ -39,7 +39,7 @@ class RepeatWhenOperator<T> implements Operator<T, T> {
               protected source: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RepeatWhenSubscriber(subscriber, this.notifier, this.source));
   }
 }

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -33,7 +33,7 @@ class RetryOperator<T> implements Operator<T, T> {
               private source: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RetrySubscriber(subscriber, this.count, this.source));
   }
 }

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -39,7 +39,7 @@ class RetryWhenOperator<T> implements Operator<T, T> {
               protected source: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new RetryWhenSubscriber(subscriber, this.notifier, this.source));
   }
 }

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -52,7 +52,7 @@ class SampleOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SampleSubscriber(subscriber, this.notifier));
   }
 }

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -54,7 +54,7 @@ class SampleTimeOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SampleTimeSubscriber(subscriber, this.period, this.scheduler));
   }
 }

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -47,7 +47,7 @@ class ScanOperator<T, R> implements Operator<T, R> {
   constructor(private accumulator: (acc: R, value: T, index: number) => R, private seed?: T | R) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new ScanSubscriber(subscriber, this.accumulator, this.seed));
   }
 }

--- a/src/operator/sequenceEqual.ts
+++ b/src/operator/sequenceEqual.ts
@@ -71,7 +71,7 @@ export class SequenceEqualOperator<T> implements Operator<T, T> {
               private comparor: (a: T, b: T) => boolean) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): any {
+  connect(subscriber: Subscriber<T>, source: any): any {
     return source._subscribe(new SequenceEqualSubscriber(subscriber, this.compareTo, this.comparor));
   }
 }

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -34,7 +34,7 @@ class SingleOperator<T> implements Operator<T, T> {
               private source?: Observable<T>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SingleSubscriber(subscriber, this.predicate, this.source));
   }
 }

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -26,7 +26,7 @@ class SkipOperator<T> implements Operator<T, T> {
   constructor(private total: number) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SkipSubscriber(subscriber, this.total));
   }
 }

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -30,7 +30,7 @@ class SkipUntilOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SkipUntilSubscriber(subscriber, this.notifier));
   }
 }

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -27,7 +27,7 @@ class SkipWhileOperator<T> implements Operator<T, T> {
   constructor(private predicate: (value: T, index: number) => boolean) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new SkipWhileSubscriber(subscriber, this.predicate));
   }
 }

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -56,7 +56,7 @@ export interface SwitchSignature<T> {
 }
 
 class SwitchOperator<T, R> implements Operator<T, R> {
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new SwitchSubscriber(subscriber));
   }
 }

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -69,7 +69,7 @@ class SwitchMapOperator<T, I, R> implements Operator<T, I> {
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
   }
 
-  call(subscriber: Subscriber<I>, source: any): any {
+  connect(subscriber: Subscriber<I>, source: any): any {
     return source._subscribe(new SwitchMapSubscriber(subscriber, this.project, this.resultSelector));
   }
 }

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -69,7 +69,7 @@ class SwitchMapToOperator<T, I, R> implements Operator<T, I> {
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
   }
 
-  call(subscriber: Subscriber<I>, source: any): any {
+  connect(subscriber: Subscriber<I>, source: any): any {
     return source._subscribe(new SwitchMapToSubscriber(subscriber, this.observable, this.resultSelector));
   }
 }

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -57,7 +57,7 @@ class TakeOperator<T> implements Operator<T, T> {
     }
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeSubscriber(subscriber, this.total));
   }
 }

--- a/src/operator/takeLast.ts
+++ b/src/operator/takeLast.ts
@@ -60,7 +60,7 @@ class TakeLastOperator<T> implements Operator<T, T> {
     }
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeLastSubscriber(subscriber, this.total));
   }
 }

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -52,7 +52,7 @@ class TakeUntilOperator<T> implements Operator<T, T> {
   constructor(private notifier: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeUntilSubscriber(subscriber, this.notifier));
   }
 }

--- a/src/operator/takeWhile.ts
+++ b/src/operator/takeWhile.ts
@@ -51,7 +51,7 @@ class TakeWhileOperator<T> implements Operator<T, T> {
   constructor(private predicate: (value: T, index: number) => boolean) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TakeWhileSubscriber(subscriber, this.predicate));
   }
 }

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -57,7 +57,7 @@ class ThrottleOperator<T> implements Operator<T, T> {
   constructor(private durationSelector: (value: T) => SubscribableOrPromise<number>) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ThrottleSubscriber(subscriber, this.durationSelector));
   }
 }

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -57,7 +57,7 @@ class ThrottleTimeOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new ThrottleTimeSubscriber(subscriber, this.duration, this.scheduler));
   }
 }

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -29,8 +29,8 @@ class TimeIntervalOperator<T> implements Operator<T, TimeInterval<T>> {
 
   }
 
-  call(observer: Subscriber<TimeInterval<T>>, source: any): any {
-    return source._subscribe(new TimeIntervalSubscriber(observer, this.scheduler));
+  connect(subscriber: Subscriber<TimeInterval<T>>, source: any): any {
+    return source._subscribe(new TimeIntervalSubscriber(subscriber, this.scheduler));
   }
 }
 

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -33,7 +33,7 @@ class TimeoutOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TimeoutSubscriber<T>(
       subscriber, this.absoluteTimeout, this.waitFor, this.errorToSend, this.scheduler
     ));

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -36,7 +36,7 @@ class TimeoutWithOperator<T> implements Operator<T, T> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+  connect(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source._subscribe(new TimeoutWithSubscriber(
       subscriber, this.absoluteTimeout, this.waitFor, this.withObservable, this.scheduler
     ));

--- a/src/operator/timestamp.ts
+++ b/src/operator/timestamp.ts
@@ -27,8 +27,8 @@ class TimestampOperator<T> implements Operator<T, Timestamp<T>> {
   constructor(private scheduler: Scheduler) {
   }
 
-  call(observer: Subscriber<Timestamp<T>>, source: any): any {
-    return source._subscribe(new TimestampSubscriber(observer, this.scheduler));
+  connect(subscriber: Subscriber<Timestamp<T>>, source: any): any {
+    return source._subscribe(new TimestampSubscriber(subscriber, this.scheduler));
   }
 }
 

--- a/src/operator/toArray.ts
+++ b/src/operator/toArray.ts
@@ -16,7 +16,7 @@ export interface ToArraySignature<T> {
 }
 
 class ToArrayOperator<T> implements Operator<T, T[]> {
-  call(subscriber: Subscriber<T[]>, source: any): any {
+  connect(subscriber: Subscriber<T[]>, source: any): any {
     return source._subscribe(new ToArraySubscriber(subscriber));
   }
 }

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -56,7 +56,7 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
   constructor(private windowBoundaries: Observable<any>) {
   }
 
-  call(subscriber: Subscriber<Observable<T>>, source: any): any {
+  connect(subscriber: Subscriber<Observable<T>>, source: any): any {
     const windowSubscriber = new WindowSubscriber(subscriber);
     const sourceSubscription = source._subscribe(windowSubscriber);
     if (!sourceSubscription.closed) {

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -66,7 +66,7 @@ class WindowCountOperator<T> implements Operator<T, Observable<T>> {
               private startWindowEvery: number) {
   }
 
-  call(subscriber: Subscriber<Observable<T>>, source: any): any {
+  connect(subscriber: Subscriber<Observable<T>>, source: any): any {
     return source._subscribe(new WindowCountSubscriber(subscriber, this.windowSize, this.startWindowEvery));
   }
 }

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -73,7 +73,7 @@ class WindowTimeOperator<T> implements Operator<T, Observable<T>> {
               private scheduler: Scheduler) {
   }
 
-  call(subscriber: Subscriber<Observable<T>>, source: any): any {
+  connect(subscriber: Subscriber<Observable<T>>, source: any): any {
     return source._subscribe(new WindowTimeSubscriber(
       subscriber, this.windowTimeSpan, this.windowCreationInterval, this.scheduler
     ));

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -67,7 +67,7 @@ class WindowToggleOperator<T, O> implements Operator<T, Observable<T>> {
               private closingSelector: (openValue: O) => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<Observable<T>>, source: any): any {
+  connect(subscriber: Subscriber<Observable<T>>, source: any): any {
     return source._subscribe(new WindowToggleSubscriber(
       subscriber, this.openings, this.closingSelector
     ));

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -61,7 +61,7 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
   constructor(private closingSelector: () => Observable<any>) {
   }
 
-  call(subscriber: Subscriber<Observable<T>>, source: any): any {
+  connect(subscriber: Subscriber<Observable<T>>, source: any): any {
     return source._subscribe(new WindowSubscriber(subscriber, this.closingSelector));
   }
 }

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -78,7 +78,7 @@ class WithLatestFromOperator<T, R> implements Operator<T, R> {
               private project?: (...values: any[]) => Observable<R>) {
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new WithLatestFromSubscriber(subscriber, this.observables, this.project));
   }
 }

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -88,7 +88,7 @@ export class ZipOperator<T, R> implements Operator<T, R> {
     this.project = project;
   }
 
-  call(subscriber: Subscriber<R>, source: any): any {
+  connect(subscriber: Subscriber<R>, source: any): any {
     return source._subscribe(new ZipSubscriber(subscriber, this.project));
   }
 }


### PR DESCRIPTION
because `call` is a method on `Function.prototype`, renaming this method to `connect` to prevent confusion. `connect` is more descriptive for what the method is doing, given than it connects two subscribers and subscribes to an observable

BREAKING CHANGE: `Operator.prototype.call` is now `Operator.prototype.connect`