### PR TITLE
chore(danger): warn only for non conventional changelog

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -63,6 +63,6 @@ var messageConventionValid = danger.git.commits.reduce(function (acc, value) {
 }, true);
 
 if (!messageConventionValid) {
-  fail('commit message does not follows conventional change log (' + ++errorCount + ')');
+  warn('commit message does not follows conventional change log (' + ++errorCount + ')');
   markdown('> (' + errorCount + ') : RxJS uses conventional change log to generate changelog automatically. It seems some of commit messages are not following those, please check [contributing guideline](https://github.com/ReactiveX/rxjs/blob/master/CONTRIBUTING.md#commit-message-format) and update commit messages.');
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR lower failure checker for conventional change log commit message into warning, to avoid checker fails due to commit like merge commits.

**Related issue (if exists):**
