### PR TITLE
Update to TypeScript 2.1, Update Errors, Breaking Changes!

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "build_test": "shx rm -rf ./dist/ && npm-run-all build_cjs clean_spec build_spec test_mocha",
     "build_cover": "shx rm -rf ./dist/ && npm-run-all build_cjs build_spec cover",
     "build_docs": "npm-run-all build_global build_es6_for_docs build_cjs clean_spec build_spec tests2png decision_tree_widget && esdoc -c esdoc.json && npm-run-all clean_dist_es6",
-    "build_spec": "tsc --project ./spec --pretty",
+    "build_spec": "tsc --project ./spec --lib es5,es2015.iterable,es2015.collection,es2015.promise,dom --pretty",
     "build_spec_browser": "webpack --config spec/support/webpack.mocha.config.js",
     "check_circular_dependencies": "madge ./dist/cjs --circular",
     "clean_spec": "shx rm -rf spec-js",
@@ -75,10 +75,10 @@
     "copy_src_cjs": "mkdirp ./dist/cjs/src && shx cp -r ./src/* ./dist/cjs/src",
     "copy_src_es6": "mkdirp ./dist/es6/src && shx cp -r ./src/* ./dist/es6/src",
     "commit": "git-cz",
-    "compile_dist_cjs": "tsc ./dist/cjs/src/Rx.ts ./dist/cjs/src/add/observable/of.ts -m commonjs --lib es5,es2015.iterable,es2015.collection,es2015.promise,dom --sourceMap --outDir ./dist/cjs --target ES5 -d --diagnostics --pretty --noImplicitAny --noImplicitReturns --noImplicitThis --suppressImplicitAnyIndexErrors --moduleResolution node",
-    "compile_module_es6": "tsc ./dist/es6/src/Rx.ts ./dist/es6/src/add/observable/of.ts -m es2015   --sourceMap --outDir ./dist/es6 --target ES5 -d --diagnostics --pretty --noImplicitAny --noImplicitReturns --noImplicitThis --suppressImplicitAnyIndexErrors --moduleResolution node --noEmitHelpers --lib es5,es2015.iterable,es2015.collection,es2015.promise,dom ",
-    "compile_dist_es6_for_docs": "tsc ./dist/es6/src/Rx.ts ./dist/es6/src/add/observable/of.ts ./dist/es6/src/MiscJSDoc.ts -m es2015   --sourceMap --outDir ./dist/es6 --target ES6 -d --diagnostics --pretty --noImplicitAny --noImplicitReturns --noImplicitThis --suppressImplicitAnyIndexErrors --moduleResolution node",
-    "cover": "shx rm -rf dist/cjs && tsc src/Rx.ts src/add/observable/of.ts -m commonjs --lib es5,es2015.iterable,es2015.collection,es2015.promise,dom --outDir dist/cjs --sourceMap --target ES5 -d && nyc --reporter=lcov --reporter=html --exclude=spec/support/**/* --exclude=spec-js/**/* --exclude=node_modules mocha --opts spec/support/default.opts spec-js",
+    "compile_dist_cjs": "tsc ./dist/cjs/src/Rx.ts ./dist/cjs/src/add/observable/of.ts -m commonjs --lib es5,es2015.iterable,es2015.collection,es2015.promise,dom --importHelpers --sourceMap --outDir ./dist/cjs --target ES5 -d --diagnostics --pretty --noImplicitAny --noImplicitReturns --noImplicitThis --suppressImplicitAnyIndexErrors --moduleResolution node",
+    "compile_module_es6": "tsc ./dist/es6/src/Rx.ts ./dist/es6/src/add/observable/of.ts -m es2015  --importHelpers  --sourceMap --outDir ./dist/es6 --target ES5 -d --diagnostics --pretty --noImplicitAny --noImplicitReturns --noImplicitThis --suppressImplicitAnyIndexErrors --moduleResolution node --importHelpers --lib es5,es2015.iterable,es2015.collection,es2015.promise,dom ",
+    "compile_dist_es6_for_docs": "tsc ./dist/es6/src/Rx.ts ./dist/es6/src/add/observable/of.ts ./dist/es6/src/MiscJSDoc.ts -m es2015  --importHelpers  --sourceMap --outDir ./dist/es6 --target ES6 -d --diagnostics --pretty --noImplicitAny --noImplicitReturns --noImplicitThis --suppressImplicitAnyIndexErrors --moduleResolution node",
+    "cover": "shx rm -rf dist/cjs && tsc src/Rx.ts src/add/observable/of.ts -m commonjs --lib es5,es2015.iterable,es2015.collection,es2015.promise,dom --outDir dist/cjs  --importHelpers --sourceMap --target ES5 -d && nyc --reporter=lcov --reporter=html --exclude=spec/support/**/* --exclude=spec-js/**/* --exclude=node_modules mocha --opts spec/support/default.opts spec-js",
     "decision_tree_widget": "cd doc/decision-tree-widget && npm run build && cd ../..",
     "doctoc": "doctoc CONTRIBUTING.md",
     "generate_packages": "node .make-packages.js",
@@ -191,7 +191,7 @@
     "source-map-support": "^0.4.0",
     "tslib": "^1.5.0",
     "tslint": "^4.4.2",
-    "typescript": "~2.0.6",
+    "typescript": "~2.1.0",
     "typings": "^2.0.0",
     "validate-commit-msg": "^2.3.1",
     "watch": "^1.0.1",
