### PR TITLE
fix(Subscriber): do not call complete with undefined value param

### DIFF
--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -85,7 +85,7 @@ describe('Subscriber', () => {
   });
 
   it('should not be closed when other subscriber with same observer instance completes', () => {
-    let observer = {
+    const observer = {
       next: function () { /*noop*/ }
     };
 
@@ -96,5 +96,20 @@ describe('Subscriber', () => {
 
     expect(sub1.closed).to.be.false;
     expect(sub2.closed).to.be.true;
+  });
+
+  it('should call complete observer without any arguments', () => {
+    let argument: Array<any> = null;
+
+    const observer = {
+      complete: (...args: Array<any>) => {
+        argument = args;
+      }
+    };
+
+    const sub1 = new Subscriber(observer);
+    sub1.complete();
+
+    expect(argument).to.have.lengthOf(0);
   });
 });

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -234,11 +234,13 @@ class SafeSubscriber<T> extends Subscriber<T> {
     if (!this.isStopped) {
       const { _parentSubscriber } = this;
       if (this._complete) {
+        const wrappedComplete = () => this._complete.call(this._context);
+
         if (!_parentSubscriber.syncErrorThrowable) {
-          this.__tryOrUnsub(this._complete);
+          this.__tryOrUnsub(wrappedComplete);
           this.unsubscribe();
         } else {
-          this.__tryOrSetError(_parentSubscriber, this._complete);
+          this.__tryOrSetError(_parentSubscriber, wrappedComplete);
           this.unsubscribe();
         }
       } else {


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR makes to call observer's complete function without delivering one param as undefined value all times. While observer is requested to follow its contract interfaces, change seems trivial to avoid this behavior in code as well. 

I think this is non-breaking changes maybe?

**Related issue (if exists):**
- closes #2502