### PR TITLE
feat(AjaxObservable) : support 'PATCH' request type

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -853,6 +853,21 @@ describe('Observable.ajax', () => {
     delete root.XMLHttpRequest.prototype.onerror;
     delete root.XMLHttpRequest.prototype.upload;
   });
+
+  describe('ajax.patch', () => {
+    it('should create an AjaxObservable with correct options', () => {
+      const body = { foo: 'bar' };
+      const headers = { first: 'first' };
+      // returns Observable, not AjaxObservable, so needs a cast
+      const { request } = <any>Rx.Observable
+        .ajax.patch('/flibbertyJibbet', body, headers);
+
+      expect(request.method).to.equal('PATCH');
+      expect(request.url).to.equal('/flibbertyJibbet');
+      expect(request.body).to.equal(body);
+      expect(request.headers).to.equal(headers);
+    });
+  });
 });
 
 class MockXMLHttpRequest {

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -66,6 +66,7 @@ export interface AjaxCreationMethod {
   get(url: string, headers?: Object): Observable<AjaxResponse>;
   post(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
   put(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
+  patch(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
   delete(url: string, headers?: Object): Observable<AjaxResponse>;
   getJSON<T>(url: string, headers?: Object): Observable<T>;
 }
@@ -84,6 +85,10 @@ export function ajaxDelete(url: string, headers?: Object): Observable<AjaxRespon
 
 export function ajaxPut(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
   return new AjaxObservable<AjaxResponse>({ method: 'PUT', url, body, headers });
+};
+
+export function ajaxPatch(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
+  return new AjaxObservable<AjaxResponse>({ method: 'PATCH', url, body, headers });
 };
 
 export function ajaxGetJSON<T>(url: string, headers?: Object): Observable<T> {
@@ -132,6 +137,7 @@ export class AjaxObservable<T> extends Observable<T> {
     create.post = ajaxPost;
     create.delete = ajaxDelete;
     create.put = ajaxPut;
+    create.patch = ajaxPatch;
     create.getJSON = ajaxGetJSON;
 
     return <AjaxCreationMethod>create;


### PR DESCRIPTION
Add support of the 'PATCH' request type based on the already existing 'PUT' request.
