### PR TITLE
fix(Observable): errors thrown during subscription are now properly s…

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -29,6 +29,18 @@ describe('Observable', () => {
     source.subscribe(function (x) { expect(x).to.equal(1); }, null, done);
   });
 
+  it('should send errors thrown in the constructor down the error path', (done) => {
+    new Observable((observer) => {
+      throw new Error('this should be handled');
+    })
+    .subscribe({
+      error(err) {
+        expect(err).to.deep.equal(new Error('this should be handled'));
+        done();
+      }
+    });
+  });
+
   describe('forEach', () => {
     it('should iterate and return a Promise', (done: MochaDone) => {
       const expected = [1, 2, 3];
@@ -581,6 +593,18 @@ describe('Observable.create', () => {
       //noop
     });
     expect(called).to.be.true;
+  });
+
+  it('should send errors thrown in the passed function down the error path', (done) => {
+    Observable.create((observer) => {
+      throw new Error('this should be handled');
+    })
+    .subscribe({
+      error(err) {
+        expect(err).to.deep.equal(new Error('this should be handled'));
+        done();
+      }
+    });
   });
 });
 

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -261,10 +261,8 @@ describe('Subject', () => {
     expect(() => {
       subject.subscribe(
         function (x) { results3.push(x); },
-        function (e) { results3.push('E'); },
-        () => { results3.push('C'); }
       );
-    }).to.throw();
+    }).to.throw(Rx.ObjectUnsubscribedError);
 
     expect(results1).to.deep.equal([1, 2, 3, 4, 5]);
     expect(results2).to.deep.equal([3, 4, 5]);

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -95,7 +95,7 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink.add(this._subscribe(sink));
+      sink.add(this._trySubscribe(sink));
     }
 
     if (sink.syncErrorThrowable) {
@@ -106,6 +106,16 @@ export class Observable<T> implements Subscribable<T> {
     }
 
     return sink;
+  }
+
+  private _trySubscribe(sink: Subscriber<T>): TeardownLogic {
+    try {
+      return this._subscribe(sink);
+    } catch (err) {
+      sink.syncErrorThrown = true;
+      sink.syncErrorValue = err;
+      sink.error(err);
+    }
   }
 
   /**


### PR DESCRIPTION
…ent down error channel

- Fixes `Observable.create(fn)` and `new Observable(fn)` such that any error thrown in `fn` on subscription will be sent to the subscriber's error handler.
- Fixes a subject test that was relying on the errant behavior.

fixes #1833 

Apologies for letting this one slip for so long, everyone. I thought it had been taken care of ages ago.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
