### PR TITLE
fix: Make WebSocketSubjectConfig a generic type

### DIFF
--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -10,10 +10,10 @@ import { tryCatch } from '../../util/tryCatch';
 import { errorObject } from '../../util/errorObject';
 import { assign } from '../../util/assign';
 
-export interface WebSocketSubjectConfig {
+export interface WebSocketSubjectConfig<T> {
   url: string;
   protocol?: string | Array<string>;
-  resultSelector?: <T>(e: MessageEvent) => T;
+  resultSelector?: (e: MessageEvent) => T;
   openObserver?: NextObserver<Event>;
   closeObserver?: NextObserver<CloseEvent>;
   closingObserver?: NextObserver<void>;
@@ -75,17 +75,17 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
    *
    * socket$.next(JSON.stringify({ op: 'hello' }));
    *
-   * @param {string | WebSocketSubjectConfig} urlConfigOrSource the source of the websocket as an url or a structure defining the websocket object
+   * @param {string | WebSocketSubjectConfig<T>} urlConfigOrSource the source of the websocket as an url or a structure defining the websocket object
    * @return {WebSocketSubject}
    * @static true
    * @name webSocket
    * @owner Observable
    */
-  static create<T>(urlConfigOrSource: string | WebSocketSubjectConfig): WebSocketSubject<T> {
+  static create<T>(urlConfigOrSource: string | WebSocketSubjectConfig<T>): WebSocketSubject<T> {
     return new WebSocketSubject<T>(urlConfigOrSource);
   }
 
-  constructor(urlConfigOrSource: string | WebSocketSubjectConfig | Observable<T>, destination?: Observer<T>) {
+  constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>) {
     if (urlConfigOrSource instanceof Observable) {
       super(destination, <Observable<T>> urlConfigOrSource);
     } else {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fix typescript type issue for websocket #2754, make `WebSocketSubjectConfig` a generic type, so that it will respect the type T from websocket.

In this way, the type can be inferred correctly from the resultSelector's result type, you can write something like

```typescript
const myWebSocket = webSocket({
  url: 'ws://localhost:8080',
  resultSelector: (e: MessageEvent) => e.data + '!'
})
```

the `myWebSocket` will automatically inferred as `WebSocketSubject<string>`
