### PR TITLE
Update example docs for `.throttle()`

### DIFF
--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -28,7 +28,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  *
  * @example <caption>Emit clicks at a rate of at most one click per second</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.throttle(ev => Rx.Observable.interval(1000));
+ * var result = clicks.throttle(1000);
  * result.subscribe(x => console.log(x));
  *
  * @see {@link audit}


### PR DESCRIPTION
**Description:** the example for `.throttle()` was incorrect and resulted in errors being thrown, if it was run.

**Related issue (if exists):** none

