### PR TITLE
fix(bindCallback): emit undefined when callback is without arguments

### DIFF
--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -8,6 +8,23 @@ const Observable = Rx.Observable;
 /** @test {bindCallback} */
 describe('Observable.bindCallback', () => {
   describe('when not scheduled', () => {
+    it('should emit undefined from a callback without arguments', () => {
+      function callback(cb) {
+        cb();
+      }
+      const boundCallback = Observable.bindCallback(callback);
+      const results = [];
+
+      boundCallback()
+        .subscribe((x: any) => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
     it('should emit one value from a callback', () => {
       function callback(datum, cb) {
         cb(datum);
@@ -104,6 +121,25 @@ describe('Observable.bindCallback', () => {
   });
 
   describe('when scheduled', () => {
+    it('should emit undefined from a callback without arguments', () => {
+      function callback(cb) {
+        cb();
+      }
+      const boundCallback = Observable.bindCallback(callback, null, rxTestScheduler);
+      const results = [];
+
+      boundCallback()
+        .subscribe((x: any) => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      rxTestScheduler.flush();
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
     it('should emit one value from a callback', () => {
       function callback(datum, cb) {
         cb(datum);

--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -15,6 +15,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
   subject: AsyncSubject<T>;
 
   /* tslint:disable:max-line-length */
+  static create(callbackFunc: (callback: () => any) => any, selector?: void, scheduler?: IScheduler): () => Observable<void>;
   static create<R>(callbackFunc: (callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): () => Observable<R>;
   static create<T, R>(callbackFunc: (v1: T, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T) => Observable<R>;
   static create<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (result: R) => any) => any, selector?: void, scheduler?: IScheduler): (v1: T, v2: T2) => Observable<R>;
@@ -119,7 +120,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
               subject.complete();
             }
           } else {
-            subject.next(innerArgs.length === 1 ? innerArgs[0] : innerArgs);
+            subject.next(innerArgs.length <= 1 ? innerArgs[0] : innerArgs);
             subject.complete();
           }
         };
@@ -157,7 +158,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
             self.add(scheduler.schedule(dispatchNext, 0, { value: result, subject }));
           }
         } else {
-          const value = innerArgs.length === 1 ? innerArgs[0] : innerArgs;
+          const value = innerArgs.length <= 1 ? innerArgs[0] : innerArgs;
           self.add(scheduler.schedule(dispatchNext, 0, { value, subject }));
         }
       };


### PR DESCRIPTION
**Description**
Related to issue #2254 in `bindNodeCallback`. It turns out `bindCallback` has the same problem:

When wrapped function calls its callback without any arguments, resulting Observable will emit empty array, intead of undefined.

```javascript
function callback(cb) {
   cb();
}

Observable.bindCallback(callback)
.subscribe(value => console.log(value)); // value is []
```

In RxJS 4 in `fromCalllback` resulting Observable emits undefined as seen here:
https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/fromcallback.js#L20-L21
(when array is empty, calling `results[0]` results in `undefined`, which is emitted).

**Related to**
#2254