### PR TITLE
test(browser): polyfill promise for unsuppoerted browser

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../dist/cjs/Rx';
 import {TeardownLogic} from '../dist/cjs/Subscription';
 
-declare const {asDiagram, expectObservable};
+declare const {asDiagram, expectObservable, rxTestScheduler};
 const Subscriber = Rx.Subscriber;
 const Observable = Rx.Observable;
 

--- a/spec/helpers/testScheduler-ui.ts
+++ b/spec/helpers/testScheduler-ui.ts
@@ -15,6 +15,10 @@ chai.use(sinonChai);
 
 declare const module, global, Suite, Test: any;
 
+if (!global.Promise) {
+  global.Promise = require('promise'); // tslint:disable-line
+}
+
 const diagramFunction = global.asDiagram;
 
 //mocha creates own global context per each test suite, simple patching to global won't deliver its context into test cases.

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -1,4 +1,5 @@
 declare const {rxTestScheduler, time, type};
+import * as _ from 'lodash';
 
 const booleans = { T: true, F: false };
 
@@ -193,7 +194,7 @@ describe('Observable.prototype.sequenceEqual', () => {
       z: { value: 'derp', weCouldBe: 'dancin, yeah' }
     };
 
-    expectObservable(source).toBe(expected, Object.assign({}, booleans, values), new Error('shazbot'));
+    expectObservable(source).toBe(expected, _.assign(booleans, values), new Error('shazbot'));
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
     expectSubscriptions(s2.subscriptions).toBe(s2subs);
   });
@@ -217,7 +218,7 @@ describe('Observable.prototype.sequenceEqual', () => {
       z: { value: 'derp', weCouldBe: 'dancin, yeah' }
     };
 
-    expectObservable(source).toBe(expected, Object.assign({}, booleans, values));
+    expectObservable(source).toBe(expected, _.assign(booleans, values));
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
     expectSubscriptions(s2.subscriptions).toBe(s2subs);
   });

--- a/spec/support/mocha.sauce.runner.js
+++ b/spec/support/mocha.sauce.runner.js
@@ -83,9 +83,15 @@ var customLaunchers = {
   },
   sl_edge: {
     base: 'SauceLabs',
-    browserName: 'microsoftedge',
+    browserName: 'MicrosoftEdge',
     platform: 'Windows 10',
-    version: '20.10240'
+    version: '14.14393'
+  },
+  sl_edge_13: {
+    base: 'SauceLabs',
+    browserName: 'MicrosoftEdge',
+    platform: 'Windows 10',
+    version: '13.10586'
   },
   sl_android_4_1: {
     base: 'SauceLabs',

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -7,6 +7,7 @@
         "allowJs": true,
         "target": "es5",
         "module": "commonjs",
+        "moduleResolution": "node",
         "outDir": "../spec-js",
         "lib": [
             "es5",

--- a/typings.json
+++ b/typings.json
@@ -6,6 +6,7 @@
     "sinon-chai": "registry:npm/sinon-chai#2.8.0+20160310030142"
   },
   "globalDevDependencies": {
-    "mocha": "registry:env/mocha#2.2.5+20160926180742"
+    "mocha": "registry:env/mocha#2.2.5+20160926180742",
+    "node": "registry:env/node#6.0.0+20161105011511"
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
It seems IE browser testing fails by not able to look up promise implementation, which some of spec creates as test fixture. This PR patches global if promise doesn't exists to let test works correctly.

**Related issue (if exists):**

