### PR TITLE
refactor(windowTime): clarify type definition of windowTime

### DIFF
--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -83,13 +83,30 @@ interface CreationState<T> {
   scheduler: IScheduler;
 }
 
+interface TimeSpanOnlyState<T> {
+    window: Subject<T>;
+    windowTimeSpan: number;
+    subscriber: WindowTimeSubscriber<T>;
+  }
+
+interface CloseWindowContext<T> {
+  action: Action<CreationState<T>>;
+  subscription: Subscription;
+}
+
+interface CloseState<T> {
+  subscriber: WindowTimeSubscriber<T>;
+  window: Subject<T>;
+  context: CloseWindowContext<T>;
+}
+
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @ignore
  * @extends {Ignored}
  */
 class WindowTimeSubscriber<T> extends Subscriber<T> {
-  private windows: Subject<T>[] = [];
+  private windows: Array<Subject<T>> = [];
 
   constructor(protected destination: Subscriber<Observable<T>>,
               private windowTimeSpan: number,
@@ -98,18 +115,18 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     super(destination);
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
       let window = this.openWindow();
-      const closeState = { subscriber: this, window, context: <any>null };
+      const closeState: CloseState<T> = { subscriber: this, window, context: <any>null };
       const creationState: CreationState<T> = { windowTimeSpan, windowCreationInterval, subscriber: this, scheduler };
       this.add(scheduler.schedule(dispatchWindowClose, windowTimeSpan, closeState));
       this.add(scheduler.schedule(dispatchWindowCreation, windowCreationInterval, creationState));
     } else {
       let window = this.openWindow();
-      const timeSpanOnlyState = { subscriber: this, window, windowTimeSpan };
+      const timeSpanOnlyState: TimeSpanOnlyState<T> = { subscriber: this, window, windowTimeSpan };
       this.add(scheduler.schedule(dispatchWindowTimeSpanOnly, windowTimeSpan, timeSpanOnlyState));
     }
   }
 
-  protected _next(value: T) {
+  protected _next(value: T): void {
     const windows = this.windows;
     const len = windows.length;
     for (let i = 0; i < len; i++) {
@@ -120,7 +137,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  protected _error(err: any) {
+  protected _error(err: any): void {
     const windows = this.windows;
     while (windows.length > 0) {
       windows.shift().error(err);
@@ -128,7 +145,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     this.destination.error(err);
   }
 
-  protected _complete() {
+  protected _complete(): void {
     const windows = this.windows;
     while (windows.length > 0) {
       const window = windows.shift();
@@ -139,7 +156,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     this.destination.complete();
   }
 
-  openWindow(): Subject<T> {
+  public openWindow(): Subject<T> {
     const window = new Subject<T>();
     this.windows.push(window);
     const destination = this.destination;
@@ -147,20 +164,14 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     return window;
   }
 
-  closeWindow(window: Subject<T>) {
+  public closeWindow(window: Subject<T>): void {
     window.complete();
     const windows = this.windows;
     windows.splice(windows.indexOf(window), 1);
   }
 }
 
-interface TimeSpanOnlyState<T> {
-  window: Subject<any>;
-  windowTimeSpan: number;
-  subscriber: WindowTimeSubscriber<T>;
-}
-
-function dispatchWindowTimeSpanOnly<T>(this: Action<TimeSpanOnlyState<T>>, state: TimeSpanOnlyState<T>) {
+function dispatchWindowTimeSpanOnly<T>(this: Action<TimeSpanOnlyState<T>>, state: TimeSpanOnlyState<T>): void {
   const { subscriber, windowTimeSpan, window } = state;
   if (window) {
     window.complete();
@@ -169,30 +180,19 @@ function dispatchWindowTimeSpanOnly<T>(this: Action<TimeSpanOnlyState<T>>, state
   this.schedule(state, windowTimeSpan);
 }
 
-interface Context<T> {
-  action: Action<CreationState<T>>;
-  subscription: Subscription;
-}
-
-interface DispatchArg<T> {
-  subscriber: WindowTimeSubscriber<T>;
-  window: Subject<T>;
-  context: Context<T>;
-}
-
-function dispatchWindowCreation<T>(this: Action<CreationState<T>>, state: CreationState<T>) {
-  let { windowTimeSpan, subscriber, scheduler, windowCreationInterval } = state;
-  let window = subscriber.openWindow();
-  let action = this;
-  let context: Context<T> = { action, subscription: <any>null };
-  const timeSpanState: DispatchArg<T> = { subscriber, window, context };
+function dispatchWindowCreation<T>(this: Action<CreationState<T>>, state: CreationState<T>): void {
+  const { windowTimeSpan, subscriber, scheduler, windowCreationInterval } = state;
+  const window = subscriber.openWindow();
+  const action = this;
+  let context: CloseWindowContext<T> = { action, subscription: <any>null };
+  const timeSpanState: CloseState<T> = { subscriber, window, context };
   context.subscription = scheduler.schedule(dispatchWindowClose, windowTimeSpan, timeSpanState);
   action.add(context.subscription);
   action.schedule(state, windowCreationInterval);
 }
 
-function dispatchWindowClose<T>(arg: DispatchArg<T>) {
-  const { subscriber, window, context } = arg;
+function dispatchWindowClose<T>(state: CloseState<T>): void {
+  const { subscriber, window, context } = state;
   if (context && context.action && context.subscription) {
     context.action.remove(context.subscription);
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR separates https://github.com/ReactiveX/rxjs/pull/2240 , refactor type definition around windowTime to have better clarity.

**Related issue (if exists):**
