### PR TITLE
fix(test-helper): Add test-helper dependency to spec/support/default.opt

### DIFF
--- a/spec/support/default.opts
+++ b/spec/support/default.opts
@@ -1,5 +1,6 @@
 --require source-map-support/register
 --require spec-js/helpers/testScheduler-ui.js
+--require spec-js/helpers/test-helper.js
 --ui spec-js/helpers/testScheduler-ui.js
 
 --reporter dot


### PR DESCRIPTION
Since some specs are dependent on global `__root__` (e.g Observable-spec) without explicit `reuiqre/import', running those specs will fail.

To reproduce:

  > npm run build_spec
  > ./node_modules/.bin/mocha --opts spec/support/default.opts spec-js/Observable-spec.js

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
