### PR TITLE
fix(Subscriber): creates subscriber throwable by default

### DIFF
--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -39,7 +39,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
 
   public syncErrorValue: any = null;
   public syncErrorThrown: boolean = false;
-  public syncErrorThrowable: boolean = false;
+  public syncErrorThrowable: boolean = true;
 
   protected isStopped: boolean = false;
   protected destination: PartialObserver<any>; // this `any` is the escape hatch to erase extra type param (e.g. R)
@@ -60,10 +60,12 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     switch (arguments.length) {
       case 0:
         this.destination = emptyObserver;
+        this.syncErrorThrowable = false;
         break;
       case 1:
         if (!destinationOrNext) {
           this.destination = emptyObserver;
+          this.syncErrorThrowable = false;
           break;
         }
         if (typeof destinationOrNext === 'object') {
@@ -71,13 +73,11 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
             this.destination = (<Subscriber<any>> destinationOrNext);
             (<any> this.destination).add(this);
           } else {
-            this.syncErrorThrowable = true;
             this.destination = new SafeSubscriber<T>(this, <PartialObserver<any>> destinationOrNext);
           }
           break;
         }
       default:
-        this.syncErrorThrowable = true;
         this.destination = new SafeSubscriber<T>(this, <((value: T) => void)> destinationOrNext, error, complete);
         break;
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**I have gut feeling this might not be appropriate fix, feel free to close.**

This PR ensure subscriber created internally have nested parents (i.e CombineLatestSubscriber has Mergemap as parents, etcs) are having proper syncErrorThrown behavior. Previously it bypasses setting syncError* property as well as wrapping it into safesubscriber, allows some of cases errors are not thrown but just swallowed.

**Related issue (if exists):**
- closes #2813