### PR TITLE
chore(*): correctly scope disabled `max-line-length` tslint rule

### DIFF
--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -11,7 +11,7 @@ import { isScheduler } from '../util/isScheduler';
 export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, scheduler?: IScheduler): Observable<T[]>;
 export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, scheduler?: IScheduler): Observable<T[]>;
 export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, maxBufferSize: number, scheduler?: IScheduler): Observable<T[]>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Buffers the source Observable values for a specific time period.

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -23,7 +23,7 @@ export function combineLatest<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: Ob
 export function combineLatest<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): Observable<R>;
 export function combineLatest<T, R>(this: Observable<T>, array: ObservableInput<T>[]): Observable<Array<T>>;
 export function combineLatest<T, TOther, R>(this: Observable<T>, array: ObservableInput<TOther>[], project: (v1: T, ...values: Array<TOther>) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Combines multiple Observables to create an Observable whose values are

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -13,7 +13,7 @@ export function concat<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInp
 export function concat<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
 export function concat<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | IScheduler>): Observable<T>;
 export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler>): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Creates an output Observable which sequentially emits all values from every

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -5,7 +5,7 @@ import { MergeAllOperator } from './mergeAll';
 /* tslint:disable:max-line-length */
 export function concatAll<T>(this: Observable<T>): T;
 export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Converts a higher-order Observable into a first-order Observable by

--- a/src/operator/concatMap.ts
+++ b/src/operator/concatMap.ts
@@ -4,7 +4,7 @@ import { Observable, ObservableInput } from '../Observable';
 /* tslint:disable:max-line-length */
 export function concatMap<T, R>(this: Observable<T>, project: (value: T, index: number) =>  ObservableInput<R>): Observable<R>;
 export function concatMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) =>  ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to an Observable which is merged in the output

