### PR TITLE
docs(bindNodeCallback): add more details and examples

### DIFF
--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -38,16 +38,58 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
    * Observables. The input is a function `func` with some parameters, but the
    * last parameter must be a callback function that `func` calls when it is
    * done. The callback function is expected to follow Node.js conventions,
-   * where the first argument to the callback is an error, while remaining
-   * arguments are the callback result.
+   * where the first argument to the callback is an error object, signaling
+   * whether call was successful. If that object is passed to callback, it means
+   * something went wrong.
    *
-   * The output of `bindNodeCallback` is a
-   * function that takes the same parameters as `func`, except the last one (the
-   * callback). When the output function is called with arguments, it will
-   * return an Observable where the results will be delivered to.
+   * The output of `bindNodeCallback` is a function that takes the same
+   * parameters as `func`, except the last one (the callback). When the output
+   * function is called with arguments, it will return an Observable.
+   * If `func` calls its callback with error parameter present, Observable will
+   * error with that value as well. If error parameter is not passed, Observable will emit
+   * second parameter. If there are more parameters (third and so on),
+   * Observable will emit an array with all arguments, except first error argument.
+   *
+   * Optionally `bindNodeCallback` accepts selector function, which allows you to
+   * make resulting Observable emit value computed by selector, instead of regular
+   * callback arguments. It works similarly to {@link bindCallback} selector, but
+   * Node.js-style error argument will never be passed to that function.
+   *
+   * Note that `func` will not be called at the same time output function is,
+   * but rather whenever resulting Observable is subscribed. By default call to
+   * `func` will happen synchronously after subscription, but that can be changed
+   * with proper {@link Scheduler} provided as optional third parameter. Scheduler
+   * can also control when values from callback will be emitted by Observable.
+   * To find out more, check out documentation for {@link bindCallback}, where
+   * Scheduler works exactly the same.
    *
    * As in {@link bindCallback}, context (`this` property) of input function will be set to context
    * of returned function, when it is called.
+   *
+   * After Observable emits value, it will complete immediately. This means
+   * even if `func` calls callback again, values from second and consecutive
+   * calls will never appear on the stream. If you need to handle functions
+   * that call callbacks multiple times, check out {@link fromEvent} or
+   * {@link fromEventPattern} instead.
+   *
+   * Note that `bindNodeCallback` can be used in non-Node.js environments as well.
+   * "Node.js-style" callbacks are just a convention, so if you write for
+   * browsers or any other environment and API you use implements that callback style,
+   * `bindNodeCallback` can be safely used on that API functions as well.
+   *
+   * Remember that Error object passed to callback does not have to be an instance
+   * of JavaScript built-in `Error` object. In fact, it does not even have to an object.
+   * Error parameter of callback function is interpreted as "present", when value
+   * of that parameter is truthy. It could be, for example, non-zero number, non-empty
+   * string or boolean `true`. In all of these cases resulting Observable would error
+   * with that value. This means usually regular style callbacks will fail very often when
+   * `bindNodeCallback` is used. If your Observable errors much more often then you
+   * would expect, check if callback really is called in Node.js-style and, if not,
+   * switch to {@link bindCallback} instead.
+   *
+   * Note that even if error parameter is technically present in callback, but its value
+   * is falsy, it still won't appear in array emitted by Observable or in selector function.
+   *
    *
    * @example <caption>Read a file from the filesystem and get the data as an Observable</caption>
    * import * as fs from 'fs';
@@ -55,13 +97,52 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
    * var result = readFileAsObservable('./roadNames.txt', 'utf8');
    * result.subscribe(x => console.log(x), e => console.error(e));
    *
+   *
+   * @example <caption>Use on function calling callback with multiple arguments</caption>
+   * someFunction((err, a, b) => {
+   *   console.log(err); // null
+   *   console.log(a); // 5
+   *   console.log(b); // "some string"
+   * });
+   * var boundSomeFunction = Rx.Observable.bindNodeCallback(someFunction);
+   * boundSomeFunction()
+   * .subscribe(value => {
+   *   console.log(value); // [5, "some string"]
+   * });
+   *
+   *
+   * @example <caption>Use with selector function</caption>
+   * someFunction((err, a, b) => {
+   *   console.log(err); // undefined
+   *   console.log(a); // "abc"
+   *   console.log(b); // "DEF"
+   * });
+   * var boundSomeFunction = Rx.Observable.bindNodeCallback(someFunction, (a, b) => a + b);
+   * boundSomeFunction()
+   * .subscribe(value => {
+   *   console.log(value); // "abcDEF"
+   * });
+   *
+   *
+   * @example <caption>Use on function calling callback in regular style</caption>
+   * someFunction(a => {
+   *   console.log(a); // 5
+   * });
+   * var boundSomeFunction = Rx.Observable.bindNodeCallback(someFunction);
+   * boundSomeFunction()
+   * .subscribe(
+   *   value => {}             // never gets called
+   *   err => console.log(err) // 5
+   *);
+   *
+   *
    * @see {@link bindCallback}
    * @see {@link from}
    * @see {@link fromPromise}
    *
-   * @param {function} func Function with a callback as the last parameter.
+   * @param {function} func Function with a Node.js-style callback as the last parameter.
    * @param {function} [selector] A function which takes the arguments from the
-   * callback and maps those a value to emit on the output Observable.
+   * callback and maps those to a value to emit on the output Observable.
    * @param {Scheduler} [scheduler] The scheduler on which to schedule the
    * callbacks.
    * @return {function(...params: *): Observable} A function which returns the


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Another attempt to make docs more in-depth and complete, with descriptions of all modes of usage and more examples.

More background on what and why I am doing is here: https://github.com/ReactiveX/rxjs/pull/2322
