### PR TITLE
fix(delayWhen): correctly handle synchronous duration observable

### DIFF
--- a/spec/operators/delayWhen-spec.ts
+++ b/spec/operators/delayWhen-spec.ts
@@ -1,5 +1,6 @@
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
+import { expect } from 'chai';
 
 declare const { asDiagram };
 declare const hot: typeof marbleTestingSignature.hot;
@@ -214,5 +215,17 @@ describe('Observable.prototype.delayWhen', () => {
     expectSubscriptions(e1.subscriptions).toBe([]);
     expectSubscriptions(selector.subscriptions).toBe([]);
     expectSubscriptions(subDelay.subscriptions).toBe(subDelaySub);
+  });
+
+  it('should complete when duration selector returns synchronous observable', () => {
+    let next: boolean = false;
+    let complete: boolean = false;
+
+    Rx.Observable.of(1)
+      .delayWhen(() => Rx.Observable.of(2))
+      .subscribe(() => next = true, null, () => complete = true);
+
+    expect(next).to.be.true;
+    expect(complete).to.be.true;
   });
 });

--- a/src/operator/delayWhen.ts
+++ b/src/operator/delayWhen.ts
@@ -56,7 +56,7 @@ export function delayWhen<T>(this: Observable<T>, delayDurationSelector: (value:
                              subscriptionDelay?: Observable<any>): Observable<T> {
   if (subscriptionDelay) {
     return new SubscriptionDelayObservable(this, subscriptionDelay)
-            .lift(new DelayWhenOperator(delayDurationSelector));
+      .lift(new DelayWhenOperator(delayDurationSelector));
   }
   return this.lift(new DelayWhenOperator(delayDurationSelector));
 }
@@ -112,7 +112,7 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
         this.tryDelay(delayNotifier, value);
       }
     } catch (err) {
-        this.destination.error(err);
+      this.destination.error(err);
     }
   }
 
@@ -138,9 +138,12 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private tryDelay(delayNotifier: Observable<any>, value: T): void {
     const notifierSubscription = subscribeToResult(this, delayNotifier, value);
-    this.add(notifierSubscription);
 
-    this.delayNotifierSubscriptions.push(notifierSubscription);
+    if (notifierSubscription && !notifierSubscription.closed) {
+      this.add(notifierSubscription);
+      this.delayNotifierSubscriptions.push(notifierSubscription);
+    }
+
     this.values.push(value);
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR fixes outersubscriber behavior of delayWhen operator, to complete it correctly when duration selector returns synchronous observable. Similar to https://github.com/ReactiveX/rxjs/pull/1490 in crux.

**Related issue (if exists):**
- closes #2587