### PR TITLE
feat(Subject): implement hasObservers

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -473,6 +473,18 @@ describe('Subject', () => {
     expect(results).to.deep.equal(['a', error]);
   });
 
+  it('should return corresponding hasObserver value', () => {
+    const subject = new Rx.Subject();
+
+    expect(subject.hasObservers()).to.be.false;
+
+    subject.subscribe(() => {
+      //noop
+    });
+
+    expect (subject.hasObservers()).to.be.true;
+  });
+
   describe('asObservable', () => {
     it('should hide subject', () => {
       const subject = new Rx.Subject();

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -43,6 +43,10 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     return new AnonymousSubject<T>(destination, source);
   }
 
+  public hasObservers(): boolean {
+    return this.observers && this.observers.length > 0;
+  }
+
   lift<R>(operator: Operator<T, R>): Observable<T> {
     const subject = new AnonymousSubject(this, this);
     subject.operator = <any>operator;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Related with https://github.com/ReactiveX/rxjs/pull/2279#discussion_r98346733.

I was originally under assumption of `Subject::observers` is publicly exposed as readonly to allow check Subject has observer or not, But since it's encapsulated, current implementation of subject does not have way to check if it has observers or not. This PR implements `Subject::hasObservers` corresponds to RxJS v4.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/2232
