### PR TITLE
fix(merge): return Observable when called with single lowerCaseO

### DIFF
--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -8,11 +8,10 @@ import {$$iterator} from '../../dist/cjs/symbol/iterator';
 import $$symbolObservable from 'symbol-observable';
 
 export function lowerCaseO<T>(...args): Rx.Observable<T> {
-  const values = [].slice.apply(arguments);
 
   const o = {
     subscribe: function (observer) {
-      values.forEach(function (v) {
+      args.forEach(function (v) {
         observer.next(v);
       });
       observer.complete();

--- a/spec/observables/merge-spec.ts
+++ b/spec/observables/merge-spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
+import {lowerCaseO} from '../helpers/test-helper';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
 declare const hot: typeof marbleTestingSignature.hot;
@@ -209,6 +210,36 @@ describe('Observable.merge(...observables)', () => {
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should merge single lowerCaseO into RxJS Observable', () => {
+    const e1 = lowerCaseO('a', 'b', 'c');
+
+    const result = Observable.merge(e1);
+
+    expect(result).to.be.instanceof(Observable);
+    expectObservable(result).toBe('(abc|)');
+  });
+
+  it('should merge two lowerCaseO into RxJS Observable', () => {
+    const e1 = lowerCaseO('a', 'b', 'c');
+    const e2 = lowerCaseO('d', 'e', 'f');
+
+    const result = Observable.merge(e1, e2);
+
+    expect(result).to.be.instanceof(Observable);
+    expectObservable(result).toBe('(abcdef|)');
+  });
+});
+
+describe('Observable.merge(...observables, Scheduler)', () => {
+  it('should merge single lowerCaseO into RxJS Observable', () => {
+    const e1 = lowerCaseO('a', 'b', 'c');
+
+    const result = Observable.merge(e1, rxTestScheduler);
+
+    expect(result).to.be.instanceof(Observable);
+    expectObservable(result).toBe('(abc|)');
   });
 });
 

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -160,7 +160,7 @@ export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | I
     concurrent = <number>observables.pop();
   }
 
-  if (scheduler === null && observables.length === 1) {
+  if (scheduler === null && observables.length === 1 && observables[0] instanceof Observable) {
     return <Observable<R>>observables[0];
   }
 


### PR DESCRIPTION
**Description:**

Currently when `merge` is used with lower case observable, it returns lower case observable itself, instead of adapting it to RxJS Observable.

```ts
Observable.merge(lowerCaseO).map(...); // throws, since 'map' is not on lower case observable
```
