### PR TITLE
refactor: cast types so library works with TS 2.4x and 2.5x

### DIFF
--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -50,7 +50,7 @@ export class ConnectableObservable<T> extends Observable<T> {
   }
 
   refCount(): Observable<T> {
-    return higherOrderRefCount()(this);
+    return higherOrderRefCount()(this) as Observable<T>;
   }
 }
 

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -101,13 +101,13 @@ export class FromEventObservable<T> extends Observable<T> {
    */
   static create<T>(target: EventTargetLike,
                    eventName: string,
-                   options?: EventListenerOptions,
+                   options?: EventListenerOptions | SelectorMethodSignature<T>,
                    selector?: SelectorMethodSignature<T>): Observable<T> {
     if (isFunction(options)) {
       selector = <any>options;
       options = undefined;
     }
-    return new FromEventObservable(target, eventName, selector, options);
+    return new FromEventObservable(target, eventName, selector, options as EventListenerOptions | undefined);
   }
 
   constructor(private sourceObj: EventTargetLike,

--- a/src/observable/GenerateObservable.ts
+++ b/src/observable/GenerateObservable.ts
@@ -179,7 +179,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
         (<GenerateOptions<T, S>>initialStateOrOptions).initialState,
         (<GenerateOptions<T, S>>initialStateOrOptions).condition,
         (<GenerateOptions<T, S>>initialStateOrOptions).iterate,
-        (<GenerateOptions<T, S>>initialStateOrOptions).resultSelector || selfSelector,
+        (<GenerateOptions<T, S>>initialStateOrOptions).resultSelector || selfSelector as ResultFunc<S, T>,
         (<GenerateOptions<T, S>>initialStateOrOptions).scheduler);
     }
 
@@ -188,7 +188,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
         <S>initialStateOrOptions,
         condition,
         iterate,
-        selfSelector,
+        selfSelector as ResultFunc<S, T>,
         <IScheduler>resultSelectorOrObservable);
     }
 

--- a/src/observable/concat.ts
+++ b/src/observable/concat.ts
@@ -112,5 +112,5 @@ export function concat<T, R>(...observables: Array<ObservableInput<any> | ISched
   if (observables.length === 1 || (observables.length === 2 && isScheduler(observables[1]))) {
     return from(<any>observables[0]);
   }
-  return concatAll()(of(...observables));
+  return concatAll()(of(...observables)) as Observable<R>;
 }

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -255,7 +255,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       // timeout, responseType and withCredentials can be set once the XHR is open
       if (async) {
         xhr.timeout = request.timeout;
-        xhr.responseType = request.responseType;
+        xhr.responseType = request.responseType as any;
       }
 
       if ('withCredentials' in xhr) {

--- a/src/operator/auditTime.ts
+++ b/src/operator/auditTime.ts
@@ -46,5 +46,5 @@ import { auditTime as higherOrder } from '../operators/auditTime';
  * @owner Observable
  */
 export function auditTime<T>(this: Observable<T>, duration: number, scheduler: IScheduler = async): Observable<T> {
-  return higherOrder(duration, scheduler)(this);
+  return higherOrder(duration, scheduler)(this) as Observable<T>;
 }

--- a/src/operator/buffer.ts
+++ b/src/operator/buffer.ts
@@ -35,5 +35,5 @@ import { buffer as higherOrder } from '../operators/buffer';
  * @owner Observable
  */
 export function buffer<T>(this: Observable<T>, closingNotifier: Observable<any>): Observable<T[]> {
-  return higherOrder(closingNotifier)(this);
+  return higherOrder(closingNotifier)(this) as Observable<T[]>;
 }

--- a/src/operator/bufferCount.ts
+++ b/src/operator/bufferCount.ts
@@ -44,5 +44,5 @@ import { bufferCount as higherOrder } from '../operators/bufferCount';
  * @owner Observable
  */
 export function bufferCount<T>(this: Observable<T>, bufferSize: number, startBufferEvery: number = null): Observable<T[]> {
-  return higherOrder(bufferSize, startBufferEvery)(this);
+  return higherOrder(bufferSize, startBufferEvery)(this) as Observable<T[]>;
 }

--- a/src/operator/bufferTime.ts
+++ b/src/operator/bufferTime.ts
@@ -72,5 +72,5 @@ export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number): Obse
     maxBufferSize = arguments[2];
   }
 
