### PR TITLE
docs(Observable): fix typo

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -18,7 +18,7 @@ export type SubscribableOrPromise<T> = Subscribable<T> | PromiseLike<T>;
 export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T>;
 
 /**
- * A representation of any set of values over any amount of time. This the most basic building block
+ * A representation of any set of values over any amount of time. This is the most basic building block
  * of RxJS.
  *
  * @class Observable<T>
@@ -32,7 +32,7 @@ export class Observable<T> implements Subscribable<T> {
 
   /**
    * @constructor
-   * @param {Function} subscribe the function that is  called when the Observable is
+   * @param {Function} subscribe the function that is called when the Observable is
    * initially subscribed to. This function is given a Subscriber, to which new values
    * can be `next`ed, or an `error` method can be called to raise an error, or
    * `complete` can be called to notify of a successful completion.
@@ -79,7 +79,7 @@ export class Observable<T> implements Subscribable<T> {
    *
    * <span class="informal">Use it when you have all these Observables, but still nothing is happening.</span>
    *
-   * `subscribe` is not a regular operator, but a method that calls Observables internal `subscribe` function. It
+   * `subscribe` is not a regular operator, but a method that calls Observable's internal `subscribe` function. It
    * might be for example a function that you passed to a {@link create} static factory, but most of the time it is
    * a library implementation, which defines what and when will be emitted by an Observable. This means that calling
    * `subscribe` is actually the moment when Observable starts its work, not when it is created, as it is often
@@ -176,7 +176,7 @@ export class Observable<T> implements Subscribable<T> {
    * // Logs:
    * // 0 after 1s
    * // 1 after 2s
-   * // "unsubscribed!" after 2,5s
+   * // "unsubscribed!" after 2.5s
    *
    *
    * @param {Observer|Function} observerOrNext (optional) Either an observer with methods to be called,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fix several typos in document of Observable.ts