### PR TITLE
fix(bindNodeCallback): use scheduler on error in callback

### DIFF
--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -153,7 +153,7 @@ function dispatch<T>(this: Action<DispatchState<T>>, state: DispatchState<T>) {
       const err = innerArgs.shift();
 
       if (err) {
-        subject.error(err);
+        self.add(scheduler.schedule(dispatchError, 0, { err, subject }));
       } else if (selector) {
         const result = tryCatch(selector).apply(this, innerArgs);
         if (result === errorObject) {
@@ -171,7 +171,7 @@ function dispatch<T>(this: Action<DispatchState<T>>, state: DispatchState<T>) {
 
     const result = tryCatch(callbackFunc).apply(context, args.concat(handler));
     if (result === errorObject) {
-      subject.error(errorObject.e);
+      self.add(scheduler.schedule(dispatchError, 0, { err: errorObject.e, subject }));
     }
   }
 


### PR DESCRIPTION
**Description:**

`bindNodeCallback` with schedulers have different behaviour for errors from selector function and different for errors passed to callback. When selector throws, scheduler is used to schedule error as seen in
https://github.com/ReactiveX/rxjs/blob/master/src/observable/BoundNodeCallbackObservable.ts#L160

Yet when error comes from error object passed to callback by input function, error is just passed to subscriber, ignoring current scheduler:
https://github.com/ReactiveX/rxjs/blob/master/src/observable/BoundNodeCallbackObservable.ts#L156

I decided to let scheduler send error, since for me personally it is more predictable behaviour, when scheduler is passed. But if I am wrong and all errors should be sent synchronously, let me know and I will switch that change in other direction. Either way there is some disparity here.

Have a great day.