### PR TITLE
fix(AjaxObservable): catch XHR send failures to observer

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -177,6 +177,33 @@ describe('Observable.ajax', () => {
     expect(error).to.be.an('error', 'wokka wokka');
   });
 
+  it('should error if send request throws', (done: MochaDone) => {
+    const expected = new Error('xhr send failure');
+
+    const obj = {
+      url: '/flibbertyJibbet',
+      responseType: 'text',
+      method: '',
+      createXHR: () => {
+        const ret = new MockXMLHttpRequest();
+        ret.send = () => {
+          throw expected;
+        };
+        return ret as any;
+      }
+    };
+
+    Rx.Observable.ajax(obj)
+      .subscribe(() => {
+        done(new Error('should not be called'));
+      }, (e: Error) => {
+        expect(e).to.be.equal(expected);
+        done();
+      }, () => {
+        done(new Error('should not be called'));
+      });
+  });
+
   it('should succeed on 200', () => {
     const expected = { foo: 'bar' };
     let result;
@@ -409,6 +436,34 @@ describe('Observable.ajax', () => {
 
       expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
       expect(MockXMLHttpRequest.mostRecent.data).to.equal('{"🌟":"🚀"}');
+    });
+
+    it('should error if send request throws', (done: MochaDone) => {
+      const expected = new Error('xhr send failure');
+
+      const obj = {
+        url: '/flibbertyJibbet',
+        responseType: 'text',
+        method: '',
+        body: 'foobar',
+        createXHR: () => {
+          const ret = new MockXMLHttpRequest();
+          ret.send = () => {
+            throw expected;
+          };
+          return ret as any;
+        }
+      };
+
+      Rx.Observable.ajax(obj)
+        .subscribe(() => {
+          done(new Error('should not be called'));
+        }, (e: Error) => {
+          expect(e).to.be.equal(expected);
+          done();
+        }, () => {
+          done(new Error('should not be called'));
+        });
     });
   });
 

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -248,10 +248,10 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       this.setupEvents(xhr, request);
 
       // finally send the request
-      if (body) {
-        xhr.send(body);
-      } else {
-        xhr.send();
+      result = body ? tryCatch(xhr.send).call(xhr, body) : tryCatch(xhr.send).call(xhr);
+      if (result === errorObject) {
+        this.error(errorObject.e);
+        return null;
       }
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Currently when `XMLHttpRequest::send()` throws, AjaxObservable does not deliver those failures to observer different to other XHR behaviors. This PR updates behavior of `AjaxObservable` to change those behavior to deliver error to observer as well.

**Related issue (if exists):**

