### PR TITLE
perf(bufferCount): optimize bufferCount operator

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/buffercount-skip.js
+++ b/perf/micro/current-thread-scheduler/operators/buffercount-skip.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldBufferCountWithCurrentThreadScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.currentThread).bufferWithCount(5, 3);
+  var newBufferCountWithCurrentThreadScheduler = RxNew.Observable.range(0, 25, RxNew.Scheduler.queue).bufferCount(5, 3);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old bufferCount with current thread scheduler', function () {
+      oldBufferCountWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new bufferCount with current thread scheduler', function () {
+      newBufferCountWithCurrentThreadScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/buffercount-skip.js
+++ b/perf/micro/immediate-scheduler/operators/buffercount-skip.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldBufferCountWithImmediateScheduler = RxOld.Observable.range(0, 25, RxOld.Scheduler.immediate).bufferWithCount(5, 3);
+  var newBufferCountWithImmediateScheduler = RxNew.Observable.range(0, 25).bufferCount(5, 3);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old bufferCount with immediate scheduler', function () {
+        oldBufferCountWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new bufferCount with immediate scheduler', function () {
+        newBufferCountWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -110,9 +110,10 @@ class BufferSkipCountSubscriber<T> extends Subscriber<T> {
   }
 
   protected _next(value: T): void {
-    const { bufferSize, startBufferEvery, buffers } = this;
+    const { bufferSize, startBufferEvery, buffers, count } = this;
 
-    if (this.count++ % startBufferEvery === 0) {
+    this.count++;
+    if (count % startBufferEvery === 0) {
       buffers.push([]);
     }
 

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -1,6 +1,7 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
+import { TeardownLogic } from '../Subscription';
 
 /**
  * Buffers the source Observable values until the size hits the maximum
@@ -58,7 +59,7 @@ class BufferCountOperator<T> implements Operator<T, T[]> {
     }
   }
 
-  call(subscriber: Subscriber<T[]>, source: any): any {
+  call(subscriber: Subscriber<T[]>, source: any): TeardownLogic {
     return source.subscribe(new this.subscriberClass(subscriber, this.bufferSize, this.startBufferEvery));
   }
 }
@@ -108,7 +109,7 @@ class BufferSkipCountSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  protected _next(value: T) {
+  protected _next(value: T): void {
     const { bufferSize, startBufferEvery, buffers } = this;
 
     if (this.count++ % startBufferEvery === 0) {
@@ -125,7 +126,7 @@ class BufferSkipCountSubscriber<T> extends Subscriber<T> {
     }
   }
 
-  protected _complete() {
+  protected _complete(): void {
     const buffers = this.buffers;
 
     while (buffers.length > 0) {

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -128,12 +128,12 @@ class BufferSkipCountSubscriber<T> extends Subscriber<T> {
   }
 
   protected _complete(): void {
-    const buffers = this.buffers;
+    const { buffers, destination } = this;
 
     while (buffers.length > 0) {
       let buffer = buffers.shift();
       if (buffer.length > 0) {
-        this.destination.next(buffer);
+        destination.next(buffer);
       }
     }
     super._complete();


### PR DESCRIPTION
The `bufferCount()` operator can be used as `bufferCount(5, 3)` or `bufferCount(5)` (= `bufferCount(5, 5)`.

My assumption is that the second use-case `bufferCount(5)` is very common (maybe even more common that the first one) and can be handled in an simpler way. This means instead of keeping an array of buffers `T[][]` we can have just a single buffer `T[]`. This simplifies the subscriber class significantly and runs faster.

For this reason I split the original subscriber into two classes `BufferSkipCountSubscriber` and `BufferCountSubscriber` each handling one use-case.

**Performance of `bufferCount(5)`:**

Before:

```
$ node perf/micro buffercount 
                                         |                     RxJS 4.1.0 |                     RxJS 5.1.0 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                 buffercount - immediate |                13,277 (±1.39%) |               308,516 (±2.25%) |          23.24x |        2,223.6%
                             buffercount |                 9,046 (±2.52%) |               143,636 (±2.19%) |          15.88x |        1,487.9%
```

After:

```
$ node perf/micro buffercount 
                                         |                     RxJS 4.1.0 |                     RxJS 5.1.0 |          factor |      % improved
---------------------------------------------------------------------------------------------------------------------------------------------------
                 buffercount - immediate |                13,205 (±1.02%) |               525,996 (±1.84%) |          39.83x |        3,883.2%
                             buffercount |                 9,330 (±2.55%) |               204,174 (±2.12%) |          21.88x |        2,088.4%
```

This improves performance on the `buffercount - immediate` script roughly from `23.24x` to `39.83x` and `buffercount` from `15.88x` to `21.88x`.

Performance of `bufferCount(5, 3)` remains the same. I could just remove one additional condition that wasn't necessary any more when we have two separate classes now.

I also tried to make an implementations using only fixed size arrays for both use-cases but these always turned out to be less efficient than the current implementation. It required calculating indices on every `next()`, at least one additional `if` condition and calling `Array.split()` to clone the buffer when calling `destination.next(...)`. Using `Array.push()` without `Array.split()` was always faster.