### PR TITLE
docs(webSocket): fix node.js example

### DIFF
--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -48,30 +48,32 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
    *
    * @example <caption>Wraps browser WebSocket</caption>
    *
-   * let subject = Observable.webSocket('ws://localhost:8081');
-   * subject.subscribe(
+   * let socket$ = Observable.webSocket('ws://localhost:8081');
+   *
+   * socket$.subscribe(
    *    (msg) => console.log('message received: ' + msg),
    *    (err) => console.log(err),
    *    () => console.log('complete')
    *  );
-   * subject.next(JSON.stringify({ op: 'hello' }));
+   *
+   * socket$.next(JSON.stringify({ op: 'hello' }));
    *
    * @example <caption>Wraps WebSocket from nodejs-websocket (using node.js)</caption>
    *
    * import { w3cwebsocket } from 'websocket';
    *
-   * let socket = new WebSocketSubject({
+   * let socket$ = Observable.webSocket({
    *   url: 'ws://localhost:8081',
    *   WebSocketCtor: w3cwebsocket
    * });
    *
-   * let subject = Observable.webSocket('ws://localhost:8081');
-   * subject.subscribe(
+   * socket$.subscribe(
    *    (msg) => console.log('message received: ' + msg),
    *    (err) => console.log(err),
    *    () => console.log('complete')
    *  );
-   * subject.next(JSON.stringify({ op: 'hello' }));
+   *
+   * socket$.next(JSON.stringify({ op: 'hello' }));
    *
    * @param {string | WebSocketSubjectConfig} urlConfigOrSource the source of the websocket as an url or a structure defining the websocket object
    * @return {WebSocketSubject}


### PR DESCRIPTION
**Description:** Fixes the example showing the usage of `WebSocketSubject` on Node.js.

**Related issue (if exists):** none
