### PR TITLE
chore(example): add basic TS import bootstrap example

### DIFF
--- a/examples/typescript/import-all.ts
+++ b/examples/typescript/import-all.ts
@@ -1,0 +1,6 @@
+import * as Rx from 'rxjs';
+
+Rx.Observable
+  .range(1, 3)
+  .map(x => x * 2)
+  .subscribe(console.log.bind(console));

--- a/examples/typescript/import-operators.ts
+++ b/examples/typescript/import-operators.ts
@@ -1,0 +1,8 @@
+import {Observable} from 'rxjs';
+import 'rxjs/add/observable/range';
+import 'rxjs/add/operator/map';
+
+Observable
+  .range(1, 3)
+  .map(x => x * 2)
+  .subscribe(console.log.bind(console));

--- a/examples/typescript/package.json
+++ b/examples/typescript/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "rxjs-bootstrap-typescript",
+  "version": "1.0.0",
+  "main": "index.js",
+  "scripts": {
+    "all": "ts-node import-all.ts",
+    "operators": "ts-node import-operators.ts",
+    "build:es5": "tsc -p tsconfig_es5.json",
+    "build:es2015": "tsc -p tsconfig_es2015.json"
+  },
+  "license": "Apache-2.0",
+  "dependencies": {
+    "rxjs": "latest"
+  },
+  "devDependencies": {
+    "ts-node": "^1.7.0",
+    "typescript": "latest"
+  }
+}

--- a/examples/typescript/tsconfig_es2015.json
+++ b/examples/typescript/tsconfig_es2015.json
@@ -1,0 +1,8 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es6",
+    "module": "commonjs",
+    "outDir": "dist/es6"
+  }
+}

--- a/examples/typescript/tsconfig_es5.json
+++ b/examples/typescript/tsconfig_es5.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "moduleResolution": "node",
+    "target": "es5",
+    "module": "commonjs",
+    "outDir": "dist/es5",
+    "lib": [
+      "es5",
+      "es2015.iterable",
+      "es2015.collection",
+      "es2015.promise",
+      "dom"
+    ]
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR is  discussion point for initial bootstrap(module import, mostly) example of RxJS on various compiler / bundling configurations. Each example should include

- how to import all operators of Rx via entry point
- how to selectively import specific operator as needed
- npm script to invoke each cases
- (and link from readme)

discussion point
- [ ] code organization: where is best place to locate those? under main repo (like this PR) vs. separate repo?
- [ ] what's most compelling code snippet to show after module is imported?
- [ ] which compiler / bundler should be included? (babel, webpack, etcs..)

separately
- [ ] maybe instead of installing published package, always install from master (via `npm pack` generated) to use these example as very basic package sanity test as well?

**Related issue (if exists):**

#2116 and others
