### PR TITLE
fix(typings): fixed Subject<T>.lift to have the same shape as Observable<T>.lift

### DIFF
--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -43,9 +43,9 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     return new AnonymousSubject<T>(destination, source);
   };
 
-  lift<T, R>(operator: Operator<T, R>): Observable<T> {
+  lift<R>(operator: Operator<T, R>): Observable<T> {
     const subject = new AnonymousSubject(this, this);
-    subject.operator = operator;
+    subject.operator = <any>operator;
     return <any>subject;
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This addresses the problem described in #2029.

`Observable<T>` implements `lift<R>(...)`
`Subject<T>` implements `lift<T, R>(...)`

The extra generic type argument `T`, causes type inference to break in horrible ways.

**Related issue (if exists):**
#2029