### PR TITLE
Make subscribeOn use lift, refactor operators to call public subscribe method

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -93,7 +93,7 @@ export class Observable<T> implements Subscribable<T> {
     const sink = toSubscriber(observerOrNext, error, complete);
 
     if (operator) {
-      operator.call(sink, this);
+      operator.call(sink, this.source);
     } else {
       sink.add(this._subscribe(sink));
     }

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -97,7 +97,7 @@ class RefCountOperator<T> implements Operator<T, T> {
     (<any> connectable)._refCount++;
 
     const refCounter = new RefCountSubscriber(subscriber, connectable);
-    const subscription = source._subscribe(refCounter);
+    const subscription = source.subscribe(refCounter);
 
     if (!refCounter.closed) {
       (<any> refCounter).connection = connectable.connect();

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -1,3 +1,4 @@
+import { Action } from '../scheduler/Action';
 import { Scheduler } from '../Scheduler';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
@@ -20,9 +21,9 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     return new SubscribeOnObservable(source, delay, scheduler);
   }
 
-  static dispatch<T>(arg: DispatchArg<T>): Subscription {
+  static dispatch<T>(this: Action<T>, arg: DispatchArg<T>): Subscription {
     const { source, subscriber } = arg;
-    return source.subscribe(subscriber);
+    return this.add(source.subscribe(subscriber));
   }
 
   constructor(public source: Observable<T>,

--- a/src/operator/audit.ts
+++ b/src/operator/audit.ts
@@ -57,7 +57,7 @@ class AuditOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new AuditSubscriber<T, T>(subscriber, this.durationSelector));
+    return source.subscribe(new AuditSubscriber<T, T>(subscriber, this.durationSelector));
   }
 }
 

--- a/src/operator/auditTime.ts
+++ b/src/operator/auditTime.ts
@@ -57,7 +57,7 @@ class AuditTimeOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new AuditTimeSubscriber(subscriber, this.duration, this.scheduler));
+    return source.subscribe(new AuditTimeSubscriber(subscriber, this.duration, this.scheduler));
   }
 }
 

--- a/src/operator/buffer.ts
+++ b/src/operator/buffer.ts
@@ -48,7 +48,7 @@ class BufferOperator<T> implements Operator<T, T[]> {
   }
 
   call(subscriber: Subscriber<T[]>, source: any): any {
-    return source._subscribe(new BufferSubscriber(subscriber, this.closingNotifier));
+    return source.subscribe(new BufferSubscriber(subscriber, this.closingNotifier));
   }
 }
 

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -52,7 +52,7 @@ class BufferCountOperator<T> implements Operator<T, T[]> {
   }
 
   call(subscriber: Subscriber<T[]>, source: any): any {
-    return source._subscribe(new BufferCountSubscriber(subscriber, this.bufferSize, this.startBufferEvery));
+    return source.subscribe(new BufferCountSubscriber(subscriber, this.bufferSize, this.startBufferEvery));
   }
 }
 

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -86,7 +86,7 @@ class BufferTimeOperator<T> implements Operator<T, T[]> {
   }
 
   call(subscriber: Subscriber<T[]>, source: any): any {
-    return source._subscribe(new BufferTimeSubscriber(
+    return source.subscribe(new BufferTimeSubscriber(
       subscriber, this.bufferTimeSpan, this.bufferCreationInterval, this.maxBufferSize, this.scheduler
     ));
   }

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -57,7 +57,7 @@ class BufferToggleOperator<T, O> implements Operator<T, T[]> {
   }
 
   call(subscriber: Subscriber<T[]>, source: any): any {
-    return source._subscribe(new BufferToggleSubscriber(subscriber, this.openings, this.closingSelector));
+    return source.subscribe(new BufferToggleSubscriber(subscriber, this.openings, this.closingSelector));
   }
 }
 

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -52,7 +52,7 @@ class BufferWhenOperator<T> implements Operator<T, T[]> {
   }
 
   call(subscriber: Subscriber<T[]>, source: any): any {
-    return source._subscribe(new BufferWhenSubscriber(subscriber, this.closingSelector));
+    return source.subscribe(new BufferWhenSubscriber(subscriber, this.closingSelector));
   }
 }
 

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -29,7 +29,7 @@ class CatchOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new CatchSubscriber(subscriber, this.selector, this.caught));
+    return source.subscribe(new CatchSubscriber(subscriber, this.selector, this.caught));
   }
 }
 

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -87,7 +87,7 @@ export class CombineLatestOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new CombineLatestSubscriber(subscriber, this.project));
+    return source.subscribe(new CombineLatestSubscriber(subscriber, this.project));
   }
 }
 

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -58,7 +58,7 @@ class CountOperator<T> implements Operator<T, number> {
   }
 
   call(subscriber: Subscriber<number>, source: any): any {
-    return source._subscribe(new CountSubscriber(subscriber, this.predicate, this.source));
+    return source.subscribe(new CountSubscriber(subscriber, this.predicate, this.source));
   }
 }
 

