### PR TITLE
fix(mergeAll): add source subscription to composite before actually subscribing

### DIFF
--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -139,7 +139,9 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(ish: ObservableInput<R>, value: T, index: number): void {
-    this.add(subscribeToResult<T, R>(this, ish, value, index));
+    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    this.add(innerSubscriber);
+    subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
   }
 
   protected _complete(): void {

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -1,19 +1,26 @@
-
 import { ObservableInput } from '../types';
 import { Subscription } from '../Subscription';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { OuterSubscriber } from '../OuterSubscriber';
+import { Subscriber } from '../Subscriber';
 import { subscribeTo } from './subscribeTo';
 
-export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
-                                        result: any,
-                                        outerValue?: T,
-                                        outerIndex?: number): Subscription;
-export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
-                                     result: ObservableInput<T>,
-                                     outerValue?: T,
-                                     outerIndex?: number): Subscription | void {
-  const destination = new InnerSubscriber(outerSubscriber, outerValue, outerIndex);
-
+export function subscribeToResult<T, R>(
+  outerSubscriber: OuterSubscriber<T, R>,
+  result: any,
+  outerValue?: T,
+  outerIndex?: number,
+  destination?: Subscriber<any>
+): Subscription;
+export function subscribeToResult<T, R>(
+  outerSubscriber: OuterSubscriber<T, R>,
+  result: any,
+  outerValue?: T,
+  outerIndex?: number,
+  destination: Subscriber<any> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
+): Subscription | void {
+  if (destination.closed) {
+    return;
+  }
   return subscribeTo(result)(destination);
 }


### PR DESCRIPTION
Add subscriptions for source Observables to mergeAll composite subscription before actually subscribing to any of these Observables, so that if source Observable emits synchronously and consumer of mergeAll unsubscribes at that moment (for example `take` operator), subscription to source is unsubscribed as well and Observable stops emitting.

Closes #2476