@@ -203,6 +203,7 @@
   },
   "typings": "./dist/cjs/Rx.d.ts",
   "dependencies": {
-    "symbol-observable": "^1.0.1"
+    "symbol-observable": "^1.0.1",
+    "tslib": "^1.7.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -189,7 +189,7 @@
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",
     "source-map-support": "^0.4.0",
-    "tslib": "^1.5.0",
+    "tslib": "^1.7.1",
     "tslint": "^4.4.2",
     "typescript": "~2.1.0",
     "typings": "^2.0.0",
@@ -203,7 +203,6 @@
   },
   "typings": "./dist/cjs/Rx.d.ts",
   "dependencies": {
-    "symbol-observable": "^1.0.1",
-    "tslib": "^1.7.1"
+    "symbol-observable": "^1.0.1"
   }
 }

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -261,14 +261,18 @@ describe('Subject', () => {
     subscription2.unsubscribe();
     subject.unsubscribe();
 
-    expect(() => {
+    let thrownError: any;
+    try {
       subject.subscribe(
         function (x) { results3.push(x); },
         function (err) {
           expect(false).to.equal('should not throw error: ' + err.toString());
         }
       );
-    }).to.throw(Rx.ObjectUnsubscribedError);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isObjectUnsubscribedError(thrownError)).to.be.true;
 
     expect(results1).to.deep.equal([1, 2, 3, 4, 5]);
     expect(results2).to.deep.equal([3, 4, 5]);
@@ -285,7 +289,14 @@ describe('Subject', () => {
 
     subject.next('foo');
     subject.unsubscribe();
-    expect(() => subject.next('bar')).to.throw(Rx.ObjectUnsubscribedError);
+
+    let thrownError: any;
+    try {
+      subject.next('bar');
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isObjectUnsubscribedError(thrownError)).to.be.true;
     done();
   });
 
@@ -439,17 +450,30 @@ describe('Subject', () => {
     const subject = new Rx.Subject();
     subject.unsubscribe();
 
-    expect(() => {
+    let thrownError: any;
+    try {
       subject.next('a');
-    }).to.throw(Rx.ObjectUnsubscribedError);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isObjectUnsubscribedError(thrownError)).to.be.true;
+    thrownError = null;
 
-    expect(() => {
+    try {
       subject.error('a');
-    }).to.throw(Rx.ObjectUnsubscribedError);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isObjectUnsubscribedError(thrownError)).to.be.true;
+    thrownError = null;
 
-    expect(() => {
+    try {
       subject.complete();
-    }).to.throw(Rx.ObjectUnsubscribedError);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isObjectUnsubscribedError(thrownError)).to.be.true;
+    thrownError = null;
   });
 
   it('should not next after completed', () => {

--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -31,9 +31,14 @@ describe('Subscription', () => {
     const subscription = Observable.merge(source1, source2, source3).subscribe();
 
     setTimeout(() => {
-      expect(() => {
+      let thrownError: any;
+      try {
         subscription.unsubscribe();
-      }).to.throw(Rx.UnsubscriptionError);
+      } catch (err) {
+        thrownError = err;
+      }
+
+      expect(Rx.Util.isUnsubscriptionError(thrownError)).to.be.true;
       expect(tearDowns).to.deep.equal([1, 2, 3]);
       done();
     });
@@ -71,9 +76,13 @@ describe('Subscription', () => {
     sub.add(Observable.merge(source1, source2, source3).subscribe());
 
     setTimeout(() => {
-      expect(() => {
+      let thrownError: any;
+      try {
         sub.unsubscribe();
-      }).to.throw(Rx.UnsubscriptionError);
+      } catch (err) {
+        thrownError = err;
+      }
+      expect(Rx.Util.isUnsubscriptionError(thrownError)).to.be.true;
       expect(tearDowns).to.deep.equal([1, 2, 3]);
       done();
     });

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -261,7 +261,7 @@ describe('Observable.ajax', () => {
       'responseText': 'Wee! I am text!'
     });
 
-    expect(error instanceof Rx.AjaxError).to.be.true;
+    expect(Rx.Util.isAjaxError(error)).to.be.true;
     expect(error.message).to.equal('ajax error 404');
     expect(error.status).to.equal(404);
   });
@@ -293,7 +293,7 @@ describe('Observable.ajax', () => {
       'responseText': 'Wee! I am text!'
     });
 
-    expect(error instanceof Rx.AjaxError).to.be.true;
+    expect(Rx.Util.isAjaxError(error)).to.be.true;
     expect(error.message).to.equal('ajax error 300');
     expect(error.status).to.equal(300);
   });
@@ -772,7 +772,7 @@ describe('Observable.ajax', () => {
     try {
       request.ontimeout((<any>'ontimeout'));
     } catch (e) {
-      expect(e.message).to.equal(new Rx.AjaxTimeoutError((<any>request), ajaxRequest).message);
+      expect(e.message).to.equal(Rx.Util.createAjaxTimeoutError((<any>request), ajaxRequest).message);
     }
     delete root.XMLHttpRequest.prototype.ontimeout;
   });

--- a/spec/operators/elementAt-spec.ts
+++ b/spec/operators/elementAt-spec.ts
@@ -53,7 +53,7 @@ describe('Observable.prototype.elementAt', () => {
     const subs =        '(^!)';
     const expected =    '#';
 
-    expectObservable((<any>source).elementAt(0)).toBe(expected, undefined, new Rx.ArgumentOutOfRangeError());
+    expectObservable((<any>source).elementAt(0)).toBe(expected, undefined, Rx.Util.createArgumentOutOfRangeError());
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -103,8 +103,13 @@ describe('Observable.prototype.elementAt', () => {
   });
 
   it('should throw if index is smaller than zero', () => {
-    expect(() => { (<any>Observable.range(0, 10)).elementAt(-1); })
-      .to.throw(Rx.ArgumentOutOfRangeError);
+    let thrownError: any;
+    try {
+      (<any>Observable.range(0, 10)).elementAt(-1);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isArgumentOutOfRangeError(thrownError)).to.be.true;
   });
 
   it('should raise error if index is out of range but does not have default value', () => {
@@ -113,7 +118,7 @@ describe('Observable.prototype.elementAt', () => {
     const expected =   '-----#';
 
     expectObservable((<any>source).elementAt(3))
-      .toBe(expected, null, new Rx.ArgumentOutOfRangeError());
+      .toBe(expected, null, Rx.Util.createArgumentOutOfRangeError());
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -34,7 +34,7 @@ describe('Observable.prototype.first', () => {
     const expected =    '-----#';
     const sub =         '^    !';
 
-    expectObservable(e1.first()).toBe(expected, null, new Rx.EmptyError());
+    expectObservable(e1.first()).toBe(expected, null, Rx.Util.createEmptyError());
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -136,7 +136,7 @@ describe('Observable.prototype.first', () => {
       return value === 's';
     };
 
-    expectObservable(e1.first(predicate)).toBe(expected, null, new Rx.EmptyError());
+    expectObservable(e1.first(predicate)).toBe(expected, null, Rx.Util.createEmptyError());
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 

--- a/spec/operators/last-spec.ts
+++ b/spec/operators/last-spec.ts
@@ -26,7 +26,7 @@ describe('Observable.prototype.last', () => {
     const e1subs =      '^    !';
     const expected =    '-----#';
 
-    expectObservable(e1.last()).toBe(expected, null, new Rx.EmptyError());
+    expectObservable(e1.last()).toBe(expected, null, Rx.Util.createEmptyError());
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -35,7 +35,7 @@ describe('Observable.prototype.last', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.last()).toBe(expected, null, new Rx.EmptyError());
+    expectObservable(e1.last()).toBe(expected, null, Rx.Util.createEmptyError());
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/spec/operators/single-spec.ts
+++ b/spec/operators/single-spec.ts
@@ -25,7 +25,7 @@ describe('Observable.prototype.single', () => {
     const e1subs =      '^  !';
     const expected =    '---#';
 
-    expectObservable(e1.single()).toBe(expected, null, new Rx.EmptyError());
+    expectObservable(e1.single()).toBe(expected, null, Rx.Util.createEmptyError());
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -136,7 +136,7 @@ describe('Observable.prototype.single', () => {
       return value === 'a';
     };
 
-    expectObservable(e1.single(predicate)).toBe(expected, null, new Rx.EmptyError());
+    expectObservable(e1.single(predicate)).toBe(expected, null, Rx.Util.createEmptyError());
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/spec/operators/skipLast-spec.ts
+++ b/spec/operators/skipLast-spec.ts
@@ -134,8 +134,13 @@ describe('Observable.prototype.skipLast', () => {
   });
 
   it('should throw if total is less than zero', () => {
-    expect(() => { Observable.range(0, 10).skipLast(-1); })
-      .to.throw(Rx.ArgumentOutOfRangeError);
+    let thrownError: any;
+    try {
+      Observable.range(0, 10).skipLast(-1);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isArgumentOutOfRangeError(thrownError)).to.be.true;
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -114,8 +114,13 @@ describe('Observable.prototype.take', () => {
   });
 
   it('should throw if total is less than zero', () => {
-    expect(() => { Observable.range(0, 10).take(-1); })
-      .to.throw(Rx.ArgumentOutOfRangeError);
+    let thrownError: any;
+    try {
+      Observable.range(0, 10).take(-1);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isArgumentOutOfRangeError(thrownError)).to.be.true;
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {

--- a/spec/operators/takeLast-spec.ts
+++ b/spec/operators/takeLast-spec.ts
@@ -147,8 +147,13 @@ describe('Observable.prototype.takeLast', () => {
   });
 
   it('should throw if total is less than zero', () => {
-    expect(() => { Observable.range(0, 10).takeLast(-1); })
-      .to.throw(Rx.ArgumentOutOfRangeError);
+    let thrownError: any;
+    try {
+      Observable.range(0, 10).takeLast(-1);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isArgumentOutOfRangeError(thrownError)).to.be.true;
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -13,7 +13,7 @@ const Observable = Rx.Observable;
 
 /** @test {timeout} */
 describe('Observable.prototype.timeout', () => {
-  const defaultTimeoutError = new Rx.TimeoutError();
+  const defaultTimeoutError = Rx.Util.createTimeoutError();
 
   asDiagram('timeout(50)')('should timeout after a specified timeout period', () => {
     const e1 =  cold('-------a--b--|');
@@ -26,13 +26,13 @@ describe('Observable.prototype.timeout', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should emit and error of an instanceof TimeoutError on timeout', () => {
+  it('should emit and error of an RxJS TimeoutError on timeout', () => {
     const e1 =  cold('-------a--b--|');
     const result = e1.timeout(50, rxTestScheduler);
     result.subscribe(() => {
       throw new Error('this should not next');
     }, err => {
-      expect(err).to.be.an.instanceof(Rx.TimeoutError);
+      expect(Rx.Util.isTimeoutError(err)).to.be.true;
     }, () => {
       throw new Error('this should not complete');
     });

--- a/spec/operators/windowToggle-spec.ts
+++ b/spec/operators/windowToggle-spec.ts
@@ -222,9 +222,11 @@ describe('Observable.prototype.windowToggle', () => {
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
     rxTestScheduler.schedule(() => {
-      expect(() => {
+      try {
         window.subscribe();
-      }).to.throw(Rx.ObjectUnsubscribedError);
+      } catch (err) {
+        expect(Rx.Util.isObjectUnsubscribedError(err)).to.be.true;
+      }
     }, late);
   });
 

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -8,7 +8,6 @@ declare const expectObservable: typeof marbleTestingSignature.expectObservable;
 
 const BehaviorSubject = Rx.BehaviorSubject;
 const Observable = Rx.Observable;
-const ObjectUnsubscribedError = Rx.ObjectUnsubscribedError;
 
 /** @test {BehaviorSubject} */
 describe('BehaviorSubject', () => {
@@ -29,9 +28,13 @@ describe('BehaviorSubject', () => {
     'and the BehaviorSubject has been unsubscribed', () => {
     const subject = new BehaviorSubject('hi there');
     subject.unsubscribe();
-    expect(() => {
+    let thrownError: any;
+    try {
       subject.getValue();
-    }).to.throw(ObjectUnsubscribedError);
+    } catch (err) {
+      thrownError = err;
+    }
+    expect(Rx.Util.isObjectUnsubscribedError(thrownError)).to.be.true;
   });
 
   it('should have a getValue() method to retrieve the current value', () => {

--- a/spec/util/UnsubscriptionError-spec.ts
+++ b/spec/util/UnsubscriptionError-spec.ts
@@ -1,10 +1,10 @@
 import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 
-const { Observable, UnsubscriptionError } = Rx;
+const { Observable } = Rx;
 
 /** @test {UnsubscriptionError} */
-describe('UnsubscriptionError', () => {
+describe('createUnsubscriptionError', () => {
   it('should create a message that is a clear indication of its internal errors', () => {
     const err1 = new Error('Swiss cheese tastes amazing but smells like socks');
     const err2 = new Error('User too big to fit in tiny European elevator');
@@ -18,11 +18,10 @@ describe('UnsubscriptionError', () => {
     try {
       subscription.unsubscribe();
     } catch (err) {
-      expect(err instanceof UnsubscriptionError).to.equal(true);
+      expect(Rx.Util.isUnsubscriptionError(err)).to.be.true;
       expect(err.message).to.equal(`2 errors occurred during unsubscription:
   1) ${err1}
   2) ${err2}`);
-      expect(err.name).to.equal('UnsubscriptionError');
     }
   });
 });

--- a/spec/util/assign-spec.ts
+++ b/spec/util/assign-spec.ts
@@ -6,9 +6,9 @@ describe('assign', () => {
     expect(assign).to.be.a('function');
   });
 
-  if (Object.assign) {
+  if ((<any>Object).assign) {
     it('should use Object.assign if available', () => {
-      expect(assign).to.equal(Object.assign);
+      expect(assign).to.equal((<any>Object).assign);
     });
   }
 
@@ -36,7 +36,7 @@ describe('assignImpl', () => {
 });
 
 describe('getAssign', () => {
-  it('should return assignImpl if Object.assign does not exist on root', () => {
+  it('should return assignImpl if (<any>Object).assign does not exist on root', () => {
     const result = getAssign({ Object: {} });
     expect(result).to.equal(assignImpl);
   });

--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -1,7 +1,7 @@
 import { Subject } from './Subject';
 import { Subscriber } from './Subscriber';
 import { Subscription, ISubscription } from './Subscription';
-import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
+import { createObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 
 /**
  * @class BehaviorSubject<T>
@@ -28,7 +28,7 @@ export class BehaviorSubject<T> extends Subject<T> {
     if (this.hasError) {
       throw this.thrownError;
     } else if (this.closed) {
-      throw new ObjectUnsubscribedError();
+      throw createObjectUnsubscribedError();
     } else {
       return this._value;
     }

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -4,7 +4,7 @@ import { queue } from './scheduler/queue';
 import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
 import { ObserveOnSubscriber } from './operator/observeOn';
-import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
+import { createObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 import { SubjectSubscription } from './SubjectSubscription';
 /**
  * @class ReplaySubject<T>
@@ -35,7 +35,7 @@ export class ReplaySubject<T> extends Subject<T> {
     let subscription: Subscription;
 
     if (this.closed) {
-      throw new ObjectUnsubscribedError();
+      throw createObjectUnsubscribedError();
     } else if (this.hasError) {
       subscription = Subscription.EMPTY;
     } else if (this.isStopped) {

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -1,4 +1,6 @@
 /* tslint:disable:no-unused-variable */
+import 'tslib';
+
 // Subject imported before Observable to bypass circular dependency issue since
 // Subject extends Observable and Observable references Subject in it's
 // definition

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -154,16 +154,11 @@ export {ReplaySubject} from './ReplaySubject';
 export {BehaviorSubject} from './BehaviorSubject';
 export {ConnectableObservable} from './observable/ConnectableObservable';
 export {Notification} from './Notification';
-export {EmptyError} from './util/EmptyError';
-export {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
-export {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';
-export {TimeoutError} from './util/TimeoutError';
-export {UnsubscriptionError} from './util/UnsubscriptionError';
 export {TimeInterval} from './operator/timeInterval';
 export {Timestamp} from './operator/timestamp';
 export {TestScheduler} from './testing/TestScheduler';
 export {VirtualTimeScheduler} from './scheduler/VirtualTimeScheduler';
-export {AjaxRequest, AjaxResponse, AjaxError, AjaxTimeoutError} from './observable/dom/AjaxObservable';
+export {AjaxRequest, AjaxResponse } from './observable/dom/AjaxObservable';
 
 import { asap } from './scheduler/asap';
 import { async } from './scheduler/async';
@@ -218,7 +213,62 @@ let Symbol = {
   iterator
 };
 
+import { createEmptyError, isEmptyError } from './util/EmptyError';
+import { createArgumentOutOfRangeError, isArgumentOutOfRangeError } from './util/ArgumentOutOfRangeError';
+import { createObjectUnsubscribedError, isObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
+import { createTimeoutError, isTimeoutError } from './util/TimeoutError';
+import { createUnsubscriptionError, isUnsubscriptionError } from './util/UnsubscriptionError';
+import { createAjaxError, isAjaxError, createAjaxTimeoutError, isAjaxTimeoutError } from './observable/dom/AjaxObservable';
+/**
+ * @typedef {Object} Rx.Util
+ * @property {function} createEmptyError creates an Error that is an RxJS
+ * EmptyError.
+ * @property {function} createArgumentOutOfRangeError creates an Error that is
+ * an RxJS ArgumentOutOfRangeError.
+ * @property {function} createObjectUnsubscribedError creates an Error that is
+ * an RxJS ObjectUnsubscribedError.
+ * @property {function} createTimeoutError creates an Error that is an RxJS
+ * TimeoutError.
+ * @property {function} createUnsubscriptionError creates an Error that is an
+ * RxJS UnsubscriptionError.
+ * @property {function} createAjaxError creates an Error that is an RxJS
+ * AjaxError
+ * @property {function} createAjaxTimeoutError creates an Error that is an RxJS
+ * AjaxTimeoutError
+ * @property {function} isEmptyError verifies that a passed error is an RxJS
+ * EmptyError
+ * @property {function} isArgumentOutOfRangeError verifies that a passed error
+ * is an RxJS ArgumentOutOfRangeError
+ * @property {function} isObjectUnsubscribedError verifies that a passed error
+ * is an RxJS ObjectUnsubscribedError
+ * @property {function} isTimeoutError verifies that a passed error is an RxJS
+ * TimeoutError
+ * @property {function} isUnsubscriptionError verifies that a passed error is an
+ *  RxJS UnsubscriptionError
+ * @property {function} isAjaxError verifies that a passed error is an RxJS
+ * AjaxError
+ * @property {function} isAjaxTimeoutError verifies that a passed error is an
+ * RxJS AjaxTimeoutError
+ */
+let Util = {
+  createEmptyError,
+  createArgumentOutOfRangeError,
+  createObjectUnsubscribedError,
+  createTimeoutError,
+  createUnsubscriptionError,
+  createAjaxError,
+  createAjaxTimeoutError,
+  isEmptyError,
+  isArgumentOutOfRangeError,
+  isObjectUnsubscribedError,
+  isTimeoutError,
+  isUnsubscriptionError,
+  isAjaxError,
+  isAjaxTimeoutError
+};
+
 export {
     Scheduler,
-    Symbol
+    Symbol,
+    Util
 };

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -3,7 +3,7 @@ import { Observer } from './Observer';
 import { Observable } from './Observable';
 import { Subscriber } from './Subscriber';
 import { ISubscription, Subscription, TeardownLogic } from './Subscription';
-import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
+import { createObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 import { SubjectSubscription } from './SubjectSubscription';
 import { rxSubscriber as rxSubscriberSymbol } from './symbol/rxSubscriber';
 
@@ -51,7 +51,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   next(value?: T) {
     if (this.closed) {
-      throw new ObjectUnsubscribedError();
+      throw createObjectUnsubscribedError();
     }
     if (!this.isStopped) {
       const { observers } = this;
@@ -65,7 +65,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   error(err: any) {
     if (this.closed) {
-      throw new ObjectUnsubscribedError();
+      throw createObjectUnsubscribedError();
     }
     this.hasError = true;
     this.thrownError = err;
@@ -81,7 +81,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   complete() {
     if (this.closed) {
-      throw new ObjectUnsubscribedError();
+      throw createObjectUnsubscribedError();
     }
     this.isStopped = true;
     const { observers } = this;
@@ -101,7 +101,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   protected _trySubscribe(subscriber: Subscriber<T>): TeardownLogic {
     if (this.closed) {
-      throw new ObjectUnsubscribedError();
+      throw createObjectUnsubscribedError();
     } else {
       return super._trySubscribe(subscriber);
     }
@@ -109,7 +109,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
 
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
     if (this.closed) {
-      throw new ObjectUnsubscribedError();
+      throw createObjectUnsubscribedError();
     } else if (this.hasError) {
       subscriber.error(this.thrownError);
       return Subscription.EMPTY;

--- a/src/Subscription.ts
+++ b/src/Subscription.ts
@@ -3,7 +3,7 @@ import { isObject } from './util/isObject';
 import { isFunction } from './util/isFunction';
 import { tryCatch } from './util/tryCatch';
 import { errorObject } from './util/errorObject';
-import { UnsubscriptionError } from './util/UnsubscriptionError';
+import { createUnsubscriptionError, isUnsubscriptionError } from './util/UnsubscriptionError';
 
 export interface AnonymousSubscription {
   unsubscribe(): void;
@@ -94,7 +94,7 @@ export class Subscription implements ISubscription {
       if (trial === errorObject) {
         hasErrors = true;
         errors = errors || (
-          errorObject.e instanceof UnsubscriptionError ?
+          isUnsubscriptionError(errorObject.e) ?
             flattenUnsubscriptionErrors(errorObject.e.errors) : [errorObject.e]
         );
       }
@@ -113,7 +113,7 @@ export class Subscription implements ISubscription {
             hasErrors = true;
             errors = errors || [];
             let err = errorObject.e;
-            if (err instanceof UnsubscriptionError) {
+            if (isUnsubscriptionError(err)) {
               errors = errors.concat(flattenUnsubscriptionErrors(err.errors));
             } else {
               errors.push(err);
@@ -124,7 +124,7 @@ export class Subscription implements ISubscription {
     }
 
     if (hasErrors) {
-      throw new UnsubscriptionError(errors);
+      throw createUnsubscriptionError(errors);
     }
   }
 
@@ -218,5 +218,5 @@ export class Subscription implements ISubscription {
 }
 
 function flattenUnsubscriptionErrors(errors: any[]) {
- return errors.reduce((errs, err) => errs.concat((err instanceof UnsubscriptionError) ? err.errors : err), []);
+ return errors.reduce((errs, err) => errs.concat((isUnsubscriptionError(err)) ? err.errors : err), []);
 }

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -5,6 +5,7 @@ import { Observable } from '../../Observable';
 import { Subscriber } from '../../Subscriber';
 import { TeardownLogic } from '../../Subscription';
 import { MapOperator } from '../../operator/map';
+import 'tslib';
 
 export interface AjaxRequest {
   url?: string;
@@ -417,7 +418,7 @@ export class AjaxResponse {
           this.response = JSON.parse(xhr.responseText || 'null');
         }
         break;
-      case 'xml':
+      case 'document':
         this.response = xhr.responseXML;
         break;
       case 'text':

--- a/src/operator/elementAt.ts
+++ b/src/operator/elementAt.ts
@@ -1,6 +1,6 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
+import { createArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 
@@ -16,7 +16,7 @@ import { TeardownLogic } from '../Subscription';
  * `index` in the source Observable, or a default value if that `index` is out
  * of range and the `default` argument is provided. If the `default` argument is
  * not given and the `index` is out of range, the output Observable will emit an
- * `ArgumentOutOfRangeError` error.
+ * error. This error can be verified with {@link isArgumentOutOfRangeError}
  *
  * @example <caption>Emit only the third click event</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
@@ -34,9 +34,10 @@ import { TeardownLogic } from '../Subscription';
  * @see {@link single}
  * @see {@link take}
  *
- * @throws {ArgumentOutOfRangeError} When using `elementAt(i)`, it delivers an
- * ArgumentOutOrRangeError to the Observer's `error` callback if `i < 0` or the
+ * @throws {Error} When using `elementAt(i)`, it delivers an
+ * Error to the Observer's `error` callback if `i < 0` or the
  * Observable has completed before emitting the i-th `next` notification.
+ * This error can be tested for with {@link isArgumentOutOfRangeError}
  *
  * @param {number} index Is the number `i` for the i-th source emission that has
  * happened since the subscription, starting from the number `0`.
@@ -54,7 +55,7 @@ class ElementAtOperator<T> implements Operator<T, T> {
 
   constructor(private index: number, private defaultValue?: T) {
     if (index < 0) {
-      throw new ArgumentOutOfRangeError;
+      throw createArgumentOutOfRangeError();
     }
   }
 
@@ -87,7 +88,7 @@ class ElementAtSubscriber<T> extends Subscriber<T> {
       if (typeof this.defaultValue !== 'undefined') {
         destination.next(this.defaultValue);
       } else {
-        destination.error(new ArgumentOutOfRangeError);
+        destination.error(createArgumentOutOfRangeError());
       }
     }
     destination.complete();

--- a/src/operator/first.ts
+++ b/src/operator/first.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { EmptyError } from '../util/EmptyError';
+import { createEmptyError } from '../util/EmptyError';
 
 /* tslint:disable:max-line-length */
 export function first<T, S extends T>(this: Observable<T>,
@@ -55,8 +55,9 @@ export function first<T>(this: Observable<T>,
  * @see {@link find}
  * @see {@link take}
  *
- * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
+ * @throws {Error} Delivers an Error to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
+ * The error can be tested with {@link isEmptyError}
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} [predicate]
  * An optional function called with each item to test for condition matching.
@@ -166,7 +167,7 @@ class FirstSubscriber<T, R> extends Subscriber<T> {
       destination.next(this.defaultValue);
       destination.complete();
     } else if (!this.hasCompleted) {
-      destination.error(new EmptyError);
+      destination.error(createEmptyError());
     }
   }
 }

--- a/src/operator/last.ts
+++ b/src/operator/last.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { EmptyError } from '../util/EmptyError';
+import { createEmptyError } from '../util/EmptyError';
 
 /* tslint:disable:max-line-length */
 export function last<T, S extends T>(this: Observable<T>,
@@ -33,8 +33,9 @@ export function last<T>(this: Observable<T>,
  *
  * <img src="./img/last.png" width="100%">
  *
- * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
+ * @throws {Error} Delivers an Error to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
+ * The error can be tested with {@link isEmptyError}
  * @param {function} predicate - The condition any source emitted item has to satisfy.
  * @return {Observable} An Observable that emits only the last item satisfying the given condition
  * from the source, or an NoSuchElementException if no such items are emitted.
@@ -132,7 +133,7 @@ class LastSubscriber<T, R> extends Subscriber<T> {
       destination.next(this.lastValue);
       destination.complete();
     } else {
-      destination.error(new EmptyError);
+      destination.error(createEmptyError());
     }
   }
 }

--- a/src/operator/single.ts
+++ b/src/operator/single.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observer } from '../Observer';
-import { EmptyError } from '../util/EmptyError';
+import { createEmptyError } from '../util/EmptyError';
 import { TeardownLogic } from '../Subscription';
 
 /**
@@ -12,8 +12,9 @@ import { TeardownLogic } from '../Subscription';
  *
  * <img src="./img/single.png" width="100%">
  *
- * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
+ * @throws {Error} Delivers an Error to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
+ * The error can be checked with {@link isEmptyError}
  * @param {Function} predicate - A predicate function to evaluate items emitted by the source Observable.
  * @return {Observable<T>} An Observable that emits the single item emitted by the source Observable that matches
  * the predicate.
@@ -87,7 +88,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
       destination.next(this.seenValue ? this.singleValue : undefined);
       destination.complete();
     } else {
-      destination.error(new EmptyError);
+      destination.error(createEmptyError());
     }
   }
 }

--- a/src/operator/skipLast.ts
+++ b/src/operator/skipLast.ts
@@ -1,6 +1,6 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
+import { createArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 
@@ -27,8 +27,9 @@ import { TeardownLogic } from '../Subscription';
  * @see {@link skipWhile}
  * @see {@link take}
  *
- * @throws {ArgumentOutOfRangeError} When using `skipLast(i)`, it throws
- * ArgumentOutOrRangeError if `i < 0`.
+ * @throws {Error} When using `skipLast(i)`, it throws
+ * ArgumentOutOrRangeError if `i < 0`. This error can be tested for with
+ * {@link isArgumentOutOfRangeError}
  *
  * @param {number} count Number of elements to skip from the end of the source Observable.
  * @returns {Observable<T>} An Observable that skips the last count values
@@ -43,7 +44,7 @@ export function skipLast<T>(this: Observable<T>, count: number): Observable<T> {
 class SkipLastOperator<T> implements Operator<T, T> {
   constructor(private _skipCount: number) {
     if (this._skipCount < 0) {
-      throw new ArgumentOutOfRangeError;
+      throw createArgumentOutOfRangeError();
     }
   }
 

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -1,6 +1,6 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
+import { createArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { EmptyObservable } from '../observable/EmptyObservable';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
@@ -28,8 +28,9 @@ import { TeardownLogic } from '../Subscription';
  * @see {@link takeWhile}
  * @see {@link skip}
  *
- * @throws {ArgumentOutOfRangeError} When using `take(i)`, it delivers an
- * ArgumentOutOrRangeError to the Observer's `error` callback if `i < 0`.
+ * @throws {Error} When using `take(i)`, it delivers an
+ * Error to the Observer's `error` callback if `i < 0`. This error can be tested
+ * for with {@link isArgumentOutOfRangeError}
  *
  * @param {number} count The maximum number of `next` values to emit.
  * @return {Observable<T>} An Observable that emits only the first `count`
@@ -49,7 +50,7 @@ export function take<T>(this: Observable<T>, count: number): Observable<T> {
 class TakeOperator<T> implements Operator<T, T> {
   constructor(private total: number) {
     if (this.total < 0) {
-      throw new ArgumentOutOfRangeError;
+      throw createArgumentOutOfRangeError();
     }
   }
 

--- a/src/operator/takeLast.ts
+++ b/src/operator/takeLast.ts
@@ -1,6 +1,6 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
+import { createArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { EmptyObservable } from '../observable/EmptyObservable';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
@@ -31,8 +31,9 @@ import { TeardownLogic } from '../Subscription';
  * @see {@link takeWhile}
  * @see {@link skip}
  *
- * @throws {ArgumentOutOfRangeError} When using `takeLast(i)`, it delivers an
+ * @throws {Error} When using `takeLast(i)`, it delivers an
  * ArgumentOutOrRangeError to the Observer's `error` callback if `i < 0`.
+ * This error can be tested for with {@link isArgumentOutOfRangeError}
  *
  * @param {number} count The maximum number of values to emit from the end of
  * the sequence of values emitted by the source Observable.
@@ -52,7 +53,7 @@ export function takeLast<T>(this: Observable<T>, count: number): Observable<T> {
 class TakeLastOperator<T> implements Operator<T, T> {
   constructor(private total: number) {
     if (this.total < 0) {
-      throw new ArgumentOutOfRangeError;
+      throw createArgumentOutOfRangeError();
     }
   }
 

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -6,7 +6,7 @@ import { Subscriber } from '../Subscriber';
 import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
-import { TimeoutError } from '../util/TimeoutError';
+import { createTimeoutError } from '../util/TimeoutError';
 
 /**
  * @param {number} due
@@ -20,14 +20,14 @@ export function timeout<T>(this: Observable<T>,
                            scheduler: IScheduler = async): Observable<T> {
   const absoluteTimeout = isDate(due);
   const waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
-  return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, scheduler, new TimeoutError()));
+  return this.lift(new TimeoutOperator(waitFor, absoluteTimeout, scheduler, createTimeoutError()));
 }
 
 class TimeoutOperator<T> implements Operator<T, T> {
   constructor(private waitFor: number,
               private absoluteTimeout: boolean,
               private scheduler: IScheduler,
-              private errorInstance: TimeoutError) {
+              private errorInstance: Error) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -50,7 +50,7 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
               private absoluteTimeout: boolean,
               private waitFor: number,
               private scheduler: IScheduler,
-              private errorInstance: TimeoutError) {
+              private errorInstance: Error) {
     super(destination);
     this.scheduleTimeout();
   }

--- a/src/util/ArgumentOutOfRangeError.ts
+++ b/src/util/ArgumentOutOfRangeError.ts
@@ -1,18 +1,25 @@
+const message = 'argument out of range (RxJS)';
+
+const symbol = Symbol(message);
 /**
- * An error thrown when an element was queried at a certain index of an
+ * Creates an error thrown when an element was queried at a certain index of an
  * Observable, but no such index or position exists in that sequence.
  *
+ * Can be tested for with {@link isArgumentOutOfRangeError}
  * @see {@link elementAt}
  * @see {@link take}
  * @see {@link takeLast}
- *
- * @class ArgumentOutOfRangeError
  */
-export class ArgumentOutOfRangeError extends Error {
-  constructor() {
-    const err: any = super('argument out of range');
-    (<any> this).name = err.name = 'ArgumentOutOfRangeError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export function createArgumentOutOfRangeError(): Error {
+  const error = new Error(message);
+  error[symbol] = true;
+  return error;
+}
+
+/**
+ * Tests to see if an Error is an RxJS ArgumentOutOfRange error.
+ * @param err any error object to test
+ */
+export function isArgumentOutOfRangeError(err: Error): boolean {
+  return err && err[symbol];
 }

--- a/src/util/EmptyError.ts
+++ b/src/util/EmptyError.ts
@@ -1,18 +1,25 @@
+const message = 'sequence empty (RxJS)';
+
+const symbol = Symbol(message);
 /**
- * An error thrown when an Observable or a sequence was queried but has no
+ * Creates an error thrown when an Observable or a sequence was queried but has no
  * elements.
  *
+ * Can be tested for with {@link isEmptyError}
  * @see {@link first}
  * @see {@link last}
  * @see {@link single}
- *
- * @class EmptyError
  */
-export class EmptyError extends Error {
-  constructor() {
-    const err: any = super('no elements in sequence');
-    (<any> this).name = err.name = 'EmptyError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export function createEmptyError(): Error {
+  const error = new Error(message);
+  error[symbol] = true;
+  return error;
+}
+
+/**
+ * Tests to see if an Error is an RxJS Empty error.
+ * @param err any error object to test
+ */
+export function isEmptyError(err: Error): boolean {
+  return err && err[symbol];
 }

--- a/src/util/ObjectUnsubscribedError.ts
+++ b/src/util/ObjectUnsubscribedError.ts
@@ -1,17 +1,23 @@
+const message = 'object unsubscribed (RxJS)';
+
+const symbol = Symbol(message);
 /**
- * An error thrown when an action is invalid because the object has been
+ * Creates an error thrown when an action is invalid because the object has been
  * unsubscribed.
  *
  * @see {@link Subject}
  * @see {@link BehaviorSubject}
- *
- * @class ObjectUnsubscribedError
  */
-export class ObjectUnsubscribedError extends Error {
-  constructor() {
-    const err: any = super('object unsubscribed');
-    (<any> this).name = err.name = 'ObjectUnsubscribedError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export function createObjectUnsubscribedError(): Error {
+  const error = new Error(message);
+  error[symbol] = true;
+  return error;
+}
+
+/**
+ * Tests to see if an Error is an RxJS ObjectUnsubscribed error.
+ * @param err any error object to test
+ */
+export function isObjectUnsubscribedError(err: Error): boolean {
+  return err && err[symbol];
 }

--- a/src/util/TimeoutError.ts
+++ b/src/util/TimeoutError.ts
@@ -1,15 +1,24 @@
+const message = 'timeout (RxJS)';
+
+const symbol = Symbol(message);
 /**
- * An error thrown when duetime elapses.
+ * Creates an error thrown when duetime elapses.
+ *
+ * Can be tested for with {@link isTimeoutError}
  *
  * @see {@link timeout}
  *
- * @class TimeoutError
  */
-export class TimeoutError extends Error {
-  constructor() {
-    const err: any = super('Timeout has occurred');
-    (<any> this).name = err.name = 'TimeoutError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export function createTimeoutError(): Error {
+  const error = new Error(message);
+  error[symbol] = true;
+  return error;
+}
+
+/**
+ * Tests to see if an Error is an RxJS Timeout error.
+ * @param err any error object to test
+ */
+export function isTimeoutError(err: Error): boolean {
+  return err && err[symbol];
 }

--- a/src/util/UnsubscriptionError.ts
+++ b/src/util/UnsubscriptionError.ts
@@ -1,15 +1,28 @@
+const symbol = Symbol('unsubscription error (RxJS)');
 /**
- * An error thrown when one or more errors have occurred during the
+ * Creates an error thrown when one or more errors have occurred during the
  * `unsubscribe` of a {@link Subscription}.
+ *
+ * Can be tested for with {@link isUnsubscriptionError}
+ *
  */
-export class UnsubscriptionError extends Error {
-  constructor(public errors: any[]) {
-    super();
-    const err: any = Error.call(this, errors ?
-      `${errors.length} errors occurred during unsubscription:
-  ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '');
-    (<any> this).name = err.name = 'UnsubscriptionError';
-    (<any> this).stack = err.stack;
-    (<any> this).message = err.message;
-  }
+export function createUnsubscriptionError(errors: Error[]): Error {
+  const errorList = errors
+    .map((err, i) => `  ${i + 1}) Error: ${err && err.message ? err.message : err}`)
+    .join('\n');
+  const message = `${errors.length} errors occurred during unsubscription:
+${errorList}`;
+
+  const error = new Error(message);
+  error[symbol] = true;
+  (<any>error).errors = errors;
+  return error;
+}
+
+/**
+ * Tests to see if an Error is an RxJS Unsubscription error.
+ * @param err any error object to test
+ */
+export function isUnsubscriptionError(err: Error): boolean {
+  return err && err[symbol];
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "importHelpers": true,
     "removeComments": false,
     "preserveConstEnums": true,
     "sourceMap": true,


### PR DESCRIPTION
### Breaking Changes!!

- Updates to TS 2.1
- Eliminates duplicate class helpers in every CJS output file 
- adds tslib
- No longer exporting any `Error` subclasses, rather there are utility functions to create Errors, and to test if an error is a specific type.
- Requires that `Symbol` is properly shimmed
