### PR TITLE
fix(window*): always emit only Observables

### DIFF
--- a/spec/operators/window-spec.ts
+++ b/spec/operators/window-spec.ts
@@ -1,3 +1,4 @@
+import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
@@ -252,5 +253,21 @@ describe('Observable.prototype.window', () => {
     expectObservable(result).toBe(expected, expectedValues);
     expectSubscriptions(source.subscriptions).toBe(subs);
     expectSubscriptions(closings.subscriptions).toBe(closingSubs);
+  });
+
+  it('should emit Observables instead of Subjects', () => {
+    const source =   hot('---a---b---c---');
+    const closings = hot('---------w----|');
+    const expected =     'x--------y----|';
+    const x = cold(      '---a---b-|     ');
+    const y = cold(               '--c--|');
+    const expectedValues = { x: x, y: y };
+
+    const result = source.window(closings);
+
+    expectObservable(result.do(observable => {
+      expect(observable).to.be.instanceof(Rx.Observable);
+      expect(observable).not.to.be.instanceof(Rx.Subject);
+    })).toBe(expected, expectedValues);
   });
 });

--- a/spec/operators/windowCount-spec.ts
+++ b/spec/operators/windowCount-spec.ts
@@ -1,3 +1,4 @@
+import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
@@ -154,5 +155,20 @@ describe('Observable.prototype.windowCount', () => {
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should emit Observables instead of Subjects', () => {
+    const source =   hot('---a---b---c--|');
+    const expected =     'x------y------|';
+    const x = cold(      '---a---(b|)    ');
+    const y = cold(             '----c--|');
+    const expectedValues = { x: x, y: y };
+
+    const result = source.windowCount(2);
+
+    expectObservable(result.do(observable => {
+      expect(observable).to.be.instanceof(Rx.Observable);
+      expect(observable).not.to.be.instanceof(Rx.Subject);
+    })).toBe(expected, expectedValues);
   });
 });

--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -1,3 +1,4 @@
+import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
@@ -235,5 +236,20 @@ describe('Observable.prototype.windowTime', () => {
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(sourcesubs);
+  });
+
+  it('should emit Observables instead of Subjects', () => {
+    const source =   hot('--a-b--c---d--|');
+    const expected =     'x---------y---|';
+    const x = cold(      '--a-b|         ');
+    const y = cold(                '-d--|');
+    const expectedValues = { x: x, y: y };
+
+    const result = source.windowTime(50, 100, rxTestScheduler);
+
+    expectObservable(result.do(observable => {
+      expect(observable).to.be.instanceof(Rx.Observable);
+      expect(observable).not.to.be.instanceof(Rx.Subject);
+    })).toBe(expected, expectedValues);
   });
 });

--- a/spec/operators/windowToggle-spec.ts
+++ b/spec/operators/windowToggle-spec.ts
@@ -432,4 +432,21 @@ describe('Observable.prototype.windowToggle', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
+
+  it('should emit Observables instead of Subjects', () => {
+    const source =   hot('---a---b---c--|');
+    const e2 = cold(     '--o-------o---|');
+    const expected =     '--x-------y---|';
+    const closing = cold(  '--------|');
+    const x = cold(        '-a---b--|    ');
+    const y = cold(                '-c--|');
+    const expectedValues = { x: x, y: y };
+
+    const result = source.windowToggle(e2, () => closing);
+
+    expectObservable(result.do(observable => {
+      expect(observable).to.be.instanceof(Rx.Observable);
+      expect(observable).not.to.be.instanceof(Rx.Subject);
+    })).toBe(expected, expectedValues);
+  });
 });

--- a/spec/operators/windowWhen-spec.ts
+++ b/spec/operators/windowWhen-spec.ts
@@ -1,3 +1,4 @@
+import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
@@ -336,5 +337,21 @@ describe('Observable.prototype.windowWhen', () => {
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should emit Observables instead of Subjects', () => {
+    const source =   hot('--a---b---c-|');
+    const expected =     'x-------y---|';
+    const closing = cold('--------|');
+    const x = cold(      '--a---b-|    ');
+    const y = cold(              '--c-|');
+    const expectedValues = { x: x, y: y };
+
+    const result = source.windowWhen(() => closing);
+
+    expectObservable(result.do(observable => {
+      expect(observable).to.be.instanceof(Rx.Observable);
+      expect(observable).not.to.be.instanceof(Rx.Subject);
+    })).toBe(expected, expectedValues);
   });
 });

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -73,7 +73,7 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
 
   constructor(destination: Subscriber<Observable<T>>) {
     super(destination);
-    destination.next(this.window);
+    destination.next(this.window.asObservable());
   }
 
   notifyNext(outerValue: T, innerValue: any,
@@ -115,6 +115,6 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     }
     const destination = this.destination;
     const newWindow = this.window = new Subject<T>();
-    destination.next(newWindow);
+    destination.next(newWindow.asObservable());
   }
 }

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -80,7 +80,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
               private windowSize: number,
               private startWindowEvery: number) {
     super(destination);
-    destination.next(this.windows[0]);
+    destination.next(this.windows[0].asObservable());
   }
 
   protected _next(value: T) {
@@ -100,7 +100,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     if (++this.count % startWindowEvery === 0 && !this.closed) {
       const window = new Subject<T>();
       windows.push(window);
-      destination.next(window);
+      destination.next(window.asObservable());
     }
   }
 

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -221,7 +221,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     const window = new CountedSubject<T>();
     this.windows.push(window);
     const destination = this.destination;
-    destination.next(window);
+    destination.next(window.asObservable());
     return window;
   }
 

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -174,7 +174,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
           subscription.add(innerSubscription);
         }
 
-        this.destination.next(window);
+        this.destination.next(window.asObservable());
 
       }
     } else {

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -125,7 +125,7 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     }
 
     const window = this.window = new Subject<T>();
-    this.destination.next(window);
+    this.destination.next(window.asObservable());
 
     const closingNotifier = tryCatch(this.closingSelector)();
     if (closingNotifier === errorObject) {


### PR DESCRIPTION
**Description:**
This PR makes `window*` operators emit only Observables instead of Subjects.

**Related issue (if exists):**
#2391 