### PR TITLE
fix(audit): fix crashes in case of the duration Observable completes

### DIFF
--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -139,6 +139,18 @@ describe('Observable.prototype.audit', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should mirror source if durations are Observable.of()', () => {
+      const e1 =   hot('abcdefabcdefabcdefabcdefa|');
+      const e1subs =   '^                        !';
+      const e2 =  Rx.Observable.of('one single value');
+      const expected = 'abcdefabcdefabcdefabcdefa|';
+
+      const result = e1.audit(() => e2);
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should emit no values if duration is a never', () => {
     const e1 =   hot('----abcdefabcdefabcdefabcdefa|');
     const e1subs =   '^                            !';

--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -139,7 +139,7 @@ describe('Observable.prototype.audit', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should mirror source if durations are Observable.of()', () => {
+  it('should mirror source if durations are synchronous observables', () => {
       const e1 =   hot('abcdefabcdefabcdefabcdefa|');
       const e1subs =   '^                        !';
       const e2 =  Rx.Observable.of('one single value');

--- a/src/operator/audit.ts
+++ b/src/operator/audit.ts
@@ -86,7 +86,7 @@ class AuditSubscriber<T, R> extends OuterSubscriber<T, R> {
         this.destination.error(errorObject.e);
       } else {
         const innerSubscription = subscribeToResult(this, duration);
-        if (innerSubscription.closed) {
+        if (!innerSubscription || innerSubscription.closed) {
           this.clearThrottle();
         } else {
           this.add(this.throttled = innerSubscription);


### PR DESCRIPTION
**Description:**
fix the problem when subscribeToResult() returns null it will crash described by @deadbeef84
**Related issue (if exists):**
fixes #2595 