### PR TITLE
docs(single): add missing param name

### DIFF
--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -14,7 +14,7 @@ import { TeardownLogic } from '../Subscription';
  *
  * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
- * @param {Function} a predicate function to evaluate items emitted by the source Observable.
+ * @param {Function} predicate A predicate function to evaluate items emitted by the source Observable.
  * @return {Observable<T>} an Observable that emits the single item emitted by the source Observable that matches
  * the predicate.
  .


### PR DESCRIPTION
**Description:**
Add missing param name (and fix casing).