### PR TITLE
feat(isEmpty): add higher-order lettable version of isEmpty

### DIFF
--- a/src/operator/isEmpty.ts
+++ b/src/operator/isEmpty.ts
@@ -1,6 +1,6 @@
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
+
 import { Observable } from '../Observable';
+import { isEmpty as higherOrder } from '../operators';
 
 /**
  * If the source Observable is empty it returns an Observable that emits true, otherwise it emits false.
@@ -12,37 +12,5 @@ import { Observable } from '../Observable';
  * @owner Observable
  */
 export function isEmpty<T>(this: Observable<T>): Observable<boolean> {
-  return this.lift(new IsEmptyOperator());
-}
-
-class IsEmptyOperator implements Operator<any, boolean> {
-  call (observer: Subscriber<boolean>, source: any): any {
-    return source.subscribe(new IsEmptySubscriber(observer));
-  }
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class IsEmptySubscriber extends Subscriber<any> {
-  constructor(destination: Subscriber<boolean>) {
-    super(destination);
-  }
-
-  private notifyComplete(isEmpty: boolean): void {
-    const destination = this.destination;
-
-    destination.next(isEmpty);
-    destination.complete();
-  }
-
-  protected _next(value: boolean) {
-    this.notifyComplete(false);
-  }
-
-  protected _complete() {
-    this.notifyComplete(true);
-  }
+  return higherOrder()(this);
 }

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -31,6 +31,7 @@ export { findIndex } from './findIndex';
 export { first } from './first';
 export { groupBy } from './groupBy';
 export { ignoreElements } from './ignoreElements';
+export { isEmpty } from './isEmpty';
 export { map } from './map';
 export { materialize } from './materialize';
 export { max } from './max';

--- a/src/operators/isEmpty.ts
+++ b/src/operators/isEmpty.ts
@@ -1,0 +1,40 @@
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Observable } from '../Observable';
+import { OperatorFunction } from '../interfaces';
+
+export function isEmpty<T>(): OperatorFunction<T, boolean> {
+  return (source: Observable<T>) => source.lift(new IsEmptyOperator());
+}
+
+class IsEmptyOperator implements Operator<any, boolean> {
+  call (observer: Subscriber<boolean>, source: any): any {
+    return source.subscribe(new IsEmptySubscriber(observer));
+  }
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
+class IsEmptySubscriber extends Subscriber<any> {
+  constructor(destination: Subscriber<boolean>) {
+    super(destination);
+  }
+
+  private notifyComplete(isEmpty: boolean): void {
+    const destination = this.destination;
+
+    destination.next(isEmpty);
+    destination.complete();
+  }
+
+  protected _next(value: boolean) {
+    this.notifyComplete(false);
+  }
+
+  protected _complete() {
+    this.notifyComplete(true);
+  }
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
