### PR TITLE
fix: mergeAll and concatAll type signatures

### DIFF
--- a/src/operator/concatAll.ts
+++ b/src/operator/concatAll.ts
@@ -1,10 +1,9 @@
-import { Observable } from '../Observable';
-import { Subscribable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { MergeAllOperator } from './mergeAll';
 
 /* tslint:disable:max-line-length */
-export function concatAll<T>(this: Observable<T>): T;
-export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
+export function concatAll<T>(this: Observable<T[]>): Observable<T>;
+export function concatAll<T extends ObservableInput<R>, R>(this: Observable<T>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -1,13 +1,12 @@
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { Operator } from '../Operator';
 import { Observer } from '../Observer';
 import { Subscription } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
-import { Subscribable } from '../Observable';
 import { subscribeToResult } from '../util/subscribeToResult';
 
-export function mergeAll<T>(this: Observable<T>, concurrent?: number): T;
-export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscribable<R>;
+export function mergeAll<T>(this: Observable<T[]>, concurrent?: number): Observable<T>;
+export function mergeAll<T extends ObservableInput<R>, R>(this: Observable<T>, concurrent?: number): Observable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable which


### PR DESCRIPTION
**Description:**
Change the type signatures for mergeAll and concatAll to be correct.
The previous signatures did not work for merging/concatenating an
observable of an array.

**Related issue (if exists):**

Fixes #2759