### PR TITLE
docs(toPromise): fix the type and attribute of `PromiseCtor` param

### DIFF
--- a/src/operator/toPromise.ts
+++ b/src/operator/toPromise.ts
@@ -47,7 +47,7 @@ export function toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): 
  * source.then((value) => console.log('Value: %s', value));
  * // => Value: 42
  *
- * @param PromiseCtor promise The constructor of the promise. If not provided,
+ * @param {PromiseConstructor} [PromiseCtor] The constructor of the promise. If not provided,
  * it will look for a constructor first in Rx.config.Promise then fall back to
  * the native Promise constructor if available.
  * @return {Promise<T>} An ES2015 compatible promise with the last value from


### PR DESCRIPTION
This PR is need you guys to check because I'm not so sure the format and the type of the params whether it is correct. @kwonoj  @staltz @benlesh 
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
In the param of toPromise operator, now the `PromiseCtor` param is as below:
`@param PromiseCtor promise The constructor of the promise. If not provided, it will look for a constructor first in Rx.config.Promise then fall back to the native Promise constructor if available.`

First the `PromiseCtor` is optional, and secondly there is no type for it.

**Related issue (if exists):**
