### PR TITLE
chore(package.json): upgrade typescript to v2.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "source-map-support": "^0.4.0",
     "tslib": "^1.0.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.6",
+    "typescript": "^2.1.4",
     "typings": "^2.0.0",
     "validate-commit-msg": "^2.3.1",
     "watch": "^1.0.1",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->


BREAKING CHANGE: TypeScript definitions are now for TS 2.1 and higher.

Abstract
----------

- This change does not cause any breaking change directly, but we would causes some breaking change by using new features intoduced by v2.1 for the future.
- If we upgrade typescript to v2.1, there are some pros/cons.

### pros

- we can switch to npm:@types type dependencies by https://github.com/Microsoft/TypeScript/issues/11849 is fixed in v2.1.
- we can use more powerfull features introduced by v2.1.
  - We can use [tslib](https://github.com/Microsoft/tslib) to reduce our compiled code size.
- we don't have to upgrade major version v5 stable release if we merge this now before v5 stable release.

### cons

- This would introduce some breaking change for the future.
  - But we might cause some breaking change intentionally because we don't lock the range of our typescript version to patch version. This might causes to accept new features which uses the lang features introduced by a latest version of TypeScript

## Relations links

- [TypeScript 2.1 RC: Better Inference, Async Functions, and More](https://blogs.msdn.microsoft.com/typescript/2016/11/08/typescript-2-1-rc-better-inference-async-functions-and-more/)
- [Announcing TypeScript 2.1](https://blogs.msdn.microsoft.com/typescript/2016/12/07/announcing-typescript-2-a1/)

## Related issues

- https://github.com/ReactiveX/rxjs/issues/2178
  - We should wait it if we merge this into master.