### PR TITLE
fix(AjaxObservable): fix AjaxObservable's XML responseType for TS 2.3

### DIFF
--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -20,7 +20,7 @@ export interface AjaxRequest {
   withCredentials?: boolean;
   createXHR?: () => XMLHttpRequest;
   progressSubscriber?: Subscriber<any>;
-  responseType?: string;
+  responseType?: typeof XMLHttpRequest.prototype.responseType;
 }
 
 function getCORSRequest(this: AjaxRequest): XMLHttpRequest {
@@ -401,8 +401,8 @@ export class AjaxResponse {
   /** @type {string} The raw responseText */
   responseText: string;
 
-  /** @type {string} The responseType (e.g. 'json', 'arraybuffer', or 'xml') */
-  responseType: string;
+  /** @type {string} The responseType (e.g. 'json', 'arraybuffer', or 'document') */
+  responseType: typeof XMLHttpRequest.prototype.responseType;
 
   constructor(public originalEvent: Event, public xhr: XMLHttpRequest, public request: AjaxRequest) {
     this.status = xhr.status;
@@ -417,7 +417,10 @@ export class AjaxResponse {
           this.response = JSON.parse(xhr.responseText || 'null');
         }
         break;
-      case 'xml':
+      // TODO: The 'xml' case exists for backwards compatibility, but is not a
+      // valid responseType and should be removed.
+      case 'xml' as any:
+      case 'document':
         this.response = xhr.responseXML;
         break;
       case 'text':


### PR DESCRIPTION
**Description:**
This change fixes the type of the `responseType` property for TS 2.3, which introduced stricter typings, and changes the AjaxObservable code to look for the `document` responseType instead of `xml` (which isn't a valid responseType). See the MDN article on `.responseXML` usage:
https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseXML

For reference, here is the relevant section of the TS 2.3 typings: https://github.com/Microsoft/TypeScript/blob/master/lib/lib.d.ts#L17605

Note that this doesn't tackle any of the other tasks necessary to upgrade to TS 2.3, which seem to be being tracked at #2582.