-  return higherOrder(bufferTimeSpan, bufferCreationInterval, maxBufferSize, scheduler)(this);
+  return higherOrder(bufferTimeSpan, bufferCreationInterval, maxBufferSize, scheduler)(this) as Observable<T[]>;
 }

--- a/src/operator/bufferToggle.ts
+++ b/src/operator/bufferToggle.ts
@@ -42,5 +42,5 @@ import { bufferToggle as higherOrder } from '../operators/bufferToggle';
  */
 export function bufferToggle<T, O>(this: Observable<T>, openings: SubscribableOrPromise<O>,
                                    closingSelector: (value: O) => SubscribableOrPromise<any>): Observable<T[]> {
-  return higherOrder(openings, closingSelector)(this);
+  return higherOrder(openings, closingSelector)(this) as Observable<T[]>;
 }

--- a/src/operator/bufferWhen.ts
+++ b/src/operator/bufferWhen.ts
@@ -36,5 +36,5 @@ import { bufferWhen as higherOrder } from '../operators/bufferWhen';
  * @owner Observable
  */
 export function bufferWhen<T>(this: Observable<T>, closingSelector: () => Observable<any>): Observable<T[]> {
-  return higherOrder(closingSelector)(this);
+  return higherOrder(closingSelector)(this) as Observable<T[]>;
 }

--- a/src/operator/debounceTime.ts
+++ b/src/operator/debounceTime.ts
@@ -51,5 +51,5 @@ import { debounceTime as higherOrder } from '../operators/debounceTime';
  * @owner Observable
  */
 export function debounceTime<T>(this: Observable<T>, dueTime: number, scheduler: IScheduler = async): Observable<T> {
-  return higherOrder(dueTime, scheduler)(this);
+  return higherOrder(dueTime, scheduler)(this) as Observable<T>;
 }

--- a/src/operator/dematerialize.ts
+++ b/src/operator/dematerialize.ts
@@ -44,5 +44,5 @@ import { dematerialize as higherOrder } from '../operators/dematerialize';
  * @owner Observable
  */
 export function dematerialize<T>(this: Observable<Notification<T>>): Observable<T> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<T>;
 }

--- a/src/operator/do.ts
+++ b/src/operator/do.ts
@@ -54,5 +54,5 @@ export function _do<T>(this: Observable<T>, observer: PartialObserver<T>): Obser
 export function _do<T>(this: Observable<T>, nextOrObserver?: PartialObserver<T> | ((x: T) => void),
                        error?: (e: any) => void,
                        complete?: () => void): Observable<T> {
-  return higherOrder(<any>nextOrObserver, error, complete)(this);
+  return higherOrder(<any>nextOrObserver, error, complete)(this) as Observable<T>;
 }

--- a/src/operator/exhaust.ts
+++ b/src/operator/exhaust.ts
@@ -38,5 +38,5 @@ import { exhaust as higherOrder } from '../operators/exhaust';
  * @owner Observable
  */
 export function exhaust<T>(this: Observable<T>): Observable<T> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<T>;
 }

--- a/src/operator/finally.ts
+++ b/src/operator/finally.ts
@@ -11,5 +11,5 @@ import { finalize } from '../operators/finalize';
  * @owner Observable
  */
 export function _finally<T>(this: Observable<T>, callback: () => void): Observable<T> {
-  return finalize(callback)(this);
+  return finalize(callback)(this) as Observable<T>;
 }

--- a/src/operator/ignoreElements.ts
+++ b/src/operator/ignoreElements.ts
@@ -12,5 +12,5 @@ import { ignoreElements as higherOrder } from '../operators/ignoreElements';
  * @owner Observable
  */
 export function ignoreElements<T>(this: Observable<T>): Observable<T> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<T>;
 };

--- a/src/operator/materialize.ts
+++ b/src/operator/materialize.ts
@@ -48,5 +48,5 @@ import { materialize as higherOrder } from '../operators/materialize';
  * @owner Observable
  */
 export function materialize<T>(this: Observable<T>): Observable<Notification<T>> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<Notification<T>>;
 }

