### PR TITLE
Patch custom Error object to inherit base Error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,9 @@ install:
   - npm install && npm run lint
 
 script:
-  - npm run build_spec && npm run test_mocha && node ./node_modules/markdown-doctest/bin/cmd.js
+  - npm install typescript@2.0.7 && npm run build_spec && npm run test_mocha
+  - npm install typescript@latest && npm run build_spec && npm run test_mocha
+  - node ./node_modules/markdown-doctest/bin/cmd.js
   - npm run check_circular_dependencies
 
 after_success:

--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "source-map-support": "^0.4.0",
     "tslib": "^1.0.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.6",
+    "typescript": "^2.1.4",
     "typings": "^2.0.0",
     "validate-commit-msg": "^2.3.1",
     "watch": "^1.0.1",

--- a/spec/support/mocha.sauce.runner.js
+++ b/spec/support/mocha.sauce.runner.js
@@ -63,18 +63,6 @@ var customLaunchers = {
     platform: 'OS X 10.11',
     version: '9.1'
   },
-  sl_ie9: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    platform: 'Windows 2008',
-    version: '9'
-  },
-  sl_ie10: {
-    base: 'SauceLabs',
-    browserName: 'internet explorer',
-    platform: 'Windows 2012',
-    version: '10'
-  },
   sl_ie11: {
     base: 'SauceLabs',
     browserName: 'internet explorer',

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -435,6 +435,8 @@ export class AjaxError extends Error {
 
   constructor(message: string, xhr: XMLHttpRequest, request: AjaxRequest) {
     super(message);
+    (this as any).__proto__ = AjaxError.prototype;
+
     this.message = message;
     this.xhr = xhr;
     this.request = request;

--- a/src/util/ArgumentOutOfRangeError.ts
+++ b/src/util/ArgumentOutOfRangeError.ts
@@ -11,6 +11,8 @@
 export class ArgumentOutOfRangeError extends Error {
   constructor() {
     const err: any = super('argument out of range');
+    (this as any).__proto__ = ArgumentOutOfRangeError.prototype;
+
     (<any> this).name = err.name = 'ArgumentOutOfRangeError';
     (<any> this).stack = err.stack;
     (<any> this).message = err.message;

--- a/src/util/EmptyError.ts
+++ b/src/util/EmptyError.ts
@@ -11,6 +11,8 @@
 export class EmptyError extends Error {
   constructor() {
     const err: any = super('no elements in sequence');
+    (this as any).__proto__ = EmptyError.prototype;
+
     (<any> this).name = err.name = 'EmptyError';
     (<any> this).stack = err.stack;
     (<any> this).message = err.message;

--- a/src/util/ObjectUnsubscribedError.ts
+++ b/src/util/ObjectUnsubscribedError.ts
@@ -10,6 +10,8 @@
 export class ObjectUnsubscribedError extends Error {
   constructor() {
     const err: any = super('object unsubscribed');
+    (this as any).__proto__ = ObjectUnsubscribedError.prototype;
+
     (<any> this).name = err.name = 'ObjectUnsubscribedError';
     (<any> this).stack = err.stack;
     (<any> this).message = err.message;

--- a/src/util/TimeoutError.ts
+++ b/src/util/TimeoutError.ts
@@ -8,6 +8,8 @@
 export class TimeoutError extends Error {
   constructor() {
     const err: any = super('Timeout has occurred');
+    (this as any).__proto__ = TimeoutError.prototype;
+
     (<any> this).name = err.name = 'TimeoutError';
     (<any> this).stack = err.stack;
     (<any> this).message = err.message;

--- a/src/util/UnsubscriptionError.ts
+++ b/src/util/UnsubscriptionError.ts
@@ -5,6 +5,8 @@
 export class UnsubscriptionError extends Error {
   constructor(public errors: any[]) {
     super();
+    (this as any).__proto__ = UnsubscriptionError.prototype;
+
     const err: any = Error.call(this, errors ?
       `${errors.length} errors occurred during unsubscription:
   ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '');


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Per breaking changes of TS 2.1 (https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work) Inheriting built in object no longer gives prototype chain. This PR updates each custom error object to have prototype of Error.

**Related issue (if exists):**
#2178 

*BREAKING CHANGE*: This change drops support of IE 10 and prior
