### PR TITLE
docs: style problem in light theme

### DIFF
--- a/doc/styles/main.css
+++ b/doc/styles/main.css
@@ -112,6 +112,11 @@ body.light-theme .search-result li.selected {
   color: #EC0C8E;
 }
 
+body.light-theme .search-result li a:hover {
+ background: #ddd;
+  
+}
+
 .search-box img {
   -webkit-filter: brightness(1.7);
   filter: brightness(1.7);


### PR DESCRIPTION
When the website  chosen theme is on the light mode, and you search something, mouse hovering on link will make it disappear because the `: hover` of the link is still white but there is not any background (same as dark-theme) for the search-result container. 
The simple style will resolve the problem

The image below show the problem, you will see a white space which is where I put the mouse on a link.

![screenshot from 2017-07-12 17-45-34](https://user-images.githubusercontent.com/7496103/28119724-1aac5554-672b-11e7-8fa3-45cc1fbe8d57.png)
