### PR TITLE
Align fromEventPattern behavior to RxJS v4

### DIFF
--- a/spec/observables/fromEventPattern-spec.ts
+++ b/spec/observables/fromEventPattern-spec.ts
@@ -1,5 +1,7 @@
 import {expect} from 'chai';
+import * as sinon from 'sinon';
 import * as Rx from '../../dist/cjs/Rx';
+import {noop} from '../../dist/cjs/util/noop';
 
 declare const rxTestScheduler: Rx.TestScheduler;
 declare const {hot, asDiagram, expectObservable, expectSubscriptions};
@@ -56,6 +58,23 @@ describe('Observable.fromEventPattern', () => {
     subscription.unsubscribe();
 
     expect(removeHandlerCalledWith).to.be.a('function');
+  });
+
+  it('should work without optional removeHandler', () => {
+    const addHandler: (h: Function) => any = sinon.spy();
+    Observable.fromEventPattern(addHandler).subscribe(noop);
+
+    expect(addHandler).calledOnce;
+  });
+
+  it('should deliver return value of addHandler to removeHandler as signal', () => {
+    const expected = { signal: true};
+    const addHandler = () => expected;
+    const removeHandler = sinon.spy();
+    Observable.fromEventPattern(addHandler, removeHandler).subscribe(noop).unsubscribe();
+
+    const call = removeHandler.getCall(0);
+    expect(call).calledWith(sinon.match.any, expected);
   });
 
   it('should send errors in addHandler down the error path', () => {

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -1,3 +1,4 @@
+import { isFunction } from '../util/isFunction';
 import { Observable } from '../Observable';
 import { Subscription } from '../Subscription';
 import { Subscriber } from '../Subscriber';
@@ -45,7 +46,7 @@ export class FromEventPatternObservable<T> extends Observable<T> {
    * @param {function(handler: Function): any} addHandler A function that takes
    * a `handler` function as argument and attaches it somehow to the actual
    * source of events.
-   * @param {function(handler: Function, signal?: any): void} removeHandler A function that
+   * @param {function(handler: Function, signal?: any): void} [removeHandler] An optional function that
    * takes a `handler` function as argument and removes it in case it was
    * previously attached using `addHandler`. if addHandler returns signal to teardown when remove,
    * removeHandler function will forward it.
@@ -58,13 +59,13 @@ export class FromEventPatternObservable<T> extends Observable<T> {
    * @owner Observable
    */
   static create<T>(addHandler: (handler: Function) => any,
-                   removeHandler: (handler: Function, signal?: any) => void,
+                   removeHandler?: (handler: Function, signal?: any) => void,
                    selector?: (...args: Array<any>) => T) {
     return new FromEventPatternObservable(addHandler, removeHandler, selector);
   }
 
   constructor(private addHandler: (handler: Function) => any,
-              private removeHandler: (handler: Function, signal?: any) => void,
+              private removeHandler?: (handler: Function, signal?: any) => void,
               private selector?: (...args: Array<any>) => T) {
     super();
   }
@@ -77,6 +78,10 @@ export class FromEventPatternObservable<T> extends Observable<T> {
     } : function(e: any) { subscriber.next(e); };
 
     const retValue = this._callAddHandler(handler, subscriber);
+
+    if (!isFunction(removeHandler)) {
+      return;
+    }
 
     subscriber.add(new Subscription(() => {
       //TODO: determine whether or not to forward to error handler

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -45,9 +45,10 @@ export class FromEventPatternObservable<T> extends Observable<T> {
    * @param {function(handler: Function): any} addHandler A function that takes
    * a `handler` function as argument and attaches it somehow to the actual
    * source of events.
-   * @param {function(handler: Function): void} removeHandler A function that
+   * @param {function(handler: Function, signal?: any): void} removeHandler A function that
    * takes a `handler` function as argument and removes it in case it was
-   * previously attached using `addHandler`.
+   * previously attached using `addHandler`. if addHandler returns signal to teardown when remove,
+   * removeHandler function will forward it.
    * @param {function(...args: any): T} [selector] An optional function to
    * post-process results. It takes the arguments from the event handler and
    * should return a single value.
@@ -57,13 +58,13 @@ export class FromEventPatternObservable<T> extends Observable<T> {
    * @owner Observable
    */
   static create<T>(addHandler: (handler: Function) => any,
-                   removeHandler: (handler: Function) => void,
+                   removeHandler: (handler: Function, signal?: any) => void,
                    selector?: (...args: Array<any>) => T) {
     return new FromEventPatternObservable(addHandler, removeHandler, selector);
   }
 
   constructor(private addHandler: (handler: Function) => any,
-              private removeHandler: (handler: Function) => void,
+              private removeHandler: (handler: Function, signal?: any) => void,
               private selector?: (...args: Array<any>) => T) {
     super();
   }
@@ -75,10 +76,11 @@ export class FromEventPatternObservable<T> extends Observable<T> {
       this._callSelector(subscriber, args);
     } : function(e: any) { subscriber.next(e); };
 
-    this._callAddHandler(handler, subscriber);
+    const retValue = this._callAddHandler(handler, subscriber);
+
     subscriber.add(new Subscription(() => {
       //TODO: determine whether or not to forward to error handler
-      removeHandler(handler);
+      removeHandler(handler, retValue) ;
     }));
   }
 
@@ -92,9 +94,9 @@ export class FromEventPatternObservable<T> extends Observable<T> {
     }
   }
 
-  private _callAddHandler(handler: (e: any) => void, errorSubscriber: Subscriber<T>): void {
+  private _callAddHandler(handler: (e: any) => void, errorSubscriber: Subscriber<T>): any | null {
     try {
-      this.addHandler(handler);
+      return this.addHandler(handler) || null;
     }
     catch (e) {
       errorSubscriber.error(e);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR aligns `fromEventPattern`'s behavior to RxJS v4, including 2 changes
- `removeHandler` is now optional
- `removeHandler` signature now accepts optional `signal` parameter, `(handler: Function, signal?: any) => void` forwarded value of `addHandler` for eventlistener disposal.

This PR is currently ⚠️ Targeting master ⚠️, since both of changes are optional probably won't breaking any existing usecases. 

**Related issue (if exists):**

#1900, #2088