### PR TITLE
fix(PromiseObservable): fromPromise does not accept PromiseLike object

### DIFF
--- a/spec/observables/from-promise-spec.ts
+++ b/spec/observables/from-promise-spec.ts
@@ -72,6 +72,25 @@ describe('Observable.fromPromise', () => {
     });
   });
 
+  it('should accept PromiseLike object for interoperability', (done: MochaDone) => {
+    class CustomPromise<T> implements PromiseLike<T> {
+      constructor(private promise: PromiseLike<T>) {
+      }
+      then(onFulfilled?, onRejected?): PromiseLike<T> {
+        return new CustomPromise(this.promise.then(onFulfilled, onRejected));
+      };
+    }
+    const promise = new CustomPromise(Promise.resolve(42));
+    Observable.fromPromise(promise)
+      .subscribe(
+        (x: number) => { expect(x).to.equal(42); },
+        () => {
+          done(new Error('should not be called'));
+        }, () => {
+          done();
+        });
+  });
+
   it('should emit a value from a resolved promise on a separate scheduler', (done: MochaDone) => {
     const promise = Promise.resolve(42);
     Observable.fromPromise(promise, Rx.Scheduler.asap)

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -31,7 +31,7 @@ export class PromiseObservable<T> extends Observable<T> {
    * @see {@link bindCallback}
    * @see {@link from}
    *
-   * @param {Promise<T>} promise The promise to be converted.
+   * @param {PromiseLike<T>} promise The promise to be converted.
    * @param {Scheduler} [scheduler] An optional IScheduler to use for scheduling
    * the delivery of the resolved value (or the rejection).
    * @return {Observable<T>} An Observable which wraps the Promise.

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -39,11 +39,11 @@ export class PromiseObservable<T> extends Observable<T> {
    * @name fromPromise
    * @owner Observable
    */
-  static create<T>(promise: Promise<T>, scheduler?: IScheduler): Observable<T> {
+  static create<T>(promise: PromiseLike<T>, scheduler?: IScheduler): Observable<T> {
     return new PromiseObservable(promise, scheduler);
   }
 
-  constructor(private promise: Promise<T>, private scheduler?: IScheduler) {
+  constructor(private promise: PromiseLike<T>, private scheduler?: IScheduler) {
     super();
   }
 


### PR DESCRIPTION
I can not use `Observable.fromPromise` with promises from [when](https://github.com/cujojs/when).  
The class is clearly documented that it should accept Promises/A+ spec compliant Promise.  
I think the type should be relaxed.