--- a/src/operator/debounce.ts
+++ b/src/operator/debounce.ts
@@ -58,7 +58,7 @@ class DebounceOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new DebounceSubscriber(subscriber, this.durationSelector));
+    return source.subscribe(new DebounceSubscriber(subscriber, this.durationSelector));
   }
 }
 

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -60,7 +60,7 @@ class DebounceTimeOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new DebounceTimeSubscriber(subscriber, this.dueTime, this.scheduler));
+    return source.subscribe(new DebounceTimeSubscriber(subscriber, this.dueTime, this.scheduler));
   }
 }
 

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -47,7 +47,7 @@ class DefaultIfEmptyOperator<T, R> implements Operator<T, T | R> {
   }
 
   call(subscriber: Subscriber<T | R>, source: any): any {
-    return source._subscribe(new DefaultIfEmptySubscriber(subscriber, this.defaultValue));
+    return source.subscribe(new DefaultIfEmptySubscriber(subscriber, this.defaultValue));
   }
 }
 

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -59,7 +59,7 @@ class DelayOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new DelaySubscriber(subscriber, this.delay, this.scheduler));
+    return source.subscribe(new DelaySubscriber(subscriber, this.delay, this.scheduler));
   }
 }
 

--- a/src/operator/delayWhen.ts
+++ b/src/operator/delayWhen.ts
@@ -66,7 +66,7 @@ class DelayWhenOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new DelayWhenSubscriber(subscriber, this.delayDurationSelector));
+    return source.subscribe(new DelayWhenSubscriber(subscriber, this.delayDurationSelector));
   }
 }
 

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -44,7 +44,7 @@ export function dematerialize<T>(this: Observable<T>): Observable<any> {
 
 class DeMaterializeOperator<T extends Notification<any>, R> implements Operator<T, R> {
   call(subscriber: Subscriber<any>, source: any): any {
-    return source._subscribe(new DeMaterializeSubscriber(subscriber));
+    return source.subscribe(new DeMaterializeSubscriber(subscriber));
   }
 }
 

--- a/src/operator/distinct.ts
+++ b/src/operator/distinct.ts
@@ -34,7 +34,7 @@ class DistinctOperator<T, K> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new DistinctSubscriber(subscriber, this.keySelector, this.flushes));
+    return source.subscribe(new DistinctSubscriber(subscriber, this.keySelector, this.flushes));
   }
 }
 

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -29,7 +29,7 @@ class DistinctUntilChangedOperator<T, K> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new DistinctUntilChangedSubscriber(subscriber, this.compare, this.keySelector));
+    return source.subscribe(new DistinctUntilChangedSubscriber(subscriber, this.compare, this.keySelector));
   }
 }
 

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -64,7 +64,7 @@ class DoOperator<T> implements Operator<T, T> {
               private complete?: () => void) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new DoSubscriber(subscriber, this.nextOrObserver, this.error, this.complete));
