### PR TITLE
fix(bindNodeCallback): emit undefined when callback has no success ar…

### DIFF
--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -8,6 +8,24 @@ const Observable = Rx.Observable;
 /** @test {bindNodeCallback} */
 describe('Observable.bindNodeCallback', () => {
   describe('when not scheduled', () => {
+    it('should emit undefined when callback is called without success arguments', () => {
+      function callback(cb) {
+        cb(null);
+      }
+
+      const boundCallback = Observable.bindNodeCallback(callback);
+      const results = [];
+
+      boundCallback()
+        .subscribe((x: any) => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
     it('should emit one value from a callback', () => {
       function callback(datum, cb) {
         cb(null, datum);
@@ -126,6 +144,26 @@ describe('Observable.bindNodeCallback', () => {
   });
 
   describe('when scheduled', () => {
+    it('should emit undefined when callback is called without success arguments', () => {
+      function callback(cb) {
+        cb(null);
+      }
+
+      const boundCallback = Observable.bindNodeCallback(callback, null, rxTestScheduler);
+      const results = [];
+
+      boundCallback()
+        .subscribe((x: any) => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      rxTestScheduler.flush();
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
     it('should emit one value from a callback', () => {
       function callback(datum, cb) {
         cb(null, datum);

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -112,7 +112,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
               subject.complete();
             }
           } else {
-            subject.next(innerArgs.length === 1 ? innerArgs[0] : innerArgs);
+            subject.next(innerArgs.length <= 1 ? innerArgs[0] : innerArgs);
             subject.complete();
           }
         };
@@ -162,7 +162,7 @@ function dispatch<T>(this: Action<DispatchState<T>>, state: DispatchState<T>) {
           self.add(scheduler.schedule(dispatchNext, 0, { value: result, subject }));
         }
       } else {
-        const value = innerArgs.length === 1 ? innerArgs[0] : innerArgs;
+        const value = innerArgs.length <= 1 ? innerArgs[0] : innerArgs;
         self.add(scheduler.schedule(dispatchNext, 0, { value, subject }));
       }
     };


### PR DESCRIPTION
**Description:**

Currently when callback is called without success arguments (second and following arguments),
`bindNodeCallback` emits empty array.

In RxJS 4 `undefined` is emitted instead as can be seen here:
https://github.com/Reactive-Extensions/RxJS/blob/master/src/core/perf/operators/fromnodecallback.js#L23-L24
(when results array is empty `results[0]` returns `undefined` which is then emitted)

**Related issue (if exists):**
Related issue with `bindCallback` #2328 
Closes #2254
