### PR TITLE
fix(first): force unsubscription logic on complete and error

### DIFF
--- a/spec/helpers/doNotUnsubscribe.ts
+++ b/spec/helpers/doNotUnsubscribe.ts
@@ -1,0 +1,16 @@
+///<reference path='../../typings/index.d.ts'/>
+import * as Rx from '../../dist/cjs/Rx';
+
+export function doNotUnsubscribe<T>(ob: Rx.Observable<T>): Rx.Observable<T> {
+  return ob.lift(new DoNotUnsubscribeOperator());
+}
+
+class DoNotUnsubscribeOperator<T, R> implements Rx.Operator<T, R> {
+  call(subscriber: Rx.Subscriber<R>, source: any): any {
+    return source.subscribe(new DoNotUnsubscribeSubscriber(subscriber));
+  }
+}
+
+class DoNotUnsubscribeSubscriber<T> extends Rx.Subscriber<T> {
+  unsubscribe() {} // tslint:disable-line no-empty
+}

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -156,6 +156,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
       this._emitted = true;
       destination.next(value);
       destination.complete();
+      this.unsubscribe();
       this.hasCompleted = true;
     }
   }
@@ -165,8 +166,10 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
     if (!this.hasCompleted && typeof this.defaultValue !== 'undefined') {
       destination.next(this.defaultValue);
       destination.complete();
+      this.unsubscribe();
     } else if (!this.hasCompleted) {
       destination.error(new EmptyError);
+      this.unsubscribe();
     }
   }
 }


### PR DESCRIPTION
**Description**

Force unsubscription logic when operator completes or errors, so that source Observable is only subscribed as long as it has to, even when combined with operators that do not immediately unsubscribe
from 'first' when it completes or errors.

Introduces test-only `doNotUnsubscribe` operator, which simulates operators that are unreliable with managing subscriptions (like `switchMap` for example - see #2459).

**Related issue (if exists):**

Closes #2455

This issue is a concrete example of more general one: #2459 
