### PR TITLE
fix(race): support array of observables other than rest param

### DIFF
--- a/spec/observables/race-spec.ts
+++ b/spec/observables/race-spec.ts
@@ -35,6 +35,20 @@ describe('Observable.race', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
+  it('should race with array of observable', () => {
+    const e1 =  cold('---a-----b-----c----|');
+    const e1subs =   '^                   !';
+    const e2 =  cold('------x-----y-----z----|');
+    const e2subs =   '^  !';
+    const expected = '---a-----b-----c----|';
+
+    const result = Observable.race([e1, e2]);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
   it('should race hot and hot', () => {
     const e1 =   hot('---a-----b-----c----|');
     const e1subs =   '^                   !';

--- a/src/operator/race.ts
+++ b/src/operator/race.ts
@@ -9,8 +9,10 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 /* tslint:disable:max-line-length */
+export function race<T>(this: Observable<T>, observables: Array<Observable<T>>): Observable<T>;
+export function race<T, R>(this: Observable<T>, observables: Array<Observable<T>>): Observable<R>;
 export function race<T>(this: Observable<T>, ...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T>;
-export function race<T, R>(this: Observable<T>, ...observables: Array<Observable<any> | Array<Observable<T>>>): Observable<R>;
+export function race<T, R>(this: Observable<T>, ...observables: Array<Observable<any> | Array<Observable<any>>>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -39,10 +41,12 @@ export function race<T>(this: Observable<T>, ...observables: Array<Observable<T>
  * @name race
  * @owner Observable
  */
+export function raceStatic<T>(observables: Array<Observable<T>>): Observable<T>;
+export function raceStatic<T>(observables: Array<Observable<any>>): Observable<T>;
 export function raceStatic<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): Observable<T>;
 export function raceStatic<T>(...observables: Array<Observable<any> | Array<Observable<any>>>): Observable<T> {
   // if the only argument is an array, it was most likely called with
-  // `pair([obs1, obs2, ...])`
+  // `race([obs1, obs2, ...])`
   if (observables.length === 1) {
     if (isArray(observables[0])) {
       observables = <Array<Observable<any>>>observables[0];


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
I just noticed `Observable.race([o1, o2])` is not working cause current definition is shaped for rest param args only (so `Observable.race(...[o1, o2])` works. This PR aligns type definition to support those forms to actual operator behavior.

**Related issue (if exists):**