+    return source.subscribe(new DoSubscriber(subscriber, this.nextOrObserver, this.error, this.complete));
   }
 }
 

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -54,7 +54,7 @@ class ElementAtOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new ElementAtSubscriber(subscriber, this.index, this.defaultValue));
+    return source.subscribe(new ElementAtSubscriber(subscriber, this.index, this.defaultValue));
   }
 }
 

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -23,7 +23,7 @@ class EveryOperator<T> implements Operator<T, boolean> {
   }
 
   call(observer: Subscriber<boolean>, source: any): any {
-    return source._subscribe(new EverySubscriber(observer, this.predicate, this.thisArg, this.source));
+    return source.subscribe(new EverySubscriber(observer, this.predicate, this.thisArg, this.source));
   }
 }
 

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -47,7 +47,7 @@ export function exhaust<T>(this: Observable<T>): Observable<T> {
 
 class SwitchFirstOperator<T> implements Operator<T, T> {
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new SwitchFirstSubscriber(subscriber));
+    return source.subscribe(new SwitchFirstSubscriber(subscriber));
   }
 }
 

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -67,7 +67,7 @@ class SwitchFirstMapOperator<T, I, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new SwitchFirstMapSubscriber(subscriber, this.project, this.resultSelector));
+    return source.subscribe(new SwitchFirstMapSubscriber(subscriber, this.project, this.resultSelector));
   }
 }
 

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -74,7 +74,7 @@ export class ExpandOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new ExpandSubscriber(subscriber, this.project, this.concurrent, this.scheduler));
+    return source.subscribe(new ExpandSubscriber(subscriber, this.project, this.concurrent, this.scheduler));
   }
 }
 

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -62,7 +62,7 @@ class FilterOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new FilterSubscriber(subscriber, this.predicate, this.thisArg));
+    return source.subscribe(new FilterSubscriber(subscriber, this.predicate, this.thisArg));
   }
 }
 

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -20,7 +20,7 @@ class FinallyOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new FinallySubscriber(subscriber, this.callback));
+    return source.subscribe(new FinallySubscriber(subscriber, this.callback));
   }
 }
 

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -60,7 +60,7 @@ export class FindValueOperator<T> implements Operator<T, T> {
   }
 
   call(observer: Subscriber<T>, source: any): any {
-    return source._subscribe(new FindValueSubscriber(observer, this.predicate, this.source, this.yieldIndex, this.thisArg));
+    return source.subscribe(new FindValueSubscriber(observer, this.predicate, this.source, this.yieldIndex, this.thisArg));
   }
 }
 

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -87,7 +87,7 @@ class FirstOperator<T, R> implements Operator<T, R> {
   }
 
   call(observer: Subscriber<R>, source: any): any {
-    return source._subscribe(new FirstSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source));
+    return source.subscribe(new FirstSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source));
   }
 }
 

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -56,7 +56,7 @@ class GroupByOperator<T, K, R> implements Operator<T, GroupedObservable<K, R>> {
   }
 
   call(subscriber: Subscriber<GroupedObservable<K, R>>, source: any): any {
-    return source._subscribe(new GroupBySubscriber(
+    return source.subscribe(new GroupBySubscriber(
       subscriber, this.keySelector, this.elementSelector, this.durationSelector, this.subjectSelector
     ));
   }

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -19,7 +19,7 @@ export function ignoreElements<T>(this: Observable<T>): Observable<T> {
 
 class IgnoreElementsOperator<T, R> implements Operator<T, R> {
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new IgnoreElementsSubscriber(subscriber));
+    return source.subscribe(new IgnoreElementsSubscriber(subscriber));
   }
 }
 

--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -17,7 +17,7 @@ export function isEmpty<T>(this: Observable<T>): Observable<boolean> {
 
 class IsEmptyOperator implements Operator<any, boolean> {
   call (observer: Subscriber<boolean>, source: any): any {
-    return source._subscribe(new IsEmptySubscriber(observer));
+    return source.subscribe(new IsEmptySubscriber(observer));
   }
 }
 

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -56,7 +56,7 @@ class LastOperator<T, R> implements Operator<T, R> {
   }
 
   call(observer: Subscriber<R>, source: any): any {
-    return source._subscribe(new LastSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source));
+    return source.subscribe(new LastSubscriber(observer, this.predicate, this.resultSelector, this.defaultValue, this.source));
   }
 }
 

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -47,7 +47,7 @@ export class MapOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new MapSubscriber(subscriber, this.project, this.thisArg));
+    return source.subscribe(new MapSubscriber(subscriber, this.project, this.thisArg));
   }
 }
 

