### PR TITLE
chore(dangerfile): fix test for hot and cold usages without types

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -40,10 +40,10 @@ if (testFilesIncludeExclusion.length > 0) {
 var testFilesMissingTypes = modifiedSpecFiles.reduce(function (acc, value) {
   var content = fs.readFileSync(value).toString();
 
-  var hotFnMatches = content.match(hotMatch) && content.match(hotSignatureMatch);
-  var coldFnMatches = content.match(coldMatch) && content.match(coldSignatureMatch);
+  var hotFnMatchesWithoutTypes = content.match(hotMatch) && !content.match(hotSignatureMatch);
+  var coldFnMatchesWithoutTypes = content.match(coldMatch) && !content.match(coldSignatureMatch);
 
-  if (!hotFnMatches || !coldFnMatches) {
+  if (hotFnMatchesWithoutTypes || coldFnMatchesWithoutTypes) {
     acc.push(path.basename(value));
   }
 


### PR DESCRIPTION
**Description:**

Hi, I just made two prs: #2329 #2328 and automatic checks fail on them, claiming I used `hot` and `cold` helpers in modified specs without type declarations for them.

Problem is, modified files seem to not use hot and cold helpers at all.

After checking `dangerfile.js` I suspect that logic in that file is flawed, so here is my attempt to fix it.

**Warning**
Note that I had no idea how to test this file, so please do yourself, or just carefully review.

**Related issue (if exists):**
Failing prs: #2329 #2328
