### PR TITLE
fix(Subject): Limit Subject interface public accessibility

### DIFF
--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -41,7 +41,7 @@ export class ReplaySubject<T> extends Subject<T> {
     } else if (this.isStopped) {
       subscription = Subscription.EMPTY;
     } else {
-      this.observers.push(subscriber);
+      this._observers.push(subscriber);
       subscription = new SubjectSubscription(this, subscriber);
     }
 

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -25,15 +25,23 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     return new SubjectSubscriber(this);
   }
 
-  observers: Observer<T>[] = [];
+  protected _observers: Array<Observer<T>> = [];
+  public get observers(): ReadonlyArray<Observer<T>> {
+    return this._observers;
+  }
 
-  closed = false;
+  protected _closed: boolean = false;
+  public get closed(): boolean {
+    return this._closed;
+  }
 
-  isStopped = false;
+  protected _isStopped: boolean = false;
+  public get isStopped(): boolean {
+    return this._isStopped;
+  }
 
-  hasError = false;
-
-  thrownError: any = null;
+  protected hasError: boolean = false;
+  protected thrownError: any = null;
 
   constructor() {
     super();
@@ -69,34 +77,34 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     }
     this.hasError = true;
     this.thrownError = err;
-    this.isStopped = true;
+    this._isStopped = true;
     const { observers } = this;
     const len = observers.length;
     const copy = observers.slice();
     for (let i = 0; i < len; i++) {
       copy[i].error(err);
     }
-    this.observers.length = 0;
+    this._observers.length = 0;
   }
 
   complete() {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     }
-    this.isStopped = true;
+    this._isStopped = true;
     const { observers } = this;
     const len = observers.length;
     const copy = observers.slice();
     for (let i = 0; i < len; i++) {
       copy[i].complete();
     }
-    this.observers.length = 0;
+    this._observers.length = 0;
   }
 
   unsubscribe() {
-    this.isStopped = true;
-    this.closed = true;
-    this.observers = null;
+    this._isStopped = true;
+    this._closed = true;
+    this._observers = null;
   }
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
@@ -109,7 +117,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
       subscriber.complete();
       return Subscription.EMPTY;
     } else {
-      this.observers.push(subscriber);
+      this._observers.push(subscriber);
       return new SubjectSubscription(this, subscriber);
     }
   }

--- a/src/SubjectSubscription.ts
+++ b/src/SubjectSubscription.ts
@@ -22,7 +22,7 @@ export class SubjectSubscription<T> extends Subscription {
     this.closed = true;
 
     const subject = this.subject;
-    const observers = subject.observers;
+    const observers = (subject as any)._observers;
 
     this.subject = null;
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR updates interface of `Subject`. I came to notice current Subject interface expose its properties too wide to public scope, any instance of Subject exposes state variables like `observers`, `isStopped` can be mutated. This PR limits those variables to inherited scope only, and expose it as readonly property.

It is certainly breaking change since anyone have used those property to change Subject's state now it won't work - but not sure how popular usecase it'll be. (and is it recommended pattern?) For now, I've targeted this into master until gets reviewed and approved.

BREAKING CHANGE: if there's code change state of Subject via publicly exposed properties, it won't work anymore

**Related issue (if exists):**
Related note, is it worth #2232 to add `Subject:hasObservers()` interface or should recommend to use `Subject::observers.length` and update migration guide?
