### PR TITLE
docs(*): add more descriptive @param definitions for callbacks

### DIFF
--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -55,11 +55,11 @@ import { subscribeToResult } from '../util/subscribeToResult';
  *   );
  *   // 1, 2, 3, error in source. Details: four!
  *
- * @param {function} selector a function that takes as arguments `err`, which is the error, and `caught`, which
- *  is the source observable, in case you'd like to "retry" that observable by returning it again. Whatever observable
- *  is returned by the `selector` will be used to continue the observable chain.
- * @return {Observable} An observable that originates from either the source or the observable returned by the
- *  catch `selector` function.
+ * @param {function(err: any, caught: Observable<T>): Observable<T|R>} selector a function that takes as arguments `err`,
+ * which is the error, and `caught`, which is the source observable, in case you'd like to "retry" that observable by
+ * returning it again. Whatever observable is returned by the `selector` will be used to continue the observable chain.
+ * @return {Observable<T>} An observable that originates from either the source or the observable returned by the
+ * catch `selector` function.
  * @method catch
  * @name catch
  * @owner Observable

--- a/src/operator/combineAll.ts
+++ b/src/operator/combineAll.ts
@@ -33,7 +33,7 @@ import { Observable } from '../Observable';
  * @see {@link combineLatest}
  * @see {@link mergeAll}
  *
- * @param {function} [project] An optional function to map the most recent
+ * @param {function(...values: T[]): R} [project] An optional function to map the most recent
  * values from each inner Observable into a new result. Takes each of the most
  * recent values from each collected inner Observable as arguments, in order.
  * @return {Observable} An Observable of projected results or arrays of recent

