### PR TITLE
chore(lgtm): remove .lgtm

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 1
-pattern = "(?i):shipit:|:\\+1:|LGTM"


### PR DESCRIPTION
the LGTM service we use as an approval system has been discontinued and no longer works, so we can't merge PRs. This PR removes the .lgtm config file, but I believe @blesh will have to remove it from our status checks in the admin Settings to unblock us.

https://lgtm.co