### PR TITLE
refactor(filter): remove extra predicate setting

### DIFF
--- a/src/operator/filter.ts
+++ b/src/operator/filter.ts
@@ -79,7 +79,6 @@ class FilterSubscriber<T> extends Subscriber<T> {
               private predicate: (value: T, index: number) => boolean,
               private thisArg: any) {
     super(destination);
-    this.predicate = predicate;
   }
 
   // the try catch block below is left specifically for


### PR DESCRIPTION
**Description:**
I was looking at the generated javascript today and saw that `this.predicate` was being set twice. The declaration of the `private predicate` should suffice to set the property to the argument. The additional setting is unnecessary.
