### PR TITLE
refactor(Subject): introduce interface to Subject

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -36,7 +36,7 @@ describe('Subject', () => {
       expect(x).to.equal(expected[j++]);
     }, null, done);
 
-    expect(subject.observers.length).to.equal(2);
+    expect((subject as any).observers.length).to.equal(2);
     subject.next('foo');
     subject.next('bar');
     subject.complete();
@@ -296,11 +296,11 @@ describe('Subject', () => {
       //noop
     });
 
-    expect(subject.observers.length).to.equal(2);
+    expect((subject as any).observers.length).to.equal(2);
     sub1.unsubscribe();
-    expect(subject.observers.length).to.equal(1);
+    expect((subject as any).observers.length).to.equal(1);
     sub2.unsubscribe();
-    expect(subject.observers.length).to.equal(0);
+    expect((subject as any).observers.length).to.equal(0);
     done();
   });
 

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -537,7 +537,7 @@ describe('Observable.prototype.multicast', () => {
     });
 
     source.connect();
-    expect(subject.observers.length).to.equal(0);
+    expect((subject as any).observers.length).to.equal(0);
   });
 
   describe('when given a subject factory', () => {

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -87,7 +87,7 @@ describe('BehaviorSubject', () => {
       expect(x).to.equal(expected[j++]);
     }, null, done);
 
-    expect(subject.observers.length).to.equal(2);
+    expect((subject as any).observers.length).to.equal(2);
     subject.next('foo');
     subject.next('bar');
     subject.complete();
@@ -123,11 +123,11 @@ describe('BehaviorSubject', () => {
       expect(x).to.equal('init');
     });
 
-    expect(subject.observers.length).to.equal(2);
+    expect((subject as any).observers.length).to.equal(2);
     sub1.unsubscribe();
-    expect(subject.observers.length).to.equal(1);
+    expect((subject as any).observers.length).to.equal(1);
     sub2.unsubscribe();
-    expect(subject.observers.length).to.equal(0);
+    expect((subject as any).observers.length).to.equal(0);
     done();
   });
 

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -16,40 +16,41 @@ export class SubjectSubscriber<T> extends Subscriber<T> {
   }
 }
 
+export interface ISubject<T> extends ISubscription, Observable<T>, Observer<T> {
+  readonly closed: boolean;
+  asObservable(): Observable<T>;
+}
+
 /**
  * @class Subject<T>
  */
-export class Subject<T> extends Observable<T> implements ISubscription {
+export class Subject<T> extends Observable<T> implements ISubject<T> {
 
   [$$rxSubscriber]() {
     return new SubjectSubscriber(this);
   }
 
-  observers: Observer<T>[] = [];
-
+  protected observers: Observer<T>[] = [];
+  protected isStopped = false;
+  protected hasError = false;
+  protected thrownError: any = null;
   closed = false;
-
-  isStopped = false;
-
-  hasError = false;
-
-  thrownError: any = null;
 
   constructor() {
     super();
   }
 
-  static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
+  static create: Function = <T>(destination: Observer<T>, source: Observable<T>): ISubject<T> => {
     return new AnonymousSubject<T>(destination, source);
   }
 
-  lift<R>(operator: Operator<T, R>): Observable<T> {
+  public lift<R>(operator: Operator<T, R>): Observable<T> {
     const subject = new AnonymousSubject(this, this);
     subject.operator = <any>operator;
     return <any>subject;
   }
 
-  next(value?: T) {
+  public next(value?: T): void {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     }
@@ -63,7 +64,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     }
   }
 
-  error(err: any) {
+  public error(err: any): void {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     }
@@ -79,7 +80,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     this.observers.length = 0;
   }
 
-  complete() {
+  public complete(): void {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     }
@@ -93,7 +94,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     this.observers.length = 0;
   }
 
-  unsubscribe() {
+  public unsubscribe(): void {
     this.isStopped = true;
     this.closed = true;
     this.observers = null;
@@ -114,7 +115,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     }
   }
 
-  asObservable(): Observable<T> {
+  public asObservable(): Observable<T> {
     const observable = new Observable<T>();
     (<any>observable).source = this;
     return observable;
@@ -130,21 +131,21 @@ export class AnonymousSubject<T> extends Subject<T> {
     this.source = source;
   }
 
-  next(value: T) {
+  public next(value: T): void {
     const { destination } = this;
     if (destination && destination.next) {
       destination.next(value);
     }
   }
 
-  error(err: any) {
+  public error(err: any): void {
     const { destination } = this;
     if (destination && destination.error) {
       this.destination.error(err);
     }
   }
 
-  complete() {
+  public complete(): void {
     const { destination } = this;
     if (destination && destination.complete) {
       this.destination.complete();

--- a/src/SubjectSubscription.ts
+++ b/src/SubjectSubscription.ts
@@ -22,11 +22,11 @@ export class SubjectSubscription<T> extends Subscription {
     this.closed = true;
 
     const subject = this.subject;
-    const observers = subject.observers;
+    const observers = (subject as any).observers; //accessing protected members, escape types
 
     this.subject = null;
 
-    if (!observers || observers.length === 0 || subject.isStopped || subject.closed) {
+    if (!observers || observers.length === 0 || (subject as any).isStopped || subject.closed) {
       return;
     }
 

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -24,7 +24,7 @@ export class ConnectableObservable<T> extends Observable<T> {
 
   protected getSubject(): Subject<T> {
     const subject = this._subject;
-    if (!subject || subject.isStopped) {
+    if (!subject || (subject as any).isStopped) {
       this._subject = this.subjectFactory();
     }
     return this._subject;

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -220,7 +220,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     subscription.add(this._output.subscribe(subscriber));
     subscription.add(() => {
       const { socket } = this;
-      if (this._output.observers.length === 0) {
+      if ((this._output as any).observers.length === 0) {
         if (socket && socket.readyState === 1) {
           socket.close();
         }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR enhances type definition of `subject` separated from https://github.com/ReactiveX/rxjs/pull/2233, similar to https://github.com/ReactiveX/rxjs/pull/2249.

This change introduces new interface `ISubject<T>` have more clear type definition regarding its properties, and let static creation method returns interface instead of actual implementation type.

**Related issue (if exists):**
