### PR TITLE
docs(DeferObservable.ts, EmptyObservable.ts, FromEventObservable.ts, …

### DIFF
--- a/src/observable/DeferObservable.ts
+++ b/src/observable/DeferObservable.ts
@@ -38,6 +38,12 @@ export class DeferObservable<T> extends Observable<T> {
    *   }
    * });
    * clicksOrInterval.subscribe(x => console.log(x));
+   * 
+   * // Results in the following behavior:
+   * // If the result of Math.random() is greater than 0.5 it will listen
+   * // for clicks anywhere on the "document"; when document is clicked it
+   * // will log a MouseEvent object to the console. If the result is less
+   * // than 0.5 it will emit ascending numbers, one every second(1000ms).
    *
    * @see {@link create}
    *

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -37,6 +37,12 @@ export class EmptyObservable<T> extends Observable<T> {
    *   x % 2 === 1 ? Rx.Observable.of('a', 'b', 'c') : Rx.Observable.empty()
    * );
    * result.subscribe(x => console.log(x));
+   * 
+   * // Results in the following to the console:
+   * // x is equal to the count on the interval eg(0,1,2,3,...)
+   * // x will occur every 1000ms
+   * // if x % 2 is equal to 1 print abc
+   * // if x % 2 is not equal to 1 nothing will be output
    *
    * @see {@link create}
    * @see {@link never}

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -37,7 +37,7 @@ export class EmptyObservable<T> extends Observable<T> {
    *   x % 2 === 1 ? Rx.Observable.of('a', 'b', 'c') : Rx.Observable.empty()
    * );
    * result.subscribe(x => console.log(x));
