### PR TITLE
fix(event): uses `Object.prototype.toString.call` on objects

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -279,4 +279,21 @@ describe('Observable.fromEvent', () => {
 
     send(1, 2, 3);
   });
+
+  it('should not throw an exception calling toString on obj with a null prototype', (done: MochaDone) => {
+    // NOTE: Can not test with Object.create(null) or `class Foo extends null`
+    // due to TypeScript bug. https://github.com/Microsoft/TypeScript/issues/1108
+    class NullProtoEventTarget {
+      on() { /*noop*/ }
+      off() { /*noop*/ }
+    }
+    NullProtoEventTarget.prototype.toString = null;
+    const obj: NullProtoEventTarget = new NullProtoEventTarget();
+
+    expect(() => {
+      Observable.fromEvent(obj, 'foo').subscribe();
+      done();
+    }).to.not.throw(TypeError);
+  });
+
 });

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -5,6 +5,8 @@ import { errorObject } from '../util/errorObject';
 import { Subscription } from '../Subscription';
 import { Subscriber } from '../Subscriber';
 
+const toString: Function = Object.prototype.toString;
+
 export type NodeStyleEventEmmitter = {
   addListener: (eventName: string, handler: Function) => void;
   removeListener: (eventName: string, handler: Function) => void;
@@ -22,11 +24,11 @@ function isJQueryStyleEventEmitter(sourceObj: any): sourceObj is JQueryStyleEven
 }
 
 function isNodeList(sourceObj: any): sourceObj is NodeList {
-  return !!sourceObj && sourceObj.toString() === '[object NodeList]';
+  return !!sourceObj && toString.call(sourceObj) === '[object NodeList]';
 }
 
 function isHTMLCollection(sourceObj: any): sourceObj is HTMLCollection {
-  return !!sourceObj && sourceObj.toString() === '[object HTMLCollection]';
+  return !!sourceObj && toString.call(sourceObj) === '[object HTMLCollection]';
 }
 
 function isEventTarget(sourceObj: any): sourceObj is EventTarget {


### PR DESCRIPTION
**Description:**

Objects created with a null prototype do not have a toString method.

