### PR TITLE
fix(Notification): Don't reference `this` from static methods.

### DIFF
--- a/src/Notification.ts
+++ b/src/Notification.ts
@@ -107,7 +107,7 @@ export class Notification<T> {
     if (typeof value !== 'undefined') {
       return new Notification('N', value);
     }
-    return this.undefinedValueNotification;
+    return Notification.undefinedValueNotification;
   }
 
   /**
@@ -126,6 +126,6 @@ export class Notification<T> {
    * @return {Notification<any>} The valueless "complete" Notification.
    */
   static createComplete(): Notification<any> {
-    return this.completeNotification;
+    return Notification.completeNotification;
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Fixes bug caused by referencing `this` from static methods. 

**Related issue (if exists):**
