### PR TITLE
fix(Subscription): Limit Subscription::closed public accessibility to readonly

### DIFF
--- a/spec/observables/ScalarObservable-spec.ts
+++ b/spec/observables/ScalarObservable-spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import * as sinon from 'sinon';
 import * as Rx from '../../dist/cjs/Rx';
 import {ScalarObservable} from '../../dist/cjs/observable/ScalarObservable';
 
@@ -18,11 +19,14 @@ describe('ScalarObservable', () => {
   });
 
   it('should not schedule further if subscriber unsubscribed', () => {
-    const s = new ScalarObservable(1, rxTestScheduler);
+    const schedulerMock = sinon.stub(rxTestScheduler);
+    const s = new ScalarObservable(1, schedulerMock as any);
     const subscriber = new Rx.Subscriber();
     s.subscribe(subscriber);
-    subscriber.closed = true;
+    subscriber.unsubscribe();
     rxTestScheduler.flush();
+
+    expect((schedulerMock as any).schedule).calledOnce;
   });
 
   it('should set `_isScalar` to true when NOT called with a Scheduler', () => {

--- a/src/SubjectSubscription.ts
+++ b/src/SubjectSubscription.ts
@@ -8,9 +8,7 @@ import { Subscription } from './Subscription';
  * @extends {Ignored}
  */
 export class SubjectSubscription<T> extends Subscription {
-  closed: boolean = false;
-
-  constructor(public subject: Subject<T>, public subscriber: Observer<T>) {
+  constructor(private subject: Subject<T>, private subscriber: Observer<T>) {
     super();
   }
 
@@ -19,7 +17,7 @@ export class SubjectSubscription<T> extends Subscription {
       return;
     }
 
-    this.closed = true;
+    this._closed = true;
 
     const subject = this.subject;
     const observers = subject.observers;

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -13,7 +13,7 @@ export type TeardownLogic = AnonymousSubscription | Function | void;
 
 export interface ISubscription extends AnonymousSubscription {
   unsubscribe(): void;
-  closed: boolean;
+  readonly closed: boolean;
 }
 
 /**
@@ -30,15 +30,18 @@ export interface ISubscription extends AnonymousSubscription {
  */
 export class Subscription implements ISubscription {
   public static EMPTY: Subscription = (function(empty: any){
-    empty.closed = true;
+    empty._closed = true;
     return empty;
   }(new Subscription()));
 
+  protected _closed: boolean = false;
   /**
    * A flag to indicate whether this Subscription has already been unsubscribed.
    * @type {boolean}
    */
-  public closed: boolean = false;
+  public get closed(): boolean {
+    return this._closed;
+  }
 
   /**
    * @param {function(): void} [unsubscribe] A function describing how to
@@ -64,7 +67,7 @@ export class Subscription implements ISubscription {
       return;
     }
 
-    this.closed = true;
+    this._closed = true;
 
     const { _unsubscribe, _subscriptions } = (<any> this);
 

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -58,7 +58,7 @@ class RepeatSubscriber<T> extends Subscriber<T> {
       }
       this.unsubscribe();
       this.isStopped = false;
-      this.closed = false;
+      this._closed = false;
       source.subscribe(this);
     }
   }

--- a/src/operator/repeatWhen.ts
+++ b/src/operator/repeatWhen.ts
@@ -77,7 +77,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
       }
 
       this.unsubscribe();
-      this.closed = false;
+      this._closed = false;
 
       this.notifications = notifications;
       this.retries = retries;
@@ -111,7 +111,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
     this.unsubscribe();
     this.isStopped = false;
-    this.closed = false;
+    this._closed = false;
 
     this.notifications = notifications;
     this.retries = retries;

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -55,7 +55,7 @@ class RetrySubscriber<T> extends Subscriber<T> {
       }
       this.unsubscribe();
       this.isStopped = false;
-      this.closed = false;
+      this._closed = false;
       source.subscribe(this);
     }
   }

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -77,7 +77,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
       }
 
       this.unsubscribe();
-      this.closed = false;
+      this._closed = false;
 
       this.errors = errors;
       this.retries = retries;
@@ -111,7 +111,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
     this.unsubscribe();
     this.isStopped = false;
-    this.closed = false;
+    this._closed = false;
 
     this.errors = errors;
     this.retries = retries;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes the signature of `ISubscription::closed` to `readonly`. 
Currently, it is allowed to change state of `closed` as well as `unsubscribe()` but those two are causing different outcome by `unsubscribe` actually does necessary teardown for unsubscription, while `closed` flag only changes state flag. Instead, this PR explicitly makes given flag as getter only to read state, otherwise let use `unsubscribe()` if needed.

This is indeed breaking change if anyone has been using `closed` to control subscription state, it won't work anymore. For now, I have targeted this to master until gets reviewed and approved.

BREAKING CHANGE: Cannot change closed state without unsubscribe()

**Related issue (if exists):**
