### PR TITLE
feat(takeUntil): change behavior of takeUntil to not subscribe to source if notifier is synchronous

### DIFF
--- a/spec/operators/takeUntil-spec.ts
+++ b/spec/operators/takeUntil-spec.ts
@@ -126,6 +126,15 @@ describe('Observable.prototype.takeUntil', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
+  it('should complete without subscribing to the source when notifier synchronously emits', () => {
+    const e1 =   hot('----a--|');
+    const e2 =  Observable.of(0);
+    const expected = '(|)     ';
+
+    expectObservable(e1.takeUntil(e2)).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe([]);
+  });
+
   it('should raise error if source raises error before notifier emits', () => {
     const e1 =     hot('--a--b--c--d--#     ');
     const e1subs =     '^             !     ';

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -49,7 +49,13 @@ class TakeUntilOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source.subscribe(new TakeUntilSubscriber(subscriber, this.notifier));
+    const takeUntilSubscriber = new TakeUntilSubscriber(subscriber);
+    const notifierSubscription = subscribeToResult(takeUntilSubscriber, this.notifier);
+    if (notifierSubscription && !notifierSubscription.closed) {
+      takeUntilSubscriber.add(notifierSubscription);
+      return source.subscribe(takeUntilSubscriber);
+    }
+    return takeUntilSubscriber;
   }
 }
 
@@ -60,10 +66,8 @@ class TakeUntilOperator<T> implements Operator<T, T> {
  */
 class TakeUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  constructor(destination: Subscriber<any>,
-              private notifier: Observable<any>) {
+  constructor(destination: Subscriber<any>) {
     super(destination);
-    this.add(subscribeToResult(this, notifier));
   }
 
   notifyNext(outerValue: T, innerValue: R,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
If the notifier supplied to takeUntil synchronously emits a value, the source should not be subscribed to.

**Related issue (if exists):**
#1360

cc: @mattpodwysocki 

Side note: `subscribeToResult` should _definitely_ not return `null` cc: @blesh @jayphelps 