### PR TITLE
fix(IteratorObservable): Observables `from` generators will now final…

### DIFF
--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -36,6 +36,9 @@ export class IteratorObservable<T> extends Observable<T> {
     state.index = index + 1;
 
     if (subscriber.closed) {
+      if (typeof iterator.return === 'function') {
+        iterator.return();
+      }
       return;
     }
 
@@ -71,6 +74,9 @@ export class IteratorObservable<T> extends Observable<T> {
           subscriber.next(result.value);
         }
         if (subscriber.closed) {
+          if (typeof iterator.return === 'function') {
+            iterator.return();
+          }
           break;
         }
       } while (true);


### PR DESCRIPTION
...ize when subscription ends

In order to model the behavior of `for..of` when consuming a Generator, if a `break` is hit in the `for..of`, `return()` is called on the generator and the generator will jump to a `finally` block if it has one. Observables created from generators will now have this same behavior.

```js
    Observable.from((function* () {
      try {
        yield 1;
        yield 2;
        yield 3;
      } finally {
        console.log('finalized');
      }
    })())
    .take(2)
    .subscribe(x => console.log(x));
    
    // should log
    // 1
    // 2
    // finalized
```
    
fixes #1938