### PR TITLE
ErrorObservable changed to subtype of Observable<never>

### DIFF
--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -13,7 +13,7 @@ export interface DispatchArg {
  * @extends {Ignored}
  * @hide true
  */
-export class ErrorObservable extends Observable<any> {
+export class ErrorObservable extends Observable<never> {
 
   /**
    * Creates an Observable that emits no items to the Observer and immediately


### PR DESCRIPTION
**Description:**

`ErrorObservable` was changed to be a subtype of `Observable<never>`.  Also fixed several build issues on the latest TS compiler so I could run the tests.

**Related issue (if exists):**

Fixes #2776