### PR TITLE
docs(decision-tree-widget): fix the type of `merge` operator

### DIFF
--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -313,7 +313,7 @@ children:
         - label: race
       - label: I want to output the values from either of them
         children:
-        - label: Observable.merge
+        - label: merge
       - label: I want to output a value computed from values of the source Observables
         children:
         - label: using the latest value of each source whenever any source emits


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
In the decision-tree-widget, the instance operator merge was assigned to the static operator by mistake.

**Related issue (if exists):**
