### PR TITLE
feat(operator): Add toSet operator

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -112,7 +112,6 @@ enabling "composite" subscription behavior.
 |`tapOnCompleted`|`do`|
 |`timestamp`|Not yet implemented|
 |`toMap`|Not yet implemented|
-|`toSet`|Not yet implemented|
 |`transduce`|Not yet implemented|
 |`windowWithTimeOrCount`|Not yet implemented|
 

--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -160,6 +160,9 @@ children:
         - label: and convert to a Promise
           children:
           - label: toPromise
+        - label: and convert to an set
+          children:
+          - label: toSet
       - label: consecutively in pairs, as arrays
         children:
         - label: pairwise

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -237,6 +237,7 @@ There are operators for different purposes, and they may be categorized as: crea
 - [`timeoutWith`](../class/es6/Observable.js~Observable.html#instance-method-timeoutWith)
 - [`toArray`](../class/es6/Observable.js~Observable.html#instance-method-toArray)
 - [`toPromise`](../class/es6/Observable.js~Observable.html#instance-method-toPromise)
+- [`toSet`](../class/es6/Observable.js~Observable.html#instance-method-toSet)
 
 ### Conditional and Boolean Operators
 

--- a/perf/micro/current-thread-scheduler/operators/toset.js
+++ b/perf/micro/current-thread-scheduler/operators/toset.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldToSetWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread).toSet();
+  var newToSetWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue).toSet();
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old toSet with current thread scheduler', function () {
+      oldToSetWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new toSet with current thread scheduler', function () {
+      newToSetWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/toset.js
+++ b/perf/micro/immediate-scheduler/operators/toset.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldToSetWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate).toSet();
+  var newToSetWithImmediateScheduler = RxNew.Observable.range(0, 25).toSet();
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old toSet with immediate scheduler', function () {
+        oldToSetWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new toSet with immediate scheduler', function () {
+        newToSetWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/spec/operators/toSet-spec.ts
+++ b/spec/operators/toSet-spec.ts
@@ -1,0 +1,112 @@
+import * as Rx from '../../dist/cjs/Rx';
+declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions, type};
+
+const Observable = Rx.Observable;
+
+/** @test {toSet} */
+describe('Observable.prototype.toSet', () => {
+  asDiagram('toSet')('should reduce the values of an observable into an set', () => {
+    const e1 =   hot('-a-a--b-b|');
+    const e1subs =   '^        !';
+    const expected = '---------(w|)';
+
+    expectObservable(e1.toSet()).toBe(expected, { w: new Set(['a', 'b']) });
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should be never when source is never', () => {
+    const e1 =  cold('-');
+    const e1subs =   '^';
+    const expected = '-';
+
+    expectObservable(e1.toSet()).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should be never when source is empty', () => {
+    const e1 =  cold('|');
+    const e1subs =   '(^!)';
+    const expected = '(w|)';
+
+    expectObservable(e1.toSet()).toBe(expected, { w: new Set() });
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should be never when source doesn\'t complete', () => {
+    const e1 = hot('--x--^--y--');
+    const e1subs =      '^     ';
+    const expected =    '------';
+
+    expectObservable(e1.toSet()).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should reduce observable without values into an set of size zero', () => {
+    const e1 = hot('-x-^---|');
+    const e1subs =    '^   !';
+    const expected =  '----(w|)';
+
+    expectObservable(e1.toSet()).toBe(expected, { w: new Set() });
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should reduce the a single value of an observable into an set', () => {
+    const e1 = hot('-x-^--y--|');
+    const e1subs =    '^     !';
+    const expected =  '------(w|)';
+
+    expectObservable(e1.toSet()).toBe(expected, { w: new Set(['y']) });
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should allow unsubscribing explicitly and early', () => {
+    const e1 =   hot('--a--b----c-----d----e---|');
+    const unsub =    '        !                 ';
+    const e1subs =   '^       !                 ';
+    const expected = '---------                 ';
+
+    expectObservable(e1.toSet(), unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
+    const e1 =   hot('--a--b----c-----d----e---|');
+    const e1subs =   '^       !                 ';
+    const expected = '---------                 ';
+    const unsub =    '        !                 ';
+
+    const result = e1
+      .mergeMap((x: string) => Observable.of(x))
+      .toSet()
+      .mergeMap((x: Array<string>) => Observable.of(x));
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should work with error', () => {
+    const e1 = hot('-x-^--y--z--#', { x: 1, y: 2, z: 3 }, 'too bad');
+    const e1subs =    '^        !';
+    const expected =  '---------#';
+
+    expectObservable(e1.toSet()).toBe(expected, null, 'too bad');
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should work with throw', () => {
+    const e1 =  cold('#');
+    const e1subs =   '(^!)';
+    const expected = '#';
+
+    expectObservable(e1.toSet()).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  type(() => {
+    const typeValue = {
+      val: 3
+    };
+
+    Observable.of(typeValue).toSet().subscribe(x => { x.values().next().value.val.toString(); });
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -133,6 +133,7 @@ import './add/operator/timeoutWith';
 import './add/operator/timestamp';
 import './add/operator/toArray';
 import './add/operator/toPromise';
+import './add/operator/toSet';
 import './add/operator/window';
 import './add/operator/windowCount';
 import './add/operator/windowTime';

--- a/src/add/operator/toSet.ts
+++ b/src/add/operator/toSet.ts
@@ -1,0 +1,10 @@
+import { Observable } from '../../Observable';
+import { toSet, ToSetSignature } from '../../operator/toSet';
+
+Observable.prototype.toSet = toSet;
+
+declare module '../../Observable' {
+  interface Observable<T> {
+    toSet: ToSetSignature<T>;
+  }
+}

--- a/src/operator/toSet.ts
+++ b/src/operator/toSet.ts
@@ -1,0 +1,45 @@
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Observable } from '../Observable';
+
+/**
+ * @return {Observable< Set<T>>|WebSocketSubject<T>|Observable<T>}
+ * @method toSet
+ * @owner Observable
+ */
+export function toSet<T>(): Observable< Set<T>> {
+  return this.lift(new ToSetOperator());
+}
+
+export interface ToSetSignature<T> {
+  (): Observable< Set<T>>;
+}
+
+class ToSetOperator<T> implements Operator<T, Set<T>> {
+    call(subscriber: Subscriber< Set<T>>, source: any): any {
+    return source._subscribe(new ToSetSubscriber(subscriber));
+  }
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
+class ToSetSubscriber<T> extends Subscriber<T> {
+
+  private set: Set<{}> = new Set();
+
+  constructor(destination: Subscriber< Set<T>>) {
+    super(destination);
+  }
+
+  protected _next(x: T) {
+    this.set.add(x);
+  }
+
+  protected _complete() {
+    this.destination.next(this.set);
+    this.destination.complete();
+  }
+}


### PR DESCRIPTION
**Description:**
Bring back the `toSet` operator from RxJS 4.

**Disclaimer:**
I have no idea what I'm doing, I mostly just copied `toArray` stuff and modified it to make sense. It works, and the tests seem happy, but if you're even considering maybe thinking about possibly merging this, read through it or ask me simple questions that I'll fail to answer so you're forced to read through it.

Specific things I'm sure I must've messed up:
- The JSDoc in `src/operator/toSet.ts`
- The spec, probably. I mean, the tests pass, but I'm sure that's just luck.
