### PR TITLE
feat(filter, find, first, last): support type guard predicates that don't requiring casting

### DIFF
--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -44,9 +44,10 @@ import { TeardownLogic } from '../Subscription';
  * @owner Observable
  */
 /* tslint:disable:max-line-length */
-export function filter<T>(this: Observable<T>, predicate: (value: T, index: number) => boolean, thisArg?: any): Observable<T>;
-export function filter<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number) => value is S, thisArg?: any): Observable<S>;
-/* tslint:disable:max-line-length */
+export function filter<T, S extends T>(this: Observable<T>,
+                                       predicate: ((value: T, index: number) => boolean) |
+                                                  ((value: T, index: number) => value is S),
+                                       thisArg?: any): Observable<S>;
 export function filter<T>(this: Observable<T>, predicate: (value: T, index: number) => boolean,
                           thisArg?: any): Observable<T> {
   return this.lift(new FilterOperator(predicate, thisArg));

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -36,8 +36,10 @@ import { Subscriber } from '../Subscriber';
  * @owner Observable
  */
 /* tslint:disable:max-line-length */
-export function find<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): Observable<T>;
-export function find<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, thisArg?: any): Observable<S>;
+export function find<T, S extends T>(this: Observable<T>,
+                                     predicate: ((value: T, index: number, source: Observable<T>) => boolean) |
+                                                ((value: T, index: number, source: Observable<T>) => value is S),
+                                     thisArg?: any): Observable<S>;
 /* tslint:disable:max-line-length */
 export function find<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean,
                         thisArg?: any): Observable<T> {

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -53,10 +53,15 @@ import { EmptyError } from '../util/EmptyError';
  * @owner Observable
  */
 /* tslint:disable:max-line-length */
-export function first<T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
-export function first<T, S extends T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
+export function first<T, S extends T>(this: Observable<T>,
+                                      predicate?: ((value: T, index: number, source: Observable<T>) => boolean) |
+                                                  ((value: T, index: number, source: Observable<T>) => value is S)): Observable<S>;
 export function first<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, resultSelector: void, defaultValue?: T): Observable<T>;
-export function first<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, resultSelector: void, defaultValue?: S): Observable<S>;
+export function first<T, S extends T, R>(this: Observable<T>,
+                                         predicate: ((value: T, index: number, source: Observable<T>) => boolean) |
+                                                    ((value: T, index: number, source: Observable<T>) => value is S),
+                                         resultSelector?: ((value: S, index: number) => R) | void,
+                                         defaultValue?: S): Observable<S>;
 export function first<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, defaultValue?: R): Observable<R>;
 /* tslint:disable:max-line-length */
 export function first<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -21,10 +21,15 @@ import { EmptyError } from '../util/EmptyError';
  * @owner Observable
  */
 /* tslint:disable:max-line-length */
-export function last<T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
-export function last<T, S extends T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
+export function last<T, S extends T>(this: Observable<T>,
+                                     predicate?: ((value: T, index: number, source: Observable<T>) => boolean) |
+                                                 ((value: T, index: number, source: Observable<T>) => value is S)): Observable<S>;
 export function last<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, resultSelector: void, defaultValue?: T): Observable<T>;
-export function last<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, resultSelector: void, defaultValue?: S): Observable<S>;
+export function last<T, S extends T, R>(this: Observable<T>,
+                                        predicate: ((value: T, index: number, source: Observable<T>) => boolean) |
+                                                   ((value: T, index: number, source: Observable<T>) => value is S),
+                                        resultSelector?: ((value: S, index: number) => R) | void,
+                                        defaultValue?: S): Observable<S>;
 export function last<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, defaultValue?: R): Observable<R>;
 /* tslint:disable:max-line-length */
 export function last<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
These updates allow the use of type guard predicates to flow narrowed types through Observable operator chains using the `filter`, `find`, `first`, and `last` operators without requiring casting. Unfortunately, direct use of `typeof x === 'string'` style boolean predicates are not able to be supported yet in this context, even though typescript understands how to use them in other contexts (e.g. `if/else` statements and such). However, type guard functions can still reduce a lot of boilerplate casting noise with these new definitions.  Examples for each operator appear below.

```typescript
// x is `Observable<string | number>`
let x = Observable.from([1, 'aaa', 3, 'bb']);

// This type guard will narrow a `string | number` to a string in the examples below
let isString = (x: string | number): x is string => typeof x === 'string';

// Here, `s` is a string in the second filter predicate after the type guard (yay - intellisense!)
let guardedFilter = x.filter(isString).filter(s => s.length === 2); // Observable<string>
// In contrast, this type of regular boolean predicate still maintains the original type
let boolFilter = x.filter(s => typeof s === 'number'); // Observable<string | number>

// After the type guard `find` predicate, the type is narrowed to string
let guardedFind = x.find(isString).filter(s => s.length > 1).map(s => s.substr(1)); // Observable<string>  
// In contrast, a boolean predicate maintains the original type
let boolFind = x.find(x => typeof x === 'string'); // Observable<string | number>

// After the type guard `first` predicates, the type is narrowed to string
let guardedFirst1 = x.first(isString).filter(s => s.length > 1).map(s => s.substr(1)); // Observable<string>
let guardedFirst2 = x.first(isString, s => s.substr(0)).filter(s => s.length > 1); // Observable<string>

// Without a resultSelector, `first` maintains the original type (TS can't do this yet)
let boolFirst1 = x.first(x => typeof x === 'string', null, ''); // Observable<string | number>
// `first` still uses the `resultSelector` return type, if it exists.
let boolFirst2 = x.first(x => typeof x === 'string', s => ({str: `${s}`}), {str: ''}); // Observable<{str: string}>

// Same for `last`:
let guardedLast1 = x.last(isString).filter(s => s.length > 1).map(s => s.substr(1)); // Observable<string>
let guardedLast2 = x.last(isString, s => s.substr(0)).filter(s => s.length > 1); // Observable<string>
let boolLast1 = x.last(x => typeof x === 'string', null, ''); // Observable<string | number>
let boolLast2 = x.last(x => typeof x === 'string', s => ({str: `${s}`}), {str: ''}); // Observable<{str: string}>
```

**Related issue (if exists):**
This enhances the initial attempt to integrate type guards for narrowing types in operator chains in https://github.com/ReactiveX/rxjs/pull/1936. I had initially asked about a solution to this in https://github.com/Microsoft/TypeScript/issues/7657#issuecomment-258544213, but arrived at this solution before there was any response.
