### PR TITLE
fix(build): make CJS references to import X from '../operators' work …

### DIFF
--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,0 +1,1 @@
+export * from './operators/index';


### PR DESCRIPTION
…correctly with SystemJS

The problem with using `index.ts` exports in sources is when we do something like:

`import { merge as higherOrder } from '../operators';`

This works fine with Node module resolution. The generated code becomes:

`var operators_1 = require('../operators');`

When using SystemJS and a `defaultExtension` configuration of `js`, the HTTP request becomes:

`GET ROOT_URL/_cjs/operators.js`

Which doesn't exist. This PR adds the `operators.js` file that explicitly re-exports `/operators/index` so SystemJS resolution will work.