### PR TITLE
fix(never): Observable.never() Observable.empty() .ignoreElements () now return Observable<never>

### DIFF
--- a/spec/observables/empty-spec.ts
+++ b/spec/observables/empty-spec.ts
@@ -10,7 +10,7 @@ const Observable = Rx.Observable;
 describe('Observable.empty', () => {
   asDiagram('empty')('should create a cold observable with only complete', () => {
     const expected = '|';
-    const e1 = Observable.empty();
+    const e1: Rx.Observable<never> = Observable.empty();
     expectObservable(e1).toBe(expected);
   });
 });

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -28,7 +28,7 @@ describe('Observable.from', () => {
     type(() => {
       /* tslint:disable:no-unused-variable */
       let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
-      let o2: Rx.Observable<{ a: string }> = Observable.from(Observable.empty<{ a: string }>());
+      let o2: Rx.Observable<never> = Observable.from(Observable.empty());
       let o3: Rx.Observable<{ b: number }> = Observable.from(new Promise<{b: number}>(resolve => resolve()));
       /* tslint:enable:no-unused-variable */
     });

--- a/spec/observables/never-spec.ts
+++ b/spec/observables/never-spec.ts
@@ -10,7 +10,7 @@ const Observable = Rx.Observable;
 describe('Observable.never', () => {
   asDiagram('never')('should create a cold observable that never emits', () => {
     const expected = '-';
-    const e1 = Observable.never();
+    const e1: Rx.Observable<never> = Observable.never();
     expectObservable(e1).toBe(expected);
   });
 });

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -294,7 +294,7 @@ describe('Observable.prototype.debounce', () => {
     const e1subs =   '^                                   !';
     const expected = '--------a-x-yz---bxy---z--c--x--y--z|';
 
-    function selectorFunction(x) { return Observable.empty<number>(); }
+    function selectorFunction(x) { return Observable.empty(); }
 
     expectObservable(e1.debounce(selectorFunction)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -305,7 +305,7 @@ describe('Observable.prototype.debounce', () => {
     const e1subs =   '^                                   !';
     const expected = '------------------------------------(z|)';
 
-    function selectorFunction(x) { return Observable.never<number>(); }
+    function selectorFunction(x) { return Observable.never(); }
 
     expectObservable(e1.debounce(selectorFunction)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/race-spec.ts
+++ b/spec/operators/race-spec.ts
@@ -192,7 +192,7 @@ describe('Observable.prototype.race', () => {
   it('should unsubscribe former observables if a latter one emits immediately', () => {
     const onNext = sinon.spy();
     const onUnsubscribe = sinon.spy();
-    const e1 = Observable.never<string>().finally(onUnsubscribe); // Should be unsubscribed
+    const e1 = Observable.never().finally(onUnsubscribe); // Should be unsubscribed
     const e2 = Observable.of('b'); // Wins the race
 
     e1.race(e2).subscribe(onNext);
@@ -203,8 +203,8 @@ describe('Observable.prototype.race', () => {
   it('should unsubscribe from immediately emitting observable on unsubscription', () => {
     const onNext = sinon.spy();
     const onUnsubscribe = sinon.spy();
-    const e1 = Observable.never<string>().startWith('a').finally(onUnsubscribe); // Wins the race
-    const e2 = Observable.never<string>(); // Loses the race
+    const e1 = Observable.never().startWith('a').finally(onUnsubscribe); // Wins the race
+    const e2 = Observable.never(); // Loses the race
 
     const subscription = e1.race(e2).subscribe(onNext);
     expect(onNext.calledWithExactly('a')).to.be.true;

--- a/src/Notification.ts
+++ b/src/Notification.ts
@@ -88,7 +88,7 @@ export class Notification<T> {
       case 'E':
         return Observable.throw(this.error);
       case 'C':
-        return Observable.empty<T>();
+        return Observable.empty();
     }
     throw new Error('unexpected notification kind value');
   }

--- a/src/observable/ArrayLikeObservable.ts
+++ b/src/observable/ArrayLikeObservable.ts
@@ -15,7 +15,7 @@ export class ArrayLikeObservable<T> extends Observable<T> {
   static create<T>(arrayLike: ArrayLike<T>, scheduler?: IScheduler): Observable<T> {
     const length = arrayLike.length;
     if (length === 0) {
-      return new EmptyObservable<T>();
+      return new EmptyObservable();
     } else if (length === 1) {
       return new ScalarObservable<T>(<any>arrayLike[0], scheduler);
     } else {

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -74,7 +74,7 @@ export class ArrayObservable<T> extends Observable<T> {
     } else if (len === 1) {
       return new ScalarObservable<T>(<any>array[0], scheduler);
     } else {
-      return new EmptyObservable<T>(scheduler);
+      return new EmptyObservable(scheduler);
     }
   }
 

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -3,8 +3,8 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 
-export interface DispatchArg<T> {
-  subscriber: Subscriber<T>;
+export interface DispatchArg {
+  subscriber: Subscriber<never>;
 }
 
 /**
@@ -12,7 +12,7 @@ export interface DispatchArg<T> {
  * @extends {Ignored}
  * @hide true
  */
-export class EmptyObservable<T> extends Observable<T> {
+export class EmptyObservable extends Observable<never> {
 
   /**
    * Creates an Observable that emits no items to the Observer and immediately
@@ -57,11 +57,11 @@ export class EmptyObservable<T> extends Observable<T> {
    * @name empty
    * @owner Observable
    */
-  static create<T>(scheduler?: IScheduler): Observable<T> {
-    return new EmptyObservable<T>(scheduler);
+  static create(scheduler?: IScheduler): Observable<never> {
+    return new EmptyObservable(scheduler);
   }
 
-  static dispatch<T>(arg: DispatchArg<T>) {
+  static dispatch(arg: DispatchArg) {
     const { subscriber } = arg;
     subscriber.complete();
   }
@@ -70,7 +70,7 @@ export class EmptyObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  protected _subscribe(subscriber: Subscriber<never>): TeardownLogic {
 
     const scheduler = this.scheduler;
 

--- a/src/observable/ForkJoinObservable.ts
+++ b/src/observable/ForkJoinObservable.ts
@@ -50,7 +50,7 @@ export class ForkJoinObservable<T> extends Observable<T> {
                                   Array<SubscribableOrPromise<any>> |
                                   ((...values: Array<any>) => any)>): Observable<T> {
     if (sources === null || arguments.length === 0) {
-      return new EmptyObservable<T>();
+      return new EmptyObservable();
     }
 
     let resultSelector: (...values: Array<any>) => any = null;
@@ -65,7 +65,7 @@ export class ForkJoinObservable<T> extends Observable<T> {
     }
 
     if (sources.length === 0) {
-      return new EmptyObservable<T>();
+      return new EmptyObservable();
     }
 
     return new ForkJoinObservable(<Array<SubscribableOrPromise<any>>>sources, resultSelector);

--- a/src/observable/NeverObservable.ts
+++ b/src/observable/NeverObservable.ts
@@ -7,7 +7,7 @@ import { noop } from '../util/noop';
  * @extends {Ignored}
  * @hide true
  */
-export class NeverObservable<T> extends Observable<T> {
+export class NeverObservable extends Observable<never> {
   /**
    * Creates an Observable that emits no items to the Observer.
    *
@@ -39,15 +39,15 @@ export class NeverObservable<T> extends Observable<T> {
    * @name never
    * @owner Observable
    */
-  static create<T>() {
-    return new NeverObservable<T>();
+  static create() {
+    return new NeverObservable();
   }
 
   constructor() {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): void {
+  protected _subscribe(subscriber: Subscriber<never>): void {
     noop();
   }
 }

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -13,12 +13,12 @@ import { noop } from '../util/noop';
  * @method ignoreElements
  * @owner Observable
  */
-export function ignoreElements<T>(this: Observable<T>): Observable<T> {
+export function ignoreElements<T>(this: Observable<T>): Observable<never> {
   return this.lift(new IgnoreElementsOperator());
 }
 
-class IgnoreElementsOperator<T, R> implements Operator<T, R> {
-  call(subscriber: Subscriber<R>, source: any): any {
+class IgnoreElementsOperator<T> implements Operator<T, never> {
+  call(subscriber: Subscriber<never>, source: any): any {
     return source.subscribe(new IgnoreElementsSubscriber(subscriber));
   }
 }

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -18,7 +18,7 @@ import { TeardownLogic } from '../Subscription';
  */
 export function repeat<T>(this: Observable<T>, count: number = -1): Observable<T> {
   if (count === 0) {
-    return new EmptyObservable<T>();
+    return new EmptyObservable();
   } else if (count < 0) {
     return this.lift(new RepeatOperator(-1, this));
   } else {

--- a/src/operator/startWith.ts
+++ b/src/operator/startWith.ts
@@ -44,6 +44,6 @@ export function startWith<T>(this: Observable<T>, ...array: Array<T | IScheduler
   } else if (len > 1) {
     return concatStatic(new ArrayObservable<T>(<T[]>array, scheduler), <Observable<T>>this);
   } else {
-    return concatStatic(new EmptyObservable<T>(scheduler), <Observable<T>>this);
+    return concatStatic(new EmptyObservable(scheduler), <Observable<T>>this);
   }
 }

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -40,7 +40,7 @@ import { TeardownLogic } from '../Subscription';
  */
 export function take<T>(this: Observable<T>, count: number): Observable<T> {
   if (count === 0) {
-    return new EmptyObservable<T>();
+    return new EmptyObservable();
   } else {
     return this.lift(new TakeOperator(count));
   }

--- a/src/operator/takeLast.ts
+++ b/src/operator/takeLast.ts
@@ -43,7 +43,7 @@ import { TeardownLogic } from '../Subscription';
  */
 export function takeLast<T>(this: Observable<T>, count: number): Observable<T> {
   if (count === 0) {
-    return new EmptyObservable<T>();
+    return new EmptyObservable();
   } else {
     return this.lift(new TakeLastOperator(count));
   }


### PR DESCRIPTION
fixes #2640

BREAKING CHANGE: Previously, `Observable.never()` `Observable.empty()`
and the `.ignoreElements()` operator all returned `Observable<T>` which
was incorrect since they actually never emit anything. Now they all
return `Observable<never>` (`never` was added in TS 2.0 as a special
type)