### PR TITLE
docs(decision-tree-widget): Add header to decision tree widget section

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -15,6 +15,8 @@ RxJS is a library for reactive programming using Observables, to make it easier 
 
 - - -
 
+### Find the right Operator
+
 <div class="decision-tree-widget"></div>
 
 **Hint: open your DevTools to experiment with RxJS.**


### PR DESCRIPTION
I commonly tell people about the decision tree widget and _every_ time I do they alway say the same thing: "Oh you should make that more noticeable" 😆 

So...I did the laziest thing I could think of, gave it a header.

![image](https://cloud.githubusercontent.com/assets/762949/24487242/4327f318-14c3-11e7-9f93-b24c2d186e5e.png)

If someone has better suggestions, go with them instead 😄 

I thought about moving it to be at the top, but absolute first-timers might be confused. **then again** maybe that's an acceptable risk at the expense of helping tons of people discover it. I really is useful to them (and me even). On my laptop, the wizard is below the fold which is likely one of the reasons it's never seen.