### PR TITLE
fix(build): make build_test run the minimum to speed it up

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -86,28 +86,34 @@ mkdirp.sync(PKG_ROOT);
 // Copy over the sources
 copySources('src/', PKG_ROOT + 'src/');
 copySources(CJS_ROOT, CJS_PKG);
-copySources(ESM5_ROOT, ESM5_PKG);
-copySources(ESM2015_ROOT, ESM2015_PKG);
 fs.copySync(TYPE_ROOT, TYPE_PKG);
+
+copySources(ESM5_ROOT, ESM5_PKG, true);
+copySources(ESM2015_ROOT, ESM2015_PKG, true);
+
 
 fs.writeJsonSync(PKG_ROOT + 'package.json', rootPackageJson);
 
-fs.copySync(UMD_ROOT, UMD_PKG);
-// Add licenses to tops of bundles
-addLicenseToFile('LICENSE.txt', UMD_PKG + 'Rx.js');
-addLicenseTextToFile(license, UMD_PKG + 'Rx.min.js');
-addLicenseToFile('LICENSE.txt', UMD_PKG + 'Rx.js');
-addLicenseTextToFile(license, UMD_PKG + 'Rx.min.js');
+if (fs.existsSync(UMD_ROOT)) {
+  fs.copySync(UMD_ROOT, UMD_PKG);
+  // Add licenses to tops of bundles
+  addLicenseToFile('LICENSE.txt', UMD_PKG + 'Rx.js');
+  addLicenseTextToFile(license, UMD_PKG + 'Rx.min.js');
+  addLicenseToFile('LICENSE.txt', UMD_PKG + 'Rx.js');
+  addLicenseTextToFile(license, UMD_PKG + 'Rx.min.js');
+}
 
-// Copy over the ESM5 files
-fs.copySync(ESM5_ROOT, ESM5_PKG);
-
-function copySources(rootDir, packageDir, packageJson) {
+function copySources(rootDir, packageDir, ignoreMissing) {
+  // If we are ignoring missing directories, early return when source doesn't exist
+  if (!fs.existsSync(rootDir)) {
+    if (ignoreMissing) {
+      return;
+    } else {
+      throw "Source root dir does not exist!";
+    }
+  }
   // Copy over the CommonJS files
   fs.copySync(rootDir, packageDir);
   fs.copySync('./LICENSE.txt', packageDir + 'LICENSE.txt');
   fs.copySync('./README.md', packageDir + 'README.md');
-  if (packageJson) {
-    fs.writeJsonSync(packageDir + 'package.json', packageJson);
-  }
 }

--- a/package.json
+++ b/package.json
@@ -68,7 +68,7 @@
     "build_global": "npm-run-all clean_dist_global build_esm5_for_rollup && mkdirp ./dist/global && node ./tools/make-umd-bundle.js && npm-run-all build_closure_core clean_dist_esm5_for_rollup",
     "build_umd": "npm-run-all clean_dist_global && mkdirp ./dist/global && node ./tools/make-umd-bundle.js && npm-run-all build_closure_core",
     "build_perf": "webdriver-manager update && npm-run-all build_cjs build_global perf",
-    "build_test": "shx rm -rf ./dist/ && npm-run-all build_all clean_spec build_spec test_mocha",
+    "build_test": "shx rm -rf ./dist/ && npm-run-all copy_sources build_cjs generate_packages clean_spec build_spec test_mocha",
     "build_cover": "shx rm -rf ./dist/ && npm-run-all build_all build_spec cover",
     "build_docs": "npm-run-all build_global build_esm2015_for_docs build_cjs clean_spec build_spec tests2png decision_tree_widget && esdoc -c esdoc.json && npm-run-all clean_dist_esm2015",
     "build_spec": "tsc --project ./spec --pretty",


### PR DESCRIPTION
Changing the build slowed down the `npm run build_test` command significantly. This PR should improve speed by only building one copy of the sources. It still runs the same packaging code, skipping packaging of ESM5 and ESM2015.