### PR TITLE
fix(audit): mirror source if durations are Observable.empty()

### DIFF
--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -127,6 +127,18 @@ describe('Observable.prototype.audit', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should mirror source if durations are Observable.empty()', () => {
+    const e1 =   hot('abcdefabcdefabcdefabcdefa|');
+    const e1subs =   '^                        !';
+    const e2 =  Rx.Observable.empty();
+    const expected = 'abcdefabcdefabcdefabcdefa|';
+
+    const result = e1.audit(() => e2);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should emit no values if duration is a never', () => {
     const e1 =   hot('----abcdefabcdefabcdefabcdefa|');
     const e1subs =   '^                            !';

--- a/src/operator/audit.ts
+++ b/src/operator/audit.ts
@@ -86,6 +86,9 @@ class AuditSubscriber<T, R> extends OuterSubscriber<T, R> {
         this.destination.error(errorObject.e);
       } else {
         this.add(this.throttled = subscribeToResult(this, duration));
+        if (this.throttled.closed) {
+          this.clearThrottle();
+        }
       }
     }
   }

--- a/src/operator/audit.ts
+++ b/src/operator/audit.ts
@@ -85,9 +85,11 @@ class AuditSubscriber<T, R> extends OuterSubscriber<T, R> {
       if (duration === errorObject) {
         this.destination.error(errorObject.e);
       } else {
-        this.add(this.throttled = subscribeToResult(this, duration));
-        if (this.throttled.closed) {
+        const innerSubscription = subscribeToResult(this, duration);
+        if (innerSubscription.closed) {
           this.clearThrottle();
+        } else {
+          this.add(this.throttled = innerSubscription);
         }
       }
     }


### PR DESCRIPTION
**Description:**
The `audit` operator was suppressing all events if the duration was `Observable.empty()` or any observable that was already complete.

There was already a similar test for this, but it relied upon `cold('|')`. It might be worth considering either duplicating tests involving `cold('|')` to use `Observable.empty()` or special-casing it to return `Observable.empty()`