### PR TITLE
fix(zipAll): complete when the source is empty

### DIFF
--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -723,4 +723,11 @@ describe('Observable.prototype.zipAll', () => {
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
+
+  it('should complete when empty source', () => {
+    const source = hot('|');
+    const expected =   '|';
+
+    expectObservable(source.zipAll()).toBe(expected);
+  });
 });

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -145,6 +145,12 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   protected _complete() {
     const iterators = this.iterators;
     const len = iterators.length;
+
+    if (len === 0) {
+      this.destination.complete();
+      return;
+    }
+
     this.active = len;
     for (let i = 0; i < len; i++) {
       let iterator: ZipBufferIterator<any, any> = <any>iterators[i];


### PR DESCRIPTION
This fixes the situation where the `zipAll()` operator doesn't send `complete` notification when the source Observable is empty:

```
Observable
  .empty()
  .zipAll()
  .subscribe(null, null, () => console.log('complete 1'));
```

This doesn't print anything. Demo: https://jsbin.com/fucijuz/2/edit?js,console

**Description:**

This problem occurs only when using `zipAll()` and not `zip()`. The `zip()` operator internally [wraps `zipAll()` with `ArrayObservable`](https://github.com/ReactiveX/rxjs/blob/master/src/operator/zip.ts#L99). So the following works fine:

```
Observable
  .zip(Observable.empty())
  .subscribe(null, null, () => console.log('complete 2'));
```
This is internally called as:
```
Observable
  .from([Observable.empty()])
  .zipAll()
  .subscribe(null, null, () => console.log('complete 3'));
```

which is all right.

**Related issue (if exists):**
#2426