### PR TITLE
refactor(TestScheduler): return hot and cold observables

### DIFF
--- a/src/testing/TestScheduler.ts
+++ b/src/testing/TestScheduler.ts
@@ -1,6 +1,5 @@
 import { Observable } from '../Observable';
 import { Notification } from '../Notification';
-import { Subject } from '../Subject';
 import { ColdObservable } from './ColdObservable';
 import { HotObservable } from './HotObservable';
 import { TestMessage } from './TestMessage';
@@ -36,7 +35,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     return indexOf * TestScheduler.frameTimeFactor;
   }
 
-  createColdObservable<T>(marbles: string, values?: any, error?: any): Observable<T> {
+  createColdObservable<T>(marbles: string, values?: any, error?: any): ColdObservable<T> {
     if (marbles.indexOf('^') !== -1) {
       throw new Error('cold observable cannot have subscription offset "^"');
     }
@@ -49,7 +48,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     return cold;
   }
 
-  createHotObservable<T>(marbles: string, values?: any, error?: any): Subject<T> {
+  createHotObservable<T>(marbles: string, values?: any, error?: any): HotObservable<T> {
     if (marbles.indexOf('!') !== -1) {
       throw new Error('hot observable cannot have unsubscription marker "!"');
     }


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Return HotObservable and ColdObservable instead of simply Observable, in order to give users access to subscriptions parameter.

**Motivation:**

Previously getting subscriptions of observables for `expectSubscriptions` assertions was impossible without typecasting:
```javascript
const hot = scheduler.createHotObservable('--a---b--|');
hot.subscriptions // does not compile
```
