### PR TITLE
fix(Subject): ensure subject properly throws ObjectUnsubscribedError …

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -261,6 +261,9 @@ describe('Subject', () => {
     expect(() => {
       subject.subscribe(
         function (x) { results3.push(x); },
+        function (err) {
+          expect(false).to.equal('should not throw error: ' + err.toString());
+        }
       );
     }).to.throw(Rx.ObjectUnsubscribedError);
 

--- a/spec/subjects/AsyncSubject-spec.ts
+++ b/spec/subjects/AsyncSubject-spec.ts
@@ -157,7 +157,7 @@ describe('AsyncSubject', () => {
     const expected = new Error('bad');
     const subject = new AsyncSubject();
     const observer = new TestObserver();
-    subject.subscribe(observer);
+    const subscription = subject.subscribe(observer);
 
     subject.next(1);
     expect(observer.results).to.deep.equal([]);
@@ -165,7 +165,7 @@ describe('AsyncSubject', () => {
     subject.error(expected);
     expect(observer.results).to.deep.equal([expected]);
 
-    subject.unsubscribe();
+    subscription.unsubscribe();
 
     observer.results = [];
     subject.subscribe(observer);

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -108,7 +108,7 @@ export class Observable<T> implements Subscribable<T> {
     return sink;
   }
 
-  private _trySubscribe(sink: Subscriber<T>): TeardownLogic {
+  protected _trySubscribe(sink: Subscriber<T>): TeardownLogic {
     try {
       return this._subscribe(sink);
     } catch (err) {

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -2,7 +2,7 @@ import { Operator } from './Operator';
 import { Observer } from './Observer';
 import { Observable } from './Observable';
 import { Subscriber } from './Subscriber';
-import { ISubscription, Subscription } from './Subscription';
+import { ISubscription, Subscription, TeardownLogic } from './Subscription';
 import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 import { SubjectSubscription } from './SubjectSubscription';
 import { $$rxSubscriber } from './symbol/rxSubscriber';
@@ -97,6 +97,14 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     this.isStopped = true;
     this.closed = true;
     this.observers = null;
+  }
+
+  protected _trySubscribe(subscriber: Subscriber<T>): TeardownLogic {
+    if (this.closed) {
+      throw new ObjectUnsubscribedError();
+    } else {
+      return super._trySubscribe(subscriber);
+    }
   }
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {


### PR DESCRIPTION
…when unsubscribed then resubscribed to

- Also changes one AsyncSubject test that seemed to have a typo where the author intended to dispose of a subscription, but disposed of the subject itself instead

