### PR TITLE
Link an externally available System bundle repackaging in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,20 @@ npm install @reactivex/rxjs@5.0.0
 
 ### CDN
 
-For CDN, you can use [unpkg](https://unpkg.com/):
-  
+For CDN, you can use [unpkg](https://unpkg.com/) to retrieve the single-file UMD
+bundle:
+
 https://unpkg.com/rxjs/bundles/Rx.min.js
+
+Alternatively, the following package publishes a single-file System bundle for
+easy consumption via Plunkr. This bundle makes it possible to consume the
+various sub-modules with a single network request:
+
+https://www.npmjs.com/package/rxjs-system-bundle
+
+And is also available via unpkg:
+
+https://unpkg.com/rxjs-system-bundle@5.1.1/Rx.system.min.js
 
 #### Node.js Usage:
 


### PR DESCRIPTION
**Description:**

In the past the RxJS project published a System bundle, but decided not to continue doing so.  Studying the discussion of that decision, there did not appear to be a strong motivation against the availability of such a bundle (and indeed it is very convenient for consumption via a Plunkr or any other contacts without a build process), avoiding the numerous separate requests that otherwise happen when using System.

Therefore, this adds links to a parallel package I have created to publish the System bundles.

**Related issue (if exists):**

https://github.com/ReactiveX/rxjs/issues/1776
