### PR TITLE
refactor(Scheduler): clearify the signature which `Scheduler.schedule()` takes as `work`.

### DIFF
--- a/spec/schedulers/VirtualTimeScheduler-spec.ts
+++ b/spec/schedulers/VirtualTimeScheduler-spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
+import { VirtualAction } from '../../dist/cjs/scheduler/VirtualTimeScheduler';
 
 const VirtualTimeScheduler = Rx.VirtualTimeScheduler;
 
@@ -68,7 +69,7 @@ describe('VirtualTimeScheduler', () => {
     let count = 0;
     const expected = [100, 200, 300];
 
-    v.schedule(function(state) {
+    v.schedule<string>(function(this: VirtualAction<string>, state: string) {
       if (++count === 3) {
         return;
       }

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -53,7 +53,7 @@ export class Scheduler {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
-  public schedule<T>(work: (state?: T) => void, delay: number = 0, state?: T): Subscription {
+  public schedule<T>(work: (this: Action<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
     return new this.SchedulerAction<T>(this, work).schedule(state, delay);
   }
 }

--- a/src/scheduler/Action.ts
+++ b/src/scheduler/Action.ts
@@ -16,7 +16,7 @@ import { Subscription } from '../Subscription';
  * @class Action<T>
  */
 export class Action<T> extends Subscription {
-  constructor(scheduler: Scheduler, work: (state?: T) => void) {
+  constructor(scheduler: Scheduler, work: (this: Action<T>, state?: T) => void) {
     super();
   }
   /**

--- a/src/scheduler/AnimationFrameAction.ts
+++ b/src/scheduler/AnimationFrameAction.ts
@@ -10,7 +10,7 @@ import { AnimationFrameScheduler } from './AnimationFrameScheduler';
 export class AnimationFrameAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AnimationFrameScheduler,
-              protected work: (state?: T) => void) {
+              protected work: (this: AnimationFrameAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/scheduler/AsapAction.ts
+++ b/src/scheduler/AsapAction.ts
@@ -10,7 +10,7 @@ import { AsapScheduler } from './AsapScheduler';
 export class AsapAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AsapScheduler,
-              protected work: (state?: T) => void) {
+              protected work: (this: AsapAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/scheduler/AsyncAction.ts
+++ b/src/scheduler/AsyncAction.ts
@@ -16,7 +16,7 @@ export class AsyncAction<T> extends Action<T> {
   protected pending: boolean = false;
 
   constructor(protected scheduler: AsyncScheduler,
-              protected work: (state?: T) => void) {
+              protected work: (this: AsyncAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/scheduler/QueueAction.ts
+++ b/src/scheduler/QueueAction.ts
@@ -10,7 +10,7 @@ import { QueueScheduler } from './QueueScheduler';
 export class QueueAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: QueueScheduler,
-              protected work: (state?: T) => void) {
+              protected work: (this: QueueAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -47,7 +47,7 @@ export class VirtualTimeScheduler extends AsyncScheduler {
 export class VirtualAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: VirtualTimeScheduler,
-              protected work: (state?: T) => void,
+              protected work: (this: VirtualAction<T>, state?: T) => void,
               protected index: number = scheduler.index += 1) {
     super(scheduler, work);
     this.index = scheduler.index = index;


### PR DESCRIPTION
**Description:**
- For more readability, more consistently.
- I think this would not be a breaking change by these reasons:
  - There are no problem if we pass the function which does not has `this` specifying.
  - There are no problem if we pass the function which has `this: any` or `this: Action<T>`.
    - This case is valid with the actual behavior.
  - If we pass the function which has `this: SomeNonValidTypeWithAction<T>`,
    then, basically, its code would be wrong.
