### PR TITLE
fix(ErrorObservable): remove type constraint to error value

### DIFF
--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -12,7 +12,7 @@ export interface DispatchArg {
  * @extends {Ignored}
  * @hide true
  */
-export class ErrorObservable<T> extends Observable<any> {
+export class ErrorObservable extends Observable<any> {
 
   /**
    * Creates an Observable that emits no items to the Observer and immediately
@@ -54,7 +54,7 @@ export class ErrorObservable<T> extends Observable<any> {
    * @name throw
    * @owner Observable
    */
-  static create<T>(error: T, scheduler?: IScheduler): ErrorObservable<T> {
+  static create(error: any, scheduler?: IScheduler): ErrorObservable {
     return new ErrorObservable(error, scheduler);
   }
 
@@ -63,7 +63,7 @@ export class ErrorObservable<T> extends Observable<any> {
     subscriber.error(error);
   }
 
-  constructor(public error: T, private scheduler?: IScheduler) {
+  constructor(public error: any, private scheduler?: IScheduler) {
     super();
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR updates type signature of static creation method for `ErrorObservable` to no longer carry type constraint to value of error.

**Related issue (if exists):**
- closes #2395