--- a/src/operator/merge.ts
+++ b/src/operator/merge.ts
@@ -68,5 +68,5 @@ export function merge<T, R>(this: Observable<T>, ...observables: Array<Observabl
  * @owner Observable
  */
 export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R> {
-  return higherOrder(...observables)(this);
+  return higherOrder(...observables)(this) as Observable<R>;
 }

--- a/src/operator/mergeAll.ts
+++ b/src/operator/mergeAll.ts
@@ -49,6 +49,6 @@ export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscr
  * @method mergeAll
  * @owner Observable
  */
-export function mergeAll<T>(this: Observable<T>, concurrent: number = Number.POSITIVE_INFINITY): T {
-  return <any>higherOrder(concurrent)(this);
+export function mergeAll<T>(this: Observable<T>, concurrent: number = Number.POSITIVE_INFINITY): Observable<T> {
+  return higherOrder(concurrent)(this) as Observable<T>;
 }

--- a/src/operator/mergeMap.ts
+++ b/src/operator/mergeMap.ts
@@ -67,5 +67,5 @@ export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index
 export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>,
                                   resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
                                   concurrent: number = Number.POSITIVE_INFINITY): Observable<I | R> {
-  return higherOrderMergeMap(project, <any>resultSelector, concurrent)(this);
+  return higherOrderMergeMap(project, <any>resultSelector, concurrent)(this) as Observable<I | R>;
 }

--- a/src/operator/mergeMapTo.ts
+++ b/src/operator/mergeMapTo.ts
@@ -52,5 +52,5 @@ export function mergeMapTo<T, I, R>(this: Observable<T>, observable: ObservableI
 export function mergeMapTo<T, I, R>(this: Observable<T>, innerObservable: Observable<I>,
                                     resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
                                     concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
-  return higherOrder(innerObservable, resultSelector as any, concurrent)(this);
+  return higherOrder(innerObservable, resultSelector as any, concurrent)(this) as Observable<R>;
 }

--- a/src/operator/observeOn.ts
+++ b/src/operator/observeOn.ts
@@ -49,5 +49,5 @@ import { observeOn as higherOrder } from '../operators/observeOn';
  * @owner Observable
  */
 export function observeOn<T>(this: Observable<T>, scheduler: IScheduler, delay: number = 0): Observable<T> {
-  return higherOrder(scheduler, delay)(this);
+  return higherOrder(scheduler, delay)(this) as Observable<T>;
 }

--- a/src/operator/pairwise.ts
+++ b/src/operator/pairwise.ts
@@ -37,5 +37,5 @@ import { pairwise as higherOrder } from '../operators/pairwise';
  * @owner Observable
  */
 export function pairwise<T>(this: Observable<T>): Observable<[T, T]> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<[T, T]>;
 }

--- a/src/operator/pluck.ts
+++ b/src/operator/pluck.ts
@@ -28,5 +28,5 @@ import { pluck as higherOrder } from '../operators/pluck';
  * @owner Observable
  */
 export function pluck<T, R>(this: Observable<T>, ...properties: string[]): Observable<R> {
-  return higherOrder(...properties)(this);
+  return higherOrder(...properties)(this) as Observable<R>;
 }

--- a/src/operator/publishReplay.ts
+++ b/src/operator/publishReplay.ts
@@ -14,5 +14,5 @@ import { publishReplay as higherOrder } from '../operators/publishReplay';
 export function publishReplay<T>(this: Observable<T>, bufferSize: number = Number.POSITIVE_INFINITY,
                                  windowTime: number = Number.POSITIVE_INFINITY,
                                  scheduler?: IScheduler): ConnectableObservable<T> {
-  return higherOrder(bufferSize, windowTime, scheduler)(this);
+  return higherOrder(bufferSize, windowTime, scheduler)(this) as ConnectableObservable<T>;
 }

--- a/src/operator/repeat.ts
+++ b/src/operator/repeat.ts
@@ -15,5 +15,5 @@ import { repeat as higherOrder } from '../operators/repeat';
  * @owner Observable
  */
 export function repeat<T>(this: Observable<T>, count: number = -1): Observable<T> {
-  return higherOrder(count)(this);
+  return higherOrder(count)(this) as Observable<T>;
 }

--- a/src/operator/repeatWhen.ts
+++ b/src/operator/repeatWhen.ts
@@ -16,5 +16,5 @@ import { repeatWhen as higherOrder } from '../operators/repeatWhen';
  * @owner Observable
  */
 export function repeatWhen<T>(this: Observable<T>, notifier: (notifications: Observable<any>) => Observable<any>): Observable<T> {
-  return higherOrder(notifier)(this);
+  return higherOrder(notifier)(this) as Observable<T>;
 }

--- a/src/operator/retry.ts
+++ b/src/operator/retry.ts
@@ -18,5 +18,5 @@ import { retry as higherOrder } from '../operators/retry';
  * @owner Observable
  */
 export function retry<T>(this: Observable<T>, count: number = -1): Observable<T> {
-  return higherOrder(count)(this);
+  return higherOrder(count)(this) as Observable<T>;
 }

--- a/src/operator/retryWhen.ts
+++ b/src/operator/retryWhen.ts
@@ -15,5 +15,5 @@ import { retryWhen as higherOrder } from '../operators/retryWhen';
  * @owner Observable
  */
 export function retryWhen<T>(this: Observable<T>, notifier: (errors: Observable<any>) => Observable<any>): Observable<T> {
-  return higherOrder(notifier)(this);
+  return higherOrder(notifier)(this) as Observable<T>;
 }

--- a/src/operator/sample.ts
+++ b/src/operator/sample.ts
@@ -36,5 +36,5 @@ import { sample as higherOrder } from '../operators/sample';
  * @owner Observable
  */
 export function sample<T>(this: Observable<T>, notifier: Observable<any>): Observable<T> {
-  return higherOrder(notifier)(this);
+  return higherOrder(notifier)(this) as Observable<T>;
 }

--- a/src/operator/sampleTime.ts
+++ b/src/operator/sampleTime.ts
@@ -40,5 +40,5 @@ import { sampleTime as higherOrder } from '../operators/sampleTime';
  * @owner Observable
  */
 export function sampleTime<T>(this: Observable<T>, period: number, scheduler: IScheduler = async): Observable<T> {
-  return higherOrder(period, scheduler)(this);
+  return higherOrder(period, scheduler)(this) as Observable<T>;
 }

--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -47,7 +47,7 @@ export function scan<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, 
  */
 export function scan<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed?: T | R): Observable<R> {
   if (arguments.length >= 2) {
-    return higherOrderScan(accumulator, seed)(this);
+    return higherOrderScan(accumulator, seed)(this) as Observable<R>;
   }
   return higherOrderScan(accumulator)(this);
 }

