### PR TITLE
fix(IteratorObservable): clarify the return type of IteratorObservable.create()

### DIFF
--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -13,7 +13,7 @@ import { Subscriber } from '../Subscriber';
 export class IteratorObservable<T> extends Observable<T> {
   private iterator: any;
 
-  static create<T>(iterator: any, scheduler?: Scheduler) {
+  static create<T>(iterator: any, scheduler?: Scheduler): IteratorObservable<T> {
     return new IteratorObservable(iterator, scheduler);
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
- Before this change, if call `IteratorObservable.create<number>()` with specifying type parameter, the return type of it was `IteratorObservable<{}>`. This pull request fix this.
  - This might be potential breaking change.
