### PR TITLE
chore(package.json): auto fix possible lint errors when commit

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,8 +13,8 @@
     }
   },
   "lint-staged": {
-    "eslint": "*.@(js)",
-    "tslint": "*.@(ts)"
+    "*.@(js)": ["eslint --fix", "git add"],
+    "*.@(ts)": ["tslint --fix", "git add"]
   },
   "scripts-info": {
     "info": "List available script",
@@ -80,8 +80,8 @@
     "doctoc": "doctoc CONTRIBUTING.md",
     "generate_packages": "node .make-packages.js",
     "lint_perf": "eslint perf/",
-    "lint_spec": "tslint -c tslint.json spec/*.ts spec/**/*.ts spec/**/**/*.ts",
-    "lint_src": "tslint -c tslint.json src/*.ts src/**/*.ts src/**/**/*.ts",
+    "lint_spec": "tslint -c tslint.json \"spec/**/*.ts\"",
+    "lint_src": "tslint -c tslint.json \"src/**/*.ts\"",
     "lint_staged": "lint-staged",
     "lint": "npm-run-all --parallel lint_*",
     "perf": "protractor protractor.conf.js",
@@ -163,7 +163,7 @@
     "google-closure-compiler-js": "^20160916.0.0",
     "gzip-size": "^3.0.0",
     "http-server": "^0.9.0",
-    "lint-staged": "^3.1.0",
+    "lint-staged": "^3.2.5",
     "lodash": "^4.15.0",
     "madge": "^1.4.3",
     "markdown-doctest": "^0.8.1",
@@ -185,7 +185,7 @@
     "sinon-chai": "^2.8.0",
     "source-map-support": "^0.4.0",
     "tslib": "^1.0.0",
-    "tslint": "^3.15.1",
+    "tslint": "^4.2.0",
     "typescript": "~2.0.6",
     "typings": "^2.0.0",
     "validate-commit-msg": "^2.3.1",

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -55,7 +55,7 @@ export class Observable<T> implements Subscribable<T> {
    */
   static create: Function = <T>(subscribe?: <R>(subscriber: Subscriber<R>) => TeardownLogic) => {
     return new Observable<T>(subscribe);
-  };
+  }
 
   /**
    * Creates a new Observable, with this Observable as the source, and the passed

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -41,7 +41,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
-  };
+  }
 
   lift<R>(operator: Operator<T, R>): Observable<T> {
     const subject = new AnonymousSubject(this, this);

--- a/src/util/errorObject.ts
+++ b/src/util/errorObject.ts
@@ -1,2 +1,2 @@
 // typeof any so that it we don't have to cast when comparing a result to the error object
-export var errorObject: any = { e: {} };
+export const errorObject: any = { e: {} };

--- a/tslint.json
+++ b/tslint.json
@@ -8,9 +8,7 @@
     "max-line-length": [true, 150],
     "no-consecutive-blank-lines": true,
     "no-trailing-whitespace": true,
-    "no-duplicate-key": true,
     "no-duplicate-variable": true,
-    "no-unreachable": true,
     "no-var-keyword": true,
     "no-empty": true,
     "no-unused-expression": true,
@@ -25,7 +23,7 @@
     "quotemark": [true,
       "single",
       "avoid-escape"],
-    "semicolon": true,
+    "semicolon": [true, "always"],
     "typedef-whitespace": [true, {
       "call-signature": "nospace",
       "index-signature": "nospace",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Small ergonomics enhancement for linting, now it'll fix possible errors automatically when try to commit.

**Related issue (if exists):**
