### PR TITLE
style(linting): remove needless members detected by noUnusedLocals

### DIFF
--- a/src/Operator.ts
+++ b/src/Operator.ts
@@ -1,6 +1,7 @@
+import { Observable } from './Observable';
 import { Subscriber } from './Subscriber';
 import { TeardownLogic } from './Subscription';
 
 export interface Operator<T, R> {
-  call(subscriber: Subscriber<R>, source: any): TeardownLogic;
+  call(subscriber: Subscriber<R>, source: Observable<T>): TeardownLogic;
 }

--- a/src/observable/ForkJoinObservable.ts
+++ b/src/observable/ForkJoinObservable.ts
@@ -87,7 +87,7 @@ class ForkJoinSubscriber<T> extends OuterSubscriber<T, T> {
   private haveValues = 0;
 
   constructor(destination: Subscriber<T>,
-              private sources: Array<SubscribableOrPromise<any>>,
+              sources: Array<SubscribableOrPromise<any>>,
               private resultSelector?: (...values: Array<any>) => T) {
     super(destination);
 

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -115,7 +115,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T[]>,
               private bufferTimeSpan: number,
-              private bufferCreationInterval: number,
+              bufferCreationInterval: number,
               private maxBufferSize: number,
               private scheduler: Scheduler) {
     super(destination);

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -75,7 +75,7 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
   private contexts: Array<BufferContext<T>> = [];
 
   constructor(destination: Subscriber<T[]>,
-              private openings: SubscribableOrPromise<O>,
+              openings: SubscribableOrPromise<O>,
               private closingSelector: (value: O) => SubscribableOrPromise<any> | void) {
     super(destination);
     this.add(subscribeToResult(this, openings));

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -128,7 +128,7 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * @name concat
  * @owner Observable
  */
-export function concatStatic<T, R>(...observables: Array<ObservableInput<any> | Scheduler>): Observable<R> {
+export function concatStatic<R>(...observables: Array<ObservableInput<any> | Scheduler>): Observable<R> {
   let scheduler: Scheduler = null;
   let args = <any[]>observables;
   if (isScheduler(args[observables.length - 1])) {

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -73,7 +73,7 @@ class LastSubscriber<T, R> extends Subscriber<T> {
   constructor(destination: Subscriber<R>,
               private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
               private resultSelector?: ((value: T, index: number) => R) | void,
-              private defaultValue?: any,
+              defaultValue?: any,
               private source?: Observable<T>) {
     super(destination);
     if (typeof defaultValue !== 'undefined') {

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -147,7 +147,7 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * @name merge
  * @owner Observable
  */
-export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
+export function mergeStatic<R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
  let scheduler: Scheduler = null;
   let last: any = observables[observables.length - 1];

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -66,8 +66,8 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
   hasValue: boolean = false;
 
   constructor(destination: Subscriber<T>,
-              private period: number,
-              private scheduler: Scheduler) {
+              period: number,
+              scheduler: Scheduler) {
     super(destination);
     this.add(scheduler.schedule(dispatchNotification, period, { subscriber: this, period }));
   }
@@ -85,7 +85,12 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
   }
 }
 
-function dispatchNotification<T>(this: Action<any>, state: any) {
+interface SampleTimeState<T> {
+  subscriber: SampleTimeSubscriber<T>;
+  period: number;
+}
+
+function dispatchNotification<T>(this: Action<SampleTimeState<T>>, state: SampleTimeState<T>) {
   let { subscriber, period } = state;
   subscriber.notifyNext();
   this.schedule(state, period);

--- a/src/operator/sequenceEqual.ts
+++ b/src/operator/sequenceEqual.ts
@@ -83,7 +83,7 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
   private _oneComplete = false;
 
   constructor(destination: Observer<R>,
-              private compareTo: Observable<T>,
+              compareTo: Observable<T>,
               private comparor: (a: T, b: T) => boolean) {
     super(destination);
     this.add(compareTo.subscribe(new SequenceEqualCompareToSubscriber(destination, this)));

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -61,7 +61,7 @@ class TakeUntilOperator<T> implements Operator<T, T> {
 class TakeUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   constructor(destination: Subscriber<any>,
-              private notifier: Observable<any>) {
+              notifier: Observable<any>) {
     super(destination);
     this.add(subscribeToResult(this, notifier));
   }

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -92,9 +92,9 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
   private windows: Subject<T>[] = [];
 
   constructor(protected destination: Subscriber<Observable<T>>,
-              private windowTimeSpan: number,
-              private windowCreationInterval: number,
-              private scheduler: Scheduler) {
+              windowTimeSpan: number,
+              windowCreationInterval: number,
+              scheduler: Scheduler) {
     super(destination);
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
       let window = this.openWindow();

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -89,7 +89,7 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
   private toRespond: number[] = [];
 
   constructor(destination: Subscriber<R>,
-              private observables: Observable<any>[],
+              observables: Observable<any>[],
               private project?: (...values: any[]) => Observable<R>) {
     super(destination);
     const len = observables.length;

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -67,7 +67,7 @@ export function zipStatic<R>(...observables: Array<ObservableInput<any> | ((...v
  * @name zip
  * @owner Observable
  */
-export function zipStatic<T, R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R> {
+export function zipStatic<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R> {
   const project = <((...ys: Array<any>) => R)> observables[observables.length - 1];
   if (typeof project === 'function') {
     observables.pop();

--- a/src/util/Set.ts
+++ b/src/util/Set.ts
@@ -11,7 +11,7 @@ export interface ISet<T> {
   clear(): void;
 }
 
-export function minimalSetImpl<T>(): ISetCtor {
+export function minimalSetImpl(): ISetCtor {
   // THIS IS NOT a full impl of Set, this is just the minimum
   // bits of functionality we need for this library.
   return class MinimalSet<T> implements ISet<T> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

- This retake the par of https://github.com/ReactiveX/rxjs/pull/2104 to remove needless members or type parameters.
  -  But this does not enable `noUnusedLocals` option according to the decision of #2104.
- This would not be a breaking change.
  - Because these change only internal signatures.

**Related issue (if exists):**

- https://github.com/ReactiveX/rxjs/pull/2104
- https://github.com/ReactiveX/rxjs/issues/1969
