### PR TITLE
chore(README): Update our branching strategy

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,11 +20,10 @@ Reactive Extensions Library for JavaScript. This is a rewrite of [Reactive-Exten
 
 ## Versions In This Repository
 
-Different branches contain different versions
+- [master](https://github.com/ReactiveX/rxjs/commits/master) - commits that will be included in the next _minor_ or _patch_ release
+- [next](https://github.com/ReactiveX/rxjs/commits/next) - commits that will be included in the next _major_ release (breaking changes)
 
-- [master](https://github.com/ReactiveX/rxjs/commits/master) - **canary** the next _major_ release (aka RxJS 6 😱)
-- [5.1.x](https://github.com/ReactiveX/rxjs/commits/5.1.x) - **beta** the next _minor_ release
-- [5.0.x](https://github.com/ReactiveX/rxjs/commits/5.0.x) - **stable** the current _stable_ release and its patches
+Most PRs should be made to **master**, unless you know it is a breaking change.
 
 ## Important
 


### PR DESCRIPTION
As discussed [in today's RxJS team meeting](https://github.com/ReactiveX/rxjs-core-notes/blob/master/2016-12/december-20.md#branching-strategy), we feel it would be more simple to use two branches instead of three.

- [master](https://github.com/ReactiveX/rxjs/commits/master) - commits that will be included in the next _minor_ or _patch_ release
- [next](https://github.com/ReactiveX/rxjs/commits/next) - commits that will be included in the next _major_ release (breaking changes)

We need to make the actual branches for `next` still.

***

We haven't really thought through the name `"next"` much. It is ambiguous, since it is intended to mean "next **major** release" (right now 6.0) not "next release in general" (e.g. 5.0.2) We didn't want to name the branch the literal version number, e.g. `6.0` because it would mean switching branches for every major release--but perhaps that's not the end of the world. Alternative name suggestions welcome. Maybe just `major` ?

We may also find that this approach isn't ideal. For example, ember and react both consider the `master` branch to be the latest and greatest canary, which includes everything (except short-lived patches that are incompatible), including breaking changes for future major version bumps. They then maintain a separate branch for the current stable version, cherry-picking commits for minor/patch releases. This is basically the opposite of what we just decided to do (described in this PR) It's unclear which approach is best for us. 