### PR TITLE
fix(operator): Fix take to complete when the source is re-entrant.

### DIFF
--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions};
 
+const Subject = Rx.Subject;
 const Observable = Rx.Observable;
 
 /** @test {take} */
@@ -134,5 +135,20 @@ describe('Observable.prototype.take', () => {
     }).take(1);
 
     source.subscribe();
+  });
+
+  it('should complete when the source is reentrant', () => {
+    let completed = false;
+    const source = new Subject();
+    source.take(5).subscribe({
+      next() {
+        source.next();
+      },
+      complete() {
+        completed = true;
+      }
+    });
+    source.next();
+    expect(completed).to.be.true;
   });
 });

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -76,9 +76,10 @@ class TakeSubscriber<T> extends Subscriber<T> {
 
   protected _next(value: T): void {
     const total = this.total;
-    if (++this.count <= total) {
+    const count = ++this.count;
+    if (count <= total) {
       this.destination.next(value);
-      if (this.count === total) {
+      if (count === total) {
         this.destination.complete();
         this.unsubscribe();
       }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The TakeSubscriber compares the instance variable `count` to determine if it should complete or not.

If the source Observable is re-entrant, this check fails (because `count` is updated in each `next`), and take never completes.

I encountered this issue with expand and take on a multicast Observable, but here's a much simpler repro example:

```es6
import { Subject } from 'rxjs';

const subject = new Subject();

subject
  .take(10)
  .subscribe(
    (i) => {
      console.log(i);
      subject.next(i + 1);
    },
    (err) => {},
    () => console.log('done') // never gets printed
  );

subject.next(0);
```