### PR TITLE
Ensure withCredentials is set after open for IE10

### DIFF
--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -25,11 +25,7 @@ export interface AjaxRequest {
 
 function getCORSRequest(this: AjaxRequest): XMLHttpRequest {
   if (root.XMLHttpRequest) {
-    const xhr = new root.XMLHttpRequest();
-    if ('withCredentials' in xhr) {
-      xhr.withCredentials = !!this.withCredentials;
-    }
-    return xhr;
+    return new root.XMLHttpRequest();
   } else if (!!root.XDomainRequest) {
     return new root.XDomainRequest();
   } else {
@@ -242,9 +238,13 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
         return null;
       }
 
-      // timeout and responseType can be set once the XHR is open
+      // timeout, responseType and withCredentials can be set once the XHR is open
       xhr.timeout = request.timeout;
       xhr.responseType = request.responseType;
+
+      if ('withCredentials' in xhr) {
+        xhr.withCredentials = !!request.withCredentials;
+      }
 
       // set headers
       this.setHeaders(xhr, headers);


### PR DESCRIPTION
**Description:**
IE10 throws an `InvalidStateError` due to `withCredentials` being set **before** `open()`.  This seems to be due to the release of IE10 stuck on an older spec [as described in this StackOverflow ticket](http://stackoverflow.com/questions/19666809/cors-withcredentials-support-limited)

**Related issue (if exists):**
None.