### PR TITLE
build(global): enable aggressive closure optimization

### DIFF
--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
     "ghooks": "^1.3.2",
     "glob": "^7.0.3",
     "gm": "^1.22.0",
-    "google-closure-compiler-js": "^20160916.0.0",
+    "google-closure-compiler-js": "^20161201.0.0",
     "gzip-size": "^3.0.0",
     "http-server": "^0.9.0",
     "lint-staged": "^3.1.0",

--- a/tools/make-closure-core.js
+++ b/tools/make-closure-core.js
@@ -7,6 +7,7 @@ var compilerFlags = {
   jsCode: [{src: source}],
   languageIn: 'ES5',
   createSourceMap: true,
+  compilationLevel: 'ADVANCED'
 };
 
 var output = compiler(compilerFlags);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR enables 'ADVANCED' optimization in closure compiler to generate more compressed minified global build. 

Size comparsion:
![image](https://cloud.githubusercontent.com/assets/1210596/21594748/166c63d0-d0db-11e6-9cb2-d547c0f1fdc2.png)

gain around ~30kb of more compression.

I'm marking it as **BLOCKED** - cause there isn't reliable way to validate regressions of this optimization. I have filed related issue https://github.com/ReactiveX/rxjs/issues/2229, which'll allow to test global builds correctly on browsers.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/2229
https://github.com/ReactiveX/rxjs/pull/2227
https://github.com/ReactiveX/rxjs/pull/2225