### PR TITLE
Add sample/sampleTime operator split

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -243,6 +243,15 @@ To reduce polymorphism and get better performance out of operators, some operato
       <td><code>timeout(dueTime: number | Date, other?: Observable | Promise, scheduler?: Scheduler)</code></td>
       <td><code>timeoutWith(due: number | Date, withObservable: ObservableInput, scheduler: Scheduler)</code></td>
     </tr>
+    <tr>
+      <td rowspan="2"><code>sample</code></td>
+      <td><code>sample(interval: number, scheduler?: Scheduler)</code></td>
+      <td><code>sampleTime(interval: number, scheduler?: Scheduler)</code></td>
+    </tr>
+    <tr>
+      <td><code>sample(notifier: Observable)</code></td>
+      <td><code>sample(notifier: Observable)</code></td>
+    </tr>
   </tbody>
 </table>
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
When using a number interval, we must now use `sampleTime` instead of `sample`. This was not specified in the document.

**Related issue (if exists):**
