### PR TITLE
fix(Subject): lift signature is now appropriate for stricter TS 2.4 c…

### DIFF
--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -43,7 +43,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     return new AnonymousSubject<T>(destination, source);
   }
 
-  lift<R>(operator: Operator<T, R>): Observable<T> {
+  lift<R>(operator: Operator<T, R>): Observable<R> {
     const subject = new AnonymousSubject(this, this);
     subject.operator = <any>operator;
     return <any>subject;


### PR DESCRIPTION
…hecks

Type safety wasn't really gauranteed with lift before because we survived for a long time with an incorrect type signature, TypeScript 2.4 introduces stricter type-checking, and all of a sudden `lift` on `Subject` was breaking builds for those that are riding the wave of the latest-and-greatest.

EDIT: Upon review, really not sure of any way this change could break anyone. So I'm going to push this through as a patch. It was basically building with an incorrect type signature in TS 2.3 and lower, so correcting it should not break anyone's builds.
