### PR TITLE
fix(subscribeToResult): accept array-like as result

### DIFF
--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -58,6 +58,17 @@ describe('subscribeToResult', () => {
     expect(expected).to.be.deep.equal(result);
   });
 
+  it('should subscribe to an array-like and emit synchronously', () => {
+    const result = {0: 0, 1: 1, 2: 2, length: 3};
+    const expected = [];
+
+    const subscriber = new OuterSubscriber(x => expected.push(x));
+
+    subscribeToResult(subscriber, result);
+
+    expect(expected).to.be.deep.equal([0, 1, 2]);
+  });
+
   it('should subscribe to a promise', (done: MochaDone) => {
     const result = Promise.resolve(42);
 

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -1,4 +1,5 @@
 import { isArray } from '../util/isArray';
+import { isArrayLike } from '../util/isArrayLike';
 import { isPromise } from '../util/isPromise';
 import { PromiseObservable } from './PromiseObservable';
 import { IteratorObservable } from'./IteratorObservable';
@@ -11,8 +12,6 @@ import { Observable, ObservableInput } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { ObserveOnSubscriber } from '../operator/observeOn';
 import { $$observable } from '../symbol/observable';
-
-const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 'number');
 
 /**
  * We need this JSDoc comment for affecting ESDoc.

--- a/src/util/isArrayLike.ts
+++ b/src/util/isArrayLike.ts
@@ -1,0 +1,1 @@
+export const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 'number');

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -1,5 +1,5 @@
 import { root } from './root';
-import { isArray } from './isArray';
+import { isArrayLike } from './isArrayLike';
 import { isPromise } from './isPromise';
 import { isObject } from './isObject';
 import { Subscriber } from '../Subscriber';
@@ -32,7 +32,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
     } else {
       return result.subscribe(destination);
     }
-  } else if (isArray(result)) {
+  } else if (isArrayLike(result)) {
     for (let i = 0, len = result.length; i < len && !destination.closed; i++) {
       destination.next(result[i]);
     }


### PR DESCRIPTION
**Description:**

`Observable.from` and operators using `subscribeToResult` both use interface `ObservableInput` for describing their input, so it follows that they should accept and work properly on the same kind of input.

And yet
```ts
Observable.from({0: 0, 1: 1, length: 2});
```
works as expected on array-likes, while
```ts
Observable.merge({0: 0, 1: 1, length: 2});
```
errors, saying that given argument is not proper observable.

Since array-likes belong to `ObservableInput` interface, I submit fix that makes operators using `subscribeToResult` work properly with array-likes.
