### PR TITLE
feat(join): add join operator

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -81,7 +81,6 @@ enabling "composite" subscription behavior.
 |`groupJoin`|No longer implemented|
 |`includes(v)`|`.first(x => x === v, () => true, false)`|
 |`indexOf(v)`|`.map((x, i) => [x === v, i]).filter(([x]) => x).map(([_, i]) => i).first()`|
-|`join`|No longer implemented|
 |`jortSortUntil`|No longer implemented|
 |`jortSort`|No longer implemented|
 |`just(v)` or `just(a, b, c)`|`of(v)`, `of(a, b, c)`|

--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -322,6 +322,9 @@ children:
         - label: using each source value only once
           children:
           - label: zip
+        - label: by defining how long value from one source will wait for values from the other one
+          children:
+          - label: join
   - label: 'I have some Observables to combine together as one Observable, and'
     children:
     - label: I want to receive values only from the Observable that emits a value first

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -195,6 +195,7 @@ There are operators for different purposes, and they may be categorized as: crea
 - [`concatAll`](../class/es6/Observable.js~Observable.html#instance-method-concatAll)
 - [`exhaust`](../class/es6/Observable.js~Observable.html#instance-method-exhaust)
 - [`forkJoin`](../class/es6/Observable.js~Observable.html#static-method-forkJoin)
+- [`join`](../class/es6/Observable.js~Observable.html#static-method-join)
 - [`merge`](../class/es6/Observable.js~Observable.html#instance-method-merge)
 - [`mergeAll`](../class/es6/Observable.js~Observable.html#instance-method-mergeAll)
 - [`race`](../class/es6/Observable.js~Observable.html#instance-method-race)

--- a/spec/operators/join-spec.ts
+++ b/spec/operators/join-spec.ts
@@ -1,0 +1,353 @@
+import {expect} from 'chai';
+import * as Rx from '../../dist/cjs/Rx';
+declare const {hot, cold, time, asDiagram, expectObservable, expectSubscriptions};
+
+declare const rxTestScheduler: Rx.TestScheduler;
+const Observable = Rx.Observable;
+
+interface TimeInterval {
+  value: any;
+  interval: number;
+}
+
+function ti(v: any, i: number = 0): TimeInterval {
+  return { value: v, interval: i };
+};
+
+function duration(x: TimeInterval): Rx.Observable<number> {
+  return Observable.timer(x.interval, undefined, rxTestScheduler);
+};
+
+function concat(x: TimeInterval, y: TimeInterval): any {
+  return x.value + y.value;
+};
+
+describe('Observable.prototype.join()', () => {
+  it('should work for synced sources and duration', () => {
+    const xs = { a: ti('first0'), b: ti('first1'), c: ti('first2') };
+    const ys = { d: ti('second0'), e: ti('second1'), f: ti('second2') };
+
+    let x =          hot('--a--b--c--|', xs);
+    const xsubs =        '^          !';
+    xs.a.interval = time(  '|         ');
+    xs.b.interval = time(     '|      ');
+    xs.c.interval = time(        '|   ');
+
+    let y =          hot('--d--e--f--|', ys);
+    const ysubs =        '^          !';
+    ys.d.interval = time(  '|         ');
+    ys.e.interval = time(     '|      ');
+    ys.f.interval = time(        '|   ');
+
+    const expected =     '--g--h--i--|';
+    const values = { g: 'first0second0', h: 'first1second1', i: 'first2second2' };
+
+    const r = x.join(y, duration, duration, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should work if left emits a single value with full duration', () => {
+    const xs = { a: ti('first0') };
+    const ys = { d: ti('second0'), e: ti('second1'), f: ti('second2') };
+
+    let x =          hot('--a--------|', xs);
+    const xsubs =        '^          !';
+    xs.a.interval = time('-----------|');
+
+    let y =          hot('--d--e--f--|', ys);
+    const ysubs =        '^          !';
+    ys.d.interval = time(  '|         ');
+    ys.e.interval = time(     '|      ');
+    ys.f.interval = time(        '|   ');
+
+    const expected =     '--g--h--i--|';
+    const values = { g: 'first0second0', h: 'first0second1', i: 'first0second2' };
+
+    const r = x.join(y, duration, duration, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should work if right emits a single value with full duration', () => {
+    const xs = { a: ti('first0'), b: ti('first1'), c: ti('first2') };
+    const ys = { d: ti('second0') };
+
+    let x =          hot('--a--b--c--|', xs);
+    const xsubs =        '^          !';
+    xs.a.interval = time(  '|         ');
+    xs.b.interval = time(     '|      ');
+    xs.c.interval = time(        '|   ');
+
+    let y =          hot('--d--------|', ys);
+    const ysubs =        '^          !';
+    ys.d.interval = time('-----------|');
+
+    const expected =     '--g--h--i--|';
+    const values = { g: 'first0second0', h: 'first1second0', i: 'first2second0' };
+
+    const r = x.join(y, duration, duration, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should work when sources and duration are not synced', () => {
+    const xs = { a: ti(0), b: ti(1), c: ti(2), d: ti(3) };
+    const ys = { g: ti('hat'), h: ti('bat'), i: ti('wag'), j: ti('pig') };
+
+    let x =          hot('-a----b----------c-----d-|', xs);
+    const xsubs =        '^                        !';
+    xs.a.interval = time( '---|                     ');
+    xs.b.interval = time(      '---|                ');
+    xs.c.interval = time(                 '----|    ');
+    xs.d.interval = time(                       '-| ');
+
+    let y =          hot('--gh------i-j------------|', ys);
+    const ysubs =        '^                        !';
+    ys.g.interval = time(  '|                       ');
+    ys.h.interval = time(   '|                      ');
+    ys.i.interval = time(          '---------|      ');
+    ys.j.interval = time(            '---------|    ');
+
+    const expected =     '--tu-------------(wz)----|';
+    const values = { t: '0hat', u: '0bat', w: '2wag', z: '2pig' };
+
+    const r = x.join(y, duration, duration, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should propagate errors from left', () => {
+    const xs = { a: ti(0) };
+    const ys = { g: ti('hat'), h: ti('bat') };
+
+    let x =          hot('-a----#', xs);
+    const xsubs =        '^     !';
+    xs.a.interval = time( '---|  ');
+
+    let y =          hot('--gh------i-j------------|', ys);
+    const ysubs =        '^     !';
+    ys.g.interval = time(  '|                       ');
+    ys.h.interval = time(   '|                      ');
+
+    const expected =     '--tu--#';
+    const values = { t: '0hat', u: '0bat' };
+
+    const r = x.join(y, duration, duration, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should propagate errors from right', () => {
+    const xs = { a: ti(0), b: ti(1), c: ti(2), d: ti(3) };
+    const ys = { g: ti('hat'), h: ti('bat') };
+
+    let x =          hot('-a----b----------c-----d-|', xs);
+    const xsubs =        '^         !';
+    xs.a.interval = time( '---|                     ');
+    xs.b.interval = time(      '---|                ');
+    xs.c.interval = time(                 '----|    ');
+    xs.d.interval = time(                       '-| ');
+
+    let y =          hot('--gh------#', ys);
+    const ysubs =        '^         !';
+    ys.g.interval = time(  '|        ');
+    ys.h.interval = time(   '|       ');
+
+    const expected =     '--tu------#';
+    const values = { t: '0hat', u: '0bat' };
+
+    const r = x.join(y, duration, duration, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should propagate errors from left duration selector', () => {
+    const xs = { a: ti('first0'), b: ti('first1'), c: ti('first2') };
+    const ys = { d: ti('second0'), e: ti('second1'), f: ti('second2') };
+
+    let x =          hot('--a--b--c--|', xs);
+    const xsubs =        '^    !       ';
+    xs.a.interval = time(  '|         ');
+    xs.b.interval = time(     '|      ');
+    xs.c.interval = time(        '|   ');
+
+    let y =          hot('--d--e--f--|', ys);
+    const ysubs =        '^    !      ';
+    ys.d.interval = time(  '|         ');
+    ys.e.interval = time(     '|      ');
+    ys.f.interval = time(        '|   ');
+
+    const expected =     '--g--#';
+    const values = { g: 'first0second0' };
+
+    const throwError = (v: TimeInterval) => {
+      if (v.value === 'first1') {
+        throw 'error';
+      } else {
+        return duration(v);
+      }
+    };
+
+    const r = x.join(y, throwError, duration, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should propagate errors from right duration selector', () => {
+    const xs = { a: ti('first0'), b: ti('first1'), c: ti('first2') };
+    const ys = { d: ti('second0'), e: ti('second1'), f: ti('second2') };
+
+    let x =          hot('--a--b--c--|', xs);
+    const xsubs =        '^    !       ';
+    xs.a.interval = time(  '|         ');
+    xs.b.interval = time(     '|      ');
+    xs.c.interval = time(        '|   ');
+
+    let y =          hot('--d--e--f--|', ys);
+    const ysubs =        '^    !      ';
+    ys.d.interval = time(  '|         ');
+    ys.e.interval = time(     '|      ');
+    ys.f.interval = time(        '|   ');
+
+    const expected =     '--g--#';
+    const values = { g: 'first0second0' };
+
+    const throwError = (v: TimeInterval) => {
+      if (v.value === 'second1') {
+        throw 'error';
+      } else {
+        return duration(v);
+      }
+    };
+
+    const r = x.join(y, duration, throwError, concat);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should propagate errors from result selector', () => {
+    const xs = { a: ti('first0'), b: ti('first1'), c: ti('first2') };
+    const ys = { d: ti('second0'), e: ti('second1'), f: ti('second2') };
+
+    let x =          hot('--a--b--c--|', xs);
+    const xsubs =        '^       !   ';
+    xs.a.interval = time(  '|         ');
+    xs.b.interval = time(     '|      ');
+    xs.c.interval = time(        '|   ');
+
+    let y =          hot('--d--e--f--|', ys);
+    const ysubs =        '^       !   ';
+    ys.d.interval = time(  '|         ');
+    ys.e.interval = time(     '|      ');
+    ys.f.interval = time(        '|   ');
+
+    const expected =     '--g--h--#';
+    const values = { g: 'first0second0', h: 'first1second1' };
+
+    const throwError = (vx: TimeInterval, vy: TimeInterval) => {
+      if (vx.value === 'first2') {
+        throw 'error';
+      } else {
+        return concat(vx, vy);
+      }
+    };
+
+    const r = x.join(y, duration, duration, throwError);
+    expectObservable(r).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should work when left is never', () => {
+    const ys = { d: ti('second0'), e: ti('second1'), f: ti('second2') };
+
+    let x =          hot('------------');
+    const xsubs =        '^          !';
+
+    let y =          hot('--d--e--f--|', ys);
+    const ysubs =        '^          !';
+    ys.d.interval = time(  '|         ');
+    ys.e.interval = time(     '|      ');
+    ys.f.interval = time(        '|   ');
+
+    const expected =     '-----------|';
+
+    let calls = 0;
+    const durationCounted = (v: TimeInterval) => {
+      calls++;
+      return duration(v);
+    };
+
+    const r = x.join(y, duration, durationCounted, concat)
+      .do(undefined, undefined, () => expect(calls).to.equal(3));
+    expectObservable(r).toBe(expected);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should work when right is never', () => {
+    const xs = { a: ti('first0'), b: ti('first1'), c: ti('first2') };
+
+    let x =          hot('--a--b--c--|', xs);
+    const xsubs =        '^          !';
+    xs.a.interval = time(  '|         ');
+    xs.b.interval = time(     '|      ');
+    xs.c.interval = time(        '|   ');
+
+    let y =          hot('------------');
+    const ysubs =        '^          !';
+
+    const expected =     '-----------|';
+
+    let calls = 0;
+    const durationCounted = (v: TimeInterval) => {
+      calls++;
+      return duration(v);
+    };
+
+    const r = x.join(y, durationCounted, duration, concat)
+      .do(undefined, undefined, () => expect(calls).to.equal(3));
+    expectObservable(r).toBe(expected);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+
+  it('should not break unsubscription chain when unsubscribed explicitly', () => {
+    const xs = { a: ti('first0'), b: ti('first1'), c: ti('first2') };
+    const ys = { d: ti('second0'), e: ti('second1'), f: ti('second2') };
+
+    let x =          hot('--a--b--c--|', xs);
+    const unsub =        '       !    ';
+    const xsubs =        '^      !    ';
+    xs.a.interval = time(  '|         ');
+    xs.b.interval = time(     '|      ');
+    xs.c.interval = time(        '|   ');
+
+    let y =          hot('--d--e--f--|', ys);
+    const ysubs =        '^      !     ';
+    ys.d.interval = time(  '|         ');
+    ys.e.interval = time(     '|      ');
+    ys.f.interval = time(        '|   ');
+
+    const expected =       '--g--h--';
+    const values = { g: 'first0second0', h: 'first1second1' };
+
+    const r = x
+      .mergeMap((v: TimeInterval) => Observable.of(v))
+      .join(y, duration, duration, concat)
+      .mergeMap((v: TimeInterval) => Observable.of(v));
+
+    expectObservable(r, unsub).toBe(expected, values);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+  });
+});

--- a/src/InnerSubscriber.ts
+++ b/src/InnerSubscriber.ts
@@ -9,7 +9,7 @@ import { OuterSubscriber } from './OuterSubscriber';
 export class InnerSubscriber<T, R> extends Subscriber<R> {
   private index: number = 0;
 
-  constructor(private parent: OuterSubscriber<T, R>, private outerValue: T, private outerIndex: number) {
+  constructor(private parent: OuterSubscriber<T, R>, private outerValue: T, public outerIndex: number) {
     super();
   }
 

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -74,6 +74,7 @@ import './add/operator/first';
 import './add/operator/groupBy';
 import './add/operator/ignoreElements';
 import './add/operator/isEmpty';
+import './add/operator/join';
 import './add/operator/audit';
 import './add/operator/auditTime';
 import './add/operator/last';

--- a/src/add/operator/join.ts
+++ b/src/add/operator/join.ts
@@ -1,0 +1,11 @@
+
+import { Observable } from '../../Observable';
+import { join } from '../../operator/join';
+
+Observable.prototype.join = join;
+
+declare module '../../Observable' {
+  interface Observable<T> {
+    join: typeof join;
+  }
+}

--- a/src/operator/join.ts
+++ b/src/operator/join.ts
@@ -9,21 +9,36 @@ import { subscribeToResult } from '../util/subscribeToResult';
 import { take } from './take';
 
 /**
- * Returns an Observable that combines the items emitted by two Observables, and selects which items to combine
- * based on duration-windows that you define on a per-item basis via the durtionSelector functions. You implement
- * these windows as Observables whose lifespans begin with each item emitted by either Observable. When such a
- * window-defining Observable either emits an item or completes, the window for the item it is associated with
- * closes. So long as an item's window is open, it will combine with any item emitted by the other Observable.
+ * Combines values from two Observables, based on time windows defined for each
+ * value and each stream.
+ *
+ * <span class="informal">Combine values from two streams, but only
+ * sometimes</span>
+ * <img src="./img/join.png" width="100%">
+ *
+ * Returns an Observable that combines the items emitted by two Observables,
+ * and selects which items to combine
+ * based on duration-windows that you define on a per-item basis via the
+ * durtionSelector functions. You implement
+ * these windows as Observables whose lifespans begin with each item emitted by
+ * either Observable. When such a
+ * window-defining Observable either emits an item or completes, the window for
+ * the item it is associated with
+ * closes. So long as an item's window is open, it will combine with any item
+ * emitted by the other Observable.
  * `resultSelector` is the function you define to combine the items.
  *
  * @param {Observable} right  the right observable sequence to join elements for
- * @param {Function} leftDurationSelector  a function to select the duration (expressed as an observable sequence)
+ * @param {Function} leftDurationSelector  a function to select the duration
+ * (expressed as an observable sequence)
  * of each element of the left observable sequence, used to determine overlap
- * @param {Function} rightDurationSelector  a function to select the duration (expressed as an observable sequence)
+ * @param {Function} rightDurationSelector  a function to select the duration
+ * (expressed as an observable sequence)
  * of each element of the left observable sequence, used to determine overlap
- * @param {Function} resultSelector  a function invoked to compute a result element for any two overlapping elements
+ * @param {Function} resultSelector  a function invoked to compute a result
+ * element for any two overlapping elements
  * of the left and right observable sequences.
- * @returns {Observable} an observable sequence that contains result elements computed from source elements that
+ * @returns {Observable} an observable sequence that contains result elements * * computed from source elements that
  * have an overlapping duration
  */
 export function join<T1, T2, R>(this: Observable<T1>,

--- a/src/operator/join.ts
+++ b/src/operator/join.ts
@@ -1,0 +1,182 @@
+import { Observable } from '../Observable';
+import { ArrayObservable } from '../observable/ArrayObservable';
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { TeardownLogic } from '../Subscription';
+import { OuterSubscriber } from '../OuterSubscriber';
+import { InnerSubscriber } from '../InnerSubscriber';
+import { subscribeToResult } from '../util/subscribeToResult';
+import { take } from './take';
+
+/**
+ * Returns an Observable that combines the items emitted by two Observables, and selects which items to combine
+ * based on duration-windows that you define on a per-item basis via the durtionSelector functions. You implement
+ * these windows as Observables whose lifespans begin with each item emitted by either Observable. When such a
+ * window-defining Observable either emits an item or completes, the window for the item it is associated with
+ * closes. So long as an item's window is open, it will combine with any item emitted by the other Observable.
+ * `resultSelector` is the function you define to combine the items.
+ *
+ * @param {Observable} right  the right observable sequence to join elements for
+ * @param {Function} leftDurationSelector  a function to select the duration (expressed as an observable sequence)
+ * of each element of the left observable sequence, used to determine overlap
+ * @param {Function} rightDurationSelector  a function to select the duration (expressed as an observable sequence)
+ * of each element of the left observable sequence, used to determine overlap
+ * @param {Function} resultSelector  a function invoked to compute a result element for any two overlapping elements
+ * of the left and right observable sequences.
+ * @returns {Observable} an observable sequence that contains result elements computed from source elements that
+ * have an overlapping duration
+ */
+export function join<T1, T2, R>(this: Observable<T1>,
+                                right: Observable<T2>,
+                                leftDurationSelector: (value: T1) => Observable<any>,
+                                rightDurationSelector: (value: T2) => Observable<any>,
+                                resultSelector: (left: T1, right: T2) => R): Observable<R> {
+  const o = new ArrayObservable([this, right]);
+  return o.lift(new JoinOperator(leftDurationSelector, rightDurationSelector, resultSelector));
+}
+
+class JoinOperator<T1, T2, R> implements Operator<any, R> {
+  constructor(private leftDurationSelector: (value: T1) => Observable<any>,
+              private rightDurationSelector: (value: T2) => Observable<any>,
+              private resultSelector: (left: T1, right: T2) => R) {
+  }
+
+  call(subscriber: Subscriber<R>, source: any): TeardownLogic {
+    return source.subscribe(new JoinSubscriber(subscriber, this.leftDurationSelector, this.rightDurationSelector, this.resultSelector));
+  }
+}
+
+class Context<T> {
+  public map: Map<number, T> = new Map<number, T>();
+  public done: boolean = false;
+
+  constructor(public idCounter: number, public source: Observable<T>) {
+  }
+
+  get empty(): boolean {
+    return this.map.size === 0;
+  }
+
+  add(value: T): number {
+    const id = this.idCounter;
+    this.idCounter += 2;
+    this.map.set(id, value);
+    return id;
+  }
+
+  remove(id: number): void {
+    this.map.delete(id);
+  }
+}
+
+class JoinSubscriber<T1, T2, R> extends OuterSubscriber<any, R> {
+  private left: Context<T1>;
+  private right: Context<T2>;
+
+  constructor(destination: Subscriber<R>,
+              private leftDurationSelector: (value: T1) => Observable<any>,
+              private rightDurationSelector: (value: T2) => Observable<any>,
+              private resultSelector: (left: T1, right: T2) => R) {
+    super(destination);
+  }
+
+  protected _next(value: Observable<T1 | T2>): void {
+    if (this.left) {
+      this.right = new Context<T2>(3, <Observable<T2>>value);
+    } else {
+      this.left = new Context<T1>(2, <Observable<T1>>value);
+    }
+  }
+
+  protected _complete(): void {
+    this.add(subscribeToResult(this, this.left.source, null, 0));
+    this.add(subscribeToResult(this, this.right.source, null, 1));
+  }
+
+  notifyNext(outerValue: any, innerValue: any,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<any, R>): void {
+    if (outerIndex === 0) {
+      this.leftNext(innerValue);
+    } else if (outerIndex === 1) {
+      this.rightNext(innerValue);
+    }
+  }
+
+  private leftNext(value: T1): void {
+    const id = this.left.add(value);
+    const success = this.tryDurationSelector(this.leftDurationSelector, value, id);
+    if (success) {
+      this.right.map.forEach((v: T2) => {
+        this.tryResultSelector(value, v);
+      });
+    }
+  }
+
+  private rightNext(value: T2): void {
+    const id = this.right.add(value);
+    const success = this.tryDurationSelector(this.rightDurationSelector, value, id);
+    if (success) {
+      this.left.map.forEach((v: T1) => {
+        this.tryResultSelector(v, value);
+      });
+    }
+  }
+
+  private tryDurationSelector(durationSelector: (value: T1 | T2) => Observable<any>,
+                              value: T1 | T2, id: number): boolean {
+    let duration: Observable<any>;
+    try {
+      duration = durationSelector(value);
+    } catch (err) {
+      this.destination.error(err);
+      return false;
+    }
+    this.subscribeToDuration(duration, id);
+    return true;
+  }
+
+  private subscribeToDuration(duration: Observable<any>, id: number): void {
+    const durationObservable = take.call(duration, 1);
+    this.add(subscribeToResult(this, durationObservable, null, id));
+  }
+
+  private tryResultSelector(leftValue: T1, rightValue: T2): void {
+    const destination = this.destination;
+    let result: R;
+    try {
+      result = this.resultSelector(leftValue, rightValue);
+    } catch (err) {
+      destination.error(err);
+      return;
+    }
+    destination.next(result);
+  }
+
+  notifyComplete(innerSub: InnerSubscriber<any, R>): void {
+    const id = innerSub.outerIndex;
+    this.remove(innerSub);
+    if (id === 0) {
+      this.mainComplete(this.left, this.right);
+    } else if (id === 1) {
+      this.mainComplete(this.right, this.left);
+    } else {
+      const context = id % 2 === 0 ? this.left : this.right;
+      this.durationComplete(id, context);
+    }
+  }
+
+  private mainComplete(x: Context<T1 | T2>, y: Context<T1 | T2>): void {
+    x.done = true;
+    if (y.done || x.empty) {
+      this.destination.complete();
+    }
+  }
+
+  private durationComplete(id: number, context: Context<T1 | T2>): void {
+    context.remove(id);
+    if (context.done && context.empty) {
+      this.destination.complete();
+    }
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Implements join operator as described in ReactiveX docs

This implementation was created by @luisgabriel. At some moment he closed pr - https://github.com/ReactiveX/rxjs/pull/1371 - claiming code is not working for some reason. 

I took his commits and rebased them to current master. I also fixed (quite trivial as it turned out) error. Now all tests pass.

If there is any work that needs to be done on this operator, let me know - I will be more than happy to help.

**Related issue (if exists):**

Closes #1341