### PR TITLE
chore(danger): tweak size reporting

### DIFF
--- a/dangerfile.js
+++ b/dangerfile.js
@@ -77,7 +77,13 @@ var globalFile = 'Rx.js';
 var minFile = 'Rx.min.js';
 
 function sizeDiffBadge(name, value) {
-  return 'https://img.shields.io/badge/' + name + '-' + value + 'KB-red.svg?style=flat-square';
+  var color = 'lightgrey';
+  if (value > 0) {
+    color = 'red';
+  } else if (value < 0) {
+    color = 'lime';
+  }
+  return 'https://img.shields.io/badge/' + name + '-' + getKB(value) + 'KB-' + color + '.svg?style=flat-square';
 }
 
 //post size of build
@@ -108,10 +114,10 @@ schedule(new Promise(function (res) {
     var bundle_min_gzip = gzipSize.sync(fs.readFileSync(bundleMinFile, 'utf8'));
 
     var sizeMessage = '<img src="https://img.shields.io/badge/Size%20Diff%20%28' + releaseVersion + '%29--lightgrey.svg?style=flat-square"/> ';
-    sizeMessage += '<img src="' + sizeDiffBadge('Global', getKB(global.size) - getKB(bundleGlobal.size)) + '"/>';
-    sizeMessage += '<img src="' + sizeDiffBadge('Global(gzipped)', getKB(global_gzip) - getKB(bundle_global_gzip)) + '"/>';
-    sizeMessage += '<img src="' + sizeDiffBadge('Min', getKB(min.size) - getKB(bundleMin.size)) + '"/>';
-    sizeMessage += '<img src="' + sizeDiffBadge('Min (gzipped)', getKB(min_gzip) - getKB(bundle_min_gzip)) + '"/>';
+    sizeMessage += '<img src="' + sizeDiffBadge('Global', global.size - bundleGlobal.size) + '"/>';
+    sizeMessage += '<img src="' + sizeDiffBadge('Global(gzipped)', global_gzip - bundle_global_gzip) + '"/>';
+    sizeMessage += '<img src="' + sizeDiffBadge('Min', min.size - bundleMin.size) + '"/>';
+    sizeMessage += '<img src="' + sizeDiffBadge('Min (gzipped)', min_gzip - bundle_min_gzip) + '"/>';
     message(sizeMessage);
 
     markdown('> CJS: **' + getKB(result) +


### PR DESCRIPTION
- adds colorization to reporting (grey for no change, red for size increase, green for size decrease)
- fixes formatting of decimals for differences

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
