### PR TITLE
refactor: remove src/operators.ts re-export

### DIFF
--- a/src/operators.ts
+++ b/src/operators.ts
@@ -1,1 +1,0 @@
-export * from './operators/index';


### PR DESCRIPTION
* This re-export was added to support CJS and internal require statements.
Those internal requires were require('rxjs/operators') and with SystemJS
this would try to find a "rxjs/operators.js" file. Now that the internal
references have changed to deep imports, we should remove this re-export
to ensure we don't again add internal references to rxjs/operators.