### PR TITLE
fix(scan-operator): Remove redundant function overload types for .scan 

### DIFF
--- a/src/operator/scan.ts
+++ b/src/operator/scan.ts
@@ -3,8 +3,6 @@ import { Observable } from '../Observable';
 import { scan as higherOrderScan } from '../operators/scan';
 
 /* tslint:disable:max-line-length */
-export function scan<T>(this: Observable<T>, accumulator: (acc: T, value: T, index: number) => T, seed?: T): Observable<T>;
-export function scan<T>(this: Observable<T>, accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): Observable<T[]>;
 export function scan<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed?: R): Observable<R>;
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
This PR removes redundant function overloads for the `.scan` operator. It also fixes the type inference when dealing with a source observable representing `union` types. i.e Consider the following =>  

```typescript
const mergedObservable = Observable.merge(
  Observable.of({ loading: true }),
  Observable.of({ loading: false, data: ['hello'] })
)
.scan((acc, e) => Object.assign({}, acc, e), { loading: false, data: [] as string[] })

// typeof mergedObservable
// { loading: boolean } | { loading: boolean, data: string[] }

// typeof mergedObservable after this change.
// This is the correct return type for the above code. 
// { loading: boolean, data: string[] }
```

### Current Inferred type 
![image](https://user-images.githubusercontent.com/2698319/31177118-4f32b04c-a958-11e7-8f09-83ba9a027039.png)

### Inferred type with the changes from this PR.
![image](https://user-images.githubusercontent.com/2698319/31177293-edda0cb8-a958-11e7-9a0c-131a04a8b363.png)


