### PR TITLE
Correct takeUntil comment - does not stop taking values if notifier completes without emitting

### DIFF
--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -18,7 +18,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  *
  * `takeUntil` subscribes and begins mirroring the source Observable. It also
  * monitors a second Observable, `notifier` that you provide. If the `notifier`
- * emits a value, the output Observable stops mirroring the source Observable 
+ * emits a value, the output Observable stops mirroring the source Observable
  * and completes.
  *
  * @example <caption>Tick every second until the first click happens</caption>

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -18,8 +18,8 @@ import { subscribeToResult } from '../util/subscribeToResult';
  *
  * `takeUntil` subscribes and begins mirroring the source Observable. It also
  * monitors a second Observable, `notifier` that you provide. If the `notifier`
- * emits a value or a complete notification, the output Observable stops
- * mirroring the source Observable and completes.
+ * emits a value, the output Observable stops mirroring the source Observable 
+ * and completes.
  *
  * @example <caption>Tick every second until the first click happens</caption>
  * var interval = Rx.Observable.interval(1000);


### PR DESCRIPTION
If this takeUntil test is correct then I believe the comment is wrong, it will not stop taking values if the notifier completes without emitting any values (empty).

https://github.com/ReactiveX/rxjs/blob/master/spec/operators/takeUntil-spec.ts#L38-L48