### PR TITLE
refactor(window): remove redundant if condition

### DIFF
--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -109,12 +109,9 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
   }
 
   private openWindow(): void  {
-    const prevWindow = this.window;
-    if (prevWindow) {
-      prevWindow.complete();
-    }
-    const destination = this.destination;
+    this.window.complete();
+
     const newWindow = this.window = new Subject<T>();
-    destination.next(newWindow);
+    this.destination.next(newWindow);
   }
 }


### PR DESCRIPTION
**Description:**

I was porting `window` operator to RxPHP and I stumbled upon this condition inside `window.ts`:

```
private openWindow(): void  {
  const prevWindow = this.window;
  if (prevWindow) {
    prevWindow.complete();		
  }
  ...
```

I think this condition is redundant because its always true. The `this.window` property is set right when the property is created and the only situation it's set to null `this.window = null;` is in `_unsubscribe()` method. 

I think this was supposed to handle situations where the closing Observable keeps emitting closing signals even after unsubscribing the source Observable. For example like the following diagram:

```
const source = hot('-1-2-^3-4-5-6-7-8-9-|         ');
const subs =            '^       !                ';
const closings = hot('---^---x---x---x---x---x---|');
```

However, the closing Observable is automatically unsubscribed at [`window.ts#59`](https://github.com/ReactiveX/rxjs/blob/master/src/operator/window.ts#L59).

All the tests are passing. I didn't add any new tests because I think this is already covered in existing test cases.

