### PR TITLE
fix(repeatWhen): wait for source to complete after notifier completes

### DIFF
--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -10,9 +10,9 @@ describe('Observable.prototype.repeatWhen', () => {
     const source =  cold('-1--2--|');
     const subs =        ['^      !                     ',
                        '             ^      !        ',
-                       '                          ^ !'];
+                       '                          ^      !'];
     const notifier = hot('-------------r------------r-|');
-    const expected =     '-1--2---------1--2---------1|';
+    const expected =     '-1--2---------1--2---------1--2--|';
 
     const result = source.repeatWhen((notifications: any) => notifier);
 

--- a/src/operator/repeatWhen.ts
+++ b/src/operator/repeatWhen.ts
@@ -27,16 +27,15 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * @owner Observable
  */
 export function repeatWhen<T>(this: Observable<T>, notifier: (notifications: Observable<any>) => Observable<any>): Observable<T> {
-  return this.lift(new RepeatWhenOperator(notifier, this));
+  return this.lift(new RepeatWhenOperator(notifier));
 }
 
 class RepeatWhenOperator<T> implements Operator<T, T> {
-  constructor(protected notifier: (notifications: Observable<any>) => Observable<any>,
-              protected source: Observable<T>) {
+  constructor(protected notifier: (notifications: Observable<any>) => Observable<any>) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source.subscribe(new RepeatWhenSubscriber(subscriber, this.notifier, this.source));
+    return source.subscribe(new RepeatWhenSubscriber(subscriber, this.notifier, source));
   }
 }
 
@@ -50,6 +49,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
   private notifications: Subject<any>;
   private retries: Observable<any>;
   private retriesSubscription: Subscription;
+  private sourceIsBeingSubscribedTo: boolean = true;
 
   constructor(destination: Subscriber<R>,
               private notifier: (notifications: Observable<any>) => Observable<any>,
@@ -57,33 +57,31 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
+  notifyNext(outerValue: T, innerValue: R,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, R>): void {
+    this.source.subscribe(this);
+    this.sourceIsBeingSubscribedTo = true;
+  }
+
+  notifyComplete(innerSub: InnerSubscriber<T, R>): void {
+    if (this.sourceIsBeingSubscribedTo === false) {
+      return super.complete();
+    }
+  }
+
   complete() {
+    this.sourceIsBeingSubscribedTo = false;
+
     if (!this.isStopped) {
-
-      let notifications = this.notifications;
-      let retries: any = this.retries;
-      let retriesSubscription = this.retriesSubscription;
-
-      if (!retries) {
-        notifications = new Subject();
-        retries = tryCatch(this.notifier)(notifications);
-        if (retries === errorObject) {
-          return super.complete();
-        }
-        retriesSubscription = subscribeToResult(this, retries);
-      } else {
-        this.notifications = null;
-        this.retriesSubscription = null;
+      if (!this.retries) {
+        this.subscribeToRetries();
+      } else if (this.retriesSubscription.closed) {
+        return super.complete();
       }
 
-      this.unsubscribe();
-      this.closed = false;
-
-      this.notifications = notifications;
-      this.retries = retries;
-      this.retriesSubscription = retriesSubscription;
-
-      notifications.next();
+      this.temporarilyUnsubscribe();
+      this.notifications.next();
     }
   }
 
@@ -100,10 +98,17 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.retries = null;
   }
 
-  notifyNext(outerValue: T, innerValue: R,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, R>): void {
+  private subscribeToRetries() {
+    this.notifications = new Subject();
+    const retries = tryCatch(this.notifier)(this.notifications);
+    if (retries === errorObject) {
+      return super.complete();
+    }
+    this.retries = retries;
+    this.retriesSubscription = subscribeToResult(this, retries);
+  }
 
+  private temporarilyUnsubscribe() {
     const { notifications, retries, retriesSubscription } = this;
     this.notifications = null;
     this.retries = null;
@@ -116,7 +121,6 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.notifications = notifications;
     this.retries = retries;
     this.retriesSubscription = retriesSubscription;
-
-    this.source.subscribe(this);
   }
+
 }


### PR DESCRIPTION
**Description:**

After notifier completes wait for source observable to complete instead
of ending stream immediately

**Related issue (if exists):**

Closes #2054

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->
