### PR TITLE
fix(build): set tslib as dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -199,7 +199,6 @@
     "sinon": "^2.3.5",
     "sinon-chai": "^2.11.0",
     "source-map-support": "^0.4.0",
-    "tslib": "^1.7.1",
     "tslint": "^5.4.3",
     "typescript": "^2.4.0",
     "validate-commit-msg": "^2.3.1",
@@ -212,6 +211,7 @@
   },
   "typings": "./dist/cjs/Rx.d.ts",
   "dependencies": {
-    "symbol-observable": "^1.0.1"
+    "symbol-observable": "^1.0.1",
+    "tslib": "^1.7.1"
   }
 }


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
we were importing tslib in next major, but didn't bump it up as dependency but left it as devDep.

**Related issue (if exists):**
- closes #2709