### PR TITLE
fix(ISubscription): update type definition of ISubscription::closed

### DIFF
--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -13,7 +13,7 @@ export type TeardownLogic = AnonymousSubscription | Function | void;
 
 export interface ISubscription extends AnonymousSubscription {
   unsubscribe(): void;
-  closed: boolean;
+  readonly closed: boolean;
 }
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Originated from https://github.com/ReactiveX/rxjs/pull/2234, doesn't add any code changes but only update type definition for interface clarity. 

Currently it's not so benefitable even for TS user since all of codebase just return `Subscription` everywhere instead of using interfaces, that need to be dealt with separate refactoring.

**Related issue (if exists):**
#2234