--- a/src/operator/concatMapTo.ts
+++ b/src/operator/concatMapTo.ts
@@ -4,7 +4,7 @@ import { MergeMapToOperator } from './mergeMapTo';
 /* tslint:disable:max-line-length */
 export function concatMapTo<T, R>(this: Observable<T>, observable: ObservableInput<R>): Observable<R>;
 export function concatMapTo<T, I, R>(this: Observable<T>, observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to the same Observable which is merged multiple
@@ -39,7 +39,7 @@ export function concatMapTo<T, I, R>(this: Observable<T>, observable: Observable
  * // For every click on the "document" it will emit values 0 to 3 spaced
  * // on a 1000ms interval
  * // one click = 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3
- * 
+ *
  * @see {@link concat}
  * @see {@link concatAll}
  * @see {@link concatMap}

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -5,7 +5,7 @@ import { Subscriber } from '../Subscriber';
 /* tslint:disable:max-line-length */
 export function defaultIfEmpty<T>(this: Observable<T>, defaultValue?: T): Observable<T>;
 export function defaultIfEmpty<T, R>(this: Observable<T>, defaultValue?: R): Observable<T | R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Emits a given value if the source Observable completes without emitting any

--- a/src/operator/distinctUntilChanged.ts
+++ b/src/operator/distinctUntilChanged.ts
@@ -8,7 +8,7 @@ import { TeardownLogic } from '../Subscription';
 /* tslint:disable:max-line-length */
 export function distinctUntilChanged<T>(this: Observable<T>, compare?: (x: T, y: T) => boolean): Observable<T>;
 export function distinctUntilChanged<T, K>(this: Observable<T>, compare: (x: K, y: K) => boolean, keySelector: (x: T) => K): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from the previous item.

--- a/src/operator/distinctUntilKeyChanged.ts
+++ b/src/operator/distinctUntilKeyChanged.ts
@@ -4,7 +4,7 @@ import { Observable } from '../Observable';
 /* tslint:disable:max-line-length */
 export function distinctUntilKeyChanged<T>(this: Observable<T>, key: string): Observable<T>;
 export function distinctUntilKeyChanged<T, K>(this: Observable<T>, key: string, compare: (x: K, y: K) => boolean): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from the previous item,

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -7,7 +7,7 @@ import { TeardownLogic } from '../Subscription';
 /* tslint:disable:max-line-length */
 export function _do<T>(this: Observable<T>, next: (x: T) => void, error?: (e: any) => void, complete?: () => void): Observable<T>;
 export function _do<T>(this: Observable<T>, observer: PartialObserver<T>): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Perform a side effect for every emission on the source Observable, but return

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -9,7 +9,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 /* tslint:disable:max-line-length */
 export function exhaustMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>): Observable<R>;
 export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to an Observable which is merged in the output

--- a/src/operator/expand.ts
+++ b/src/operator/expand.ts
@@ -12,7 +12,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 /* tslint:disable:max-line-length */
 export function expand<T>(this: Observable<T>, project: (value: T, index: number) => Observable<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
 export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => Observable<R>, concurrent?: number, scheduler?: IScheduler): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Recursively projects each source value to an Observable which is merged in

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -10,7 +10,7 @@ export function filter<T, S extends T>(this: Observable<T>,
 export function filter<T>(this: Observable<T>,
                           predicate: (value: T, index: number) => boolean,
                           thisArg?: any): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Filter items emitted by the source Observable by only emitting those that

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -9,7 +9,7 @@ export function find<T, S extends T>(this: Observable<T>,
 export function find<T>(this: Observable<T>,
                         predicate: (value: T, index: number) => boolean,
                         thisArg?: any): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Emits only the first value emitted by the source Observable that meets some

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -11,7 +11,7 @@ export function groupBy<T, K>(this: Observable<T>, keySelector: (value: T) => K)
 export function groupBy<T, K>(this: Observable<T>, keySelector: (value: T) => K, elementSelector: void, durationSelector: (grouped: GroupedObservable<K, T>) => Observable<any>): Observable<GroupedObservable<K, T>>;
 export function groupBy<T, K, R>(this: Observable<T>, keySelector: (value: T) => K, elementSelector?: (value: T) => R, durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>): Observable<GroupedObservable<K, R>>;
 export function groupBy<T, K, R>(this: Observable<T>, keySelector: (value: T) => K, elementSelector?: (value: T) => R, durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>, subjectSelector?: () => Subject<R>): Observable<GroupedObservable<K, R>>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Groups the items emitted by an Observable according to a specified criterion,

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -23,7 +23,7 @@ export function last<T>(this: Observable<T>,
                         predicate: (value: T, index: number, source: Observable<T>) => boolean,
                         resultSelector: void,
                         defaultValue?: T): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Returns an Observable that emits only the last item emitted by the source Observable.

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -19,7 +19,7 @@ export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: Observable
 export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
 export function merge<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | IScheduler | number>): Observable<T>;
 export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Creates an output Observable which concurrently emits all values from every

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -9,7 +9,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 /* tslint:disable:max-line-length */
 export function mergeMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>, concurrent?: number): Observable<R>;
 export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to an Observable which is merged in the output
@@ -40,7 +40,7 @@ export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index
  * // b1
  * // c1
  * // continues to list a,b,c with respective ascending integers
- * 
+ *
  * @see {@link concatMap}
  * @see {@link exhaustMap}
  * @see {@link merge}

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -10,7 +10,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 /* tslint:disable:max-line-length */
 export function mergeMapTo<T, R>(this: Observable<T>, observable: ObservableInput<R>, concurrent?: number): Observable<R>;
 export function mergeMapTo<T, I, R>(this: Observable<T>, observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to the same Observable which is merged multiple

--- a/src/operator/multicast.ts
+++ b/src/operator/multicast.ts
@@ -7,7 +7,7 @@ import { ConnectableObservable, connectableObservableDescriptor } from '../obser
 /* tslint:disable:max-line-length */
 export function multicast<T>(this: Observable<T>, subjectOrSubjectFactory: factoryOrValue<Subject<T>>): ConnectableObservable<T>;
 export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: selector<T>): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Returns an Observable that emits the results of invoking a specified selector on items

--- a/src/operator/onErrorResumeNext.ts
+++ b/src/operator/onErrorResumeNext.ts
@@ -15,7 +15,7 @@ export function onErrorResumeNext<T, T2, T3, T4, T5, R>(this: Observable<T>, v2:
 export function onErrorResumeNext<T, T2, T3, T4, T5, T6, R>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<R> ;
 export function onErrorResumeNext<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
 export function onErrorResumeNext<T, R>(this: Observable<T>, array: ObservableInput<any>[]): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 export function onErrorResumeNext<T, R>(this: Observable<T>, ...nextSources: Array<ObservableInput<any> |
                                                        Array<ObservableInput<any>> |
                                                        ((...values: Array<any>) => R)>): Observable<R> {

--- a/src/operator/publish.ts
+++ b/src/operator/publish.ts
@@ -6,7 +6,7 @@ import { ConnectableObservable } from '../observable/ConnectableObservable';
 /* tslint:disable:max-line-length */
 export function publish<T>(this: Observable<T>): ConnectableObservable<T>;
 export function publish<T>(this: Observable<T>, selector: selector<T>): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Returns a ConnectableObservable, which is a variety of Observable that waits until its connect method is called

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -11,7 +11,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 /* tslint:disable:max-line-length */
 export function race<T>(this: Observable<T>, ...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T>;
 export function race<T, R>(this: Observable<T>, ...observables: Array<Observable<any> | Array<Observable<T>>>): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Returns an Observable that mirrors the first source Observable to emit an item

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -6,7 +6,7 @@ import { Subscriber } from '../Subscriber';
 export function reduce<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
 export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): Observable<T[]>;
 export function reduce<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed?: R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Applies an accumulator function over the source Observable, and returns the

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -6,7 +6,7 @@ import { Subscriber } from '../Subscriber';
 export function scan<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
 export function scan<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): Observable<T[]>;
 export function scan<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed?: R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Applies an accumulator function over the source Observable, and returns each
@@ -84,7 +84,8 @@ class ScanSubscriber<T, R> extends Subscriber<T> {
     this._seed = value;
   }
 
-  constructor(destination: Subscriber<R>, private accumulator: (acc: R, value: T, index: number) => R, private _seed: T | R, private hasSeed: boolean) {
+  constructor(destination: Subscriber<R>, private accumulator: (acc: R, value: T, index: number) => R, private _seed: T | R,
+              private hasSeed: boolean) {
     super(destination);
   }
 

--- a/src/operator/startWith.ts
+++ b/src/operator/startWith.ts
@@ -14,7 +14,7 @@ export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, sc
 export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: IScheduler): Observable<T>;
 export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: IScheduler): Observable<T>;
 export function startWith<T>(this: Observable<T>, ...array: Array<T | IScheduler>): Observable<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Returns an Observable that emits the items in a specified Iterable before it begins to emit items emitted by the

--- a/src/operator/switchMap.ts
+++ b/src/operator/switchMap.ts
@@ -9,7 +9,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 /* tslint:disable:max-line-length */
 export function switchMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>): Observable<R>;
 export function switchMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to an Observable which is merged in the output

