### PR TITLE
fix(build): UMD Wrap global bundle

### DIFF
--- a/tools/make-umd-bundle.js
+++ b/tools/make-umd-bundle.js
@@ -3,6 +3,26 @@ var fs = require('fs');
 
 var babel = require('babel-core');
 
+var umdPrelude = [
+  ';(function (global, factory) {',
+  '  if (typeof define === "function" && define.amd) {',
+  '      define(["exports"], factory);',
+  '  } else if (typeof exports !== "undefined") {',
+  '      factory(exports);',
+  '  } else {',
+  '      var _exports = {};',
+  '      factory(_exports);',
+  '      global.Rx = _exports;',
+  '  }',
+  '})(this, (function (exports) {', // The extra wrapping parens are important.
+  ''                                // https://github.com/nolanlawson/optimize-js
+].join('\n');
+
+var umdPostlude = [
+  '',
+  '}));'
+].join('\n');
+
 rollup.rollup({
   entry: 'dist/es6/Rx.js'
 }).then(function (bundle) {
@@ -17,5 +37,5 @@ rollup.rollup({
     ],
   });
 
-  fs.writeFileSync('dist/global/Rx.js', out.code);
+  fs.writeFileSync('dist/global/Rx.js', umdPrelude + out.code + umdPostlude);
 });


### PR DESCRIPTION
In #2064, I bundled the build as a CommonJS package, completely neglecting web use. This PR UMD wraps the bundle so it's AMD/CommonJS/Web friendly.

Ideally, I would've liked to use `babel-plugin-transform-es2015-modules-umd` instead of using my own wrapper, but the perf cost of not including the parens is measurable:

**Without parens:**

```
$ for i in {1..5}; do node -p "s=Date.now();require('./dist/global/Rx.js');Date.now()-s"; done
49
48
48
43
40
```

**With parens:**

```
$ for i in {1..5}; do node -p "s=Date.now();require('./dist/global/Rx.js');Date.now()-s"; done
36
28
27
27
32
```

The wrapper I'm using came from `babel-plugin-transform-es2015-modules-umd`. I'll add the option to the plugin so it adds parens. Once that's in, I'll come back here and remove the custom wrapper in favor of the plugin.

## Test plan:

* In Node, made sure that `require('./dist/global/Rx.js').Observable` existed.
* Created an `index.html` with `<script src="dist/global/Rx.js"></script>` and made sure that `Rx.Observable` existed from the console.