### PR TITLE
fix(partition): update signature to match docs and filter operator

### DIFF
--- a/spec/operators/partition-spec.ts
+++ b/spec/operators/partition-spec.ts
@@ -45,6 +45,20 @@ describe('Observable.prototype.partition', () => {
     expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
   });
 
+  it('should partition an observable into two using a predicate that takes an index', () => {
+    const e1 =    hot('--a-b---a------d--e---c--|');
+    const e1subs =    '^                        !';
+    const expected = ['--a-----a---------e------|',
+                      '----b----------d------c--|'];
+
+    function predicate(value, index: number) {
+      return index % 2 === 0;
+    }
+
+    expectObservableArray(e1.partition(predicate), expected);
+    expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
+  });
+
   it('should partition an observable into two using a predicate and thisArg', () => {
     const e1 =    hot('--a-b---a------d--a---c--|');
     const e1subs =    '^                        !';

--- a/src/operator/partition.ts
+++ b/src/operator/partition.ts
@@ -41,6 +41,6 @@ import { partition as higherOrder } from '../operators/partition';
  * @method partition
  * @owner Observable
  */
-export function partition<T>(this: Observable<T>, predicate: (value: T) => boolean, thisArg?: any): [Observable<T>, Observable<T>] {
+export function partition<T>(this: Observable<T>, predicate: (value: T, index: number) => boolean, thisArg?: any): [Observable<T>, Observable<T>] {
   return higherOrder(predicate, thisArg)(this);
 }

--- a/src/operators/partition.ts
+++ b/src/operators/partition.ts
@@ -44,7 +44,8 @@ import { UnaryFunction } from '../interfaces';
  * @method partition
  * @owner Observable
  */
-export function partition<T>(predicate: (value: T, index: number) => boolean, thisArg?: any): UnaryFunction<Observable<T>, [Observable<T>, Observable<T>]> {
+export function partition<T>(predicate: (value: T, index: number) => boolean,
+                             thisArg?: any): UnaryFunction<Observable<T>, [Observable<T>, Observable<T>]> {
   return (source: Observable<T>) => [
     filter(predicate, thisArg)(source),
     filter(not(predicate, thisArg) as any)(source)

--- a/src/operators/partition.ts
+++ b/src/operators/partition.ts
@@ -44,7 +44,7 @@ import { UnaryFunction } from '../interfaces';
  * @method partition
  * @owner Observable
  */
-export function partition<T>(predicate: (value: T) => boolean, thisArg?: any): UnaryFunction<Observable<T>, [Observable<T>, Observable<T>]> {
+export function partition<T>(predicate: (value: T, index: number) => boolean, thisArg?: any): UnaryFunction<Observable<T>, [Observable<T>, Observable<T>]> {
   return (source: Observable<T>) => [
     filter(predicate, thisArg)(source),
     filter(not(predicate, thisArg) as any)(source)


### PR DESCRIPTION
**Description:**

This PR adds the index parameter to the predicate signature for the partition operator. This change matches the docs as well as the existing `filter` operator.
