### PR TITLE
Add jsDelivr links

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,8 +120,9 @@ npm install @reactivex/rxjs@5.0.0
 
 ### CDN
 
-For CDN, you can use [unpkg](https://unpkg.com/):
+For CDN, you can use [jsDelivr](https://www.jsdelivr.com/package/npm/rxjs) or [unpkg](https://unpkg.com/):
   
+https://cdn.jsdelivr.net/npm/rxjs@5.4.3/bundles/Rx.min.js
 https://unpkg.com/rxjs/bundles/Rx.min.js
 
 #### Node.js Usage:

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "5.4.3",
   "description": "Reactive Extensions for modern JavaScript",
   "main": "index.js",
+  "jsdelivr": "bundles/Rx.min.js",
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"


### PR DESCRIPTION
[jsDelivr](https://www.jsdelivr.com/) is the [fastest opensource cdn](https://www.cdnperf.com/) available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg. This PR adds it to the readme as an alternative to unpkg.