--- a/src/operator/mapTo.ts
+++ b/src/operator/mapTo.ts
@@ -41,7 +41,7 @@ class MapToOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new MapToSubscriber(subscriber, this.value));
+    return source.subscribe(new MapToSubscriber(subscriber, this.value));
   }
 }
 

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -46,7 +46,7 @@ export function materialize<T>(this: Observable<T>): Observable<Notification<T>>
 
 class MaterializeOperator<T> implements Operator<T, Notification<T>> {
   call(subscriber: Subscriber<Notification<T>>, source: any): any {
-    return source._subscribe(new MaterializeSubscriber(subscriber));
+    return source.subscribe(new MaterializeSubscriber(subscriber));
   }
 }
 

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -58,7 +58,7 @@ export class MergeAllOperator<T> implements Operator<Observable<T>, T> {
   }
 
   call(observer: Observer<T>, source: any): any {
-    return source._subscribe(new MergeAllSubscriber(observer, this.concurrent));
+    return source.subscribe(new MergeAllSubscriber(observer, this.concurrent));
   }
 }
 

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -77,7 +77,7 @@ export class MergeMapOperator<T, I, R> implements Operator<T, I> {
   }
 
   call(observer: Subscriber<I>, source: any): any {
-    return source._subscribe(new MergeMapSubscriber(
+    return source.subscribe(new MergeMapSubscriber(
       observer, this.project, this.resultSelector, this.concurrent
     ));
   }

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -74,7 +74,7 @@ export class MergeMapToOperator<T, I, R> implements Operator<Observable<T>, R> {
   }
 
   call(observer: Subscriber<R>, source: any): any {
-    return source._subscribe(new MergeMapToSubscriber(observer, this.ish, this.resultSelector, this.concurrent));
+    return source.subscribe(new MergeMapToSubscriber(observer, this.ish, this.resultSelector, this.concurrent));
   }
 }
 

--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -29,7 +29,7 @@ export class MergeScanOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new MergeScanSubscriber(
+    return source.subscribe(new MergeScanSubscriber(
       subscriber, this.project, this.seed, this.concurrent
     ));
   }

--- a/src/operator/multicast.ts
+++ b/src/operator/multicast.ts
@@ -61,7 +61,7 @@ export class MulticastOperator<T> implements Operator<T, T> {
     const { selector } = this;
     const subject = this.subjectFactory();
     const subscription = selector(subject).subscribe(subscriber);
-    subscription.add(source._subscribe(subject));
+    subscription.add(source.subscribe(subject));
     return subscription;
   }
 }

--- a/src/operator/observeOn.ts
+++ b/src/operator/observeOn.ts
@@ -24,7 +24,7 @@ export class ObserveOnOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new ObserveOnSubscriber(subscriber, this.scheduler, this.delay));
+    return source.subscribe(new ObserveOnSubscriber(subscriber, this.scheduler, this.delay));
   }
 }
 

--- a/src/operator/onErrorResumeNext.ts
+++ b/src/operator/onErrorResumeNext.ts
@@ -55,7 +55,7 @@ class OnErrorResumeNextOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new OnErrorResumeNextSubscriber(subscriber, this.nextSources));
+    return source.subscribe(new OnErrorResumeNextSubscriber(subscriber, this.nextSources));
   }
 }
 

--- a/src/operator/pairwise.ts
+++ b/src/operator/pairwise.ts
@@ -43,7 +43,7 @@ export function pairwise<T>(this: Observable<T>): Observable<[T, T]> {
 
 class PairwiseOperator<T> implements Operator<T, [T, T]> {
   call(subscriber: Subscriber<[T, T]>, source: any): any {
-    return source._subscribe(new PairwiseSubscriber(subscriber));
+    return source.subscribe(new PairwiseSubscriber(subscriber));
   }
 }
 

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -56,7 +56,7 @@ export function raceStatic<T>(...observables: Array<Observable<any> | Array<Obse
 
 export class RaceOperator<T> implements Operator<T, T> {
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new RaceSubscriber(subscriber));
+    return source.subscribe(new RaceSubscriber(subscriber));
   }
 }
 

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -71,7 +71,7 @@ export class ReduceOperator<T, R> implements Operator<T, R> {
   constructor(private accumulator: (acc: R, value: T) => R, private seed?: R, private hasSeed: boolean = false) {}
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new ReduceSubscriber(subscriber, this.accumulator, this.seed, this.hasSeed));
+    return source.subscribe(new ReduceSubscriber(subscriber, this.accumulator, this.seed, this.hasSeed));
   }
 }
 

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -33,7 +33,7 @@ class RepeatOperator<T> implements Operator<T, T> {
               private source: Observable<T>) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new RepeatSubscriber(subscriber, this.count, this.source));
