### PR TITLE
fix(reduce): fix overload ordering

### DIFF
--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -302,23 +302,84 @@ describe('Observable.prototype.reduce', () => {
 
   it('should accept T typed reducers', () => {
     type(() => {
-      let a: Rx.Observable<{ a?: number; b?: string }>;
-      a.reduce((acc, value) => {
+      let a: Rx.Observable<{ a: number; b: string }>;
+      const reduced = a.reduce((acc, value) => {
         value.a = acc.a;
         value.b = acc.b;
         return acc;
-      }, {});
+      });
+
+      reduced.subscribe(r => {
+        r.a.toExponential();
+        r.b.toLowerCase();
+      });
     });
   });
 
-  it('should accept R typed reducers', () => {
+  it('should accept R typed reducers when R is assignable to T', () => {
     type(() => {
-      let a: Rx.Observable<{ a: number; b: string }>;
-      a.reduce<{ a?: number; b?: string }>((acc, value) => {
+      let a: Rx.Observable<{ a?: number; b?: string }>;
+      const reduced = a.reduce((acc, value) => {
         value.a = acc.a;
         value.b = acc.b;
         return acc;
       }, {});
+
+      reduced.subscribe(r => {
+        r.a.toExponential();
+        r.b.toLowerCase();
+      });
+    });
+  });
+
+  it('should accept R typed reducers when R is not assignable to T', () => {
+    type(() => {
+      let a: Rx.Observable<{ a: number; b: string }>;
+      const seed = {
+        as: [1],
+        bs: ['a']
+      };
+      const reduced = a.reduce((acc, value) => {
+        acc.as.push(value.a);
+        acc.bs.push(value.b);
+        return acc;
+      }, seed);
+
+      reduced.subscribe(r => {
+        r.as[0].toExponential();
+        r.bs[0].toLowerCase();
+      });
+    });
+  });
+
+  it('should accept R typed reducers and reduce to type R', () => {
+    type(() => {
+      let a: Rx.Observable<{ a: number; b: string }>;
+      const reduced = a.reduce<{ a?: number; b?: string }>((acc, value) => {
+        value.a = acc.a;
+        value.b = acc.b;
+        return acc;
+      }, {});
+
+      reduced.subscribe(r => {
+        r.a.toExponential();
+        r.b.toLowerCase();
+      });
+    });
+  });
+
+  it('should accept array of R typed reducers and reduce to array of R', () => {
+    type(() => {
+      let a: Rx.Observable<number>;
+      const reduced = a.reduce((acc, cur) => {
+        console.log(acc);
+        acc.push(cur.toString());
+        return acc;
+      }, [] as string[]);
+
+      reduced.subscribe(rs => {
+        rs[0].toLowerCase();
+      });
     });
   });
 });

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -3,9 +3,9 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
-export function reduce<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed: R): Observable<R>;
 export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed: T[]): Observable<T[]>;
 export function reduce<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
+export function reduce<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed: R): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -3,9 +3,9 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
-export function reduce<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
-export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): Observable<T[]>;
 export function reduce<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed?: R): Observable<R>;
+export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): Observable<T[]>;
+export function reduce<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -3,8 +3,8 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
-export function reduce<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed?: R): Observable<R>;
-export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): Observable<T[]>;
+export function reduce<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed: R): Observable<R>;
+export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed: T[]): Observable<T[]>;
 export function reduce<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
**Description:**
Type inference for `Observable.prototype.reduce` currently behaves incorrectly, resulting in spurious type errors, in many common cases, when the type of `seed` is a different type than the value type of the Observable.

One of the declared overloads is intended to specifically cater to this scenario but fails to do so because of its ordering with respect to the other overload declared.

The overload in question takes two type arguments, `T` and `R`, making it more specific than the overloads declared before it.

Due to TypeScript's overload resolution algorithm, which picks the first matching overload, this overload does not have the intended effect.

This is documented here https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html in the section entitled **Function Overloads**, under the **Ordering** heading, which states

> Don’t put more general overloads before more specific overloads:

> Do sort overloads by putting the more general signatures after more specific signatures:

> Why: TypeScript chooses the first matching overload when resolving function calls. When an earlier overload is “more general” than a later one, the later one is effectively hidden and cannot be called.

**Related issue (if exists):**
This fixes #2338
