### PR TITLE
docs(never): fix a typo

### DIFF
--- a/src/observable/NeverObservable.ts
+++ b/src/observable/NeverObservable.ts
@@ -17,7 +17,7 @@ export class NeverObservable<T> extends Observable<T> {
    *
    * This static operator is useful for creating a simple Observable that emits
    * neither values nor errors nor the completion notification. It can be used
-   * for testing purposes or for composing with other Observables. Please not
+   * for testing purposes or for composing with other Observables. Please note
    * that by never emitting a complete notification, this Observable keeps the
    * subscription from being disposed automatically. Subscriptions need to be
    * manually disposed.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
In the  docs of the never operator, there is a typo, see below:
'Please **_not_** that by never emitting a complete notification'
I think that It should be 'note' rather than 'not'.

**Related issue (if exists):**