+    return source.subscribe(new RepeatSubscriber(subscriber, this.count, this.source));
   }
 }
 

--- a/src/operator/repeatWhen.ts
+++ b/src/operator/repeatWhen.ts
@@ -36,7 +36,7 @@ class RepeatWhenOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new RepeatWhenSubscriber(subscriber, this.notifier, this.source));
+    return source.subscribe(new RepeatWhenSubscriber(subscriber, this.notifier, this.source));
   }
 }
 

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -30,7 +30,7 @@ class RetryOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new RetrySubscriber(subscriber, this.count, this.source));
+    return source.subscribe(new RetrySubscriber(subscriber, this.count, this.source));
   }
 }
 

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -36,7 +36,7 @@ class RetryWhenOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new RetryWhenSubscriber(subscriber, this.notifier, this.source));
+    return source.subscribe(new RetryWhenSubscriber(subscriber, this.notifier, this.source));
   }
 }
 

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -50,7 +50,7 @@ class SampleOperator<T> implements Operator<T, T> {
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     const sampleSubscriber = new SampleSubscriber(subscriber);
-    const subscription = source._subscribe(sampleSubscriber);
+    const subscription = source.subscribe(sampleSubscriber);
     subscription.add(subscribeToResult(sampleSubscriber, this.notifier));
     return subscription;
   }

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -52,7 +52,7 @@ class SampleTimeOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new SampleTimeSubscriber(subscriber, this.period, this.scheduler));
+    return source.subscribe(new SampleTimeSubscriber(subscriber, this.period, this.scheduler));
   }
 }
 

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -63,7 +63,7 @@ class ScanOperator<T, R> implements Operator<T, R> {
   constructor(private accumulator: (acc: R, value: T, index: number) => R, private seed?: T | R, private hasSeed: boolean = false) {}
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new ScanSubscriber(subscriber, this.accumulator, this.seed, this.hasSeed));
+    return source.subscribe(new ScanSubscriber(subscriber, this.accumulator, this.seed, this.hasSeed));
   }
 }
 

--- a/src/operator/sequenceEqual.ts
+++ b/src/operator/sequenceEqual.ts
@@ -68,7 +68,7 @@ export class SequenceEqualOperator<T> implements Operator<T, boolean> {
   }
 
   call(subscriber: Subscriber<boolean>, source: any): any {
-    return source._subscribe(new SequenceEqualSubscriber(subscriber, this.compareTo, this.comparor));
+    return source.subscribe(new SequenceEqualSubscriber(subscriber, this.compareTo, this.comparor));
   }
 }
 

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -31,7 +31,7 @@ class SingleOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new SingleSubscriber(subscriber, this.predicate, this.source));
+    return source.subscribe(new SingleSubscriber(subscriber, this.predicate, this.source));
   }
 }
 

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -23,7 +23,7 @@ class SkipOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new SkipSubscriber(subscriber, this.total));
+    return source.subscribe(new SkipSubscriber(subscriber, this.total));
   }
 }
 

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -27,7 +27,7 @@ class SkipUntilOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new SkipUntilSubscriber(subscriber, this.notifier));
+    return source.subscribe(new SkipUntilSubscriber(subscriber, this.notifier));
   }
 }
 

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -24,7 +24,7 @@ class SkipWhileOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new SkipWhileSubscriber(subscriber, this.predicate));
+    return source.subscribe(new SkipWhileSubscriber(subscriber, this.predicate));
   }
 }
 

--- a/src/operator/subscribeOn.ts
+++ b/src/operator/subscribeOn.ts
@@ -1,5 +1,8 @@
+import { Operator } from '../Operator';
 import { Scheduler } from '../Scheduler';
