### PR TITLE
docs(operators): examples for 'every' operator

### DIFF
--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -5,6 +5,25 @@ import { Subscriber } from '../Subscriber';
 
 /**
  * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
+ *
+ * @example <caption>A simple example emitting true if all elements are less than 5, false otherwise</caption>
+ *  Observable.of(1, 2, 3, 4, 5, 6)
+ *     .every(x => x < 5)
+ *     .subscribe(x => console.log(x)); // -> false
+ * 
+ * @example <caption>An example passing this (if you cannot use ES6 arrow function)</caption>
+ * class MyClass {
+ *     private isSmallEnough(n: number): boolean {
+ *         return n < 7;
+ *     }
+ *     constructor() {
+ *         Observable.of(1, 2, 3, 4, 5, 6)
+ *             .every(function(x) { return this.isSmallEnough(x); }, this)
+ *             .subscribe(function(x) { console.log(x); });
+ *     } 
+ * }
+ * let c: MyClass = new MyClass(); // -> true
+ * 
  * @param {function} predicate a function for determining if an item meets a specified condition.
  * @param {any} [thisArg] optional object to use for `this` in the callback
  * @return {Observable} an Observable of booleans that determines if all items of the source Observable meet the condition specified.

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -11,19 +11,6 @@ import { Subscriber } from '../Subscriber';
  *     .every(x => x < 5)
  *     .subscribe(x => console.log(x)); // -> false
  * 
- * @example <caption>An example passing this (if you cannot use ES6 arrow function)</caption>
- * class MyClass {
- *     private isSmallEnough(n: number): boolean {
- *         return n < 7;
- *     }
- *     constructor() {
- *         Observable.of(1, 2, 3, 4, 5, 6)
- *             .every(function(x) { return this.isSmallEnough(x); }, this)
- *             .subscribe(function(x) { console.log(x); });
- *     } 
- * }
- * let c: MyClass = new MyClass(); // -> true
- * 
  * @param {function} predicate a function for determining if an item meets a specified condition.
  * @param {any} [thisArg] optional object to use for `this` in the callback
  * @return {Observable} an Observable of booleans that determines if all items of the source Observable meet the condition specified.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Examples for 'every' operator

**Related issue (if exists):**
