### PR TITLE
feat(package.json): update TypeScript to v2.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -183,7 +183,7 @@
     "sinon-chai": "^2.8.0",
     "source-map-support": "^0.4.0",
     "tslint": "^3.15.1",
-    "typescript": "^1.8.10",
+    "typescript": "^2.0.3",
     "typings": "^1.3.3",
     "validate-commit-msg": "^2.3.1",
     "watch": "^0.18.0",

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -44,7 +44,8 @@ describe('BehaviorSubject', () => {
     const subject = new BehaviorSubject('flibberty');
 
     try {
-      subject.value = 'jibbets';
+      // XXX: escape from readonly restriction for testing.
+      (subject as any).value = 'jibbets';
     } catch (e) {
       //noop
     }


### PR DESCRIPTION
BREAKING CHANGE: TypeScript definitions are now for TS 2.0 and higher

Even if we use getter for class, they are marked with `readonly` properties
in d.ts.

this is a "fixed" version of #1968, retaining @saneyuki's work, just rebasing and updating the commit message.