### PR TITLE
fix(combineLatest): When the first argument to combineLatest is an array, clone it before modifying it, so we don't mutate the array passed by the caller

### DIFF
--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -79,7 +79,7 @@ export function combineLatest<T, R>(this: Observable<T>, ...observables: Array<O
   // if the first and only other argument besides the resultSelector is an array
   // assume it's been called with `combineLatest([obs1, obs2, obs3], project)`
   if (observables.length === 1 && isArray(observables[0])) {
-    observables = <any>observables[0];
+    observables = <any>observables[0].slice();
   }
 
   observables.unshift(this);


### PR DESCRIPTION
**Description:**

`combineLatest` was mutating the array of observables passed to it. This is a very simple fix to clone the array before modifying it.

See this codepen for example of the problem: https://codepen.io/anon/pen/qRNBVJ?editors=1111