### PR TITLE
Ignore coverage

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ perf
 spec
 .git
 yarn.lock
+coverage


### PR DESCRIPTION
It's 5.5mb that people installing this don't need :)

**RxJS version:**
<= 5 beta 12

**Code to reproduce:**

     > npm install @reactivex/rxjs@5.0.0-beta.12

**Expected behavior:**

     > test -e node_modules/@reactivex/rxjs/coverage
     > echo $?
     1

**Actual behavior:**

    > test -e node_modules/@reactivex/rxjs/coverage
    > echo $?
    0




