### PR TITLE
docs(subscribe): create the documentation

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -71,20 +71,123 @@ export class Observable<T> implements Subscribable<T> {
     return observable;
   }
 
-  /**
-   * Registers handlers for handling emitted values, error and completions from the observable, and
-   *  executes the observable's subscriber function, which will take action to set up the underlying data stream
-   * @method subscribe
-   * @param {PartialObserver|Function} observerOrNext (optional) either an observer defining all functions to be called,
-   *  or the first of three possible handlers, which is the handler for each value emitted from the observable.
-   * @param {Function} error (optional) a handler for a terminal event resulting from an error. If no error handler is provided,
-   *  the error will be thrown as unhandled
-   * @param {Function} complete (optional) a handler for a terminal event resulting from successful completion.
-   * @return {ISubscription} a subscription reference to the registered handlers
-   */
   subscribe(): Subscription;
   subscribe(observer: PartialObserver<T>): Subscription;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
+  /**
+   * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.
+   *
+   * <span class="informal">Use it when you have all these Observables, but still nothing is happening.</span>
+   *
+   * `subscribe` is not a regular operator, but a method that calls Observables internal `subscribe` function. It
+   * might be for example a function that you passed to a {@link create} static factory, but most of the time it is
+   * a library implementation, which defines what and when will be emitted by an Observable. This means that calling
+   * `subscribe` is actually the moment when Observable starts its work, not when it is created, as it is often
+   * thought.
+   *
+   * Apart from starting the execution of an Observable, this method allows you to listen for values
+   * that an Observable emits, as well as for when it completes or errors. You can achieve this in two
+   * following ways.
+   *
+   * The first way is creating an object that implements {@link Observer} interface. It should have methods
+   * defined by that interface, but note that it should be just a regular JavaScript object, which you can create
+   * yourself in any way you want (ES6 class, classic function constructor, object literal etc.). In particular do
+   * not attempt to use any RxJS implementation details to create Observers - you don't need them. Remember also
+   * that your object does not have to implement all methods. If you find yourself creating a method that doesn't
+   * do anything, you can simply omit it. Note however, that if `error` method is not provided, all errors will
+   * be left uncaught.
+   *
+   * The second way is to give up on Observer object altogether and simply provide callback functions in place of its methods.
+   * This means you can provide three functions as arguments to `subscribe`, where first function is equivalent
+   * of a `next` method, second of an `error` method and third of a `complete` method. Just as in case of Observer,
+   * if you do not need to listen for something, you can omit a function, preferably by passing `undefined` or `null`,
+   * since `subscribe` recognizes these functions by where they were placed in function call. When it comes
+   * to `error` function, just as before, if not provided, errors emitted by an Observable will be thrown.
+   *
+   * Whatever style of calling `subscribe` you use, in both cases it returns a Subscription object.
+   * This object allows you to call `unsubscribe` on it, which in turn will stop work that an Observable does and will clean
+   * up all resources that an Observable used. Note that cancelling a subscription will not call `complete` callback
+   * provided to `subscribe` function, which is reserved for a regular completion signal that comes from an Observable.
+   *
+   * Remember that callbacks provided to `subscribe` are not guaranteed to be called asynchronously.
+   * It is an Observable itself that decides when these functions will be called. For example {@link of}
+   * by default emits all its values synchronously. Always check documentation for how given Observable
+   * will behave when subscribed and if its default behavior can be modified with a {@link Scheduler}.
+   *
+   * @example <caption>Subscribe with an Observer</caption>
+   * const sumObserver = {
+   *   sum: 0,
+   *   next(value) {
+   *     console.log('Adding: ' + value);
+   *     this.sum = this.sum + value;
+   *   },
+   *   error() { // We actually could just remote this method,
+   *   },        // since we do not really care about errors right now.
+   *   complete() {
+   *     console.log('Sum equals: ' + this.sum);
+   *   }
+   * };
+   *
+   * Rx.Observable.of(1, 2, 3) // Synchronously emits 1, 2, 3 and then completes.
+   * .subscribe(sumObserver);
+   *
+   * // Logs:
+   * // "Adding: 1"
+   * // "Adding: 2"
+   * // "Adding: 3"
+   * // "Sum equals: 6"
+   *
+   *
+   * @example <caption>Subscribe with functions</caption>
+   * let sum = 0;
+   *
+   * Rx.Observable.of(1, 2, 3)
+   * .subscribe(
+   *   function(value) {
+   *     console.log('Adding: ' + value);
+   *     sum = sum + value;
+   *   },
+   *   undefined,
+   *   function() {
+   *     console.log('Sum equals: ' + sum);
+   *   }
+   * );
+   *
+   * // Logs:
+   * // "Adding: 1"
+   * // "Adding: 2"
+   * // "Adding: 3"
+   * // "Sum equals: 6"
+   *
+   *
+   * @example <caption>Cancel a subscription</caption>
+   * const subscription = Rx.Observable.interval(1000).subscribe(
+   *   num => console.log(num),
+   *   undefined,
+   *   () => console.log('completed!') // Will not be called, even
+   * );                                // when cancelling subscription
+   *
+   *
+   * setTimeout(() => {
+   *   subscription.unsubscribe();
+   *   console.log('unsubscribed!');
+   * }, 2500);
+   *
+   * // Logs:
+   * // 0 after 1s
+   * // 1 after 2s
+   * // "unsubscribed!" after 2,5s
+   *
+   *
+   * @param {Observer|Function} observerOrNext (optional) Either an observer with methods to be called,
+   *  or the first of three possible handlers, which is the handler for each value emitted from the subscribed
+   *  Observable.
+   * @param {Function} error (optional) A handler for a terminal event resulting from an error. If no error handler is provided,
+   *  the error will be thrown as unhandled.
+   * @param {Function} complete (optional) A handler for a terminal event resulting from successful completion.
+   * @return {ISubscription} a subscription reference to the registered handlers
+   * @method subscribe
+   */
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
             error?: (error: any) => void,
             complete?: () => void): Subscription {


### PR DESCRIPTION
Document subscribe method, focusing on what it accepts and returns, how it differs from regular operators and whether it calls its callbacks synchronously or asynchronously.

Closes #2449
