### PR TITLE
fix(multicast): Ensure ConnectableObservables returned by multicast are state-isolated

### DIFF
--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -41,6 +41,33 @@ describe('Observable.prototype.multicast', () => {
     connectable.connect();
   });
 
+  it('should multicast a ConnectableObservable', (done: MochaDone) => {
+    const expected = [1, 2, 3, 4];
+
+    const source = new Subject<number>();
+    const connectable = source.multicast(new Subject<number>());
+    const replayed = connectable.multicast(new ReplaySubject<number>());
+
+    connectable.connect();
+    replayed.connect();
+
+    source.next(1);
+    source.next(2);
+    source.next(3);
+    source.next(4);
+    source.complete();
+
+    replayed.do({
+      next(x: number) {
+        expect(x).to.equal(expected.shift());
+      },
+      complete() {
+        expect(expected.length).to.equal(0);
+      }
+    })
+    .subscribe(null, done, done);
+  });
+
   it('should accept Subject factory functions', (done: MochaDone) => {
     const expected = [1, 2, 3, 4];
 

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -54,6 +54,8 @@ export class ConnectableObservable<T> extends Observable<T> {
 export const connectableObservableDescriptor: PropertyDescriptorMap = {
   operator: { value: null },
   _refCount: { value: 0, writable: true },
+  _subject: { value: null, writable: true },
+  _connection: { value: null, writable: true },
   _subscribe: { value: (<any> ConnectableObservable.prototype)._subscribe },
   getSubject: { value: (<any> ConnectableObservable.prototype).getSubject },
   connect: { value: (<any> ConnectableObservable.prototype).connect },


### PR DESCRIPTION
This fix ensures ConnectableObservables created by multicast start with null _subject, _connection,
and 0 _refCount. Fixes #2401.