### PR TITLE
Fix (Observable.fromEvent): event listener with options is not removed

### DIFF
--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -130,7 +130,7 @@ export class FromEventObservable<T> extends Observable<T> {
     } else if (isEventTarget(sourceObj)) {
       const source = sourceObj;
       sourceObj.addEventListener(eventName, <EventListener>handler, <boolean>options);
-      unsubscribe = () => source.removeEventListener(eventName, <EventListener>handler);
+      unsubscribe = () => source.removeEventListener(eventName, <EventListener>handler, <boolean>options);
     } else if (isJQueryStyleEventEmitter(sourceObj)) {
       const source = sourceObj;
       sourceObj.on(eventName, handler);


### PR DESCRIPTION
removeEventListener must be called with the same options used in addEventListener

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** This problem is noticeable in combination with Angular2. When having subscribed to and then unsubscribed from an observable created with Observable.fromEvent with options, each time the event is triggered it causes Angular's change detection.

**Related issue (if exists):**
