### PR TITLE
Fix typings for mergeAll and concatAll

### DIFF
--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -3,6 +3,7 @@ import { Subscribable } from '../Observable';
 import { MergeAllOperator } from './mergeAll';
 
 /* tslint:disable:max-line-length */
+export function concatAll<T>(this: Observable<ArrayLike<T>>): Observable<T>;
 export function concatAll<T>(this: Observable<T>): T;
 export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
 /* tslint:enable:max-line-length */

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -6,6 +6,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { Subscribable } from '../Observable';
 import { subscribeToResult } from '../util/subscribeToResult';
 
+export function mergeAll<T>(this: Observable<ArrayLike<T>>, concurrent?: number): Observable<T>;
 export function mergeAll<T>(this: Observable<T>, concurrent?: number): T;
 export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscribable<R>;
 


### PR DESCRIPTION
```ts
// this is how the typings work
const numbers: number[] = Observable.of([1, 2, 3]).mergeAll();
// this would be correct (I think)
const numbers: Observable<number> = Observable.of([1, 2, 3]).mergeAll();
```

I believe that it is fixed in the next major release #2690