### PR TITLE
docs(operator-creation): fix a typo

### DIFF
--- a/doc/operator-creation.md
+++ b/doc/operator-creation.md
@@ -111,7 +111,7 @@ Hopefully the information provided here will give context to decisions made whil
 There are a few things to know and (try to) understand while developing operators:
 
 1. All operator methods are actually created in separate modules from `Observable`. This is so developers can
- "build their own observable" by pulling in operator methods an adding them to observable in their own module.
+ "build their own observable" by pulling in operator methods and adding them to observable in their own module.
  It also means operators can be brought in ad-hock and used directly, either with the ES7 function bind operator
  in Babel (`::`) or by using it with `.call()`.
 2. Every operator has an `Operator` class. The `Operator` class is really a `Subscriber` "factory". It's


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
There is a typo In the `doc/operator-creation.md`, seen as below:
> by pulling in operator methods **an** adding them to observable in their own module.

It should be a typo and correct one is **and**.

**Related issue (if exists):**
