### PR TITLE
docs: Fix case of Observable imports in lettables

### DIFF
--- a/doc/lettable-operators.md
+++ b/doc/lettable-operators.md
@@ -34,7 +34,7 @@ There is also a `pipe` utility function at `rxjs/utils/pipe` that can be used to
 You pull in any operator you need from one spot, under `'rxjs/operators'` (**plural!**). It's also recommended to pull in the Observable creation methods you need directly as shown below with `range`:
 
 ```ts
-import { range } from 'rxjs/observable/range';
+import { range } from 'rxjs/Observable/range';
 import { map, filter, scan } from 'rxjs/operators';
 
 const source$ = range(0, 10);
@@ -52,7 +52,7 @@ source$.pipe(
 You, in fact, could _always_ do this with `let`... but building your own operator is as simple as writing a function now. Notice, that you can compose your custom operator in with other rxjs operators seamlessly.
 
 ```ts
-import { interval } from 'rxjs/observable/interval';
+import { interval } from 'rxjs/Observable/interval';
 import { map, take, toArray } from 'rxjs/operators';
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** The imports were wrong and this was stinging me when deploying to Heroku (linux) but didn't fail on OSX locally

**Related issue (if exists):** Casing is confusing as it causes issues across OSes
