### PR TITLE
feat(operate): Adds a .operate() and alias .o() operator

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -831,3 +831,21 @@ describe('Observable.lift', () => {
       });
   });
 });
+
+/** @test {Observable} */
+describe('Observable.op', () => {
+  it('should apply the provided operator and args to the given stream', () => {
+    const { map, filter } = Rx.Observable.prototype;
+    const e1 =   cold('-a-b-c-|', { a: 1, b: 2, c: 3 });
+    const expected =  '---b-c-|';
+
+    const result = e1
+      .op(filter, i => i > 1)
+      .op(map, i => i * 10);
+
+    expectObservable(result).toBe(expected, {
+      b: 20,
+      c: 30
+    });
+  });
+});


### PR DESCRIPTION
Allows you to apply an operator to a given stream, without it needing to be on the Observable prototype. This is mostly useful for library authors where adding operators to `Observable.prototype` can cause headaches to their users.

It takes the provided operator function and any arbitrary arguments then internally just calls `operator.apply(this, args)`.

This is solves a similar problem as the TC39 proposed [bind operator syntax](https://github.com/tc39/proposal-bind-operator) e.g. `stream::map(i => i + 1)` but that's stage-0 and not supported by TypeScript. Note that this current implementation lacks type safety/suggestions, just like it would if you used `map.call(stream, i => i + 1)`.

There is also an alias of just the letter `o`, as in `.o(map, i => i + 1)` so your code can remain fairly terse.

``` js
import { of } from 'rxjs/observable/of';
import { filter } from 'rxjs/operator/filter';
import { map } from 'rxjs/operator/map';

of(1, 2, 3)
  .o(filter, i => i > 1)
  .o(map, i => i * 10)
  .subscribe(x => console.log(x));
// 20..30
```

Without this, you'd need to something like this, which can get rather hairy quick:

``` js
let result = of(1, 2, 3);
result = filter.call(result, i => i > 1);
result = map.call(result, i => i * 10);
result.subscribe(x => console.log(x));
```

---

The name `operate` and having an short alias like `o` hasn't had a ton of thought into it, just what @blesh and I came up with in 5 minutes. While I generally hate aliases, the idea was that searching and discovering `o` in our documentation is basically fruitless, but having a long name is annoying when using these often in a library. We considered `._(operator)` `.$(operator)` `.invoke(operator)`

Cc/ @IgorMinar ng2 may like this and it adds nearly trivial overhead since it only has the extra function invocation on stream setup, not next()'s so should be out of the hot path for nearly all cases
