### PR TITLE
fix(switch): stop leaking ChildSubscriptions

### DIFF
--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -75,7 +75,7 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
   protected _next(value: T): void {
     this.unsubscribeInner();
     this.active++;
-    this.add(this.innerSubscription = subscribeToResult(this, value));
+    this.innerSubscription = this.add(subscribeToResult(this, value));
   }
 
   protected _complete(): void {
@@ -90,7 +90,6 @@ class SwitchSubscriber<T, R> extends OuterSubscriber<T, R> {
     const innerSubscription = this.innerSubscription;
     if (innerSubscription) {
       innerSubscription.unsubscribe();
-      this.remove(innerSubscription);
     }
   }
 


### PR DESCRIPTION
**Description:**

For the switch operator, fix issue of ChildSubscriptions not removed, not GCd. (#2355)


