### PR TITLE
fix(Notification): `materialize` output will now match Rx4

### DIFF
--- a/spec/Notification-spec.ts
+++ b/spec/Notification-spec.ts
@@ -22,7 +22,7 @@ describe('Notification', () => {
       expect(n instanceof Notification).to.be.true;
       expect(n.value).to.equal('test');
       expect(n.kind).to.equal('N');
-      expect(n.exception).to.be.a('undefined');
+      expect(n.error).to.be.a('undefined');
       expect(n.hasValue).to.be.true;
     });
   });
@@ -33,7 +33,7 @@ describe('Notification', () => {
       expect(n instanceof Notification).to.be.true;
       expect(n.value).to.be.a('undefined');
       expect(n.kind).to.equal('E');
-      expect(n.exception).to.equal('test');
+      expect(n.error).to.equal('test');
       expect(n.hasValue).to.be.false;
     });
   });
@@ -44,7 +44,7 @@ describe('Notification', () => {
       expect(n instanceof Notification).to.be.true;
       expect(n.value).to.be.a('undefined');
       expect(n.kind).to.equal('C');
-      expect(n.exception).to.be.a('undefined');
+      expect(n.error).to.be.a('undefined');
       expect(n.hasValue).to.be.false;
     });
   });

--- a/spec/helpers/testScheduler-ui.ts
+++ b/spec/helpers/testScheduler-ui.ts
@@ -106,9 +106,9 @@ module.exports = function(suite) {
     function deleteErrorNotificationStack(marble) {
       const { notification } = marble;
       if (notification) {
-        const { kind, exception } = notification;
-        if (kind === 'E' && exception instanceof Error) {
-          notification.exception = { name: exception.name, message: exception.message };
+        const { kind, error } = notification;
+        if (kind === 'E' && error instanceof Error) {
+          notification.error = { name: error.name, message: error.message };
         }
       }
       return marble;

--- a/src/Notification.ts
+++ b/src/Notification.ts
@@ -18,7 +18,7 @@ import { Observable } from './Observable';
 export class Notification<T> {
   hasValue: boolean;
 
-  constructor(public kind: string, public value?: T, public exception?: any) {
+  constructor(public kind: string, public value?: T, public error?: any) {
     this.hasValue = kind === 'N';
   }
 
@@ -32,7 +32,7 @@ export class Notification<T> {
       case 'N':
         return observer.next && observer.next(this.value);
       case 'E':
-        return observer.error && observer.error(this.exception);
+        return observer.error && observer.error(this.error);
       case 'C':
         return observer.complete && observer.complete();
     }
@@ -52,7 +52,7 @@ export class Notification<T> {
       case 'N':
         return next && next(this.value);
       case 'E':
-        return error && error(this.exception);
+        return error && error(this.error);
       case 'C':
         return complete && complete();
     }
@@ -86,7 +86,7 @@ export class Notification<T> {
       case 'N':
         return Observable.of(this.value);
       case 'E':
-        return Observable.throw(this.exception);
+        return Observable.throw(this.error);
       case 'C':
         return Observable.empty<T>();
     }
@@ -113,7 +113,7 @@ export class Notification<T> {
   /**
    * A shortcut to create a Notification instance of the type `error` from a
    * given error.
-   * @param {any} [err] The `error` exception.
+   * @param {any} [err] The `error` error.
    * @return {Notification<T>} The "error" Notification representing the
    * argument.
    */


### PR DESCRIPTION
- changed notification's `exception` property to by named `error`

BREAKING CHANGE: `Notification.prototype.exception` is now `Notification.prototype.error` to match Rx4 semantics

fixes #2105