### PR TITLE
docs(throttleTime): fix the description of `scheduler` param

### DIFF
--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -39,7 +39,7 @@ import { ThrottleConfig, defaultThrottleConfig } from './throttle';
  * emitting the last value, measured in milliseconds or the time unit determined
  * internally by the optional `scheduler`.
  * @param {Scheduler} [scheduler=async] The {@link IScheduler} to use for
- * managing the timers that handle the sampling.
+ * managing the timers that handle the throttling.
  * @return {Observable<T>} An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.
  * @method throttleTime


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Hi, @kwonoj , it's me again. 
In the params of throttleTime operator, there is a issues within the description of `scheduler` param:
`The IScheduler to use for managing the timers that handle the sampling.`
It should be `throttling` rather than `sampling`.

**Related issue (if exists):**
