### PR TITLE
docs(css): enable momentum scrolling for iOS

### DIFF
--- a/doc/styles/main.css
+++ b/doc/styles/main.css
@@ -127,6 +127,7 @@ body.light-theme .navigation, body.dark-theme .navigation {
   height: calc(100% - 40px);
   background-color: #333;
   padding: 10px;
+  -webkit-overflow-scrolling: touch;
 }
 
 body.light-theme .navigation {
@@ -208,6 +209,7 @@ a:hover {
   overflow-y: scroll;
   height: calc(100vh - 40px);
   box-sizing: border-box;
+  -webkit-overflow-scrolling: touch;
 }
 
 .content .detail {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

https://developer.mozilla.org/en-US/docs/Web/CSS/-webkit-overflow-scrolling

All other mobile and desktop platforms with built-in momentum scrolling
enable it by default. iOS requires an explicit CSS rule.

