### PR TITLE
refactor(AjaxObservable): remove needles type param T from AjaxObservable.getJSON()

### DIFF
--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -67,7 +67,7 @@ export interface AjaxCreationMethod {
   post(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
   put(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
   delete(url: string, headers?: Object): Observable<AjaxResponse>;
-  getJSON<T, R>(url: string, headers?: Object): Observable<R>;
+  getJSON<T>(url: string, headers?: Object): Observable<T>;
 }
 
 export function ajaxGet(url: string, headers: Object = null) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

BREAKING CHANGE: 
- Remove the unused type parameter `T`
  - By this change, the user does not have to specify needless type parameter.

**Related issue (if exists):**
