### PR TITLE
chore(typings): improve zip typings

### DIFF
--- a/spec/operators/zip-spec.ts
+++ b/spec/operators/zip-spec.ts
@@ -2,6 +2,7 @@ import {expect} from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
+declare const type;
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
@@ -594,5 +595,29 @@ describe('Observable.prototype.zip', () => {
     expectObservable(r, unsub).toBe(expected, { x: ['1', '4'], y: ['2', '5']});
     expectSubscriptions(a.subscriptions).toBe(asubs);
     expectSubscriptions(b.subscriptions).toBe(bsubs);
+  });
+
+  type('should support rest parameter observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let o: Rx.Observable<number>;
+    let z: Rx.Observable<number>[];
+    let a: Rx.Observable<number[]> = o.zip(...z);
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type('should support projected rest parameter observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let o: Rx.Observable<number>;
+    let z: Rx.Observable<number>[];
+    let a: Rx.Observable<string[]> = o.zip(...z, (...r) => r.map(v => v.toString()));
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type('should support projected arrays of observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let o: Rx.Observable<number>;
+    let z: Rx.Observable<number>[];
+    let a: Rx.Observable<string[]> = o.zip(z, (...r) => r.map(v => v.toString()));
+    /* tslint:enable:no-unused-variable */
   });
 });

--- a/src/operator/zip.ts
+++ b/src/operator/zip.ts
@@ -21,6 +21,7 @@ export function zipProto<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>
 export function zipProto<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<[T, T2, T3, T4]>;
 export function zipProto<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<[T, T2, T3, T4, T5]>;
 export function zipProto<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<[T, T2, T3, T4, T5, T6]> ;
+export function zipProto<T>(this: Observable<T>, ...observables: Array<ObservableInput<T>>): Observable<T[]>;
 export function zipProto<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): Observable<R>;
 export function zipProto<T, R>(this: Observable<T>, array: Array<ObservableInput<T>>): Observable<R>;
 export function zipProto<T, TOther, R>(this: Observable<T>, array: Array<ObservableInput<TOther>>, project: (v1: T, ...values: Array<TOther>) => R): Observable<R>;


### PR DESCRIPTION
Add signature to zipProto so it's consistent with zipStatic.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** Add a rest parameters signature that does not include a `project` function.

At the moment, `zipProto` is not consistent with `zipStatic`, as the only rest parameter signature accounts for a project function, and if it's not specified, the result is of type `Observable<{}>` - losing the type information.

**Related issue (if exists):** #2784 
