### PR TITLE
feat: `Observable.fromDOMObserver`: adapts MutationObserver and friends

### DIFF
--- a/spec/observables/dom/fromDOMObserver-spec.ts
+++ b/spec/observables/dom/fromDOMObserver-spec.ts
@@ -1,0 +1,116 @@
+import {expect} from 'chai';
+import * as Rx from '../../../dist/cjs/Rx';
+import marbleTestingSignature = require('../../helpers/marble-testing'); // tslint:disable-line:no-require-imports
+
+declare const { asDiagram };
+declare const expectObservable: typeof marbleTestingSignature.expectObservable;
+declare const rxTestScheduler: Rx.TestScheduler;
+
+const Observable = Rx.Observable;
+
+type RecordCallback = (record: any, ...rest: any[]) => void;
+
+/** @test {fromDOMObserver} */
+describe('Observable.fromDOMObserver', () => {
+  let observerInstance;
+  class MockDOMObserver {
+    protected _args: any[];
+    protected _connected: boolean;
+
+    constructor(protected _callback: RecordCallback) {
+      observerInstance = this;
+    }
+    observe(...args: any[]) {
+      this._args = args;
+      this._connected = true;
+    }
+    disconnect() {
+      this._connected = false;
+    }
+  }
+
+  beforeEach(() => {
+    observerInstance = null;
+  });
+
+  it('does not construct a DOM Observer until the Rx Observable is subscribed to', () => {
+    const o = Observable.fromDOMObserver(MockDOMObserver, 'some', 'additional', {args: true});
+    expect(observerInstance).to.be.null;
+
+    /* tslint:disable:no-empty */
+    const subscription = o.subscribe(() => {});
+    /* tslint:enable:no-empty */
+    expect(observerInstance).not.to.be.null;
+    expect(observerInstance._args).to.deep.equal(['some', 'additional', {args: true}]);
+    expect(observerInstance._connected).to.be.true;
+    subscription.unsubscribe();
+  });
+
+  it('calls `disconnect` on the underlying DOM Observer', () => {
+    const o = Observable.fromDOMObserver(MockDOMObserver, 'some', 'additional', {args: true});
+
+    /* tslint:disable:no-empty */
+    const subscription = o.subscribe(() => {});
+    /* tslint:enable:no-empty */
+    expect(observerInstance._connected).to.be.true;
+    subscription.unsubscribe();
+    expect(observerInstance._connected).to.be.false;
+  });
+
+  asDiagram('fromDOMObserver that emits arrays')
+  ('should create an observable of the individual elements of the array emitted from the DOM Observer', () => {
+    class MockDOMObserverEmitsArray extends MockDOMObserver {
+      observe(...args: any[]) {
+        super.observe(...args);
+        Observable.timer(50, 60, rxTestScheduler)
+          .mapTo(['foo', 'bar', 'baz'])
+          .take(2)
+          .subscribe(this._callback);
+        }
+    }
+
+    const e1 = Observable.fromDOMObserver(MockDOMObserverEmitsArray, 'some', 'additional', {args: true});
+
+    const expected = '-----(xyz)-(xyz)---';
+    expectObservable(e1).toBe(expected, {x: 'foo', y: 'bar', z: 'baz'});
+  });
+
+  asDiagram('fromDOMObserver that emits an entryList ({ getEntries: () => any[] })')
+  ('should create an observable of the individual elements of the array returned ' +
+   'from the getEntries method of the entrylist emitted from the DOM Observer', () => {
+    class MockDOMObserverEmitsEntryList extends MockDOMObserver {
+      observe(...args: any[]) {
+        super.observe(...args);
+        Observable.timer(50, 60, rxTestScheduler)
+          .mapTo({
+            getEntries: () => ['foo', 'bar', 'baz']
+          })
+          .take(2)
+          .subscribe(this._callback);
+        }
+    }
+
+    const e1 = Observable.fromDOMObserver(MockDOMObserverEmitsEntryList, 'some', 'additional', {args: true});
+
+    const expected = '-----(xyz)-(xyz)---';
+    expectObservable(e1).toBe(expected, {x: 'foo', y: 'bar', z: 'baz'});
+  });
+
+  asDiagram('fromDOMObserver that emits any object')
+  ('should create an observable of the records emitted from the DOM Observer', () => {
+    class MockDOMObserverEmitsAnything extends MockDOMObserver {
+      observe(...args: any[]) {
+        super.observe(...args);
+        Observable.timer(50, 20, rxTestScheduler)
+          .mapTo('record')
+          .take(2)
+          .subscribe(this._callback);
+        }
+    }
+
+    const e1 = Observable.fromDOMObserver(MockDOMObserverEmitsAnything, 'some', 'additional', {args: true});
+
+    const expected = '-----x-x---';
+    expectObservable(e1).toBe(expected, {x: 'record'});
+  });
+});

--- a/src/Rx.ts
+++ b/src/Rx.ts
@@ -36,6 +36,7 @@ import './add/observable/zip';
 
 //dom
 import './add/observable/dom/ajax';
+import './add/observable/dom/fromDOMObserver';
 import './add/observable/dom/webSocket';
 
 //operators

--- a/src/add/observable/dom/fromDOMObserver.ts
+++ b/src/add/observable/dom/fromDOMObserver.ts
@@ -1,0 +1,10 @@
+import { Observable } from '../../../Observable';
+import { fromDOMObserver as staticFromDOMObserver } from '../../../observable/dom/fromDOMObserver';
+
+Observable.fromDOMObserver = staticFromDOMObserver;
+
+declare module '../../../Observable' {
+  namespace Observable {
+    export let fromDOMObserver: typeof staticFromDOMObserver;
+  }
+}