+import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
+import { TeardownLogic } from '../Subscription';
 import { SubscribeOnObservable } from '../observable/SubscribeOnObservable';
 
 /**
@@ -14,5 +17,16 @@ import { SubscribeOnObservable } from '../observable/SubscribeOnObservable';
  * @owner Observable
  */
 export function subscribeOn<T>(this: Observable<T>, scheduler: Scheduler, delay: number = 0): Observable<T> {
-  return new SubscribeOnObservable<T>(this, delay, scheduler);
+  return this.lift(new SubscribeOnOperator<T>(scheduler, delay));
+}
+
+class SubscribeOnOperator<T> implements Operator<T, T> {
+  constructor(private scheduler: Scheduler,
+              private delay: number) {
+  }
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+    return new SubscribeOnObservable(
+      source, this.delay, this.scheduler
+    ).subscribe(subscriber);
+  }
 }

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -54,7 +54,7 @@ export function _switch<T>(this: Observable<T>): T {
 
 class SwitchOperator<T, R> implements Operator<T, R> {
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new SwitchSubscriber(subscriber));
+    return source.subscribe(new SwitchSubscriber(subscriber));
   }
 }
 

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -69,7 +69,7 @@ class SwitchMapOperator<T, I, R> implements Operator<T, I> {
   }
 
   call(subscriber: Subscriber<I>, source: any): any {
-    return source._subscribe(new SwitchMapSubscriber(subscriber, this.project, this.resultSelector));
+    return source.subscribe(new SwitchMapSubscriber(subscriber, this.project, this.resultSelector));
   }
 }
 

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -69,7 +69,7 @@ class SwitchMapToOperator<T, I, R> implements Operator<T, I> {
   }
 
   call(subscriber: Subscriber<I>, source: any): any {
-    return source._subscribe(new SwitchMapToSubscriber(subscriber, this.observable, this.resultSelector));
+    return source.subscribe(new SwitchMapToSubscriber(subscriber, this.observable, this.resultSelector));
   }
 }
 

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -54,7 +54,7 @@ class TakeOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new TakeSubscriber(subscriber, this.total));
+    return source.subscribe(new TakeSubscriber(subscriber, this.total));
   }
 }
 

--- a/src/operator/takeLast.ts
+++ b/src/operator/takeLast.ts
@@ -57,7 +57,7 @@ class TakeLastOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new TakeLastSubscriber(subscriber, this.total));
+    return source.subscribe(new TakeLastSubscriber(subscriber, this.total));
   }
 }
 

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -49,7 +49,7 @@ class TakeUntilOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new TakeUntilSubscriber(subscriber, this.notifier));
+    return source.subscribe(new TakeUntilSubscriber(subscriber, this.notifier));
   }
 }
 

--- a/src/operator/takeWhile.ts
+++ b/src/operator/takeWhile.ts
@@ -48,7 +48,7 @@ class TakeWhileOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new TakeWhileSubscriber(subscriber, this.predicate));
+    return source.subscribe(new TakeWhileSubscriber(subscriber, this.predicate));
   }
 }
 

--- a/src/operator/throttle.ts
+++ b/src/operator/throttle.ts
@@ -54,7 +54,7 @@ class ThrottleOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new ThrottleSubscriber(subscriber, this.durationSelector));
+    return source.subscribe(new ThrottleSubscriber(subscriber, this.durationSelector));
   }
 }
 

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -54,7 +54,7 @@ class ThrottleTimeOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new ThrottleTimeSubscriber(subscriber, this.duration, this.scheduler));
+    return source.subscribe(new ThrottleTimeSubscriber(subscriber, this.duration, this.scheduler));
   }
 }
 

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -26,7 +26,7 @@ class TimeIntervalOperator<T> implements Operator<T, TimeInterval<T>> {
   }
 
   call(observer: Subscriber<TimeInterval<T>>, source: any): any {
-    return source._subscribe(new TimeIntervalSubscriber(observer, this.scheduler));
+    return source.subscribe(new TimeIntervalSubscriber(observer, this.scheduler));
   }
 }
 

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -30,7 +30,7 @@ class TimeoutOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new TimeoutSubscriber<T>(
+    return source.subscribe(new TimeoutSubscriber<T>(
       subscriber, this.absoluteTimeout, this.waitFor, this.scheduler, this.errorInstance
     ));
   }

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -37,7 +37,7 @@ class TimeoutWithOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source._subscribe(new TimeoutWithSubscriber(
+    return source.subscribe(new TimeoutWithSubscriber(
       subscriber, this.absoluteTimeout, this.waitFor, this.withObservable, this.scheduler
     ));
   }

--- a/src/operator/timestamp.ts
+++ b/src/operator/timestamp.ts
@@ -24,7 +24,7 @@ class TimestampOperator<T> implements Operator<T, Timestamp<T>> {
   }
 
   call(observer: Subscriber<Timestamp<T>>, source: any): any {
-    return source._subscribe(new TimestampSubscriber(observer, this.scheduler));
+    return source.subscribe(new TimestampSubscriber(observer, this.scheduler));
   }
 }
 

