### PR TITLE
Observe on leak

### DIFF
--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -112,15 +112,19 @@ describe('Subscription', () => {
       expect(isCalled).to.equal(true);
     });
 
-    it('Should returns the passed one if passed a unsubscribed AnonymousSubscription', () => {
-      const sub = new Subscription();
+    it('Should wrap the AnonymousSubscription and return a subscription that unsubscribes and removes it when unsubbed', () => {
+      const sub: any = new Subscription();
+      let called = false;
       const arg = {
-        isUnsubscribed: true,
-        unsubscribe: () => undefined,
+        unsubscribe: () => called = true,
       };
       const ret = sub.add(arg);
 
-      expect(ret).to.equal(arg);
+      expect(called).to.equal(false);
+      expect(sub._subscriptions.length).to.equal(1);
+      ret.unsubscribe();
+      expect(called).to.equal(true);
+      expect(sub._subscriptions.length).to.equal(0);
     });
 
     it('Should returns the passed one if passed a AnonymousSubscription having not function `unsubscribe` member', () => {

--- a/spec/operators/observeOn-spec.ts
+++ b/spec/operators/observeOn-spec.ts
@@ -1,4 +1,6 @@
 import * as Rx from '../../dist/cjs/Rx';
+import { expect } from 'chai';
+
 declare const {hot, asDiagram, expectObservable, expectSubscriptions};
 
 declare const rxTestScheduler: Rx.TestScheduler;
@@ -76,5 +78,47 @@ describe('Observable.prototype.observeOn', () => {
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
+  });
+
+  it('should clean up subscriptions created by async scheduling (prevent memory leaks #2244)', (done) => {
+    //HACK: Deep introspection to make sure we're cleaning up notifications in scheduling.
+    // as the architecture changes, this test may become brittle.
+    const results = [];
+    const subscription: any = new Observable(observer => {
+      let i = 1;
+      const id = setInterval(() => {
+        if (i > 3) {
+          observer.complete();
+        } else {
+          observer.next(i++);
+        }
+      }, 0);
+
+      return () => clearInterval(id);
+    })
+      .observeOn(Rx.Scheduler.asap)
+      .subscribe(
+        x => {
+          const observeOnSubscriber = subscription._subscriptions[0]._innerSub;
+          expect(observeOnSubscriber._subscriptions.length).to.equal(2); // 1 for the consumer, and one for the notification
+          expect(observeOnSubscriber._subscriptions[1]._innerSub.state.notification.kind)
+            .to.equal('N');
+          expect(observeOnSubscriber._subscriptions[1]._innerSub.state.notification.value)
+            .to.equal(x);
+          results.push(x);
+        },
+        err => done(err),
+        () => {
+          // now that the last nexted value is done, there should only be a complete notification scheduled
+          const observeOnSubscriber = subscription._subscriptions[0]._innerSub;
+          expect(observeOnSubscriber._subscriptions.length).to.equal(2); // 1 for the consumer, one for the complete notification
+          // only this completion notification should remain.
+          expect(observeOnSubscriber._subscriptions[1]._innerSub.state.notification.kind)
+            .to.equal('C');
+          // After completion, the entire _subscriptions list is nulled out anyhow, so we can't test much further than this.
+          expect(results).to.deep.equal([1, 2, 3]);
+          done();
+        }
+      );
   });
 });

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -58,6 +58,10 @@ export class VirtualAction<T> extends AsyncAction<T> {
       return super.schedule(state, delay);
     }
 
+    // If an action is rescheduled, we save allocations by mutating its state,
+    // pushing it to the end of the scheduler queue, and recycling the action.
+    // But since the VirtualTimeScheduler is used for testing, VirtualActions
+    // must be immutable so they can be inspected later.
     const action = new VirtualAction(this.scheduler, this.work);
     this.add(action);
     return action.schedule(state, delay);

--- a/src/scheduler/VirtualTimeScheduler.ts
+++ b/src/scheduler/VirtualTimeScheduler.ts
@@ -54,15 +54,13 @@ export class VirtualAction<T> extends AsyncAction<T> {
   }
 
   public schedule(state?: T, delay: number = 0): Subscription {
-    return !this.id ?
-      super.schedule(state, delay) : (
-      // If an action is rescheduled, we save allocations by mutating its state,
-      // pushing it to the end of the scheduler queue, and recycling the action.
-      // But since the VirtualTimeScheduler is used for testing, VirtualActions
-      // must be immutable so they can be inspected later.
-      <VirtualAction<T>> this.add(
-        new VirtualAction<T>(this.scheduler, this.work))
-      ).schedule(state, delay);
+    if (!this.id) {
+      return super.schedule(state, delay);
+    }
+
+    const action = new VirtualAction(this.scheduler, this.work);
+    this.add(action);
+    return action.schedule(state, delay);
   }
 
   protected requestAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay: number = 0): any {


### PR DESCRIPTION
- ensures child subscriptions created via `Subscription.prototype.add` remove themselves from the internal subscriptions list.
- ensures scheduled notifications from observeOn remove themselves from the subscription by calling unsubscribe on themselves.

fixes #2244
