### PR TITLE
docs(groupBy): fix a typo in the example of the instance operator gro…

### DIFF
--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -56,7 +56,7 @@ export function groupBy<T, K, R>(this: Observable<T>, keySelector: (value: T) =>
  *                    {id: 3, name: 'qfs1'},
  *                    {id: 2, name: 'qsgqsfg2'}
  *                   )
- *     .groupBy(p => p.id, p => p.anme)
+ *     .groupBy(p => p.id, p => p.name)
  *     .flatMap( (group$) => group$.reduce((acc, cur) => [...acc, cur], ["" + group$.key]))
  *     .map(arr => ({'id': parseInt(arr[0]), 'values': arr.slice(1)}))
  *     .subscribe(p => console.log(p));


### PR DESCRIPTION
hi, @benlesh. I'm working in progress on Chinese localization of the RxJS 5 official document.
During this process I find something wrong such as a typo, a problematic example code.
I will report these issues consistently for making RxJS better.
By the way, I'm your huge fan.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
In the second example of groupBy operator, there is a typo(anme) in the example code as belowing:
`.groupBy(p => p.id, p => p.anme)`

**Related issue (if exists):**
