### PR TITLE
feat(delayWhen): add index to the selector function

### DIFF
--- a/spec/operators/delayWhen-spec.ts
+++ b/spec/operators/delayWhen-spec.ts
@@ -1,3 +1,4 @@
+import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
@@ -214,5 +215,23 @@ describe('Observable.prototype.delayWhen', () => {
     expectSubscriptions(e1.subscriptions).toBe([]);
     expectSubscriptions(selector.subscriptions).toBe([]);
     expectSubscriptions(subDelay.subscriptions).toBe(subDelaySub);
+  });
+
+  it('should call predicate with indices starting at 0', () => {
+    const e1 =    hot('--a--b--c--|');
+    const expected =  '--a--b--c--|';
+    const selector = cold('(x|)');
+
+    let indices = [];
+    const predicate = (value, index) => {
+      indices.push(index);
+      return selector;
+    };
+
+    const result = e1.delayWhen(predicate);
+
+    expectObservable(result.do(null, null, () => {
+      expect(indices).to.deep.equal([0, 1, 2]);
+    })).toBe(expected);
   });
 });


### PR DESCRIPTION
This PR adds current index to the selector function in `delayWhen`operator.

```
source.delayWhen((value, index) => {
  ...
});
```

**Related issue (if exists):**
#2388