--- a/src/operator/switchMapTo.ts
+++ b/src/operator/switchMapTo.ts
@@ -9,7 +9,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 /* tslint:disable:max-line-length */
 export function switchMapTo<T, R>(this: Observable<T>, observable: ObservableInput<R>): Observable<R>;
 export function switchMapTo<T, I, R>(this: Observable<T>, observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to the same Observable which is flattened multiple

--- a/src/operator/timeoutWith.ts
+++ b/src/operator/timeoutWith.ts
@@ -11,7 +11,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 /* tslint:disable:max-line-length */
 export function timeoutWith<T>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
 export function timeoutWith<T, R>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<R>, scheduler?: IScheduler): Observable<T | R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * @param due

--- a/src/operator/toPromise.ts
+++ b/src/operator/toPromise.ts
@@ -4,7 +4,7 @@ import { root } from '../util/root';
 /* tslint:disable:max-line-length */
 export function toPromise<T>(this: Observable<T>): Promise<T>;
 export function toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Converts an Observable sequence to a ES2015 compliant promise.

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -20,7 +20,7 @@ export function withLatestFrom<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: O
 export function withLatestFrom<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
 export function withLatestFrom<T, R>(this: Observable<T>, array: ObservableInput<any>[]): Observable<R>;
 export function withLatestFrom<T, R>(this: Observable<T>, array: ObservableInput<any>[], project: (...values: Array<any>) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * Combines the source Observable with other Observables to create an Observable

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -24,7 +24,7 @@ export function zipProto<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: Observa
 export function zipProto<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): Observable<R>;
 export function zipProto<T, R>(this: Observable<T>, array: Array<ObservableInput<T>>): Observable<R>;
 export function zipProto<T, TOther, R>(this: Observable<T>, array: Array<ObservableInput<TOther>>, project: (v1: T, ...values: Array<TOther>) => R): Observable<R>;
-/* tslint:disable:max-line-length */
+/* tslint:enable:max-line-length */
 
 /**
  * @param observables
@@ -61,10 +61,10 @@ export function zipStatic<R>(...observables: Array<ObservableInput<any> | ((...v
 /* tslint:enable:max-line-length */
 
 /**
- * Combines multiple Observables to create an Observable whose values are calculated from the values, in order, of each 
+ * Combines multiple Observables to create an Observable whose values are calculated from the values, in order, of each
  * of its input Observables.
  *
- * If the latest parameter is a function, this function is used to compute the created value from the input values. 
+ * If the latest parameter is a function, this function is used to compute the created value from the input values.
  * Otherwise, an array of the input values is returned.
  *
  * @example <caption>Combine age and name from different sources</caption>
@@ -80,11 +80,11 @@ export function zipStatic<R>(...observables: Array<ObservableInput<any> | ((...v
  *          (age: number, name: string, isDev: boolean) => ({ age, name, isDev }))
  *     .subscribe(x => console.log(x));
  *
- * // outputs 
+ * // outputs
  * // { age: 7, name: 'Foo', isDev: true }
  * // { age: 5, name: 'Bar', isDev: true }
  * // { age: 9, name: 'Beer', isDev: false }
- * 
+ *
  * @param observables
  * @return {Observable<R>}
  * @static true


### PR DESCRIPTION
**Description:**
The max line length is set to 150 in 'tslint.json'. In specific regions, it is desirable to allow longer lines, so these regions should be wrapped in comments like the following:

```js
// Max line length enforced here.

/* tslint:disable:max-line-length */
// Max line length NOT enforced here.
/* tslint:enable:max-line-length */   <-- CORRECT

// Max line length enforced here.
```

In many cases, the re-enabling comment incorrectly included `disable` instead of `enable` (as shown below), which essentially keeps the `max-line-length` rule **disabled** for the rest of the file:

```js
// Max line length enforced here.

/* tslint:disable:max-line-length */
// Max line length NOT enforced here.
/* tslint:disable:max-line-length */   <-- INCORRECT

// Max line length NOT enforced here.
```

This commit fixes these comments, so the `max-line-length` rule is properly enforced in regions that don't need longer lines.

(Luckily, there was only 1 violation :smiley:)