### PR TITLE
fix(TypeScript): interfaces that accepted `Scheduler` now accept `ISc…

### DIFF
--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -1,5 +1,5 @@
 import { Subject } from './Subject';
-import { Scheduler } from './Scheduler';
+import { IScheduler } from './Scheduler';
 import { queue } from './scheduler/queue';
 import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
@@ -16,7 +16,7 @@ export class ReplaySubject<T> extends Subject<T> {
 
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
               windowTime: number = Number.POSITIVE_INFINITY,
-              private scheduler?: Scheduler) {
+              private scheduler?: IScheduler) {
     super();
     this._bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;

--- a/src/Scheduler.ts
+++ b/src/Scheduler.ts
@@ -1,6 +1,10 @@
 import { Action } from './scheduler/Action';
 import { Subscription } from './Subscription';
 
+export interface IScheduler {
+  now(): number;
+  schedule<T>(work: (this: Action<T>, state?: T) => void, delay?: number, state?: T): Subscription;
+}
 /**
  * An execution context and a data structure to order tasks and schedule their
  * execution. Provides a notion of (potentially virtual) time, through the
@@ -17,7 +21,7 @@ import { Subscription } from './Subscription';
  *
  * @class Scheduler
  */
-export class Scheduler {
+export class Scheduler implements IScheduler {
 
   public static now: () => number = Date.now ? Date.now : () => +new Date();
 

--- a/src/observable/ArrayLikeObservable.ts
+++ b/src/observable/ArrayLikeObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { ScalarObservable } from './ScalarObservable';
 import { EmptyObservable } from './EmptyObservable';
@@ -12,7 +12,7 @@ import { TeardownLogic } from '../Subscription';
  */
 export class ArrayLikeObservable<T> extends Observable<T> {
 
-  static create<T>(arrayLike: ArrayLike<T>, scheduler?: Scheduler): Observable<T> {
+  static create<T>(arrayLike: ArrayLike<T>, scheduler?: IScheduler): Observable<T> {
     const length = arrayLike.length;
     if (length === 0) {
       return new EmptyObservable<T>();
@@ -45,7 +45,7 @@ export class ArrayLikeObservable<T> extends Observable<T> {
   // value used if Array has one value and _isScalar
   private value: any;
 
-  constructor(private arrayLike: ArrayLike<T>, private scheduler?: Scheduler) {
+  constructor(private arrayLike: ArrayLike<T>, private scheduler?: IScheduler) {
     super();
     if (!scheduler && arrayLike.length === 1) {
       this._isScalar = true;

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { ScalarObservable } from './ScalarObservable';
 import { EmptyObservable } from './EmptyObservable';
@@ -13,17 +13,17 @@ import { TeardownLogic } from '../Subscription';
  */
 export class ArrayObservable<T> extends Observable<T> {
 
-  static create<T>(array: T[], scheduler?: Scheduler): Observable<T> {
+  static create<T>(array: T[], scheduler?: IScheduler): Observable<T> {
     return new ArrayObservable(array, scheduler);
   }
 
-  static of<T>(item1: T, scheduler?: Scheduler): Observable<T>;
-  static of<T>(item1: T, item2: T, scheduler?: Scheduler): Observable<T>;
-  static of<T>(item1: T, item2: T, item3: T, scheduler?: Scheduler): Observable<T>;
-  static of<T>(item1: T, item2: T, item3: T, item4: T, scheduler?: Scheduler): Observable<T>;
-  static of<T>(item1: T, item2: T, item3: T, item4: T, item5: T, scheduler?: Scheduler): Observable<T>;
-  static of<T>(item1: T, item2: T, item3: T, item4: T, item5: T, item6: T, scheduler?: Scheduler): Observable<T>;
-  static of<T>(...array: Array<T | Scheduler>): Observable<T>;
+  static of<T>(item1: T, scheduler?: IScheduler): Observable<T>;
+  static of<T>(item1: T, item2: T, scheduler?: IScheduler): Observable<T>;
+  static of<T>(item1: T, item2: T, item3: T, scheduler?: IScheduler): Observable<T>;
+  static of<T>(item1: T, item2: T, item3: T, item4: T, scheduler?: IScheduler): Observable<T>;
+  static of<T>(item1: T, item2: T, item3: T, item4: T, item5: T, scheduler?: IScheduler): Observable<T>;
+  static of<T>(item1: T, item2: T, item3: T, item4: T, item5: T, item6: T, scheduler?: IScheduler): Observable<T>;
+  static of<T>(...array: Array<T | IScheduler>): Observable<T>;
   /**
    * Creates an Observable that emits some values you specify as arguments,
    * immediately one after the other, and then emits a complete notification.
@@ -36,8 +36,8 @@ export class ArrayObservable<T> extends Observable<T> {
    * This static operator is useful for creating a simple Observable that only
    * emits the arguments given, and the complete notification thereafter. It can
    * be used for composing with other Observables, such as with {@link concat}.
-   * By default, it uses a `null` Scheduler, which means the `next`
-   * notifications are sent synchronously, although with a different Scheduler
+   * By default, it uses a `null` IScheduler, which means the `next`
+   * notifications are sent synchronously, although with a different IScheduler
    * it is possible to determine when those notifications will be delivered.
    *
    * @example <caption>Emit 10, 20, 30, then 'a', 'b', 'c', then start ticking every second.</caption>
@@ -53,15 +53,15 @@ export class ArrayObservable<T> extends Observable<T> {
    * @see {@link throw}
    *
    * @param {...T} values Arguments that represent `next` values to be emitted.
-   * @param {Scheduler} [scheduler] A {@link Scheduler} to use for scheduling
+   * @param {Scheduler} [scheduler] A {@link IScheduler} to use for scheduling
    * the emissions of the `next` notifications.
    * @return {Observable<T>} An Observable that emits each given input value.
    * @static true
    * @name of
    * @owner Observable
    */
-  static of<T>(...array: Array<T | Scheduler>): Observable<T> {
-    let scheduler = <Scheduler>array[array.length - 1];
+  static of<T>(...array: Array<T | IScheduler>): Observable<T> {
+    let scheduler = <IScheduler>array[array.length - 1];
     if (isScheduler(scheduler)) {
       array.pop();
     } else {
@@ -101,7 +101,7 @@ export class ArrayObservable<T> extends Observable<T> {
   // value used if Array has one value and _isScalar
   value: any;
 
-  constructor(private array: T[], private scheduler?: Scheduler) {
+  constructor(private array: T[], private scheduler?: IScheduler) {
     super();
     if (!scheduler && array.length === 1) {
       this._isScalar = true;

--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { tryCatch } from '../util/tryCatch';
 import { errorObject } from '../util/errorObject';
 import { AsyncSubject } from '../AsyncSubject';
@@ -15,22 +15,22 @@ export class BoundCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
 
   /* tslint:disable:max-line-length */
-  static create<R>(callbackFunc: (callback: (result: R) => any) => any, selector?: void, scheduler?: Scheduler): () => Observable<R>;
-  static create<T, R>(callbackFunc: (v1: T, callback: (result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T) => Observable<R>;
-  static create<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2) => Observable<R>;
-  static create<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
-  static create<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
-  static create<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
-  static create<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
-  static create<R>(callbackFunc: (callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: Scheduler): () => Observable<R>;
-  static create<T, R>(callbackFunc: (v1: T, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: Scheduler): (v1: T) => Observable<R>;
-  static create<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: Scheduler): (v1: T, v2: T2) => Observable<R>;
-  static create<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
-  static create<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
-  static create<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
-  static create<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
-  static create<T>(callbackFunc: Function, selector?: void, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
-  static create<T>(callbackFunc: Function, selector?: (...args: any[]) => T, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
+  static create<R>(callbackFunc: (callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): () => Observable<R>;
+  static create<T, R>(callbackFunc: (v1: T, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T) => Observable<R>;
+  static create<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2) => Observable<R>;
+  static create<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
+  static create<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
+  static create<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
+  static create<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
+  static create<R>(callbackFunc: (callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: IScheduler): () => Observable<R>;
+  static create<T, R>(callbackFunc: (v1: T, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: IScheduler): (v1: T) => Observable<R>;
+  static create<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: IScheduler): (v1: T, v2: T2) => Observable<R>;
+  static create<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
+  static create<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
+  static create<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
+  static create<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (...args: any[]) => any) => any, selector: (...args: any[]) => R, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
+  static create<T>(callbackFunc: Function, selector?: void, scheduler?: IScheduler): (...args: any[]) => Observable<T>;
+  static create<T>(callbackFunc: Function, selector?: (...args: any[]) => T, scheduler?: IScheduler): (...args: any[]) => Observable<T>;
   /* tslint:enable:max-line-length */
 
   /**
@@ -71,7 +71,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
    */
   static create<T>(func: Function,
                    selector: Function | void = undefined,
-                   scheduler?: Scheduler): (...args: any[]) => Observable<T> {
+                   scheduler?: IScheduler): (...args: any[]) => Observable<T> {
     return (...args: any[]): Observable<T> => {
       return new BoundCallbackObservable<T>(func, <any>selector, args, scheduler);
     };
@@ -80,7 +80,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
   constructor(private callbackFunc: Function,
               private selector: Function,
               private args: any[],
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super();
   }
 

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Action } from '../scheduler/Action';
 import { tryCatch } from '../util/tryCatch';
 import { errorObject } from '../util/errorObject';
@@ -16,15 +16,15 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
 
   /* tslint:disable:max-line-length */
-  static create<R>(callbackFunc: (callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: Scheduler): () => Observable<R>;
-  static create<T, R>(callbackFunc: (v1: T, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T) => Observable<R>;
-  static create<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2) => Observable<R>;
-  static create<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
-  static create<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
-  static create<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
-  static create<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: Scheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
-  static create<T>(callbackFunc: Function, selector?: void, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
-  static create<T>(callbackFunc: Function, selector?: (...args: any[]) => T, scheduler?: Scheduler): (...args: any[]) => Observable<T>;
+  static create<R>(callbackFunc: (callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: IScheduler): () => Observable<R>;
+  static create<T, R>(callbackFunc: (v1: T, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T) => Observable<R>;
+  static create<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2) => Observable<R>;
+  static create<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
+  static create<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
+  static create<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
+  static create<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (err: any, result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
+  static create<T>(callbackFunc: Function, selector?: void, scheduler?: IScheduler): (...args: any[]) => Observable<T>;
+  static create<T>(callbackFunc: Function, selector?: (...args: any[]) => T, scheduler?: IScheduler): (...args: any[]) => Observable<T>;
   /* tslint:enable:max-line-length */
 
   /**
@@ -68,7 +68,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
    */
   static create<T>(func: Function,
                    selector: Function | void = undefined,
-                   scheduler?: Scheduler): (...args: any[]) => Observable<T> {
+                   scheduler?: IScheduler): (...args: any[]) => Observable<T> {
     return (...args: any[]): Observable<T> => {
       return new BoundNodeCallbackObservable<T>(func, <any>selector, args, scheduler);
     };
@@ -77,7 +77,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
   constructor(private callbackFunc: Function,
               private selector: Function,
               private args: any[],
-              public scheduler: Scheduler) {
+              public scheduler: IScheduler) {
     super();
   }
 

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
@@ -49,7 +49,7 @@ export class EmptyObservable<T> extends Observable<T> {
    * @see {@link of}
    * @see {@link throw}
    *
-   * @param {Scheduler} [scheduler] A {@link Scheduler} to use for scheduling
+   * @param {Scheduler} [scheduler] A {@link IScheduler} to use for scheduling
    * the emission of the complete notification.
    * @return {Observable} An "empty" Observable: emits only the complete
    * notification.
@@ -57,7 +57,7 @@ export class EmptyObservable<T> extends Observable<T> {
    * @name empty
    * @owner Observable
    */
-  static create<T>(scheduler?: Scheduler): Observable<T> {
+  static create<T>(scheduler?: IScheduler): Observable<T> {
     return new EmptyObservable<T>(scheduler);
   }
 
@@ -66,7 +66,7 @@ export class EmptyObservable<T> extends Observable<T> {
     subscriber.complete();
   }
 
-  constructor(private scheduler?: Scheduler) {
+  constructor(private scheduler?: IScheduler) {
     super();
   }
 

--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 
@@ -46,7 +46,7 @@ export class ErrorObservable<T> extends Observable<any> {
    * @see {@link of}
    *
    * @param {any} error The particular Error to pass to the error notification.
-   * @param {Scheduler} [scheduler] A {@link Scheduler} to use for scheduling
+   * @param {Scheduler} [scheduler] A {@link IScheduler} to use for scheduling
    * the emission of the error notification.
    * @return {Observable} An error Observable: emits only the error notification
    * using the given error argument.
@@ -54,7 +54,7 @@ export class ErrorObservable<T> extends Observable<any> {
    * @name throw
    * @owner Observable
    */
-  static create<T>(error: T, scheduler?: Scheduler): ErrorObservable<T> {
+  static create<T>(error: T, scheduler?: IScheduler): ErrorObservable<T> {
     return new ErrorObservable(error, scheduler);
   }
 
@@ -63,7 +63,7 @@ export class ErrorObservable<T> extends Observable<any> {
     subscriber.error(error);
   }
 
-  constructor(public error: T, private scheduler?: Scheduler) {
+  constructor(public error: T, private scheduler?: IScheduler) {
     super();
   }
 

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -5,7 +5,7 @@ import { IteratorObservable } from'./IteratorObservable';
 import { ArrayObservable } from './ArrayObservable';
 import { ArrayLikeObservable } from './ArrayLikeObservable';
 
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { $$iterator } from '../symbol/iterator';
 import { Observable, ObservableInput } from '../Observable';
 import { Subscriber } from '../Subscriber';
@@ -20,12 +20,12 @@ const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 
  * @hide true
  */
 export class FromObservable<T> extends Observable<T> {
-  constructor(private ish: ObservableInput<T>, private scheduler?: Scheduler) {
+  constructor(private ish: ObservableInput<T>, private scheduler?: IScheduler) {
     super(null);
   }
 
-  static create<T>(ish: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;
-  static create<T, R>(ish: ArrayLike<T>, scheduler?: Scheduler): Observable<R>;
+  static create<T>(ish: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
+  static create<T, R>(ish: ArrayLike<T>, scheduler?: IScheduler): Observable<R>;
 
   /**
    * Creates an Observable from an Array, an array-like object, a Promise, an
@@ -83,7 +83,7 @@ export class FromObservable<T> extends Observable<T> {
    * @name from
    * @owner Observable
    */
-  static create<T>(ish: ObservableInput<T>, scheduler?: Scheduler): Observable<T> {
+  static create<T>(ish: ObservableInput<T>, scheduler?: IScheduler): Observable<T> {
     if (ish != null) {
       if (typeof ish[$$observable] === 'function') {
         if (ish instanceof Observable && !scheduler) {

--- a/src/observable/GenerateObservable.ts
+++ b/src/observable/GenerateObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Action } from '../scheduler/Action';
 import { Observable } from '../Observable' ;
 import { Subscriber } from '../Subscriber';
@@ -36,10 +36,10 @@ export interface GenerateBaseOptions<S> {
    */
   iterate: IterateFunc<S>;
   /**
-   * Scheduler to use for generation process.
+   * IScheduler to use for generation process.
    * By default, a generator starts immediately.
   */
-  scheduler?: Scheduler;
+  scheduler?: IScheduler;
 }
 
 export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
@@ -59,7 +59,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
               private condition: ConditionFunc<S>,
               private iterate: IterateFunc<S>,
               private resultSelector: ResultFunc<S, T>,
-              private scheduler?: Scheduler) {
+              private scheduler?: IScheduler) {
       super();
   }
 
@@ -83,14 +83,14 @@ export class GenerateObservable<T, S> extends Observable<T> {
    * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
    * @param {function (state: S): S} iterate Iteration step function.
    * @param {function (state: S): T} resultSelector Selector function for results produced in the sequence.
-   * @param {Scheduler} [scheduler] A {@link Scheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
+   * @param {Scheduler} [scheduler] A {@link IScheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
    * @returns {Observable<T>} The generated sequence.
    */
   static create<T, S>(initialState: S,
                       condition: ConditionFunc<S>,
                       iterate: IterateFunc<S>,
                       resultSelector: ResultFunc<S, T>,
-                      scheduler?: Scheduler): Observable<T>
+                      scheduler?: IScheduler): Observable<T>
 
   /**
    * Generates an observable sequence by running a state-driven loop
@@ -112,13 +112,13 @@ export class GenerateObservable<T, S> extends Observable<T> {
    * @param {S} initialState Initial state.
    * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
    * @param {function (state: S): S} iterate Iteration step function.
-   * @param {Scheduler} [scheduler] A {@link Scheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
+   * @param {Scheduler} [scheduler] A {@link IScheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
    * @returns {Observable<S>} The generated sequence.
    */
   static create<S>(initialState: S,
                    condition: ConditionFunc<S>,
                    iterate: IterateFunc<S>,
-                   scheduler?: Scheduler): Observable<S>
+                   scheduler?: IScheduler): Observable<S>
 
   /**
    * Generates an observable sequence by running a state-driven loop
@@ -172,8 +172,8 @@ export class GenerateObservable<T, S> extends Observable<T> {
   static create<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
                       condition?: ConditionFunc<S>,
                       iterate?: IterateFunc<S>,
-                      resultSelectorOrObservable?: (ResultFunc<S, T>) | Scheduler,
-                      scheduler?: Scheduler): Observable<T> {
+                      resultSelectorOrObservable?: (ResultFunc<S, T>) | IScheduler,
+                      scheduler?: IScheduler): Observable<T> {
     if (arguments.length == 1) {
       return new GenerateObservable<T, S>(
         (<GenerateOptions<T, S>>initialStateOrOptions).initialState,
@@ -189,7 +189,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
         condition,
         iterate,
         selfSelector,
-        <Scheduler>resultSelectorOrObservable);
+        <IScheduler>resultSelectorOrObservable);
     }
 
     return new GenerateObservable<T, S>(
@@ -197,7 +197,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
       condition,
       iterate,
       <ResultFunc<S, T>>resultSelectorOrObservable,
-      <Scheduler>scheduler);
+      <IScheduler>scheduler);
   }
 
   protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {

--- a/src/observable/IntervalObservable.ts
+++ b/src/observable/IntervalObservable.ts
@@ -1,6 +1,6 @@
 import { Subscriber } from '../Subscriber';
 import { isNumeric } from '../util/isNumeric';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { async } from '../scheduler/async';
 
@@ -12,7 +12,7 @@ import { async } from '../scheduler/async';
 export class IntervalObservable extends Observable<number> {
   /**
    * Creates an Observable that emits sequential numbers every specified
-   * interval of time, on a specified Scheduler.
+   * interval of time, on a specified IScheduler.
    *
    * <span class="informal">Emits incremental numbers periodically in time.
    * </span>
@@ -23,8 +23,8 @@ export class IntervalObservable extends Observable<number> {
    * ascending integers, with a constant interval of time of your choosing
    * between those emissions. The first emission is not sent immediately, but
    * only after the first period has passed. By default, this operator uses the
-   * `async` Scheduler to provide a notion of time, but you may pass any
-   * Scheduler to it.
+   * `async` IScheduler to provide a notion of time, but you may pass any
+   * IScheduler to it.
    *
    * @example <caption>Emits ascending numbers, one every second (1000ms)</caption>
    * var numbers = Rx.Observable.interval(1000);
@@ -35,7 +35,7 @@ export class IntervalObservable extends Observable<number> {
    *
    * @param {number} [period=0] The interval size in milliseconds (by default)
    * or the time unit determined by the scheduler's clock.
-   * @param {Scheduler} [scheduler=async] The Scheduler to use for scheduling
+   * @param {Scheduler} [scheduler=async] The IScheduler to use for scheduling
    * the emission of values, and providing a notion of "time".
    * @return {Observable} An Observable that emits a sequential number each time
    * interval.
@@ -44,7 +44,7 @@ export class IntervalObservable extends Observable<number> {
    * @owner Observable
    */
   static create(period: number = 0,
-                scheduler: Scheduler = async): Observable<number> {
+                scheduler: IScheduler = async): Observable<number> {
     return new IntervalObservable(period, scheduler);
   }
 
@@ -63,7 +63,7 @@ export class IntervalObservable extends Observable<number> {
   }
 
   constructor(private period: number = 0,
-              private scheduler: Scheduler = async) {
+              private scheduler: IScheduler = async) {
     super();
     if (!isNumeric(period) || period < 0) {
       this.period = 0;

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -1,5 +1,5 @@
 import { root } from '../util/root';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { $$iterator } from '../symbol/iterator';
 import { TeardownLogic } from '../Subscription';
@@ -13,7 +13,7 @@ import { Subscriber } from '../Subscriber';
 export class IteratorObservable<T> extends Observable<T> {
   private iterator: any;
 
-  static create<T>(iterator: any, scheduler?: Scheduler): IteratorObservable<T> {
+  static create<T>(iterator: any, scheduler?: IScheduler): IteratorObservable<T> {
     return new IteratorObservable(iterator, scheduler);
   }
 
@@ -45,7 +45,7 @@ export class IteratorObservable<T> extends Observable<T> {
     (<any> this).schedule(state);
   }
 
-  constructor(iterator: any, private scheduler?: Scheduler) {
+  constructor(iterator: any, private scheduler?: IScheduler) {
     super();
 
     if (iterator == null) {

--- a/src/observable/PairsObservable.ts
+++ b/src/observable/PairsObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Action } from '../scheduler/Action';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
@@ -38,7 +38,7 @@ export class PairsObservable<T> extends Observable<Array<string | T>> {
 
   /**
    * Convert an object into an observable sequence of [key, value] pairs
-   * using an optional Scheduler to enumerate the object.
+   * using an optional IScheduler to enumerate the object.
    *
    * @example <caption>Converts a javascript object to an Observable</caption>
    * var obj = {
@@ -62,16 +62,16 @@ export class PairsObservable<T> extends Observable<Array<string | T>> {
    *
    * @param {Object} obj The object to inspect and turn into an
    * Observable sequence.
-   * @param {Scheduler} [scheduler] An optional Scheduler to run the
+   * @param {Scheduler} [scheduler] An optional IScheduler to run the
    * enumeration of the input sequence on.
    * @returns {(Observable<Array<string | T>>)} An observable sequence of
    * [key, value] pairs from the object.
    */
-  static create<T>(obj: Object, scheduler?: Scheduler): Observable<Array<string | T>> {
+  static create<T>(obj: Object, scheduler?: IScheduler): Observable<Array<string | T>> {
     return new PairsObservable<T>(obj, scheduler);
   }
 
-  constructor(private obj: Object, private scheduler?: Scheduler) {
+  constructor(private obj: Object, private scheduler?: IScheduler) {
     super();
     this.keys = Object.keys(obj);
   }

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -1,5 +1,5 @@
 import { root } from '../util/root';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { TeardownLogic } from '../Subscription';
@@ -32,18 +32,18 @@ export class PromiseObservable<T> extends Observable<T> {
    * @see {@link from}
    *
    * @param {Promise<T>} promise The promise to be converted.
-   * @param {Scheduler} [scheduler] An optional Scheduler to use for scheduling
+   * @param {Scheduler} [scheduler] An optional IScheduler to use for scheduling
    * the delivery of the resolved value (or the rejection).
    * @return {Observable<T>} An Observable which wraps the Promise.
    * @static true
    * @name fromPromise
    * @owner Observable
    */
-  static create<T>(promise: Promise<T>, scheduler?: Scheduler): Observable<T> {
+  static create<T>(promise: Promise<T>, scheduler?: IScheduler): Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }
 
-  constructor(private promise: Promise<T>, private scheduler?: Scheduler) {
+  constructor(private promise: Promise<T>, private scheduler?: IScheduler) {
     super();
   }
 

--- a/src/observable/RangeObservable.ts
+++ b/src/observable/RangeObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 import { Subscriber } from '../Subscriber';
@@ -20,8 +20,8 @@ export class RangeObservable extends Observable<number> {
    *
    * `range` operator emits a range of sequential integers, in order, where you
    * select the `start` of the range and its `length`. By default, uses no
-   * Scheduler and just delivers the notifications synchronously, but may use
-   * an optional Scheduler to regulate those deliveries.
+   * IScheduler and just delivers the notifications synchronously, but may use
+   * an optional IScheduler to regulate those deliveries.
    *
    * @example <caption>Emits the numbers 1 to 10</caption>
    * var numbers = Rx.Observable.range(1, 10);
@@ -32,7 +32,7 @@ export class RangeObservable extends Observable<number> {
    *
    * @param {number} [start=0] The value of the first integer in the sequence.
    * @param {number} [count=0] The number of sequential integers to generate.
-   * @param {Scheduler} [scheduler] A {@link Scheduler} to use for scheduling
+   * @param {Scheduler} [scheduler] A {@link IScheduler} to use for scheduling
    * the emissions of the notifications.
    * @return {Observable} An Observable of numbers that emits a finite range of
    * sequential integers.
@@ -42,7 +42,7 @@ export class RangeObservable extends Observable<number> {
    */
   static create(start: number = 0,
                 count: number = 0,
-                scheduler?: Scheduler): Observable<number> {
+                scheduler?: IScheduler): Observable<number> {
     return new RangeObservable(start, count, scheduler);
   }
 
@@ -69,11 +69,11 @@ export class RangeObservable extends Observable<number> {
 
   private start: number;
   private _count: number;
-  private scheduler: Scheduler;
+  private scheduler: IScheduler;
 
   constructor(start: number,
               count: number,
-              scheduler?: Scheduler) {
+              scheduler?: IScheduler) {
     super();
     this.start = start;
     this._count = count;

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { TeardownLogic } from '../Subscription';
@@ -9,7 +9,7 @@ import { TeardownLogic } from '../Subscription';
  * @hide true
  */
 export class ScalarObservable<T> extends Observable<T> {
-  static create<T>(value: T, scheduler?: Scheduler): ScalarObservable<T> {
+  static create<T>(value: T, scheduler?: IScheduler): ScalarObservable<T> {
     return new ScalarObservable(value, scheduler);
   }
 
@@ -32,7 +32,7 @@ export class ScalarObservable<T> extends Observable<T> {
 
   _isScalar: boolean = true;
 
-  constructor(public value: T, private scheduler?: Scheduler) {
+  constructor(public value: T, private scheduler?: IScheduler) {
     super();
     if (scheduler) {
       this._isScalar = false;

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -1,5 +1,5 @@
 import { Action } from '../scheduler/Action';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
@@ -17,7 +17,7 @@ export interface DispatchArg<T> {
  * @hide true
  */
 export class SubscribeOnObservable<T> extends Observable<T> {
-  static create<T>(source: Observable<T>, delay: number = 0, scheduler: Scheduler = asap): Observable<T> {
+  static create<T>(source: Observable<T>, delay: number = 0, scheduler: IScheduler = asap): Observable<T> {
     return new SubscribeOnObservable(source, delay, scheduler);
   }
 
@@ -28,7 +28,7 @@ export class SubscribeOnObservable<T> extends Observable<T> {
 
   constructor(public source: Observable<T>,
               private delayTime: number = 0,
-              private scheduler: Scheduler = asap) {
+              private scheduler: IScheduler = asap) {
     super();
     if (!isNumeric(delayTime) || delayTime < 0) {
       this.delayTime = 0;

--- a/src/observable/TimerObservable.ts
+++ b/src/observable/TimerObservable.ts
@@ -1,5 +1,5 @@
 import { isNumeric } from '../util/isNumeric';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { async } from '../scheduler/async';
 import { isScheduler } from '../util/isScheduler';
@@ -27,8 +27,8 @@ export class TimerObservable extends Observable<number> {
    * integers, with a constant interval of time, `period` of your choosing
    * between those emissions. The first emission happens after the specified
    * `initialDelay`. The initial delay may be a {@link Date}. By default, this
-   * operator uses the `async` Scheduler to provide a notion of time, but you
-   * may pass any Scheduler to it. If `period` is not specified, the output
+   * operator uses the `async` IScheduler to provide a notion of time, but you
+   * may pass any IScheduler to it. If `period` is not specified, the output
    * Observable emits only one value, `0`. Otherwise, it emits an infinite
    * sequence.
    *
@@ -47,7 +47,7 @@ export class TimerObservable extends Observable<number> {
    * emitting the first value of `0`.
    * @param {number} [period] The period of time between emissions of the
    * subsequent numbers.
-   * @param {Scheduler} [scheduler=async] The Scheduler to use for scheduling
+   * @param {Scheduler} [scheduler=async] The IScheduler to use for scheduling
    * the emission of values, and providing a notion of "time".
    * @return {Observable} An Observable that emits a `0` after the
    * `initialDelay` and ever increasing numbers after each `period` of time
@@ -57,8 +57,8 @@ export class TimerObservable extends Observable<number> {
    * @owner Observable
    */
   static create(initialDelay: number | Date = 0,
-                period?: number | Scheduler,
-                scheduler?: Scheduler): Observable<number> {
+                period?: number | IScheduler,
+                scheduler?: IScheduler): Observable<number> {
     return new TimerObservable(initialDelay, period, scheduler);
   }
 
@@ -81,17 +81,17 @@ export class TimerObservable extends Observable<number> {
 
   private period: number = -1;
   private dueTime: number = 0;
-  private scheduler: Scheduler;
+  private scheduler: IScheduler;
 
   constructor(dueTime: number | Date = 0,
-              period?: number | Scheduler,
-              scheduler?: Scheduler) {
+              period?: number | IScheduler,
+              scheduler?: IScheduler) {
     super();
 
     if (isNumeric(period)) {
       this.period = Number(period) < 1 && 1 || Number(period);
     } else if (isScheduler(period)) {
-      scheduler = <Scheduler> period;
+      scheduler = <IScheduler> period;
     }
 
     if (!isScheduler(scheduler)) {

--- a/src/observable/combineLatest.ts
+++ b/src/observable/combineLatest.ts
@@ -1,31 +1,31 @@
 import {  Observable, ObservableInput  } from '../Observable';
-import {  Scheduler  } from '../Scheduler';
+import {  IScheduler  } from '../Scheduler';
 import {  isScheduler  } from '../util/isScheduler';
 import {  isArray  } from '../util/isArray';
 import {  ArrayObservable  } from './ArrayObservable';
 import {  CombineLatestOperator  } from '../operator/combineLatest';
 
 /* tslint:disable:max-line-length */
-export function combineLatest<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<[T, T2]>;
-export function combineLatest<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<[T, T2, T3]>;
-export function combineLatest<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<[T, T2, T3, T4]>;
-export function combineLatest<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<[T, T2, T3, T4, T5]>;
-export function combineLatest<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<[T, T2, T3, T4, T5, T6]>;
+export function combineLatest<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<[T, T2]>;
+export function combineLatest<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<[T, T2, T3]>;
+export function combineLatest<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<[T, T2, T3, T4]>;
+export function combineLatest<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<[T, T2, T3, T4, T5]>;
+export function combineLatest<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<[T, T2, T3, T4, T5, T6]>;
 
-export function combineLatest<T, R>(v1: ObservableInput<T>, project: (v1: T) => R, scheduler?: Scheduler): Observable<R>;
-export function combineLatest<T, T2, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R, scheduler?: Scheduler): Observable<R>;
-export function combineLatest<T, T2, T3, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R, scheduler?: Scheduler): Observable<R>;
-export function combineLatest<T, T2, T3, T4, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R, scheduler?: Scheduler): Observable<R>;
-export function combineLatest<T, T2, T3, T4, T5, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R, scheduler?: Scheduler): Observable<R>;
-export function combineLatest<T, T2, T3, T4, T5, T6, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R, scheduler?: Scheduler): Observable<R>;
+export function combineLatest<T, R>(v1: ObservableInput<T>, project: (v1: T) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T, T2, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T, T2, T3, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T, T2, T3, T4, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T, T2, T3, T4, T5, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T, T2, T3, T4, T5, T6, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R, scheduler?: IScheduler): Observable<R>;
 
-export function combineLatest<T>(array: ObservableInput<T>[], scheduler?: Scheduler): Observable<T[]>;
-export function combineLatest<R>(array: ObservableInput<any>[], scheduler?: Scheduler): Observable<R>;
-export function combineLatest<T, R>(array: ObservableInput<T>[], project: (...values: Array<T>) => R, scheduler?: Scheduler): Observable<R>;
-export function combineLatest<R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R, scheduler?: Scheduler): Observable<R>;
-export function combineLatest<T>(...observables: Array<ObservableInput<T> | Scheduler>): Observable<T[]>;
-export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R) | Scheduler>): Observable<R>;
-export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | Scheduler>): Observable<R>;
+export function combineLatest<T>(array: ObservableInput<T>[], scheduler?: IScheduler): Observable<T[]>;
+export function combineLatest<R>(array: ObservableInput<any>[], scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T, R>(array: ObservableInput<T>[], project: (...values: Array<T>) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T>(...observables: Array<ObservableInput<T> | IScheduler>): Observable<T[]>;
+export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R) | IScheduler>): Observable<R>;
+export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | IScheduler>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -67,7 +67,7 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * source Observable. More than one input Observables may be given as argument.
  * @param {function} [project] An optional function to project the values from
  * the combined latest values into a new value on the output Observable.
- * @param {Scheduler} [scheduler=null] The Scheduler to use for subscribing to
+ * @param {Scheduler} [scheduler=null] The IScheduler to use for subscribing to
  * each input Observable.
  * @return {Observable} An Observable of projected values from the most recent
  * values from each input Observable, or an array of the most recent values from
@@ -79,12 +79,12 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
 export function combineLatest<T, R>(...observables: Array<any | ObservableInput<any> |
                                                     Array<ObservableInput<any>> |
                                                     (((...values: Array<any>) => R)) |
-                                                    Scheduler>): Observable<R> {
+                                                    IScheduler>): Observable<R> {
   let project: (...values: Array<any>) => R =  null;
-  let scheduler: Scheduler = null;
+  let scheduler: IScheduler = null;
 
   if (isScheduler(observables[observables.length - 1])) {
-    scheduler = <Scheduler>observables.pop();
+    scheduler = <IScheduler>observables.pop();
   }
 
   if (typeof observables[observables.length - 1] === 'function') {

--- a/src/operator/auditTime.ts
+++ b/src/operator/auditTime.ts
@@ -1,6 +1,6 @@
 import { async } from '../scheduler/async';
 import { Operator } from '../Operator';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subscription, TeardownLogic } from '../Subscription';
@@ -24,7 +24,7 @@ import { Subscription, TeardownLogic } from '../Subscription';
  * the time unit determined internally by the optional `scheduler`) has passed,
  * the timer is disabled, then the most recent source value is emitted on the
  * output Observable, and this process repeats for the next source value.
- * Optionally takes a {@link Scheduler} for managing timers.
+ * Optionally takes a {@link IScheduler} for managing timers.
  *
  * @example <caption>Emit clicks at a rate of at most one click per second</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
@@ -40,20 +40,20 @@ import { Subscription, TeardownLogic } from '../Subscription';
  * @param {number} duration Time to wait before emitting the most recent source
  * value, measured in milliseconds or the time unit determined internally
  * by the optional `scheduler`.
- * @param {Scheduler} [scheduler=async] The {@link Scheduler} to use for
+ * @param {Scheduler} [scheduler=async] The {@link IScheduler} to use for
  * managing the timers that handle the rate-limiting behavior.
  * @return {Observable<T>} An Observable that performs rate-limiting of
  * emissions from the source Observable.
  * @method auditTime
  * @owner Observable
  */
-export function auditTime<T>(this: Observable<T>, duration: number, scheduler: Scheduler = async): Observable<T> {
+export function auditTime<T>(this: Observable<T>, duration: number, scheduler: IScheduler = async): Observable<T> {
   return this.lift(new AuditTimeOperator(duration, scheduler));
 }
 
 class AuditTimeOperator<T> implements Operator<T, T> {
   constructor(private duration: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -74,7 +74,7 @@ class AuditTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private duration: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
   }
 

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Action } from '../scheduler/Action';
 import { Operator } from '../Operator';
 import { async } from '../scheduler/async';
@@ -8,9 +8,9 @@ import { Subscription } from '../Subscription';
 import { isScheduler } from '../util/isScheduler';
 
 /* tslint:disable:max-line-length */
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, scheduler?: Scheduler): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, scheduler?: Scheduler): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, maxBufferSize: number, scheduler?: Scheduler): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, scheduler?: IScheduler): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, scheduler?: IScheduler): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, maxBufferSize: number, scheduler?: IScheduler): Observable<T[]>;
 /* tslint:disable:max-line-length */
 
 /**
@@ -59,7 +59,7 @@ export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, buffe
 export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number): Observable<T[]> {
   let length: number = arguments.length;
 
-  let scheduler: Scheduler = async;
+  let scheduler: IScheduler = async;
   if (isScheduler(arguments[arguments.length - 1])) {
     scheduler = arguments[arguments.length - 1];
     length--;
@@ -82,7 +82,7 @@ class BufferTimeOperator<T> implements Operator<T, T[]> {
   constructor(private bufferTimeSpan: number,
               private bufferCreationInterval: number,
               private maxBufferSize: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<T[]>, source: any): any {
@@ -101,7 +101,7 @@ type CreationState<T> = {
   bufferTimeSpan: number;
   bufferCreationInterval: number,
   subscriber: BufferTimeSubscriber<T>;
-  scheduler: Scheduler;
+  scheduler: IScheduler;
 };
 
 /**
@@ -117,7 +117,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
               private bufferTimeSpan: number,
               private bufferCreationInterval: number,
               private maxBufferSize: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
     const context = this.openContext();
     this.timespanOnly = bufferCreationInterval == null || bufferCreationInterval < 0;

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -1,18 +1,18 @@
 import { Observable, ObservableInput } from '../Observable';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { isScheduler } from '../util/isScheduler';
 import { ArrayObservable } from '../observable/ArrayObservable';
 import { MergeAllOperator } from './mergeAll';
 
 /* tslint:disable:max-line-length */
-export function concat<T>(this: Observable<T>, scheduler?: Scheduler): Observable<T>;
-export function concat<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
-export function concat<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
-export function concat<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
-export function concat<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function concat<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function concat<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | Scheduler>): Observable<T>;
-export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | Scheduler>): Observable<R>;
+export function concat<T>(this: Observable<T>, scheduler?: IScheduler): Observable<T>;
+export function concat<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
+export function concat<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
+export function concat<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
+export function concat<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function concat<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function concat<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | IScheduler>): Observable<T>;
+export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler>): Observable<R>;
 /* tslint:disable:max-line-length */
 
 /**
@@ -44,7 +44,7 @@ export function concat<T, R>(this: Observable<T>, ...observables: Array<Observab
  * var timer3 = Rx.Observable.interval(500).take(10);
  * var result = timer1.concat(timer2, timer3);
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // results in the following:
  * // (Prints to console sequentially)
  * // -1000ms-> 0 -1000ms-> 1 -1000ms-> ... 9
@@ -57,26 +57,26 @@ export function concat<T, R>(this: Observable<T>, ...observables: Array<Observab
  *
  * @param {Observable} other An input Observable to concatenate after the source
  * Observable. More than one input Observables may be given as argument.
- * @param {Scheduler} [scheduler=null] An optional Scheduler to schedule each
+ * @param {Scheduler} [scheduler=null] An optional IScheduler to schedule each
  * Observable subscription on.
  * @return {Observable} All values of each passed Observable merged into a
  * single Observable, in order, in serial fashion.
  * @method concat
  * @owner Observable
  */
-export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | Scheduler>): Observable<R> {
+export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler>): Observable<R> {
   return this.lift.call(concatStatic<T, R>(this, ...observables));
 }
 
 /* tslint:disable:max-line-length */
-export function concatStatic<T>(v1: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;
-export function concatStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
-export function concatStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
-export function concatStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
-export function concatStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function concatStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function concatStatic<T>(...observables: (ObservableInput<T> | Scheduler)[]): Observable<T>;
-export function concatStatic<T, R>(...observables: (ObservableInput<any> | Scheduler)[]): Observable<R>;
+export function concatStatic<T>(v1: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
+export function concatStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
+export function concatStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
+export function concatStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
+export function concatStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function concatStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function concatStatic<T>(...observables: (ObservableInput<T> | IScheduler)[]): Observable<T>;
+export function concatStatic<T, R>(...observables: (ObservableInput<any> | IScheduler)[]): Observable<R>;
 /* tslint:enable:max-line-length */
 /**
  * Creates an output Observable which sequentially emits all values from every
@@ -112,7 +112,7 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * // -1000ms-> 0 -1000ms-> 1 -1000ms-> ... 9
  * // -2000ms-> 0 -2000ms-> 1 -2000ms-> ... 5
  * // -500ms-> 0 -500ms-> 1 -500ms-> ... 9
- * 
+ *
  * @see {@link concatAll}
  * @see {@link concatMap}
  * @see {@link concatMapTo}
@@ -120,7 +120,7 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * @param {Observable} input1 An input Observable to concatenate with others.
  * @param {Observable} input2 An input Observable to concatenate with others.
  * More than one input Observables may be given as argument.
- * @param {Scheduler} [scheduler=null] An optional Scheduler to schedule each
+ * @param {Scheduler} [scheduler=null] An optional IScheduler to schedule each
  * Observable subscription on.
  * @return {Observable} All values of each passed Observable merged into a
  * single Observable, in order, in serial fashion.
@@ -128,8 +128,8 @@ export function concatStatic<T, R>(...observables: (ObservableInput<any> | Sched
  * @name concat
  * @owner Observable
  */
-export function concatStatic<T, R>(...observables: Array<ObservableInput<any> | Scheduler>): Observable<R> {
-  let scheduler: Scheduler = null;
+export function concatStatic<T, R>(...observables: Array<ObservableInput<any> | IScheduler>): Observable<R> {
+  let scheduler: IScheduler = null;
   let args = <any[]>observables;
   if (isScheduler(args[observables.length - 1])) {
     scheduler = args.pop();

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -1,7 +1,7 @@
 import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Subscription, TeardownLogic } from '../Subscription';
 import { async } from '../scheduler/async';
 
@@ -25,7 +25,7 @@ import { async } from '../scheduler/async';
  * This is a rate-limiting operator, because it is impossible for more than one
  * value to be emitted in any time window of duration `dueTime`, but it is also
  * a delay-like operator since output emissions do not occur at the same time as
- * they did on the source Observable. Optionally takes a {@link Scheduler} for
+ * they did on the source Observable. Optionally takes a {@link IScheduler} for
  * managing timers.
  *
  * @example <caption>Emit the most recent click after a burst of clicks</caption>
@@ -43,7 +43,7 @@ import { async } from '../scheduler/async';
  * unit determined internally by the optional `scheduler`) for the window of
  * time required to wait for emission silence before emitting the most recent
  * source value.
- * @param {Scheduler} [scheduler=async] The {@link Scheduler} to use for
+ * @param {Scheduler} [scheduler=async] The {@link IScheduler} to use for
  * managing the timers that handle the timeout for each value.
  * @return {Observable} An Observable that delays the emissions of the source
  * Observable by the specified `dueTime`, and may drop some values if they occur
@@ -51,12 +51,12 @@ import { async } from '../scheduler/async';
  * @method debounceTime
  * @owner Observable
  */
-export function debounceTime<T>(this: Observable<T>, dueTime: number, scheduler: Scheduler = async): Observable<T> {
+export function debounceTime<T>(this: Observable<T>, dueTime: number, scheduler: IScheduler = async): Observable<T> {
   return this.lift(new DebounceTimeOperator(dueTime, scheduler));
 }
 
 class DebounceTimeOperator<T> implements Operator<T, T> {
-  constructor(private dueTime: number, private scheduler: Scheduler) {
+  constructor(private dueTime: number, private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -76,7 +76,7 @@ class DebounceTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private dueTime: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
   }
 

--- a/src/operator/delay.ts
+++ b/src/operator/delay.ts
@@ -1,7 +1,7 @@
 import { async } from '../scheduler/async';
 import { isDate } from '../util/isDate';
 import { Operator } from '../Operator';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Subscriber } from '../Subscriber';
 import { Notification } from '../Notification';
 import { Observable } from '../Observable';
@@ -39,7 +39,7 @@ import { TeardownLogic } from '../Subscription';
  *
  * @param {number|Date} delay The delay duration in milliseconds (a `number`) or
  * a `Date` until which the emission of the source items is delayed.
- * @param {Scheduler} [scheduler=async] The Scheduler to use for
+ * @param {Scheduler} [scheduler=async] The IScheduler to use for
  * managing the timers that handle the time-shift for each item.
  * @return {Observable} An Observable that delays the emissions of the source
  * Observable by the specified timeout or Date.
@@ -47,7 +47,7 @@ import { TeardownLogic } from '../Subscription';
  * @owner Observable
  */
 export function delay<T>(this: Observable<T>, delay: number|Date,
-                         scheduler: Scheduler = async): Observable<T> {
+                         scheduler: IScheduler = async): Observable<T> {
   const absoluteDelay = isDate(delay);
   const delayFor = absoluteDelay ? (+delay - scheduler.now()) : Math.abs(<number>delay);
   return this.lift(new DelayOperator(delayFor, scheduler));
@@ -55,7 +55,7 @@ export function delay<T>(this: Observable<T>, delay: number|Date,
 
 class DelayOperator<T> implements Operator<T, T> {
   constructor(private delay: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -93,11 +93,11 @@ class DelaySubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private delay: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
   }
 
-  private _schedule(scheduler: Scheduler): void {
+  private _schedule(scheduler: IScheduler): void {
     this.active = true;
     this.add(scheduler.schedule(DelaySubscriber.dispatch, this.delay, {
       source: this, destination: this.destination, scheduler: scheduler

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { tryCatch } from '../util/tryCatch';
@@ -10,8 +10,8 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 /* tslint:disable:max-line-length */
-export function expand<T>(this: Observable<T>, project: (value: T, index: number) => Observable<T>, concurrent?: number, scheduler?: Scheduler): Observable<T>;
-export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => Observable<R>, concurrent?: number, scheduler?: Scheduler): Observable<R>;
+export function expand<T>(this: Observable<T>, project: (value: T, index: number) => Observable<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
+export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => Observable<R>, concurrent?: number, scheduler?: IScheduler): Observable<R>;
 /* tslint:disable:max-line-length */
 
 /**
@@ -50,7 +50,7 @@ export function expand<T, R>(this: Observable<T>, project: (value: T, index: num
  * returns an Observable.
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
- * @param {Scheduler} [scheduler=null] The Scheduler to use for subscribing to
+ * @param {Scheduler} [scheduler=null] The IScheduler to use for subscribing to
  * each projected inner Observable.
  * @return {Observable} An Observable that emits the source values and also
  * result of applying the projection function to each value emitted on the
@@ -61,7 +61,7 @@ export function expand<T, R>(this: Observable<T>, project: (value: T, index: num
  */
 export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => Observable<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,
-                             scheduler: Scheduler = undefined): Observable<R> {
+                             scheduler: IScheduler = undefined): Observable<R> {
   concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;
 
   return this.lift(new ExpandOperator(project, concurrent, scheduler));
@@ -70,7 +70,7 @@ export function expand<T, R>(this: Observable<T>, project: (value: T, index: num
 export class ExpandOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => Observable<R>,
               private concurrent: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
@@ -99,7 +99,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => Observable<R>,
               private concurrent: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
     if (concurrent < Number.POSITIVE_INFINITY) {
       this.buffer = [];

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -1,24 +1,24 @@
 import { Observable, ObservableInput } from '../Observable';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { ArrayObservable } from '../observable/ArrayObservable';
 import { MergeAllOperator } from './mergeAll';
 import { isScheduler } from '../util/isScheduler';
 
 /* tslint:disable:max-line-length */
-export function merge<T>(this: Observable<T>, scheduler?: Scheduler): Observable<T>;
-export function merge<T>(this: Observable<T>, concurrent?: number, scheduler?: Scheduler): Observable<T>;
-export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
-export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2>;
-export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
-export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3>;
-export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | Scheduler | number>): Observable<T>;
-export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R>;
+export function merge<T>(this: Observable<T>, scheduler?: IScheduler): Observable<T>;
+export function merge<T>(this: Observable<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
+export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
+export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2>;
+export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
+export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3>;
+export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
+export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
+export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function merge<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | IScheduler | number>): Observable<T>;
+export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R>;
 /* tslint:disable:max-line-length */
 
 /**
@@ -60,32 +60,32 @@ export function merge<T, R>(this: Observable<T>, ...observables: Array<Observabl
  * Observable. More than one input Observables may be given as argument.
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
- * @param {Scheduler} [scheduler=null] The Scheduler to use for managing
+ * @param {Scheduler} [scheduler=null] The IScheduler to use for managing
  * concurrency of input Observables.
  * @return {Observable} an Observable that emits items that are the result of
  * every input Observable.
  * @method merge
  * @owner Observable
  */
-export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
+export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R> {
   return this.lift.call(mergeStatic<T, R>(this, ...observables));
 }
 
 /* tslint:disable:max-line-length */
-export function mergeStatic<T>(v1: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;
-export function mergeStatic<T>(v1: ObservableInput<T>, concurrent?: number, scheduler?: Scheduler): Observable<T>;
-export function mergeStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: Scheduler): Observable<T | T2>;
-export function mergeStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2>;
-export function mergeStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: Scheduler): Observable<T | T2 | T3>;
-export function mergeStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3>;
-export function mergeStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
-export function mergeStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4>;
-export function mergeStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function mergeStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function mergeStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function mergeStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: Scheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function mergeStatic<T>(...observables: (ObservableInput<T> | Scheduler | number)[]): Observable<T>;
-export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Scheduler | number)[]): Observable<R>;
+export function mergeStatic<T>(v1: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
+export function mergeStatic<T>(v1: ObservableInput<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
+export function mergeStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
+export function mergeStatic<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2>;
+export function mergeStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
+export function mergeStatic<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3>;
+export function mergeStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
+export function mergeStatic<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
+export function mergeStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function mergeStatic<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function mergeStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function mergeStatic<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function mergeStatic<T>(...observables: (ObservableInput<T> | IScheduler | number)[]): Observable<T>;
+export function mergeStatic<T, R>(...observables: (ObservableInput<any> | IScheduler | number)[]): Observable<R>;
 /* tslint:enable:max-line-length */
 /**
  * Creates an output Observable which concurrently emits all values from every
@@ -126,9 +126,9 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * // - First timer1 and timer2 will run concurrently
  * // - timer1 will emit a value every 1000ms for 10 iterations
  * // - timer2 will emit a value every 2000ms for 6 iterations
- * // - after timer1 hits it's max iteration, timer2 will 
+ * // - after timer1 hits it's max iteration, timer2 will
  * //   continue, and timer3 will start to run concurrently with timer2
- * // - when timer2 hits it's max iteration it terminates, and 
+ * // - when timer2 hits it's max iteration it terminates, and
  * //   timer3 will continue to emit a value every 500ms until it is complete
  *
  * @see {@link mergeAll}
@@ -139,7 +139,7 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * @param {...Observable} observables Input Observables to merge together.
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
- * @param {Scheduler} [scheduler=null] The Scheduler to use for managing
+ * @param {Scheduler} [scheduler=null] The IScheduler to use for managing
  * concurrency of input Observables.
  * @return {Observable} an Observable that emits items that are the result of
  * every input Observable.
@@ -147,12 +147,12 @@ export function mergeStatic<T, R>(...observables: (ObservableInput<any> | Schedu
  * @name merge
  * @owner Observable
  */
-export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | Scheduler | number>): Observable<R> {
+export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
- let scheduler: Scheduler = null;
+ let scheduler: IScheduler = null;
   let last: any = observables[observables.length - 1];
   if (isScheduler(last)) {
-    scheduler = <Scheduler>observables.pop();
+    scheduler = <IScheduler>observables.pop();
     if (observables.length > 1 && typeof observables[observables.length - 1] === 'number') {
       concurrent = <number>observables.pop();
     }

--- a/src/operator/observeOn.ts
+++ b/src/operator/observeOn.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Operator } from '../Operator';
 import { PartialObserver } from '../Observer';
 import { Subscriber } from '../Subscriber';
@@ -15,12 +15,12 @@ import { TeardownLogic } from '../Subscription';
  * @method observeOn
  * @owner Observable
  */
-export function observeOn<T>(this: Observable<T>, scheduler: Scheduler, delay: number = 0): Observable<T> {
+export function observeOn<T>(this: Observable<T>, scheduler: IScheduler, delay: number = 0): Observable<T> {
   return this.lift(new ObserveOnOperator(scheduler, delay));
 }
 
 export class ObserveOnOperator<T> implements Operator<T, T> {
-  constructor(private scheduler: Scheduler, private delay: number = 0) {
+  constructor(private scheduler: IScheduler, private delay: number = 0) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -40,7 +40,7 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
   }
 
   constructor(destination: Subscriber<T>,
-              private scheduler: Scheduler,
+              private scheduler: IScheduler,
               private delay: number = 0) {
     super(destination);
   }

--- a/src/operator/publishReplay.ts
+++ b/src/operator/publishReplay.ts
@@ -1,6 +1,6 @@
 import { Observable } from '../Observable';
 import { ReplaySubject } from '../ReplaySubject';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { multicast } from './multicast';
 import { ConnectableObservable } from '../observable/ConnectableObservable';
 
@@ -14,6 +14,6 @@ import { ConnectableObservable } from '../observable/ConnectableObservable';
  */
 export function publishReplay<T>(this: Observable<T>, bufferSize: number = Number.POSITIVE_INFINITY,
                                  windowTime: number = Number.POSITIVE_INFINITY,
-                                 scheduler?: Scheduler): ConnectableObservable<T> {
+                                 scheduler?: IScheduler): ConnectableObservable<T> {
   return multicast.call(this, new ReplaySubject<T>(bufferSize, windowTime, scheduler));
 }

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -6,11 +6,11 @@ import { TeardownLogic } from '../Subscription';
 
 /**
  * Returns an Observable that repeats the stream of items emitted by the source Observable at most count times,
- * on a particular Scheduler.
+ * on a particular IScheduler.
  *
  * <img src="./img/repeat.png" width="100%">
  *
- * @param {Scheduler} [scheduler] the Scheduler to emit the items on.
+ * @param {Scheduler} [scheduler] the IScheduler to emit the items on.
  * @param {number} [count] the number of times the source Observable items are repeated, a count of 0 will yield
  * an empty Observable.
  * @return {Observable} an Observable that repeats the stream of items emitted by the source Observable at most

--- a/src/operator/repeatWhen.ts
+++ b/src/operator/repeatWhen.ts
@@ -15,13 +15,13 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * A `complete` will cause the emission of the Throwable that cause the complete to the Observable returned from
  * notificationHandler. If that Observable calls onComplete or `complete` then retry will call `complete` or `error`
  * on the child subscription. Otherwise, this Observable will resubscribe to the source observable, on a particular
- * Scheduler.
+ * IScheduler.
  *
  * <img src="./img/repeatWhen.png" width="100%">
  *
  * @param {notificationHandler} receives an Observable of notifications with which a user can `complete` or `error`,
  * aborting the retry.
- * @param {scheduler} the Scheduler on which to subscribe to the source Observable.
+ * @param {scheduler} the IScheduler on which to subscribe to the source Observable.
  * @return {Observable} the source Observable modified with retry logic.
  * @method repeatWhen
  * @owner Observable

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -15,13 +15,13 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * An `error` will cause the emission of the Throwable that cause the error to the Observable returned from
  * notificationHandler. If that Observable calls onComplete or `error` then retry will call `complete` or `error`
  * on the child subscription. Otherwise, this Observable will resubscribe to the source observable, on a particular
- * Scheduler.
+ * IScheduler.
  *
  * <img src="./img/retryWhen.png" width="100%">
  *
  * @param {notificationHandler} receives an Observable of notifications with which a user can `complete` or `error`,
  * aborting the retry.
- * @param {scheduler} the Scheduler on which to subscribe to the source Observable.
+ * @param {scheduler} the IScheduler on which to subscribe to the source Observable.
  * @return {Observable} the source Observable modified with retry logic.
  * @method retryWhen
  * @owner Observable

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Action } from '../scheduler/Action';
 import { async } from '../scheduler/async';
 import { TeardownLogic } from '../Subscription';
@@ -35,20 +35,20 @@ import { TeardownLogic } from '../Subscription';
  *
  * @param {number} period The sampling period expressed in milliseconds or the
  * time unit determined internally by the optional `scheduler`.
- * @param {Scheduler} [scheduler=async] The {@link Scheduler} to use for
+ * @param {Scheduler} [scheduler=async] The {@link IScheduler} to use for
  * managing the timers that handle the sampling.
  * @return {Observable<T>} An Observable that emits the results of sampling the
  * values emitted by the source Observable at the specified time interval.
  * @method sampleTime
  * @owner Observable
  */
-export function sampleTime<T>(this: Observable<T>, period: number, scheduler: Scheduler = async): Observable<T> {
+export function sampleTime<T>(this: Observable<T>, period: number, scheduler: IScheduler = async): Observable<T> {
   return this.lift(new SampleTimeOperator(period, scheduler));
 }
 
 class SampleTimeOperator<T> implements Operator<T, T> {
   constructor(private period: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -67,7 +67,7 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private period: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
     this.add(scheduler.schedule(dispatchNotification, period, { subscriber: this, period }));
   }

--- a/src/operator/startWith.ts
+++ b/src/operator/startWith.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { ArrayObservable } from '../observable/ArrayObservable';
 import { ScalarObservable } from '../observable/ScalarObservable';
@@ -7,13 +7,13 @@ import { concatStatic } from './concat';
 import { isScheduler } from '../util/isScheduler';
 
 /* tslint:disable:max-line-length */
-export function startWith<T>(this: Observable<T>, v1: T, scheduler?: Scheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, scheduler?: Scheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, scheduler?: Scheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, scheduler?: Scheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: Scheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: Scheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, ...array: Array<T | Scheduler>): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, scheduler?: IScheduler): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, scheduler?: IScheduler): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, scheduler?: IScheduler): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, scheduler?: IScheduler): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: IScheduler): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: IScheduler): Observable<T>;
+export function startWith<T>(this: Observable<T>, ...array: Array<T | IScheduler>): Observable<T>;
 /* tslint:disable:max-line-length */
 
 /**
@@ -28,8 +28,8 @@ export function startWith<T>(this: Observable<T>, ...array: Array<T | Scheduler>
  * @method startWith
  * @owner Observable
  */
-export function startWith<T>(this: Observable<T>, ...array: Array<T | Scheduler>): Observable<T> {
-  let scheduler = <Scheduler>array[array.length - 1];
+export function startWith<T>(this: Observable<T>, ...array: Array<T | IScheduler>): Observable<T> {
+  let scheduler = <IScheduler>array[array.length - 1];
   if (isScheduler(scheduler)) {
     array.pop();
   } else {

--- a/src/operator/subscribeOn.ts
+++ b/src/operator/subscribeOn.ts
@@ -1,27 +1,27 @@
 import { Operator } from '../Operator';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 import { SubscribeOnObservable } from '../observable/SubscribeOnObservable';
 
 /**
- * Asynchronously subscribes Observers to this Observable on the specified Scheduler.
+ * Asynchronously subscribes Observers to this Observable on the specified IScheduler.
  *
  * <img src="./img/subscribeOn.png" width="100%">
  *
- * @param {Scheduler} the Scheduler to perform subscription actions on.
- * @return {Observable<T>} the source Observable modified so that its subscriptions happen on the specified Scheduler
+ * @param {Scheduler} the IScheduler to perform subscription actions on.
+ * @return {Observable<T>} the source Observable modified so that its subscriptions happen on the specified IScheduler
  .
  * @method subscribeOn
  * @owner Observable
  */
-export function subscribeOn<T>(this: Observable<T>, scheduler: Scheduler, delay: number = 0): Observable<T> {
+export function subscribeOn<T>(this: Observable<T>, scheduler: IScheduler, delay: number = 0): Observable<T> {
   return this.lift(new SubscribeOnOperator<T>(scheduler, delay));
 }
 
 class SubscribeOnOperator<T> implements Operator<T, T> {
-  constructor(private scheduler: Scheduler,
+  constructor(private scheduler: IScheduler,
               private delay: number) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -1,6 +1,6 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Subscription, TeardownLogic } from '../Subscription';
 import { async } from '../scheduler/async';
 import { Observable } from '../Observable';
@@ -21,7 +21,7 @@ import { Observable } from '../Observable';
  * is enabled. After `duration` milliseconds (or the time unit determined
  * internally by the optional `scheduler`) has passed, the timer is disabled,
  * and this process repeats for the next source value. Optionally takes a
- * {@link Scheduler} for managing timers.
+ * {@link IScheduler} for managing timers.
  *
  * @example <caption>Emit clicks at a rate of at most one click per second</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
@@ -37,20 +37,20 @@ import { Observable } from '../Observable';
  * @param {number} duration Time to wait before emitting another value after
  * emitting the last value, measured in milliseconds or the time unit determined
  * internally by the optional `scheduler`.
- * @param {Scheduler} [scheduler=async] The {@link Scheduler} to use for
+ * @param {Scheduler} [scheduler=async] The {@link IScheduler} to use for
  * managing the timers that handle the sampling.
  * @return {Observable<T>} An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.
  * @method throttleTime
  * @owner Observable
  */
-export function throttleTime<T>(this: Observable<T>, duration: number, scheduler: Scheduler = async): Observable<T> {
+export function throttleTime<T>(this: Observable<T>, duration: number, scheduler: IScheduler = async): Observable<T> {
   return this.lift(new ThrottleTimeOperator(duration, scheduler));
 }
 
 class ThrottleTimeOperator<T> implements Operator<T, T> {
   constructor(private duration: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -68,7 +68,7 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private duration: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
   }
 

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -1,7 +1,7 @@
 import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { async } from '../scheduler/async';
 
 /**
@@ -10,7 +10,7 @@ import { async } from '../scheduler/async';
  * @method timeInterval
  * @owner Observable
  */
-export function timeInterval<T>(this: Observable<T>, scheduler: Scheduler = async): Observable<TimeInterval<T>> {
+export function timeInterval<T>(this: Observable<T>, scheduler: IScheduler = async): Observable<TimeInterval<T>> {
   return this.lift(new TimeIntervalOperator(scheduler));
 }
 
@@ -21,7 +21,7 @@ export class TimeInterval<T> {
 };
 
 class TimeIntervalOperator<T> implements Operator<T, TimeInterval<T>> {
-  constructor(private scheduler: Scheduler) {
+  constructor(private scheduler: IScheduler) {
 
   }
 
@@ -38,7 +38,7 @@ class TimeIntervalOperator<T> implements Operator<T, TimeInterval<T>> {
 class TimeIntervalSubscriber<T> extends Subscriber<T> {
   private lastTime: number = 0;
 
-  constructor(destination: Subscriber<TimeInterval<T>>, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<TimeInterval<T>>, private scheduler: IScheduler) {
     super(destination);
 
     this.lastTime = scheduler.now();

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -2,7 +2,7 @@ import { async } from '../scheduler/async';
 import { isDate } from '../util/isDate';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 import { TimeoutError } from '../util/TimeoutError';
@@ -16,7 +16,7 @@ import { TimeoutError } from '../util/TimeoutError';
  */
 export function timeout<T>(this: Observable<T>,
                            due: number | Date,
-                           scheduler: Scheduler = async): Observable<T> {
+                           scheduler: IScheduler = async): Observable<T> {
   const absoluteTimeout = isDate(due);
   const waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, scheduler, new TimeoutError()));
@@ -25,7 +25,7 @@ export function timeout<T>(this: Observable<T>,
 class TimeoutOperator<T> implements Operator<T, T> {
   constructor(private waitFor: number,
               private absoluteTimeout: boolean,
-              private scheduler: Scheduler,
+              private scheduler: IScheduler,
               private errorInstance: TimeoutError) {
   }
 
@@ -55,7 +55,7 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
   constructor(destination: Subscriber<T>,
               private absoluteTimeout: boolean,
               private waitFor: number,
-              private scheduler: Scheduler,
+              private scheduler: IScheduler,
               private errorInstance: TimeoutError) {
     super(destination);
     this.scheduleTimeout();

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -1,6 +1,6 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { async } from '../scheduler/async';
 import { Subscription, TeardownLogic } from '../Subscription';
 import { Observable, ObservableInput } from '../Observable';
@@ -9,8 +9,8 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 /* tslint:disable:max-line-length */
-export function timeoutWith<T>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<T>, scheduler?: Scheduler): Observable<T>;
-export function timeoutWith<T, R>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<R>, scheduler?: Scheduler): Observable<T | R>;
+export function timeoutWith<T>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
+export function timeoutWith<T, R>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<R>, scheduler?: IScheduler): Observable<T | R>;
 /* tslint:disable:max-line-length */
 
 /**
@@ -23,7 +23,7 @@ export function timeoutWith<T, R>(this: Observable<T>, due: number | Date, withO
  */
 export function timeoutWith<T, R>(this: Observable<T>, due: number | Date,
                                   withObservable: ObservableInput<R>,
-                                  scheduler: Scheduler = async): Observable<T | R> {
+                                  scheduler: IScheduler = async): Observable<T | R> {
   let absoluteTimeout = isDate(due);
   let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
   return this.lift(new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));
@@ -33,7 +33,7 @@ class TimeoutWithOperator<T> implements Operator<T, T> {
   constructor(private waitFor: number,
               private absoluteTimeout: boolean,
               private withObservable: ObservableInput<any>,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -64,7 +64,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
               private absoluteTimeout: boolean,
               private waitFor: number,
               private withObservable: ObservableInput<any>,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super();
     destination.add(this);
     this.scheduleTimeout();

--- a/src/operator/timestamp.ts
+++ b/src/operator/timestamp.ts
@@ -1,7 +1,7 @@
 import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { async } from '../scheduler/async';
 
 /**
@@ -10,7 +10,7 @@ import { async } from '../scheduler/async';
  * @method timestamp
  * @owner Observable
  */
-export function timestamp<T>(this: Observable<T>, scheduler: Scheduler = async): Observable<Timestamp<T>> {
+export function timestamp<T>(this: Observable<T>, scheduler: IScheduler = async): Observable<Timestamp<T>> {
   return this.lift(new TimestampOperator(scheduler));
 }
 
@@ -20,7 +20,7 @@ export class Timestamp<T> {
 };
 
 class TimestampOperator<T> implements Operator<T, Timestamp<T>> {
-  constructor(private scheduler: Scheduler) {
+  constructor(private scheduler: IScheduler) {
   }
 
   call(observer: Subscriber<Timestamp<T>>, source: any): any {
@@ -29,7 +29,7 @@ class TimestampOperator<T> implements Operator<T, Timestamp<T>> {
 }
 
 class TimestampSubscriber<T> extends Subscriber<T> {
-  constructor(destination: Subscriber<Timestamp<T>>, private scheduler: Scheduler) {
+  constructor(destination: Subscriber<Timestamp<T>>, private scheduler: IScheduler) {
     super(destination);
   }
 

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -1,4 +1,4 @@
-import { Scheduler } from '../Scheduler';
+import { IScheduler } from '../Scheduler';
 import { Action } from '../scheduler/Action';
 import { Subject } from '../Subject';
 import { Operator } from '../Operator';
@@ -58,7 +58,7 @@ import { Subscription } from '../Subscription';
  */
 export function windowTime<T>(this: Observable<T>, windowTimeSpan: number,
                               windowCreationInterval: number = null,
-                              scheduler: Scheduler = async): Observable<Observable<T>> {
+                              scheduler: IScheduler = async): Observable<Observable<T>> {
   return this.lift(new WindowTimeOperator<T>(windowTimeSpan, windowCreationInterval, scheduler));
 }
 
@@ -66,7 +66,7 @@ class WindowTimeOperator<T> implements Operator<T, Observable<T>> {
 
   constructor(private windowTimeSpan: number,
               private windowCreationInterval: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
   }
 
   call(subscriber: Subscriber<Observable<T>>, source: any): any {
@@ -80,7 +80,7 @@ interface CreationState<T> {
   windowTimeSpan: number;
   windowCreationInterval: number;
   subscriber: WindowTimeSubscriber<T>;
-  scheduler: Scheduler;
+  scheduler: IScheduler;
 }
 
 /**
@@ -94,7 +94,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
   constructor(protected destination: Subscriber<Observable<T>>,
               private windowTimeSpan: number,
               private windowCreationInterval: number,
-              private scheduler: Scheduler) {
+              private scheduler: IScheduler) {
     super(destination);
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
       let window = this.openWindow();


### PR DESCRIPTION
…heduler` interface

this should be a non-breaking change. It just makes sense to accept a minimal interface here rather than a full-on class

The full on class was giving me difficulties in another TypeScript project where I wanted to mock a Scheduler.