### PR TITLE
chore(tests): add scripts for running browser tests against global builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,6 +67,8 @@
     "build_docs": "npm-run-all build_global build_es6_for_docs build_cjs clean_spec build_spec tests2png decision_tree_widget && esdoc -c esdoc.json && npm-run-all clean_dist_es6",
     "build_spec": "tsc --project ./spec --pretty",
     "build_spec_browser": "webpack --config spec/support/webpack.mocha.config.js",
+    "build_spec_browser_global": "webpack --config spec/support/webpack.mocha.config.global.js",
+    "build_spec_browser_global_min": "webpack --config spec/support/webpack.mocha.config.global.min.js",
     "check_circular_dependencies": "madge ./dist/cjs --circular",
     "clean_spec": "shx rm -rf spec-js",
     "clean_dist_cjs": "shx rm -rf ./dist/cjs",
@@ -146,6 +148,7 @@
   },
   "homepage": "https://github.com/ReactiveX/RxJS",
   "devDependencies": {
+    "babel-polyfill": "^6.23.0",
     "benchmark": "^2.1.0",
     "benchpress": "2.0.0-beta.1",
     "chai": "^3.5.0",

--- a/spec/observables/IteratorObservable-spec.ts
+++ b/spec/observables/IteratorObservable-spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import {queue} from '../../dist/cjs/scheduler/queue';
 import {IteratorObservable} from '../../dist/cjs/observable/IteratorObservable';
+import '../../dist/cjs/add/operator/take';
 
 declare const expectObservable;
 declare const rxTestScheduler: Rx.TestScheduler;

--- a/spec/observables/SubscribeOnObservable-spec.ts
+++ b/spec/observables/SubscribeOnObservable-spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import * as sinon from 'sinon';
 import * as Rx from '../../dist/cjs/Rx';
 import {SubscribeOnObservable} from '../../dist/cjs/observable/SubscribeOnObservable';
+import {asap} from '../../dist/cjs/scheduler/asap';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
 declare const hot: typeof marbleTestingSignature.hot;
@@ -26,7 +27,7 @@ describe('SubscribeOnObservable', () => {
 
     const scheduler = (<any>new SubscribeOnObservable(e1, 0, obj)).scheduler;
 
-    expect(scheduler).to.deep.equal(Rx.Scheduler.asap);
+    expect(scheduler).to.deep.equal(asap);
   });
 
   it('should create observable via staic create function', () => {

--- a/spec/observables/of-spec.ts
+++ b/spec/observables/of-spec.ts
@@ -3,19 +3,21 @@ import * as Rx from '../../dist/cjs/Rx';
 import {ArrayObservable} from '../../dist/cjs/observable/ArrayObservable';
 import {ScalarObservable} from '../../dist/cjs/observable/ScalarObservable';
 import {EmptyObservable} from '../../dist/cjs/observable/EmptyObservable';
+import { Observable } from '../../dist/cjs/Observable';
+import '../../dist/cjs/add/observable/of';
+import '../../dist/cjs/add/operator/concatAll';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
 declare const { asDiagram };
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
 declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
 
 /** @test {of} */
 describe('Observable.of', () => {
   asDiagram('of(1, 2, 3)')('should create a cold observable that emits 1, 2, 3', () => {
-    const e1 = Observable.of(1, 2, 3)
+    const e1 = Rx.Observable.of(1, 2, 3)
       // for the purpose of making a nice diagram, spread out the synchronous emissions
-      .concatMap((x, i) => Observable.of(x).delay(i === 0 ? 0 : 20, rxTestScheduler));
+      .concatMap((x, i) => Rx.Observable.of(x).delay(i === 0 ? 0 : 20, rxTestScheduler));
     const expected = 'x-y-(z|)';
     expectObservable(e1).toBe(expected, {x: 1, y: 2, z: 3});
   });
@@ -25,7 +27,7 @@ describe('Observable.of', () => {
     const expected = [1, 'a', x];
     let i = 0;
 
-    Observable.of<any>(1, 'a', x)
+    Rx.Observable.of<any>(1, 'a', x)
       .subscribe((y: any) => {
         expect(y).to.equal(expected[i++]);
       }, (x) => {
@@ -63,7 +65,7 @@ describe('Observable.of', () => {
   it('should emit one value', (done: MochaDone) => {
     let calls = 0;
 
-    Observable.of(42).subscribe((x: number) => {
+    Rx.Observable.of(42).subscribe((x: number) => {
       expect(++calls).to.equal(1);
       expect(x).to.equal(42);
     }, (err: any) => {

--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -1,6 +1,5 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
-import {GroupedObservable} from '../../dist/cjs/operator/groupBy';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
 declare const { asDiagram };
@@ -203,28 +202,6 @@ describe('Observable.prototype.groupBy', () => {
 
     const source = e1
       .groupBy((val: string) => val.toLowerCase().trim());
-
-    expectObservable(source).toBe(expected, expectedValues);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should emit GroupObservables', () => {
-    const values = {
-      a: '  foo',
-      b: ' FoO '
-    };
-    const e1 = hot('-1--2--^-a-b----|', values);
-    const e1subs =        '^        !';
-    const expected =      '--g------|';
-    const expectedValues = { g: 'foo' };
-
-    const source = e1
-      .groupBy((val: string) => val.toLowerCase().trim())
-      .do((group: any) => {
-        expect(group.key).to.equal('foo');
-        expect(group instanceof GroupedObservable).to.be.true;
-      })
-      .map((group: any) => { return group.key; });
 
     expectObservable(source).toBe(expected, expectedValues);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/support/webpack.mocha.config.global.js
+++ b/spec/support/webpack.mocha.config.global.js
@@ -1,0 +1,11 @@
+var webpack = require('webpack');
+var config = require('./webpack.mocha.config');
+
+config.plugins.push(
+  new webpack.NormalModuleReplacementPlugin(
+    /\.\.\/dist\/cjs\/Rx/,
+    function(result) { result.request = result.request.replace('cjs', 'global'); }
+  )
+);
+
+module.exports = config;

--- a/spec/support/webpack.mocha.config.global.min.js
+++ b/spec/support/webpack.mocha.config.global.min.js
@@ -1,0 +1,11 @@
+var webpack = require('webpack');
+var config = require('./webpack.mocha.config');
+
+config.plugins.push(
+  new webpack.NormalModuleReplacementPlugin(
+    /\.\.\/dist\/cjs\/Rx/,
+    function(result) { result.request = result.request.replace('cjs', 'global') + '.min'; }
+  )
+);
+
+module.exports = config;

--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -1,13 +1,15 @@
 import {expect} from 'chai';
-import * as Rx from '../../dist/cjs/Rx';
 import {subscribeToResult} from '../../dist/cjs/util/subscribeToResult';
 import {OuterSubscriber} from '../../dist/cjs/OuterSubscriber';
+import {Observable} from '../../dist/cjs/Observable';
+import '../../dist/cjs/add/observable/range';
+import '../../dist/cjs/add/observable/throw';
 import {$$iterator} from '../../dist/cjs/symbol/iterator';
 import $$symbolObservable from 'symbol-observable';
 
 describe('subscribeToResult', () => {
   it('should synchronously complete when subscribe to scalarObservable', () => {
-    const result = Rx.Observable.of(42);
+    const result = Observable.of(42);
     let expected: number;
     const subscriber = new OuterSubscriber((x: number) => expected = x);
 
@@ -19,7 +21,7 @@ describe('subscribeToResult', () => {
 
   it('should subscribe to observables that are an instanceof Rx.Observable', (done: MochaDone) => {
     const expected = [1, 2, 3];
-    const result = Rx.Observable.range(1, 3);
+    const result = Observable.range(1, 3);
 
     const subscriber = new OuterSubscriber(x => {
       expect(expected.shift()).to.be.equal(x);
@@ -34,7 +36,7 @@ describe('subscribeToResult', () => {
   });
 
   it('should emit error when observable emits error', (done: MochaDone) => {
-    const result = Rx.Observable.throw(new Error('error'));
+    const result = Observable.throw(new Error('error'));
     const subscriber = new OuterSubscriber(x => {
       done(new Error('should not be called'));
     }, (err) => {
@@ -119,7 +121,7 @@ describe('subscribeToResult', () => {
   });
 
   it('should subscribe to to an object that implements Symbol.observable', (done: MochaDone) => {
-    const observableSymbolObject = { [$$symbolObservable]: () => Rx.Observable.of(42) };
+    const observableSymbolObject = { [$$symbolObservable]: () => Observable.of(42) };
 
     const subscriber = new OuterSubscriber(x => {
       expect(x).to.be.equal(42);


### PR DESCRIPTION
**Description:**

Add scripts for building specs including global builds (Rx.js
and Rx.min.js) instead of cjs builds, so that these packages can
be regression tested in browsers.

**Related issue (if exists):**

Closes #2229

**Caveats:**
Running against global builds crashes few tests, because there are conflicts between global and cjs codebases. For example some tests check if returned values are `instanceof` some internal Observable (say, `GroupedObservable`) which is not exported in global build. Since cjs and global are two different codebases, such checks fail.
