### PR TITLE
fix(groupBy): Fix groupBy to dispose of outer subscription.

### DIFF
--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -340,6 +340,34 @@ describe('Observable.prototype.groupBy', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should unsubscribe from the source when the outer and inner subscriptions are disposed', () => {
+    const values = {
+      a: '  foo',
+      b: ' FoO ',
+      c: 'baR  ',
+      d: 'foO ',
+      e: ' Baz   ',
+      f: '  qux ',
+      g: '   bar',
+      h: ' BAR  ',
+      i: 'FOO ',
+      j: 'baz  ',
+      k: ' bAZ ',
+      l: '    fOo    '
+    };
+    const e1 = hot('-1--2--^-a-b-c-d-e-f-g-h-i-j-k-l-|', values);
+    const e1subs =        '^ !';
+    const expected =      '--(a|)';
+
+    const source = e1
+      .groupBy((val: string) => val.toLowerCase().trim())
+      .take(1)
+      .mergeMap((group: any) => group.take(1));
+
+    expectObservable(source).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
     const values = {
       a: '  foo',

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -163,7 +163,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
   }
 
   unsubscribe() {
-    if (!this.closed && !this.attemptedToUnsubscribe) {
+    if (!this.closed) {
       this.attemptedToUnsubscribe = true;
       if (this.count === 0) {
         super.unsubscribe();


### PR DESCRIPTION
Not sure how groupBy is passing current unit tests, as we seem to be covering this case.

This PR fixes a bug where groupBy wasn't unsubscribing from its source when the outer subscription has been disposed and all inner subscriptions are inactive.

If you see [here](https://github.com/trxcllnt/rxjs/blob/04b7757dd6e661e7a7be48231d0261790327b9f5/src/operator/groupBy.ts#L250), the inner refCount subscription calls `parent.unsubscribe()` if `parent.count === 0` and `parent.attemptedToUnsubscribe` is true. But the parent only unsubscribes if `parent.attemptedToUnsubscribe` is false, which means the subscription to the source is never disposed.

This is easily replicated with groupBy on a Subject, where you'll see the observers list grow indefinitely.

