### PR TITLE
fix(concat): return Observable when called with single lowerCaseO

### DIFF
--- a/spec/observables/concat-spec.ts
+++ b/spec/observables/concat-spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
+import {lowerCaseO} from '../helpers/test-helper';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
 declare const hot: typeof marbleTestingSignature.hot;
@@ -366,5 +367,21 @@ describe('Observable.concat', () => {
       });
 
     expect(e1Subscribed).to.be.false;
+  });
+
+  it('should return passed observable if no scheduler was passed', () => {
+    const source = cold('--a---b----c---|');
+    const result = Observable.concat(source);
+
+    expect(result).to.equal(source);
+    expectObservable(result).toBe('--a---b----c---|');
+  });
+
+  it('should return RxJS Observable when single lowerCaseO was passed', () => {
+    const source = lowerCaseO('a', 'b', 'c');
+    const result = Observable.concat(source);
+
+    expect(result).to.be.an.instanceof(Observable);
+    expectObservable(result).toBe('(abc|)');
   });
 });

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -135,7 +135,7 @@ export function concatStatic<T, R>(...observables: Array<ObservableInput<any> | 
     scheduler = args.pop();
   }
 
-  if (scheduler === null && observables.length === 1) {
+  if (scheduler === null && observables.length === 1 && observables[0] instanceof Observable) {
     return <Observable<R>>observables[0];
   }
 


### PR DESCRIPTION
**Description:**

When static `concat` is passed single lower case observable, it returns that lower case observable, instead of adapting it to RxJS Observable.

**Related issue:**
https://github.com/ReactiveX/rxjs/pull/2363 <- we had exactly the same issue with merge
