### PR TITLE
chore(package.json): pin down lint-staged pkg version

### DIFF
--- a/package.json
+++ b/package.json
@@ -165,7 +165,7 @@
     "gzip-size": "^3.0.0",
     "http-server": "^0.9.0",
     "husky": "^0.13.3",
-    "lint-staged": "^3.2.5",
+    "lint-staged": "3.2.5",
     "lodash": "^4.15.0",
     "madge": "^1.4.3",
     "markdown-doctest": "^0.9.1",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This is simple pkg pin down, I found latest ^ bump up (above 3.2.7) has regressions to deal with windows paths.

**Related issue (if exists):**