-   * 
+   *
    * // Results in the following to the console:
    * // x is equal to the count on the interval eg(0,1,2,3,...)
    * // x will occur every 1000ms

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -78,6 +78,10 @@ export class FromEventObservable<T> extends Observable<T> {
    * @example <caption>Emits clicks happening on the DOM document</caption>
    * var clicks = Rx.Observable.fromEvent(document, 'click');
    * clicks.subscribe(x => console.log(x));
+   * 
+   * // Results in:
+   * // MouseEvent object logged to console everytime a click
+   * // occurs on the document.
    *
    * @see {@link from}
    * @see {@link fromEventPattern}

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -78,7 +78,7 @@ export class FromEventObservable<T> extends Observable<T> {
    * @example <caption>Emits clicks happening on the DOM document</caption>
    * var clicks = Rx.Observable.fromEvent(document, 'click');
    * clicks.subscribe(x => console.log(x));
-   * 
+   *
    * // Results in:
    * // MouseEvent object logged to console everytime a click
    * // occurs on the document.

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -47,6 +47,9 @@ export class FromObservable<T> extends Observable<T> {
    * var array = [10, 20, 30];
    * var result = Rx.Observable.from(array);
    * result.subscribe(x => console.log(x));
+   * 
+   * // Results in the following:
+   * // 10 20 30
    *
    * @example <caption>Convert an infinite iterable (from a generator) to an Observable</caption>
    * function* generateDoubles(seed) {
@@ -60,6 +63,10 @@ export class FromObservable<T> extends Observable<T> {
    * var iterator = generateDoubles(3);
    * var result = Rx.Observable.from(iterator).take(10);
    * result.subscribe(x => console.log(x));
+   * 
+   * // Results in the following:
+   * // 3 6 12 24 48 96 192 384 768 1536
+   * 
    *
    * @see {@link create}
    * @see {@link fromEvent}

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -47,7 +47,7 @@ export class FromObservable<T> extends Observable<T> {
    * var array = [10, 20, 30];
    * var result = Rx.Observable.from(array);
    * result.subscribe(x => console.log(x));
-   * 
+   *
    * // Results in the following:
    * // 10 20 30
    *
@@ -63,10 +63,9 @@ export class FromObservable<T> extends Observable<T> {
    * var iterator = generateDoubles(3);
    * var result = Rx.Observable.from(iterator).take(10);
    * result.subscribe(x => console.log(x));
-   * 
+   *
    * // Results in the following:
    * // 3 6 12 24 48 96 192 384 768 1536
-   * 
    *
    * @see {@link create}
    * @see {@link fromEvent}

--- a/src/observable/combineLatest.ts
+++ b/src/observable/combineLatest.ts
@@ -51,7 +51,7 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * var height = Rx.Observable.of(1.76, 1.77, 1.78);
  * var bmi = Rx.Observable.combineLatest(weight, height, (w, h) => w / (h * h));
  * bmi.subscribe(x => console.log('BMI is ' + x));
- * 
+ *
  * // With output to console:
  * // BMI is 24.212293388429753
  * // BMI is 23.93948099205209

--- a/src/observable/combineLatest.ts
+++ b/src/observable/combineLatest.ts
@@ -51,6 +51,11 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * var height = Rx.Observable.of(1.76, 1.77, 1.78);
  * var bmi = Rx.Observable.combineLatest(weight, height, (w, h) => w / (h * h));
  * bmi.subscribe(x => console.log('BMI is ' + x));
+ * 
+ * // With output to console:
+ * // BMI is 24.212293388429753
+ * // BMI is 23.93948099205209
+ * // BMI is 23.671253629592222
  *
  * @see {@link combineAll}
  * @see {@link merge}

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -49,6 +49,11 @@ export function combineLatest<T, TOther, R>(this: Observable<T>, array: Observab
  * var bmi = weight.combineLatest(height, (w, h) => w / (h * h));
  * bmi.subscribe(x => console.log('BMI is ' + x));
  *
+ * // With output to console:
+ * // BMI is 24.212293388429753
+ * // BMI is 23.93948099205209
+ * // BMI is 23.671253629592222
+ *
  * @see {@link combineAll}
  * @see {@link merge}
  * @see {@link withLatestFrom}

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -34,6 +34,10 @@ export function concat<T, R>(this: Observable<T>, ...observables: Array<Observab
  * var sequence = Rx.Observable.range(1, 10);
  * var result = timer.concat(sequence);
  * result.subscribe(x => console.log(x));
+ * 
+ * // results in:
+ * // 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3 -immediate-> 1 ... 10
+ * 
  *
  * @example <caption>Concatenate 3 Observables</caption>
  * var timer1 = Rx.Observable.interval(1000).take(10);
@@ -41,6 +45,12 @@ export function concat<T, R>(this: Observable<T>, ...observables: Array<Observab
  * var timer3 = Rx.Observable.interval(500).take(10);
  * var result = timer1.concat(timer2, timer3);
  * result.subscribe(x => console.log(x));
+ * 
+ * * // results in the following:
+ * // (Prints to console sequentially)
+ * // -1000ms-> 0 -1000ms-> 1 -1000ms-> ... 9
+ * // -2000ms-> 0 -2000ms-> 1 -2000ms-> ... 5
+ * // -500ms-> 0 -500ms-> 1 -500ms-> ... 9
  *
  * @see {@link concatAll}
  * @see {@link concatMap}
@@ -87,6 +97,9 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * var sequence = Rx.Observable.range(1, 10);
  * var result = Rx.Observable.concat(timer, sequence);
  * result.subscribe(x => console.log(x));
+ * 
+ * // results in:
+ * // 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3 -immediate-> 1 ... 10
  *
  * @example <caption>Concatenate 3 Observables</caption>
  * var timer1 = Rx.Observable.interval(1000).take(10);
@@ -94,7 +107,13 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * var timer3 = Rx.Observable.interval(500).take(10);
  * var result = Rx.Observable.concat(timer1, timer2, timer3);
  * result.subscribe(x => console.log(x));
- *
+ * 
+ * // results in the following:
+ * // (Prints to console sequentially)
+ * // -1000ms-> 0 -1000ms-> 1 -1000ms-> ... 9
+ * // -2000ms-> 0 -2000ms-> 1 -2000ms-> ... 5
+ * // -500ms-> 0 -500ms-> 1 -500ms-> ... 9
+ * 
  * @see {@link concatAll}
  * @see {@link concatMap}
  * @see {@link concatMapTo}

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -34,10 +34,9 @@ export function concat<T, R>(this: Observable<T>, ...observables: Array<Observab
  * var sequence = Rx.Observable.range(1, 10);
  * var result = timer.concat(sequence);
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // results in:
- * // 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3 -immediate-> 1 ... 10
- * 
+ * // 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3 -immediate-> 1 ... 10
  *
  * @example <caption>Concatenate 3 Observables</caption>
  * var timer1 = Rx.Observable.interval(1000).take(10);
@@ -46,7 +45,7 @@ export function concat<T, R>(this: Observable<T>, ...observables: Array<Observab
  * var result = timer1.concat(timer2, timer3);
  * result.subscribe(x => console.log(x));
  * 
- * * // results in the following:
+ * // results in the following:
  * // (Prints to console sequentially)
  * // -1000ms-> 0 -1000ms-> 1 -1000ms-> ... 9
  * // -2000ms-> 0 -2000ms-> 1 -2000ms-> ... 5
@@ -97,7 +96,7 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * var sequence = Rx.Observable.range(1, 10);
  * var result = Rx.Observable.concat(timer, sequence);
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // results in:
  * // 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3 -immediate-> 1 ... 10
  *
@@ -107,7 +106,7 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * var timer3 = Rx.Observable.interval(500).take(10);
  * var result = Rx.Observable.concat(timer1, timer2, timer3);
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // results in the following:
  * // (Prints to console sequentially)
  * // -1000ms-> 0 -1000ms-> 1 -1000ms-> ... 9

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -34,6 +34,12 @@ export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
  * var higherOrder = clicks.map(ev => Rx.Observable.interval(1000).take(4));
  * var firstOrder = higherOrder.concatAll();
  * firstOrder.subscribe(x => console.log(x));
+ * 
+ * // Results in the following:
+ * // (results are not concurrent)
+ * // For every click on the "document" it will emit values 0 to 3 spaced
+ * // on a 1000ms interval
+ * // one click = 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3
  *
  * @see {@link combineAll}
  * @see {@link concat}

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -34,7 +34,7 @@ export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
  * var higherOrder = clicks.map(ev => Rx.Observable.interval(1000).take(4));
  * var firstOrder = higherOrder.concatAll();
  * firstOrder.subscribe(x => console.log(x));
- * 
+ *
  * // Results in the following:
  * // (results are not concurrent)
  * // For every click on the "document" it will emit values 0 to 3 spaced

--- a/src/operator/concatMap.ts
+++ b/src/operator/concatMap.ts
@@ -33,6 +33,12 @@ export function concatMap<T, I, R>(this: Observable<T>, project: (value: T, inde
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.concatMap(ev => Rx.Observable.interval(1000).take(4));
  * result.subscribe(x => console.log(x));
+ * 
+ * // Results in the following:
+ * // (results are not concurrent)
+ * // For every click on the "document" it will emit values 0 to 3 spaced
+ * // on a 1000ms interval
+ * // one click = 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3
  *
  * @see {@link concat}
  * @see {@link concatAll}

--- a/src/operator/concatMap.ts
+++ b/src/operator/concatMap.ts
@@ -33,7 +33,7 @@ export function concatMap<T, I, R>(this: Observable<T>, project: (value: T, inde
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.concatMap(ev => Rx.Observable.interval(1000).take(4));
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // Results in the following:
  * // (results are not concurrent)
  * // For every click on the "document" it will emit values 0 to 3 spaced

--- a/src/operator/concatMapTo.ts
+++ b/src/operator/concatMapTo.ts
@@ -34,6 +34,12 @@ export function concatMapTo<T, I, R>(this: Observable<T>, observable: Observable
  * var result = clicks.concatMapTo(Rx.Observable.interval(1000).take(4));
  * result.subscribe(x => console.log(x));
  *
+ * // Results in the following:
+ * // (results are not concurrent)
+ * // For every click on the "document" it will emit values 0 to 3 spaced
+ * // on a 1000ms interval
+ * // one click = 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3
+ * 
  * @see {@link concat}
  * @see {@link concatAll}
  * @see {@link concatMap}

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -32,6 +32,9 @@ import { Subscriber } from '../Subscriber';
  * var numbers = Rx.Observable.range(1, 7);
  * var result = numbers.count(i => i % 2 === 1);
  * result.subscribe(x => console.log(x));
+ * 
+ * // Results in:
+ * // 4
  *
  * @see {@link max}
  * @see {@link min}

--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -32,7 +32,7 @@ import { Subscriber } from '../Subscriber';
  * var numbers = Rx.Observable.range(1, 7);
  * var result = numbers.count(i => i % 2 === 1);
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // Results in:
  * // 4
  *

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -29,6 +29,11 @@ import { Notification } from '../Notification';
  * var materialized = Rx.Observable.of(notifA, notifB, notifE);
  * var upperCase = materialized.dematerialize();
  * upperCase.subscribe(x => console.log(x), e => console.error(e));
+ * 
+ * // Results in:
+ * // A
+ * // B
+ * // TypeError: x.toUpperCase is not a function
  *
  * @see {@link Notification}
  * @see {@link materialize}

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -29,7 +29,7 @@ import { Notification } from '../Notification';
  * var materialized = Rx.Observable.of(notifA, notifB, notifE);
  * var upperCase = materialized.dematerialize();
  * upperCase.subscribe(x => console.log(x), e => console.error(e));
- * 
+ *
  * // Results in:
  * // A
  * // B

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -22,6 +22,11 @@ import { TeardownLogic } from '../Subscription';
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.elementAt(2);
  * result.subscribe(x => console.log(x));
+ * 
+ * // Results in:
+ * // click 1 = nothing
+ * // click 2 = nothing
+ * // click 3 = MouseEvent object logged to console
  *
  * @see {@link first}
  * @see {@link last}

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -22,7 +22,7 @@ import { TeardownLogic } from '../Subscription';
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.elementAt(2);
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // Results in:
  * // click 1 = nothing
  * // click 2 = nothing

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -30,6 +30,13 @@ import { Notification } from '../Notification';
  * var upperCase = letters.map(x => x.toUpperCase());
  * var materialized = upperCase.materialize();
  * materialized.subscribe(x => console.log(x));
+ * 
+ * // Results in the following:
+ * // - Notification {kind: "N", value: "A", error: undefined, hasValue: true}
+ * // - Notification {kind: "N", value: "B", error: undefined, hasValue: true}
+ * // - Notification {kind: "E", value: undefined, error: TypeError:
+ * //   x.toUpperCase is not a function at MapSubscriber.letters.map.x 
+ * //   [as project] (http://1…, hasValue: false}
  *
  * @see {@link Notification}
  * @see {@link dematerialize}

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -30,7 +30,7 @@ import { Notification } from '../Notification';
  * var upperCase = letters.map(x => x.toUpperCase());
  * var materialized = upperCase.materialize();
  * materialized.subscribe(x => console.log(x));
- * 
+ *
  * // Results in the following:
  * // - Notification {kind: "N", value: "A", error: undefined, hasValue: true}
  * // - Notification {kind: "N", value: "B", error: undefined, hasValue: true}

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -107,6 +107,12 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * var timer = Rx.Observable.interval(1000);
  * var clicksOrTimer = Rx.Observable.merge(clicks, timer);
  * clicksOrTimer.subscribe(x => console.log(x));
+ * 
+ * // Results in the following:
+ * // timer will emit ascending values, one every second(1000ms) to console
+ * // clicks logs MouseEvents to console everytime the "document" is clicked
+ * // Since the two streams are merged you see these happening
+ * // as they occur.
  *
  * @example <caption>Merge together 3 Observables, but only 2 run concurrently</caption>
  * var timer1 = Rx.Observable.interval(1000).take(10);
@@ -115,6 +121,15 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * var concurrent = 2; // the argument
  * var merged = Rx.Observable.merge(timer1, timer2, timer3, concurrent);
  * merged.subscribe(x => console.log(x));
+ * 
+ * // Results in the following:
+ * // - First timer1 and timer2 will run concurrently
+ * // - timer1 will emit a value every 1000ms for 10 iterations
+ * // - timer2 will emit a value every 2000ms for 6 iterations
+ * // - after timer1 hits it's max iteration, timer2 will 
+ * //   continue, and timer3 will start to run concurrently with timer2
+ * // - when timer2 hits it's max iteration it terminates, and 
+ * //   timer3 will continue to emit a value every 500ms until it is complete
  *
  * @see {@link mergeAll}
  * @see {@link mergeMap}

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -107,7 +107,7 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * var timer = Rx.Observable.interval(1000);
  * var clicksOrTimer = Rx.Observable.merge(clicks, timer);
  * clicksOrTimer.subscribe(x => console.log(x));
- * 
+ *
  * // Results in the following:
  * // timer will emit ascending values, one every second(1000ms) to console
  * // clicks logs MouseEvents to console everytime the "document" is clicked
@@ -121,7 +121,7 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * var concurrent = 2; // the argument
  * var merged = Rx.Observable.merge(timer1, timer2, timer3, concurrent);
  * merged.subscribe(x => console.log(x));
- * 
+ *
  * // Results in the following:
  * // - First timer1 and timer2 will run concurrently
  * // - timer1 will emit a value every 1000ms for 10 iterations

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -31,7 +31,16 @@ export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index
  *   Rx.Observable.interval(1000).map(i => x+i)
  * );
  * result.subscribe(x => console.log(x));
- *
+ * 
+ * // Results in the following:
+ * // a0
+ * // b0
+ * // c0
+ * // a1
+ * // b1
+ * // c1
+ * // continues to list a,b,c with respective ascending integers
+ * 
  * @see {@link concatMap}
  * @see {@link exhaustMap}
  * @see {@link merge}

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -31,7 +31,7 @@ export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index
  *   Rx.Observable.interval(1000).map(i => x+i)
  * );
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // Results in the following:
  * // a0
  * // b0

--- a/src/operator/sequenceEqual.ts
+++ b/src/operator/sequenceEqual.ts
@@ -22,7 +22,7 @@ import { errorObject } from '../util/errorObject';
  * completes or emits after the other complets, the returned observable will never complete.
  *
  * @example <caption>figure out if the Konami code matches</caption>
- * var code = Observable.from([
+ * var code = Rx.Observable.from([
  *  "ArrowUp",
  *  "ArrowUp",
  *  "ArrowDown",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**

…FromObservable.ts, combineLates

Add output results for the examples in the documentation pertaining to the operators. Change

seqenceEqual.ts 'var code = Observable.from' to 'var code = Rx.Observable.from'. If the current

example is pasted into an editor and executed it will throw an error of 'Observable not defined'.

The addition of Rx. fixes this.

Issue: Examples do not have resulting output #2171