### PR TITLE
docs(advanced): add advanced section

### DIFF
--- a/doc/index.md
+++ b/doc/index.md
@@ -12,6 +12,8 @@ RxJS is a library for reactive programming using Observables, to make it easier 
 *Read detailed documentation on each operator*
 ### [» View examples](./manual/tutorial.html)
 *Read our tutorials on using RxJS in real applications*
+### [» Advanced](./manual/usage.html)
+*Read advanced topic about RxJS*
 
 - - -
 

--- a/doc/writing-marble-tests.md
+++ b/doc/writing-marble-tests.md
@@ -7,8 +7,8 @@ from many teachings and documents by people such as @jhusain, @headinthebox, @ma
 
 #### links
 
-- [Contribution](../CONTRIBUTING.md)
-- [Code of Conduct](../CODE_OF_CONDUCT.md)
+- [Contribution](https://github.com/ReactiveX/rxjs/blob/master/CONTRIBUTING.md)
+- [Code of Conduct](https://github.com/ReactiveX/rxjs/blob/master/CODE_OF_CONDUCT.md)
 
 ## Basic methods
 

--- a/esdoc.json
+++ b/esdoc.json
@@ -38,6 +38,10 @@
       "./doc/tutorial/basics.md",
       "./doc/tutorial/applications.md",
       "./doc/external-references.md"
+    ],
+    "usage": [
+      "./doc/writing-marble-tests.md",
+      "./doc/operator-creation.md"
     ]
   }
 }


### PR DESCRIPTION
Hi, @benlesh and @kwonoj , this PR is completely a suggestion. If you guys think there is no need fot it, please close it directly.
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The `doc/writing-marble-tests.md` and `doc/operator-creation.md` are both so amazing, they are incredible useful rather than the basic topic(eg. Observable, Subject, etc) for the mid-level developer of RxJS. But in the officel document site, there's no entry for them at all, what a pity!

Now I suggest add a entry on the `index.html` for these advanced topic. I configure the `manual.usage` for now, I know it's not exactly for our need, but `manual.advanced` is available in the esdoc 0.5.0. If one day update the esdoc version beyond 0.5.0, you can use `manual.advanced` replace `manual.usage`.

**Related issue (if exists):**