--- a/src/operator/combineLatest.ts
+++ b/src/operator/combineLatest.ts
@@ -60,9 +60,9 @@ export function combineLatest<T, TOther, R>(this: Observable<T>, array: Observab
  *
  * @param {ObservableInput} other An input Observable to combine with the source
  * Observable. More than one input Observables may be given as argument.
- * @param {function} [project] An optional function to project the values from
+ * @param {function(...values: T[]): R} [project] An optional function to project the values from
  * the combined latest values into a new value on the output Observable.
- * @return {Observable} An Observable of projected values from the most recent
+ * @return {Observable<R>} An Observable of projected values from the most recent
  * values from each input Observable, or an array of the most recent values from
  * each input Observable.
  * @method combineLatest

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -6,7 +6,7 @@ import { Observable } from '../Observable';
 /**
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
  * the source terminates on complete or error.
- * @param {function} callback Function to be called when source terminates.
+ * @param {function(): void} callback Function to be called when source terminates.
  * @return {Observable} An Observable that mirrors the source, but will call the specified function on termination.
  * @method finally
  * @owner Observable

--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -7,7 +7,7 @@ import { Observable } from '../Observable';
  *
  * <img src="./img/isEmpty.png" width="100%">
  *
- * @return {Observable} An Observable that emits a Boolean.
+ * @return {Observable<boolean>} An Observable that emits a Boolean.
  * @method isEmpty
  * @owner Observable
  */

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -35,8 +35,12 @@ export function last<T>(this: Observable<T>,
  *
  * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
- * @param {function} predicate - The condition any source emitted item has to satisfy.
- * @return {Observable} An Observable that emits only the last item satisfying the given condition
+ * @param {function(value: T, index: number, source: Observable<T>): boolean} [predicate] - The condition any source
+ * emitted item has to satisfy.
+ * @param {function(value: T, index: number): R} [resultSelector] - A function to
+ * produce the value on the output Observable
+ * @param {R} [defaultValue] - The default value returned with empty source Observable.
+ * @return {Observable<T|R>} An Observable that emits only the last item satisfying the given condition
  * from the source, or an NoSuchElementException if no such items are emitted.
  * @throws - Throws if no items that match the predicate are emitted by the source Observable.
  * @method last

--- a/src/operator/max.ts
+++ b/src/operator/max.ts
@@ -26,9 +26,9 @@ import { ReduceOperator } from './reduce';
  *
  * @see {@link min}
  *
- * @param {Function} [comparer] - Optional comparer function that it will use instead of its default to compare the
+ * @param {function(x: T, y: T): number} [comparer] - Optional comparer function that it will use instead of its default to compare the
  * value of two items.
- * @return {Observable} An Observable that emits item with the largest value.
+ * @return {Observable<T>} An Observable that emits item with the largest value.
  * @method max
  * @owner Observable
  */

--- a/src/operator/min.ts
+++ b/src/operator/min.ts
@@ -26,9 +26,9 @@ import { ReduceOperator } from './reduce';
  *
  * @see {@link max}
  *
- * @param {Function} [comparer] - Optional comparer function that it will use instead of its default to compare the
+ * @param {function(x: T, y: T): number} [comparer] - Optional comparer function that it will use instead of its default to compare the
  * value of two items.
- * @return {Observable<R>} An Observable that emits item with the smallest value.
+ * @return {Observable<T>} An Observable that emits item with the smallest value.
  * @method min
  * @owner Observable
  */

--- a/src/operator/sequenceEqual.ts
+++ b/src/operator/sequenceEqual.ts
@@ -50,9 +50,9 @@ import { errorObject } from '../util/errorObject';
  * @see {@link zip}
  * @see {@link withLatestFrom}
  *
- * @param {Observable} compareTo The observable sequence to compare the source sequence to.
- * @param {function} [comparor] An optional function to compare each value pair
- * @return {Observable} An Observable of a single boolean value representing whether or not
+ * @param {Observable<T>} compareTo The observable sequence to compare the source sequence to.
+ * @param {function(a: T, b: T): boolean} [comparor] An optional function to compare each value pair
+ * @return {Observable<boolean>} An Observable of a single boolean value representing whether or not
  * the values emitted by both observables were equal in sequence.
  * @method sequenceEqual
  * @owner Observable

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -14,10 +14,10 @@ import { TeardownLogic } from '../Subscription';
  *
  * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
- * @param {Function} predicate - A predicate function to evaluate items emitted by the source Observable.
+ * @param {function(value: T, index: number, source: Observable<T>): boolean} [predicate] - A predicate function to
+ * evaluate items emitted by the source Observable.
  * @return {Observable<T>} An Observable that emits the single item emitted by the source Observable that matches
  * the predicate.
- .
  * @method single
  * @owner Observable
  */

--- a/src/operator/skipWhile.ts
+++ b/src/operator/skipWhile.ts
@@ -9,7 +9,7 @@ import { TeardownLogic } from '../Subscription';
  *
  * <img src="./img/skipWhile.png" width="100%">
  *
- * @param {Function} predicate - A function to test each item emitted from the source Observable.
+ * @param {function(value: T, index: number): boolean} predicate - A function to test each item emitted from the source Observable.
  * @return {Observable<T>} An Observable that begins emitting items emitted by the source Observable when the
  * specified predicate becomes false.
  * @method skipWhile

--- a/src/operator/withLatestFrom.ts
+++ b/src/operator/withLatestFrom.ts
@@ -49,7 +49,7 @@ export function withLatestFrom<T, R>(this: Observable<T>, array: ObservableInput
  *
  * @param {ObservableInput} other An input Observable to combine with the source
  * Observable. More than one input Observables may be given as argument.
- * @param {Function} [project] Projection function for combining values
+ * @param {function(...values: T[]): R} [project] Projection function for combining values
  * together. Receives all values in order of the Observables passed, where the
  * first parameter is a value from the source Observable. (e.g.
  * `a.withLatestFrom(b, c, (a1, b1, c1) => a1 + b1 + c1)`). If this is not


### PR DESCRIPTION
I updated a couple of `@param` tags to include more precise definitions for callback functions