### PR TITLE
docs(operators): webSocket documentation

### DIFF
--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -42,7 +42,36 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   }
 
   /**
-   * @param urlConfigOrSource
+   * Wrapper around the w3c-compatible WebSocket object provided by the browser.
+   *
+   * @example <caption>Wraps browser WebSocket</caption>
+   *
+   * let subject = Observable.webSocket('ws://localhost:8081');
+   * subject.subscribe(
+   *    (msg) => console.log('message received: ' + msg),
+   *    (err) => console.log(err),
+   *    () => console.log('complete')
+   *  );
+   * subject.next(JSON.stringify({ op: 'hello' }));
+   *
+   * @example <caption>Wraps WebSocket from nodejs-websocket (using node.js)</caption>
+   *
+   * import { w3cwebsocket } from 'websocket';
+   * 
+   * let socket = new WebSocketSubject({
+   *   url: 'ws://localhost:8081',
+   *   WebSocketCtor: w3cwebsocket
+   * });
+   *
+   * let subject = Observable.webSocket('ws://localhost:8081');
+   * subject.subscribe(
+   *    (msg) => console.log('message received: ' + msg),
+   *    (err) => console.log(err),
+   *    () => console.log('complete')
+   *  );
+   * subject.next(JSON.stringify({ op: 'hello' }));
+   *
+   * @param {string | WebSocketSubjectConfig} urlConfigOrSource the source of the websocket as an url or a structure defining the websocket object
    * @return {WebSocketSubject}
    * @static true
    * @name webSocket


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Documentation of webSocket operator

**Related issue (if exists):**
