### PR TITLE
fix(GenerateObservable): fix type definition for GenerateObservable

### DIFF
--- a/src/observable/GenerateObservable.ts
+++ b/src/observable/GenerateObservable.ts
@@ -1,11 +1,11 @@
 import { IScheduler } from '../Scheduler';
 import { Action } from '../scheduler/Action';
-import { Observable } from '../Observable' ;
+import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { isScheduler } from '../util/isScheduler';
 
-const selfSelector = <T>(value: T) => value;
+const selfSelector = <S, T>(state: S): T => (state as any) as T;
 
 export type ConditionFunc<S> = (state: S) => boolean;
 export type IterateFunc<S> = (state: S) => S;
@@ -60,7 +60,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
               private iterate: IterateFunc<S>,
               private resultSelector: ResultFunc<S, T>,
               private scheduler?: IScheduler) {
-      super();
+    super();
   }
 
   /**
@@ -208,7 +208,8 @@ export class GenerateObservable<T, S> extends Observable<T> {
         iterate: this.iterate,
         condition: this.condition,
         resultSelector: this.resultSelector,
-        state });
+        state
+      });
     }
     const { condition, resultSelector, iterate } = this;
     do {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
