### PR TITLE
fix(typings): fix typings for error prone operators like concatAll

### DIFF
--- a/spec/helpers/marble-testing.ts
+++ b/spec/helpers/marble-testing.ts
@@ -8,14 +8,18 @@ declare const global: any;
 
 export const rxTestScheduler: TestScheduler = global.rxTestScheduler;
 
-export function hot(marbles: string, values?: any, error?: any): HotObservable<any> {
+export function hot(marbles: string, values?: void, error?: any): HotObservable<string>;
+export function hot<V>(marbles: string, values?: { [index: string]: V; }, error?: any): HotObservable<V>;
+export function hot<V>(marbles: string, values?: { [index: string]: V; } | void, error?: any): HotObservable<any> {
   if (!global.rxTestScheduler) {
     throw 'tried to use hot() in async test';
   }
   return global.rxTestScheduler.createHotObservable.apply(global.rxTestScheduler, arguments);
 }
 
-export function cold(marbles: string, values?: any, error?: any): ColdObservable<any> {
+export function cold(marbles: string, values?: void, error?: any): ColdObservable<string>;
+export function cold<V>(marbles: string, values?: { [index: string]: V; }, error?: any): ColdObservable<V>;
+export function cold<V>(marbles: string, values?: { [index: string]: V; } | void, error?: any): ColdObservable<V> {
   if (!global.rxTestScheduler) {
     throw 'tried to use cold() in async test';
   }

--- a/spec/operators/combineAll-spec.ts
+++ b/spec/operators/combineAll-spec.ts
@@ -2,7 +2,8 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
+declare const type: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -19,7 +20,7 @@ describe('Observable.prototype.combineAll', () => {
     const outer = hot('-x----y--------|           ', { x: x, y: y });
     const expected =  '-----------------A-B--C---|';
 
-    const result = outer.combineAll((a: any, b: any) => String(a) + String(b));
+    const result = outer.combineAll((a, b) => String(a) + String(b));
 
     expectObservable(result).toBe(expected, { A: 'a1', B: 'a2', C: 'b2' });
   });
@@ -31,7 +32,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -45,7 +46,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '(^!)';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -59,7 +60,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -73,7 +74,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =  '(^!)';
     const expected = '|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -87,7 +88,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -101,7 +102,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.of(e2, e1).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e2, e1).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -115,7 +116,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^  ';
     const expected =         '-'; //never
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -129,7 +130,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '-----'; //never
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -143,7 +144,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =        '^         !';
     const expected =      '----x-yz--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -159,7 +160,7 @@ describe('Observable.prototype.combineAll', () => {
     const unsub =         '         !    ';
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -176,9 +177,9 @@ describe('Observable.prototype.combineAll', () => {
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
     const result = Observable.of(e1, e2)
-      .mergeMap((x: any) => Observable.of(x))
-      .combineAll((x: any, y: any) => x + y)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x))
+      .combineAll((x, y) => x + y)
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -209,7 +210,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^     !';
     const expected = '------#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'shazbot!');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -223,7 +224,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =     '^   !';
     const expected =   '----#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'too bad, honk');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -237,7 +238,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -251,7 +252,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -265,7 +266,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -279,7 +280,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -293,7 +294,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -307,7 +308,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^     !';
     const expected =     '------#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -321,7 +322,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^    !';
     const expected =     '-----#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -335,7 +336,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { a: 1, b: 2}, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -349,7 +350,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -363,7 +364,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -377,7 +378,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =       '^      !';
     const expected =        '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -391,7 +392,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =     '^           !';
     const expected =   '-----x-y-z--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'be', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -405,7 +406,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =      '^                   !';
     const expected =    '-----------x--y--z--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -419,7 +420,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'jenga');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -433,7 +434,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^                   !';
     const expected =       '-----------x--y--z--#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' }, 'dun dun dun');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -447,7 +448,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =      '^  !';
     const expected =    '---#';
 
-    const result = Observable.of(e1, e2).combineAll(<any>((x: string, y: string) => { throw 'ha ha ' + x + ', ' + y; }));
+    const result = Observable.of(e1, e2).combineAll(((x: string, y: string) => { throw 'ha ha ' + x + ', ' + y; }));
 
     expectObservable(result).toBe(expected, null, 'ha ha b, d');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -458,7 +459,7 @@ describe('Observable.prototype.combineAll', () => {
     const a = Observable.of(1, 2, 3);
     const b = Observable.of(4, 5, 6, 7, 8);
     const expected = [[3, 4], [3, 5], [3, 6], [3, 7], [3, 8]];
-    Observable.of(a, b).combineAll().subscribe((vals: any) => {
+    Observable.of(a, b).combineAll().subscribe((vals) => {
       expect(vals).to.deep.equal(expected.shift());
     }, null, () => {
       expect(expected.length).to.equal(0);
@@ -472,11 +473,52 @@ describe('Observable.prototype.combineAll', () => {
     const r = [[1, 4], [2, 4], [2, 5], [3, 5], [3, 6], [3, 7], [3, 8]];
 
     Observable.of<Rx.Observable<number>>(a, b, queueScheduler).combineAll()
-      .subscribe((vals: any) => {
+      .subscribe((vals) => {
         expect(vals).to.deep.equal(r.shift());
     }, null, () => {
       expect(r.length).to.equal(0);
       done();
+    });
+  });
+
+  it ('types should flow with arrays', () => {
+    type(() => {
+      let o: Rx.Observable<number[]>;
+      let r: Rx.Observable<number[]> = o.combineAll();
+    });
+  });
+
+  it ('types should flow with promises', () => {
+    type(() => {
+      let o: Rx.Observable<Promise<string>>;
+      let r: Rx.Observable<string[]> = o.combineAll();
+    });
+  });
+
+  it ('types should flow with observables', () => {
+    type(() => {
+      let o: Rx.Observable<Rx.Observable<{ a: string }>>;
+      let r: Rx.Observable<{ a: string }[]> = o.combineAll();
+    });
+  });
+
+  it ('types should flow with mixed', () => {
+    type(() => {
+      let o1: Rx.Observable<Rx.Observable<{ b: string }>>;
+      let o2: Rx.Observable<{ b: string }[]>;
+      let o3: Rx.Observable<Promise<{ b: string }>>;
+      let r: Rx.Observable<{ b: string }[]> = Rx.Observable.concat(o1, o2, o3)
+        .combineAll();
+    });
+  });
+
+  it ('types should flow with mixed projection', () => {
+    type(() => {
+      let o1: Rx.Observable<Rx.Observable<{ b: string }>>;
+      let o2: Rx.Observable<{ b: string }[]>;
+      let o3: Rx.Observable<Promise<{ b: string }>>;
+      let r: Rx.Observable<string> = Rx.Observable.concat(o1, o2, o3)
+        .combineAll((...values) => values.map(z => z.b).join(''));
     });
   });
 });

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -2,7 +2,8 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
+declare const type: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -27,17 +28,16 @@ describe('Observable.prototype.concatAll', () => {
   it('should concat sources from promise', function (done: MochaDone) {
     this.timeout(2000);
     const sources = Rx.Observable.from([
-      new Promise((res: any) => { res(0); }),
-      new Promise((res: any) => { res(1); }),
-      new Promise((res: any) => { res(2); }),
-      new Promise((res: any) => { res(3); }),
+      new Promise<number>((res) => { res(0); }),
+      new Promise<number>((res) => { res(1); }),
+      new Promise<number>((res) => { res(2); }),
+      new Promise<number>((res) => { res(3); }),
     ]).take(10);
 
     const res = [];
-    (<any>sources.concatAll()).subscribe(
+    sources.concatAll().subscribe(
       (x: number) => { res.push(x); },
-      (err: any) => { done(new Error('should not be called')); },
-      () => {
+      (err: any) => { done(new Error('should not be called')); },      () => {
         expect(res).to.deep.equal([0, 1, 2, 3]);
         done();
       });
@@ -47,14 +47,14 @@ describe('Observable.prototype.concatAll', () => {
     this.timeout(2000);
 
     const sources = Rx.Observable.from([
-      new Promise((res: any) => { res(0); }),
-      new Promise((res: any, rej: any) => { rej(1); }),
-      new Promise((res: any) => { res(2); }),
-      new Promise((res: any) => { res(3); }),
+      new Promise<number>((res) => { res(0); }),
+      new Promise<number>((res, rej: any) => { rej(1); }),
+      new Promise<number>((res) => { res(2); }),
+      new Promise<number>((res) => { res(3); }),
     ]).take(10);
 
     const res = [];
-    (<any>sources.concatAll()).subscribe(
+    sources.concatAll().subscribe(
       (x: number) => { res.push(x); },
       (err: any) => {
         expect(res.length).to.equal(1);
@@ -433,5 +433,37 @@ describe('Observable.prototype.concatAll', () => {
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it ('types should flow with arrays', () => {
+    type(() => {
+      let o: Rx.Observable<number[]>;
+      let r: Rx.Observable<number> = o.concatAll();
+    });
+  });
+
+  it ('types should flow with promises', () => {
+    type(() => {
+      let o: Rx.Observable<Promise<string>>;
+      let r: Rx.Observable<string> = o.concatAll();
+    });
+  });
+
+  it ('types should flow with observables', () => {
+    type(() => {
+      let o: Rx.Observable<Rx.Observable<{ a: string }>>;
+      let r: Rx.Observable<{ a: string }> = o.concatAll();
+    });
+  });
+
+  it ('types should flow with mixed', () => {
+    type(() => {
+      let o1: Rx.Observable<Rx.Observable<{ b: string }>>;
+      let o2: Rx.Observable<{ b: string }[]>;
+      let o3: Rx.Observable<Promise<{ b: string }>>;
+      let r: Rx.Observable<{ b: string }> = Rx.Observable
+        .concat(o1, o2, o3)
+        .concatAll();
+    });
   });
 });

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -19,7 +19,7 @@ describe('Observable.prototype.concatMap', () => {
     const expected =  '--x-x-x-y-y-yz-z-z-|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.concatMap(x => e2.map(i => i * x));
+    const result = e1.concatMap(x => e2.map(i => i * parseInt(x)));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/exhaust-spec.ts
+++ b/spec/operators/exhaust-spec.ts
@@ -2,7 +2,8 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
+declare const type: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -16,10 +17,10 @@ describe('Observable.prototype.exhaust', () => {
     const x =   cold(      '--a---b---c--|               ');
     const y =   cold(              '---d--e---f---|      ');
     const z =   cold(                    '---g--h---i---|');
-    const e1 = hot(  '------x-------y-----z-------------|', { x: x, y: y, z: z });
+    const e1 = hot(  '------x-------y-----z-------------|', { x, y, z });
     const expected = '--------a---b---c------g--h---i---|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
   });
 
   it('should switch to first immediately-scheduled inner Observable', () => {
@@ -29,7 +30,7 @@ describe('Observable.prototype.exhaust', () => {
     const e2subs = [];
     const expected = '(ab|)';
 
-    expectObservable((<any>Observable.of(e1, e2)).exhaust()).toBe(expected);
+    expectObservable((Observable.of(e1, e2)).exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -39,7 +40,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -48,7 +49,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -57,7 +58,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -68,10 +69,10 @@ describe('Observable.prototype.exhaust', () => {
     const ysubs = [];
     const z = cold(                      '---g--h---i---|');
     const zsubs =    '                    ^             !';
-    const e1 = hot(  '------x-------y-----z-------------|', { x: x, y: y, z: z });
+    const e1 = hot(  '------x-------y-----z-------------|', { x, y, z });
     const expected = '--------a---b---c------g--h---i---|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(z.subscriptions).toBe(zsubs);
@@ -82,11 +83,11 @@ describe('Observable.prototype.exhaust', () => {
     const xsubs =    '      ^         !           ';
     const y = cold(                '---d--e---f---|');
     const ysubs = [];
-    const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|       ', { x, y });
     const unsub =    '                !            ';
     const expected = '--------a---b---             ';
 
-    expectObservable((<any>e1).exhaust(), unsub).toBe(expected);
+    expectObservable(e1.exhaust(), unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -96,14 +97,14 @@ describe('Observable.prototype.exhaust', () => {
     const xsubs =    '      ^         !           ';
     const y = cold(                '---d--e---f---|');
     const ysubs = [];
-    const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|       ', { x, y });
     const unsub =    '                !            ';
     const expected = '--------a---b----            ';
 
-    const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
+    const result = e1
+      .mergeMap((x) => Observable.of(x))
       .exhaust()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -117,10 +118,10 @@ describe('Observable.prototype.exhaust', () => {
     const ysubs = [];
     const z = cold(                '---f--g---h--');
     const zsubs =    '              ^            ';
-    const e1 = hot(  '---x---y------z----------| ', { x: x, y: y, z: z });
+    const e1 = hot(  '---x---y------z----------| ', { x, y, z });
     const expected = '-----a---b-------f--g---h--';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(z.subscriptions).toBe(zsubs);
@@ -131,10 +132,10 @@ describe('Observable.prototype.exhaust', () => {
     const xsubs =    '      ^            !   ';
     const y = cold(        '---d--e---f---|  ');
     const ysubs = [];
-    const e1 = hot(  '------(xy)------------|', { x: x, y: y });
+    const e1 = hot(  '------(xy)------------|', { x, y });
     const expected = '--------a---b---c-----|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -144,10 +145,10 @@ describe('Observable.prototype.exhaust', () => {
     const xsubs =    '      ^     !                ';
     const y = cold(                '---d--e---f---|');
     const ysubs = [];
-    const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|       ', { x, y });
     const expected = '--------a---#                ';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -157,10 +158,10 @@ describe('Observable.prototype.exhaust', () => {
     const xsubs =    '      ^            !         ';
     const y = cold(                '---d--e---f---|');
     const ysubs = [];
-    const e1 = hot(  '------x-------y-------#      ', { x: x, y: y });
+    const e1 = hot(  '------x-------y-------#      ', { x, y });
     const expected = '--------a---b---c-----#      ';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -170,7 +171,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '^     !';
     const expected = '------|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -179,26 +180,26 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
   it('should complete not before the outer completes', () => {
     const x = cold(        '--a---b---c--|   ');
     const xsubs =    '      ^            !   ';
-    const e1 = hot(  '------x---------------|', { x: x });
+    const e1 = hot(  '------x---------------|', { x });
     const expected = '--------a---b---c-----|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
   });
 
-  it('should handle an observable of promises', (done: MochaDone) => {
+  it('should handle an observable of promises', (done) => {
     const expected = [1];
 
-    (<any>Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)))
+    (Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)))
       .exhaust()
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, () => {
         expect(expected.length).to.equal(0);
@@ -206,16 +207,48 @@ describe('Observable.prototype.exhaust', () => {
       });
   });
 
-  it('should handle an observable of promises, where one rejects', (done: MochaDone) => {
-    (<any>Observable.of<any>(Promise.reject(2), Promise.resolve(1)))
+  it('should handle an observable of promises, where one rejects', (done) => {
+    Observable.of(Promise.reject(2), Promise.resolve(1))
       .exhaust()
-      .subscribe((x: any) => {
+      .subscribe((x) => {
         done(new Error('should not be called'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.equal(2);
         done();
       }, () => {
         done(new Error('should not be called'));
       });
+  });
+
+  it ('types should flow with arrays', () => {
+    type(() => {
+      let o: Rx.Observable<number[]>;
+      let r: Rx.Observable<number> = o.exhaust();
+    });
+  });
+
+  it ('types should flow with promises', () => {
+    type(() => {
+      let o: Rx.Observable<Promise<string>>;
+      let r: Rx.Observable<string> = o.exhaust();
+    });
+  });
+
+  it ('types should flow with observables', () => {
+    type(() => {
+      let o: Rx.Observable<Rx.Observable<{ a: string }>>;
+      let r: Rx.Observable<{ a: string }> = o.exhaust();
+    });
+  });
+
+  it ('types should flow with mixed', () => {
+    type(() => {
+      let o1: Rx.Observable<Rx.Observable<{ b: string }>>;
+      let o2: Rx.Observable<{ b: string }[]>;
+      let o3: Rx.Observable<Promise<{ b: string }>>;
+      let r: Rx.Observable<{ b: string }> = Rx.Observable
+        .concat(o1, o2, o3)
+        .exhaust();
+    });
   });
 });

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -19,7 +19,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const expected =  '--x-x-x-y-y-y------|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.exhaustMap(x => e2.map(i => i * x));
+    const result = e1.exhaustMap(x => e2.map(i => i * parseInt(x)));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -366,7 +366,7 @@ describe('Observable.prototype.exhaustMap', () => {
       n: ['z', 'n', 1, 3],
     };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value],
+    const result = e1.exhaustMap((value) => observableLookup[value],
     (innerValue, outerValue, innerIndex, outerIndex) => [innerValue, outerValue, innerIndex, outerIndex]);
 
     expectObservable(result).toBe(expected, expectedValues);

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -93,9 +93,9 @@ describe('Observable.prototype.expand', () => {
     const e2shape =  '---(z|)      ';
     const expected = 'a--b--c--(d#)';
 
-    const result = e1.expand((x: number) => {
+    const result = e1.expand((x) => {
       if (x === 8) {
-        return cold('#');
+        return cold<number>(<any>'#');
       }
       return cold(e2shape, { z: x + x });
     });

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -178,8 +178,8 @@ describe('Observable.prototype.filter', () => {
 
     expectObservable(
       source
-        .filter((x: number) => x % 2 === 0)
-        .filter((x: number) => x % 3 === 0)
+        .filter((x) => parseInt(x) % 2 === 0)
+        .filter((x) => parseInt(x) % 3 === 0)
     ).toBe(expected);
   });
 
@@ -209,8 +209,8 @@ describe('Observable.prototype.filter', () => {
 
     expectObservable(
       source
-        .filter((x: number) => x % 2 === 0)
-        .map((x: number) => x * x)
+        .filter((x) => parseInt(x) % 2 === 0)
+        .map((x) => parseInt(x) * parseInt(x))
     ).toBe(expected, values);
   });
 

--- a/spec/operators/map-spec.ts
+++ b/spec/operators/map-spec.ts
@@ -22,7 +22,7 @@ describe('Observable.prototype.map', () => {
     const asubs =    '^          !';
     const expected = '--x--y--z--|';
 
-    const r = a.map(function (x) { return 10 * x; });
+    const r = a.map(function (x) { return 10 * parseInt(x); });
 
     expectObservable(r).toBe(expected, {x: 10, y: 20, z: 30});
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -20,7 +20,7 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =  '--x-x-x-y-yzyz-z---|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.mergeMap(x => e2.map(i => i * x));
+    const result = e1.mergeMap(x => e2.map(i => i * parseInt(x)));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -165,7 +165,7 @@ describe('Observable.prototype.pluck', () => {
     const expected = '--1--2-     ';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .pluck('prop')
       .mergeMap((x: string) => Observable.of(x));
 

--- a/spec/operators/switch-spec.ts
+++ b/spec/operators/switch-spec.ts
@@ -2,7 +2,8 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
+declare const type: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -16,20 +17,20 @@ describe('Observable.prototype.switch', () => {
   asDiagram('switch')('should switch a hot observable of cold observables', () => {
     const x = cold(    '--a---b--c---d--|      ');
     const y = cold(           '----e---f--g---|');
-    const e1 = hot(  '--x------y-------|       ', { x: x, y: y });
+    const e1 = hot(  '--x------y-------|       ', { x, y });
     const expected = '----a---b----e---f--g---|';
 
     expectObservable(e1.switch()).toBe(expected);
   });
 
-  it('should switch to each immediately-scheduled inner Observable', (done: MochaDone) => {
+  it('should switch to each immediately-scheduled inner Observable', (done) => {
     const a = Observable.of<number>(1, 2, 3, queueScheduler);
     const b = Observable.of<number>(4, 5, 6, queueScheduler);
     const r = [1, 4, 5, 6];
     let i = 0;
     Observable.of<Rx.Observable<number>>(a, b, queueScheduler)
       .switch()
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(r[i++]);
       }, null, done);
   });
@@ -37,7 +38,7 @@ describe('Observable.prototype.switch', () => {
   it('should unsub inner observables', () => {
     const unsubbed = [];
 
-    Observable.of('a', 'b').map((x: string) =>
+    Observable.of('a', 'b').map((x) =>
       Observable.create((subscriber: Rx.Subscriber<string>) => {
         subscriber.complete();
         return () => {
@@ -50,12 +51,12 @@ describe('Observable.prototype.switch', () => {
     expect(unsubbed).to.deep.equal(['a', 'b']);
   });
 
-  it('should switch to each inner Observable', (done: MochaDone) => {
+  it('should switch to each inner Observable', (done) => {
     const a = Observable.of(1, 2, 3);
     const b = Observable.of(4, 5, 6);
     const r = [1, 2, 3, 4, 5, 6];
     let i = 0;
-    Observable.of(a, b).switch().subscribe((x: number) => {
+    Observable.of(a, b).switch().subscribe((x) => {
       expect(x).to.equal(r[i++]);
     }, null, done);
   });
@@ -65,7 +66,7 @@ describe('Observable.prototype.switch', () => {
     const xsubs =    '      ^       !              ';
     const y = cold(                '---d--e---f---|');
     const ysubs =    '              ^             !';
-    const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|       ', { x, y });
     const expected = '--------a---b----d--e---f---|';
     expectObservable(e1.switch()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -77,7 +78,7 @@ describe('Observable.prototype.switch', () => {
     const xsubs =    '      ^       !              ';
     const y = cold(                '---d--e---f---|');
     const ysubs =    '              ^ !            ';
-    const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|       ', { x, y });
     const unsub =    '                !            ';
     const expected = '--------a---b---             ';
     expectObservable(e1.switch(), unsub).toBe(expected);
@@ -90,14 +91,14 @@ describe('Observable.prototype.switch', () => {
     const xsubs =    '      ^       !              ';
     const y = cold(                '---d--e---f---|');
     const ysubs =    '              ^ !            ';
-    const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|       ', { x, y });
     const expected = '--------a---b----            ';
     const unsub =    '                !            ';
 
-    const result = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
+    const result = e1
+      .mergeMap((x) => Observable.of(x))
       .switch()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -109,7 +110,7 @@ describe('Observable.prototype.switch', () => {
     const xsubs =    '      ^       !               ';
     const y = cold(                '---d--e---f-----');
     const ysubs =    '              ^               ';
-    const e1 = hot(  '------x-------y------|        ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|        ', { x, y });
     const expected = '--------a---b----d--e---f-----';
     expectObservable(e1.switch()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -121,7 +122,7 @@ describe('Observable.prototype.switch', () => {
     const xsubs =    '      (^!)             ';
     const y = cold(        '---d--e---f---|  ');
     const ysubs =    '      ^             !  ';
-    const e1 = hot(  '------(xy)------------|', { x: x, y: y });
+    const e1 = hot(  '------(xy)------------|', { x, y });
     const expected = '---------d--e---f-----|';
     expectObservable(e1.switch()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -133,7 +134,7 @@ describe('Observable.prototype.switch', () => {
     const xsubs =    '      ^     !                ';
     const y = cold(                '---d--e---f---|');
     const ysubs = [];
-    const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
+    const e1 = hot(  '------x-------y------|       ', { x, y });
     const expected = '--------a---#                ';
     expectObservable(e1.switch()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -145,7 +146,7 @@ describe('Observable.prototype.switch', () => {
     const xsubs =    '      ^       !              ';
     const y = cold(                '---d--e---f---|');
     const ysubs =    '              ^       !      ';
-    const e1 = hot(  '------x-------y-------#      ', { x: x, y: y });
+    const e1 = hot(  '------x-------y-------#      ', { x, y });
     const expected = '--------a---b----d--e-#      ';
     expectObservable(e1.switch()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -173,7 +174,7 @@ describe('Observable.prototype.switch', () => {
   it('should complete not before the outer completes', () => {
     const x = cold(        '--a---b---c--|   ');
     const xsubs =    '      ^            !   ';
-    const e1 = hot(  '------x---------------|', { x: x });
+    const e1 = hot(  '------x---------------|', { x });
     const e1subs =   '^                     !';
     const expected = '--------a---b---c-----|';
 
@@ -182,12 +183,12 @@ describe('Observable.prototype.switch', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should handle an observable of promises', (done: MochaDone) => {
+  it('should handle an observable of promises', (done) => {
     const expected = [3];
 
-    (<any>Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)))
+    Observable.of<Promise<number>>(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3))
       .switch()
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, () => {
         expect(expected.length).to.equal(0);
@@ -195,12 +196,12 @@ describe('Observable.prototype.switch', () => {
       });
   });
 
-  it('should handle an observable of promises, where last rejects', (done: MochaDone) => {
-    Observable.of<any>(Promise.resolve(1), Promise.resolve(2), Promise.reject(3))
+  it('should handle an observable of promises, where last rejects', (done) => {
+    Observable.of<Promise<number>>(Promise.resolve(1), Promise.resolve(2), Promise.reject(3))
       .switch()
       .subscribe(() => {
         done(new Error('should not be called'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.equal(3);
         done();
       }, () => {
@@ -212,9 +213,9 @@ describe('Observable.prototype.switch', () => {
     const expected = [1, 2, 3, 4];
     let completed = false;
 
-    Observable.of<any>(Observable.never(), Observable.never(), [1, 2, 3, 4])
+    Observable.of<any>(Observable.never(), Observable.never<number>(), [1, 2, 3, 4])
       .switch()
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, () => {
         completed = true;
@@ -232,7 +233,7 @@ describe('Observable.prototype.switch', () => {
     });
     const switcher = oStream.switch();
     const result = [];
-    let sub = switcher.subscribe((x: number) => result.push(x));
+    let sub = switcher.subscribe((x) => result.push(x));
 
     [0, 1, 2, 3, 4].forEach((n) => {
       oStreamControl.next(n); // creates inner
@@ -252,7 +253,7 @@ describe('Observable.prototype.switch', () => {
     });
     const switcher = oStream.switch();
     const result = [];
-    let sub = switcher.subscribe((x: number) => result.push(x));
+    let sub = switcher.subscribe((x) => result.push(x));
 
     [0, 1, 2, 3, 4].forEach((n) => {
       oStreamControl.next(n); // creates inner
@@ -262,5 +263,37 @@ describe('Observable.prototype.switch', () => {
       (<any>sub)._subscriptions[0]._subscriptions.length
     ).to.equal(2);
     sub.unsubscribe();
+  });
+
+  it ('types should flow with arrays', () => {
+    type(() => {
+      let o: Rx.Observable<number[]>;
+      let r: Rx.Observable<number> = o.switch();
+    });
+  });
+
+  it ('types should flow with promises', () => {
+    type(() => {
+      let o: Rx.Observable<Promise<string>>;
+      let r: Rx.Observable<string> = o.switch();
+    });
+  });
+
+  it ('types should flow with observables', () => {
+    type(() => {
+      let o: Rx.Observable<Rx.Observable<{ a: string }>>;
+      let r: Rx.Observable<{ a: string }> = o.switch();
+    });
+  });
+
+  it ('types should flow with mixed', () => {
+    type(() => {
+      let o1: Rx.Observable<Rx.Observable<{ b: string }>>;
+      let o2: Rx.Observable<{ b: string }[]>;
+      let o3: Rx.Observable<Promise<{ b: string }>>;
+      let r: Rx.Observable<{ b: string }> = Rx.Observable
+        .concat(o1, o2, o3)
+        .switch();
+    });
   });
 });

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -20,7 +20,7 @@ describe('Observable.prototype.switchMap', () => {
     const expected =  '--x-x-x-y-yz-z-z---|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.switchMap(x => e2.map(i => i * x));
+    const result = e1.switchMap(x => e2.map(i => i * parseInt(x)));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -2,13 +2,14 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
+declare const type: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
 declare const expectSubscriptions: typeof marbleTestingSignature.expectSubscriptions;
 
-declare const Symbol: any;
+declare const Symbol;
 const Observable = Rx.Observable;
 const queueScheduler = Rx.Scheduler.queue;
 
@@ -20,7 +21,7 @@ describe('Observable.prototype.zipAll', () => {
     const outer = hot('-x----y--------|         ', { x: x, y: y });
     const expected =  '-----------------A----B-|';
 
-    const result = outer.zipAll((a: string, b: string) => String(a) + String(b));
+    const result = outer.zipAll((a, b) => a + b);
 
     expectObservable(result).toBe(expected, { A: 'a1', B: 'b2' });
   });
@@ -33,7 +34,7 @@ describe('Observable.prototype.zipAll', () => {
     const expected = '---x---y---z';
     const values = { x: ['1', '4'], y: ['2', '5'], z: ['3', '6'] };
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, values);
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, values);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -41,12 +42,12 @@ describe('Observable.prototype.zipAll', () => {
   it('should take all observables from the source and zip them', (done: MochaDone) => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
-    Observable.of<any>(
-      Observable.of<any>('a', 'b', 'c'),
-      Observable.of<any>(1, 2, 3)
+    Observable.of<Rx.Observable<number | string>>(
+      Observable.of('a', 'b', 'c'),
+      Observable.of(1, 2, 3)
     )
-    .zipAll((a: any, b: any) => a + b)
-    .subscribe((x: any) => {
+    .zipAll((a, b) => `${a}${b}`)
+    .subscribe((x) => {
       expect(x).to.equal(expected[i++]);
     }, null, done);
   });
@@ -65,7 +66,7 @@ describe('Observable.prototype.zipAll', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(Observable.of<any>(e1, e2, e3).zipAll()).toBe(expected, values);
+    expectObservable(Observable.of(e1, e2, e3).zipAll()).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -86,7 +87,7 @@ describe('Observable.prototype.zipAll', () => {
       z: ['c', 'f', 'j']
     };
 
-    expectObservable(Observable.of<any>(e1, e2, e3).zipAll()).toBe(expected, values);
+    expectObservable(Observable.of(e1, e2, e3).zipAll()).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -113,7 +114,7 @@ describe('Observable.prototype.zipAll', () => {
         z: ['d', 3]
       };
 
-      expectObservable(Observable.of<any>(e1, myIterator).zipAll()).toBe(expected, values);
+      expectObservable(Observable.of<Rx.Observable<number | string>>(e1, <any>myIterator).zipAll()).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
 
@@ -128,7 +129,7 @@ describe('Observable.prototype.zipAll', () => {
       };
       myIterator[Symbol.iterator] = function () { return this; };
 
-      Observable.of<any>(Observable.of<any>(1, 2, 3), myIterator).zipAll()
+      Observable.of<Rx.Observable<number | string>>(Observable.of(1, 2, 3), <any>myIterator).zipAll()
         .subscribe();
 
       // since zip will call `next()` in advance, total calls when
@@ -139,20 +140,20 @@ describe('Observable.prototype.zipAll', () => {
     it('should work with never observable and empty iterable', () => {
       const a = cold(  '-');
       const asubs =    '^';
-      const b = [];
+      const b = <string[]>[];
       const expected = '-';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<Rx.Observable<string> | string[]>(a, b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
     it('should work with empty observable and empty iterable', () => {
       const a = cold('|');
       const asubs = '(^!)';
-      const b = [];
+      const b = <string[]>[];
       const expected = '|';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<Rx.Observable<string> | string[]>(a, b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -162,17 +163,17 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '|';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<Rx.Observable<string> | number[]>(a, b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
     it('should work with non-empty observable and empty iterable', () => {
       const a = hot('---^----a--|');
       const asubs =    '^       !';
-      const b = [];
+      const b = <string[]>[];
       const expected = '--------|';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<Rx.Observable<string> | string[]>(a, b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -182,7 +183,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '-';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<Rx.Observable<string> | number[]>(a, b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -192,17 +193,17 @@ describe('Observable.prototype.zipAll', () => {
       const b = [2];
       const expected = '-----(x|)';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, { x: ['1', 2] });
+      expectObservable(Observable.of<Rx.Observable<string> | number[]>(a, b).zipAll()).toBe(expected, { x: ['1', 2] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
     it('should work with non-empty observable and empty iterable', () => {
       const a = hot('---^----#');
       const asubs =    '^    !';
-      const b = [];
+      const b = <string[]>[];
       const expected = '-----#';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<Rx.Observable<string> | string[]>(a, b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -212,7 +213,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [1];
       const expected = '-----#';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+      expectObservable(Observable.of<Rx.Observable<string> | number[]>(a, b).zipAll()).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
 
@@ -222,7 +223,7 @@ describe('Observable.prototype.zipAll', () => {
       const b = [4, 5, 6];
       const expected = '---x--y--(z|)';
 
-      expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected,
+      expectObservable(Observable.of<Rx.Observable<string> | number[]>(a, b).zipAll()).toBe(expected,
         { x: ['1', 4], y: ['2', 5], z: ['3', 6] });
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -239,7 +240,7 @@ describe('Observable.prototype.zipAll', () => {
         } else {
           return x + y;
         }};
-      expectObservable(Observable.of<any>(a, b).zipAll(selector)).toBe(expected,
+      expectObservable(Observable.of<Rx.Observable<string> | number[]>(a, b).zipAll(selector)).toBe(expected,
         { x: '14' }, new Error('too bad'));
       expectSubscriptions(a.subscriptions).toBe(asubs);
     });
@@ -252,7 +253,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((e1: string, e2: string) => e1 + e2))
+    expectObservable(Observable.of(a, b).zipAll((e1: string, e2: string) => e1 + e2))
       .toBe(expected, { x: '14', y: '25', z: '36' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -266,7 +267,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    expectObservable(Observable.of<any>(a, b, c).zipAll()).toBe(expected,
+    expectObservable(Observable.of(a, b, c).zipAll()).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -280,7 +281,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = Observable.of<any>(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
+    const observable = Observable.of(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -295,7 +296,7 @@ describe('Observable.prototype.zipAll', () => {
     const c = hot('---1-^---3---6-|  ');
     const expected =   '----x---y-|  ';
 
-    const observable = Observable.of<any>(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
+    const observable = Observable.of(a, b, c).zipAll((r0, r1, r2) => [r0, r1, r2]);
     expectObservable(observable).toBe(expected,
       { x: ['1', '2', '3'], y: ['4', '5', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -309,7 +310,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((r1: string, r2: string) => r1 + r2))
+    expectObservable(Observable.of(a, b).zipAll((r1: string, r2: string) => r1 + r2))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -322,7 +323,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                 !    ';
     const expected =   '---a--b--c--d--e--|    ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((r1: string, r2: string) => r1 + r2))
+    expectObservable(Observable.of(a, b).zipAll((r1: string, r2: string) => r1 + r2))
       .toBe(expected, { a: '21', b: '43', c: '65', d: '87', e: '09' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -335,7 +336,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =      '^                ! ';
     const expected =   '---a--b--c--d--e-| ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll((r1: string, r2: string) => r1 + r2))
+    expectObservable(Observable.of(a, b).zipAll((r1: string, r2: string) => r1 + r2))
       .toBe(expected, { a: '12', b: '34', c: '56', d: '78', e: '90' });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -354,7 +355,7 @@ describe('Observable.prototype.zipAll', () => {
       } else {
         return x + y;
       }};
-    const observable = Observable.of<any>(a, b).zipAll(selector);
+    const observable = Observable.of(a, b).zipAll(selector);
     expectObservable(observable).toBe(expected,
       { x: '23' }, new Error('too bad'));
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -376,12 +377,12 @@ describe('Observable.prototype.zipAll', () => {
   it('should zip until one child terminates', (done: MochaDone) => {
     const expected = ['a1', 'b2'];
     let i = 0;
-    Observable.of<any>(
-      Observable.of<any>('a', 'b', 'c'),
-      Observable.of<any>(1, 2)
+    Observable.of<Rx.Observable<string | number>>(
+      Observable.of('a', 'b', 'c'),
+      Observable.of(1, 2)
     )
-    .zipAll((a: any, b: any) => a + b)
-    .subscribe((x: any) => {
+    .zipAll((a, b) => `${a}${b}`)
+    .subscribe((x) => {
       expect(x).to.equal(expected[i++]);
     }, null, done);
   });
@@ -469,7 +470,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -481,7 +482,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -493,7 +494,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -505,7 +506,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -517,7 +518,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -529,7 +530,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -541,7 +542,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '-';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -553,7 +554,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '-';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -565,7 +566,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^';
     const expected = '---x---y---z';
 
-    expectObservable(Observable.of<any>(a, b).zipAll())
+    expectObservable(Observable.of(a, b).zipAll())
       .toBe(expected, { x: ['1', '4'], y: ['2', '5'], z: ['3', '6'] });
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
@@ -578,7 +579,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -590,7 +591,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '|';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -602,7 +603,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !    ';
     const expected = '------#    ';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -614,7 +615,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -626,7 +627,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -638,7 +639,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^     !';
     const expected = '------#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, null, 'too bad');
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, null, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -650,7 +651,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, { x: [1, 2] }, 'too bad');
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, { x: [1, 2] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -662,7 +663,7 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '^       !';
     const expected = '-----x--#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected, { x: [2, 1] }, 'too bad');
+    expectObservable(Observable.of(a, b).zipAll()).toBe(expected, { x: [2, 1] }, 'too bad');
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
@@ -674,33 +675,33 @@ describe('Observable.prototype.zipAll', () => {
     const bsubs =    '(^!)';
     const expected = '#';
 
-    expectObservable(Observable.of<any>(a, b).zipAll()).toBe(expected);
+    expectObservable(Observable.of<Rx.Observable<string>>(a, b).zipAll()).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
 
   it('should combine two immediately-scheduled observables', (done: MochaDone) => {
-    const a = Observable.of<any>(1, 2, 3, queueScheduler);
-    const b = Observable.of<any>(4, 5, 6, 7, 8, queueScheduler);
+    const a = Observable.of(1, 2, 3, queueScheduler);
+    const b = Observable.of(4, 5, 6, 7, 8, queueScheduler);
     const r = [[1, 4], [2, 5], [3, 6]];
     let i = 0;
 
-    const result = Observable.of<any>(a, b, queueScheduler).zipAll();
+    const result = Observable.of(a, b, queueScheduler).zipAll();
 
-    result.subscribe((vals: any) => {
+    result.subscribe((vals) => {
       expect(vals).to.deep.equal(r[i++]);
     }, null, done);
   });
 
   it('should combine a source with an immediately-scheduled source', (done: MochaDone) => {
-    const a = Observable.of<any>(1, 2, 3, queueScheduler);
-    const b = Observable.of<any>(4, 5, 6, 7, 8);
+    const a = Observable.of(1, 2, 3, queueScheduler);
+    const b = Observable.of(4, 5, 6, 7, 8);
     const r = [[1, 4], [2, 5], [3, 6]];
     let i = 0;
 
-    const result = Observable.of<any>(a, b, queueScheduler).zipAll();
+    const result = Observable.of(a, b, queueScheduler).zipAll();
 
-    result.subscribe((vals: any) => {
+    result.subscribe((vals) => {
       expect(vals).to.deep.equal(r[i++]);
     }, null, done);
   });
@@ -714,10 +715,10 @@ describe('Observable.prototype.zipAll', () => {
     const expected = '---x---y--';
     const values = { x: ['1', '4'], y: ['2', '5']};
 
-    const r = Observable.of<any>(a, b)
-      .mergeMap((x: string) => Observable.of(x))
+    const r = Observable.of(a, b)
+      .mergeMap((x) => Observable.of(x))
       .zipAll()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(r, unsub).toBe(expected, values);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -729,5 +730,46 @@ describe('Observable.prototype.zipAll', () => {
     const expected =   '|';
 
     expectObservable(source.zipAll()).toBe(expected);
+  });
+
+  it ('types should flow with arrays', () => {
+    type(() => {
+      let o: Rx.Observable<number[]>;
+      let r: Rx.Observable<number[]> = o.zipAll();
+    });
+  });
+
+  it ('types should flow with promises', () => {
+    type(() => {
+      let o: Rx.Observable<Promise<string>>;
+      let r: Rx.Observable<string[]> = o.zipAll();
+    });
+  });
+
+  it ('types should flow with observables', () => {
+    type(() => {
+      let o: Rx.Observable<Rx.Observable<{ a: string }>>;
+      let r: Rx.Observable<{ a: string }[]> = o.zipAll();
+    });
+  });
+
+  it ('types should flow with mixed', () => {
+    type(() => {
+      let o1: Rx.Observable<Rx.Observable<{ b: string }>>;
+      let o2: Rx.Observable<{ b: string }[]>;
+      let o3: Rx.Observable<Promise<{ b: string }>>;
+      let r: Rx.Observable<{ b: string }[]> = Rx.Observable.concat(o1, o2, o3)
+        .zipAll();
+    });
+  });
+
+  it ('types should flow with mixed projection', () => {
+    type(() => {
+      let o1: Rx.Observable<Rx.Observable<{ b: string }>>;
+      let o2: Rx.Observable<{ b: string }[]>;
+      let o3: Rx.Observable<Promise<{ b: string }>>;
+      let r: Rx.Observable<string> = Rx.Observable.concat(o1, o2, o3)
+        .zipAll((...values) => values.map(z => z.b).join(''));
+    });
   });
 });

--- a/src/operator/combineAll.ts
+++ b/src/operator/combineAll.ts
@@ -1,6 +1,9 @@
 import { CombineLatestOperator } from './combineLatest';
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 
+export function combineAll<T>(this: Observable<ObservableInput<T>>): Observable<T[]>;
+export function combineAll<T, R>(this: Observable<ObservableInput<T>>, project: (...values: T[]) => R): Observable<R>;
+export function combineAll<T, R>(this: Observable<T>, project?: (...values: any[]) => R): Observable<R>;
 /**
  * Converts a higher-order Observable into a first-order Observable by waiting
  * for the outer Observable to complete, then applying {@link combineLatest}.

--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -1,10 +1,10 @@
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { Subscribable } from '../Observable';
 import { MergeAllOperator } from './mergeAll';
 
 /* tslint:disable:max-line-length */
-export function concatAll<T>(this: Observable<T>): T;
-export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
+export function concatAll<T>(this: Observable<ObservableInput<T>>): Observable<T>;
+export function concatAll<T, R>(this: Observable<T>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -55,6 +55,6 @@ export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
  * @method concatAll
  * @owner Observable
  */
-export function concatAll<T>(this: Observable<T>): T {
-  return <any>this.lift<any>(new MergeAllOperator<T>(1));
+export function concatAll<T, R>(this: Observable<T>): Observable<R> {
+  return this.lift(new MergeAllOperator<R>(1));
 }

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -1,10 +1,12 @@
 import { Operator } from '../Operator';
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription, TeardownLogic } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
+export function exhaust<T>(this: Observable<ObservableInput<T>>): Observable<T>;
+export function exhaust<T, R>(this: Observable<T>): Observable<R>;
 /**
  * Converts a higher-order Observable into a first-order Observable by dropping
  * inner Observables while the previous inner Observable has not yet completed.
@@ -40,8 +42,8 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * @method exhaust
  * @owner Observable
  */
-export function exhaust<T>(this: Observable<T>): Observable<T> {
-  return this.lift(new SwitchFirstOperator<T>());
+export function exhaust<T, R>(this: Observable<T>): Observable<R> {
+  return this.lift<R>(new SwitchFirstOperator<R>());
 }
 
 class SwitchFirstOperator<T> implements Operator<T, T> {

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -1,13 +1,13 @@
-import { Observable } from '../Observable';
-import { Operator } from '../Operator';
-import { Observer } from '../Observer';
-import { Subscription } from '../Subscription';
-import { OuterSubscriber } from '../OuterSubscriber';
+import { Observable, ObservableInput } from '../Observable';
 import { Subscribable } from '../Observable';
+import { Observer } from '../Observer';
+import { Operator } from '../Operator';
+import { OuterSubscriber } from '../OuterSubscriber';
+import { Subscription } from '../Subscription';
 import { subscribeToResult } from '../util/subscribeToResult';
 
-export function mergeAll<T>(this: Observable<T>, concurrent?: number): T;
-export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscribable<R>;
+export function mergeAll<T>(this: Observable<ObservableInput<T>>, concurrent?: number): Observable<T>;
+export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Observable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable which
@@ -53,7 +53,7 @@ export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscr
  * @method mergeAll
  * @owner Observable
  */
-export function mergeAll<T>(this: Observable<T>, concurrent: number = Number.POSITIVE_INFINITY): T {
+export function mergeAll<T, R>(this: Observable<T>, concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
   return <any>this.lift<any>(new MergeAllOperator<T>(concurrent));
 }
 

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -1,4 +1,4 @@
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
@@ -6,6 +6,8 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
+export function _switch<T>(this: Observable<ObservableInput<T>>): Observable<T>;
+export function _switch<T, R>(this: Observable<T>): Observable<R>;
 /**
  * Converts a higher-order Observable into a first-order Observable by
  * subscribing to only the most recently emitted of those inner Observables.
@@ -48,8 +50,8 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * @name switch
  * @owner Observable
  */
-export function _switch<T>(this: Observable<T>): T {
-  return <any>this.lift<any>(new SwitchOperator());
+export function _switch<T, R>(this: Observable<T>): Observable<R> {
+  return this.lift(new SwitchOperator<T, R>());
 }
 
 class SwitchOperator<T, R> implements Operator<T, R> {

--- a/src/operator/zipAll.ts
+++ b/src/operator/zipAll.ts
@@ -1,6 +1,9 @@
 import { ZipOperator } from './zip';
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 
+export function zipAll<T>(this: Observable<ObservableInput<T>>): Observable<T[]>;
+export function zipAll<T, R>(this: Observable<ObservableInput<T>>, project: (...values: T[]) => R): Observable<R>;
+export function zipAll<T, R>(this: Observable<T>, project?: (...values: any[]) => R): Observable<R>;
 /**
  * @param project
  * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
fixes concatAll, combineAll, exhaust, mergeAll, switch, zipAll.  Also made a few improvements to
how hot and cold observables are typed.  A few compiler errors were fixed due to this change.


**Related issue (if exists):**
fixes #2658 #2493 #2551
