### PR TITLE
fix(bufferTime): no errors with take after bufferTime with maxBufferSize

### DIFF
--- a/spec/operators/bufferTime-spec.ts
+++ b/spec/operators/bufferTime-spec.ts
@@ -300,4 +300,23 @@ describe('Observable.prototype.bufferTime', () => {
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
+
+  it('should not have errors when take follows and maxBufferSize is provided', () => {
+    const tick = 10;
+    const bufferTime = 50;
+    const expected = '-----a----b----c----d----(e|)';
+    const values = {
+      a: [0, 1, 2, 3],
+      b: [4, 5, 6, 7, 8],
+      c: [9, 10, 11, 12, 13],
+      d: [14, 15, 16, 17, 18],
+      e: [19, 20, 21, 22, 23]
+    };
+
+    const source = Rx.Observable.interval(tick, rxTestScheduler)
+      .bufferTime(bufferTime, null, 10, rxTestScheduler)
+      .take(5);
+
+    expectObservable(source).toBe(expected, values);
+  });
 });

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -174,7 +174,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     closeAction.unsubscribe();
     this.remove(closeAction);
 
-    if (this.timespanOnly) {
+    if (!this.closed && this.timespanOnly) {
       context = this.openContext();
       const bufferTimeSpan = this.bufferTimeSpan;
       const timeSpanOnlyState = { subscriber: this, context, bufferTimeSpan };


### PR DESCRIPTION
Ensures that a buffer context is not created if the subscriber is closed

fixes #1944