### PR TITLE
fix(timeout): wrap customError with TimeoutError

### DIFF
--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -1,4 +1,6 @@
 import * as Rx from '../../dist/cjs/Rx';
+import {TimeoutError} from '../../dist/cjs/util/TimeoutError';
+
 declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions};
 
 declare const rxTestScheduler: Rx.TestScheduler;
@@ -19,11 +21,35 @@ describe('Observable.prototype.timeout', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should timeout after specified timeout period and send the passed error', () => {
+  it('should timeout after specified timeout period and send the passed error as TimeoutError', () => {
     const e1 =  cold('-');
     const e1subs =   '^    !';
     const expected = '-----#';
     const value = 'hello';
+
+    const result = e1.timeout(50, value, rxTestScheduler);
+
+    expectObservable(result).toBe(expected, null, new TimeoutError(value));
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should timeout after specified timeout period and send the passed error', () => {
+    const e1 =  cold('-');
+    const e1subs =   '^    !';
+    const expected = '-----#';
+    const value = new Error('hello');
+
+    const result = e1.timeout(50, value, rxTestScheduler);
+
+    expectObservable(result).toBe(expected, null, value);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should timeout after specified timeout period and send the passed TimeoutError', () => {
+    const e1 =  cold('-');
+    const e1subs =   '^    !';
+    const expected = '-----#';
+    const value = new TimeoutError('hello');
 
     const result = e1.timeout(50, value, rxTestScheduler);
 
@@ -92,7 +118,7 @@ describe('Observable.prototype.timeout', () => {
   });
 
   it('should timeout after a specified delay with passed error while source emits', () => {
-    const value = 'hello';
+    const value = new TimeoutError('hello');
     const e1 =   hot('---a---b---c------d---e---|');
     const e1subs =   '^               !          ';
     const expected = '---a---b---c----#          ';
@@ -128,7 +154,7 @@ describe('Observable.prototype.timeout', () => {
   });
 
   it('should timeout specified Date with passed error while source emits', () => {
-    const value = 'hello';
+    const value = new TimeoutError('hello');
     const e1 =   hot('--a--b--c--d--e--|');
     const e1subs =   '^         !       ';
     const expected = '--a--b--c-#       ';

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -20,7 +20,8 @@ export function timeout<T>(this: Observable<T>, due: number | Date,
                            scheduler: Scheduler = async): Observable<T> {
   const absoluteTimeout = isDate(due);
   const waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
-  const error = errorToSend || new TimeoutError();
+  const error = errorToSend instanceof Error ? errorToSend : new TimeoutError(errorToSend);
+
   return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, error, scheduler));
 }
 

--- a/src/util/TimeoutError.ts
+++ b/src/util/TimeoutError.ts
@@ -6,8 +6,8 @@
  * @class TimeoutError
  */
 export class TimeoutError extends Error {
-  constructor() {
-    const err: any = super('Timeout has occurred');
+  constructor(message?: any) {
+    const err: any = super(message || 'Timeout has occurred');
     (<any> this).name = err.name = 'TimeoutError';
     (<any> this).stack = err.stack;
     (<any> this).message = err.message;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR updates behavior of `timeout` when specify `errorToSend` for custom timeout message. Since custom timeout message can be anything (literally `any`), if caller does not specify it as timeouterror, when it's thrown it does not deliver context of error thrown. This PR checks type of error, wraps into timeout error to have additional context to debug. 

with given example snippet
`Rx.Observable.never().timeout(10, 'customerr').subscribe(console.log.bind(console));`

*Before*
```js
D:\github\rxjs\dist\cjs\scheduler\AsyncScheduler.js:45
            throw error;
            ^
customerr
```

*After*
```js
D:\github\rxjs\dist\cjs\scheduler\AsyncScheduler.js:45
            throw error;
            ^
TimeoutError: customerr
    at new TimeoutError (D:\github\rxjs\dist\cjs\util\TimeoutError.js:17:26)
    at NeverObservable.timeout (D:\github\rxjs\dist\cjs\operator\timeout.js:30:17)
    at Object.<anonymous> (D:\github\rxjs\dummy.js:3:23)
    at Module._compile (module.js:573:32)
    at Object.Module._extensions..js (module.js:582:10)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.runMain (module.js:607:10)
    at run (bootstrap_node.js:382:7)
```

**Related issue (if exists):**

