### PR TITLE
feat(catch): make rethrow idiom type safe

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -280,8 +280,8 @@ describe('Observable.webSocket', () => {
 
       const subject = Observable.webSocket({
         url: 'ws://mysocket',
-        resultSelector: (e: any) => {
-          return e.data + '!';
+        resultSelector: e => {
+          return e.data + '!' as any;
         }
       });
 

--- a/spec/observables/from-promise-spec.ts
+++ b/spec/observables/from-promise-spec.ts
@@ -76,8 +76,9 @@ describe('Observable.fromPromise', () => {
     class CustomPromise<T> implements PromiseLike<T> {
       constructor(private promise: PromiseLike<T>) {
       }
-      then(onFulfilled?, onRejected?): PromiseLike<T> {
-        return new CustomPromise(this.promise.then(onFulfilled, onRejected));
+      // tslint:disable-next-line:max-line-length
+      then<TResult1 = T, TResult2 = never>(onfulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null, onrejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): PromiseLike<TResult1 | TResult2> {
+      return new CustomPromise(this.promise.then(onfulfilled, onrejected));
       }
     }
     const promise = new CustomPromise(Promise.resolve(42));

--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -358,4 +358,11 @@ describe('Observable.prototype.catch', () => {
     });
   });
 
+  it('should return a T typed Observable when selector returns an ErrorObservable', (done: MochaDone) => {
+    const input$ = Observable.of(class { });
+
+    input$.catch((err, caught) => Observable.throw(Error(err)))
+      .map(C => class extends C { })
+      .subscribe({ complete: done });
+  });
 });

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -350,7 +350,7 @@ describe('Observable.prototype.reduce', () => {
         value.a = acc.a;
         value.b = acc.b;
         return acc;
-      }, {});
+      }, {a: 1, b: 'b'});
 
       reduced.subscribe(r => {
         r.a.toExponential();

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -242,7 +242,7 @@ describe('Observable.prototype.scan', () => {
         value.a = acc.a;
         value.b = acc.b;
         return acc;
-      }, {});
+      });
     });
   });
 

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -4,7 +4,7 @@ import { Observable, ObservableInput } from '../Observable';
 
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
-import { ErrorObservable } from '../Observable/ErrorObservable';
+import { ErrorObservable } from '../observable/ErrorObservable';
 
 /**
  * Catches errors on the observable to be handled by returning a new observable or throwing an error.

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -4,6 +4,7 @@ import { Observable, ObservableInput } from '../Observable';
 
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
+import { ErrorObservable } from '../Observable/ErrorObservable';
 
 /**
  * Catches errors on the observable to be handled by returning a new observable or throwing an error.
@@ -65,6 +66,9 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * @owner Observable
  */
 export function _catch<T, R = T>(this: Observable<T>, selector: (err: any, caught: Observable<R>) => ObservableInput<R>): Observable<R> {
+export function _catch<T>(this: Observable<T>, selector: (err: any, caught: Observable<T>) => ErrorObservable): Observable<T>;
+export function _catch<T, R>(this: Observable<T>, selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<T | R>;
+export function _catch<T, R>(this: Observable<T>, selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<T | R> {
   const operator = new CatchOperator(selector);
   const caught = this.lift(operator);
   return (operator.caught = caught);

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -65,10 +65,9 @@ import { ErrorObservable } from '../Observable/ErrorObservable';
  * @name catch
  * @owner Observable
  */
-export function _catch<T, R = T>(this: Observable<T>, selector: (err: any, caught: Observable<R>) => ObservableInput<R>): Observable<R> {
 export function _catch<T>(this: Observable<T>, selector: (err: any, caught: Observable<T>) => ErrorObservable): Observable<T>;
-export function _catch<T, R>(this: Observable<T>, selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<T | R>;
-export function _catch<T, R>(this: Observable<T>, selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<T | R> {
+export function _catch<T, R = T>(this: Observable<T>, selector: (err: any, caught: Observable<R>) => ObservableInput<R>): Observable<R>;
+export function _catch<T, R = T>(this: Observable<T>, selector: (err: any, caught: Observable<R>) => ObservableInput<R>): Observable<R> {
   const operator = new CatchOperator(selector);
   const caught = this.lift(operator);
   return (operator.caught = caught);


### PR DESCRIPTION
**Description:**
For better or worse, the catch and rethrow idiom seems to have overtaken RxJS. I suspect the Angular docs are the primary reason for this trend but that is beside the point except that it gives me the opportunity to remark that clearer usage guidelines for operators would be helpful.

For reference, this is what the code that I see daily, both at work and on Stack Overflow, looks like:
```ts
import { Observable } from 'rxjs/Observable';
import 'rxjs/add/operator/map';
import 'rxjs/add/operator/catch';

export interface Something {
  name: string;
}

export class SomeService {
  getItems() {
    return this.http('api/something')
      .map(x => x.json() as Model) // Observable<Model>
      .catch((err, caught) => Observable.throw(err.json())); // Observable<any>
  }
}
```
The problem with this idiom, and it really is pervasive in Angular at least, is that chaining `catch` removes all type information unless the user actually uses it to recover by supplying another strongly Observable.

While recovering from an error seems like the primary purpose of the operator, the rethrow idiom is widespread.

If they return the result of an `Observable.throw` call all further operations receive `Observable<any>`.

This PR changes the type of `_catch` by introducing an overload which explicitly accepts a projection to `ErrorObservable` and preserves the original value type of the observable in that case.

I have also added a test verifying that `any` is no longer the value type of the chained observable by leveraging perhaps the only restriction on _any_, that it cannot be the object of an `extends` clause.

**Related issue (if exists):**
#2488