### PR TITLE
feat(typings): propogate thisArgs using this syntax

### DIFF
--- a/spec/operators/every-spec.ts
+++ b/spec/operators/every-spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -12,11 +12,11 @@ const Observable = Rx.Observable;
 
 /** @test {every} */
 describe('Observable.prototype.every', () => {
-  function truePredicate(x) {
+  function truePredicate(x: never) {
     return true;
   }
 
-  function predicate(x) {
+  function predicate(x: number) {
     return x % 5 === 0;
   }
 
@@ -55,13 +55,13 @@ describe('Observable.prototype.every', () => {
       observer.next(1);
       observer.complete();
     })
-    .every(function (value: number, index: number) {
+    .every(function (this: typeof thisArg, value: number, index: number) {
       expect(this).to.deep.equal(thisArg);
     }, thisArg).subscribe();
   });
 
   it('should emit true if source is empty', () => {
-    const source = hot('-----|');
+    const source = hot('-----|', <{ [index: string]: number; }>{});
     const sourceSubs = '^    !';
     const expected =   '-----(x|)';
 
@@ -70,7 +70,7 @@ describe('Observable.prototype.every', () => {
   });
 
   it('should emit false if single source of element does not match with predicate', () => {
-    const source = hot('--a--|');
+    const source = hot('--a--|', <{ [index: string]: number; }>{});
     const sourceSubs = '^ !';
     const expected =   '--(x|)';
 
@@ -79,7 +79,7 @@ describe('Observable.prototype.every', () => {
   });
 
   it('should emit false if none of element does not match with predicate', () => {
-    const source = hot('--a--b--c--d--e--|');
+    const source = hot('--a--b--c--d--e--|', { a: 1, b: 2, c: 3, d: 4, e: 5 });
     const sourceSubs = '^ !';
     const expected =   '--(x|)';
 
@@ -115,9 +115,9 @@ describe('Observable.prototype.every', () => {
     const unsub =      '       !          ';
 
     const result = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .every(predicate)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -128,7 +128,7 @@ describe('Observable.prototype.every', () => {
     const sourceSubs = '^       !';
     const expected =   '--------#';
 
-    function faultyPredicate(x) {
+    function faultyPredicate(x: string) {
       if (x === 'c') {
         throw 'error';
       } else {
@@ -167,7 +167,7 @@ describe('Observable.prototype.every', () => {
     const source = Observable.of(3);
     const expected = '#';
 
-    function faultyPredicate(x) {
+    function faultyPredicate(x: number) {
       throw 'error';
     }
 
@@ -192,7 +192,7 @@ describe('Observable.prototype.every', () => {
     const source = Observable.of(5, 10, 15, 20);
     const expected = '#';
 
-    function faultyPredicate(x) {
+    function faultyPredicate(x: number) {
       if (x === 15) {
         throw 'error';
       }
@@ -257,7 +257,7 @@ describe('Observable.prototype.every', () => {
   });
 
   it('should emit true if source does not emit after subscription', () => {
-    const source = hot('--z--^-----|');
+    const source = hot('--z--^-----|', { z: 0 });
     const sourceSubs =      '^     !';
     const expected =        '------(x|)';
 

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -12,13 +12,13 @@ const Observable = Rx.Observable;
 
 /** @test {filter} */
 describe('Observable.prototype.filter', () => {
-  function oddFilter(x) {
-    return (+x) % 2 === 1;
+  function oddFilter(x: number) {
+    return x % 2 === 1;
   }
 
-  function isPrime(i) {
+  function isPrime(i: number) {
     if (+i <= 1) { return false; }
-    const max = Math.floor(Math.sqrt(+i));
+    const max = Math.floor(Math.sqrt(Number(i)));
     for (let j = 2; j <= max; ++j) {
       if (+i % j === 0) { return false; }
     }
@@ -26,18 +26,18 @@ describe('Observable.prototype.filter', () => {
   }
 
   asDiagram('filter(x => x % 2 === 1)')('should filter out even values', () => {
-    const source = hot('--0--1--2--3--4--|');
-    const subs =       '^                !';
-    const expected =   '-----1-----3-----|';
+    const source = hot<number>('--0--1--2--3--4--|');
+    const subs =               '^                !';
+    const expected =           '-----1-----3-----|';
 
     expectObservable(source.filter(oddFilter)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should filter in only prime numbers', () => {
-    const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
-    const subs =              '^                  !';
-    const expected =          '--3---5----7-------|';
+    const source = hot<number>('-1--2--^-3-4-5-6--7-8--9--|');
+    const subs =                      '^                  !';
+    const expected =                  '--3---5----7-------|';
 
     expectObservable(source.filter(isPrime)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -60,19 +60,19 @@ describe('Observable.prototype.filter', () => {
   });
 
   it('should filter in only prime numbers, source unsubscribes early', () => {
-    const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
-    const subs =              '^           !       ';
-    const unsub =             '            !       ';
-    const expected =          '--3---5----7-       ';
+    const source = hot<number>('-1--2--^-3-4-5-6--7-8--9--|');
+    const subs =                      '^           !       ';
+    const unsub =                     '            !       ';
+    const expected =                  '--3---5----7-       ';
 
     expectObservable(source.filter(isPrime), unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should filter in only prime numbers, source throws', () => {
-    const source = hot('-1--2--^-3-4-5-6--7-8--9--#');
-    const subs =              '^                  !';
-    const expected =          '--3---5----7-------#';
+    const source = hot<number>('-1--2--^-3-4-5-6--7-8--9--#');
+    const subs =                      '^                  !';
+    const expected =                  '--3---5----7-------#';
 
     expectObservable(source.filter(isPrime)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -92,7 +92,7 @@ describe('Observable.prototype.filter', () => {
       return isPrime(x);
     }
 
-    expectObservable((<any>source).filter(predicate)).toBe(expected);
+    expectObservable(source.filter(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -102,19 +102,19 @@ describe('Observable.prototype.filter', () => {
     const expected =          '--3--------7-------|';
 
     function predicate(x: any, i: number) {
-      return isPrime((+x) + i * 10);
+      return isPrime(Number(x) + i * 10);
     }
 
-    expectObservable((<any>source).filter(predicate)).toBe(expected);
+    expectObservable(source.filter(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should invoke predicate once for each checked value', () => {
-    const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
-    const expected =          '--3---5----7-------|';
+    const source = hot<number>('-1--2--^-3-4-5-6--7-8--9--|');
+    const expected =                  '--3---5----7-------|';
 
     let invoked = 0;
-    const predicate = (x: any) => {
+    const predicate = (x: number) => {
       invoked++;
       return isPrime(x);
     };
@@ -136,9 +136,9 @@ describe('Observable.prototype.filter', () => {
     const expected =          '--3--------7-       ';
 
     function predicate(x: any, i: number) {
-      return isPrime((+x) + i * 10);
+      return isPrime(Number(x) + i * 10);
     }
-    expectObservable((<any>source).filter(predicate), unsub).toBe(expected);
+    expectObservable(source.filter(predicate), unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -148,9 +148,9 @@ describe('Observable.prototype.filter', () => {
     const expected =          '--3--------7-------#';
 
     function predicate(x: any, i: number) {
-      return isPrime((+x) + i * 10);
+      return isPrime(Number(x) + i * 10);
     }
-    expectObservable((<any>source).filter(predicate)).toBe(expected);
+    expectObservable(source.filter(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -165,10 +165,10 @@ describe('Observable.prototype.filter', () => {
       if (invoked === 4) {
         throw 'error';
       }
-      return isPrime((+x) + i * 10);
+      return isPrime(Number(x) + i * 10);
     }
 
-    expectObservable((<any>source).filter(predicate)).toBe(expected);
+    expectObservable(source.filter(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -178,8 +178,8 @@ describe('Observable.prototype.filter', () => {
 
     expectObservable(
       source
-        .filter((x) => parseInt(x) % 2 === 0)
-        .filter((x) => parseInt(x) % 3 === 0)
+        .filter((x) => Number(x) % 2 === 0)
+        .filter((x) => Number(x) % 3 === 0)
     ).toBe(expected);
   });
 
@@ -187,9 +187,9 @@ describe('Observable.prototype.filter', () => {
     const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
     const expected =          '--------6----------|';
 
-    function Filterer() {
-      this.filter1 = (x: number) => x % 2 === 0;
-      this.filter2 = (x: number) => x % 3 === 0;
+    class Filterer {
+      filter1 = (x: string) => Number(x) % 2 === 0;
+      filter2 = (x: string) => Number(x) % 3 === 0;
     }
 
     const filterer = new Filterer();
@@ -203,60 +203,60 @@ describe('Observable.prototype.filter', () => {
   });
 
   it('should be able to use filter and map composed', () => {
-    const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
-    const expected =          '----a---b----c-----|';
+    const source = hot<number>('-1--2--^-3-4-5-6--7-8--9--|');
+    const expected =                  '----a---b----c-----|';
     const values = { a: 16, b: 36, c: 64 };
 
     expectObservable(
       source
-        .filter((x) => parseInt(x) % 2 === 0)
-        .map((x) => parseInt(x) * parseInt(x))
+        .filter((x) => Number(x) % 2 === 0)
+        .map((x) => Number(x) * Number(x))
     ).toBe(expected, values);
   });
 
   it('should propagate errors from the source', () => {
-    const source = hot('--0--1--2--3--4--#');
-    const subs =       '^                !';
-    const expected =   '-----1-----3-----#';
+    const source = hot<number>('--0--1--2--3--4--#');
+    const subs =               '^                !';
+    const expected =           '-----1-----3-----#';
 
     expectObservable(source.filter(oddFilter)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should support Observable.empty', () => {
-    const source = cold('|');
-    const subs =        '(^!)';
-    const expected =    '|';
+    const source = cold<number>('|');
+    const subs =                '(^!)';
+    const expected =            '|';
 
     expectObservable(source.filter(oddFilter)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should support Observable.never', () => {
-    const source = cold('-');
-    const subs =        '^';
-    const expected =    '-';
+    const source = cold<number>('-');
+    const subs =                '^';
+    const expected =            '-';
 
     expectObservable(source.filter(oddFilter)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should support Observable.throw', () => {
-    const source = cold('#');
-    const subs =        '(^!)';
-    const expected =    '#';
+    const source = cold<number>('#');
+    const subs =                '(^!)';
+    const expected =            '#';
 
     expectObservable(source.filter(oddFilter)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  it('should send errors down the error path', (done: MochaDone) => {
+  it('should send errors down the error path', (done) => {
     Observable.of(42).filter(<any>((x: number, index: number) => {
       throw 'bad';
     }))
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         done(new Error('should not be called'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.equal('bad');
         done();
       }, () => {
@@ -265,15 +265,15 @@ describe('Observable.prototype.filter', () => {
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
-    const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
-    const subs =              '^           !       ';
-    const unsub =             '            !       ';
-    const expected =          '--3---5----7-       ';
+    const source = hot<number>('-1--2--^-3-4-5-6--7-8--9--|');
+    const subs =                       '^           !       ';
+    const unsub =                      '            !       ';
+    const expected =                   '--3---5----7-       ';
 
     const r = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .filter(isPrime)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(r, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -3,7 +3,7 @@ import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 import { doNotUnsubscribe } from '../helpers/doNotUnsubscribe';
 
-declare const { asDiagram };
+declare const asDiagram: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -13,7 +13,7 @@ const Observable = Rx.Observable;
 
 /** @test {find} */
 describe('Observable.prototype.find', () => {
-  function truePredicate(x) {
+  function truePredicate(x: number) {
     return true;
   }
 
@@ -23,9 +23,9 @@ describe('Observable.prototype.find', () => {
     const subs =       '^        !       ';
     const expected =   '---------(c|)    ';
 
-    const predicate = function (x) { return x % 5 === 0; };
+    const predicate = function (x: number) { return x % 5 === 0; };
 
-    expectObservable((<any>source).find(predicate)).toBe(expected, values);
+    expectObservable(source.find(predicate)).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -36,20 +36,20 @@ describe('Observable.prototype.find', () => {
   });
 
   it('should not emit if source does not emit', () => {
-    const source = hot('-');
-    const subs =       '^';
-    const expected =   '-';
+    const source = hot<number>('-');
+    const subs =               '^';
+    const expected =           '-';
 
-    expectObservable((<any>source).find(truePredicate)).toBe(expected);
+    expectObservable(source.find(truePredicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should return empty if source is empty to match predicate', () => {
-    const source = cold('|');
-    const subs =        '(^!)';
-    const expected =    '(|)';
+    const source = cold<number>('|');
+    const subs =                '(^!)';
+    const expected =            '(|)';
 
-    const result = (<any>source).find(truePredicate);
+    const result = source.find(truePredicate);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -60,11 +60,11 @@ describe('Observable.prototype.find', () => {
     const subs =       '^ !';
     const expected =   '--(a|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'a';
     };
 
-    expectObservable((<any>source).find(predicate)).toBe(expected);
+    expectObservable(source.find(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -73,11 +73,11 @@ describe('Observable.prototype.find', () => {
     const subs =       '^    !';
     const expected =   '-----(b|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'b';
     };
 
-    expectObservable((<any>source).find(predicate)).toBe(expected);
+    expectObservable(source.find(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -89,11 +89,11 @@ describe('Observable.prototype.find', () => {
     const finder = {
       target: 'b'
     };
-    const predicate = function (value) {
+    const predicate = function (this: typeof finder, value: string) {
       return value === this.target;
     };
 
-    expectObservable((<any>source).find(predicate, finder)).toBe(expected);
+    expectObservable(source.find(predicate, finder)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -102,7 +102,7 @@ describe('Observable.prototype.find', () => {
     const subs =       '^          !';
     const expected =   '-----------|';
 
-    const predicate = (value) => value === 'z';
+    const predicate = (value: string) => value === 'z';
 
     expectObservable(source.find(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -114,7 +114,7 @@ describe('Observable.prototype.find', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source).find((value: string) => value === 'z');
+    const result = source.find((value) => value === 'z');
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -126,10 +126,10 @@ describe('Observable.prototype.find', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source)
-      .mergeMap((x: string) => Observable.of(x))
-      .find((value: string) => value === 'z')
-      .mergeMap((x: string) => Observable.of(x));
+    const result = source
+      .mergeMap((x) => Observable.of(x))
+      .find((value) => value === 'z')
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -140,11 +140,11 @@ describe('Observable.prototype.find', () => {
     const subs =       '^       !';
     const expected =   '--------#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'z';
     };
 
-    expectObservable((<any>source).find(predicate)).toBe(expected);
+    expectObservable(source.find(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -153,11 +153,11 @@ describe('Observable.prototype.find', () => {
     const subs =       '^ !';
     const expected =   '--#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       throw 'error';
     };
 
-    expectObservable((<any>source).find(predicate)).toBe(expected);
+    expectObservable(source.find(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -167,9 +167,9 @@ describe('Observable.prototype.find', () => {
     const subs =       '^        !       ';
     const expected =   '---------(c|)    ';
 
-    const predicate = function (x) { return x % 5 === 0; };
+    const predicate = function (x: number) { return x % 5 === 0; };
 
-    expectObservable((<any>source).find(predicate).let(doNotUnsubscribe)).toBe(expected, values);
+    expectObservable(source.find(predicate).let(doNotUnsubscribe)).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -180,11 +180,11 @@ describe('Observable.prototype.find', () => {
     const subs =       '^ !';
     const expected =   '--#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       throw 'error';
     };
 
-    expectObservable((<any>source).find(predicate).let(doNotUnsubscribe)).toBe(expected);
+    expectObservable(source.find(predicate).let(doNotUnsubscribe)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -1,7 +1,7 @@
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -11,7 +11,7 @@ const Observable = Rx.Observable;
 
 /** @test {findIndex} */
 describe('Observable.prototype.findIndex', () => {
-  function truePredicate(x) {
+  function truePredicate(x: never) {
     return true;
   }
 
@@ -21,9 +21,9 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^        !       ';
     const expected =   '---------(x|)    ';
 
-    const predicate = function (x) { return x % 5 === 0; };
+    const predicate = function (x: number) { return x % 5 === 0; };
 
-    expectObservable((<any>source).findIndex(predicate)).toBe(expected, { x: 2 });
+    expectObservable(source.findIndex(predicate)).toBe(expected, { x: 2 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -32,7 +32,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^';
     const expected =   '-';
 
-    expectObservable((<any>source).findIndex(truePredicate)).toBe(expected);
+    expectObservable(source.findIndex(truePredicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -41,7 +41,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =        '(^!)';
     const expected =    '(x|)';
 
-    const result = (<any>source).findIndex(truePredicate);
+    const result = source.findIndex(truePredicate);
 
     expectObservable(result).toBe(expected, {x: -1});
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -53,11 +53,11 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^ !   ';
     const expected =   '--(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: number) {
       return value === sourceValue;
     };
 
-    expectObservable((<any>source).findIndex(predicate)).toBe(expected, { x: 0 });
+    expectObservable(source.findIndex(predicate)).toBe(expected, { x: 0 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -66,11 +66,11 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^    !';
     const expected =   '-----(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: number) {
       return value === 7;
     };
 
-    expectObservable((<any>source).findIndex(predicate)).toBe(expected, { x: 1 });
+    expectObservable(source.findIndex(predicate)).toBe(expected, { x: 1 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -80,10 +80,10 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^    !';
     const expected =   '-----(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (this: typeof sourceValues, value: number) {
       return value === this.b;
     };
-    const result = (<any>source).findIndex(predicate, sourceValues);
+    const result = source.findIndex(predicate, sourceValues);
 
     expectObservable(result).toBe(expected, { x: 1 });
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -94,11 +94,11 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^          !';
     const expected =   '-----------(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'z';
     };
 
-    expectObservable((<any>source).findIndex(predicate)).toBe(expected, { x: -1 });
+    expectObservable(source.findIndex(predicate)).toBe(expected, { x: -1 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -108,7 +108,7 @@ describe('Observable.prototype.findIndex', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source).findIndex((value: string) => value === 'z');
+    const result = source.findIndex((value) => value === 'z');
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -120,10 +120,10 @@ describe('Observable.prototype.findIndex', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source)
-      .mergeMap((x: string) => Observable.of(x))
-      .findIndex((value: string) => value === 'z')
-      .mergeMap((x: string) => Observable.of(x));
+    const result = source
+      .mergeMap((x) => Observable.of(x))
+      .findIndex((value) => value === 'z')
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -134,11 +134,11 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^       !';
     const expected =   '--------#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'z';
     };
 
-    expectObservable((<any>source).findIndex(predicate)).toBe(expected);
+    expectObservable(source.findIndex(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -147,11 +147,11 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^ !';
     const expected =   '--#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       throw 'error';
     };
 
-    expectObservable((<any>source).findIndex(predicate)).toBe(expected);
+    expectObservable(source.findIndex(predicate)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 });

--- a/spec/operators/map-spec.ts
+++ b/spec/operators/map-spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -11,8 +11,8 @@ declare const expectSubscriptions: typeof marbleTestingSignature.expectSubscript
 const Observable = Rx.Observable;
 
 // function shortcuts
-const addDrama = function (x) { return x + '!'; };
-const identity = function (x) { return x; };
+const addDrama = function (x: number | string) { return x + '!'; };
+const identity = function <T>(x: T) { return x; };
 const throwError = function () { throw new Error(); };
 
 /** @test {map} */
@@ -22,7 +22,7 @@ describe('Observable.prototype.map', () => {
     const asubs =    '^          !';
     const expected = '--x--y--z--|';
 
-    const r = a.map(function (x) { return 10 * parseInt(x); });
+    const r = a.map(function (x) { return 10 * Number(x); });
 
     expectObservable(r).toBe(expected, {x: 10, y: 20, z: 30});
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -61,7 +61,7 @@ describe('Observable.prototype.map', () => {
     const asubs =    '^ !   ';
     const expected = '--#   ';
 
-    const r = a.map((x: any) => {
+    const r = a.map((x) => {
       throw 'too bad';
     });
 
@@ -106,7 +106,7 @@ describe('Observable.prototype.map', () => {
 
     let invoked = 0;
     const r = a
-      .map((x: any) => { invoked++; return x; })
+      .map((x) => { invoked++; return x; })
       .do(null, null, () => {
         expect(invoked).to.equal(0);
       });
@@ -136,7 +136,7 @@ describe('Observable.prototype.map', () => {
     let invoked = 0;
     const r = a.map((x: string, index: number) => {
       invoked++;
-      return (parseInt(x) + 1) + (index * 10);
+      return (Number(x) + 1) + (index * 10);
     }).do(null, null, () => {
       expect(invoked).to.equal(4);
     });
@@ -154,7 +154,7 @@ describe('Observable.prototype.map', () => {
     let invoked = 0;
     const r = a.map((x: string, index: number) => {
       invoked++;
-      return (parseInt(x) + 1) + (index * 10);
+      return (Number(x) + 1) + (index * 10);
     }).do(null, null, () => {
       expect(invoked).to.equal(4);
     });
@@ -172,7 +172,7 @@ describe('Observable.prototype.map', () => {
     let invoked = 0;
     const r = a.map((x: string, index: number) => {
       invoked++;
-      return (parseInt(x) + 1) + (index * 10);
+      return (Number(x) + 1) + (index * 10);
     }).do(null, null, () => {
       expect(invoked).to.equal(4);
     });
@@ -195,7 +195,7 @@ describe('Observable.prototype.map', () => {
       .map(function (x: string, index: number) {
         invoked++;
         expect(this).to.equal(foo);
-        return (parseInt(x) + 1) + (index * 10);
+        return (Number(x) + 1) + (index * 10);
       }, foo)
       .do(null, null, () => {
         expect(invoked).to.equal(4);
@@ -214,8 +214,8 @@ describe('Observable.prototype.map', () => {
     let invoked1 = 0;
     let invoked2 = 0;
     const r = a
-      .map((x: string) => { invoked1++; return parseInt(x) * 2; })
-      .map((x: number) => { invoked2++; return x / 2; })
+      .map((x) => { invoked1++; return Number(x) * 2; })
+      .map((x) => { invoked2++; return x / 2; })
       .do(null, null, () => {
         expect(invoked1).to.equal(7);
         expect(invoked2).to.equal(7);
@@ -231,9 +231,9 @@ describe('Observable.prototype.map', () => {
     const expected = '--a--b--c--d--|';
     const values = {a: 11, b: 14, c: 17, d: 20};
 
-    function Filterer() {
-      this.selector1 = (x: string) => parseInt(x) + 2;
-      this.selector2 = (x: string) => parseInt(x) * 3;
+    class Filterer {
+      selector1 = (x: any) => Number(x) + 2;
+      selector2 = (x: any) => Number(x) * 3;
     }
     const filterer = new Filterer();
 
@@ -253,9 +253,9 @@ describe('Observable.prototype.map', () => {
     const expected = '--x--y-     ';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .map(addDrama)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(r, unsub).toBe(expected, {x: '1!', y: '2!'});
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/partition-spec.ts
+++ b/spec/operators/partition-spec.ts
@@ -2,7 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
-declare const { asDiagram };
+declare const asDiagram: Function;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -12,7 +12,7 @@ const Observable = Rx.Observable;
 
 /** @test {partition} */
 describe('Observable.prototype.partition', () => {
-  function expectObservableArray(result, expected) {
+  function expectObservableArray(result: Rx.Observable<string>[], expected: string[]) {
     for (let idx = 0; idx < result.length; idx++ ) {
       expectObservable(result[idx]).toBe(expected[idx]);
     }
@@ -25,7 +25,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--1-----3---------5------|',
                     '----2----------4------6--|'];
 
-    const result = e1.partition((x: any) => x % 2 === 1);
+    const result = e1.partition((x) => Number(x) % 2 === 1);
 
     expectObservableArray(result, expected);
     expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
@@ -37,7 +37,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----a---------a------|',
                     '----b----------d------c--|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -51,7 +51,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----a---------a------|',
                     '----b----------d------c--|'];
 
-    function predicate(x) {
+    function predicate(this: { value: string }, x: string) {
       return x === this.value;
     }
 
@@ -65,7 +65,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----#',
                     '----b---#'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -79,7 +79,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['#',
                     '#'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -95,7 +95,7 @@ describe('Observable.prototype.partition', () => {
 
     let index = 0;
     const error = 'error';
-    function predicate(x) {
+    function predicate(x: string) {
       const match = x === 'a';
       if (match && index++ > 1) {
         throw error;
@@ -113,7 +113,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['----|',
                     '----|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'x';
     }
 
@@ -127,7 +127,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['|',
                     '|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'x';
     }
 
@@ -141,7 +141,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a--|',
                     '-----|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -155,7 +155,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a--a--a--a--a--a--a--|',
                     '-----------------------|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -169,7 +169,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['-----------------------|',
                     '--b--b--b--b--b--b--b--|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -183,7 +183,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----a-----------',
                     '----b----------d----'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -197,7 +197,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['-',
                     '-'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -212,7 +212,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----          ',
                     '----b---          '];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
     const result = e1.partition(predicate);
@@ -231,10 +231,10 @@ describe('Observable.prototype.partition', () => {
     const unsub =     '       !          ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .partition((x: string) => x === 'a')
+      .mergeMap((x) => Observable.of(x))
+      .partition((x) => x === 'a')
       .map((observable: Rx.Observable<string>) =>
-        observable.mergeMap((x: string) => Observable.of(x)));
+        observable.mergeMap((x) => Observable.of(x)));
 
     expectObservable(result[0], unsub).toBe(expected[0]);
     expectObservable(result[1], unsub).toBe(expected[1]);
@@ -249,7 +249,7 @@ describe('Observable.prototype.partition', () => {
   it('should accept thisArg', () => {
     const thisArg = {};
 
-    Observable.of(1).partition(function (value: number) {
+    Observable.of(1).partition(function (this: typeof thisArg, value: number) {
       expect(this).to.deep.equal(thisArg);
       return true;
     }, thisArg)

--- a/spec/operators/switch-spec.ts
+++ b/spec/operators/switch-spec.ts
@@ -213,7 +213,7 @@ describe('Observable.prototype.switch', () => {
     const expected = [1, 2, 3, 4];
     let completed = false;
 
-    Observable.of<any>(Observable.never(), Observable.never<number>(), [1, 2, 3, 4])
+    Observable.of<any>(Observable.never(), Observable.never(), [1, 2, 3, 4])
       .switch()
       .subscribe((x) => {
         expect(x).to.equal(expected.shift());

--- a/src/operator/every.ts
+++ b/src/operator/every.ts
@@ -17,8 +17,11 @@ import { Subscriber } from '../Subscriber';
  * @method every
  * @owner Observable
  */
-export function every<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                         thisArg?: any): Observable<boolean> {
+export function every<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean): Observable<boolean>;
+export function every<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number, source: Observable<T>) => boolean,
+                               thisArg: This): Observable<boolean>;
+export function every<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number, source: Observable<T>) => boolean,
+                               thisArg?: This): Observable<boolean> {
   return this.lift(new EveryOperator(predicate, thisArg, this));
 }
 

--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -4,12 +4,10 @@ import { Observable } from '../Observable';
 import { TeardownLogic } from '../Subscription';
 
 /* tslint:disable:max-line-length */
-export function filter<T, S extends T>(this: Observable<T>,
-                                       predicate: (value: T, index: number) => value is S,
-                                       thisArg?: any): Observable<S>;
-export function filter<T>(this: Observable<T>,
-                          predicate: (value: T, index: number) => boolean,
-                          thisArg?: any): Observable<T>;
+export function filter<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number) => value is S): Observable<S>;
+export function filter<T, S extends T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number) => value is S, thisArg: This): Observable<S>;
+export function filter<T>(this: Observable<T>, predicate: (value: T, index: number) => boolean): Observable<T>;
+export function filter<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number) => boolean, thisArg: This): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -51,14 +49,12 @@ export function filter<T>(this: Observable<T>,
  * @method filter
  * @owner Observable
  */
-export function filter<T>(this: Observable<T>, predicate: (value: T, index: number) => boolean,
-                          thisArg?: any): Observable<T> {
+export function filter<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number) => boolean, thisArg?: This): Observable<T> {
   return this.lift(new FilterOperator(predicate, thisArg));
 }
 
 class FilterOperator<T> implements Operator<T, T> {
-  constructor(private predicate: (value: T, index: number) => boolean,
-              private thisArg?: any) {
+  constructor(private predicate: (value: T, index: number) => boolean, private thisArg?: any) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {

--- a/src/operator/find.ts
+++ b/src/operator/find.ts
@@ -3,12 +3,10 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
-export function find<T, S extends T>(this: Observable<T>,
-                                     predicate: (value: T, index: number) => value is S,
-                                     thisArg?: any): Observable<S>;
-export function find<T>(this: Observable<T>,
-                        predicate: (value: T, index: number) => boolean,
-                        thisArg?: any): Observable<T>;
+export function find<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number) => value is S): Observable<S>;
+export function find<T, S extends T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number) => value is S, thisArg: This): Observable<S>;
+export function find<T>(this: Observable<T>, predicate: (value: T, index: number) => boolean): Observable<T>;
+export function find<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number) => boolean, thisArg: This): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -44,8 +42,8 @@ export function find<T>(this: Observable<T>,
  * @method find
  * @owner Observable
  */
-export function find<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                        thisArg?: any): Observable<T> {
+export function find<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number, source: Observable<T>) => boolean,
+                              thisArg?: This): Observable<T> {
   if (typeof predicate !== 'function') {
     throw new TypeError('predicate is not a function');
   }

--- a/src/operator/findIndex.ts
+++ b/src/operator/findIndex.ts
@@ -35,7 +35,10 @@ import { FindValueOperator } from './find';
  * @method find
  * @owner Observable
  */
-export function findIndex<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                             thisArg?: any): Observable<number> {
+export function findIndex<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean): Observable<number>;
+export function findIndex<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number, source: Observable<T>) => boolean,
+                                   thisArg: This): Observable<number>;
+export function findIndex<T, This>(this: Observable<T>, predicate: (this: This, value: T, index: number, source: Observable<T>) => boolean,
+                                   thisArg?: This): Observable<number> {
   return <any>this.lift<any>(new FindValueOperator(predicate, this, true, thisArg));
 }

--- a/src/operator/map.ts
+++ b/src/operator/map.ts
@@ -35,7 +35,9 @@ import { Observable } from '../Observable';
  * @method map
  * @owner Observable
  */
-export function map<T, R>(this: Observable<T>, project: (value: T, index: number) => R, thisArg?: any): Observable<R> {
+export function map<T, R>(this: Observable<T>, project: (value: T, index: number) => R): Observable<R>;
+export function map<T, R, This>(this: Observable<T>, project: (this: This, value: T, index: number) => R, thisArg: This): Observable<R>;
+export function map<T, R, This>(this: Observable<T>, project: (this: This, value: T, index: number) => R, thisArg?: This): Observable<R> {
   if (typeof project !== 'function') {
     throw new TypeError('argument is not a function. Are you looking for `mapTo()`?');
   }

--- a/src/operator/partition.ts
+++ b/src/operator/partition.ts
@@ -43,7 +43,10 @@ import { Observable } from '../Observable';
  * @method partition
  * @owner Observable
  */
-export function partition<T>(this: Observable<T>, predicate: (value: T) => boolean, thisArg?: any): [Observable<T>, Observable<T>] {
+export function partition<T>(this: Observable<T>, predicate: (value: T) => boolean): [Observable<T>, Observable<T>];
+export function partition<T, This>(this: Observable<T>, predicate: (this: This, value: T) => boolean, thisArg: This): [Observable<T>, Observable<T>];
+export function partition<T, This>(this: Observable<T>, predicate: (this: This, value: T) => boolean,
+                                   thisArg?: This): [Observable<T>, Observable<T>] {
   return [
     filter.call(this, predicate, thisArg),
     filter.call(this, not(predicate, thisArg))


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
updated all operators to use this context, if they supply a thisArg, (map, filter, etc)

**Related issue (if exists):**
