### PR TITLE
fixes for typescript 2.4

### DIFF
--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -91,7 +91,7 @@ export class FromObservable<T> extends Observable<T> {
         return new FromObservable<T>(ish, scheduler);
       } else if (isArray(ish)) {
         return new ArrayObservable<T>(ish, scheduler);
-      } else if (isPromise(ish)) {
+      } else if (isPromise<T>(ish)) {
         return new PromiseObservable<T>(ish, scheduler);
       } else if (typeof ish[Symbol_iterator] === 'function' || typeof ish === 'string') {
         return new IteratorObservable<T>(ish, scheduler);

--- a/src/operator/catch.ts
+++ b/src/operator/catch.ts
@@ -66,7 +66,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  */
 export function _catch<T, R>(this: Observable<T>, selector: (err: any, caught: Observable<T>) => ObservableInput<R>): Observable<T | R> {
   const operator = new CatchOperator(selector);
-  const caught = this.lift(operator);
+  const caught = this.lift<T>(operator);
   return (operator.caught = caught);
 }
 

--- a/src/operator/defaultIfEmpty.ts
+++ b/src/operator/defaultIfEmpty.ts
@@ -38,7 +38,7 @@ export function defaultIfEmpty<T, R>(this: Observable<T>, defaultValue?: R): Obs
  * @owner Observable
  */
 export function defaultIfEmpty<T, R>(this: Observable<T>, defaultValue: R = null): Observable<T | R> {
-  return this.lift(new DefaultIfEmptyOperator(defaultValue));
+  return this.lift<T>(new DefaultIfEmptyOperator(defaultValue));
 }
 
 class DefaultIfEmptyOperator<T, R> implements Operator<T, T | R> {


### PR DESCRIPTION
TypeScript 2.4 is more strict about assignability with generics,
and in some cases (when calling a generic function) it will infer
that the generic parameter is <{}> rather than the <T> that rxjs
typically wants.

Fix this by explicitly passing <T> in the cases where compilation
fails.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
