### PR TITLE
Bring back Iterable<T> and Iterator<T> interfaces

### DIFF
--- a/spec/observables/IteratorObservable-spec.ts
+++ b/spec/observables/IteratorObservable-spec.ts
@@ -29,7 +29,7 @@ describe('IteratorObservable', () => {
 
   it('should not accept boolean as iterator', () => {
     expect(() => {
-      IteratorObservable.create(false);
+      IteratorObservable.create(<any>false);
     }).to.throw(Error, 'object is not iterable');
   });
 
@@ -66,7 +66,7 @@ describe('IteratorObservable', () => {
 
     const results = [];
 
-    IteratorObservable.create(iterable)
+    IteratorObservable.create(<any>iterable)
       .take(3)
       .subscribe(
         x => results.push(x),
@@ -97,7 +97,7 @@ describe('IteratorObservable', () => {
 
     const results = [];
 
-    IteratorObservable.create(iterable, queue)
+    IteratorObservable.create(<any>iterable, queue)
       .take(3)
       .subscribe(
         x => results.push(x),
@@ -149,7 +149,7 @@ describe('IteratorObservable', () => {
     const expected = ['f', 'o', 'o'];
     IteratorObservable.create('foo')
       .subscribe(
-        (x: number) => { expect(x).to.equal(expected.shift()); },
+        (x) => { expect(x).to.equal(expected.shift()); },
         (x) => {
           done(new Error('should not be called'));
         }, () => {

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -15,7 +15,8 @@ export interface Subscribable<T> {
 }
 
 export type SubscribableOrPromise<T> = Subscribable<T> | PromiseLike<T>;
-export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T>;
+export type ArrayOrIterable<T> = Iterable<T> | ArrayLike<T>;
+export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayOrIterable<T>;
 
 /**
  * A representation of any set of values over any amount of time. This the most basic building block

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -1,5 +1,6 @@
 import { isArray } from '../util/isArray';
 import { isArrayLike } from '../util/isArrayLike';
+import { isIterable } from '../util/isIterable';
 import { isPromise } from '../util/isPromise';
 import { PromiseObservable } from './PromiseObservable';
 import { IteratorObservable } from'./IteratorObservable';
@@ -93,7 +94,7 @@ export class FromObservable<T> extends Observable<T> {
         return new ArrayObservable<T>(ish, scheduler);
       } else if (isPromise(ish)) {
         return new PromiseObservable<T>(ish, scheduler);
-      } else if (typeof ish[Symbol_iterator] === 'function' || typeof ish === 'string') {
+      } else if (isIterable(ish) || typeof ish === 'string') {
         return new IteratorObservable<T>(ish, scheduler);
       } else if (isArrayLike(ish)) {
         return new ArrayLikeObservable(ish, scheduler);

--- a/src/util/isIterable.ts
+++ b/src/util/isIterable.ts
@@ -1,0 +1,5 @@
+import { iterator as Symbol_iterator } from '../symbol/iterator';
+
+export function isIterable<T>(value: any): value is Iterable<T> {
+  return typeof value[Symbol_iterator] === 'function';
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Now that TypeScript supports down level compilation, we can safely bring back `Iterable<T>` and `Iterator<T>`.

**Related issue (if exists):**
Fixes #2306 #2535