### PR TITLE
docs(readme): add further instructions for building docs on Mac

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,9 @@ For Mac OS X with [Homebrew](http://brew.sh/):
 - `brew install imagemagick`
 - `brew install graphicsmagick`
 - `brew install ghostscript`
+- You may need to install the Ghostscript fonts manually:
+  - Download the tarball from the [gs-fonts project](https://sourceforge.net/projects/gs-fonts)
+  - `mkdir -p /usr/local/share/ghostscript && tar zxvf /path/to/ghostscript-fonts.tar.gz -C /usr/local/share/ghostscript`
 
 For Debian Linux:
 


### PR DESCRIPTION
**Description:**

Add instructions to install missing Ghostscript fonts on Mac.

**Related issue (if exists):**

Homebrew's `ghostscript` package does not install any fonts;
`gm convert` will fail without them.  Add instructions to install these
fonts manually.