### PR TITLE
fix(find): emit empty observable when predicate find no match

### DIFF
--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -43,14 +43,14 @@ describe('Observable.prototype.find', () => {
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  it('should return undefined if source is empty to match predicate', () => {
+  it('should return empty if source is empty to match predicate', () => {
     const source = cold('|');
     const subs =        '(^!)';
-    const expected =    '(x|)';
+    const expected =    '(|)';
 
     const result = (<any>source).find(truePredicate);
 
-    expectObservable(result).toBe(expected, {x: undefined});
+    expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -96,16 +96,14 @@ describe('Observable.prototype.find', () => {
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  it('should return undefined if element does not match with predicate', () => {
+  it('should return empty if element does not match with predicate', () => {
     const source = hot('--a--b--c--|');
     const subs =       '^          !';
-    const expected =   '-----------(x|)';
+    const expected =   '-----------|';
 
-    const predicate = function (value) {
-      return value === 'z';
-    };
+    const predicate = (value) => value === 'z';
 
-    expectObservable((<any>source).find(predicate)).toBe(expected, { x: undefined });
+    expectObservable(source.find(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -101,6 +101,10 @@ export class FindValueSubscriber<T> extends Subscriber<T> {
   }
 
   protected _complete(): void {
-    this.notifyComplete(this.yieldIndex ? -1 : undefined);
+    if (this.yieldIndex) {
+      this.notifyComplete(-1);
+    } else {
+      this.destination.complete();
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
It is my fault when I implemented `find` and `findIndex` operator, make emit `undefined` when there is no match to given predicate, while RxJS v4 states to emit empty observable when it does (https://github.com/ReactiveX/rxjs/issues/2515#issuecomment-291194777). 

This PR changes behavior to align with v4, when there isn't no match sequence will complete without emitting anything.

BREAKING CHANGES: if anyone used `undefined` emitted by unmatched predicate via find operator, it
won't work anymore

**Related issue (if exists):**
- closes #2515