### PR TITLE
fix(ajax): Only set timeout & responseType if request is asynchronous

### DIFF
--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -245,8 +245,10 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       }
 
       // timeout, responseType and withCredentials can be set once the XHR is open
-      xhr.timeout = request.timeout;
-      xhr.responseType = request.responseType;
+      if (async) {
+        xhr.timeout = request.timeout;
+        xhr.responseType = request.responseType;
+      }
 
       if ('withCredentials' in xhr) {
         xhr.withCredentials = !!request.withCredentials;


### PR DESCRIPTION
**Description:**

Setting `async: false` in the call to `Observable.ajax` results in an error:

> DOMException: Failed to set the 'timeout' property on 'XMLHttpRequest': Timeouts cannot be set for synchronous requests made from a document.

You can observe the behavior here: https://jsfiddle.net/jkrehm/k4o9do0q/1/

My solution is simply to wrap the code that sets `timeout` and `responseType` (also a problem) in an if-statement so they're only set if `async: true` (the default).