### PR TITLE
fix(Symbol.iterator): fixed typo in function name

### DIFF
--- a/spec/symbol/iterator-spec.ts
+++ b/spec/symbol/iterator-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { $$iterator, symbolIteratorPonyfill } from '../../dist/cjs/symbol/iterator';
+import { $$iterator, symbolIteratorPolyfill } from '../../dist/cjs/symbol/iterator';
 
 describe('iterator symbol', () => {
   it('should exist', () => {
@@ -7,13 +7,13 @@ describe('iterator symbol', () => {
   });
 });
 
-describe('symbolIteratorPonyfill', () => {
+describe('symbolIteratorPolyfill', () => {
   describe('when root.Symbol is a function', () => {
     describe('and Symbol.iterator exists', () => {
       it('should return Symbol.iterator', () => {
         const FakeSymbol = function () { /* lol */ };
         (<any>FakeSymbol).iterator = {};
-        const result = symbolIteratorPonyfill({ Symbol: FakeSymbol });
+        const result = symbolIteratorPolyfill({ Symbol: FakeSymbol });
         expect(result).to.equal((<any>FakeSymbol).iterator);
       });
     });
@@ -29,7 +29,7 @@ describe('symbolIteratorPonyfill', () => {
           }
         };
 
-        const result = symbolIteratorPonyfill(root);
+        const result = symbolIteratorPolyfill(root);
         expect(result).to.equal(SYMBOL_RETURN);
         expect((<any>root.Symbol).iterator).to.equal(SYMBOL_RETURN);
       });
@@ -39,7 +39,7 @@ describe('symbolIteratorPonyfill', () => {
   describe('when root.Symbol is NOT a function', () => {
     describe('and root.Set exists with an @@iterator property that is a function (Mozilla bug)', () => {
       it ('should return "$$iterator"', () => {
-        const result = symbolIteratorPonyfill({
+        const result = symbolIteratorPolyfill({
           Set: function FakeSet() {
             this['@@iterator'] = function () { /* lol */ };
           }
@@ -60,7 +60,7 @@ describe('symbolIteratorPonyfill', () => {
             Map: FakeMap
           };
 
-          const result = symbolIteratorPonyfill(root);
+          const result = symbolIteratorPolyfill(root);
           expect(result).to.equal('-omg-lol-i-can-use-whatever-I-want-YOLO-');
         });
       });
@@ -75,14 +75,14 @@ describe('symbolIteratorPonyfill', () => {
             Map: FakeMap
           };
 
-          const result = symbolIteratorPonyfill(root);
+          const result = symbolIteratorPolyfill(root);
           expect(result).to.equal('@@iterator');
         });
       });
 
       describe('if Set exists but has no iterator, and Map does not exist (bad polyfill maybe?)', () => {
         it('should return "@@iterator"', () => {
-          const result = symbolIteratorPonyfill({
+          const result = symbolIteratorPolyfill({
             Set: function () { /* lol */ }
           });
           expect(result).to.equal('@@iterator');
@@ -91,7 +91,7 @@ describe('symbolIteratorPonyfill', () => {
 
       describe('and root.Set and root.Map do NOT exist', () => {
         it('should return "@@iterator"', () => {
-          const result = symbolIteratorPonyfill({});
+          const result = symbolIteratorPolyfill({});
           expect(result).to.equal('@@iterator');
         });
       });

--- a/src/symbol/iterator.ts
+++ b/src/symbol/iterator.ts
@@ -1,6 +1,6 @@
 import { root } from '../util/root';
 
-export function symbolIteratorPonyfill(root: any) {
+export function symbolIteratorPolyfill(root: any) {
   const Symbol: any = root.Symbol;
 
   if (typeof Symbol === 'function') {
@@ -30,4 +30,4 @@ export function symbolIteratorPonyfill(root: any) {
   }
 }
 
-export const $$iterator = symbolIteratorPonyfill(root);
+export const $$iterator = symbolIteratorPolyfill(root);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Typo in function name.

**Related issue (if exists):**

