### PR TITLE
feat(fromEventPattern): improve typings

### DIFF
--- a/spec/observables/fromEventPattern-spec.ts
+++ b/spec/observables/fromEventPattern-spec.ts
@@ -4,7 +4,7 @@ import * as Rx from '../../dist/cjs/Rx';
 import {noop} from '../../dist/cjs/util/noop';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const { asDiagram, type };
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
 
 declare const rxTestScheduler: Rx.TestScheduler;
@@ -132,5 +132,122 @@ describe('Observable.fromEventPattern', () => {
       });
 
     trigger('test');
+  });
+
+  it('should be an Observable with values of empty object type if handler is Function', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: Function) { noop(); },
+        totallyCustomRemoveHandler(handler: Function) { noop(); }
+      };
+      const o1: Rx.Observable<{}> = Observable.fromEventPattern(
+        handler => eventTarget.totallyCustomAddHandler(handler)
+      );
+      /* tslint:enable:no-unused-variable */
+    });
+  });
+
+  it('should be an Observable with values of empty object type if handler is any', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: any) { noop(); },
+        totallyCustomRemoveHandler(handler: any) { noop(); }
+      };
+      const o1: Rx.Observable<{}> = Observable.fromEventPattern(
+        handler => eventTarget.totallyCustomAddHandler(handler)
+      );
+      /* tslint:enable:no-unused-variable */
+    });
+  });
+
+  it('should be an Observable with values of empty object type if handler has no arguments', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: () => void) { noop(); },
+        totallyCustomRemoveHandler(handler: () => void) { noop(); }
+      };
+      const o1: Rx.Observable<{}> = Observable.fromEventPattern(
+        handler => eventTarget.totallyCustomAddHandler(handler)
+      );
+      /* tslint:enable:no-unused-variable */
+    });
+  });
+
+  it('should be an Observable with values of handlers first argument type', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: (a: number, b: string) => void) { noop(); },
+        totallyCustomRemoveHandler(handler: (a: number, b: string) => void) { noop(); }
+      };
+      const o1: Rx.Observable<number> = Observable.fromEventPattern(
+        handler => eventTarget.totallyCustomAddHandler(handler)
+      );
+      /* tslint:enable:no-unused-variable */
+    });
+  });
+
+  it('should be an Observable with values of empty object type when API expects non-void handler', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: (a: number, b: string) => string) { noop(); },
+        totallyCustomRemoveHandler(handler: (a: number, b: string) => string) { noop(); }
+      };
+      const o1: Rx.Observable<{}> = Observable.fromEventPattern(
+        (handler: (a: number, b: string) => string) => eventTarget.totallyCustomAddHandler(handler)
+      );
+      /* tslint:enable:no-unused-variable */
+    });
+  });
+
+  it('should be an Observable with values of handlers first argument type when used with totallyCustomRemoveHandler', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: (a: number, b: string) => void) { noop(); },
+        totallyCustomRemoveHandler(handler: (a: number, b: string) => void) { noop(); }
+      };
+      const o1: Rx.Observable<number> = Observable.fromEventPattern(
+        handler => eventTarget.totallyCustomAddHandler(handler),
+        handler => eventTarget.totallyCustomRemoveHandler(handler)
+      );
+      /* tslint:enable:no-unused-variable */
+    });
+  });
+
+  it('should be an Observable with values of the same type as projects return value', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: (a: number, b: string) => void) { noop(); },
+        totallyCustomRemoveHandler(handler: (a: number, b: string) => void) { noop(); }
+      };
+      const o1: Rx.Observable<string> = Observable.fromEventPattern(
+        handler => eventTarget.totallyCustomAddHandler(handler),
+        handler => eventTarget.totallyCustomRemoveHandler(handler),
+        (a, b) => 'this is string'
+      );
+      /* tslint:enable:no-unused-variable */
+    });
+  });
+
+  it('should be an Observable with values of the same type as projects return value when handler has many parameters', () => {
+    type(() => {
+      /* tslint:disable:no-unused-variable */
+      const eventTarget = {
+        totallyCustomAddHandler(handler: (a: number, b: string, c: symbol, d: number) => void) { noop(); },
+        totallyCustomRemoveHandler(handler: (a: number, b: string, c: symbol, d: number) => void) { noop(); }
+      };
+      const o1: Rx.Observable<string> = Observable.fromEventPattern(
+        handler => eventTarget.totallyCustomAddHandler(handler),
+        handler => eventTarget.totallyCustomRemoveHandler(handler),
+        (a, b, c, d) => 'this is string'
+      );
+      /* tslint:enable:no-unused-variable */
+    });
   });
 });

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -58,6 +58,28 @@ export class FromEventPatternObservable<T> extends Observable<T> {
    * @name fromEventPattern
    * @owner Observable
    */
+  static create<T>(addHandler: (handler: (v1?: T) => void) => any,
+                   removeHandler?: (handler: (v1?: T) => void, signal?: any) => void
+  ): Observable<T>;
+  static create<T, R>(addHandler: (handler: (v1: T) => void) => any,
+                      removeHandler: (handler: (v1: T) => void, signal?: any) => void | undefined,
+                      selector: (v1: T) => R
+  ): Observable<R>;
+  static create<T1, T2, R>(addHandler: (handler: (v1: T1, v2: T2) => void) => any,
+                           removeHandler: (handler: (v1: T1, v2: T2) => void, signal?: any) => void | undefined,
+                           selector: (v1: T1, v2: T2) => R
+  ): Observable<R>;
+  static create<T1, T2, T3, R>(addHandler: (handler: (v1: T1, v2: T2, v3: T3) => void) => any,
+                               removeHandler: (handler: (v1: T1, v2: T2, v3: T3) => void, signal?: any) => void | undefined,
+                               selector: (v1: T1, v2: T2, v3: T3) => R
+  ): Observable<R>;
+  static create<T>(addHandler: (handler: (...args: any[]) => void) => any,
+                   removeHandler: (handler: (...args: any[]) => void, signal?: any) => void | undefined,
+                   selector: (...args: any[]) => T
+  ): Observable<T>;
+  static create<T>(addHandler: (handler: Function) => any,
+                   removeHandler?: (handler: Function, signal?: any) => void,
+                   selector?: (...args: Array<any>) => T): Observable<T>;
   static create<T>(addHandler: (handler: Function) => any,
                    removeHandler?: (handler: Function, signal?: any) => void,
                    selector?: (...args: Array<any>) => T) {


### PR DESCRIPTION
**Description:**

Currently `handler` injected into users function has general type signature `Function`. Because of that, even when used with properly typed APIs, TypeScript will not derive the type of resulting Observable.

Thanks to this change, output Observable is derived properly in MOST (see comment below) cases.

**Caveats:**

When `handler` expected by API has type `() => void`, I wanted to return `Observable<void>` type, but was unable to (no order of overloaded operator signatures worked well). By default TS sets returned value to `Observable<{}>`. Should not be huge issue since user does not use that `{}` value anyways. That being said type is wrong. If that is a real issue for a user, he can enforce `void` manually by calling `fromEventPattern<void>(...)`.


