### PR TITLE
perf(pluck,bufferTime,asObservable): add performance tests for pluck(), bufferTime() and asObservable() operators

### DIFF
--- a/perf/micro/current-thread-scheduler/operators/asobservable.js
+++ b/perf/micro/current-thread-scheduler/operators/asobservable.js
@@ -1,0 +1,24 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldRangeWithImmediateScheduler = RxOld.Observable.range(0, 250, RxOld.Scheduler.currentThread);
+  var newRangeWithImmediateScheduler = RxNew.Observable.range(0, 250, RxNew.Scheduler.queue);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old asObservable() with immediate scheduler', function () {
+      var oldSubject = new RxOld.Subject();
+
+      oldSubject.asObservable().subscribe(_next, _error, _complete);
+      oldRangeWithImmediateScheduler.subscribe(oldSubject);
+    })
+    .add('new asObservable() with immediate scheduler', function () {
+      var newSubject = new RxNew.Subject();
+
+      newSubject.asObservable().subscribe(_next, _error, _complete);
+      newRangeWithImmediateScheduler.subscribe(newSubject);
+    });
+};

--- a/perf/micro/current-thread-scheduler/operators/pluck-nested.js
+++ b/perf/micro/current-thread-scheduler/operators/pluck-nested.js
@@ -1,0 +1,23 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var source = [];
+  for (var i = 0; i < 25; i++) {
+    source.push({'a': {'b': {'c': i }}});
+  }
+
+  var oldPluckWithImmediateScheduler = RxOld.Observable.from(source, null, null, RxOld.Scheduler.currentThread).pluck('a', 'b', 'c');
+  var newPluckWithImmediateScheduler = RxNew.Observable.from(source, RxNew.Scheduler.queue).pluck('a', 'b', 'c');
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old pluck() with nested properties and current thread scheduler', function () {
+      oldPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new pluck() with nested properties and current thread scheduler', function () {
+      newPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/current-thread-scheduler/operators/pluck.js
+++ b/perf/micro/current-thread-scheduler/operators/pluck.js
@@ -1,0 +1,23 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var source = [];
+  for (var i = 0; i < 25; i++) {
+    source.push({'p': i});
+  }
+
+  var oldPluckWithImmediateScheduler = RxOld.Observable.from(source, null, null, RxOld.Scheduler.currentThread).pluck('p');
+  var newPluckWithImmediateScheduler = RxNew.Observable.from(source, RxNew.Scheduler.queue).pluck('p');
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old pluck() with current thread scheduler', function () {
+      oldPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new pluck() with current thread scheduler', function () {
+      newPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/asobservable.js
+++ b/perf/micro/immediate-scheduler/operators/asobservable.js
@@ -1,0 +1,24 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldRangeWithImmediateScheduler = RxOld.Observable.range(0, 250, RxOld.Scheduler.immediate);
+  var newRangeWithImmediateScheduler = RxNew.Observable.range(0, 250);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old asObservable() with immediate scheduler', function () {
+      var oldSubject = new RxOld.Subject();
+
+      oldSubject.asObservable().subscribe(_next, _error, _complete);
+      oldRangeWithImmediateScheduler.subscribe(oldSubject);
+    })
+    .add('new asObservable() with immediate scheduler', function () {
+      var newSubject = new RxNew.Subject();
+
+      newSubject.asObservable().subscribe(_next, _error, _complete);
+      newRangeWithImmediateScheduler.subscribe(newSubject);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/buffertime.js
+++ b/perf/micro/immediate-scheduler/operators/buffertime.js
@@ -1,0 +1,18 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var oldBufferWithImmediateScheduler = RxOld.Observable.interval(25, RxOld.Scheduler.immediate).bufferWithTime(60, RxOld.Scheduler.immediate).take(3);
+  var newBufferWithImmediateScheduler = RxNew.Observable.interval(25).bufferTime(60).take(3);
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+      .add('old bufferTime() with immediate scheduler', function () {
+        oldBufferWithImmediateScheduler.subscribe(_next, _error, _complete);
+      })
+      .add('new bufferTime() with immediate scheduler', function () {
+        newBufferWithImmediateScheduler.subscribe(_next, _error, _complete);
+      });
+};

--- a/perf/micro/immediate-scheduler/operators/pluck-nested.js
+++ b/perf/micro/immediate-scheduler/operators/pluck-nested.js
@@ -1,0 +1,23 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var source = [];
+  for (var i = 0; i < 25; i++) {
+    source.push({'a': {'b': {'c': i }}});
+  }
+
+  var oldPluckWithImmediateScheduler = RxOld.Observable.from(source, null, null, RxOld.Scheduler.immediate).pluck('a', 'b', 'c');
+  var newPluckWithImmediateScheduler = RxNew.Observable.from(source).pluck('a', 'b', 'c');
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old pluck() with nested properties and immediate scheduler', function () {
+      oldPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new pluck() with nested properties and immediate scheduler', function () {
+      newPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};

--- a/perf/micro/immediate-scheduler/operators/pluck.js
+++ b/perf/micro/immediate-scheduler/operators/pluck.js
@@ -1,0 +1,23 @@
+var RxOld = require('rx');
+var RxNew = require('../../../../index');
+
+module.exports = function (suite) {
+  var source = [];
+  for (var i = 0; i < 25; i++) {
+    source.push({'p': i});
+  }
+
+  var oldPluckWithImmediateScheduler = RxOld.Observable.from(source, null, null, RxOld.Scheduler.immediate).pluck('p');
+  var newPluckWithImmediateScheduler = RxNew.Observable.from(source).pluck('p');
+
+  function _next(x) { }
+  function _error(e) { }
+  function _complete() { }
+  return suite
+    .add('old pluck() with immediate scheduler', function () {
+      oldPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    })
+    .add('new pluck() with immediate scheduler', function () {
+      newPluckWithImmediateScheduler.subscribe(_next, _error, _complete);
+    });
+};


### PR DESCRIPTION
**Description:**

I've noticed that `pluck()`, `bufferTime()` and `asObservable()` operators don't have any performance tests so this PR adds them. All three of them have their RxJS 4 counterparts.

There're more operators without performance tests (for example `audit()` or `windowToggle()`) but these don't have any RxJS 4 alternative to compare them to and the current benchmark runner requires always two tests per suite. But this is probably for a separate another issue.

