### PR TITLE
docs(count): fix typo

### DIFF
--- a/src/operator/count.ts
+++ b/src/operator/count.ts
@@ -15,7 +15,7 @@ import { Subscriber } from '../Subscriber';
  * `count` transforms an Observable that emits values into an Observable that
  * emits a single value that represents the number of values emitted by the
  * source Observable. If the source Observable terminates with an error, `count`
- * will pass this error notification along without emitting an value first. If
+ * will pass this error notification along without emitting a value first. If
  * the source Observable does not terminate at all, `count` will neither emit
  * a value nor terminate. This operator takes an optional `predicate` function
  * as argument, in which case the output emission will represent the number of


### PR DESCRIPTION
**Description:**

Fix a typo ("an value" --> "a value").
