### PR TITLE
fix(timeout): throw traceable TimeoutError

### DIFF
--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -18,9 +18,10 @@ import { TimeoutError } from '../util/TimeoutError';
 export function timeout<T>(this: Observable<T>, due: number | Date,
                            errorToSend: any = null,
                            scheduler: Scheduler = async): Observable<T> {
-  let absoluteTimeout = isDate(due);
-  let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
-  return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, errorToSend, scheduler));
+  const absoluteTimeout = isDate(due);
+  const waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
+  const error = errorToSend || new TimeoutError();
+  return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, error, scheduler));
 }
 
 class TimeoutOperator<T> implements Operator<T, T> {
@@ -96,6 +97,6 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
   }
 
   notifyTimeout(): void {
-    this.error(this.errorToSend || new TimeoutError());
+    this.error(this.errorToSend);
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR updates behaivor of `timeout` operator for better readibility of stack trace when `TimeoutError` thrown. 

For example, with given code snippet

```js
Rx.Observable.never().timeout(10).subscribe(console.log.bind(console));
```

stacktrace will be like below
```js
D:\github\rxjs\dist\cjs\scheduler\AsyncScheduler.js:45
            throw error;
            ^
TimeoutError: Timeout has occurred
    at new TimeoutError (D:\github\rxjs\dist\cjs\util\TimeoutError.js:17:26)
    at TimeoutSubscriber.notifyTimeout (D:\github\rxjs\dist\cjs\operator\timeout.js:99:40)
    at AsyncAction.TimeoutSubscriber.dispatchTimeout [as work] (D:\github\rxjs\dist\cjs\operator\timeout.js:75:20)
    at AsyncAction._execute (D:\github\rxjs\dist\cjs\scheduler\AsyncAction.js:111:18)
    at AsyncAction.execute (D:\github\rxjs\dist\cjs\scheduler\AsyncAction.js:86:26)
    at AsyncScheduler.flush (D:\github\rxjs\dist\cjs\scheduler\AsyncScheduler.js:36:32)
    at ontimeout (timers.js:365:14)
    at tryOnTimeout (timers.js:237:5)
    at Timer.listOnTimeout (timers.js:207:5)
```

which loses original context of code but shows stack trace of async execution context (vary by scheduler specified). This makes hard to track down unhandled exception since it's disconnected to original codebases. Instead, this PR creates error to contain stack traces nearby originall caller, emits like below

```js
D:\github\rxjs\dist\cjs\scheduler\AsyncScheduler.js:45
            throw error;
            ^
TimeoutError: Timeout has occurred
    at new TimeoutError (D:\github\rxjs\dist\cjs\util\TimeoutError.js:17:26)
    at NeverObservable.timeout (D:\github\rxjs\dist\cjs\operator\timeout.js:24:32)
    at Object.<anonymous> (D:\github\rxjs\dummy.js:3:23)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.runMain (module.js:607:10)
    at run (bootstrap_node.js:382:7)
```
 allows bit more easier tracking.

**Related issue (if exists):**