### PR TITLE
fix(windowTime): clean up closed window with timeSpanOnly

### DIFF
--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -113,14 +113,14 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
               private windowCreationInterval: number,
               private scheduler: IScheduler) {
     super(destination);
+
+    const window = this.openWindow();
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
-      let window = this.openWindow();
       const closeState: CloseState<T> = { subscriber: this, window, context: <any>null };
       const creationState: CreationState<T> = { windowTimeSpan, windowCreationInterval, subscriber: this, scheduler };
       this.add(scheduler.schedule(dispatchWindowClose, windowTimeSpan, closeState));
       this.add(scheduler.schedule(dispatchWindowCreation, windowCreationInterval, creationState));
     } else {
-      let window = this.openWindow();
       const timeSpanOnlyState: TimeSpanOnlyState<T> = { subscriber: this, window, windowTimeSpan };
       this.add(scheduler.schedule(dispatchWindowTimeSpanOnly, windowTimeSpan, timeSpanOnlyState));
     }
@@ -174,7 +174,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
 function dispatchWindowTimeSpanOnly<T>(this: Action<TimeSpanOnlyState<T>>, state: TimeSpanOnlyState<T>): void {
   const { subscriber, windowTimeSpan, window } = state;
   if (window) {
-    window.complete();
+    subscriber.closeWindow(window);
   }
   state.window = subscriber.openWindow();
   this.schedule(state, windowTimeSpan);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR separates https://github.com/ReactiveX/rxjs/pull/2240, updates clear up closed instance of window to when invoked via timespan only.

**Related issue (if exists):**
