### PR TITLE
fix(tests): add missing babel-polyfill to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -146,6 +146,7 @@
   },
   "homepage": "https://github.com/ReactiveX/RxJS",
   "devDependencies": {
+    "babel-polyfill": "^6.23.0",
     "benchmark": "^2.1.0",
     "benchpress": "2.0.0-beta.1",
     "chai": "^3.5.0",


### PR DESCRIPTION
Add missing babel-polyfill to package.json, so that tests
run in the browsers that do not support ES6 features run
without issues.

Closes #2261

Dependency is used here: https://github.com/ReactiveX/rxjs/blob/master/spec/support/mocha-browser-runner.html#L11
