### PR TITLE
fix(Object.assign): stop polyfilling Object assign

### DIFF
--- a/spec/util/assign-spec.ts
+++ b/spec/util/assign-spec.ts
@@ -1,0 +1,49 @@
+import { expect } from 'chai';
+import { assign, getAssign, assignImpl } from '../../dist/cjs/util/assign';
+
+describe('assign', () => {
+  it('should exist', () => {
+    expect(assign).to.be.a('function');
+  });
+
+  if (Object.assign) {
+    it('should use Object.assign if available', () => {
+      expect(assign).to.equal(Object.assign);
+    });
+  }
+
+  it('should assign n objects to a target', () => {
+    const target = { what: 'what' };
+    const source1 = { wut: 'socks' };
+    const source2 = { and : 'sandals' };
+    const result = assign(target, source1, source2);
+
+    expect(result).to.equal(target);
+    expect(result).to.deep.equal({ what: 'what', wut: 'socks', and: 'sandals' });
+  });
+});
+
+describe('assignImpl', () => {
+  it('should assign n objects to a target', () => {
+    const target = { what: 'what' };
+    const source1 = { wut: 'socks' };
+    const source2 = { and : 'sandals' };
+    const result = assignImpl(target, source1, source2);
+
+    expect(result).to.equal(target);
+    expect(result).to.deep.equal({ what: 'what', wut: 'socks', and: 'sandals' });
+  });
+});
+
+describe('getAssign', () => {
+  it('should return assignImpl if Object.assign does not exist on root', () => {
+    const result = getAssign({ Object: {} });
+    expect(result).to.equal(assignImpl);
+  });
+
+  it('should return Object.assign if it exists', () => {
+    const FAKE = () => { /* lol */ };
+    const result = getAssign({ Object: { assign: FAKE } });
+    expect(result).to.equal(FAKE);
+  });
+});

--- a/src/util/assign.ts
+++ b/src/util/assign.ts
@@ -1,30 +1,20 @@
 import { root } from './root';
 
-const Object = root.Object;
-
-if (typeof (<any>Object).assign != 'function') {
-  (function () {
-    (<any>Object).assign = function assignPolyfill(target: Object, ...sources: Array<Object>): Object {
-      if (target === undefined || target === null) {
-        throw new TypeError('cannot convert undefined or null to object');
+export function assignImpl(target: Object, ...sources: Object[]) {
+  const len = sources.length;
+  for (let i = 0; i < len; i++) {
+    const source = sources[i];
+    for (let k in source) {
+      if (source.hasOwnProperty(k)) {
+        target[k] = source[k];
       }
+    }
+  }
+  return target;
+};
 
-      const output = Object(target);
-      const len = sources.length;
-      for (let index = 0; index < len; index++) {
-        let source = sources[index];
-        if (source !== undefined && source !== null) {
-          for (let key in source) {
-            if (source.hasOwnProperty(key)) {
-              output[key] = source[key];
-            }
-          }
-        }
-      }
-
-      return output;
-    };
-  })();
+export function getAssign(root: any) {
+  return root.Object.assign || assignImpl;
 }
 
-export const assign: (target: Object, ...sources: Array<Object>) => Object = Object.assign;
+export const assign = getAssign(root);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**

RxJS should not be responsible for polyfilling `Object.assign`.
This should also increase code coverage around the alternate method used for assign

BREAKING CHANGE: RxJS will no longer polyfill `Object.assign`. It does
not require `Object.assign` to function, however, your code may be
inadvertently relying on this polyfill.
