### PR TITLE
docs(tutorial): Log target values and not the events

### DIFF
--- a/doc/tutorial/basics.md
+++ b/doc/tutorial/basics.md
@@ -52,27 +52,33 @@ var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keypress')
 
 // Filter out target values less than 3 characters long
 input.filter(event => event.target.value.length > 2)
+  .map(event => event.target.value)
   .subscribe(value => console.log(value)); // "hel"
 
 // Delay the events
 input.delay(200)
+  .map(event => event.target.value)
   .subscribe(value => console.log(value)); // "h" -200ms-> "e" -200ms-> "l" ...
 
 // Only let through an event every 200 ms
 input.throttleTime(200)
+  .map(event => event.target.value)
   .subscribe(value => console.log(value)); // "h" -200ms-> "w"
 
 // Let through latest event after 200 ms
 input.debounceTime(200)
+  .map(event => event.target.value)
   .subscribe(value => console.log(value)); // "o" -200ms-> "d"
 
 // Stop the stream of events after 3 events
 input.take(3)
+  .map(event => event.target.value)
   .subscribe(value => console.log(value)); // "hel"
 
 // Passes through events until other observable triggers an event
 var stopStream = Rx.Observable.fromEvent(document.querySelector('button'), 'click');
 input.takeUntil(stopStream)
+  .map(event => event.target.value)
   .subscribe(value => console.log(value)); // "hello" (click)
 ```
 


### PR DESCRIPTION
We want to log the input values and not the keypress events.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->