--- a/src/observable/dom/FromDOMObserverObservable.ts
+++ b/src/observable/dom/FromDOMObserverObservable.ts
@@ -1,0 +1,94 @@
+import { Observable } from '../../Observable';
+import { isArray } from '../../util/isArray';
+import { Subscriber } from '../../Subscriber';
+
+export type RecordCallback = (record: any, ...rest: any[]) => void;
+
+export interface DOMObserver {
+  new (callback: RecordCallback, ...rest: any[]): DOMObserver;
+  observe(...rest: any[]): void;
+  disconnect(): void;
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @extends {Ignored}
+ * @hide true
+ */
+export class FromDOMObserverObservable<T> extends Observable<T> {
+  // Arguments to the Observer's `.observe()` method
+  private observeArgs: any[];
+
+  static create<T>(DOMObserverCtor: any, ...args: any[]): Observable<T>;
+
+  /**
+   * Creates an observable sequence from a DOM-style Observer.
+   *
+   * Emits individual items in the observable even if they were returned as batched
+   * array or EntryList (as with PerformanceObservers) in the original DOM Observable.
+   *
+   * Known to work with DOM `MutationObserver`, `IntersectionObserver`, and `PerformanceObserver`
+   *
+   * A DOM-style Observer is defined as implementing the following interface:
+   *
+   *  export interface DOMObserver {
+   *   constructor: new (callback: Function, ...rest: any[]) => DOMObserver;
+   *    observe(...rest: any[]): void;
+   *    disconnect(): void;
+   *  }
+   *
+   * @example
+   *  var mutations = Rx.DOM.fromDOMObserver(
+   *   MutationObserver,
+   *   document.getElementById('foo'),
+   *   { attributes: true, childList: true, characterData: true }
+   *  );
+   *
+   * mutations.subscribe(record => console.log(record));
+   *
+   * // Results in:
+   * // MutationRecord objects logged *individually* to console every time
+   * // a mutation occurs. Note that typically DOM MutationObservers provide
+   * // lists of records at a time. Instead, individual records are synchonrously
+   * // emitted from the RxJS Observable.
+   *
+   * @param {Function} ObserverCtor The constructor for the DOM Observer
+   *   (e.g. MutationObserver, PerformanceObserver, IntersectionObserver, etc)
+   * @param {...*} args The remainder of arguments corresponding to the DOM Observer's `observe` method
+   * @return {Obsevable<T>} An observable sequence which emits individual entries from the DOM Observer
+   * @static true
+   * @name fromDOMObserver
+   * @owner Observable
+   */
+
+  static create<T>(DOMObserverCtor: Function, ...args: any[]): Observable<T> {
+    return new FromDOMObserverObservable(DOMObserverCtor, ...args);
+  }
+
+  constructor(private ObserverCtor: any, ...observeArgs: any[]) {
+    super();
+    this.observeArgs = observeArgs;
+  }
+
+  protected _subscribe(subscriber: Subscriber<T>) {
+    const domObserver = new this.ObserverCtor((record: any) => {
+      let entries: any[];
+      if (typeof record.getEntries === 'function') {
+        // An EntryList, such as a PerformanceObserverEntryList
+        entries = record.getEntries();
+      } else if (isArray(record)) {
+        entries = record;
+      } else {
+        subscriber.next(record);
+        return;
+      }
+
+      for (let i = 0; i < entries.length; i++) {
+        subscriber.next(entries[i]);
+      }
+    });
+
+    subscriber.add(() => domObserver.disconnect());
+    domObserver.observe(...this.observeArgs);
+  }
+}

--- a/src/observable/dom/fromDOMObserver.ts
+++ b/src/observable/dom/fromDOMObserver.ts
@@ -1,0 +1,3 @@
+import { FromDOMObserverObservable } from './FromDOMObserverObservable';
+
+export const fromDOMObserver = FromDOMObserverObservable.create;


### PR DESCRIPTION
This adapts the following interface, which is becoming more and more popular in DOM apis nowadays, to RxJS Observables:

```js
type RecordCallback = (record: any, ...rest: any[]) => void;
interface DOMObserver {
  new (callback: RecordCallback, ...rest: any[]): DOMObserver;
  observe(...rest: any[]): void;
  disconnect(): void;
}
```

In practice, this means that it can adapt `MutationObserver`, `IntersectionObserver`, `ResizeObserver`, and `PerformanceObserver` to RxJS Observables.

While the DOMObserver yields lists of records (or an object that produces such a list), the returned RxJS Observable `next()`s each individual record at a time.

For example, here's a use of retrieving an observable for `MutationObserver`:

```js
var mutations = Rx.DOM.fromDOMObserver(
  MutationObserver,
  document.getElementById('foo'),
  { attributes: true, childList: true, characterData: true }
);

mutations.subscribe(record => console.log(record));
```

This `next()`s, and therefore logs, each individual [MutationRecord](https://developer.mozilla.org/en-US/docs/Web/API/MutationRecord) on the returned Observable.

If there's a trivial way to create more integration-style tests with real examples from the dom, I'd be happy to provide these to add confidence.

This particular dom api appears to have no way of signaling error or completion (much like `addEventListener`), so there is no equivalent in the returned Observable.