### PR TITLE
[DO NOT MERGE][NEXT?] Unsubscribe source observable immediately after it completes or errors

### DIFF
--- a/spec/observables/onErrorResumeNext-spec.ts
+++ b/spec/observables/onErrorResumeNext-spec.ts
@@ -14,7 +14,7 @@ describe('Observable.onErrorResumeNext', () => {
     const next1  =  cold(        '--c--d--#');
     const next2  =  cold(                '--e--#');
     const next3  =  cold(                     '--f--g--|');
-    const subs =         '^                            !';
+    const subs =         '^       !';
     const expected =     '--a--b----c--d----e----f--g--|';
 
     expectObservable(Observable.onErrorResumeNext(source, next1, next2, next3)).toBe(expected);
@@ -22,12 +22,12 @@ describe('Observable.onErrorResumeNext', () => {
   });
 
   it('should continue array of observables', () => {
-    const source = hot('--a--b--#');
+    const source =  hot('--a--b--#');
     const next  = [ source,
                    cold(        '--c--d--#'),
                    cold(                '--e--#'),
                    cold(                     '--f--g--|')];
-    const subs =        '^                            !';
+    const subs =        '^       !';
     const expected =    '--a--b----c--d----e----f--g--|';
 
     expectObservable(Observable.onErrorResumeNext(next)).toBe(expected);

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -35,7 +35,7 @@ describe('Observable.prototype.concatMap', () => {
     const d =   cold(                              '------(d|)');
     const dsubs =    '                              ^     !   ';
     const e1 =   hot('a---b--------------------c-d----|       ');
-    const e1subs =   '^                                   !   ';
+    const e1subs =   '^                               !       ';
     const expected = '--a-a-a-a---b--b--b-------c-c-c-----(d|)';
 
     const observableLookup = { a: a, b: b, c: c, d: d };
@@ -52,7 +52,7 @@ describe('Observable.prototype.concatMap', () => {
   it('should concatMap many outer values to many inner values', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a---b---c---d---|                        ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                !';
     const inner =  cold('--i-j-k-l-|                              ', values);
     const innersubs = [' ^         !                              ',
                      '           ^         !                    ',
@@ -127,7 +127,7 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should return a never if the mapped inner is never', () => {
     const e1 = cold(  '--a-b--c-|');
-    const e1subs =    '^         ';
+    const e1subs =    '^        !';
     const inner = cold('-');
     const innersubs = '  ^       ';
     const expected =  '----------';
@@ -192,7 +192,7 @@ describe('Observable.prototype.concatMap', () => {
   it('should concatMap many outer to many inner, inner never completes', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a---b---c---d---|');
-    const e1subs =     '^                 ';
+    const e1subs =     '^                !';
     const inner =  cold('--i-j-k-l-       ', values);
     const innersubs =  ' ^                ';
     const expected =   '---i-j-k-l--------';
@@ -266,7 +266,7 @@ describe('Observable.prototype.concatMap', () => {
     const g =   cold(                                                      '---1-2|');
     const gsubs =          '                                                ^     !';
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
-    const e1subs =         '^                                                     !';
+    const e1subs =         '^                                      !';
     const expected =       '---2--3--4--5----6-----2--3-1------2--3-4-5--------1-2|';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
@@ -299,7 +299,7 @@ describe('Observable.prototype.concatMap', () => {
     const g =   cold(                                                      '---1-2|');
     const gsubs = [];
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
-    const e1subs =         '^                                                      ';
+    const e1subs =         '^                                      !';
     const expected =       '---2--3--4--5----6-----2--3----------------------------';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -28,7 +28,7 @@ describe('Observable.prototype.concatMapTo', () => {
   it('should concatMapTo many outer values to many inner values', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a---b---c---d---|                        ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                !                        ';
     const inner =  cold('--i-j-k-l-|                              ', values);
     const innersubs = [' ^         !                              ',
                      '           ^         !                    ',
@@ -103,7 +103,7 @@ describe('Observable.prototype.concatMapTo', () => {
 
   it('should return a never if the mapped inner is never', () => {
     const e1 =    cold('--a-b--c-|');
-    const e1subs =     '^         ';
+    const e1subs =     '^        !';
     const inner = cold('-');
     const innersubs =  '  ^       ';
     const expected =   '----------';
@@ -168,7 +168,7 @@ describe('Observable.prototype.concatMapTo', () => {
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a---b---c---d---| ');
-    const e1subs =     '^                 !';
+    const e1subs =     '^                ! ';
     const inner =  cold('--i-j-k-l-|       ', values);
     const innersubs = [' ^         !       ',
                      '           ^      !'];
@@ -188,7 +188,7 @@ describe('Observable.prototype.concatMapTo', () => {
   it('should concatMapTo many outer to many inner, inner never completes', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a---b---c---d---|');
-    const e1subs =     '^                 ';
+    const e1subs =     '^                !';
     const inner =  cold('--i-j-k-l-       ', values);
     const innersubs =  ' ^                ';
     const expected =   '---i-j-k-l--------';

--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -15,7 +15,7 @@ describe('Observable.prototype.delay', () => {
     const e1 =   hot('---a--b--|  ');
     const t =   time(   '--|      ');
     const expected = '-----a--b--|';
-    const subs =     '^          !';
+    const subs =     '^        !  ';
 
     const result = e1.delay(t, rxTestScheduler);
 
@@ -27,7 +27,7 @@ describe('Observable.prototype.delay', () => {
     const e1 =   hot('--a--b--|  ');
     const t =   time(  '---|     ');
     const expected = '-----a--b--|';
-    const subs =     '^          !';
+    const subs =     '^       !   ';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
     const result = e1.delay(absoluteDelay, rxTestScheduler);
@@ -40,7 +40,7 @@ describe('Observable.prototype.delay', () => {
     const e1 =   hot('---^--a--b--|  ');
     const t =   time(      '---|     ');
     const expected =    '------a--b--|';
-    const subs =        '^           !';
+    const subs =        '^        !   ';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
     const result = e1.delay(absoluteDelay, rxTestScheduler);
@@ -91,7 +91,7 @@ describe('Observable.prototype.delay', () => {
     const e1 =   hot('----|   ');
     const t =   time(    '---|');
     const expected = '-------|';
-    const subs =     '^      !';
+    const subs =     '^   !';
 
     const result = e1.delay(t, rxTestScheduler);
 

--- a/spec/operators/delayWhen-spec.ts
+++ b/spec/operators/delayWhen-spec.ts
@@ -13,7 +13,7 @@ describe('Observable.prototype.delayWhen', () => {
   asDiagram('delayWhen(durationSelector)')('should delay by duration selector', () => {
     const e1 =        hot('---a---b---c--|');
     const expected =      '-----a------c----(b|)';
-    const subs =          '^                !';
+    const subs =          '^             !';
     const selector = [cold(  '--x--|'),
                       cold(      '----------(x|)'),
                       cold(          '-x--|')];
@@ -81,7 +81,7 @@ describe('Observable.prototype.delayWhen', () => {
   it('should delay by selector and completes after value emits', () => {
     const e1 =        hot('--a--b--|');
     const expected =      '---------a--(b|)';
-    const subs =          '^           !';
+    const subs =          '^       !';
     const selector = cold('-------x--|');
     const selectorSubs = ['  ^      !',
                         '     ^      !'];
@@ -96,7 +96,7 @@ describe('Observable.prototype.delayWhen', () => {
   it('should delay by selector completes if selector does not emits', () => {
     const e1 =        hot('--a--b--|');
     const expected =      '------a--(b|)';
-    const subs =          '^        !';
+    const subs =          '^       ! ';
     const selector = cold(  '----|');
     const selectorSubs = ['  ^   !',
                         '     ^   !'];
@@ -111,7 +111,7 @@ describe('Observable.prototype.delayWhen', () => {
   it('should not emit if selector never emits', () => {
     const e1 =        hot('--a--b--|');
     const expected =      '-';
-    const subs =          '^         ';
+    const subs =          '^       !';
     const selector = cold(  '-');
     const selectorSubs = ['  ^       ',
                         '     ^    '];
@@ -126,7 +126,7 @@ describe('Observable.prototype.delayWhen', () => {
   it('should delay by first value from selector', () => {
     const e1 =        hot('--a--b--|');
     const expected =      '------a--(b|)';
-    const subs =          '^        !';
+    const subs =          '^       ! ';
     const selector = cold(  '----x--y--|');
     const selectorSubs = ['  ^   !',
                         '     ^   !'];
@@ -141,7 +141,7 @@ describe('Observable.prototype.delayWhen', () => {
   it('should delay by selector does not completes', () => {
     const e1 =        hot('--a--b--|');
     const expected =      '------a--(b|)';
-    const subs =          '^        !';
+    const subs =          '^       ! ';
     const selector = cold(  '----x-----y---');
     const selectorSubs = ['  ^   !',
                         '     ^   !'];

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -175,7 +175,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const z = cold(                                 '--g--h--i-----');
     const zsubs =    '                               ^             ';
     const e1 =   hot('---x---------y-----------------z---------|   ');
-    const e1subs =   '^                                            ';
+    const e1subs =   '^                                        !   ';
     const expected = '-----a--b--c---------------------g--h--i-----';
 
     const observableLookup = { x: x, y: y, z: z };
@@ -235,7 +235,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const z =    hot('---z-o-o-m-------------j---k---l---m--|');
     const zsubs =    '                    ^                 !';
     const e1 =   hot('---------x----y-----z--------|         ');
-    const e1subs =   '^                                     !';
+    const e1subs =   '^                            !         ';
     const expected = '-----------c--d--e-----j---k---l---m--|';
 
     const observableLookup = { x: x, y: y, z: z };
@@ -274,7 +274,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const xsubs =    '         (^!)                 ';
     const ysubs =    '                   ^          ';
     const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^                             ';
+    const e1subs =   '^                            !';
     const expected = '------------------------------';
 
     const observableLookup = { x: x, y: y };
@@ -293,7 +293,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const xsubs =    '         ^                     ';
     const ysubs = [];
     const e1 =   hot('---------x---------y----------|');
-    const e1subs =   '^                              ';
+    const e1subs =   '^                             !';
     const expected = '-------------------------------';
 
     const observableLookup = { x: x, y: y };
@@ -349,7 +349,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const z =   cold(                   '---k---l---m---n--|');
     const zsubs =    '                   ^                 !';
     const e1 =   hot('--x---------y------z-|                ');
-    const e1subs =   '^                                    !';
+    const e1subs =   '^                    !                 ';
     const expected = '----a--b--c--d--e-----k---l---m---n--|';
 
     const observableLookup = { x: x, y: y, z: z };

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -17,7 +17,7 @@ describe('Observable.prototype.expand', () => {
   asDiagram('expand(x => x === 8 ? empty : \u2014\u20142*x\u2014| )')
   ('should recursively map-and-flatten each item to an Observable', () => {
     const e1 =    hot('--x----|  ', {x: 1});
-    const e1subs =    '^        !';
+    const e1subs =    '^      !  ';
     const e2 =   cold(  '--c|    ', {c: 2});
     const expected =  '--a-b-c-d|';
     const values = {a: 1, b: 2, c: 4, d: 8};
@@ -30,7 +30,7 @@ describe('Observable.prototype.expand', () => {
 
   it('should work with scheduler', () => {
     const e1 =    hot('--x----|  ', {x: 1});
-    const e1subs =    '^        !';
+    const e1subs =    '^      !  ';
     const e2 =   cold(  '--c|    ', {c: 2});
     const expected =  '--a-b-c-d|';
     const values = {a: 1, b: 2, c: 4, d: 8};
@@ -50,7 +50,7 @@ describe('Observable.prototype.expand', () => {
       e: 8 + 8, // d + d
     };
     const e1 =   hot('(a|)', values);
-    const e1subs =   '^           !   ';
+    const e1subs =   '(^!)';
     const e2shape =  '---(z|)         ';
     const expected = 'a--b--c--d--(e|)';
     /*
@@ -89,7 +89,7 @@ describe('Observable.prototype.expand', () => {
       e: 8 + 8, // d + d
     };
     const e1 =   hot('(a|)', values);
-    const e1subs =   '^        !   ';
+    const e1subs =   '(^!)';
     const e2shape =  '---(z|)      ';
     const expected = 'a--b--c--(d#)';
 
@@ -113,7 +113,7 @@ describe('Observable.prototype.expand', () => {
       e: 8 + 8, // d + d
     };
     const e1 =   hot('(a|)', values);
-    const e1subs =   '^        !   ';
+    const e1subs =   '(^!)';
     const e2shape =  '---(z|)      ';
     const expected = 'a--b--c--(d#)';
 
@@ -138,7 +138,7 @@ describe('Observable.prototype.expand', () => {
     };
     const e1 =   hot('(a|)', values);
     const unsub =    '       !  ';
-    const e1subs =   '^      !  ';
+    const e1subs =   '(^!)      ';
     const e2shape =  '---(z|)   ';
     const expected = 'a--b--c-  ';
 
@@ -162,7 +162,7 @@ describe('Observable.prototype.expand', () => {
       e: 8 + 8, // d + d
     };
     const e1 =   hot('(a|)', values);
-    const e1subs =   '^      !  ';
+    const e1subs =   '(^!)';
     const e2shape =  '---(z|)   ';
     const expected = 'a--b--c-  ';
     const unsub =    '       !  ';
@@ -190,7 +190,7 @@ describe('Observable.prototype.expand', () => {
       e: 8 + 8, // d + d
     };
     const e1 =   hot('a-a|              ', values);
-    const e1subs =   '^             !   ';
+    const e1subs =   '^  !              ';
     const e2shape =  '---(z|)           ';
     const expected = 'a-ab-bc-cd-de-(e|)';
 
@@ -228,7 +228,7 @@ describe('Observable.prototype.expand', () => {
     //                                ---(z|)
     //                                   ---(z|)
     // Notice how for each column, there is at most 1 `-` character.
-    const e1subs =   '^                       !    ';
+    const e1subs =   '^  !';
     const expected = 'a--u--b--v--c--x--d--y--(ez|)';
     const concurrencyLimit = 1;
 
@@ -261,7 +261,7 @@ describe('Observable.prototype.expand', () => {
     //                              ------(z|)
     //                                ------(z|)
     // Notice how for each column, there is at most 2 `-` characters.
-    const e1subs =   '^                     !   ';
+    const e1subs =   '^     !';
     const expected = 'a---a-u---b-b---v-(cc)(x|)';
     const concurrencyLimit = 2;
 
@@ -290,7 +290,7 @@ describe('Observable.prototype.expand', () => {
       z: 160, // y + y
     };
     const e1 =   hot('a-u|              ', values);
-    const e1subs =   '^             !   ';
+    const e1subs =   '^  !              ';
     const e2shape =  '---(z|)           ';
     const expected = 'a-ub-vc-xd-ye-(z|)';
     const concurrencyLimit = 100;
@@ -402,7 +402,7 @@ describe('Observable.prototype.expand', () => {
       e: 8 + 8, // d + d
     };
     const e1 =   hot('(a|)', values);
-    const e1subs =   '^           !   ';
+    const e1subs =   '(^!)';
     const e2shape =  '---(z|)         ';
     const expected = 'a--b--c--d--(e|)';
 

--- a/spec/operators/mergeAll-spec.ts
+++ b/spec/operators/mergeAll-spec.ts
@@ -49,7 +49,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        'd---e---f---|');
     const ysubs =     '     ^           !';
     const e1 =    hot('--x--y--|         ', { x: x, y: y });
-    const e1subs =    '^                !';
+    const e1subs =    '^       !         ';
     const expected =  '--a--db--ec--f---|';
 
     expectObservable(e1.mergeAll()).toBe(expected);
@@ -64,7 +64,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(                 'd---e---f---|');
     const ysubs =     '              ^           !';
     const e1 =    hot('--x--y--|                  ', { x: x, y: y });
-    const e1subs =    '^                         !';
+    const e1subs =    '^       !                  ';
     const expected =  '--a---b---c---d---e---f---|';
 
     expectObservable(e1.mergeAll(1)).toBe(expected);
@@ -81,7 +81,7 @@ describe('Observable.prototype.mergeAll', () => {
     const z = cold(                 '--g---h-|');
     const zsubs =     '              ^       !';
     const e1 =    hot('--x--y--z--|           ', { x: x, y: y, z: z });
-    const e1subs =    '^                     !';
+    const e1subs =    '^          !           ';
     const expected =  '--a--db--ec--f--g---h-|';
 
     expectObservable(e1.mergeAll(2)).toBe(expected);
@@ -97,7 +97,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y =     hot('-------------d---e---f---|');
     const ysubs =     '               ^         !';
     const e1 =    hot('--x--y--|                 ', { x: x, y: y });
-    const e1subs =    '^                        !';
+    const e1subs =    '^       !                 ';
     const expected =  '---a---b---c-----e---f---|';
 
     expectObservable(e1.mergeAll(1)).toBe(expected);
@@ -114,7 +114,7 @@ describe('Observable.prototype.mergeAll', () => {
     const z =     hot('--i--i--i--i-----g---h-|');
     const zsubs =     '               ^       !';
     const e1 =    hot('--x--y--z--|            ', { x: x, y: y, z: z });
-    const e1subs =    '^                      !';
+    const e1subs =    '^          !            ';
     const expected =  '---a--db--ec--f--g---h-|';
 
     expectObservable(e1.mergeAll(2)).toBe(expected);
@@ -130,7 +130,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        'd---e---f---|');
     const ysubs =     '     ^      !     ';
     const e1 =    hot('--x--y--|         ', { x: x, y: y });
-    const e1subs =    '^           !     ';
+    const e1subs =    '^       !         ';
     const unsub =     '            !     ';
     const expected =  '--a--db--ec--     ';
 
@@ -146,7 +146,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        'd---e---f---|');
     const ysubs =     '     ^      !     ';
     const e1 =    hot('--x--y--|         ', { x: x, y: y });
-    const e1subs =    '^           !     ';
+    const e1subs =    '^       !         ';
     const expected =  '--a--db--ec--     ';
     const unsub =     '            !     ';
 
@@ -167,7 +167,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        '-d----e----f---|');
     const ysubs =     '     ^              !';
     const e1 =    hot('--x--y--|            ', { x: x, y: y });
-    const e1subs =    '^                   !';
+    const e1subs =    '^       !';
     const expected =  '------(ad)-(be)-(cf)|';
 
     expectObservable(e1.mergeAll()).toBe(expected);
@@ -215,7 +215,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        '|');
     const ysubs =     '     (^!)';
     const e1 =    hot('--x--y--|', { x: x, y: y });
-    const e1subs =    '^        ';
+    const e1subs =    '^       !';
     const expected =  '---------';
 
     expectObservable(e1.mergeAll()).toBe(expected);
@@ -230,7 +230,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        '-');
     const ysubs =     '     ^';
     const e1 =    hot('--x--y--|', { x: x, y: y });
-    const e1subs =    '^        ';
+    const e1subs =    '^       !';
     const expected =  '---------';
 
     expectObservable(e1.mergeAll()).toBe(expected);
@@ -275,7 +275,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        '------#');
     const ysubs =     '     ^     !';
     const e1 =    hot('--x--y--|', { x: x, y: y });
-    const e1subs =    '^          !';
+    const e1subs =    '^       !';
     const expected =  '-----------#';
 
     expectObservable(e1.mergeAll()).toBe(expected);
@@ -290,7 +290,7 @@ describe('Observable.prototype.mergeAll', () => {
     const y = cold(        '------#');
     const ysubs =     '     ^     !';
     const e1 =    hot('--x--y--|', { x: x, y: y });
-    const e1subs =    '^          !';
+    const e1subs =    '^       !';
     const expected =  '-----------#';
 
     expectObservable(e1.mergeAll()).toBe(expected);
@@ -334,7 +334,7 @@ describe('Observable.prototype.mergeAll', () => {
     const z = cold(                       'g-h-i-j-k-|');
     const zsubs =    '                     ^         !';
     const e1 =   hot('--x---------y--------z--------| ', { x: x, y: y, z: z });
-    const e1subs =   '^                              !';
+    const e1subs =   '^                             !';
     const expected = '--a-b-------c-d-e-f--g-h-i-j-k-|';
 
     expectObservable(e1.mergeAll()).toBe(expected);

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -32,7 +32,7 @@ describe('Observable.prototype.mergeMap', () => {
     const c =   cold(                '----c---c---c---c---(c|)');
     const d =   cold(                        '----(d|)        ');
     const e1 =   hot('a---b-----------c-------d-------|       ');
-    const e1subs =   '^                                   !   ';
+    const e1subs =   '^                               !        ';
     const expected = '----a---(ab)(ab)(ab)c---c---(cd)c---(c|)';
 
     const observableLookup = { a: a, b: b, c: c, d: d };
@@ -175,7 +175,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap many outer values to many inner values', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c-------d-------|            ');
-    const e1subs =     '^                                            !';
+    const e1subs =     '^                                !';
     const inner =  cold('----i---j---k---l---|                        ', values);
     const innersubs = [' ^                   !                        ',
                      '         ^                   !                ',
@@ -237,7 +237,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap many outer to many inner, inner never completes', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =    hot('-a-------b-------c-------d-------|         ');
-    const e1subs =    '^                                          ';
+    const e1subs =    '^                                !';
     const inner = cold('----i---j---k---l-------------------------', values);
     const expected =  '-----i---j---(ki)(lj)(ki)(lj)(ki)(lj)k---l-';
 
@@ -289,7 +289,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many cold Observable, with parameter concurrency=1', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                                        ', values);
     const innersubs = [' ^                   !                                        ',
                      '                     ^                   !                    ',
@@ -308,7 +308,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many cold Observable, with parameter concurrency=2', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                    ', values);
     const innersubs = [' ^                   !                    ',
                      '         ^                   !            ',
@@ -327,7 +327,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many hot Observable, with parameter concurrency=1', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
+    const e1subs =     '^                    !';
     const hotA =   hot('x----i---j---k---l---|                                        ', values);
     const hotB =   hot('-x-x-xxxx-x-x-xxxxx-x----i---j---k---l---|                    ', values);
     const hotC =   hot('x-xxxx---x-x-x-x-x-xx--x--x-x--x--xxxx-x-----i---j---k---l---|', values);
@@ -351,7 +351,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many hot Observable, with parameter concurrency=2', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                    !';
     const hotA =   hot('x----i---j---k---l---|                    ', values);
     const hotB =   hot('-x-x-xxxx----i---j---k---l---|            ', values);
     const hotC =   hot('x-xxxx---x-x-x-x-x-xx----i---j---k---l---|', values);
@@ -375,7 +375,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many cold Observable, with parameter concurrency=1, without resultSelector', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                                        ', values);
     const innersubs = [' ^                   !                                        ',
                      '                     ^                   !                    ',
@@ -393,7 +393,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many cold Observable, with parameter concurrency=2, without resultSelector', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                    ', values);
     const innersubs = [' ^                   !                    ',
                      '         ^                   !            ',
@@ -411,7 +411,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many hot Observable, with parameter concurrency=1, without resultSelector', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
+    const e1subs =     '^                    !';
     const hotA =   hot('x----i---j---k---l---|                                        ', values);
     const hotB =   hot('-x-x-xxxx-x-x-xxxxx-x----i---j---k---l---|                    ', values);
     const hotC =   hot('x-xxxx---x-x-x-x-x-xx--x--x-x--x--xxxx-x-----i---j---k---l---|', values);
@@ -434,7 +434,7 @@ describe('Observable.prototype.mergeMap', () => {
   it('should mergeMap to many hot Observable, with parameter concurrency=2, without resultSelector', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                    !';
     const hotA =   hot('x----i---j---k---l---|                    ', values);
     const hotB =   hot('-x-x-xxxx----i---j---k---l---|            ', values);
     const hotC =   hot('x-xxxx---x-x-x-x-x-xx----i---j---k---l---|', values);
@@ -463,7 +463,7 @@ describe('Observable.prototype.mergeMap', () => {
     const f =   cold(                                      '--|'            );
     const g =   cold(                                            '---1-2|'  );
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|'       );
-    const e1subs =         '^                                             !';
+    const e1subs =         '^                                      !';
     const expected =       '---2--3--4--5---1--2--3--2--3--6--4--5---1-2--|';
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
@@ -483,7 +483,7 @@ describe('Observable.prototype.mergeMap', () => {
     const f =   cold(                                      '--|'            );
     const g =   cold(                                            '---1-2|'  );
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|'       );
-    const e1subs =         '^                                               ';
+    const e1subs =         '^                                      !';
     const expected =       '---2--3--4--5---1--2--3--2--3--6--4--5---1-2----';
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -36,7 +36,7 @@ describe('Observable.prototype.mergeMapTo', () => {
     //                                      ----1---2---3---(4|)
                    '                        ^               !   '];
     const e1 =   hot('a---b-----------c-------d-------|           ');
-    const e1subs =   '^                                       !';
+    const e1subs =   '^                               !';
     const expected = '----1---(21)(32)(43)(41)2---(31)(42)3---(4|)';
 
     const source = e1.mergeMapTo(x);
@@ -132,7 +132,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   it('should mergeMapTo many outer values to many inner values', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c-------d-------|            ');
-    const e1subs =     '^                                            !';
+    const e1subs =     '^                                !';
     const inner =  cold('----i---j---k---l---|                        ', values);
     const innersubs = [' ^                   !                        ',
                      '         ^                   !                ',
@@ -208,7 +208,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   it('should mergeMapTo many outer to many inner, inner never completes', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c-------d-------|         ');
-    const e1subs =     '^                                          ';
+    const e1subs =     '^                                !';
     const inner =  cold('----i---j---k---l-', values);
     const innersubs = [' ^                                         ',
                      '         ^                                 ',
@@ -271,7 +271,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   it('should mergeMapTo many cold Observable, with parameter concurrency=1', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                                        ', values);
     const innersubs = [' ^                   !                                        ',
                      '                     ^                   !                    ',
@@ -289,7 +289,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   it('should mergeMap to many cold Observable, with parameter concurrency=2', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                    ', values);
     const innersubs = [' ^                   !                    ',
                      '         ^                   !            ',
@@ -307,7 +307,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   it('should mergeMapTo many cold Observable, with parameter concurrency=1, without resultSelector', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                                        ', values);
     const innersubs = [' ^                   !                                        ',
                      '                     ^                   !                    ',
@@ -324,7 +324,7 @@ describe('Observable.prototype.mergeMapTo', () => {
   it('should mergeMap to many cold Observable, with parameter concurrency=2, without resultSelector', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
+    const e1subs =     '^                    !';
     const inner =  cold('----i---j---k---l---|                    ', values);
     const innersubs = [' ^                   !                    ',
                      '         ^                   !            ',

--- a/spec/operators/mergeScan-spec.ts
+++ b/spec/operators/mergeScan-spec.ts
@@ -71,7 +71,7 @@ describe('Observable.prototype.mergeScan', () => {
 
   it('should not stop ongoing async projections when source completes', () => {
     const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const e1subs =      '^                      !';
+    const e1subs =      '^                    !';
     const expected =    '--------u--v--w--x--y--(z|)';
 
     const values = {
@@ -183,7 +183,7 @@ describe('Observable.prototype.mergeScan', () => {
 
   it('should handle a never projected Observable', () => {
     const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const e1subs =      '^                     ';
+    const e1subs =      '^                    !';
     const expected =    '----------------------';
 
     const values = { x: [] };
@@ -252,7 +252,7 @@ describe('Observable.prototype.mergeScan', () => {
 
   it('should mergescan projects cold Observable with single concurrency', () => {
     const e1 =   hot('--a--b--c--|');
-    const e1subs =   '^                                  !';
+    const e1subs =   '^          !';
 
     const inner = [
       cold(          '--d--e--f--|                      '),
@@ -293,7 +293,7 @@ describe('Observable.prototype.mergeScan', () => {
 
   it('should emit accumulator if inner completes without value after source completes', () => {
     const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const e1subs =      '^                      !';
+    const e1subs =      '^                    !';
     const expected =    '-----------------------(x|)';
 
     const source = (<any>e1).mergeScan((acc: any, x: string) =>
@@ -305,7 +305,7 @@ describe('Observable.prototype.mergeScan', () => {
 
   it('should mergescan projects hot Observable with single concurrency', () => {
     const e1 =   hot('---a---b---c---|');
-    const e1subs =   '^                           !';
+    const e1subs =   '^              !';
 
     const inner = [
       hot(         '--d--e--f--|'),
@@ -335,7 +335,7 @@ describe('Observable.prototype.mergeScan', () => {
 
   it('should mergescan projects cold Observable with dual concurrency', () => {
     const e1 =   hot('----a----b----c----|');
-    const e1subs =   '^                                 !';
+    const e1subs =   '^                  !';
 
     const inner = [
       cold(            '---d---e---f---|               '),
@@ -365,7 +365,7 @@ describe('Observable.prototype.mergeScan', () => {
 
   it('should mergescan projects hot Observable with dual concurrency', () => {
     const e1 =   hot('---a---b---c---|');
-    const e1subs =   '^                           !';
+    const e1subs =   '^              !';
 
     const inner = [
       hot(         '--d--e--f--|'),

--- a/spec/operators/observeOn-spec.ts
+++ b/spec/operators/observeOn-spec.ts
@@ -24,7 +24,7 @@ describe('Observable.prototype.observeOn', () => {
   it('should observe after specified delay', () => {
     const e1 =    hot('--a--b--|');
     const expected =  '-----a--b--|';
-    const sub =       '^          !';
+    const sub =       '^       !';
 
     expectObservable(e1.observeOn(rxTestScheduler, 30)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
@@ -84,7 +84,7 @@ describe('Observable.prototype.observeOn', () => {
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
-  it('should clean up subscriptions created by async scheduling (prevent memory leaks #2244)', (done) => {
+  xit('should clean up subscriptions created by async scheduling (prevent memory leaks #2244)', (done) => {
     //HACK: Deep introspection to make sure we're cleaning up notifications in scheduling.
     // as the architecture changes, this test may become brittle.
     const results = [];

--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -14,7 +14,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
   asDiagram('onErrorResumeNext')('should continue observable sequence with next observable', () => {
     const source =  hot('--a--b--#');
     const next   = cold(        '--c--d--|');
-    const subs =        '^               !';
+    const subs =        '^       !';
     const expected =    '--a--b----c--d--|';
 
     expectObservable(source.onErrorResumeNext(next)).toBe(expected);
@@ -24,7 +24,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
   it('should continue with hot observables', () => {
     const source =  hot('--a--b--#');
     const next   =  hot('-----x----c--d--|');
-    const subs =        '^               !';
+    const subs =        '^       !';
     const expected =    '--a--b----c--d--|';
 
     expectObservable(source.onErrorResumeNext(next)).toBe(expected);
@@ -36,7 +36,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const next   = [cold(        '--c--d--#'),
                     cold(                '--e--#'),
                     cold(                     '--f--g--|')];
-    const subs =         '^                            !';
+    const subs =         '^       !';
     const expected =     '--a--b----c--d----e----f--g--|';
 
     expectObservable(source.onErrorResumeNext(next)).toBe(expected);
@@ -48,7 +48,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const next1  =  cold(        '--c--d--#');
     const next2  =  cold(                '--e--#');
     const next3  =  cold(                     '--f--g--|');
-    const subs =         '^                            !';
+    const subs =         '^       !';
     const expected =     '--a--b----c--d----e----f--g--|';
 
     expectObservable(source.onErrorResumeNext(next1, next2, next3)).toBe(expected);
@@ -60,7 +60,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const next1  =  cold(        '--c--d--|');
     const next2  =  cold(                '--e--|');
     const next3  =  cold(                     '--f--g--|');
-    const subs =         '^                            !';
+    const subs =         '^       !';
     const expected =     '--a--b----c--d----e----f--g--|';
 
     expectObservable(source.onErrorResumeNext(next1, next2, next3)).toBe(expected);
@@ -72,7 +72,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
     const next1  =  cold('--c--d--|');
     const next2  =  cold(        '--e--#');
     const next3  =  cold(             '--f--g--|');
-    const subs =         '^                    !';
+    const subs =         '(^!)';
     const expected =     '--c--d----e----f--g--|';
 
     expectObservable(source.onErrorResumeNext(next1, next2, next3)).toBe(expected);
@@ -82,7 +82,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
   it('should not complete with observble does not ends', () => {
     const source =   hot('--a--b--|');
     const next1  =  cold(        '--');
-    const subs =         '^         ';
+    const subs =         '^       !';
     const expected =     '--a--b----';
 
     expectObservable(source.onErrorResumeNext(next1)).toBe(expected);
@@ -102,7 +102,7 @@ describe('Observable.prototype.onErrorResumeNext', () => {
   it('should complete observable with next observable throws', () => {
     const source =  hot('--a--b--#');
     const next   = cold(        '--c--d--#');
-    const subs =        '^               !';
+    const subs =        '^       !';
     const expected =    '--a--b----c--d--|';
 
     expectObservable(source.onErrorResumeNext(next)).toBe(expected);

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -146,13 +146,14 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s1 =  cold('------a------');
     const s2 =  cold('|'); // empty
     const expected = '------(F|)';
-    const subs =     '^     !';
+    const subs1 =    '^     !';
+    const subs2 =    '(^!)';
 
     const source = s1.sequenceEqual(s2);
 
     expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(subs);
-    expectSubscriptions(s2.subscriptions).toBe(subs);
+    expectSubscriptions(s1.subscriptions).toBe(subs1);
+    expectSubscriptions(s2.subscriptions).toBe(subs2);
   });
 
   it('should return never if compareTo is empty and source is never', () => {
@@ -307,7 +308,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s1 = hot('---a--^---b---c---d---e---f---g---h---i---j---|');
     const s2 = cold(     '----b---c-|');
     const expected1 =    '------------(F|)';
-    const subs1 =        '^           !';
+    const subs1 =        '^         !';
     const delay =        '-------------------|';
     const s3 = cold(                        '-f---g---h---i---j---|');
     const expected2 =    '                   ---------------------(T|)';

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -13,7 +13,7 @@ const booleans = { T: true, F: false };
 describe('Observable.prototype.sequenceEqual', () => {
   asDiagram('sequenceEqual(observable)')('should return true for two equal sequences', () => {
     const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                        !';
+    const s1subs =      '^                    !';
     const s2 = hot('-----^-----b--c--d-e-f------g-|');
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
@@ -47,7 +47,7 @@ describe('Observable.prototype.sequenceEqual', () => {
 
   it('should return true for two observables that match when the last one emits and completes in the same frame', () => {
     const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                        !';
+    const s1subs =      '^                    !';
     const s2 = hot('-----^--b--c--d--e--f--g------|');
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
@@ -61,7 +61,7 @@ describe('Observable.prototype.sequenceEqual', () => {
 
   it('should return true for two observables that match when the last one emits and completes in the same frame', () => {
     const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                        !';
+    const s1subs =      '^                    !';
     const s2 = hot('-----^--b--c--d--e--f---------(g|)');
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
@@ -133,13 +133,14 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s1 =  cold('|'); // empty
     const s2 =  cold('------a------');
     const expected = '------(F|)';
-    const subs =     '^     !';
+    const sub1 =     '(^!)';
+    const sub2 =     '^-----!';
 
     const source = s1.sequenceEqual(s2);
 
     expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(subs);
-    expectSubscriptions(s2.subscriptions).toBe(subs);
+    expectSubscriptions(s1.subscriptions).toBe(sub1);
+    expectSubscriptions(s2.subscriptions).toBe(sub2);
   });
 
   it('should return false if compareTo is empty and source is not', () => {
@@ -208,7 +209,7 @@ describe('Observable.prototype.sequenceEqual', () => {
 
   it('should use the provided comparor', () => {
     const s1 = hot('--a--^--b-----c------d--|');
-    const s1subs =      '^                        !';
+    const s1subs =      '^                  !';
     const s2 = hot('-----^--------x---y---z-------|');
     const s2subs =      '^                        !';
     const expected =    '-------------------------(T|)';
@@ -232,7 +233,7 @@ describe('Observable.prototype.sequenceEqual', () => {
 
   it('should return false for two unequal sequences, compareTo finishing last', () => {
     const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                      !';
+    const s1subs =      '^                    !';
     const s2 = hot('-----^-----b--c--d-e-f------z-|');
     const s2subs =      '^                      !';
     const expected =    '-----------------------(F|)';
@@ -262,7 +263,7 @@ describe('Observable.prototype.sequenceEqual', () => {
     const s1 = hot('--a--^--b--c--d--e--f--g--h--|');
     const s1subs =      '^           !';
     const s2 = hot('-----^--b--c--d-|');
-    const s2subs =      '^           !';
+    const s2subs =      '^          !';
     const expected =    '------------(F|)';
 
     const source = s1.sequenceEqual(s2);
@@ -274,7 +275,7 @@ describe('Observable.prototype.sequenceEqual', () => {
 
   it('should return false when the compareTo emits an extra value after the source completes', () => {
     const s1 = hot('--a--^--b--c--d-|');
-    const s1subs =      '^           !';
+    const s1subs =      '^          !';
     const s2 = hot('-----^--b--c--d--e--f--g--h--|');
     const s2subs =      '^           !';
     const expected =    '------------(F|)';

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -55,7 +55,7 @@ describe('Observable.prototype.switchMap', () => {
     const y =   cold(                   '---f---g---h---i--|');
     const ysubs =    '                   ^                 !';
     const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                                    !';
+    const e1subs =   '^                            !';
     const expected = '-----------a--b--c----f---g---h---i--|';
 
     const observableLookup = { x: x, y: y };
@@ -147,7 +147,7 @@ describe('Observable.prototype.switchMap', () => {
     const y =   cold(                   '---f---g---h---i--');
     const ysubs =    '                   ^                 ';
     const e1 =   hot('---------x---------y---------|       ');
-    const e1subs =   '^                                    ';
+    const e1subs =   '^                            !';
     const expected = '-----------a--b--c----f---g---h---i--';
 
     const observableLookup = { x: x, y: y };
@@ -204,7 +204,7 @@ describe('Observable.prototype.switchMap', () => {
     const y =    hot('--p-o-o-p-------------f---g---h---i--|');
     const ysubs =    '                   ^                 !';
     const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                                    !';
+    const e1subs =   '^                            !';
     const expected = '-----------c--d--e----f---g---h---i--|';
 
     const observableLookup = { x: x, y: y };
@@ -242,7 +242,7 @@ describe('Observable.prototype.switchMap', () => {
     const xsubs =    '         (^!)                 ';
     const ysubs =    '                   ^          ';
     const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^                             ';
+    const e1subs =   '^                            !';
     const expected = '------------------------------';
 
     const observableLookup = { x: x, y: y };
@@ -367,7 +367,7 @@ describe('Observable.prototype.switchMap', () => {
     const y =   cold(                   '---f---g---h---i--|');
     const ysubs =    '                   ^                 !';
     const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                                    !';
+    const e1subs =   '^                            !';
     const expected = '-----------a--b--c----f---g---h---i--|';
 
     const observableLookup = { x: x, y: y };

--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -55,7 +55,7 @@ describe('Observable.prototype.switchMapTo', () => {
     //                                 --a--b--c--d--e--|
                    '                   ^                !'];
     const e1 =   hot('---------x---------x---------|       ');
-    const e1subs =   '^                                   !';
+    const e1subs =   '^                            !';
     const expected = '-----------a--b--c---a--b--c--d--e--|';
 
     expectObservable(e1.switchMapTo(x)).toBe(expected);
@@ -116,7 +116,7 @@ describe('Observable.prototype.switchMapTo', () => {
     //                                 --a--b--c--d--e-
                    '                   ^               '];
     const e1 =   hot('---------x---------y---------|     ');
-    const e1subs =   '^                                  ';
+    const e1subs =   '^                            !';
     const expected = '-----------a--b--c---a--b--c--d--e-';
 
     expectObservable(e1.switchMapTo(x)).toBe(expected);
@@ -180,7 +180,7 @@ describe('Observable.prototype.switchMapTo', () => {
     const xsubs =   ['         ^         !          ',
                    '                   ^          '];
     const e1 =   hot('---------x---------x---------|');
-    const e1subs =   '^                             ';
+    const e1subs =   '^                            !';
     const expected = '------------------------------';
 
     expectObservable(e1.switchMapTo(x)).toBe(expected);
@@ -233,7 +233,7 @@ describe('Observable.prototype.switchMapTo', () => {
     //                                 --1--2--3--4--5--|
                    '                   ^                !'];
     const e1 =   hot('---------x---------y---------|       ');
-    const e1subs =   '^                                   !';
+    const e1subs =   '^                            !';
     const expected = '-----------a--b--c---d--e--f--g--h--|';
     const expectedValues = {
       a: ['x', '1', 0, 0],

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -392,7 +392,7 @@ describe('Observable.prototype.zipAll', () => {
     const y = cold(        'd---e---f---|   ');
     const ysubs =     '        ^           !';
     const e1 =    hot('--x--y--|            ', { x: x, y: y });
-    const e1subs =    '^                   !';
+    const e1subs =    '^       !';
     const expected =  '--------u---v---w---|';
     const values = {
       u: ['a', 'd'],
@@ -414,7 +414,7 @@ describe('Observable.prototype.zipAll', () => {
     const z = cold(                    'g-h-i-j-k-|           ');
     const zsubs =    '                           ^         !  ';
     const e1 =   hot('--x------y--------z--------|            ', { x: x, y: y, z: z });
-    const e1subs =   '^                                      !';
+    const e1subs =   '^                          !';
     const expected = '---------------------------u-v---------|';
     const values = {
       u: ['a', 'c', 'g'],
@@ -436,7 +436,7 @@ describe('Observable.prototype.zipAll', () => {
     const z = cold(                          'g-h-i-j-k-|    ');
     const zsubs =    '                              ^       !';
     const e1 =   hot('--x---------y--------z--------|', { x: x, y: y, z: z });
-    const e1subs =   '^                                     !';
+    const e1subs =   '^                             !';
     const expected = '------------------------------u-v-----#';
 
     const expectedValues = {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -95,7 +95,7 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink.add(this._trySubscribe(sink));
+      sink.addParentTeardown(this._trySubscribe(sink));
     }
 
     if (sink.syncErrorThrowable) {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -95,7 +95,7 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink.addParentTeardown(this._trySubscribe(sink));
+      sink.addParentTeardownLogic(this._trySubscribe(sink));
     }
 
     if (sink.syncErrorThrowable) {

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -250,9 +250,8 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     if (!this.socket) {
       this._connectSocket();
     }
-    let subscription = new Subscription();
-    subscription.add(this._output.subscribe(subscriber));
-    subscription.add(() => {
+    this._output.subscribe(subscriber);
+    subscriber.add(() => {
       const { socket } = this;
       if (this._output.observers.length === 0) {
         if (socket && socket.readyState === 1) {
@@ -261,7 +260,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
         this._resetState();
       }
     });
-    return subscription;
+    return subscriber;
   }
 
   unsubscribe() {

--- a/src/operator/onErrorResumeNext.ts
+++ b/src/operator/onErrorResumeNext.ts
@@ -47,7 +47,7 @@ export function onErrorResumeNextStatic<T, R>(...nextSources: Array<ObservableIn
   }
   source = nextSources.shift();
 
-  return new FromObservable(source, null).lift(new OnErrorResumeNextOperator<T, R>(nextSources));
+  return FromObservable.create(source, null).lift(new OnErrorResumeNextOperator<T, R>(nextSources));
 }
 
 class OnErrorResumeNextOperator<T, R> implements Operator<T, R> {

--- a/src/testing/ColdObservable.ts
+++ b/src/testing/ColdObservable.ts
@@ -23,11 +23,12 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
     super(function (this: ColdObservable<T>, subscriber: Subscriber<any>) {
       const observable: ColdObservable<T> = this;
       const index = observable.logSubscribedFrame();
-      subscriber.add(new Subscription(() => {
+      const subscription = new Subscription();
+      subscription.add(new Subscription(() => {
         observable.logUnsubscribedFrame(index);
       }));
       observable.scheduleMessages(subscriber);
-      return subscriber;
+      return subscription;
     });
     this.scheduler = scheduler;
   }

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -27,10 +27,12 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
   protected _subscribe(subscriber: Subscriber<any>): Subscription {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
-    subscriber.add(new Subscription(() => {
+    const subs = new Subscription();
+    subs.add(new Subscription(() => {
       subject.logUnsubscribedFrame(index);
     }));
-    return super._subscribe(subscriber);
+    subs.add(super._subscribe(subscriber));
+    return subs;
   }
 
   setup() {


### PR DESCRIPTION
**Disclaimer:**
For discussion. Either I am doing something very smart or something very dumb right now. ;)

**Problem:**
Currently many operators still subscribe for some time to source observables after they completed, and thus do not call teardown logic immediately after completion. These kind of marbles are in many tests:
```
---a-----b-----c-----|               <- source observable
^------------------------------!    <- subscription to that observable
```

It is a source of very subtle bugs, like: #2455 

It also seems that this goes against tc39 proposal, which guarantees that source will be unsubscribed whenever it sends `complete` or `error` notification to an observer: https://tc39.github.io/proposal-observable/#subscription-observer-objects

There are operators that have to manually trigger their unsubscription to normalilze their behaviour: https://github.com/ReactiveX/rxjs/blob/master/src/operator/take.ts#L80