--- a/src/operator/share.ts
+++ b/src/operator/share.ts
@@ -18,5 +18,5 @@ import { share as higherOrder } from '../operators/share';
  * @owner Observable
  */
 export function share<T>(this: Observable<T>): Observable<T> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<T>;
 };

--- a/src/operator/shareReplay.ts
+++ b/src/operator/shareReplay.ts
@@ -8,5 +8,5 @@ import { shareReplay as higherOrder } from '../operators/shareReplay';
  */
 export function shareReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, scheduler?: IScheduler):
   Observable<T> {
-  return higherOrder(bufferSize, windowTime, scheduler)(this);
+  return higherOrder(bufferSize, windowTime, scheduler)(this) as Observable<T>;
 };

--- a/src/operator/skip.ts
+++ b/src/operator/skip.ts
@@ -13,5 +13,5 @@ import { skip as higherOrder } from '../operators/skip';
  * @owner Observable
  */
 export function skip<T>(this: Observable<T>, count: number): Observable<T> {
-  return higherOrder(count)(this);
+  return higherOrder(count)(this) as Observable<T>;
 }

--- a/src/operator/skipLast.ts
+++ b/src/operator/skipLast.ts
@@ -34,5 +34,5 @@ import { skipLast as higherOrder } from '../operators/skipLast';
  * @owner Observable
  */
 export function skipLast<T>(this: Observable<T>, count: number): Observable<T> {
-  return higherOrder(count)(this);
+  return higherOrder(count)(this) as Observable<T>;
 }

