### PR TITLE
style(MiscJSDoc): remove unnecessary import statement

### DIFF
--- a/src/MiscJSDoc.ts
+++ b/src/MiscJSDoc.ts
@@ -7,7 +7,6 @@
  */
 import { TeardownLogic } from './Subscription';
 import { Observable } from './Observable';
-import './scheduler/MiscJSDoc';
 import './observable/dom/MiscJSDoc';
 import { Observer } from './Observer';
 


### PR DESCRIPTION
remove unnecessary import statement - MiscJSDoc.ts was moved and a new import statement was added but the outdated import statement was not removed

Fixes #2453 
