### PR TITLE
Trying to fix errors for TS 2.1... DO NOT MERGE

### DIFF
--- a/src/util/ArgumentOutOfRangeError.ts
+++ b/src/util/ArgumentOutOfRangeError.ts
@@ -10,9 +10,31 @@
  */
 export class ArgumentOutOfRangeError extends Error {
   constructor() {
-    const err: any = super('argument out of range');
-    (<any> this).name = err.name = 'ArgumentOutOfRangeError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
+    const message = 'argument out of range';
+    super(message);
+
+    Object.defineProperty(this, 'name', {
+      enumerable: false,
+      writable: false,
+      value: 'ArgumentOutOfRangeError'
+    });
+
+    Object.defineProperty(this, 'message', {
+      enumerable: false,
+      writable: true,
+      value: message
+    });
+
+    Object.defineProperty(this, 'stack', {
+      enumerable: false,
+      writable: false,
+      value: (new Error(message)).stack
+    });
   }
+}
+
+if (typeof (<any>Object).setPrototypeOf === 'function') {
+  (<any>Object).setPrototypeOf(ArgumentOutOfRangeError.prototype, Error.prototype);
+} else {
+  ArgumentOutOfRangeError.prototype = Object.create(Error.prototype);
 }

--- a/src/util/EmptyError.ts
+++ b/src/util/EmptyError.ts
@@ -10,9 +10,31 @@
  */
 export class EmptyError extends Error {
   constructor() {
-    const err: any = super('no elements in sequence');
-    (<any> this).name = err.name = 'EmptyError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
+    const message = 'no elements in sequence';
+    super(message);
+
+    Object.defineProperty(this, 'name', {
+      enumerable: false,
+      writable: false,
+      value: 'EmptyError'
+    });
+
+    Object.defineProperty(this, 'message', {
+      enumerable: false,
+      writable: true,
+      value: message
+    });
+
+    Object.defineProperty(this, 'stack', {
+      enumerable: false,
+      writable: false,
+      value: (new Error(message)).stack
+    });
   }
+}
+
+if (typeof (<any>Object).setPrototypeOf === 'function') {
+  (<any>Object).setPrototypeOf(EmptyError.prototype, Error.prototype);
+} else {
+  EmptyError.prototype = Object.create(Error.prototype);
 }

--- a/src/util/ObjectUnsubscribedError.ts
+++ b/src/util/ObjectUnsubscribedError.ts
@@ -9,9 +9,31 @@
  */
 export class ObjectUnsubscribedError extends Error {
   constructor() {
-    const err: any = super('object unsubscribed');
-    (<any> this).name = err.name = 'ObjectUnsubscribedError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
+    const message = 'object unsubscribed';
+    super(message);
+
+    Object.defineProperty(this, 'name', {
+      enumerable: false,
+      writable: false,
+      value: 'ObjectUnsubscribedError'
+    });
+
+    Object.defineProperty(this, 'message', {
+      enumerable: false,
+      writable: true,
+      value: message
+    });
+
+    Object.defineProperty(this, 'stack', {
+      enumerable: false,
+      writable: false,
+      value: (new Error(message)).stack
+    });
   }
+}
+
+if (typeof (<any>Object).setPrototypeOf === 'function') {
+  (<any>Object).setPrototypeOf(ObjectUnsubscribedError.prototype, Error.prototype);
+} else {
+  ObjectUnsubscribedError.prototype = Object.create(Error.prototype);
 }

--- a/src/util/TimeoutError.ts
+++ b/src/util/TimeoutError.ts
@@ -7,9 +7,31 @@
  */
 export class TimeoutError extends Error {
   constructor() {
-    const err: any = super('Timeout has occurred');
-    (<any> this).name = err.name = 'TimeoutError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
+    const message = 'Timeout has occurred';
+    super(message);
+
+    Object.defineProperty(this, 'name', {
+      enumerable: false,
+      writable: false,
+      value: 'TimeoutError'
+    });
+
+    Object.defineProperty(this, 'message', {
+      enumerable: false,
+      writable: true,
+      value: message
+    });
+
+    Object.defineProperty(this, 'stack', {
+      enumerable: false,
+      writable: false,
+      value: (new Error(message)).stack
+    });
   }
+}
+
+if (typeof (<any>Object).setPrototypeOf === 'function') {
+  (<any>Object).setPrototypeOf(TimeoutError.prototype, Error.prototype);
+} else {
+  TimeoutError.prototype = Object.create(Error.prototype);
 }

--- a/src/util/UnsubscriptionError.ts
+++ b/src/util/UnsubscriptionError.ts
@@ -4,12 +4,34 @@
  */
 export class UnsubscriptionError extends Error {
   constructor(public errors: any[]) {
-    super();
-    const err: any = Error.call(this, errors ?
-      `${errors.length} errors occurred during unsubscription:
+    super(message = errors ?
+    `${errors.length} errors occurred during unsubscription:
   ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '');
-    (<any> this).name = err.name = 'UnsubscriptionError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
+
+    var message: string;
+
+    Object.defineProperty(this, 'name', {
+      enumerable: false,
+      writable: false,
+      value: 'UnsubscriptionError'
+    });
+
+    Object.defineProperty(this, 'message', {
+      enumerable: false,
+      writable: true,
+      value: message
+    });
+
+    Object.defineProperty(this, 'stack', {
+      enumerable: false,
+      writable: false,
+      value: (new Error(message)).stack
+    });
   }
+}
+
+if (typeof (<any>Object).setPrototypeOf === 'function') {
+  (<any>Object).setPrototypeOf(UnsubscriptionError.prototype, Error.prototype);
+} else {
+  UnsubscriptionError.prototype = <any>Object.create(Error.prototype);
 }


### PR DESCRIPTION
This is another (not working) attempt at a workaround for TypeScript 2.1's breaking changes to subclassing Errors.

cc/ @jayphelps @kwonoj 

Like I said, this doesn't work
