### PR TITLE
fix(Observable): remove unexpected dev dependency type references

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "source-map-support": "^0.4.0",
     "tslib": "^1.0.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.6",
+    "typescript": "2.1.0-dev.20161106",
     "validate-commit-msg": "^2.3.1",
     "watch": "^1.0.1",
     "watchify": "3.7.0",

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -179,7 +179,7 @@ describe('Observable.ajax', () => {
 
   it('should succeed on 200', () => {
     const expected = { foo: 'bar' };
-    let result;
+    let result: Rx.AjaxResponse;
     let complete = false;
     const obj = {
       url: '/flibbertyJibbet',
@@ -188,7 +188,7 @@ describe('Observable.ajax', () => {
     };
 
     Rx.Observable.ajax(obj)
-      .subscribe((x: any) => {
+      .subscribe(x => {
         result = x;
       }, null, () => {
         complete = true;
@@ -208,7 +208,7 @@ describe('Observable.ajax', () => {
   });
 
   it('should fail on 404', () => {
-    let error;
+    let error: Rx.AjaxError;
     const obj = {
       url: '/flibbertyJibbet',
       normalizeError: (e: any, xhr: any, type: any) => {
@@ -241,7 +241,7 @@ describe('Observable.ajax', () => {
   });
 
   it('should fail on 404', () => {
-    let error;
+    let error: Rx.AjaxError;
     const obj = {
       url: '/flibbertyJibbet',
       normalizeError: (e: any, xhr: any, type: any) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -376,7 +376,7 @@ babel-code-frame@^6.16.0:
     esutils "^2.0.2"
     js-tokens "^2.0.0"
 
-babel-core@^6.16.0, babel-core@^6.4.0, babel-core@6.17.0:
+babel-core@^6.16.0, babel-core@^6.4.0:
   version "6.17.0"
   resolved "https://registry.yarnpkg.com/babel-core/-/babel-core-6.17.0.tgz#6c4576447df479e241e58c807e4bc7da4db7f425"
   dependencies:
@@ -851,15 +851,7 @@ babel-plugin-transform-strict-mode@^6.8.0:
     babel-runtime "^6.0.0"
     babel-types "^6.8.0"
 
-babel-polyfill@6.16.0:
-  version "6.16.0"
-  resolved "https://registry.yarnpkg.com/babel-polyfill/-/babel-polyfill-6.16.0.tgz#2d45021df87e26a374b6d4d1a9c65964d17f2422"
-  dependencies:
-    babel-runtime "^6.9.1"
-    core-js "^2.4.0"
-    regenerator-runtime "^0.9.5"
-
-babel-preset-es2015@^6.3.13, babel-preset-es2015@6.16.0:
+babel-preset-es2015@^6.3.13:
   version "6.16.0"
   resolved "https://registry.yarnpkg.com/babel-preset-es2015/-/babel-preset-es2015-6.16.0.tgz#59acecd1efbebaf48f89404840f2fe78c4d2ad5c"
   dependencies:
@@ -6228,6 +6220,10 @@ tryit@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tryit/-/tryit-1.0.2.tgz#c196b0073e6b1c595d93c9c830855b7acc32a453"
 
+tslib@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.0.0.tgz#6998194cc814ec190383692a0a82bfefaf2eb0b5"
+
 tslint@^3.15.1:
   version "3.15.1"
   resolved "https://registry.yarnpkg.com/tslint/-/tslint-3.15.1.tgz#da165ca93d8fdc2c086b51165ee1bacb48c98ea5"
@@ -6270,9 +6266,9 @@ typedarray@~0.0.5:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/typedarray/-/typedarray-0.0.6.tgz#867ac74e3864187b1d3d47d996a78ec5c8830777"
 
-typescript@2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.0.6.tgz#5385499ac9811508c2c43e0ea07a1ddca435e111"
+typescript@2.1.0-dev.20161106:
+  version "2.1.0-dev.20161106"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.1.0-dev.20161106.tgz#f6197280f92e2b306f40c0bc89ccece954b5764d"
 
 uglify-js@^2.6:
   version "2.7.3"


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR amends unexpected type references occurs in transpiled type definition, seems it was known issue of TS (https://github.com/Microsoft/TypeScript/issues/11948, https://github.com/Microsoft/TypeScript/issues/11849). Updated TS to latest dev to avoid this issue.

**Related issue (if exists):**

- closes #2112