### PR TITLE
docs(tutorial): wrong keyboard event

### DIFF
--- a/doc/tutorial/basics.md
+++ b/doc/tutorial/basics.md
@@ -48,7 +48,7 @@ Which one you choose depends on the scenario. The normal **Observable** is great
 ## Controlling the flow
 ```js
 // typing "hello world"
-var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keyup');
+var input = Rx.Observable.fromEvent(document.querySelector('input'), 'input');
 
 // Filter out target values less than 3 characters long
 input.filter(event => event.target.value.length > 2)
@@ -79,7 +79,7 @@ input.takeUntil(stopStream)
 ## Producing values
 ```js
 // typing "hello world"
-var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keyup');
+var input = Rx.Observable.fromEvent(document.querySelector('input'), 'input');
 
 // Pass on a new value
 input.map(event => event.target.value)

--- a/doc/tutorial/basics.md
+++ b/doc/tutorial/basics.md
@@ -48,7 +48,7 @@ Which one you choose depends on the scenario. The normal **Observable** is great
 ## Controlling the flow
 ```js
 // typing "hello world"
-var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keypress');
+var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keyup');
 
 // Filter out target values less than 3 characters long
 input.filter(event => event.target.value.length > 2)
@@ -79,7 +79,7 @@ input.takeUntil(stopStream)
 ## Producing values
 ```js
 // typing "hello world"
-var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keypress');
+var input = Rx.Observable.fromEvent(document.querySelector('input'), 'keyup');
 
 // Pass on a new value
 input.map(event => event.target.value)


### PR DESCRIPTION
The `keypress` event is send before the value has been set on the input element : it always returns the last value of the element.
When `keyup` is send, the value has already been set on the input; returning the actual value.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
