### PR TITLE
docs(site): reword the landing description for post-release

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -2,7 +2,7 @@
 
 **The ReactiveX library for JavaScript.**
 
-This is a rewrite of [Reactive-Extensions/RxJS](https://github.com/Reactive-Extensions/RxJS) and is intended to supersede it once this is ready. This version's purpose is to have better performance, better modularity, better debuggable call stacks, while staying mostly backwards compatible, with some breaking changes that reduce the API surface.
+RxJS is a library for reactive programming using Observables, to make it easier to compose asynchronous or callback-based code. This project is a rewrite of [Reactive-Extensions/RxJS](https://github.com/Reactive-Extensions/RxJS) with better performance, better modularity, better debuggable call stacks, while staying mostly backwards compatible, with some breaking changes that reduce the API surface.
 
 ### [» Install it](./manual/installation.html)
 *How to install RxJS through npm or CDN*


### PR DESCRIPTION
It just occurred to me that we still had that "once this is ready" text on the site. This PR updates the description on the landing page, making it more credible now that it's already released as stable.