### PR TITLE
Fix type guard additions

### DIFF
--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -272,4 +272,55 @@ describe('Observable.prototype.filter', () => {
     expectObservable(r, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
+
+  it('should support type guards without breaking previous behavior', () => {
+    // tslint:disable no-unused-variable
+
+    // type guards with interfaces and classes
+    {
+      interface Bar { bar?: string; }
+      interface Baz { baz?: number; }
+      class Foo implements Bar, Baz { constructor(public bar: string = 'name', public baz: number = 42) {} }
+
+      const isBar = (x: any): x is Bar => x && (<Bar>x).bar !== undefined;
+      const isBaz = (x: any): x is Baz => x && (<Baz>x).baz !== undefined;
+
+      const foo: Foo = new Foo();
+      Observable.of(foo).filter(foo => foo.baz === 42)
+        .subscribe(x => x.baz); // x is still Foo
+      Observable.of(foo).filter(isBar)
+        .subscribe(x => x.bar); // x is Bar!
+
+      const foobar: Bar = new Foo(); // type is interface, not the class
+      Observable.of(foobar).filter(foobar => foobar.bar === 'name')
+        .subscribe(x => x.bar); // <-- x is still Bar
+      Observable.of(foobar).filter(isBar)
+        .subscribe(x => x.bar); // <--- x is Bar!
+
+      const barish = { bar: 'quack', baz: 42 } // type can quack like a Bar
+      Observable.of(barish).filter(x => x.bar === 'quack')
+        .subscribe(x => x.bar); // x is still { bar: string; baz: number; }
+      Observable.of(barish).filter(isBar)
+        .subscribe(bar => bar.bar); // x is Bar!
+    }
+
+    // type guards with primitive types
+    {
+      const xs: Rx.Observable<string | number> = Observable.from([ 1, 'aaa', 3, 'bb' ]);
+
+      // This type guard will narrow a `string | number` to a string in the examples below
+      const isString = (x: string | number): x is string => typeof x === 'string';
+
+      xs.filter(isString)
+        .subscribe(s => s.length); // s is string
+
+      // In contrast, this type of regular boolean predicate still maintains the original type
+      xs.filter(x => typeof x === 'number')
+        .subscribe(x => x); // x is still string | number
+      xs.filter((x, i) => typeof x === 'number' && x > i)
+        .subscribe(x => x); // x is still string | number
+    }
+
+    // tslint:disable enable
+  });
 });

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -297,7 +297,7 @@ describe('Observable.prototype.filter', () => {
       Observable.of(foobar).filter(isBar)
         .subscribe(x => x.bar); // <--- x is Bar!
 
-      const barish = { bar: 'quack', baz: 42 } // type can quack like a Bar
+      const barish = { bar: 'quack', baz: 42 }; // type can quack like a Bar
       Observable.of(barish).filter(x => x.bar === 'quack')
         .subscribe(x => x.bar); // x is still { bar: string; baz: number; }
       Observable.of(barish).filter(isBar)

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -155,4 +155,55 @@ describe('Observable.prototype.find', () => {
     expectObservable((<any>source).find(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
+
+  it('should support type guards without breaking previous behavior', () => {
+    // tslint:disable no-unused-variable
+
+    // type guards with interfaces and classes
+    {
+      interface Bar { bar?: string; }
+      interface Baz { baz?: number; }
+      class Foo implements Bar, Baz { constructor(public bar: string = 'name', public baz: number = 42) {} }
+
+      const isBar = (x: any): x is Bar => x && (<Bar>x).bar !== undefined;
+      const isBaz = (x: any): x is Baz => x && (<Baz>x).baz !== undefined;
+
+      const foo: Foo = new Foo();
+      Observable.of(foo).find(foo => foo.baz === 42)
+        .subscribe(x => x.baz); // x is still Foo
+      Observable.of(foo).find(isBar)
+        .subscribe(x => x.bar); // x is Bar!
+
+      const foobar: Bar = new Foo(); // type is interface, not the class
+      Observable.of(foobar).find(foobar => foobar.bar === 'name')
+        .subscribe(x => x.bar); // <-- x is still Bar
+      Observable.of(foobar).find(isBar)
+        .subscribe(x => x.bar); // <--- x is Bar!
+
+      const barish = { bar: 'quack', baz: 42 } // type can quack like a Bar
+      Observable.of(barish).find(x => x.bar === 'quack')
+        .subscribe(x => x.bar); // x is still { bar: string; baz: number; }
+      Observable.of(barish).find(isBar)
+        .subscribe(bar => bar.bar); // x is Bar!
+    }
+
+    // type guards with primitive types
+    {
+      const xs: Rx.Observable<string | number> = Observable.from([ 1, 'aaa', 3, 'bb' ]);
+
+      // This type guard will narrow a `string | number` to a string in the examples below
+      const isString = (x: string | number): x is string => typeof x === 'string';
+
+      xs.find(isString)
+        .subscribe(s => s.length); // s is string
+
+      // In contrast, this type of regular boolean predicate still maintains the original type
+      xs.find(x => typeof x === 'number')
+        .subscribe(x => x); // x is still string | number
+      xs.find((x, i) => typeof x === 'number' && x > i)
+        .subscribe(x => x); // x is still string | number
+    }
+
+    // tslint:disable enable
+  });
 });

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -180,7 +180,7 @@ describe('Observable.prototype.find', () => {
       Observable.of(foobar).find(isBar)
         .subscribe(x => x.bar); // <--- x is Bar!
 
-      const barish = { bar: 'quack', baz: 42 } // type can quack like a Bar
+      const barish = { bar: 'quack', baz: 42 }; // type can quack like a Bar
       Observable.of(barish).find(x => x.bar === 'quack')
         .subscribe(x => x.bar); // x is still { bar: string; baz: number; }
       Observable.of(barish).find(isBar)

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -243,7 +243,7 @@ describe('Observable.prototype.first', () => {
       Observable.of(foobar).first(isBaz)
         .subscribe(x => x.baz); // x is Baz!
 
-      const barish = { bar: 'quack', baz: 42 } // type can quack like a Bar
+      const barish = { bar: 'quack', baz: 42 }; // type can quack like a Bar
       Observable.of(barish).first()
         .subscribe(x => x.baz); // x is still { bar: string; baz: number; }
       Observable.of(barish).first(x => x.bar === 'quack')

--- a/spec/operators/last-spec.ts
+++ b/spec/operators/last-spec.ts
@@ -173,7 +173,7 @@ describe('Observable.prototype.last', () => {
       Observable.of(foobar).last(isBaz)
         .subscribe(x => x.baz); // x is Baz!
 
-      const barish = { bar: 'quack', baz: 42 } // type can quack like a Bar
+      const barish = { bar: 'quack', baz: 42 }; // type can quack like a Bar
       Observable.of(barish).last()
         .subscribe(x => x.baz); // x is still { bar: string; baz: number; }
       Observable.of(barish).last(x => x.bar === 'quack')

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -5,9 +5,11 @@ import { TeardownLogic } from '../Subscription';
 
 /* tslint:disable:max-line-length */
 export function filter<T, S extends T>(this: Observable<T>,
-                                       predicate: ((value: T, index: number) => boolean) |
-                                                  ((value: T, index: number) => value is S),
+                                       predicate: (value: T, index: number) => value is S,
                                        thisArg?: any): Observable<S>;
+export function filter<T>(this: Observable<T>,
+                          predicate: (value: T, index: number) => boolean,
+                          thisArg?: any): Observable<T>;
 /* tslint:disable:max-line-length */
 
 /**

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -4,9 +4,11 @@ import { Subscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
 export function find<T, S extends T>(this: Observable<T>,
-                                     predicate: ((value: T, index: number, source: Observable<T>) => boolean) |
-                                                ((value: T, index: number, source: Observable<T>) => value is S),
+                                     predicate: (value: T, index: number) => value is S,
                                      thisArg?: any): Observable<S>;
+export function find<T>(this: Observable<T>,
+                        predicate: (value: T, index: number) => boolean,
+                        thisArg?: any): Observable<T>;
 /* tslint:disable:max-line-length */
 
 /**

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -5,16 +5,24 @@ import { EmptyError } from '../util/EmptyError';
 
 /* tslint:disable:max-line-length */
 export function first<T, S extends T>(this: Observable<T>,
-                                      predicate?: ((value: T, index: number, source: Observable<T>) => boolean) |
-                                                  ((value: T, index: number, source: Observable<T>) => value is S)): Observable<S>;
-export function first<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, resultSelector: void, defaultValue?: T): Observable<T>;
+                                      predicate: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
 export function first<T, S extends T, R>(this: Observable<T>,
-                                         predicate: ((value: T, index: number, source: Observable<T>) => boolean) |
-                                                    ((value: T, index: number, source: Observable<T>) => value is S),
-                                         resultSelector?: ((value: S, index: number) => R) | void,
-                                         defaultValue?: S): Observable<S>;
-export function first<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, defaultValue?: R): Observable<R>;
-/* tslint:disable:max-line-length */
+                                         predicate: (value: T | S, index: number, source: Observable<T>) => value is S,
+                                         resultSelector: (value: S, index: number) => R, defaultValue?: R): Observable<R>;
+export function first<T, S extends T>(this: Observable<T>,
+                                      predicate: (value: T, index: number, source: Observable<T>) => value is S,
+                                      resultSelector: void,
+                                      defaultValue?: S): Observable<S>;
+export function first<T>(this: Observable<T>,
+                         predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
+export function first<T, R>(this: Observable<T>,
+                            predicate: (value: T, index: number, source: Observable<T>) => boolean,
+                            resultSelector?: (value: T, index: number) => R,
+                            defaultValue?: R): Observable<R>;
+export function first<T>(this: Observable<T>,
+                         predicate: (value: T, index: number, source: Observable<T>) => boolean,
+                         resultSelector: void,
+                         defaultValue?: T): Observable<T>;
 
 /**
  * Emits only the first value (or the first value that meets some condition)

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -5,15 +5,24 @@ import { EmptyError } from '../util/EmptyError';
 
 /* tslint:disable:max-line-length */
 export function last<T, S extends T>(this: Observable<T>,
-                                     predicate?: ((value: T, index: number, source: Observable<T>) => boolean) |
-                                                 ((value: T, index: number, source: Observable<T>) => value is S)): Observable<S>;
-export function last<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, resultSelector: void, defaultValue?: T): Observable<T>;
+                                     predicate: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
 export function last<T, S extends T, R>(this: Observable<T>,
-                                        predicate: ((value: T, index: number, source: Observable<T>) => boolean) |
-                                                   ((value: T, index: number, source: Observable<T>) => value is S),
-                                        resultSelector?: ((value: S, index: number) => R) | void,
-                                        defaultValue?: S): Observable<S>;
-export function last<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean, resultSelector?: (value: T, index: number) => R, defaultValue?: R): Observable<R>;
+                                        predicate: (value: T | S, index: number, source: Observable<T>) => value is S,
+                                        resultSelector: (value: S, index: number) => R, defaultValue?: R): Observable<R>;
+export function last<T, S extends T>(this: Observable<T>,
+                                     predicate: (value: T, index: number, source: Observable<T>) => value is S,
+                                     resultSelector: void,
+                                     defaultValue?: S): Observable<S>;
+export function last<T>(this: Observable<T>,
+                        predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
+export function last<T, R>(this: Observable<T>,
+                           predicate: (value: T, index: number, source: Observable<T>) => boolean,
+                           resultSelector?: (value: T, index: number) => R,
+                           defaultValue?: R): Observable<R>;
+export function last<T>(this: Observable<T>,
+                        predicate: (value: T, index: number, source: Observable<T>) => boolean,
+                        resultSelector: void,
+                        defaultValue?: T): Observable<T>;
 /* tslint:disable:max-line-length */
 
 /**


### PR DESCRIPTION
**Description:**
This is a fix for the recently-added type guard support in the `filter`, `find`, `first` and `last` operator typings. Please see the test cases for details of what's working now, and be sure to let me know if I missed anything this time! ;-)

**Related issue (if exists):**
Apparently, my previous PR in #2119 is being reverted in #2164 due to the important missed case mentioned in #2163. Unfortunately, I didn't receive any notifications about it, but I'm glad I saw it today while lurking through the repo! :-) Hopefully, this PR should address the problem (which I'm embarrased that I missed), and let us keep the new support without breaking previous behavior.