### PR TITLE
docs(tutorial): Changed values to keys in the examples

### DIFF
--- a/doc/tutorial/basics.md
+++ b/doc/tutorial/basics.md
@@ -81,23 +81,23 @@ input.takeUntil(stopStream)
 // typing "hello world"
 var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keypress');
 
-// Pass on a new value
-input.map(event => event.target.value)
+// Pass on a new key press
+input.map(event => event.key)
   .subscribe(value => console.log(value)); // "h"
 
-// Pass on a new value by plucking it
-input.pluck('target', 'value')
+// Pass on a new key press by plucking it
+input.pluck('key')
   .subscribe(value => console.log(value)); // "h"
 
-// Pass the two previous values
-input.pluck('target', 'value').pairwise()
-  .subscribe(value => console.log(value)); // ["h", "e"]
+// Pass paired the two previous key presses
+input.pluck('key').pairwise()
+  .subscribe(value => console.log(value)); // ["h", "e"], ["l", "l"], ...
 
-// Only pass unique values through
-input.pluck('target', 'value').distinct()
-  .subscribe(value => console.log(value)); // "helo wrd"
+// Only pass unique key presses through
+input.pluck('key').distinct()
+  .subscribe(value => console.log(value)); // "h", "e", "l", "o", " ", "w", "r", "d"
 
-// Do not pass repeating values through
-input.pluck('target', 'value').distinctUntilChanged()
-  .subscribe(value => console.log(value)); // "helo world"
+// Do not pass repeating key presses through
+input.pluck('key').distinctUntilChanged()
+  .subscribe(value => console.log(value)); // "h", "e", "l", "o", " ", "w", "o", "r", "l", "d"
 ```


### PR DESCRIPTION
**Description:**
It seems that there is a confusion between `event.key` and `event.target.value` in the doc.
As "hello world" is typed in the input box, a stream of keypress events will give as the output:

    "h"
    "e"
    "l"
    "l"
    ...

for `event.key` and will output:

    "h"
    "he"
    "hel"
    "hell"
    "hello"
    ...
for `event.target.value`.
The examples seem to imply to want the first behavior but they are using the second method.
Changed the examples code to use the first method. 

Another possibility would be to correct the examples having in mind the second case.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->



**Related issue (if exists):**
