### PR TITLE
fix(reduce): change order of reduce overload type definitions

### DIFF
--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -316,6 +316,33 @@ describe('Observable.prototype.reduce', () => {
     });
   });
 
+  it('should accept T typed reducers when T is an array', () => {
+    type(() => {
+      let a: Rx.Observable<number[]>;
+      const reduced = a.reduce((acc, value) => {
+        return acc.concat(value);
+      }, []);
+
+      reduced.subscribe(rs => {
+        rs[0].toExponential();
+      });
+    });
+  });
+
+  it('should accept R typed reduces when R is an array of T', () => {
+    type(() => {
+      let a: Rx.Observable<number>;
+      const reduced = a.reduce((acc, value) => {
+        acc.push(value);
+        return acc;
+      }, []);
+
+      reduced.subscribe(rs => {
+        rs[0].toExponential();
+      });
+    });
+  });
+
   it('should accept R typed reducers when R is assignable to T', () => {
     type(() => {
       let a: Rx.Observable<{ a?: number; b?: string }>;

--- a/src/operator/reduce.ts
+++ b/src/operator/reduce.ts
@@ -3,8 +3,8 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
-export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed: T[]): Observable<T[]>;
 export function reduce<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
+export function reduce<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed: T[]): Observable<T[]>;
 export function reduce<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed: R): Observable<R>;
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
**Description:** Update overload type definitions of operator reduce so returning type T takes precedence over returning type T[].

**Related issue (if exists):** #2519 
