### PR TITLE
fix(docs): Fix esdoc for Observable.merge spread argument

### DIFF
--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -123,8 +123,7 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * @see {@link mergeMapTo}
  * @see {@link mergeScan}
  *
- * @param {Observable} input1 An input Observable to merge with others.
- * @param {Observable} input2 An input Observable to merge with others.
+ * @param {...Observable} observables Input Observables to merge together.
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
  * @param {Scheduler} [scheduler=null] The Scheduler to use for managing


### PR DESCRIPTION
**Description:**

The documentation was misleading to me today when I was using the static merge operator of an Observable. You can pass in multiple Observables but the documentation claimed there was "input1" and "input2". This update changes the param type to be a spread type as the function expects.

**Related issue (if exists):**

