### PR TITLE
feat(generateRelativeTime)

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -77,6 +77,7 @@ enabling "composite" subscription behavior.
 |`flatMap`|`mergeMap` or `flatMap`(alias)|
 |`fromCallback`|`bindCallback`|
 |`fromNodeCallback`|`bindNodeCallback`|
+|`generateWithRelativeTime`|`generateRelativeTime`|
 |`groupByUntil`|`groupBy(keySelector, elementSelector, durationSelector)`|
 |`groupJoin`|No longer implemented|
 |`includes(v)`|`.first(x => x === v, () => true, false)`|

--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -354,6 +354,7 @@ children:
       - label: using a state machine similar to a for loop
         children:
         - label: Observable.generate
+        - label: Observable.generateRelativeTime
       - label: that throws an error
         children:
         - label: Observable.throw

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -121,6 +121,7 @@ There are operators for different purposes, and they may be categorized as: crea
 - [`fromEventPattern`](../class/es6/Observable.js~Observable.html#static-method-fromEventPattern)
 - [`fromPromise`](../class/es6/Observable.js~Observable.html#static-method-fromPromise)
 - [`generate`](../class/es6/Observable.js~Observable.html#static-method-generate)
+- [`generateRelativeTime`](../class/es6/Observable.js~Observable.html#static-method-generateRelativeTime)
 - [`interval`](../class/es6/Observable.js~Observable.html#static-method-interval)
 - [`never`](../class/es6/Observable.js~Observable.html#static-method-never)
 - [`of`](../class/es6/Observable.js~Observable.html#static-method-of)

--- a/spec/observables/generateRelativeTime-spec.ts
+++ b/spec/observables/generateRelativeTime-spec.ts
@@ -34,7 +34,7 @@ describe('Observable.generateRelativeTime', () => {
   });
 
   it('should use result selector !!!', () => {
-    const source = Observable.generateRelativeTime(1, x => x < 3, x => x + 1, x => 0, x => (x + 1).toString(), rxTestScheduler);
+    const source = Observable.generateRelativeTime(1, x => x < 3, x => x + 1, x => (x + 1).toString(), x => 0,  rxTestScheduler);
     const expected = '(23|)';
 
     expectObservable(source).toBe(expected);
@@ -155,9 +155,9 @@ describe('Observable.generateRelativeTime', () => {
   it('should emit error if condition function throws', () => {
     const source = Observable.generateRelativeTime({
       initialState: 1,
+      condition: err,
       iterate: x => x + 1,
       timeSelector: x => 0,
-      condition: err,
       scheduler: rxTestScheduler
     });
     const expected = '(#)';
@@ -168,9 +168,21 @@ describe('Observable.generateRelativeTime', () => {
   it('should emit error if condition function throws on scheduler', () => {
     const source = Observable.generateRelativeTime({
       initialState: 1,
-      iterate: x => x + 1,
       condition: err,
+      iterate: x => x + 1,
       timeSelector: x => 0,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should emit error if timeSelector function throws on scheduler', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x + 1,
+      timeSelector: err,
       scheduler: rxTestScheduler
     });
     const expected = '(#)';
@@ -182,8 +194,8 @@ describe('Observable.generateRelativeTime', () => {
   ('should delay by timeSelector', () => {
     const e1 = Observable.generateRelativeTime({
       initialState: 1,
-      iterate: x => x + 1,
       condition: x => x < 6,
+      iterate: x => x + 1,
       timeSelector: x => time('--|'),
       scheduler: rxTestScheduler
     });

--- a/spec/observables/generateRelativeTime-spec.ts
+++ b/spec/observables/generateRelativeTime-spec.ts
@@ -1,0 +1,193 @@
+import * as Rx from '../../dist/cjs/Rx';
+import '../../dist/cjs/add/observable/generateRelativeTime';
+import {TestScheduler} from '../../dist/cjs/testing/TestScheduler';
+import {expect} from 'chai';
+declare const {asDiagram, time, expectObservable};
+declare const rxTestScheduler: TestScheduler;
+
+const Observable = Rx.Observable;
+
+function err(): any {
+  throw 'error';
+}
+
+describe('Observable.generateRelativeTime', () => {
+  it('should complete if condition does not meet', () => {
+    const source = Observable.generateRelativeTime(1, x => false, x => x + 1, x => 0, rxTestScheduler);
+    const expected = '|';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should produce first value immediately', () => {
+    const source = Observable.generateRelativeTime(1, x => x == 1, x => x + 1, x => 0, rxTestScheduler);
+    const expected = '(1|)';
+
+    expectObservable(source).toBe(expected, { '1': 1 });
+  });
+
+  it('should produce all values synchronously', () => {
+    const source = Observable.generateRelativeTime(1, x => x < 3, x => x + 1, x => 0, rxTestScheduler);
+    const expected = '(12|)';
+
+    expectObservable(source).toBe(expected, { '1': 1, '2': 2 });
+  });
+
+  it('should use result selector !!!', () => {
+    const source = Observable.generateRelativeTime(1, x => x < 3, x => x + 1, x => 0, x => (x + 1).toString(), rxTestScheduler);
+    const expected = '(23|)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should allow omit condition', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x + 1,
+      timeSelector: x => 0,
+      resultSelector: x => x.toString(),
+      scheduler: rxTestScheduler
+    }).take(5);
+    const expected = '(12345|)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should stop producing when unsubscribed', () => {
+    const source = Observable.generateRelativeTime(1, x => x < 4, x => x + 1, x => 0, rxTestScheduler);
+    let count = 0;
+    const subscriber = new Rx.Subscriber<number>(
+      x => {
+        count++;
+        if (x == 2) {
+          subscriber.unsubscribe();
+        }
+      }
+    );
+    source.subscribe(subscriber);
+    rxTestScheduler.flush();
+    expect(count).to.be.equal(2);
+  });
+
+  it('should accept a scheduler', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      condition: x => x < 4,
+      iterate: x => x + 1,
+      timeSelector: x => 0,
+      resultSelector: x => x,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(123|)';
+
+    let count = 0;
+    source.subscribe(x => count++);
+
+    expect(count).to.be.equal(0);
+    rxTestScheduler.flush();
+    expect(count).to.be.equal(3);
+
+    expectObservable(source).toBe(expected, { '1': 1, '2': 2, '3': 3 });
+  });
+
+  it('should allow minimal possible options', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x * 2,
+      timeSelector: x => 0,
+      scheduler: rxTestScheduler
+    }).take(3);
+    const expected = '(124|)';
+
+    expectObservable(source).toBe(expected, { '1': 1, '2': 2, '4': 4 });
+  });
+
+  it('should emit error if result selector throws', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x * 2,
+      timeSelector: x => 0,
+      resultSelector: err,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should emit error if result selector throws on scheduler', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x * 2,
+      timeSelector: x => 0,
+      resultSelector: err,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should emit error after first value if iterate function throws', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: err,
+      timeSelector: x => 0,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(1#)';
+
+    expectObservable(source).toBe(expected, { '1': 1 });
+  });
+
+  it('should emit error after first value if iterate function throws on scheduler', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: err,
+      timeSelector: x => 0,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(1#)';
+
+    expectObservable(source).toBe(expected, { '1': 1 });
+  });
+
+  it('should emit error if condition function throws', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x + 1,
+      timeSelector: x => 0,
+      condition: err,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  it('should emit error if condition function throws on scheduler', () => {
+    const source = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x + 1,
+      condition: err,
+      timeSelector: x => 0,
+      scheduler: rxTestScheduler
+    });
+    const expected = '(#)';
+
+    expectObservable(source).toBe(expected);
+  });
+
+  asDiagram('generateRelativeTime(1, x => x < 6, x => x + 1, x => 1000)')
+  ('should delay by timeSelector', () => {
+    const e1 = Observable.generateRelativeTime({
+      initialState: 1,
+      iterate: x => x + 1,
+      condition: x => x < 6,
+      timeSelector: x => time('--|'),
+      scheduler: rxTestScheduler
+    });
+    const expected = '--1-2-3-4-(5|)';
+    expectObservable(e1).toBe(expected, {1: 1, 2: 2, 3: 3, 4: 4, 5: 5});
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -20,6 +20,7 @@ import './add/observable/fromEvent';
 import './add/observable/fromEventPattern';
 import './add/observable/fromPromise';
 import './add/observable/generate';
+import './add/observable/generateRelativeTime';
 import './add/observable/if';
 import './add/observable/interval';
 import './add/observable/merge';

--- a/src/add/observable/generateRelativeTime.ts
+++ b/src/add/observable/generateRelativeTime.ts
@@ -1,0 +1,10 @@
+import { Observable } from '../../Observable';
+import { GenerateRelativeTimeObservable } from '../../observable/GenerateRelativeTimeObservable';
+
+Observable.generateRelativeTime = GenerateRelativeTimeObservable.create;
+
+declare module '../../Observable' {
+  namespace Observable {
+    export let generateRelativeTime: typeof GenerateRelativeTimeObservable.create;
+  }
+}

--- a/src/observable/GenerateRelativeTimeObservable.ts
+++ b/src/observable/GenerateRelativeTimeObservable.ts
@@ -1,0 +1,279 @@
+import { IScheduler } from '../Scheduler';
+import { Action } from '../scheduler/Action';
+import { Observable } from '../Observable' ;
+import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
+import { isScheduler } from '../util/isScheduler';
+import { async } from '../scheduler/async';
+
+const selfSelector = <T>(value: T) => value;
+
+export type ConditionFunc<S> = (state: S) => boolean;
+export type IterateFunc<S> = (state: S) => S;
+export type ResultFunc<S, T> = (state: S) => T;
+export type TimeSelectorFunc<S> = (state: S) => number;
+
+interface SchedulerState<T, S> {
+  notFirst?: boolean;
+  result?: T;
+  state: S;
+  subscriber: Subscriber<T>;
+  condition?: ConditionFunc<S>;
+  iterate: IterateFunc<S>;
+  timeSelector: TimeSelectorFunc<S>;
+  resultSelector: ResultFunc<S, T>;
+}
+
+export interface GenerateRelativeTimeBaseOptions<S> {
+  /**
+   * Initial state.
+  */
+  initialState: S;
+  /**
+   * Condition function that accepts state and returns boolean.
+   * When it returns false, the generator stops.
+   * If not specified, a generator never stops.
+  */
+  condition?: ConditionFunc<S>;
+  /**
+   * Iterate function that accepts state and returns new state.
+   */
+  iterate: IterateFunc<S>;
+  /**
+   * Time selector function to control the speed of values being produced each
+   * iteration, returning integer values denoting milliseconds.
+   */
+  timeSelector: TimeSelectorFunc<S>;
+  /**
+   * IScheduler to use for generation process.
+   * By default, a generator starts immediately.
+  */
+  scheduler?: IScheduler;
+}
+
+export interface GenerateRelativeTimeOptions<T, S> extends GenerateRelativeTimeBaseOptions<S> {
+  /**
+   * Result selection function that accepts state and returns a value to emit.
+   */
+  resultSelector: ResultFunc<S, T>;
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
+export class GenerateRelativeTimeObservable<T, S> extends Observable<T> {
+  constructor(private initialState: S,
+              private condition: ConditionFunc<S>,
+              private iterate: IterateFunc<S>,
+              private timeSelector: TimeSelectorFunc<S>,
+              private resultSelector: ResultFunc<S, T>,
+              private scheduler: IScheduler = async) {
+      super();
+  }
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages. By default, this operator uses the
+   * `async` IScheduler to provide a notion of time, but you may pass any
+   * IScheduler to it.
+   *
+   * <img src="./img/generateRelativeTime.png" width="100%">
+   *
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate(0, x => x < 10, x => x + 1, x => x);
+   *
+   * @example <caption>Using asap scheduler, produces sequence of 2, 3, 5, then completes.</caption>
+   * var res = Rx.Observable.generate(1, x => x < 5, x => x * 2, x => x + 1, Rx.Scheduler.asap);
+   *
+   * @see {@link from}
+   * @see {@link create}
+   *
+   * @param {S} initialState Initial state.
+   * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
+   * @param {function (state: S): S} iterate Iteration step function.
+   * @param {function (state: S): number} timeSelector Time selector function to control the speed of values being produced each iteration, returning
+   * integer values denoting milliseconds.
+   * @param {function (state: S): T} resultSelector Selector function for results produced in the sequence.
+   * @param {Scheduler} [scheduler=async] A {@link IScheduler} on which to run the generator loop. If not provided, defaults to Scheduler.async.
+   * @returns {Observable<T>} The generated sequence.
+   */
+  static create<T, S>(initialState: S,
+                      condition: ConditionFunc<S>,
+                      iterate: IterateFunc<S>,
+                      timeSelector: TimeSelectorFunc<S>,
+                      resultSelector: ResultFunc<S, T>,
+                      scheduler?: IScheduler): Observable<T>
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages.
+   * The overload uses state as an emitted value.
+   *
+   * <img src="./img/generate.png" width="100%">
+   *
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate(0, x => x < 10, x => x + 1);
+   *
+   * @example <caption>Using asap scheduler, produces sequence of 1, 2, 4, then completes.</caption>
+   * var res = Rx.Observable.generate(1, x => x < 5, x => x * 2, Rx.Scheduler.asap);
+   *
+   * @see {@link from}
+   * @see {@link create}
+   *
+   * @param {S} initialState Initial state.
+   * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
+   * @param {function (state: S): S} iterate Iteration step function.
+   * @param {function (state: S): number} timeSelector Time selector function to control the speed of values being produced each iteration, returning
+   *  integer values denoting milliseconds.
+   * @param {Scheduler} [scheduler] A {@link IScheduler} on which to run the generator loop. If not provided, defaults to Scheduler.async.
+   * @returns {Observable<S>} The generated sequence.
+   */
+  static create<S>(initialState: S,
+                   condition: ConditionFunc<S>,
+                   iterate: IterateFunc<S>,
+                   timeSelector: TimeSelectorFunc<S>,
+                   scheduler?: IScheduler): Observable<S>
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages.
+   * The overload accepts options object that might contain initial state, iterate,
+   * condition and scheduler.
+   *
+   * <img src="./img/generate.png" width="100%">
+   *
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate({
+   *   initialState: 0,
+   *   condition: x => x < 10,
+   *   iterate: x => x + 1
+   * });
+   *
+   * @see {@link from}
+   * @see {@link create}
+   *
+   * @param {GenerateRelativeTimeBaseOptions<S>} options Object that must contain initialState, iterate, timeSelector and might contain condition
+   * and scheduler.
+   * @returns {Observable<S>} The generated sequence.
+   */
+  static create<S>(options: GenerateRelativeTimeBaseOptions<S>): Observable<S>
+
+  /**
+   * Generates an observable sequence by running a state-driven loop
+   * producing the sequence's elements, using the specified scheduler
+   * to send out observer messages.
+   * The overload accepts options object that might contain initial state, iterate,
+   * condition, result selector and scheduler.
+   *
+   * <img src="./img/generate.png" width="100%">
+   *
+   * @example <caption>Produces sequence of 0, 1, 2, ... 9, then completes.</caption>
+   * var res = Rx.Observable.generate({
+   *   initialState: 0,
+   *   condition: x => x < 10,
+   *   iterate: x => x + 1,
+   *   resultSelector: x => x
+   * });
+   *
+   * @see {@link from}
+   * @see {@link create}
+   *
+   * @param {GenerateRelativeTimeOptions<T, S>} options Object that must contain initialState, iterate, timeSelector, resultSelector and might
+   * contain condition and scheduler.
+   * @returns {Observable<T>} The generated sequence.
+   */
+  static create<T, S>(options: GenerateRelativeTimeOptions<T, S>): Observable<T>
+
+  static create<T, S>(initialStateOrOptions: S | GenerateRelativeTimeOptions<T, S>,
+                      condition?: ConditionFunc<S>,
+                      iterate?: IterateFunc<S>,
+                      timeSelector?: TimeSelectorFunc<S>,
+                      resultSelectorOrObservable?: (ResultFunc<S, T>) | IScheduler,
+                      scheduler: IScheduler = async): Observable<T> {
+    if (arguments.length == 1) {
+      return new GenerateRelativeTimeObservable<T, S>(
+        (<GenerateRelativeTimeOptions<T, S>>initialStateOrOptions).initialState,
+        (<GenerateRelativeTimeOptions<T, S>>initialStateOrOptions).condition,
+        (<GenerateRelativeTimeOptions<T, S>>initialStateOrOptions).iterate,
+        (<GenerateRelativeTimeOptions<T, S>>initialStateOrOptions).timeSelector,
+        (<GenerateRelativeTimeOptions<T, S>>initialStateOrOptions).resultSelector || selfSelector,
+        (<GenerateRelativeTimeOptions<T, S>>initialStateOrOptions).scheduler || async);
+    }
+
+    if (resultSelectorOrObservable === undefined || isScheduler(resultSelectorOrObservable)) {
+      return new GenerateRelativeTimeObservable<T, S>(
+        <S>initialStateOrOptions,
+        condition,
+        iterate,
+        timeSelector,
+        selfSelector,
+        <IScheduler>resultSelectorOrObservable || async);
+    }
+
+    return new GenerateRelativeTimeObservable<T, S>(
+      <S>initialStateOrOptions,
+      condition,
+      iterate,
+      timeSelector,
+      <ResultFunc<S, T>>resultSelectorOrObservable,
+      <IScheduler>scheduler);
+  }
+
+  protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+    let state = this.initialState;
+    return this.scheduler.schedule<SchedulerState<T, S>>(GenerateRelativeTimeObservable.dispatch, 0, {
+      subscriber,
+      iterate: this.iterate,
+      condition: this.condition,
+      timeSelector: this.timeSelector,
+      resultSelector: this.resultSelector,
+      state });
+  }
+
+  private static dispatch<T, S>(state: SchedulerState<T, S>): Subscription | void {
+    const { notFirst, result, subscriber, condition, resultSelector, timeSelector } = state;
+    let time = 0;
+    if (subscriber.closed) {
+      return;
+    }
+    try {
+      if (notFirst) {
+        subscriber.next(result);
+        if (subscriber.closed) {
+          return;
+        }
+        state.state = state.iterate(state.state);
+        if (subscriber.closed) {
+          return;
+        }
+      } else {
+        state.notFirst = true;
+      }
+      if (condition) {
+        if (!condition(state.state)) {
+          subscriber.complete();
+          return;
+        }
+        if (subscriber.closed) {
+          return;
+        }
+      }
+      state.result = resultSelector(state.state);
+      if (timeSelector) {
+        time = timeSelector(state.state);
+      }
+      if (subscriber.closed) {
+        return;
+      }
+    } catch (err) {
+      subscriber.error(err);
+      return;
+    }
+    return (<Action<SchedulerState<T, S>>><any>this).schedule(state, time);
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ x ] Add the operator to Rx
- [ x ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ x ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ? ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ? ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ? ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ? ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ? ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I probably forgot half the things i need to do, will go over them later, but this is my initial go at adding a new operator. I'm looking for general feedback before i move on, the rest of the work should be pretty routine i think, including adding a few extra test-cases. Would it be enough to modify the existing ones to use a non-trivial time selector instead? Or that i should add a whole bunch of new ones that cover that?

My implementation is mostly based on how Rx.Net uses `Generate`, loosely based on [that code](https://github.com/Reactive-Extensions/Rx.NET/blob/master/Rx.NET/Source/System.Reactive.Linq/Reactive/Linq/Observable/Generate.cs#L149) and the description from generateWithRelativeTime in RxJs 4.

Most of the code is also copied from `generate` in RxJs 5. Do i need to run `if (subscriber.closed) { return; }` as often as i do? This is inherited from that code.

**Related issue (if exists):**

#2033