--- a/src/operator/skipUntil.ts
+++ b/src/operator/skipUntil.ts
@@ -14,5 +14,5 @@ import { skipUntil as higherOrder } from '../operators/skipUntil';
  * @owner Observable
  */
 export function skipUntil<T>(this: Observable<T>, notifier: Observable<any>): Observable<T> {
-  return higherOrder(notifier)(this);
+  return higherOrder(notifier)(this) as Observable<T>;
 }

--- a/src/operator/subscribeOn.ts
+++ b/src/operator/subscribeOn.ts
@@ -15,5 +15,5 @@ import { subscribeOn as higherOrder } from '../operators/subscribeOn';
  * @owner Observable
  */
 export function subscribeOn<T>(this: Observable<T>, scheduler: IScheduler, delay: number = 0): Observable<T> {
-  return higherOrder(scheduler, delay)(this);
+  return higherOrder(scheduler, delay)(this) as Observable<T>;
 }

--- a/src/operator/switch.ts
+++ b/src/operator/switch.ts
@@ -44,5 +44,5 @@ import { switchAll as higherOrder } from '../operators/switchAll';
  * @owner Observable
  */
 export function _switch<T>(this: Observable<Observable<T>>): Observable<T> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<T>;
 }

--- a/src/operator/take.ts
+++ b/src/operator/take.ts
@@ -35,5 +35,5 @@ import { take as higherOrder } from '../operators/take';
  * @owner Observable
  */
 export function take<T>(this: Observable<T>, count: number): Observable<T> {
-  return higherOrder(count)(this);
+  return higherOrder(count)(this) as Observable<T>;
 }

--- a/src/operator/takeLast.ts
+++ b/src/operator/takeLast.ts
@@ -39,5 +39,5 @@ import { takeLast as higherOrderTakeLast } from '../operators/takeLast';
  * @owner Observable
  */
 export function takeLast<T>(this: Observable<T>, count: number): Observable<T> {
-  return higherOrderTakeLast(count)(this);
+  return higherOrderTakeLast(count)(this) as Observable<T>;
 }

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -35,5 +35,5 @@ import { takeUntil as higherOrder } from '../operators/takeUntil';
  * @owner Observable
  */
 export function takeUntil<T>(this: Observable<T>, notifier: Observable<any>): Observable<T> {
-  return higherOrder(notifier)(this);
+  return higherOrder(notifier)(this) as Observable<T>;
 }

--- a/src/operator/throttleTime.ts
+++ b/src/operator/throttleTime.ts
@@ -47,5 +47,5 @@ export function throttleTime<T>(this: Observable<T>,
                                 duration: number,
                                 scheduler: IScheduler = async,
                                 config: ThrottleConfig = defaultThrottleConfig): Observable<T> {
-  return higherOrder(duration, scheduler, config)(this);
+  return higherOrder(duration, scheduler, config)(this) as Observable<T>;
 }

--- a/src/operator/timeInterval.ts
+++ b/src/operator/timeInterval.ts
@@ -11,5 +11,5 @@ export {TimeInterval};
  * @owner Observable
  */
 export function timeInterval<T>(this: Observable<T>, scheduler: IScheduler = async): Observable<TimeInterval<T>> {
-  return higherOrder(scheduler)(this);
+  return higherOrder(scheduler)(this) as Observable<TimeInterval<T>>;
 }

--- a/src/operator/timeout.ts
+++ b/src/operator/timeout.ts
@@ -71,5 +71,5 @@ import { timeout as higherOrder } from '../operators/timeout';
 export function timeout<T>(this: Observable<T>,
                            due: number | Date,
                            scheduler: IScheduler = async): Observable<T> {
-  return higherOrder(due, scheduler)(this);
+  return higherOrder(due, scheduler)(this) as Observable<T>;
 }

--- a/src/operator/timestamp.ts
+++ b/src/operator/timestamp.ts
@@ -10,5 +10,5 @@ import { Timestamp } from '../operators/timestamp';
  * @owner Observable
  */
 export function timestamp<T>(this: Observable<T>, scheduler: IScheduler = async): Observable<Timestamp<T>> {
-  return higherOrder(scheduler)(this);
+  return higherOrder(scheduler)(this) as Observable<Timestamp<T>>;
 }

