### PR TITLE
chore(documentation): Update share documentation

### DIFF
--- a/src/operator/share.ts
+++ b/src/operator/share.ts
@@ -10,7 +10,11 @@ function shareSubjectFactory() {
  * Returns a new Observable that multicasts (shares) the original Observable. As long as there is at least one
  * Subscriber this Observable will be subscribed and emitting data. When all subscribers have unsubscribed it will
  * unsubscribe from the source Observable. Because the Observable is multicasting it makes the stream `hot`.
- * This is an alias for .publish().refCount().
+ *
+ * This behaves similarly to .publish().refCount(), with a behavior difference when the source observable emits complete.
+ * .publish().refCount() will not resubscribe to the original source, however .share() will resubscribe to the original source.
+ * Observable.of("test").publish().refCount() will not re-emit "test" on new subscriptions, Observable.of("test").share() will
+ * re-emit "test" to new subscriptions.
  *
  * <img src="./img/share.png" width="100%">
  *


### PR DESCRIPTION
Improve documenation on how .share() is different from .publish().refCount().

Please let me know if I should change the verbage, documentation is hard.