### PR TITLE
feat(ES2015): stop publishing `rxjs-es`

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -17,11 +17,6 @@ var cjsPkg = Object.assign({}, pkg, {
   main: 'Rx.js',
   typings: 'Rx.d.ts'
 });
-var es6Pkg = Object.assign({}, cjsPkg, {
-  name: 'rxjs-es',
-  main: 'Rx.js',
-  typings: 'Rx.d.ts'
-});
 
 fs.writeFileSync('dist/cjs/package.json', JSON.stringify(cjsPkg, null, 2));
 fs.writeFileSync('dist/cjs/LICENSE.txt', fs.readFileSync('./LICENSE.txt').toString());
@@ -33,11 +28,6 @@ mkdirp.sync('dist/cjs/bundles');
 fs.writeFileSync('dist/cjs/bundles/Rx.js', fs.readFileSync('dist/global/Rx.js').toString());
 fs.writeFileSync('dist/cjs/bundles/Rx.min.js', fs.readFileSync('dist/global/Rx.min.js').toString());
 fs.writeFileSync('dist/cjs/bundles/Rx.min.js.map', fs.readFileSync('dist/global/Rx.min.js.map').toString());
-
-// ES6 Package
-fs.writeFileSync('dist/es6/package.json', JSON.stringify(es6Pkg, null, 2));
-fs.writeFileSync('dist/es6/LICENSE.txt', fs.readFileSync('./LICENSE.txt').toString());
-fs.writeFileSync('dist/es6/README.md', fs.readFileSync('./README.md').toString());
 
 // Add licenses to tops of bundles
 addLicenseToFile('LICENSE.txt', 'dist/cjs/bundles/Rx.js');

--- a/package.json
+++ b/package.json
@@ -51,7 +51,7 @@
   },
   "scripts": {
     "info": "npm-scripts-info",
-    "build_all": "npm-run-all build_es6 build_cjs build_global generate_packages",
+    "build_all": "npm-run-all build_cjs build_global generate_packages",
     "build_cjs": "npm-run-all clean_dist_cjs copy_src_cjs compile_dist_cjs",
     "build_es6": "npm-run-all clean_dist_es6 copy_src_es6 compile_dist_es6",
     "build_es6_for_docs": "npm-run-all clean_dist_es6 copy_src_es6 compile_dist_es6_for_docs",


### PR DESCRIPTION
BREAKING CHANGE: `rxjs-es` is no longer being published
BREAKING CHANGE: `@reactivex/rxjs` no longer has `/dist/es6` output

related #2016
related #1992
closes #1671
related #1954