### PR TITLE
fix(takeWhile): force unsubscribe when it completes or errors

### DIFF
--- a/spec/helpers/doNotUnsubscribe.ts
+++ b/spec/helpers/doNotUnsubscribe.ts
@@ -1,0 +1,16 @@
+///<reference path='../../typings/index.d.ts'/>
+import * as Rx from '../../dist/cjs/Rx';
+
+export function doNotUnsubscribe<T>(ob: Rx.Observable<T>): Rx.Observable<T> {
+  return ob.lift(new DoNotUnsubscribeOperator());
+}
+
+class DoNotUnsubscribeOperator<T, R> implements Rx.Operator<T, R> {
+  call(subscriber: Rx.Subscriber<R>, source: any): any {
+    return source.subscribe(new DoNotUnsubscribeSubscriber(subscriber));
+  }
+}
+
+class DoNotUnsubscribeSubscriber<T> extends Rx.Subscriber<T> {
+  unsubscribe() {} // tslint:disable-line no-empty
+}

--- a/src/operator/takeWhile.ts
+++ b/src/operator/takeWhile.ts
@@ -72,6 +72,7 @@ class TakeWhileSubscriber<T> extends Subscriber<T> {
       result = this.predicate(value, this.index++);
     } catch (err) {
       destination.error(err);
+      this.unsubscribe();
       return;
     }
     this.nextOrComplete(value, result);
@@ -83,6 +84,7 @@ class TakeWhileSubscriber<T> extends Subscriber<T> {
       destination.next(value);
     } else {
       destination.complete();
+      this.unsubscribe();
     }
   }
 }


### PR DESCRIPTION
Force unsubscribe on `takeWhile` when it completes or errors, even when used with operator that does not unsubscribe reliably, so that source Observable is never subscribed longer than it needs to.

**Related issues:**

`takeWhile` suffered from the same problem as `first`: #2455 
It is a concrete case of more general problem: #2459  
