### PR TITLE
docs: fix typo in jsdoc

### DIFF
--- a/src/operator/onErrorResumeNext.ts
+++ b/src/operator/onErrorResumeNext.ts
@@ -37,7 +37,7 @@ export function onErrorResumeNext<T, R>(this: Observable<T>, array: ObservableIn
  * be happening until there is no more Observables left in the series, at which point returned Observable will
  * complete - even if the last subscribed stream ended with an error.
  *
- * `onErrorResumeNext` can be therefore though of as version of {@link concat} operator, which is more permissive
+ * `onErrorResumeNext` can be therefore thought of as version of {@link concat} operator, which is more permissive
  * when it comes to the errors emitted by its input Observables. While `concat` subscribes to the next Observable
  * in series only if previous one successfully completed, `onErrorResumeNext` subscribes even if it ended with
  * an error.


### PR DESCRIPTION
Hi, just noticed this typo when reading the onErrorResumeNext source. Are you interested in stuff like this? Sorry if I'm just creating clutter for you, feel free to close this if that's the case.