### PR TITLE
chore(fix-test-helpers): fix Symbol.observable refernce for Safari 8

### DIFF
--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -1,5 +1,4 @@
 declare const global: any;
-declare const Symbol: any;
 
 import * as Rx from '../../dist/cjs/Rx';
 import {ObservableInput} from '../../dist/cjs/Observable';
@@ -19,7 +18,7 @@ export function lowerCaseO<T>(...args): Rx.Observable<T> {
     }
   };
 
-  o[Symbol.observable] = function () {
+  o[$$symbolObservable] = function () {
     return this;
   };
 


### PR DESCRIPTION
This fix is related to saucelabs tests failing in Safari 8.
The suspicion is that it is a problem with the fact a line of code was
using `Symbol.observable` directly instead of `56526symbolObservable`
since we're no longer polyfilling `Symbol.observable` unless `Symbol`
exists properly. Might also be related to `symbol-observable` dependency.