### PR TITLE
fix(Observable): do not swallow error thrown in subscriber

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -46,6 +46,18 @@ describe('Observable', () => {
     });
   });
 
+  it('should not send error to error handler for observable have source', () => {
+    const source = Observable.of(1);
+    const observable = new Observable();
+    (observable as any).source = source;
+
+    expect(() => {
+      observable.subscribe((x) => {
+        throw new Error('error');
+      });
+    }).to.throw();
+  });
+
   describe('forEach', () => {
     it('should iterate and return a Promise', (done: MochaDone) => {
       const expected = [1, 2, 3];

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -95,7 +95,7 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink.add(this._trySubscribe(sink));
+      sink.add(this.source ? this._subscribe(sink) : this._trySubscribe(sink));
     }
 
     if (sink.syncErrorThrowable) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR fixes regression caused by https://github.com/ReactiveX/rxjs/pull/2313. While given PR sends errors thrown via `create`, it catches any exception thrown observable without having operator, so some of internals like `Subject.asObservable` doesn't throw errors in subscriber as well for cases doesn't chain any operator. This change checks if given observable created have sources, and let throw if it has source. Any exception thrown in `Observable.create` will be handled in source observable in those case.

**Related issue (if exists):**
- closes #2565
