### PR TITLE
fix(TypeScript): pin to TypeScript 2.0.x, fix errors with Error subcl…

### DIFF
--- a/package.json
+++ b/package.json
@@ -186,7 +186,7 @@
     "source-map-support": "^0.4.0",
     "tslib": "^1.0.0",
     "tslint": "^3.15.1",
-    "typescript": "^2.0.6",
+    "typescript": "~2.0.6",
     "typings": "^2.0.0",
     "validate-commit-msg": "^2.3.1",
     "watch": "^1.0.1",


### PR DESCRIPTION
…assing

Because the the last build was pinned to 2.x.x, it built with TypeScript 2.1.x, which had breaking changes but was not a major release.

This should fix that.

:(