### PR TITLE
fix(ErrorObservable): Added and fixed failing test for Observable.catch

### DIFF
--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -1,5 +1,6 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
+import * as sinon from 'sinon';
 import {createObservableInputs} from '../helpers/test-helper';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
@@ -278,4 +279,83 @@ describe('Observable.prototype.catch', () => {
       done();
     });
   });
+
+  context('fromPromise', () => {
+    type SetTimeout = (callback: (...args: any[]) => void, ms: number, ...args: any[]) => NodeJS.Timer;
+
+    let trueSetTimeout: SetTimeout;
+    let sandbox: sinon.SinonSandbox;
+    let timers: sinon.SinonFakeTimers;
+
+    beforeEach(() => {
+      trueSetTimeout = global.setTimeout;
+      sandbox = sinon.sandbox.create();
+      timers = sandbox.useFakeTimers();
+    });
+
+    afterEach(() => {
+      sandbox.restore();
+    });
+
+    it('should chain a throw from a promise using throw', (done: MochaDone) => {
+      const subscribeSpy = sinon.spy();
+      const testError = new Error('BROKEN PROMISE');
+      Observable.fromPromise(Promise.reject(testError)).catch(err => {
+        throw new Error('BROKEN THROW');
+      }).subscribe(subscribeSpy);
+
+      trueSetTimeout(() => {
+        try {
+          timers.tick(1);
+        } catch (e) {
+          expect(subscribeSpy).not.to.be.called;
+          expect(e.message).to.equal('BROKEN THROW');
+          return done();
+        }
+        done(new Error('This should have thrown an error'));
+      }, 0);
+    });
+
+    it('should chain a throw from a promise using Observable.throw', (done: MochaDone) => {
+      const subscribeSpy = sinon.spy();
+      const testError = new Error('BROKEN PROMISE');
+      Observable.fromPromise(Promise.reject(testError)).catch(err =>
+        Observable.throw(new Error('BROKEN THROW'))
+      ).subscribe(subscribeSpy);
+
+      trueSetTimeout(() => {
+        try {
+          timers.tick(1);
+        } catch (e) {
+          expect(subscribeSpy).not.to.be.called;
+          expect(e.message).to.equal('BROKEN THROW');
+          return done();
+        }
+        done(new Error('This should have thrown an error'));
+      }, 0);
+    });
+
+    it('should chain a throw from a promise using Observable.throw', (done: MochaDone) => {
+      const subscribeSpy = sinon.spy();
+      const errorSpy = sinon.spy();
+      const thrownError = new Error('BROKEN THROW');
+      const testError = new Error('BROKEN PROMISE');
+      Observable.fromPromise(Promise.reject(testError)).catch(err =>
+        Observable.throw(thrownError)
+      ).subscribe(subscribeSpy, errorSpy);
+
+      trueSetTimeout(() => {
+        try {
+          timers.tick(1);
+        } catch (e) {
+          return done(new Error('This should not have thrown an error'));
+        }
+        expect(subscribeSpy).not.to.be.called;
+        expect(errorSpy).to.have.been.called;
+        expect(errorSpy).to.have.been.calledWith(thrownError);
+        done();
+      }, 0);
+    });
+  });
+
 });

--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -1,6 +1,7 @@
 import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
+import { Subscriber } from '../Subscriber';
 
 export interface DispatchArg {
   error: any;
@@ -67,9 +68,11 @@ export class ErrorObservable extends Observable<any> {
     super();
   }
 
-  protected _subscribe(subscriber: any): TeardownLogic {
+  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
     const error = this.error;
     const scheduler = this.scheduler;
+
+    subscriber.syncErrorThrowable = true;
 
     if (scheduler) {
       return scheduler.schedule(ErrorObservable.dispatch, 0, {


### PR DESCRIPTION
**Description:**

Added a failing test describing unexpected behavior between throw Error and Observable.throw(Error) when the source of an observable is a Promise. In my opinion this behavior is confusing as the catch handler needs to know if the source is from a Promise vs another source. Thanks for taking a look. 

Added fix by forcing `sync.syncErrorThrowable` on `ErrorObservable`. Let me know if this is a good fix and if I should add a unit test for ErrorObservable.

**Related issue (if exists):**

Related #2485.