### PR TITLE
fix: eliminate use of instanceof

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,7 +166,7 @@
     "gzip-size": "^3.0.0",
     "http-server": "^0.9.0",
     "husky": "^0.13.3",
-    "lint-staged": "3.2.5",
+    "lint-staged": "3.5.1",
     "lodash": "^4.15.0",
     "madge": "^1.4.3",
     "markdown-doctest": "^0.9.1",

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -12,6 +12,7 @@ import { Observable, ObservableInput } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { ObserveOnSubscriber } from '../operator/observeOn';
 import { observable as Symbol_observable } from '../symbol/observable';
+import { isObservable } from '../util/isObservable';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -85,7 +86,7 @@ export class FromObservable<T> extends Observable<T> {
   static create<T>(ish: ObservableInput<T>, scheduler?: IScheduler): Observable<T> {
     if (ish != null) {
       if (typeof ish[Symbol_observable] === 'function') {
-        if (ish instanceof Observable && !scheduler) {
+        if (isObservable(ish) && !scheduler) {
           return ish;
         }
         return new FromObservable<T>(ish, scheduler);

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -9,6 +9,7 @@ import { Observer, NextObserver } from '../../Observer';
 import { tryCatch } from '../../util/tryCatch';
 import { errorObject } from '../../util/errorObject';
 import { assign } from '../../util/assign';
+import { isObservable } from '../../util/isObservable';
 
 export interface WebSocketSubjectConfig {
   url: string;
@@ -86,7 +87,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   }
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig | Observable<T>, destination?: Observer<T>) {
-    if (urlConfigOrSource instanceof Observable) {
+    if (isObservable(urlConfigOrSource)) {
       super(destination, <Observable<T>> urlConfigOrSource);
     } else {
       super();

--- a/src/operator/concat.ts
+++ b/src/operator/concat.ts
@@ -3,6 +3,7 @@ import { IScheduler } from '../Scheduler';
 import { isScheduler } from '../util/isScheduler';
 import { ArrayObservable } from '../observable/ArrayObservable';
 import { MergeAllOperator } from './mergeAll';
+import { isObservable } from '../util/isObservable';
 
 /* tslint:disable:max-line-length */
 export function concat<T>(this: Observable<T>, scheduler?: IScheduler): Observable<T>;
@@ -178,7 +179,7 @@ export function concatStatic<T, R>(...observables: Array<ObservableInput<any> | 
     scheduler = args.pop();
   }
 
-  if (scheduler === null && observables.length === 1 && observables[0] instanceof Observable) {
+  if (scheduler === null && observables.length === 1 && isObservable(observables[0])) {
     return <Observable<R>>observables[0];
   }
 

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -3,6 +3,7 @@ import { IScheduler } from '../Scheduler';
 import { ArrayObservable } from '../observable/ArrayObservable';
 import { MergeAllOperator } from './mergeAll';
 import { isScheduler } from '../util/isScheduler';
+import { isObservable } from '../util/isObservable';
 
 /* tslint:disable:max-line-length */
 export function merge<T>(this: Observable<T>, scheduler?: IScheduler): Observable<T>;
@@ -160,7 +161,7 @@ export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | I
     concurrent = <number>observables.pop();
   }
 
-  if (scheduler === null && observables.length === 1 && observables[0] instanceof Observable) {
+  if (scheduler === null && observables.length === 1 && isObservable(observables[0])) {
     return <Observable<R>>observables[0];
   }
 

--- a/src/testing/TestScheduler.ts
+++ b/src/testing/TestScheduler.ts
@@ -6,6 +6,7 @@ import { TestMessage } from './TestMessage';
 import { SubscriptionLog } from './SubscriptionLog';
 import { Subscription } from '../Subscription';
 import { VirtualTimeScheduler, VirtualAction } from '../scheduler/VirtualTimeScheduler';
+import { isObservable } from '../util/isObservable';
 
 const defaultMaxFrame: number = 750;
 
@@ -83,7 +84,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       subscription = observable.subscribe(x => {
         let value = x;
         // Support Observable-of-Observables
-        if (x instanceof Observable) {
+        if (isObservable(x)) {
           value = this.materializeInnerObservable(value, this.frame);
         }
         actual.push({ frame: this.frame, notification: Notification.createNext(value) });

--- a/src/util/isObservable.ts
+++ b/src/util/isObservable.ts
@@ -1,0 +1,4 @@
+import { Observable } from '../Observable';
+export function isObservable<T>(value: any | Observable<T>): value is Observable<T> {
+  return value && typeof (<any>value).subscribe === 'function' && typeof (<any>value)._isScalar === 'boolean';
+}

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -3,12 +3,13 @@ import { isArrayLike } from './isArrayLike';
 import { isPromise } from './isPromise';
 import { isObject } from './isObject';
 import { Subscriber } from '../Subscriber';
-import { Observable, ObservableInput } from '../Observable';
+import { ObservableInput } from '../Observable';
 import { iterator as Symbol_iterator } from '../symbol/iterator';
 import { Subscription } from '../Subscription';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { observable as Symbol_observable } from '../symbol/observable';
+import { isObservable } from './isObservable';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,
@@ -24,7 +25,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
     return null;
   }
 
-  if (result instanceof Observable) {
+  if (isObservable(result)) {
     if (result._isScalar) {
       destination.next((<any>result).value);
       destination.complete();


### PR DESCRIPTION
**Description:**
Eliminate use of instanceof to support passing observables between javascript contexts

**Related issue (if exists):**
Closes #2628
