### PR TITLE
fix(multicast.spec): typo fix

### DIFF
--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -553,7 +553,7 @@ describe('Observable.prototype.multicast', () => {
     connectable.connect();
 
     expect(results1).to.deep.equal([1, 2, 3, 4]);
-    expect(results1).to.deep.equal([1, 2, 3, 4]);
+    expect(results2).to.deep.equal([1, 2, 3, 4]);
     expect(subscriptions).to.equal(1);
     done();
   });


### PR DESCRIPTION
  results1 repeated twice. changed one to results2 to check both
  results1 and results2.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** Bug in tests (misprint?)
**Related issue (if exists):** https://github.com/ReactiveX/rxjs/issues/2698
