### PR TITLE
fix(single): predicate function receives indices starting at 0

### DIFF
--- a/spec/operators/single-spec.ts
+++ b/spec/operators/single-spec.ts
@@ -1,3 +1,4 @@
+import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
@@ -149,6 +150,23 @@ describe('Observable.prototype.single', () => {
     };
 
     expectObservable(e1.single(predicate)).toBe(expected, {z: undefined});
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should call predicate with indices starting at 0', () => {
+    const e1 =    hot('--a--b--c--|');
+    const e1subs =    '^          !';
+    const expected =  '-----------(b|)';
+
+    let indices = [];
+    const predicate = function(value, index) {
+      indices.push(index);
+      return value === 'b';
+    };
+
+    expectObservable(e1.single(predicate).do(null, null, () => {
+      expect(indices).to.deep.equal([0, 1, 2]);
+    })).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -61,19 +61,18 @@ class SingleSubscriber<T> extends Subscriber<T> {
   }
 
   protected _next(value: T): void {
-    const predicate = this.predicate;
-    this.index++;
-    if (predicate) {
-      this.tryNext(value);
+    const index = this.index++;
+
+    if (this.predicate) {
+      this.tryNext(value, index);
     } else {
       this.applySingleValue(value);
     }
   }
 
-  private tryNext(value: T): void {
+  private tryNext(value: T, index: number): void {
     try {
-      const result = this.predicate(value, this.index, this.source);
-      if (result) {
+      if (this.predicate(value, index, this.source)) {
         this.applySingleValue(value);
       }
     } catch (err) {


### PR DESCRIPTION
When using the predicate function in the `single()` operator it passes indices starting at `1` instead of `0`. 

```
Observable.from(['a', 'b', 'c', 'd', 'e'])
  .single((val, i) => {
    console.log(val + ' ' + i);
    return val === 'b';
  })
  .subscribe();
```

This prints to console:
```
a 1
b 2
c 3
d 4
e 5
```

Live demo: https://jsbin.com/raveji/2/edit?js,console

That's because it's first incremented [(single.ts#L65)](https://github.com/ReactiveX/rxjs/blob/master/src/operator/single.ts#L65) and then read again from property [(single.ts#L75)](https://github.com/ReactiveX/rxjs/blob/master/src/operator/single.ts#L75).

In RxJS 4 the indices start at `0` (which is probably more expected behavior). Live demo: https://jsbin.com/qihaqur/3/edit?js,console

If the user is relying on indices starting at `1` than this could be a BC. Otherwise now it's compatible with RxJS 4.


There's one more inconsistency with RxJS 4.

When there's no item matching the predicate function the RxJS 4 version sends an error notification `EmptyError`. Live demo: https://jsbin.com/pukikes/3/edit?js,console

```
Observable.range(1, 5)
  .single(val => {
    return false;
  })
  .subscribe(
    val => console.log(val),
    err => console.log('error', err)
  );
```
This prints to console:
```
error { [EmptyError: Sequence contains no elements.] message: 'Sequence contains no elements.' }
```

But the RxJS 5 implementation just emits `undefined` as `next` and sends `error` only when the `single()` operator received no value at all [(single.ts#L87)](https://github.com/ReactiveX/rxjs/blob/master/src/operator/single.ts#L87).

Live demo: https://jsbin.com/yavepan/2/edit?js,console.

The docblock for `single()` says:

> If the source Observable emits more than one such item or no such items, notify of an IllegalArgumentException or NoSuchElementException respectively.

This describes the RxJS 4 behavior but the RxJS 5 tests cover a use-case where `single()` emits `undefined` [single-spec.ts#L142](https://github.com/ReactiveX/rxjs/blob/master/spec/operators/single-spec.ts#L142). Also the two exception classes mentioned don't exist.

So I'm wondering what's the correct behavior?


