### PR TITLE
refactor(Error): Rewrite custom derived errors with Object.create()

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -262,9 +262,12 @@ describe('Observable.ajax', () => {
       'responseText': 'Wee! I am text!'
     });
 
+    expect(error instanceof Error).to.be.true;
     expect(error instanceof Rx.AjaxError).to.be.true;
+    expect(error.name).to.equal('AjaxError');
     expect(error.message).to.equal('ajax error 404');
     expect(error.status).to.equal(404);
+    expect(error.xhr instanceof XMLHttpRequest).to.be.true;
   });
 
   it('should fail on 404', () => {
@@ -294,9 +297,12 @@ describe('Observable.ajax', () => {
       'responseText': 'Wee! I am text!'
     });
 
+    expect(error instanceof Error).to.be.true;
     expect(error instanceof Rx.AjaxError).to.be.true;
+    expect(error.name).to.equal('AjaxError');
     expect(error.message).to.equal('ajax error 300');
     expect(error.status).to.equal(300);
+    expect(error.xhr instanceof XMLHttpRequest).to.be.true;
   });
 
   it('should succeed no settings', () => {
@@ -773,7 +779,12 @@ describe('Observable.ajax', () => {
     try {
       request.ontimeout((<any>'ontimeout'));
     } catch (e) {
+      expect(e instanceof Error).to.be.true;
+      expect(e instanceof Rx.AjaxError).to.be.true;
+      expect(e instanceof Rx.AjaxTimeoutError).to.be.true;
+      expect(e.name).to.equal('AjaxTimeoutError');
       expect(e.message).to.equal(new Rx.AjaxTimeoutError((<any>request), ajaxRequest).message);
+      expect(e.xhr instanceof XMLHttpRequest).to.be.true;
     }
     delete root.XMLHttpRequest.prototype.ontimeout;
   });

--- a/spec/util/ArgumentOutOfRangeError-spec.ts
+++ b/spec/util/ArgumentOutOfRangeError-spec.ts
@@ -1,0 +1,29 @@
+import {expect} from 'chai';
+import {ArgumentOutOfRangeError} from '../../dist/cjs/util/ArgumentOutOfRangeError';
+
+describe('ArgumentOutOfRangeError', () => {
+  let err: ArgumentOutOfRangeError;
+
+  before(() => {
+    err = new ArgumentOutOfRangeError();
+  });
+
+  it('should be an instance of Error', function () {
+    expect(err instanceof Error).to.equal(true);
+  });
+
+  it('should be an instance of ArgumentOutOfRangeError', function () {
+    expect(err instanceof ArgumentOutOfRangeError).to.equal(true);
+  });
+
+  it('should be expected name', function () {
+    expect(err.name).to.equal('ArgumentOutOfRangeError');
+  });
+
+  it('should be expected message', function () {
+    expect(err.message).to.equal('argument out of range');
+  });
+
+  // XXX: `Error.stack` is not supported in IE9.
+  // So we give up to test it.
+});

--- a/spec/util/EmptyError-spec.ts
+++ b/spec/util/EmptyError-spec.ts
@@ -1,0 +1,29 @@
+import {expect} from 'chai';
+import {EmptyError} from '../../dist/cjs/util/EmptyError';
+
+describe('EmptyError', () => {
+  let err: EmptyError;
+
+  before(() => {
+    err = new EmptyError();
+  });
+
+  it('should be an instance of Error', function () {
+    expect(err instanceof Error).to.equal(true);
+  });
+
+  it('should be an instance of EmptyError', function () {
+    expect(err instanceof EmptyError).to.equal(true);
+  });
+
+  it('should be expected name', function () {
+    expect(err.name).to.equal('EmptyError');
+  });
+
+  it('should be expected message', function () {
+    expect(err.message).to.equal('no elements in sequence');
+  });
+
+  // XXX: `Error.stack` is not supported in IE9.
+  // So we give up to test it.
+});

--- a/spec/util/ObjectUnsubscribedError-spec.ts
+++ b/spec/util/ObjectUnsubscribedError-spec.ts
@@ -1,0 +1,29 @@
+import {expect} from 'chai';
+import {ObjectUnsubscribedError} from '../../dist/cjs/util/ObjectUnsubscribedError';
+
+describe('ObjectUnsubscribedError', () => {
+  let err: ObjectUnsubscribedError;
+
+  before(() => {
+    err = new ObjectUnsubscribedError();
+  });
+
+  it('should be an instance of Error', function () {
+    expect(err instanceof Error).to.equal(true);
+  });
+
+  it('should be an instance of ObjectUnsubscribedError', function () {
+    expect(err instanceof ObjectUnsubscribedError).to.equal(true);
+  });
+
+  it('should be expected name', function () {
+    expect(err.name).to.equal('ObjectUnsubscribedError');
+  });
+
+  it('should be expected message', function () {
+    expect(err.message).to.equal('object unsubscribed');
+  });
+
+  // XXX: `Error.stack` is not supported in IE9.
+  // So we give up to test it.
+});

--- a/spec/util/TimeoutError-spec.ts
+++ b/spec/util/TimeoutError-spec.ts
@@ -1,0 +1,29 @@
+import {expect} from 'chai';
+import {TimeoutError} from '../../dist/cjs/util/TimeoutError';
+
+describe('TimeoutError', () => {
+  let err: TimeoutError;
+
+  before(() => {
+    err = new TimeoutError();
+  });
+
+  it('should be an instance of Error', function () {
+    expect(err instanceof Error).to.equal(true);
+  });
+
+  it('should be an instance of TimeoutError', function () {
+    expect(err instanceof TimeoutError).to.equal(true);
+  });
+
+  it('should be expected name', function () {
+    expect(err.name).to.equal('TimeoutError');
+  });
+
+  it('should be expected message', function () {
+    expect(err.message).to.equal('Timeout has occurred');
+  });
+
+  // XXX: `Error.stack` is not supported in IE9.
+  // So we give up to test it.
+});

--- a/spec/util/UnsubscriptionError-spec.ts
+++ b/spec/util/UnsubscriptionError-spec.ts
@@ -18,6 +18,7 @@ describe('UnsubscriptionError', () => {
     try {
       subscription.unsubscribe();
     } catch (err) {
+      expect(err instanceof Error).to.equal(true);
       expect(err instanceof UnsubscriptionError).to.equal(true);
       expect(err.message).to.equal(`2 errors occurred during unsubscription:
   1) ${err1}

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -174,6 +174,61 @@ export class AjaxObservable<T> extends Observable<T> {
 }
 
 /**
+ * A normalized AJAX error.
+ *
+ * @see {@link ajax}
+ *
+ * @class AjaxError
+ */
+export interface AjaxError extends Error {
+  /** @type {XMLHttpRequest} The XHR instance associated with the error */
+  xhr: XMLHttpRequest;
+
+  /** @type {AjaxRequest} The AjaxRequest associated with the error */
+  request: AjaxRequest;
+
+  /** @type {number} The HTTP status code */
+  status: number;
+}
+export interface AjaxErrorConstructor {
+    new(message: string, xhr: XMLHttpRequest, request: AjaxRequest): AjaxError;
+    readonly prototype: AjaxError;
+}
+
+function AjaxErrorCtor(this: AjaxError, message: string, xhr: XMLHttpRequest, request: AjaxRequest): AjaxError {
+  const err = Error.call(this, message);
+  this.name = 'AjaxError';
+  this.stack = err.stack;
+  this.message = err.message;
+  this.xhr = xhr;
+  this.request = request;
+  this.status = xhr.status;
+  return this;
+}
+AjaxErrorCtor.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: AjaxErrorCtor,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+
+export const AjaxError = AjaxErrorCtor as any as AjaxErrorConstructor;
+
+/**
+ * @see {@link ajax}
+ *
+ * @class AjaxTimeoutError
+ */
+export class AjaxTimeoutError extends AjaxError {
+  constructor(xhr: XMLHttpRequest, request: AjaxRequest) {
+    super('ajax timeout', xhr, request);
+    this.name = 'AjaxTimeoutError';
+  }
+}
+
+/**
  * We need this JSDoc comment for affecting ESDoc.
  * @ignore
  * @extends {Ignored}
@@ -419,42 +474,5 @@ export class AjaxResponse {
         this.response = ('response' in xhr) ? xhr.response : xhr.responseText;
         break;
     }
-  }
-}
-
-/**
- * A normalized AJAX error.
- *
- * @see {@link ajax}
- *
- * @class AjaxError
- */
-export class AjaxError extends Error {
-  /** @type {XMLHttpRequest} The XHR instance associated with the error */
-  xhr: XMLHttpRequest;
-
-  /** @type {AjaxRequest} The AjaxRequest associated with the error */
-  request: AjaxRequest;
-
-  /** @type {number} The HTTP status code */
-  status: number;
-
-  constructor(message: string, xhr: XMLHttpRequest, request: AjaxRequest) {
-    super(message);
-    this.message = message;
-    this.xhr = xhr;
-    this.request = request;
-    this.status = xhr.status;
-  }
-}
-
-/**
- * @see {@link ajax}
- *
- * @class AjaxTimeoutError
- */
-export class AjaxTimeoutError extends AjaxError {
-  constructor(xhr: XMLHttpRequest, request: AjaxRequest) {
-    super('ajax timeout', xhr, request);
   }
 }

--- a/src/util/ArgumentOutOfRangeError.ts
+++ b/src/util/ArgumentOutOfRangeError.ts
@@ -8,11 +8,26 @@
  *
  * @class ArgumentOutOfRangeError
  */
-export class ArgumentOutOfRangeError extends Error {
-  constructor() {
-    const err: any = super('argument out of range');
-    (<any> this).name = err.name = 'ArgumentOutOfRangeError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export interface ArgumentOutOfRangeError extends Error {}
+export interface ArgumentOutOfRangeErrorConstructor {
+    new(): ArgumentOutOfRangeError;
+    readonly prototype: ArgumentOutOfRangeError;
 }
+
+function ArgumentOutOfRangeErrorCtor(this: ArgumentOutOfRangeError): ArgumentOutOfRangeError {
+  const err = Error.call(this, 'argument out of range');
+  this.name = 'ArgumentOutOfRangeError';
+  this.stack = err.stack;
+  this.message = err.message;
+  return this;
+}
+ArgumentOutOfRangeErrorCtor.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: ArgumentOutOfRangeErrorCtor,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+
+export const ArgumentOutOfRangeError = ArgumentOutOfRangeErrorCtor as any as ArgumentOutOfRangeErrorConstructor;

--- a/src/util/EmptyError.ts
+++ b/src/util/EmptyError.ts
@@ -8,11 +8,26 @@
  *
  * @class EmptyError
  */
-export class EmptyError extends Error {
-  constructor() {
-    const err: any = super('no elements in sequence');
-    (<any> this).name = err.name = 'EmptyError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export interface EmptyError extends Error {}
+export interface EmptyErrorConstructor {
+    new(): EmptyError;
+    readonly prototype: EmptyError;
 }
+
+function EmptyErrorCtor(this: EmptyError): EmptyError {
+  const err = Error.call(this, 'no elements in sequence');
+  this.name = 'EmptyError';
+  this.stack = err.stack;
+  this.message = err.message;
+  return this;
+}
+EmptyErrorCtor.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: EmptyErrorCtor,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+
+export const EmptyError = EmptyErrorCtor as any as EmptyErrorConstructor;

--- a/src/util/ObjectUnsubscribedError.ts
+++ b/src/util/ObjectUnsubscribedError.ts
@@ -7,11 +7,26 @@
  *
  * @class ObjectUnsubscribedError
  */
-export class ObjectUnsubscribedError extends Error {
-  constructor() {
-    const err: any = super('object unsubscribed');
-    (<any> this).name = err.name = 'ObjectUnsubscribedError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export interface ObjectUnsubscribedError extends Error {}
+export interface ObjectUnsubscribedErrorConstructor {
+    new(): ObjectUnsubscribedError;
+    readonly prototype: ObjectUnsubscribedError;
 }
+
+function ObjectUnsubscribedErrorCtor(this: ObjectUnsubscribedError): ObjectUnsubscribedError {
+  const err = Error.call(this, 'object unsubscribed');
+  this.name = 'ObjectUnsubscribedError';
+  this.stack = err.stack;
+  this.message = err.message;
+  return this;
+}
+ObjectUnsubscribedErrorCtor.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: ObjectUnsubscribedErrorCtor,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+
+export const ObjectUnsubscribedError = ObjectUnsubscribedErrorCtor as any as ObjectUnsubscribedErrorConstructor;

--- a/src/util/TimeoutError.ts
+++ b/src/util/TimeoutError.ts
@@ -2,14 +2,27 @@
  * An error thrown when duetime elapses.
  *
  * @see {@link timeout}
- *
- * @class TimeoutError
  */
-export class TimeoutError extends Error {
-  constructor() {
-    const err: any = super('Timeout has occurred');
-    (<any> this).name = err.name = 'TimeoutError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export interface TimeoutError extends Error {}
+export interface TimeoutErrorConstructor {
+    new(): TimeoutError;
+    readonly prototype: TimeoutError;
 }
+
+function TimeoutErrorCtor(this: TimeoutError): TimeoutError {
+  const err = Error.call(this, 'Timeout has occurred');
+  this.name = 'TimeoutError';
+  this.stack = err.stack;
+  this.message = err.message;
+  return this;
+}
+TimeoutErrorCtor.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: TimeoutErrorCtor,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+
+export const TimeoutError = TimeoutErrorCtor as any as TimeoutErrorConstructor;

--- a/src/util/UnsubscriptionError.ts
+++ b/src/util/UnsubscriptionError.ts
@@ -2,14 +2,33 @@
  * An error thrown when one or more errors have occurred during the
  * `unsubscribe` of a {@link Subscription}.
  */
-export class UnsubscriptionError extends Error {
-  constructor(public errors: any[]) {
-    super();
-    const err: any = Error.call(this, errors ?
-      `${errors.length} errors occurred during unsubscription:
-  ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '');
-    (<any> this).name = err.name = 'UnsubscriptionError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export interface UnsubscriptionError extends Error {
+  errors: any[];
 }
+export interface UnsubscriptionErrorConstructor {
+    new(errors: any[]): UnsubscriptionError;
+    readonly prototype: UnsubscriptionError;
+}
+
+function UnsubscriptionErrorCtor(this: UnsubscriptionError, errors: any[]): UnsubscriptionError {
+  const msg = !!errors ?
+    `${errors.length} errors occurred during unsubscription:
+  ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '';
+  const err: Error = Error.call(this, msg);
+
+  this.name = 'UnsubscriptionError';
+  this.stack = err.stack;
+  this.message = err.message;
+  this.errors = errors;
+  return this;
+}
+UnsubscriptionErrorCtor.prototype = Object.create(Error.prototype, {
+  constructor: {
+    value: UnsubscriptionErrorCtor,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  }
+});
+
+export const UnsubscriptionError = UnsubscriptionErrorCtor as any as UnsubscriptionErrorConstructor;


### PR DESCRIPTION
**Description:**

- This is the alternative proposal to fix https://github.com/ReactiveX/rxjs/issues/2178 with rewriting custom derived errors by `Object.create()`'s classical inheritance by hand.
  - This approach is based on TypeScript's definitions for build-in object.
  - By this change, we can upgrade TypeScript 2.1 or later without dropping support for IE9/IE10 for the future.
- This is not a breaking change because this patch creates an inheritance by hand instead of TypeScript's transformer.

**Related issue (if exists):**

https://github.com/ReactiveX/rxjs/issues/2178
