### PR TITLE
fix(bindCallback): properly set context of input function

### DIFF
--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -25,6 +25,24 @@ describe('Observable.bindCallback', () => {
       expect(results).to.deep.equal([42, 'done']);
     });
 
+    it('should set callback function context to context of returned function', () => {
+      function callback(cb) {
+        cb(this.datum);
+      }
+
+      const boundCallback = Observable.bindCallback(callback);
+      const results = [];
+
+      boundCallback.apply({datum: 5})
+        .subscribe(
+          (x: number) => results.push(x),
+          null,
+          () => results.push('done')
+        );
+
+      expect(results).to.deep.equal([5, 'done']);
+    });
+
     it('should emit one value chosen by a selector', () => {
       function callback(datum, cb) {
         cb(datum);
@@ -103,6 +121,26 @@ describe('Observable.bindCallback', () => {
       rxTestScheduler.flush();
 
       expect(results).to.deep.equal([42, 'done']);
+    });
+
+    it('should set callback function context to context of returned function', () => {
+      function callback(cb) {
+        cb(this.datum);
+      }
+
+      const boundCallback = Observable.bindCallback(callback, null, rxTestScheduler);
+      const results = [];
+
+      boundCallback.apply({datum: 5})
+        .subscribe(
+          (x: number) => results.push(x),
+          null,
+          () => results.push('done')
+        );
+
+      rxTestScheduler.flush();
+
+      expect(results).to.deep.equal([5, 'done']);
     });
 
     it('should error if callback throws', () => {

--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -43,16 +43,29 @@ export class BoundCallbackObservable<T> extends Observable<T> {
    * `bindCallback` is not an operator because its input and output are not
    * Observables. The input is a function `func` with some parameters, but the
    * last parameter must be a callback function that `func` calls when it is
-   * done. The output of `bindCallback` is a function that takes the same
+   * done.
+   *
+   * The output of `bindCallback` is a function that takes the same
    * parameters as `func`, except the last one (the callback). When the output
    * function is called with arguments, it will return an Observable where the
    * results will be delivered to.
+   *
+   * If `func` depends on some context (`this` property), that context will be set
+   * to the same context that returned function has at call time. In particular, if `func`
+   * is usually called as method of some object, in order to preserve proper behaviour,
+   * it is recommended to set context of output function to that object as well,
+   * provided `func` is not already bound.
    *
    * @example <caption>Convert jQuery's getJSON to an Observable API</caption>
    * // Suppose we have jQuery.getJSON('/my/url', callback)
    * var getJSONAsObservable = Rx.Observable.bindCallback(jQuery.getJSON);
    * var result = getJSONAsObservable('/my/url');
    * result.subscribe(x => console.log(x), e => console.error(e));
+   *
+   * @example <caption>Use bindCallback on object method</caption>
+   * const boundMethod = Rx.Observable.bindCallback(someObject.methodWithCallback);
+   * boundMethod.call(someObject) // make sure methodWithCallback has access to someObject
+   * .subscribe(subscriber);
    *
    * @see {@link bindNodeCallback}
    * @see {@link from}
@@ -72,14 +85,15 @@ export class BoundCallbackObservable<T> extends Observable<T> {
   static create<T>(func: Function,
                    selector: Function | void = undefined,
                    scheduler?: IScheduler): (...args: any[]) => Observable<T> {
-    return (...args: any[]): Observable<T> => {
-      return new BoundCallbackObservable<T>(func, <any>selector, args, scheduler);
+    return function(this: any, ...args: any[]): Observable<T> {
+      return new BoundCallbackObservable<T>(func, <any>selector, args, this, scheduler);
     };
   }
 
   constructor(private callbackFunc: Function,
               private selector: Function,
               private args: any[],
+              private context: any,
               private scheduler: IScheduler) {
     super();
   }
@@ -112,20 +126,20 @@ export class BoundCallbackObservable<T> extends Observable<T> {
         // use named function instance to avoid closure.
         (<any>handler).source = this;
 
-        const result = tryCatch(callbackFunc).apply(this, args.concat(handler));
+        const result = tryCatch(callbackFunc).apply(this.context, args.concat(handler));
         if (result === errorObject) {
           subject.error(errorObject.e);
         }
       }
       return subject.subscribe(subscriber);
     } else {
-      return scheduler.schedule(BoundCallbackObservable.dispatch, 0, { source: this, subscriber });
+      return scheduler.schedule(BoundCallbackObservable.dispatch, 0, { source: this, subscriber, context: this.context });
     }
   }
 
-  static dispatch<T>(state: { source: BoundCallbackObservable<T>, subscriber: Subscriber<T> }) {
+  static dispatch<T>(state: { source: BoundCallbackObservable<T>, subscriber: Subscriber<T>, context: any }) {
     const self = (<Subscription><any>this);
-    const { source, subscriber } = state;
+    const { source, subscriber, context } = state;
     const { callbackFunc, args, scheduler } = source;
     let subject = source.subject;
 
@@ -150,7 +164,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
       // use named function to pass values in without closure
       (<any>handler).source = source;
 
-      const result = tryCatch(callbackFunc).apply(this, args.concat(handler));
+      const result = tryCatch(callbackFunc).apply(context, args.concat(handler));
       if (result === errorObject) {
         subject.error(errorObject.e);
       }


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Current behaviour:**
Currently when input function (function that is passed as argument to `bindCallback`) is internally called, its context is set to context of underlying observable. If input function is not bound beforehand it is possible to implement:
```ts
function intercept(cb) {
   const observable = this;
   // do something with underlying observable
}
const boundIntercept = Observable.bindCallback(intercept);
boundIntercept(); // intercept is called with underlying observable as this
```
**Expected behaviour**
Since output function (function returned by `bindCallback) should behave identically as input function (apart from changing callback to observable) it is reasonable to assume that context of ouput function will become context of input function.

```ts
const boundMethod = Observable.bindCallback(someObject.method);
boundMethod.call(someObject) // calls method with someObject as this (as it was probably intended)
```
In fact this is what rxjs 4 does, as seen here:
https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/fromcallback.js#L41

This pr implements such behaviour.

**Related**
This pr does not change operator api. There is still no option to manually set context, which is possible in rxjs 4:

```ts
const bound = Observable.fromCallback(func, context);
bound() // func is called with context as this
```

Please let me know if I should add such functionality  in this pr, create another pr or drop context setting functionality altogether.

Have a great day!
