### PR TITLE
feat(Subscription): allow subscription.add to accept promise of teardownlogic

### DIFF
--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -112,6 +112,26 @@ describe('Subscription', () => {
       expect(isCalled).to.equal(true);
     });
 
+    it('Should return a new Subscription created with teardown function if it is passed a promise', (done: MochaDone) => {
+      const sub = new Subscription();
+
+      let resolvePromise;
+      let isCalled = false;
+
+      const promise = new Promise(resolve => {
+        resolvePromise = () => resolve(() => isCalled = true);
+      });
+      const ret = sub.add(promise);
+
+      promise.then(() => {
+        ret.unsubscribe();
+      }).then(() => {
+        expect(isCalled).to.equal(true);
+      }).then(() => done(), err => done(err));
+
+      resolvePromise();
+    });
+
     it('Should wrap the AnonymousSubscription and return a subscription that unsubscribes and removes it when unsubbed', () => {
       const sub: any = new Subscription();
       let called = false;


### PR DESCRIPTION
Currently, the following code is not allowed:

```typescript
const observable = new Observable(async subscriber => {
  const value = await getAsyncValue();
  subscriber.next(value);
});
```

and it will yield the following error:
```
Argument of type '(this: Observable<{}>, observer: Subscriber<{}>) => Promise<void>' is not assignable to parameter of type '(this: Observable<{}>, subscriber: Subscriber<{}>) => TeardownLogic'. Type 'Promise<void>' is not assignable to type 'TeardownLogic'. Type 'Promise<void>' is not assignable to type 'AnonymousSubscription'. Property 'unsubscribe' is missing in type 'Promise<void>'.  
```

This is because subscriptions don't allow teardownlogic to be provided through a promise.  This PR adds that functionality to subscriptions. 