### PR TITLE
refactor(FromEventObservable): remove needless type parameter from FromEventObservable & FromEventPatternObservable

### DIFF
--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -48,7 +48,7 @@ export type SelectorMethodSignature<T> = (...args: Array<any>) => T;
  * @extends {Ignored}
  * @hide true
  */
-export class FromEventObservable<T, R> extends Observable<T> {
+export class FromEventObservable<T> extends Observable<T> {
 
   /* tslint:disable:max-line-length */
   static create<T>(target: EventTargetLike, eventName: string): Observable<T>;

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -7,7 +7,7 @@ import { Subscriber } from '../Subscriber';
  * @extends {Ignored}
  * @hide true
  */
-export class FromEventPatternObservable<T, R> extends Observable<T> {
+export class FromEventPatternObservable<T> extends Observable<T> {
 
   /**
    * Creates an Observable from an API based on addHandler/removeHandler


### PR DESCRIPTION
**Description:**
- By this change, the consumer does not simplify the type to specify to use them
- BREAKING CHANGE: `FromEventObservable<T>` & `FromEventPatternObservable<T>` are no longer take type parameter `R`.
  You don't have to pass 2nd type parameter.
