### PR TITLE
feat(operator): add 'fart' operator

### DIFF
--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -10,6 +10,9 @@ children:
       - label: to be a value calculated through a formula
         children:
         - label: map
+      - label: to be a fart
+        children:
+        - label: fart
     - label: I want to pick a property off each emitted value
       children:
       - label: pluck

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -141,6 +141,7 @@ There are operators for different purposes, and they may be categorized as: crea
 - [`concatMapTo`](../class/es6/Observable.js~Observable.html#instance-method-concatMapTo)
 - [`exhaustMap`](../class/es6/Observable.js~Observable.html#instance-method-exhaustMap)
 - [`expand`](../class/es6/Observable.js~Observable.html#instance-method-expand)
+- [`fart`](../class/es6/Observable.js~Observable.html#instance-method-fart)
 - [`groupBy`](../class/es6/Observable.js~Observable.html#instance-method-groupBy)
 - [`map`](../class/es6/Observable.js~Observable.html#instance-method-map)
 - [`mapTo`](../class/es6/Observable.js~Observable.html#instance-method-mapTo)

--- a/spec/operators/fart-spec.ts
+++ b/spec/operators/fart-spec.ts
@@ -1,0 +1,102 @@
+import {expect} from 'chai';
+import * as Rx from '../../dist/cjs/Rx';
+declare const {hot, cold, asDiagram, expectObservable, expectSubscriptions};
+
+const Observable = Rx.Observable;
+
+// function shortcuts
+const throwError = function () { throw new Error(); };
+
+/** @test {fart} */
+describe('Observable.prototype.fart', () => {
+  asDiagram('fart()')('should map multiple values', () => {
+    const a =   cold('--11--22--33--|');
+    const asubs =    '^          !';
+    const expected = '--💩💨--💩💨--💩💨--|';
+
+    expectObservable(a.fart()).toBe(expected);
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
+  it('should map one value', () => {
+    const a =   cold('--77--|');
+    const asubs =    '^    !';
+    const expected = '--💩💨--|';
+
+    expectObservable(a.fart()).toBe(expected);
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
+  it('should allow unsubscribing explicitly and early', () => {
+    const a =   cold('--11--22--33--|');
+    const unsub =    '      !     ';
+    const asubs =    '^     !     ';
+    const expected = '--💩💨--💩💨-     ';
+
+    expectObservable(a.fart(), unsub).toBe(expected);
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
+  it('should propagate errors from observable that emits only errors', () => {
+    const a =   cold('--#', null, 'too bad');
+    const asubs =    '^ !';
+    const expected = '--#';
+
+    expectObservable(a.fart()).toBe(expected, null, 'too bad');
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
+  it('should propagate errors from observable that emit values', () => {
+    const a =   cold('--11--22--#', undefined, 'too bad');
+    const asubs =    '^       !';
+    const expected = '--💩💨--💩💨--#';
+
+    expectObservable(a.fart()).toBe(expected, undefined, 'too bad');
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
+  it('should propagate errors from subscribe', () => {
+    const r = () => {
+      Observable.of(1)
+        .fart()
+        .subscribe(throwError);
+    };
+
+    expect(r).to.throw();
+  });
+
+  it('should not map an empty observable', () => {
+    const a =   cold('|');
+    const asubs =    '(^!)';
+    const expected = '|';
+
+    expectObservable(a.fart()).toBe(expected);
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
+  it('should map twice', () => {
+    const a = hot('-00----11-^-22---33--44-55--66--77-88-|');
+    const asubs =         '^                    !';
+    const expected =      '--💩💨---💩💨--💩💨-💩💨--💩💨--💩💨-💩💨-|';
+
+    const r = a.fart().fart();
+
+    expectObservable(r).toBe(expected);
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
+  it('should not break unsubscription chain when unsubscribed explicitly', () => {
+    const a =   cold('--11--22--33--|');
+    const unsub =    '      !     ';
+    const asubs =    '^     !     ';
+    const expected = '--💩💨--💩💨-     ';
+
+    const r = a
+      .mergeMap((x: string) => Observable.of(x))
+      .fart()
+      .mergeMap((x: string) => Observable.of(x));
+
+    expectObservable(r, unsub).toBe(expected);
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -66,6 +66,7 @@ import './add/operator/exhaust';
 import './add/operator/exhaustMap';
 import './add/operator/expand';
 import './add/operator/elementAt';
+import './add/operator/fart';
 import './add/operator/filter';
 import './add/operator/finally';
 import './add/operator/find';

--- a/src/add/operator/fart.ts
+++ b/src/add/operator/fart.ts
@@ -1,0 +1,11 @@
+
+import { Observable } from '../../Observable';
+import { fart } from '../../operator/fart';
+
+Observable.prototype.fart = fart;
+
+declare module '../../Observable' {
+  interface Observable<T> {
+    fart: typeof fart;
+  }
+}

--- a/src/operator/fart.ts
+++ b/src/operator/fart.ts
@@ -1,0 +1,51 @@
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Observable } from '../Observable';
+
+/**
+ * Emits gas on the output Observable every time the source
+ * Observable emits a value.
+ *
+ * <span class="informal">Like {@link map}, but it maps every source value to
+ * the same predefined output value every time.</span>
+ *
+ * <img src="./img/fart.png" width="100%">
+ *
+ * Takes no arguments, and emits a fart emoji whenever the source
+ * Observable emits a value. In other words, ignores the actual source value,
+ * and simply uses the emission moment to know when to pass gas.
+ *
+ * @example <caption>Map every every click to a fart</caption>
+ * var clicks = Rx.Observable.fromEvent(document, 'click');
+ * var greetings = clicks.fart();
+ * greetings.subscribe(x => console.log(x));
+ *
+ * @see {@link map}
+ *
+ * @return {Observable} An Observable that emits gas every time
+ * the source Observable emits something.
+ * @method fart
+ * @owner Observable
+ */
+export function fart<T>(this: Observable<T>): Observable<string> {
+  return this.lift(new FartOperator());
+}
+
+class FartOperator<T> implements Operator<T, string> {
+
+  call(subscriber: Subscriber<string>, source: any): any {
+    return source.subscribe(new FartSubscriber(subscriber));
+  }
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
+class FartSubscriber<T> extends Subscriber<T> {
+
+  protected _next(x: T) {
+    this.destination.next('💩💨');
+  }
+}


### PR DESCRIPTION
**Description:**
First of all, I'm sorry. This is all @ladyleet's fault: https://twitter.com/ladyleet/status/816416159247593473

Adds the "fart" operator.

The tests *should* be passing but either jasmine or some function in between doesn't like the Unicode emoji, for some weird reason. And yes, "weird" is certainly a debatable term in the context of this PR.

Checklist:
- [x] Add the operator to Rx
- [x] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [x] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [x] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [x] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [x] The operator should be listed in `doc/operators.md` in a category of operators
- [x] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`


P.S.: I don't actually expect you to merge this PR but I figured if I was going to do it, I'd better do it right.