### PR TITLE
chore(package.json): update typescript to v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "sinon-chai": "^2.8.0",
     "source-map-support": "^0.4.0",
     "tslint": "^3.15.1",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.3",
     "typings": "^1.3.3",
     "validate-commit-msg": "^2.3.1",
     "watch": "^0.18.0",

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -44,7 +44,8 @@ describe('BehaviorSubject', () => {
     const subject = new BehaviorSubject('flibberty');
 
     try {
-      subject.value = 'jibbets';
+      // XXX: escape from readonly restriction for testing.
+      (subject as any).value = 'jibbets';
     } catch (e) {
       //noop
     }


### PR DESCRIPTION
BREAKING CHANGE: This changes type definitions which are compiled out.

This does not changes exist APIs, but if we use getter for class, they are marked with `readonly` properties in d.ts (`readonly` modifier is the new feature from TypeScript v2.0). For example:

```typescript
export class BehaviorSubject<T> extends Subject<T> {

  constructor(private _value: T) {
    super();
  }

  get value(): T {
    return this.getValue();
  }

  protected _subscribe(subscriber: Subscriber<T>): Subscription {
    const subscription = super._subscribe(subscriber);
    if (subscription && !(<ISubscription>subscription).closed) {
      subscriber.next(this._value);
    }
    return subscription;
  }

  getValue(): T {
    if (this.hasError) {
      throw this.thrownError;
    } else if (this.closed) {
      throw new ObjectUnsubscribedError();
    } else {
      return this._value;
    }
  }

  next(value: T): void {
    super.next(this._value = value);
  }
}

```

will be compiled to in d.ts

```typescript
export declare class BehaviorSubject<T> extends Subject<T> {
    private _value;
    constructor(_value: T);
    readonly value: T;
    protected _subscribe(subscriber: Subscriber<T>): Subscription;
    getValue(): T;
    next(value: T): void;
}
```

## Related issues (edited at Sept. 23, 2016, 16:30:UTC+8)

- https://github.com/ReactiveX/rxjs/issues/1837