### PR TITLE
fix(IteratorObservable): get new iterator for each subscription

### DIFF
--- a/spec/observables/IteratorObservable-spec.ts
+++ b/spec/observables/IteratorObservable-spec.ts
@@ -47,6 +47,24 @@ describe('IteratorObservable', () => {
       );
   });
 
+  it('should get new iterator for each subscription', () => {
+    const expected = [
+      Rx.Notification.createNext(10),
+      Rx.Notification.createNext(20),
+      Rx.Notification.createComplete()
+    ];
+
+    const e1 = IteratorObservable.create<number>(new Int32Array([10, 20])).observeOn(rxTestScheduler);
+
+    let v1, v2: Array<Rx.Notification<any>>;
+    e1.materialize().toArray().subscribe((x) => v1 = x);
+    e1.materialize().toArray().subscribe((x) => v2 = x);
+
+    rxTestScheduler.flush();
+    expect(v1).to.deep.equal(expected);
+    expect(v2).to.deep.equal(expected);
+  });
+
   it('should finalize generators if the subscription ends', () => {
     const iterator = {
       finalized: false,

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -11,8 +11,6 @@ import { Subscriber } from '../Subscriber';
  * @hide true
  */
 export class IteratorObservable<T> extends Observable<T> {
-  private iterator: any;
-
   static create<T>(iterator: any, scheduler?: IScheduler): IteratorObservable<T> {
     return new IteratorObservable(iterator, scheduler);
   }
@@ -45,20 +43,20 @@ export class IteratorObservable<T> extends Observable<T> {
     (<any> this).schedule(state);
   }
 
-  constructor(iterator: any, private scheduler?: IScheduler) {
+  constructor(private readonly iteratorObject: any, private scheduler?: IScheduler) {
     super();
 
-    if (iterator == null) {
+    if (iteratorObject == null) {
       throw new Error('iterator cannot be null.');
+    } else if (!iteratorObject[Symbol_iterator]) {
+      throw new TypeError('object is not iterable');
     }
-
-    this.iterator = getIterator(iterator);
   }
 
   protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
-
     let index = 0;
-    const { iterator, scheduler } = this;
+    const { scheduler } = this;
+    const iterator = getIterator(this.iteratorObject);
 
     if (scheduler) {
       return scheduler.schedule(IteratorObservable.dispatch, 0, {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Our `IteratorObservable` gets an iterator from the object once only when it's constructed, so any subsequent subscription is not able to iterate since the first subscription will make iterator completes.

This PR updates behavior to get corresponding new iterator per each subscription, allows any subscription can correctly iterate object. I'm labeling this for next patch version, since I believe this isn't breaking changes.

**Related issue (if exists):**
- closes #2496