### PR TITLE
docs(readme): Import observable method correctly

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ To import what you need and use it with ES next function bind (best overall meth
 
 ```js
 import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
 import { map } from 'rxjs/operator/map';
 
-Observable.of(1,2,3)::map(x => x + '!!!'); // etc
+Observable::of(1,2,3)::map(x => x + '!!!'); // etc
 ```
 
 ### CommonJS via npm

--- a/doc/installation.md
+++ b/doc/installation.md
@@ -24,10 +24,11 @@ Observable.of(1,2,3).map(x => x + '!!!'); // etc
 To import what you need and use it with ES next function bind (best overall method, if possible):
 
 ```js
-import {Observable} from 'rxjs/Observable';
-import {map} from 'rxjs/operator/map';
+import { Observable } from 'rxjs/Observable';
+import { of } from 'rxjs/observable/of';
+import { map } from 'rxjs/operator/map';
 
-Observable.of(1,2,3)::map(x => x + '!!!'); // etc
+Observable::of(1,2,3)::map(x => x + '!!!'); // etc
 ```
 
 ## CommonJS via npm


### PR DESCRIPTION
**Description:**
Only importing `Obervable` does not give it the `of` method.
This imports `of` and uses the appropriate bind syntax in the README.md

This was my experience anyway. I'm not sure if the _correct_ way to do this is to `import { Observable } from 'rxjs'`, in which case the `of`-method would exst on the `Observable`-object, but this way should execute less code (as in, not import all of RxJS which I'm guessing `from 'rxjs'` would do?)

Edit: If someone wants (no need) to throw in a quick explanation as to why (if) one should import the methods separately from the `Observable`-object itself, that would be very interesting :smile: 