### PR TITLE
docs(Observable): bindNodeCallback

### DIFF
--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -59,7 +59,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
    * @see {@link fromPromise}
    *
    * @param {function} func Function with a callback as the last parameter.
-   * @param {function} selector A function which takes the arguments from the
+   * @param {function} [selector] A function which takes the arguments from the
    * callback and maps those a value to emit on the output Observable.
    * @param {Scheduler} [scheduler] The scheduler on which to schedule the
    * callbacks.

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -54,7 +54,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
    * @see {@link fromPromise}
    *
    * @param {function} func Function with a callback as the last parameter.
-   * @param {function} selector A function which takes the arguments from the
+   * @param {function} [selector] A function which takes the arguments from the
    * callback and maps those a value to emit on the output Observable.
    * @param {Scheduler} [scheduler] The scheduler on which to schedule the
    * callbacks.


### PR DESCRIPTION
Change doc to match source: bindNodeCallback's selector parameter is optional.