### PR TITLE
[Fix] Make overload signature compatible in FromEventObservable

### DIFF
--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -101,11 +101,11 @@ export class FromEventObservable<T> extends Observable<T> {
    */
   static create<T>(target: EventTargetLike,
                    eventName: string,
-                   options?: EventListenerOptions,
+                   options?: EventListenerOptions | SelectorMethodSignature<T>,
                    selector?: SelectorMethodSignature<T>): Observable<T> {
     if (isFunction(options)) {
-      selector = <any>options;
-      options = undefined;
+      selector = options;
+      options = undefined as EventListenerOptions;
     }
     return new FromEventObservable(target, eventName, selector, options);
   }


### PR DESCRIPTION
**Description:** Fix compilation error in FromEventObservable.ts file:
```bash
static create<T>(target: EventTargetLike, eventName: string, selector: SelectorMethodSignature<T>): Observable<T>;
       ~~~~~~

dist/cjs/src/observable/FromEventObservable.ts(57,10): error TS2394: Overload signature is not compatible with function implem
entation.
```

This is my first contribution to this repo so if there is something missing please let me know =)
Thanks.