### PR TITLE
fix(AsyncSubject) some cases don't behave correctly

### DIFF
--- a/spec/subjects/AsyncSubject-spec.ts
+++ b/spec/subjects/AsyncSubject-spec.ts
@@ -133,6 +133,9 @@ describe('AsyncSubject', () => {
 
     subscription.unsubscribe();
     observer.results = [];
+
+    subject.error(new Error(''));
+
     subject.subscribe(observer);
     expect(observer.results).to.deep.equal(['done']);
   });

--- a/spec/subjects/AsyncSubject-spec.ts
+++ b/spec/subjects/AsyncSubject-spec.ts
@@ -168,4 +168,25 @@ describe('AsyncSubject', () => {
     subject.subscribe(observer);
     expect(observer.results).to.deep.equal([expected]);
   });
+
+  it('should not allow send complete after error', () => {
+    const expected = new Error('bad');
+    const subject = new AsyncSubject();
+    const observer = new TestObserver();
+    const subscription = subject.subscribe(observer);
+
+    subject.next(1);
+    expect(observer.results).to.deep.equal([]);
+
+    subject.error(expected);
+    expect(observer.results).to.deep.equal([expected]);
+
+    subscription.unsubscribe();
+
+    observer.results = [];
+
+    subject.complete();
+    subject.subscribe(observer);
+    expect(observer.results).to.deep.equal([expected]);
+  });
 });

--- a/src/AsyncSubject.ts
+++ b/src/AsyncSubject.ts
@@ -29,6 +29,12 @@ export class AsyncSubject<T> extends Subject<T> {
     }
   }
 
+  error(error: any): void {
+    if (!this.hasCompleted) {
+      super.error(error);
+    }
+  }
+
   complete(): void {
     this.hasCompleted = true;
     if (this.hasNext) {

--- a/src/AsyncSubject.ts
+++ b/src/AsyncSubject.ts
@@ -11,15 +11,14 @@ export class AsyncSubject<T> extends Subject<T> {
   private hasCompleted: boolean = false;
 
   protected _subscribe(subscriber: Subscriber<any>): Subscription {
-    if (this.hasCompleted && this.hasNext) {
+    if (this.hasError) {
+      subscriber.error(this.thrownError);
+      return Subscription.EMPTY;
+    } else if (this.hasCompleted && this.hasNext) {
       subscriber.next(this.value);
       subscriber.complete();
       return Subscription.EMPTY;
-    } else if (this.hasError) {
-      subscriber.error(this.thrownError);
-      return Subscription.EMPTY;
     }
-
     return super._subscribe(subscriber);
   }
 


### PR DESCRIPTION
**Description:**
I think It can be some wrong behaviours in the current AsyncSubject:

- AsyncSubject can emit complete event after the subject has finished with an error
- AsyncSubject can emit an error event after the subject is completed

 This PR fixes that wrong cases.

If this is the intended behaviour please let me know, I check the http://reactivex.io/documentation/subject.html web and other implementations first.

I hope this will be helpful :)

**Related issue (if exists):**
