### PR TITLE
docs(repeat): Remove scheduler as param.

### DIFF
--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -10,7 +10,6 @@ import { TeardownLogic } from '../Subscription';
  *
  * <img src="./img/repeat.png" width="100%">
  *
- * @param {Scheduler} [scheduler] the IScheduler to emit the items on.
  * @param {number} [count] the number of times the source Observable items are repeated, a count of 0 will yield
  * an empty Observable.
  * @return {Observable} an Observable that repeats the stream of items emitted by the source Observable at most


### PR DESCRIPTION
**Description:**
The RxJS 5.0 repeat operator does not take a scheduler as a param but is documented as having it as a parameter. I deleted this line. Where is the ReactiveX website version control hosted so I can change the documentation for the RxJS implementation of repeat?