### PR TITLE
test(testSchedulerUi): do not convert synchronous test to async test

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -1,4 +1,5 @@
 import {expect} from 'chai';
+import * as sinon from 'sinon';
 import * as Rx from '../dist/cjs/Rx';
 import {TeardownLogic} from '../dist/cjs/Subscription';
 
@@ -211,6 +212,9 @@ describe('Observable', () => {
     });
 
     it('should run unsubscription logic when an error is sent asynchronously and subscribe is called with no arguments', (done: MochaDone) => {
+      const sandbox = sinon.sandbox.create();
+      const fakeTimer = sandbox.useFakeTimers();
+
       let unsubscribeCalled = false;
       const source = new Observable((subscriber: Rx.Subscriber<string>) => {
         const id = setInterval(() => {
@@ -244,6 +248,9 @@ describe('Observable', () => {
           }
         }
       }, 100);
+
+      fakeTimer.tick(110);
+      sandbox.restore();
     });
 
     it('should return a Subscription that calls the unsubscribe function returned by the subscriber', () => {

--- a/spec/helpers/testScheduler-ui.ts
+++ b/spec/helpers/testScheduler-ui.ts
@@ -155,18 +155,14 @@ module.exports = function(suite) {
       let modified = fn;
 
       if (fn && fn.length === 0) {
-        modified = function (done: MochaDone) {
+        modified = function () {
           context.rxTestScheduler = new Rx.TestScheduler(observableMatcher);
-          let error: Error = null;
 
           try {
             fn();
             context.rxTestScheduler.flush();
-          } catch (e) {
-            error = e instanceof Error ? e : new Error(e);
           } finally {
             context.rxTestScheduler = null;
-            error ? done(error) : done();
           }
         };
       }

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -8,10 +8,9 @@ const ObjectUnsubscribedError = Rx.ObjectUnsubscribedError;
 
 /** @test {BehaviorSubject} */
 describe('BehaviorSubject', () => {
-  it('should extend Subject', (done: MochaDone) => {
+  it('should extend Subject', () => {
     const subject = new BehaviorSubject(null);
-    expect(subject instanceof Rx.Subject).to.be.true;
-    done();
+    expect(subject).to.be.instanceof(Rx.Subject);
   });
 
   it('should throw if it has received an error and getValue() is called', () => {

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -10,10 +10,9 @@ const Observable = Rx.Observable;
 
 /** @test {ReplaySubject} */
 describe('ReplaySubject', () => {
-  it('should extend Subject', (done: MochaDone) => {
+  it('should extend Subject', () => {
     const subject = new ReplaySubject();
-    expect(subject instanceof Rx.Subject).to.be.true;
-    done();
+    expect(subject).to.be.instanceof(Rx.Subject);
   });
 
   it('should add the observer before running subscription code', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR includes minor enhancements to `testSchedulerUi`, do not convert sync test to async unnecessarily. also converted some tests to sync, use fake timers to reduce test execution time where possible.

**Related issue (if exists):**
#1660