### PR TITLE
fix(closure): don't throw at top-level scope

### DIFF
--- a/src/util/root.ts
+++ b/src/util/root.ts
@@ -12,12 +12,18 @@ declare module NodeJS {
  * self: browser in WebWorker
  * global: Node.js/other
  */
-export const root: any = (
-     typeof window == 'object' && window.window === window && window
-  || typeof self == 'object' && self.self === self && self
-  || typeof global == 'object' && global.global === global && global
-);
-
-if (!root) {
-  throw new Error('RxJS could not find any global context (window, self, global)');
+export let root: any;
+if (typeof window == 'object' && window.window === window) {
+  root = window;
+} else if (typeof self == 'object' && self.self === self) {
+  root = self;
+} else if (typeof global == 'object' && global.global === global) {
+  root = global;
+} else {
+  // Workaround Closure Compiler restriction: The body of a goog.module cannot use throw.
+  // This is needed when used with angular/tsickle which inserts a goog.module statement.
+  // Wrap in IIFE
+  (function () {
+    throw new Error('RxJS could not find any global context (window, self, global)');
+  })();
 }


### PR DESCRIPTION
Closure compiler does not allow this. We need this modification to use RxJS in Angular projects.

Addresses https://github.com/angular/tsickle/issues/420

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
