### PR TITLE
fix(errors): Better error message when you return non-observable things,

### DIFF
--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -125,7 +125,8 @@ describe('subscribeToResult', () => {
     const subscriber = new OuterSubscriber(x => {
       done(new Error('should not be called'));
     }, (x) => {
-      expect(x).to.be.an('error', 'invalid observable');
+      expect(x).to.be.an('error');
+      expect(x.message).to.be.equal('Provided object does not correctly implement Symbol.observable');
       done();
     }, () => {
       done(new Error('should not be called'));
@@ -138,12 +139,31 @@ describe('subscribeToResult', () => {
     const subscriber = new OuterSubscriber(x => {
       done(new Error('should not be called'));
     }, (x) => {
-      expect(x).to.be.an('error', 'unknown type returned');
+      expect(x).to.be.an('error');
+      const msg = 'You provided an invalid object where a stream was expected.'
+        + ' You can provide an Observable, Promise, Array, or Iterable.';
+      expect(x.message).to.be.equal(msg);
       done();
     }, () => {
       done(new Error('should not be called'));
     });
 
     subscribeToResult(subscriber, {});
+  });
+
+  it('should emit an error when trying to subscribe to a non-object', (done: MochaDone) => {
+    const subscriber = new OuterSubscriber(x => {
+      done(new Error('should not be called'));
+    }, (x) => {
+      expect(x).to.be.an('error');
+      const msg = 'You provided \'null\' where a stream was expected.'
+        + ' You can provide an Observable, Promise, Array, or Iterable.';
+      expect(x.message).to.be.equal(msg);
+      done();
+    }, () => {
+      done(new Error('should not be called'));
+    });
+
+    subscribeToResult(subscriber, null);
   });
 });


### PR DESCRIPTION
```js
item$.mergeMap(() => {})
// You provided 'undefined' where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.

item$.mergeMap(() => ({}))
// You provided an invalid object where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.
```

One thing I thought about doing is having operators (who are the ones who call `subscribeToResult`) pass in the operator name, so that the error message could also say which operator it thinks it occured in. **But**, what about operator aliases? i.e. mergeMap/flatMap, etc. And also, this could potentially be _more_ confusing if it's a custom operator that calls other operators inside of it--but perhaps that's rare enough in the wild to discount it.

So for example: `You provided 'undefined' to 'mergeMap|flatMap' where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.`

Cc/ @kentcdodds