### PR TITLE
chore(typings): unwrap it-wrapped type tests

### DIFF
--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -480,66 +480,66 @@ describe('Observable.combineLatest', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-    type('should support promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let b: Promise<string>;
-      let c: Promise<boolean>;
-      let o1: Rx.Observable<[number, string, boolean]> = Observable.combineLatest(a, b, c);
-      let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let b: Promise<string>;
+    let c: Promise<boolean>;
+    let o1: Rx.Observable<[number, string, boolean]> = Observable.combineLatest(a, b, c);
+    let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support observables', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>;
-      let b: Rx.Observable<string>;
-      let c: Rx.Observable<boolean>;
-      let o1: Rx.Observable<[number, string, boolean]> = Observable.combineLatest(a, b, c);
-      let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>;
+    let b: Rx.Observable<string>;
+    let c: Rx.Observable<boolean>;
+    let o1: Rx.Observable<[number, string, boolean]> = Observable.combineLatest(a, b, c);
+    let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support mixed observables and promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let b: Rx.Observable<string>;
-      let c: Promise<boolean>;
-      let d: Rx.Observable<string[]>;
-      let o1: Rx.Observable<[number, string, boolean, string[]]> = Observable.combineLatest(a, b, c, d);
-      let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, d, (aa, bb, cc, dd) => !!aa && !!bb && cc && !!dd.length);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support mixed observables and promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let b: Rx.Observable<string>;
+    let c: Promise<boolean>;
+    let d: Rx.Observable<string[]>;
+    let o1: Rx.Observable<[number, string, boolean, string[]]> = Observable.combineLatest(a, b, c, d);
+    let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, d, (aa, bb, cc, dd) => !!aa && !!bb && cc && !!dd.length);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support arrays of promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>[];
-      let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
-      let o2: Rx.Observable<number[]> = Observable.combineLatest(...a);
-      let o3: Rx.Observable<number> = Observable.combineLatest(a, (...x) => x.length);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support arrays of promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>[];
+    let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
+    let o2: Rx.Observable<number[]> = Observable.combineLatest(...a);
+    let o3: Rx.Observable<number> = Observable.combineLatest(a, (...x) => x.length);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support arrays of observables', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>[];
-      let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
-      let o2: Rx.Observable<number[]> = Observable.combineLatest(...a);
-      let o3: Rx.Observable<number> = Observable.combineLatest(a, (...x) => x.length);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support arrays of observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>[];
+    let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
+    let o2: Rx.Observable<number[]> = Observable.combineLatest(...a);
+    let o3: Rx.Observable<number> = Observable.combineLatest(a, (...x) => x.length);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should return Array<T> when given a single promise', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return Array<T> when given a single promise', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should return Array<T> when given a single observable', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>;
-      let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return Array<T> when given a single observable', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>;
+    let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
+    /* tslint:enable:no-unused-variable */
+  });
 });

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -480,7 +480,6 @@ describe('Observable.combineLatest', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('', () => {
     type('should support promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
@@ -490,9 +489,7 @@ describe('Observable.combineLatest', () => {
       let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
@@ -502,9 +499,7 @@ describe('Observable.combineLatest', () => {
       let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support mixed observables and promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
@@ -515,9 +510,7 @@ describe('Observable.combineLatest', () => {
       let o2: Rx.Observable<boolean> = Observable.combineLatest(a, b, c, d, (aa, bb, cc, dd) => !!aa && !!bb && cc && !!dd.length);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support arrays of promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>[];
@@ -526,9 +519,7 @@ describe('Observable.combineLatest', () => {
       let o3: Rx.Observable<number> = Observable.combineLatest(a, (...x) => x.length);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support arrays of observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>[];
@@ -537,23 +528,18 @@ describe('Observable.combineLatest', () => {
       let o3: Rx.Observable<number> = Observable.combineLatest(a, (...x) => x.length);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should return Array<T> when given a single promise', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should return Array<T> when given a single observable', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 });

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -480,8 +480,8 @@ describe('Observable.combineLatest', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should support promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let b: Promise<string>;
@@ -492,8 +492,8 @@ describe('Observable.combineLatest', () => {
     });
   });
 
-  it('should support observables', () => {
-    type(() => {
+  it('', () => {
+    type('should support observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let b: Rx.Observable<string>;
@@ -504,8 +504,8 @@ describe('Observable.combineLatest', () => {
     });
   });
 
-  it('should support mixed observables and promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support mixed observables and promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let b: Rx.Observable<string>;
@@ -517,8 +517,8 @@ describe('Observable.combineLatest', () => {
     });
   });
 
-  it('should support arrays of promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support arrays of promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>[];
       let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
@@ -528,8 +528,8 @@ describe('Observable.combineLatest', () => {
     });
   });
 
-  it('should support arrays of observables', () => {
-    type(() => {
+  it('', () => {
+    type('should support arrays of observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>[];
       let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
@@ -539,8 +539,8 @@ describe('Observable.combineLatest', () => {
     });
   });
 
-  it('should return Array<T> when given a single promise', () => {
-    type(() => {
+  it('', () => {
+    type('should return Array<T> when given a single promise', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let o1: Rx.Observable<number[]> = Observable.combineLatest(a);
@@ -548,8 +548,8 @@ describe('Observable.combineLatest', () => {
     });
   });
 
-  it('should return Array<T> when given a single observable', () => {
-    type(() => {
+  it('', () => {
+    type('should return Array<T> when given a single observable', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let o1: Rx.Observable<number[]> = Observable.combineLatest(a);

--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -360,7 +360,6 @@ describe('Observable.forkJoin', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('', () => {
     type('should support promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
@@ -370,9 +369,7 @@ describe('Observable.forkJoin', () => {
       let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
@@ -382,9 +379,7 @@ describe('Observable.forkJoin', () => {
       let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support mixed observables and promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
@@ -395,9 +390,7 @@ describe('Observable.forkJoin', () => {
       let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, d, (aa, bb, cc, dd) => !!aa && !!bb && cc && !!dd.length);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support arrays of promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>[];
@@ -406,9 +399,7 @@ describe('Observable.forkJoin', () => {
       let o3: Rx.Observable<number> = Observable.forkJoin(a, (...x) => x.length);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support arrays of observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>[];
@@ -417,23 +408,18 @@ describe('Observable.forkJoin', () => {
       let o3: Rx.Observable<number> = Observable.forkJoin(a, (...x) => x.length);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should return Array<T> when given a single promise', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should return Array<T> when given a single observable', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 });

--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -360,66 +360,66 @@ describe('Observable.forkJoin', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-    type('should support promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let b: Promise<string>;
-      let c: Promise<boolean>;
-      let o1: Rx.Observable<[number, string, boolean]> = Observable.forkJoin(a, b, c);
-      let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let b: Promise<string>;
+    let c: Promise<boolean>;
+    let o1: Rx.Observable<[number, string, boolean]> = Observable.forkJoin(a, b, c);
+    let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support observables', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>;
-      let b: Rx.Observable<string>;
-      let c: Rx.Observable<boolean>;
-      let o1: Rx.Observable<[number, string, boolean]> = Observable.forkJoin(a, b, c);
-      let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>;
+    let b: Rx.Observable<string>;
+    let c: Rx.Observable<boolean>;
+    let o1: Rx.Observable<[number, string, boolean]> = Observable.forkJoin(a, b, c);
+    let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, (aa, bb, cc) => !!aa && !!bb && cc);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support mixed observables and promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let b: Rx.Observable<string>;
-      let c: Promise<boolean>;
-      let d: Rx.Observable<string[]>;
-      let o1: Rx.Observable<[number, string, boolean, string[]]> = Observable.forkJoin(a, b, c, d);
-      let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, d, (aa, bb, cc, dd) => !!aa && !!bb && cc && !!dd.length);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support mixed observables and promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let b: Rx.Observable<string>;
+    let c: Promise<boolean>;
+    let d: Rx.Observable<string[]>;
+    let o1: Rx.Observable<[number, string, boolean, string[]]> = Observable.forkJoin(a, b, c, d);
+    let o2: Rx.Observable<boolean> = Observable.forkJoin(a, b, c, d, (aa, bb, cc, dd) => !!aa && !!bb && cc && !!dd.length);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support arrays of promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>[];
-      let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
-      let o2: Rx.Observable<number[]> = Observable.forkJoin(...a);
-      let o3: Rx.Observable<number> = Observable.forkJoin(a, (...x) => x.length);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support arrays of promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>[];
+    let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
+    let o2: Rx.Observable<number[]> = Observable.forkJoin(...a);
+    let o3: Rx.Observable<number> = Observable.forkJoin(a, (...x) => x.length);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support arrays of observables', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>[];
-      let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
-      let o2: Rx.Observable<number[]> = Observable.forkJoin(...a);
-      let o3: Rx.Observable<number> = Observable.forkJoin(a, (...x) => x.length);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support arrays of observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>[];
+    let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
+    let o2: Rx.Observable<number[]> = Observable.forkJoin(...a);
+    let o3: Rx.Observable<number> = Observable.forkJoin(a, (...x) => x.length);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should return Array<T> when given a single promise', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return Array<T> when given a single promise', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should return Array<T> when given a single observable', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>;
-      let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return Array<T> when given a single observable', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>;
+    let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
+    /* tslint:enable:no-unused-variable */
+  });
 });

--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -360,8 +360,8 @@ describe('Observable.forkJoin', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should support promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let b: Promise<string>;
@@ -372,8 +372,8 @@ describe('Observable.forkJoin', () => {
     });
   });
 
-  it('should support observables', () => {
-    type(() => {
+  it('', () => {
+    type('should support observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let b: Rx.Observable<string>;
@@ -384,8 +384,8 @@ describe('Observable.forkJoin', () => {
     });
   });
 
-  it('should support mixed observables and promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support mixed observables and promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let b: Rx.Observable<string>;
@@ -397,8 +397,8 @@ describe('Observable.forkJoin', () => {
     });
   });
 
-  it('should support arrays of promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support arrays of promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>[];
       let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
@@ -408,8 +408,8 @@ describe('Observable.forkJoin', () => {
     });
   });
 
-  it('should support arrays of observables', () => {
-    type(() => {
+  it('', () => {
+    type('should support arrays of observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>[];
       let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
@@ -419,8 +419,8 @@ describe('Observable.forkJoin', () => {
     });
   });
 
-  it('should return Array<T> when given a single promise', () => {
-    type(() => {
+  it('', () => {
+    type('should return Array<T> when given a single promise', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let o1: Rx.Observable<number[]> = Observable.forkJoin(a);
@@ -428,8 +428,8 @@ describe('Observable.forkJoin', () => {
     });
   });
 
-  it('should return Array<T> when given a single observable', () => {
-    type(() => {
+  it('', () => {
+    type('should return Array<T> when given a single observable', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let o1: Rx.Observable<number[]> = Observable.forkJoin(a);

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -24,7 +24,6 @@ describe('Observable.from', () => {
     expect(r).to.throw();
   });
 
-  it('', () => {
     type('should return T for ObservableLike objects', () => {
       /* tslint:disable:no-unused-variable */
       let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
@@ -32,15 +31,12 @@ describe('Observable.from', () => {
       let o3: Rx.Observable<{ b: number }> = Observable.from(new Promise<{b: number}>(resolve => resolve()));
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should return T for arrays', () => {
       /* tslint:disable:no-unused-variable */
       let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
   const fakervable = (...values) => ({
     [<symbol>Symbol.observable]: () => ({

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -24,8 +24,8 @@ describe('Observable.from', () => {
     expect(r).to.throw();
   });
 
-  it('should return T for ObservableLike objects', () => {
-    type(() => {
+  it('', () => {
+    type('should return T for ObservableLike objects', () => {
       /* tslint:disable:no-unused-variable */
       let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
       let o2: Rx.Observable<{ a: string }> = Observable.from(Observable.empty<{ a: string }>());
@@ -34,8 +34,8 @@ describe('Observable.from', () => {
     });
   });
 
-  it('should return T for arrays', () => {
-    type(() => {
+  it('', () => {
+    type('should return T for arrays', () => {
       /* tslint:disable:no-unused-variable */
       let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
       /* tslint:enable:no-unused-variable */

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -24,19 +24,19 @@ describe('Observable.from', () => {
     expect(r).to.throw();
   });
 
-    type('should return T for ObservableLike objects', () => {
-      /* tslint:disable:no-unused-variable */
-      let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
-      let o2: Rx.Observable<{ a: string }> = Observable.from(Observable.empty<{ a: string }>());
-      let o3: Rx.Observable<{ b: number }> = Observable.from(new Promise<{b: number}>(resolve => resolve()));
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return T for ObservableLike objects', () => {
+    /* tslint:disable:no-unused-variable */
+    let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
+    let o2: Rx.Observable<{ a: string }> = Observable.from(Observable.empty<{ a: string }>());
+    let o3: Rx.Observable<{ b: number }> = Observable.from(new Promise<{b: number}>(resolve => resolve()));
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should return T for arrays', () => {
-      /* tslint:disable:no-unused-variable */
-      let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return T for arrays', () => {
+    /* tslint:disable:no-unused-variable */
+    let o1: Rx.Observable<number> = Observable.from(<number[]>[], Rx.Scheduler.asap);
+    /* tslint:enable:no-unused-variable */
+  });
 
   const fakervable = (...values) => ({
     [<symbol>Symbol.observable]: () => ({

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -582,8 +582,8 @@ describe('Observable.zip', () => {
     }, null, done);
   });
 
-  it('should support observables', () => {
-    type(() => {
+  it('', () => {
+    type('should support observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let b: Rx.Observable<string>;
@@ -593,8 +593,8 @@ describe('Observable.zip', () => {
     });
   });
 
-  it('should support mixed observables and promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support mixed observables and promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let b: Rx.Observable<string>;
@@ -605,8 +605,8 @@ describe('Observable.zip', () => {
     });
   });
 
-  it('should support arrays of promises', () => {
-    type(() => {
+  it('', () => {
+    type('should support arrays of promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>[];
       let o1: Rx.Observable<number[]> = Observable.zip(a);
@@ -615,8 +615,8 @@ describe('Observable.zip', () => {
     });
   });
 
-  it('should support arrays of observables', () => {
-    type(() => {
+  it('', () => {
+    type('should support arrays of observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>[];
       let o1: Rx.Observable<number[]> = Observable.zip(a);
@@ -625,8 +625,8 @@ describe('Observable.zip', () => {
     });
   });
 
-  it('should return Array<T> when given a single promise', () => {
-    type(() => {
+  it('', () => {
+    type('should return Array<T> when given a single promise', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let o1: Rx.Observable<number[]> = Observable.zip(a);
@@ -634,8 +634,8 @@ describe('Observable.zip', () => {
     });
   });
 
-  it('should return Array<T> when given a single observable', () => {
-    type(() => {
+  it('', () => {
+    type('should return Array<T> when given a single observable', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let o1: Rx.Observable<number[]> = Observable.zip(a);

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -582,7 +582,6 @@ describe('Observable.zip', () => {
     }, null, done);
   });
 
-  it('', () => {
     type('should support observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
@@ -591,9 +590,7 @@ describe('Observable.zip', () => {
       let o1: Rx.Observable<[number, string, boolean]> = Observable.zip(a, b, c);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support mixed observables and promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
@@ -603,9 +600,7 @@ describe('Observable.zip', () => {
       let o1: Rx.Observable<[number, string, boolean, string[]]> = Observable.zip(a, b, c, d);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support arrays of promises', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>[];
@@ -613,9 +608,7 @@ describe('Observable.zip', () => {
       let o2: Rx.Observable<number[]> = Observable.zip(...a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should support arrays of observables', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>[];
@@ -623,23 +616,18 @@ describe('Observable.zip', () => {
       let o2: Rx.Observable<number[]> = Observable.zip(...a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should return Array<T> when given a single promise', () => {
       /* tslint:disable:no-unused-variable */
       let a: Promise<number>;
       let o1: Rx.Observable<number[]> = Observable.zip(a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 
-  it('', () => {
     type('should return Array<T> when given a single observable', () => {
       /* tslint:disable:no-unused-variable */
       let a: Rx.Observable<number>;
       let o1: Rx.Observable<number[]> = Observable.zip(a);
       /* tslint:enable:no-unused-variable */
     });
-  });
 });

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -582,52 +582,52 @@ describe('Observable.zip', () => {
     }, null, done);
   });
 
-    type('should support observables', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>;
-      let b: Rx.Observable<string>;
-      let c: Rx.Observable<boolean>;
-      let o1: Rx.Observable<[number, string, boolean]> = Observable.zip(a, b, c);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>;
+    let b: Rx.Observable<string>;
+    let c: Rx.Observable<boolean>;
+    let o1: Rx.Observable<[number, string, boolean]> = Observable.zip(a, b, c);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support mixed observables and promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let b: Rx.Observable<string>;
-      let c: Promise<boolean>;
-      let d: Rx.Observable<string[]>;
-      let o1: Rx.Observable<[number, string, boolean, string[]]> = Observable.zip(a, b, c, d);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support mixed observables and promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let b: Rx.Observable<string>;
+    let c: Promise<boolean>;
+    let d: Rx.Observable<string[]>;
+    let o1: Rx.Observable<[number, string, boolean, string[]]> = Observable.zip(a, b, c, d);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support arrays of promises', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>[];
-      let o1: Rx.Observable<number[]> = Observable.zip(a);
-      let o2: Rx.Observable<number[]> = Observable.zip(...a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support arrays of promises', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>[];
+    let o1: Rx.Observable<number[]> = Observable.zip(a);
+    let o2: Rx.Observable<number[]> = Observable.zip(...a);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should support arrays of observables', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>[];
-      let o1: Rx.Observable<number[]> = Observable.zip(a);
-      let o2: Rx.Observable<number[]> = Observable.zip(...a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should support arrays of observables', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>[];
+    let o1: Rx.Observable<number[]> = Observable.zip(a);
+    let o2: Rx.Observable<number[]> = Observable.zip(...a);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should return Array<T> when given a single promise', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Promise<number>;
-      let o1: Rx.Observable<number[]> = Observable.zip(a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return Array<T> when given a single promise', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Promise<number>;
+    let o1: Rx.Observable<number[]> = Observable.zip(a);
+    /* tslint:enable:no-unused-variable */
+  });
 
-    type('should return Array<T> when given a single observable', () => {
-      /* tslint:disable:no-unused-variable */
-      let a: Rx.Observable<number>;
-      let o1: Rx.Observable<number[]> = Observable.zip(a);
-      /* tslint:enable:no-unused-variable */
-    });
+  type('should return Array<T> when given a single observable', () => {
+    /* tslint:disable:no-unused-variable */
+    let a: Rx.Observable<number>;
+    let o1: Rx.Observable<number[]> = Observable.zip(a);
+    /* tslint:enable:no-unused-variable */
+  });
 });

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -766,14 +766,14 @@ describe('Observable.prototype.mergeMap', () => {
     expect(completed).to.be.true;
   });
 
-    type('should support type signatures', () => {
-      let o: Rx.Observable<number>;
+  type('should support type signatures', () => {
+    let o: Rx.Observable<number>;
 
-      /* tslint:disable:no-unused-variable */
-      let a1: Rx.Observable<string> = o.mergeMap(x => x.toString());
-      let a2: Rx.Observable<string> = o.mergeMap(x => x.toString(), 3);
-      let a3: Rx.Observable<{ o: number; i: string; }> = o.mergeMap(x => x.toString(), (o, i) => ({ o, i }));
-      let a4: Rx.Observable<{ o: number; i: string; }> = o.mergeMap(x => x.toString(), (o, i) => ({ o, i }), 3);
-      /* tslint:enable:no-unused-variable */
-    });
+    /* tslint:disable:no-unused-variable */
+    let a1: Rx.Observable<string> = o.mergeMap(x => x.toString());
+    let a2: Rx.Observable<string> = o.mergeMap(x => x.toString(), 3);
+    let a3: Rx.Observable<{ o: number; i: string; }> = o.mergeMap(x => x.toString(), (o, i) => ({ o, i }));
+    let a4: Rx.Observable<{ o: number; i: string; }> = o.mergeMap(x => x.toString(), (o, i) => ({ o, i }), 3);
+    /* tslint:enable:no-unused-variable */
+  });
 });

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -766,7 +766,6 @@ describe('Observable.prototype.mergeMap', () => {
     expect(completed).to.be.true;
   });
 
-  it('', () => {
     type('should support type signatures', () => {
       let o: Rx.Observable<number>;
 
@@ -777,5 +776,4 @@ describe('Observable.prototype.mergeMap', () => {
       let a4: Rx.Observable<{ o: number; i: string; }> = o.mergeMap(x => x.toString(), (o, i) => ({ o, i }), 3);
       /* tslint:enable:no-unused-variable */
     });
-  });
 });

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -766,8 +766,8 @@ describe('Observable.prototype.mergeMap', () => {
     expect(completed).to.be.true;
   });
 
-  it('should support type signatures', () => {
-    type(() => {
+  it('', () => {
+    type('should support type signatures', () => {
       let o: Rx.Observable<number>;
 
       /* tslint:disable:no-unused-variable */

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -457,8 +457,8 @@ describe('Observable.prototype.mergeMapTo', () => {
     expect(completed).to.be.true;
   });
 
-  it('should support type signatures', () => {
-    type(() => {
+  it('', () => {
+    type('should support type signatures', () => {
       let o: Rx.Observable<number>;
       let m: Rx.Observable<string>;
 

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -457,15 +457,15 @@ describe('Observable.prototype.mergeMapTo', () => {
     expect(completed).to.be.true;
   });
 
-    type('should support type signatures', () => {
-      let o: Rx.Observable<number>;
-      let m: Rx.Observable<string>;
+  type('should support type signatures', () => {
+    let o: Rx.Observable<number>;
+    let m: Rx.Observable<string>;
 
-      /* tslint:disable:no-unused-variable */
-      let a1: Rx.Observable<string> = o.mergeMapTo(m);
-      let a2: Rx.Observable<string> = o.mergeMapTo(m, 3);
-      let a3: Rx.Observable<{ o: number; i: string; }> = o.mergeMapTo(m, (o, i) => ({ o, i }));
-      let a4: Rx.Observable<{ o: number; i: string; }> = o.mergeMapTo(m, (o, i) => ({ o, i }), 3);
-      /* tslint:enable:no-unused-variable */
-    });
+    /* tslint:disable:no-unused-variable */
+    let a1: Rx.Observable<string> = o.mergeMapTo(m);
+    let a2: Rx.Observable<string> = o.mergeMapTo(m, 3);
+    let a3: Rx.Observable<{ o: number; i: string; }> = o.mergeMapTo(m, (o, i) => ({ o, i }));
+    let a4: Rx.Observable<{ o: number; i: string; }> = o.mergeMapTo(m, (o, i) => ({ o, i }), 3);
+    /* tslint:enable:no-unused-variable */
+  });
 });

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -457,7 +457,6 @@ describe('Observable.prototype.mergeMapTo', () => {
     expect(completed).to.be.true;
   });
 
-  it('', () => {
     type('should support type signatures', () => {
       let o: Rx.Observable<number>;
       let m: Rx.Observable<string>;
@@ -469,5 +468,4 @@ describe('Observable.prototype.mergeMapTo', () => {
       let a4: Rx.Observable<{ o: number; i: string; }> = o.mergeMapTo(m, (o, i) => ({ o, i }), 3);
       /* tslint:enable:no-unused-variable */
     });
-  });
 });

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -293,104 +293,104 @@ describe('Observable.prototype.reduce', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-    type('should accept array typed reducers', () => {
-      let a: Rx.Observable<{ a: number; b: string }>;
-      a.reduce((acc, value) => acc.concat(value), []);
+  type('should accept array typed reducers', () => {
+    let a: Rx.Observable<{ a: number; b: string }>;
+    a.reduce((acc, value) => acc.concat(value), []);
+  });
+
+  type('should accept T typed reducers', () => {
+    let a: Rx.Observable<{ a: number; b: string }>;
+    const reduced = a.reduce((acc, value) => {
+      value.a = acc.a;
+      value.b = acc.b;
+      return acc;
     });
 
-    type('should accept T typed reducers', () => {
-      let a: Rx.Observable<{ a: number; b: string }>;
-      const reduced = a.reduce((acc, value) => {
-        value.a = acc.a;
-        value.b = acc.b;
-        return acc;
-      });
-
-      reduced.subscribe(r => {
-        r.a.toExponential();
-        r.b.toLowerCase();
-      });
+    reduced.subscribe(r => {
+      r.a.toExponential();
+      r.b.toLowerCase();
     });
+  });
 
-    type('should accept T typed reducers when T is an array', () => {
-      let a: Rx.Observable<number[]>;
-      const reduced = a.reduce((acc, value) => {
-        return acc.concat(value);
-      }, []);
+  type('should accept T typed reducers when T is an array', () => {
+    let a: Rx.Observable<number[]>;
+    const reduced = a.reduce((acc, value) => {
+      return acc.concat(value);
+    }, []);
 
-      reduced.subscribe(rs => {
-        rs[0].toExponential();
-      });
+    reduced.subscribe(rs => {
+      rs[0].toExponential();
     });
+  });
 
-    type('should accept R typed reduces when R is an array of T', () => {
-      let a: Rx.Observable<number>;
-      const reduced = a.reduce((acc, value) => {
-        acc.push(value);
-        return acc;
-      }, []);
+  type('should accept R typed reduces when R is an array of T', () => {
+    let a: Rx.Observable<number>;
+    const reduced = a.reduce((acc, value) => {
+      acc.push(value);
+      return acc;
+    }, []);
 
-      reduced.subscribe(rs => {
-        rs[0].toExponential();
-      });
+    reduced.subscribe(rs => {
+      rs[0].toExponential();
     });
+  });
 
-    type('should accept R typed reducers when R is assignable to T', () => {
-      let a: Rx.Observable<{ a?: number; b?: string }>;
-      const reduced = a.reduce((acc, value) => {
-        value.a = acc.a;
-        value.b = acc.b;
-        return acc;
-      }, {});
+  type('should accept R typed reducers when R is assignable to T', () => {
+    let a: Rx.Observable<{ a?: number; b?: string }>;
+    const reduced = a.reduce((acc, value) => {
+      value.a = acc.a;
+      value.b = acc.b;
+      return acc;
+    }, {});
 
-      reduced.subscribe(r => {
-        r.a.toExponential();
-        r.b.toLowerCase();
-      });
+    reduced.subscribe(r => {
+      r.a.toExponential();
+      r.b.toLowerCase();
     });
+  });
 
-    type('should accept R typed reducers when R is not assignable to T', () => {
-      let a: Rx.Observable<{ a: number; b: string }>;
-      const seed = {
-        as: [1],
-        bs: ['a']
-      };
-      const reduced = a.reduce((acc, value) => {
-        acc.as.push(value.a);
-        acc.bs.push(value.b);
-        return acc;
-      }, seed);
+  type('should accept R typed reducers when R is not assignable to T', () => {
+    let a: Rx.Observable<{ a: number; b: string }>;
+    const seed = {
+      as: [1],
+      bs: ['a']
+    };
+    const reduced = a.reduce((acc, value) => {
+      acc.as.push(value.a);
+      acc.bs.push(value.b);
+      return acc;
+    }, seed);
 
-      reduced.subscribe(r => {
-        r.as[0].toExponential();
-        r.bs[0].toLowerCase();
-      });
+    reduced.subscribe(r => {
+      r.as[0].toExponential();
+      r.bs[0].toLowerCase();
     });
+  });
 
-    type('should accept R typed reducers and reduce to type R', () => {
-      let a: Rx.Observable<{ a: number; b: string }>;
-      const reduced = a.reduce<{ a?: number; b?: string }>((acc, value) => {
-        value.a = acc.a;
-        value.b = acc.b;
-        return acc;
-      }, {});
+  type('should accept R typed reducers and reduce to type R', () => {
+    let a: Rx.Observable<{ a: number; b: string }>;
+    const reduced = a.reduce<{ a?: number; b?: string }>((acc, value) => {
+      value.a = acc.a;
+      value.b = acc.b;
+      return acc;
+    }, {});
 
-      reduced.subscribe(r => {
-        r.a.toExponential();
-        r.b.toLowerCase();
-      });
+    reduced.subscribe(r => {
+      r.a.toExponential();
+      r.b.toLowerCase();
     });
+  });
 
-    type('should accept array of R typed reducers and reduce to array of R', () => {
-      let a: Rx.Observable<number>;
-      const reduced = a.reduce((acc, cur) => {
-        console.log(acc);
-        acc.push(cur.toString());
-        return acc;
-      }, [] as string[]);
+  type('should accept array of R typed reducers and reduce to array of R', () => {
+    let a: Rx.Observable<number>;
+    const reduced = a.reduce((acc, cur) => {
+      console.log(acc);
+      acc.push(cur.toString());
+      return acc;
+    }, [] as string[]);
 
-      reduced.subscribe(rs => {
-        rs[0].toLowerCase();
-      });
+    reduced.subscribe(rs => {
+      rs[0].toLowerCase();
     });
+  });
 });

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -293,15 +293,15 @@ describe('Observable.prototype.reduce', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should accept array typed reducers', () => {
-    type(() => {
+  it('', () => {
+    type('should accept array typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       a.reduce((acc, value) => acc.concat(value), []);
     });
   });
 
-  it('should accept T typed reducers', () => {
-    type(() => {
+  it('', () => {
+    type('should accept T typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       const reduced = a.reduce((acc, value) => {
         value.a = acc.a;
@@ -316,8 +316,8 @@ describe('Observable.prototype.reduce', () => {
     });
   });
 
-  it('should accept T typed reducers when T is an array', () => {
-    type(() => {
+  it('', () => {
+    type('should accept T typed reducers when T is an array', () => {
       let a: Rx.Observable<number[]>;
       const reduced = a.reduce((acc, value) => {
         return acc.concat(value);
@@ -329,8 +329,8 @@ describe('Observable.prototype.reduce', () => {
     });
   });
 
-  it('should accept R typed reduces when R is an array of T', () => {
-    type(() => {
+  it('', () => {
+    type('should accept R typed reduces when R is an array of T', () => {
       let a: Rx.Observable<number>;
       const reduced = a.reduce((acc, value) => {
         acc.push(value);
@@ -343,8 +343,8 @@ describe('Observable.prototype.reduce', () => {
     });
   });
 
-  it('should accept R typed reducers when R is assignable to T', () => {
-    type(() => {
+  it('', () => {
+    type('should accept R typed reducers when R is assignable to T', () => {
       let a: Rx.Observable<{ a?: number; b?: string }>;
       const reduced = a.reduce((acc, value) => {
         value.a = acc.a;
@@ -359,8 +359,8 @@ describe('Observable.prototype.reduce', () => {
     });
   });
 
-  it('should accept R typed reducers when R is not assignable to T', () => {
-    type(() => {
+  it('', () => {
+    type('should accept R typed reducers when R is not assignable to T', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       const seed = {
         as: [1],
@@ -379,8 +379,8 @@ describe('Observable.prototype.reduce', () => {
     });
   });
 
-  it('should accept R typed reducers and reduce to type R', () => {
-    type(() => {
+  it('', () => {
+    type('should accept R typed reducers and reduce to type R', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       const reduced = a.reduce<{ a?: number; b?: string }>((acc, value) => {
         value.a = acc.a;
@@ -395,8 +395,8 @@ describe('Observable.prototype.reduce', () => {
     });
   });
 
-  it('should accept array of R typed reducers and reduce to array of R', () => {
-    type(() => {
+  it('', () => {
+    type('should accept array of R typed reducers and reduce to array of R', () => {
       let a: Rx.Observable<number>;
       const reduced = a.reduce((acc, cur) => {
         console.log(acc);

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -293,14 +293,11 @@ describe('Observable.prototype.reduce', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('', () => {
     type('should accept array typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       a.reduce((acc, value) => acc.concat(value), []);
     });
-  });
 
-  it('', () => {
     type('should accept T typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       const reduced = a.reduce((acc, value) => {
@@ -314,9 +311,7 @@ describe('Observable.prototype.reduce', () => {
         r.b.toLowerCase();
       });
     });
-  });
 
-  it('', () => {
     type('should accept T typed reducers when T is an array', () => {
       let a: Rx.Observable<number[]>;
       const reduced = a.reduce((acc, value) => {
@@ -327,9 +322,7 @@ describe('Observable.prototype.reduce', () => {
         rs[0].toExponential();
       });
     });
-  });
 
-  it('', () => {
     type('should accept R typed reduces when R is an array of T', () => {
       let a: Rx.Observable<number>;
       const reduced = a.reduce((acc, value) => {
@@ -341,9 +334,7 @@ describe('Observable.prototype.reduce', () => {
         rs[0].toExponential();
       });
     });
-  });
 
-  it('', () => {
     type('should accept R typed reducers when R is assignable to T', () => {
       let a: Rx.Observable<{ a?: number; b?: string }>;
       const reduced = a.reduce((acc, value) => {
@@ -357,9 +348,7 @@ describe('Observable.prototype.reduce', () => {
         r.b.toLowerCase();
       });
     });
-  });
 
-  it('', () => {
     type('should accept R typed reducers when R is not assignable to T', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       const seed = {
@@ -377,9 +366,7 @@ describe('Observable.prototype.reduce', () => {
         r.bs[0].toLowerCase();
       });
     });
-  });
 
-  it('', () => {
     type('should accept R typed reducers and reduce to type R', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       const reduced = a.reduce<{ a?: number; b?: string }>((acc, value) => {
@@ -393,9 +380,7 @@ describe('Observable.prototype.reduce', () => {
         r.b.toLowerCase();
       });
     });
-  });
 
-  it('', () => {
     type('should accept array of R typed reducers and reduce to array of R', () => {
       let a: Rx.Observable<number>;
       const reduced = a.reduce((acc, cur) => {
@@ -408,5 +393,4 @@ describe('Observable.prototype.reduce', () => {
         rs[0].toLowerCase();
       });
     });
-  });
 });

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -228,26 +228,26 @@ describe('Observable.prototype.scan', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-    type('should accept array typed reducers', () => {
-      let a: Rx.Observable<{ a: number; b: string }>;
-      a.scan((acc, value) => acc.concat(value), []);
-    });
+  type('should accept array typed reducers', () => {
+    let a: Rx.Observable<{ a: number; b: string }>;
+    a.reduce((acc, value) => acc.concat(value), []);
+  });
 
-    type('should accept T typed reducers', () => {
-      let a: Rx.Observable<{ a?: number; b?: string }>;
-      a.scan((acc, value) => {
-        acc.a = value.a;
-        acc.b = value.b;
-        return acc;
-      }, {});
-    });
+  type('should accept T typed reducers', () => {
+    let a: Rx.Observable<{ a?: number; b?: string }>;
+    a.reduce((acc, value) => {
+      value.a = acc.a;
+      value.b = acc.b;
+      return acc;
+    }, {});
+  });
 
-    type('should accept R typed reducers', () => {
-      let a: Rx.Observable<{ a: number; b: string }>;
-      a.scan<{ a?: number; b?: string }>((acc, value) => {
-        acc.a = value.a;
-        acc.b = value.b;
-        return acc;
-      }, {});
-    });
+  type('should accept R typed reducers', () => {
+    let a: Rx.Observable<{ a: number; b: string }>;
+    a.reduce<{ a?: number; b?: string }>((acc, value) => {
+      value.a = acc.a;
+      value.b = acc.b;
+      return acc;
+    }, {});
+  });
 });

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -228,15 +228,15 @@ describe('Observable.prototype.scan', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should accept array types', () => {
-    type(() => {
+  it('', () => {
+    type('should accept array typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       a.scan((acc, value) => acc.concat(value), []);
     });
   });
 
-  it('should accept T types', () => {
-    type(() => {
+  it('', () => {
+    type('should accept T typed reducers', () => {
       let a: Rx.Observable<{ a?: number; b?: string }>;
       a.scan((acc, value) => {
         acc.a = value.a;
@@ -246,8 +246,8 @@ describe('Observable.prototype.scan', () => {
     });
   });
 
-  it('should accept R typed reducers', () => {
-    type(() => {
+  it('', () => {
+    type('should accept R typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       a.scan<{ a?: number; b?: string }>((acc, value) => {
         acc.a = value.a;

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -228,14 +228,11 @@ describe('Observable.prototype.scan', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('', () => {
     type('should accept array typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       a.scan((acc, value) => acc.concat(value), []);
     });
-  });
 
-  it('', () => {
     type('should accept T typed reducers', () => {
       let a: Rx.Observable<{ a?: number; b?: string }>;
       a.scan((acc, value) => {
@@ -244,9 +241,7 @@ describe('Observable.prototype.scan', () => {
         return acc;
       }, {});
     });
-  });
 
-  it('', () => {
     type('should accept R typed reducers', () => {
       let a: Rx.Observable<{ a: number; b: string }>;
       a.scan<{ a?: number; b?: string }>((acc, value) => {
@@ -255,5 +250,4 @@ describe('Observable.prototype.scan', () => {
         return acc;
       }, {});
     });
-  });
 });

--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -108,7 +108,7 @@ describe('Observable.prototype.toArray', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  type(() => {
+  type('should infer the element type', () => {
     const typeValue = {
       val: 3
     };


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This is a maintenance PR. In looking to add some tests for #2855, I found a bunch of typings tests - see the [`type`](https://github.com/ReactiveX/rxjs/blob/5.4.3/spec/helpers/testScheduler-ui.ts#L91-L100) function - that are wrapped in `it` calls. I've unwrapped them.

I've made the changes in three commits so that it should be a little easier to review what was changed. I'll squash them, if you're happy with the changes made in the PR.

**Related issue (if exists):** None.
