### PR TITLE
fix(subscribeToResult): throw error in subscriber with inner observable

### DIFF
--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -1,9 +1,11 @@
-import {expect} from 'chai';
+import { expect } from 'chai';
 import * as Rx from '../../dist/cjs/Rx';
-import {subscribeToResult} from '../../dist/cjs/util/subscribeToResult';
-import {OuterSubscriber} from '../../dist/cjs/OuterSubscriber';
-import {$$iterator} from '../../dist/cjs/symbol/iterator';
+import { subscribeToResult } from '../../dist/cjs/util/subscribeToResult';
+import { OuterSubscriber } from '../../dist/cjs/OuterSubscriber';
+import { $$iterator } from '../../dist/cjs/symbol/iterator';
 import $$symbolObservable from 'symbol-observable';
+import { Observable } from '../../dist/cjs/Observable';
+import { Subject } from '../../dist/cjs/Subject';
 
 describe('subscribeToResult', () => {
   it('should synchronously complete when subscribe to scalarObservable', () => {
@@ -59,7 +61,7 @@ describe('subscribeToResult', () => {
   });
 
   it('should subscribe to an array-like and emit synchronously', () => {
-    const result = {0: 0, 1: 1, 2: 2, length: 3};
+    const result = { 0: 0, 1: 1, 2: 2, length: 3 };
     const expected = [];
 
     const subscriber = new OuterSubscriber(x => expected.push(x));
@@ -105,12 +107,13 @@ describe('subscribeToResult', () => {
 
     const iterable = {
       [$$iterator]: () => {
-      return {
-        next: () => {
-          return iteratorResults.shift();
-        }
-      };
-    }};
+        return {
+          next: () => {
+            return iteratorResults.shift();
+          }
+        };
+      }
+    };
 
     const subscriber = new OuterSubscriber((x: number) => expected = x);
 
@@ -176,5 +179,15 @@ describe('subscribeToResult', () => {
     });
 
     subscribeToResult(subscriber, null);
+  });
+
+  it('should not swallow exception in inner subscriber', () => {
+    const source = new Subject();
+
+    source.mergeMapTo(Observable.of(1, 2, 3)).subscribe(() => {
+      throw new Error('meh');
+    });
+
+    expect(() => source.next()).to.throw();
   });
 });

--- a/src/util/subscribeToResult.ts
+++ b/src/util/subscribeToResult.ts
@@ -30,6 +30,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
       destination.complete();
       return null;
     } else {
+      destination.syncErrorThrowable = true;
       return result.subscribe(destination);
     }
   } else if (isArrayLike(result)) {


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
#2626 fixed error to be thrown when observable have sources, but it doesn't cover cases of inner observable with `subscribeToResult` as it doesn't have sources. This PR explicitly sets subscriber's `syncErrorThrowable` for inner observables, let exception in subscribers correctly thrown with inner observables as well.

**Related issue (if exists):**
- closes #2618