### PR TITLE
unsubscribe() instead of dispose()

### DIFF
--- a/doc/tutorial/applications.md
+++ b/doc/tutorial/applications.md
@@ -138,7 +138,7 @@ class MyComponent extends ObservableComponent {
       .forEach(messages => this.setState({messages: messages}));
   }
   componentWillUnmount() {
-    this.messages.dispose();
+    this.messages.unsubscribe();
   }
   render() {
     return (


### PR DESCRIPTION
dispose() is no longer the way to dispose of a subscription handle