### PR TITLE
fix(mergeAll): introduce variant support <T, R> for mergeMap

### DIFF
--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -3,7 +3,11 @@ import { Operator } from '../Operator';
 import { Observer } from '../Observer';
 import { Subscription } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
+import { Subscribable } from '../Observable';
 import { subscribeToResult } from '../util/subscribeToResult';
+
+export function mergeAll<T>(this: Observable<T>, concurrent?: number): T;
+export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscribable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable which


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR applies same type definition variant to `concatAll` (https://github.com/ReactiveX/rxjs/pull/1603) to `mergeMap`

Same as concatAll, note this doesn't provide auto-inference for types, only provides generic variant to explicitly specify types due to current design of typescript compiler.

**Related issue (if exists):**
- closes #2372