--- a/src/operator/toArray.ts
+++ b/src/operator/toArray.ts
@@ -8,5 +8,5 @@ import { toArray as higherOrder } from '../operators/toArray';
  * @owner Observable
  */
 export function toArray<T>(this: Observable<T>): Observable<T[]> {
-  return higherOrder()(this);
+  return higherOrder()(this) as Observable<T[]>;
 }

--- a/src/operator/toPromise.ts
+++ b/src/operator/toPromise.ts
@@ -56,5 +56,5 @@ export function toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): 
  * @owner Observable
  */
 export function toPromise<T>(this: Observable<T>, PromiseCtor?: typeof Promise): Promise<T> {
-  return higherOrder(PromiseCtor)(this);
+  return higherOrder(PromiseCtor)(this) as Promise<T>;
 }

--- a/src/operator/window.ts
+++ b/src/operator/window.ts
@@ -39,5 +39,5 @@ import { window as higherOrder } from '../operators/window';
  * @owner Observable
  */
 export function window<T>(this: Observable<T>, windowBoundaries: Observable<any>): Observable<Observable<T>> {
-  return higherOrder(windowBoundaries)(this);
+  return higherOrder(windowBoundaries)(this) as Observable<Observable<T>>;
 }

--- a/src/operator/windowCount.ts
+++ b/src/operator/windowCount.ts
@@ -52,5 +52,5 @@ import { windowCount as higherOrder } from '../operators/windowCount';
  */
 export function windowCount<T>(this: Observable<T>, windowSize: number,
                                startWindowEvery: number = 0): Observable<Observable<T>> {
-  return higherOrder(windowSize, startWindowEvery)(this);
+  return higherOrder(windowSize, startWindowEvery)(this) as Observable<Observable<T>>;
 }

--- a/src/operator/windowTime.ts
+++ b/src/operator/windowTime.ts
@@ -98,5 +98,5 @@ export function windowTime<T>(this: Observable<T>,
     windowCreationInterval = arguments[1];
   }
 
-  return higherOrder(windowTimeSpan, windowCreationInterval, maxWindowSize, scheduler)(this);
+  return higherOrder(windowTimeSpan, windowCreationInterval, maxWindowSize, scheduler)(this) as Observable<Observable<T>>;
 }

--- a/src/operator/windowToggle.ts
+++ b/src/operator/windowToggle.ts
@@ -45,5 +45,5 @@ import { windowToggle as higherOrder } from '../operators/windowToggle';
  */
 export function windowToggle<T, O>(this: Observable<T>, openings: Observable<O>,
                                    closingSelector: (openValue: O) => Observable<any>): Observable<Observable<T>> {
-  return higherOrder(openings, closingSelector)(this);
+  return higherOrder(openings, closingSelector)(this) as Observable<Observable<T>>;
 }

--- a/src/operator/windowWhen.ts
+++ b/src/operator/windowWhen.ts
@@ -41,5 +41,5 @@ import { windowWhen as higherOrder } from '../operators/windowWhen';
  * @owner Observable
  */
 export function windowWhen<T>(this: Observable<T>, closingSelector: () => Observable<any>): Observable<Observable<T>> {
-  return higherOrder(closingSelector)(this);
+  return higherOrder(closingSelector)(this) as Observable<Observable<T>>;
 }

--- a/src/operators/catchError.ts
+++ b/src/operators/catchError.ts
@@ -67,7 +67,7 @@ export function catchError<T, R>(selector: (err: any, caught: Observable<T>) => 
   return function catchErrorOperatorFunction(source: Observable<T>): Observable<T | R> {
     const operator = new CatchOperator(selector);
     const caught = source.lift(operator);
-    return (operator.caught = caught);
+    return (operator.caught = caught as Observable<T>);
   };
 }
 