--- a/src/operator/toArray.ts
+++ b/src/operator/toArray.ts
@@ -13,7 +13,7 @@ export function toArray<T>(this: Observable<T>): Observable<T[]> {
 
 class ToArrayOperator<T> implements Operator<T, T[]> {
   call(subscriber: Subscriber<T[]>, source: any): any {
-    return source._subscribe(new ToArraySubscriber(subscriber));
+    return source.subscribe(new ToArraySubscriber(subscriber));
   }
 }
 

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -54,7 +54,7 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
 
   call(subscriber: Subscriber<Observable<T>>, source: any): any {
     const windowSubscriber = new WindowSubscriber(subscriber);
-    const sourceSubscription = source._subscribe(windowSubscriber);
+    const sourceSubscription = source.subscribe(windowSubscriber);
     if (!sourceSubscription.closed) {
       windowSubscriber.add(subscribeToResult(windowSubscriber, this.windowBoundaries));
     }

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -63,7 +63,7 @@ class WindowCountOperator<T> implements Operator<T, Observable<T>> {
   }
 
   call(subscriber: Subscriber<Observable<T>>, source: any): any {
-    return source._subscribe(new WindowCountSubscriber(subscriber, this.windowSize, this.startWindowEvery));
+    return source.subscribe(new WindowCountSubscriber(subscriber, this.windowSize, this.startWindowEvery));
   }
 }
 

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -70,7 +70,7 @@ class WindowTimeOperator<T> implements Operator<T, Observable<T>> {
   }
 
   call(subscriber: Subscriber<Observable<T>>, source: any): any {
-    return source._subscribe(new WindowTimeSubscriber(
+    return source.subscribe(new WindowTimeSubscriber(
       subscriber, this.windowTimeSpan, this.windowCreationInterval, this.scheduler
     ));
   }

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -64,7 +64,7 @@ class WindowToggleOperator<T, O> implements Operator<T, Observable<T>> {
   }
 
   call(subscriber: Subscriber<Observable<T>>, source: any): any {
-    return source._subscribe(new WindowToggleSubscriber(
+    return source.subscribe(new WindowToggleSubscriber(
       subscriber, this.openings, this.closingSelector
     ));
   }

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -58,7 +58,7 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
   }
 
   call(subscriber: Subscriber<Observable<T>>, source: any): any {
-    return source._subscribe(new WindowSubscriber(subscriber, this.closingSelector));
+    return source.subscribe(new WindowSubscriber(subscriber, this.closingSelector));
   }
 }
 

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -75,7 +75,7 @@ class WithLatestFromOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new WithLatestFromSubscriber(subscriber, this.observables, this.project));
+    return source.subscribe(new WithLatestFromSubscriber(subscriber, this.observables, this.project));
   }
 }
 

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -84,7 +84,7 @@ export class ZipOperator<T, R> implements Operator<T, R> {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source._subscribe(new ZipSubscriber(subscriber, this.project));
+    return source.subscribe(new ZipSubscriber(subscriber, this.project));
   }
 }
 


### PR DESCRIPTION
Today, operators are passed the Observable they're attached to as the second "source" argument. They have to call a private `_subscribe` method, which is a pass-through inside Observable to `this.source.subscribe`. This is less ergonomic (someone writing a custom operator has to know to do this), and an extra function call per Observable in the chain. The solution to this is to pass `this.source` to the operators, who can then call the source's public `subscribe` method.

This PR also makes subscribeOn use lift, and fixes a bug where the subscribeOn subscriber wasn't tracking the source subscription.