### PR TITLE
feat(Subscription): allow Subscription add mutiple teardown logics

### DIFF
--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -179,7 +179,7 @@ describe('Subscription', () => {
       const main = new Subscription();
       main.unsubscribe();
 
-      let isCalled = [];
+      let isCalled: boolean[] = [];
 
       const subscriptions = range(5)
         .map((_, i) => new Subscription(() => {

--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -80,6 +80,10 @@ describe('Subscription', () => {
   });
 
   describe('Subscription.add()', () => {
+    const range = (length: number) =>
+      Array.from({ length })
+        .map((_, i) => i);
+
     it('Should returns the self if the self is passed', () => {
       const sub = new Subscription();
       const ret = sub.add(sub);
@@ -159,6 +163,51 @@ describe('Subscription', () => {
       main.add(child);
 
       expect(isCalled).to.equal(true);
+    });
+
+    it('Should returns the Subscription contains all teardown logics', () => {
+      const sub = new Subscription();
+      const teardowns = [
+        sub, () => 0, { unsubscribe: () => 1 }
+      ];
+      const ret = sub.add( ...teardowns );
+
+      expect((ret as any)._subscriptions.length).to.equal(teardowns.length);
+    });
+
+    it('Should unsubscribe all the passed subscriptions if the self has been unsubscribed', () => {
+      const main = new Subscription();
+      main.unsubscribe();
+
+      let isCalled = [];
+
+      const subscriptions = range(5)
+        .map((_, i) => new Subscription(() => {
+          isCalled[i] = true;
+        }));
+
+      main.add(...subscriptions);
+
+      expect(isCalled).to.deep.equal(range(5).map(() => true));
+    });
+
+    it('Should be able to remove the passed one from subscription', () => {
+      const main = new Subscription();
+
+      let isCalled = range(5).map(() => false);
+
+      const subscriptions = range(5)
+        .map((_, i) => new Subscription(() => {
+          isCalled[i] = true;
+        }));
+
+      const subscription = main.add(...subscriptions);
+
+      subscription.remove(subscriptions[1]);
+
+      main.unsubscribe();
+
+      expect(isCalled).to.deep.equal(range(5).map((i) => i !== 1));
     });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Allow Subscription add multiple teardown logics

**Related issue (if exists):**

resolve https://github.com/ReactiveX/rxjs/issues/2769
