### PR TITLE
[Test] Fix types in WebSockerSubject and from-promise-spec

### DIFF
--- a/spec/observables/from-promise-spec.ts
+++ b/spec/observables/from-promise-spec.ts
@@ -76,7 +76,7 @@ describe('Observable.fromPromise', () => {
     class CustomPromise<T> implements PromiseLike<T> {
       constructor(private promise: PromiseLike<T>) {
       }
-      then(onFulfilled?, onRejected?): PromiseLike<T> {
+      then(onFulfilled?, onRejected?) {
         return new CustomPromise(this.promise.then(onFulfilled, onRejected));
       }
     }

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -10,10 +10,10 @@ import { tryCatch } from '../../util/tryCatch';
 import { errorObject } from '../../util/errorObject';
 import { assign } from '../../util/assign';
 
-export interface WebSocketSubjectConfig {
+export interface WebSocketSubjectConfig<T> {
   url: string;
   protocol?: string | Array<string>;
-  resultSelector?: <T>(e: MessageEvent) => T;
+  resultSelector?: (e: MessageEvent) => T;
   openObserver?: NextObserver<Event>;
   closeObserver?: NextObserver<CloseEvent>;
   closingObserver?: NextObserver<void>;
@@ -75,17 +75,17 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
    *
    * socket$.next(JSON.stringify({ op: 'hello' }));
    *
-   * @param {string | WebSocketSubjectConfig} urlConfigOrSource the source of the websocket as an url or a structure defining the websocket object
+   * @param {string | WebSocketSubjectConfig<T>} urlConfigOrSource the source of the websocket as an url or a structure defining the websocket object
    * @return {WebSocketSubject}
    * @static true
    * @name webSocket
    * @owner Observable
    */
-  static create<T>(urlConfigOrSource: string | WebSocketSubjectConfig): WebSocketSubject<T> {
+  static create<T>(urlConfigOrSource: string | WebSocketSubjectConfig<T>): WebSocketSubject<T> {
     return new WebSocketSubject<T>(urlConfigOrSource);
   }
 
-  constructor(urlConfigOrSource: string | WebSocketSubjectConfig | Observable<T>, destination?: Observer<T>) {
+  constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>) {
     if (urlConfigOrSource instanceof Observable) {
       super(destination, <Observable<T>> urlConfigOrSource);
     } else {


### PR DESCRIPTION
**Description:** This PR fixes remaining compiler errors in unit tests along with [this one](https://github.com/ReactiveX/rxjs/pull/2893).

Once both merged you should have all tests passing.

BTW:
There is one small change in the `WebSocketSubjectConfig` type and I just want to make sure that the change I made actually makes sense.
So basically there is a property named `resultSelector` which is a function - result of which was generic.
And I bound it's generic type to `WebSocketSubject` generic type (in order to fix compiler error) assuming that this is what user will get after this function will run.
And now basically `resultSelector` prop of `WebSocketSubjectConfig` (if provided) will drive inferred type of the whole `WebSocketSubject` for ex:
```ts
const sock$ = WebSocketSubject.create('ws://socket');
// sock$ type inferred to WebSocketSubject<{}> which was always the case in prev version

const sock2$ = WebSocketSubject.create({url: 'ws://socket', resultSelector: () => false});
// sock2$ type inferred to WebSocketSubject<boolean> because of the result type of 'resultSelector' function
```

Thanks