### PR TITLE
feat(windowTime): maxWindowSize parameter in windowTime operator

### DIFF
--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -23,9 +23,46 @@ describe('Observable.prototype.windowTime', () => {
     const x = cold(            '--a--(b|)                  ');
     const y = cold(                      '-d--e|           ');
     const z = cold(                                '-g--h| ');
-    const values = { x: x, y: y, z: z };
+    const values = { x, y, z };
 
     const result = source.windowTime(50, 100, rxTestScheduler);
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should close windows after max count is reached', () => {
+    const source = hot('--1--2--^--a--b--c--d--e--f--g-----|');
+    const subs =               '^                          !';
+    const timeSpan = time(     '----------|');
+    //  100 frames              0---------1---------2------|
+    const expected =           'x---------y---------z------|';
+    const x = cold(            '---a--(b|)                  ');
+    const y = cold(                      '--d--(e|)         ');
+    const z = cold(                                '-g-----|');
+    const values = { x, y, z };
+
+    const result = source.windowTime(timeSpan, null, 2, rxTestScheduler);
+
+    expectObservable(result).toBe(expected, values);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should close window after max count is reached with' +
+  'windowCreationInterval', () => {
+    const source = hot('--1--2--^-a--b--c--de-f---g--h--i-|');
+    const subs =               '^                         !';
+    //  100 frames              0---------1---------2-----|
+    //  50                      ----|
+    //  50                                ----|
+    //  50                                          ----|
+    const expected =           'x---------y---------z-----|';
+    const x = cold(            '--a--(b|)                  ');
+    const y = cold(                      '-de-(f|)         ');
+    const z = cold(                                '-h--i| ');
+    const values = { x, y, z };
+
+    const result = source.windowTime(50, 100, 3, rxTestScheduler);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -40,9 +77,9 @@ describe('Observable.prototype.windowTime', () => {
     const x = cold(            '---a--b--c|                 ');
     const y = cold(                      '--d--e--f-|       ');
     const z = cold(                                '-g--h--|');
-    const values = { x: x, y: y, z: z };
+    const values = { x, y, z };
 
-    const result = source.windowTime(timeSpan, null, rxTestScheduler);
+    const result = source.windowTime(timeSpan, rxTestScheduler);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -61,7 +98,7 @@ describe('Observable.prototype.windowTime', () => {
     const x = cold(            '---a-|                      ');
     const y = cold(                      '--d--(e|)         ');
     const z = cold(                                '-g--h|  ');
-    const values = { x: x, y: y, z: z };
+    const values = { x, y, z };
 
     const result = source.windowTime(timeSpan, interval, rxTestScheduler);
 
@@ -74,7 +111,7 @@ describe('Observable.prototype.windowTime', () => {
     const subs =          '(^!)';
     const expected =      '(w|)';
     const w =        cold('|');
-    const expectedValues = { w: w };
+    const expectedValues = { w };
     const timeSpan = time('-----|');
     const interval = time('----------|');
 
@@ -89,7 +126,7 @@ describe('Observable.prototype.windowTime', () => {
     const subs =          '(^!)';
     const expected =      '(w|)';
     const w =        cold('(a|)');
-    const expectedValues = { w: w };
+    const expectedValues = { w };
     const timeSpan = time('-----|');
     const interval = time('----------|');
 
@@ -110,7 +147,7 @@ describe('Observable.prototype.windowTime', () => {
     const c =        cold(      '---| ');
     const d =        cold(         '--');
     const unsub =         '          !';
-    const expectedValues = { a: a, b: b, c: c, d: d };
+    const expectedValues = { a, b, c, d };
 
     const result = source.windowTime(timeSpan, interval, rxTestScheduler);
 
@@ -123,7 +160,7 @@ describe('Observable.prototype.windowTime', () => {
     const subs =          '(^!)';
     const expected =      '(w#)';
     const w =        cold('#');
-    const expectedValues = { w: w };
+    const expectedValues = { w };
     const timeSpan = time('-----|');
     const interval = time('----------|');
 
@@ -146,7 +183,7 @@ describe('Observable.prototype.windowTime', () => {
     const x = cold(            '---a-|                      ');
     const y = cold(                      '--d--(e|)         ');
     const z = cold(                                '-g--h|  ');
-    const values = { x: x, y: y, z: z };
+    const values = { x, y, z };
 
     const result = source.windowTime(timeSpan, interval, rxTestScheduler);
 
@@ -168,7 +205,7 @@ describe('Observable.prototype.windowTime', () => {
     const x = cold(            '---a-|                      ');
     const y = cold(                      '--                ');
     const unsub =              '           !                ';
-    const values = { x: x, y: y };
+    const values = { x, y };
 
     const result = source.windowTime(timeSpan, interval, rxTestScheduler);
 
@@ -189,7 +226,7 @@ describe('Observable.prototype.windowTime', () => {
     const x = cold(            '---a-|                      ');
     const y = cold(                      '--d--             ');
     const unsub =              '              !             ';
-    const values = { x: x, y: y };
+    const values = { x, y };
 
     const result = source
       .mergeMap((x: string) => Observable.of(x))


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adds new parameter in windowTime operator to control how much values given
window can emit.

**Related issue (if exists):**

Closes #1301