### PR TITLE
fix(partition): handles `thisArg` as expected

### DIFF
--- a/spec/operators/partition-spec.ts
+++ b/spec/operators/partition-spec.ts
@@ -39,6 +39,20 @@ describe('Observable.prototype.partition', () => {
     expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
   });
 
+  it('should partition an observable into two using a predicate and thisArg', () => {
+    const e1 =    hot('--a-b---a------d--a---c--|');
+    const e1subs =    '^                        !';
+    const expected = ['--a-----a---------a------|',
+                    '----b----------d------c--|'];
+
+    function predicate(x) {
+      return x === this.value;
+    }
+
+    expectObservableArray(e1.partition(predicate, {value: 'a'}), expected);
+    expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
+  });
+
   it('should pass errors to both returned observables', () => {
     const e1 =    hot('--a-b---#');
     const e1subs =    '^       !';
@@ -224,5 +238,15 @@ describe('Observable.prototype.partition', () => {
   it('should throw without predicate', () => {
     const e1 = hot('--a-b---a------d----');
     expect(e1.partition).to.throw();
+  });
+
+  it('should accept thisArg', () => {
+    const thisArg = {};
+
+    Observable.of(1).partition(function (value: number) {
+      expect(this).to.deep.equal(thisArg);
+      return true;
+    }, thisArg)
+      .forEach((observable: Rx.Observable<number>) => observable.subscribe());
   });
 });

--- a/src/operator/partition.ts
+++ b/src/operator/partition.ts
@@ -45,7 +45,7 @@ import { Observable } from '../Observable';
  */
 export function partition<T>(this: Observable<T>, predicate: (value: T) => boolean, thisArg?: any): [Observable<T>, Observable<T>] {
   return [
-    filter.call(this, predicate),
+    filter.call(this, predicate, thisArg),
     filter.call(this, not(predicate, thisArg))
   ];
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This fix ensures that the `partition` will call `predicate` with`thisArg` as expected if it is specified.

**Related issue (if exists):**

This fix ensures that the `partition` will call `predicate` with`thisArg` as expected if it is specified.