### PR TITLE
chore(danger): update dangerfile to validate commit message

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var _ = require('lodash');
+var validateMessage = require('validate-commit-msg');
 
 //simple regex matcher to detect usage of helper function and its type signature
 var hotMatch = /\bhot\(/gi;
@@ -53,4 +54,15 @@ var testFilesMissingTypes = modifiedSpecFiles.reduce(function (acc, value) {
 if (testFilesMissingTypes.length > 0) {
   fail('missing type definition import in tests (' + testFilesMissingTypes + ') (' + ++errorCount + ')');
   markdown('> (' + errorCount + ') : It seems updated test cases uses test scheduler interface `hot`, `cold` but miss to import type signature for those.');
+}
+
+//validate commit message in PR if it conforms conventional change log, notify if it doesn't.
+var messageConventionValid = danger.git.commits.reduce(function (acc, value) {
+  var valid = validateMessage(value.message);
+  return valid && acc;
+}, true);
+
+if (!messageConventionValid) {
+  fail('commit message does not follows conventional change log (' + ++errorCount + ')');
+  markdown('> (' + errorCount + ') : RxJS uses conventional change log to generate changelog automatically. It seems some of commit messages are not following those, please check [contributing guideline](https://github.com/ReactiveX/rxjs/blob/master/CONTRIBUTING.md#commit-message-format) and update commit messages.');
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR updates dangerfile to have one additional checker, to validate commit messages if it conforms conventional change log. If commits in PR does not conforms it, bot will leave messages like below to ask to update commit messages.

![screenshot_1](https://cloud.githubusercontent.com/assets/1210596/22771999/fb1d9072-ee4e-11e6-9679-e0c563ddbfe0.png)

- [ ] maybe `warn` instead of `fail` would be sufficient?
