### PR TITLE
fix(groupBy): unsubscribe & cleanup GroupDurationSubscriber

### DIFF
--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -905,47 +905,35 @@ describe('Observable.prototype.groupBy', () => {
 
   it('should dispose a durationSelector after closing the group',
   () => {
-    let durationMarble = '-------s';
-    let durations = [];
-    const duration = () => {
-      let o = cold(durationMarble); // duration 7 frames, then stop
-      durations.push(o);
-      return o;
-    };
-    const e1 = hot( '-1-2-1-3-1-4-1-5------------|');
-    const sub =     '^                            !' ;
-    const gr =      '-a-k---l-b-m---n------------|' ;
-    const empty =   '-----------------------------' ;
+    const obs = hot('-0-1--------2-|');
+    const sub =     '^              !' ;
+    let unsubs = [
+                    '-^--!',
+                    '---^--!',
+                    '------------^-!',
+    ];
+    const dur =     '---s';
+    const durations = [
+      cold(dur),
+      cold(dur),
+      cold(dur)
+    ];
 
-    let unsubs = [];
-    for (let i = 0; i < gr.length; i++) {
-      if (gr[i] !== '-' && gr[i] !== '|') {
-        unsubs.push(empty.slice(0, i) + '^' + durationMarble.slice(1, -1) + '!');
-      }
-    }
+    const unsubscribedFrame = Rx.TestScheduler
+      .parseMarblesAsSubscriptions(sub)
+      .unsubscribedFrame;
 
-    const a = cold(  '1---1--|'                     );
-    const b = cold(          '1---1--|'             );
-
-    const k = cold(    '2------|'                   );
-    const l = cold(        '3------|'               );
-    const m = cold(            '4------|'           );
-    const n = cold(                '5------|'       );
-
-    const expectedValues = { a, b, k, l, m, n };
-
-    const source = e1.groupBy(
+    obs.groupBy(
       (val: string) => val,
       (val: string) => val,
-      (group: any) => duration()
-    );
+      (group: any) => durations[group.key]
+    ).subscribe();
 
-    expectObservable(source, sub).toBe(gr, expectedValues);
     rxTestScheduler.schedule(() => {
       durations.forEach((d, i) => {
         expectSubscriptions(d.subscriptions).toBe(unsubs[i]);
       });
-    }, 500);
+    }, unsubscribedFrame);
   });
 
   it('should allow using a durationSelector, but keySelector throws', () => {

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -240,6 +240,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
       group.error(err);
     }
     this.parent.removeGroup(this.key);
+    this.unsubscribe();
   }
 
   protected _complete(): void {
@@ -248,6 +249,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
       group.complete();
     }
     this.parent.removeGroup(this.key);
+    this.unsubscribe();
   }
 }
 

--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -241,6 +241,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
     }
     this.parent.removeGroup(this.key);
     this.unsubscribe();
+    this.parent.remove(this);
   }
 
   protected _complete(): void {
@@ -250,6 +251,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
     }
     this.parent.removeGroup(this.key);
     this.unsubscribe();
+    this.parent.remove(this);
   }
 }
 


### PR DESCRIPTION
The `groupBy` operator has a `durationSelector` argument that we can use to specify additional closings for the produced groups. However, the durationSelector produces Observables that were never unsubscribed.  (#2660)

Furthermore even if the durationSelector Observable was auto-unsubscribed (due to for example a `take(1)` in that Observable) its subscription would not be removed from the `GroupBySubscriber`, which causes memory usage to grow and eventually causes a OOM exception in @crunchie84's application. (#2661)

This PR solves both problems by explicitly unsubscribing & removing the subscription from the GroupBySubscriber. I also added a test for the unsubscribing part, but could not easily create a test in the same style as the other groupBy-tests without poking into the subscription.