### PR TITLE
chore(build): Using local installed tsc

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,7 +93,8 @@
     "test_browser": "npm-run-all build_spec_browser && opn spec/support/mocha-browser-runner.html",
     "test": "npm-run-all clean_spec build_spec test_mocha clean_spec",
     "tests2png": "npm run build_spec && mkdirp tmp/docs/img && mkdirp spec-js/support && shx cp spec/support/*.opts spec-js/support/ && mocha --opts spec/support/tests2png.opts spec-js",
-    "watch": "watch \"echo triggering build && npm run build_test && echo build completed\" src -d -u -w=15"
+    "watch": "watch \"echo triggering build && npm run build_test && echo build completed\" src -d -u -w=15",
+    "tsc": "tsc"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
To ensure using `./node_modules/.bin/tsc` in npm run-script.