--- a/src/operators/concat.ts
+++ b/src/operators/concat.ts
@@ -64,7 +64,5 @@ export function concat<T, R>(...observables: Array<ObservableInput<any> | ISched
  * @owner Observable
  */
 export function concat<T, R>(...observables: Array<ObservableInput<any> | IScheduler>): OperatorFunction<T, R> {
-  return function concatOperatorFunction(source: Observable<T>): Observable<T | R> {
-    return source.lift.call(concatStatic<T, R>(source, ...observables));
-  };
+  return (source: Observable<T>) => source.lift.call(concatStatic<T, R>(source, ...observables));
 }

--- a/src/operators/defaultIfEmpty.ts
+++ b/src/operators/defaultIfEmpty.ts
@@ -39,9 +39,7 @@ export function defaultIfEmpty<T, R>(defaultValue?: R): OperatorFunction<T, T | 
  * @owner Observable
  */
 export function defaultIfEmpty<T, R>(defaultValue: R = null): OperatorFunction<T, T | R> {
-  return function defaultIfEmptyOperatorFunction(source: Observable<T>) {
-    return source.lift(new DefaultIfEmptyOperator(defaultValue));
-  };
+  return (source: Observable<T>) => source.lift(new DefaultIfEmptyOperator(defaultValue)) as Observable<T | R>;
 }
 
 class DefaultIfEmptyOperator<T, R> implements Operator<T, T | R> {

--- a/src/operators/merge.ts
+++ b/src/operators/merge.ts
@@ -119,5 +119,5 @@ export function mergeStatic<T, R>(...observables: Array<ObservableInput<any> | I
     return <Observable<R>>observables[0];
   }
 
-  return mergeAll(concurrent)(new ArrayObservable(<any>observables, scheduler));
+  return mergeAll(concurrent)(new ArrayObservable(<any>observables, scheduler)) as Observable<R>;
 }

--- a/src/operators/mergeAll.ts
+++ b/src/operators/mergeAll.ts
@@ -1,4 +1,5 @@
 
+import { ObservableInput } from '../Observable';
 import { mergeMap } from './mergeMap';
 import { identity } from '../util/identity';
 import { MonoTypeOperatorFunction } from '../interfaces';
@@ -48,5 +49,5 @@ import { MonoTypeOperatorFunction } from '../interfaces';
  * @owner Observable
  */
 export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): MonoTypeOperatorFunction<T> {
-  return mergeMap(identity, null, concurrent);
+  return mergeMap(identity as (value: T, index: number) => ObservableInput<{}>, null, concurrent);
 }

--- a/src/operators/partition.ts
+++ b/src/operators/partition.ts
@@ -49,5 +49,5 @@ export function partition<T>(predicate: (value: T, index: number) => boolean,
   return (source: Observable<T>) => [
     filter(predicate, thisArg)(source),
     filter(not(predicate, thisArg) as any)(source)
-  ];
+  ] as [Observable<T>, Observable<T>];
 }

--- a/src/operators/reduce.ts
+++ b/src/operators/reduce.ts
@@ -69,6 +69,6 @@ export function reduce<T, R>(accumulator: (acc: R, value: T, index?: number) => 
   return function reduceOperatorFunction(source: Observable<T>): Observable<R> {
     return pipe(scan<T, T | R>((acc, value, index) => {
       return accumulator(<R>acc, value, index + 1);
-    }), takeLast(1))(source);
+    }), takeLast(1))(source) as Observable<R>;
   };
 }

--- a/src/operators/share.ts
+++ b/src/operators/share.ts
@@ -22,5 +22,5 @@ function shareSubjectFactory() {
  * @owner Observable
  */
 export function share<T>(): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => refCount()(multicast(shareSubjectFactory)(source));
+  return (source: Observable<T>) => refCount()(multicast(shareSubjectFactory)(source)) as Observable<T>;
 };

--- a/src/operators/shareReplay.ts
+++ b/src/operators/shareReplay.ts
@@ -21,5 +21,5 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
       return (subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler));
     }
   });
-  return (source: Observable<T>) => refCount()(connectable(source));
+  return ((source: Observable<T>) => refCount()(connectable(source))) as MonoTypeOperatorFunction<T>;
 };


### PR DESCRIPTION
In testing Rx against projects using TS 2.4 and 2.5 (with strict compilation settings), there are a number of compilation errors. This PR adds casting to address these errors, so Rx can be used in projects using either TS 2.4 or 2.5.