### PR TITLE
fix(forEach): fix a temporal dead zone issue in forEach.

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -139,7 +139,10 @@ export class Observable<T> implements Subscribable<T> {
     }
 
     return new PromiseCtor<void>((resolve, reject) => {
-      const subscription = this.subscribe((value) => {
+      // Must be declared in a separate statement to avoid a RefernceError when
+      // accessing subscription below in the closure due to Temporal Dead Zone.
+      let subscription: Subscription;
+      subscription = this.subscribe((value) => {
         if (subscription) {
           // if there is a subscription, then we can surmise
           // the next handling is asynchronous. Any errors thrown


### PR DESCRIPTION
According to the ES6 spec and the implementation in V8, accessing a lexically scoped construct like const or let before it is assigned is a ReferenceError. Unlike var, it is not implicitly undefined. Because the closure handed to subscribe is immediately invoked and accesses `subscription` before it is assigned, this causes a ReferenceError in compliant engines.

The error is only triggered when running in plain ES6, i.e. without transpilation.