### PR TITLE
docs(exhaust/exhaustMap): fix the example code of exhaust and exhaustMap

### DIFF
--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -24,7 +24,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  *
  * @example <caption>Run a finite timer for each click, only if there is no currently active timer</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000));
+ * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000).take(5));
  * var result = higherOrder.exhaust();
  * result.subscribe(x => console.log(x));
  *

--- a/src/operator/exhaustMap.ts
+++ b/src/operator/exhaustMap.ts
@@ -31,7 +31,7 @@ export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, ind
  *
  * @example <caption>Run a finite timer for each click, only if there is no currently active timer</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000));
+ * var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000).take(5));
  * result.subscribe(x => console.log(x));
  *
  * @see {@link concatMap}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
In the example code of exhaust and exhaustMap operators, the finite timer need a operator to work with `interval`, such as `take`. The current code that need to be fixed as following:
`var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000));`

**Related issue (if exists):**
