### PR TITLE
refactor: add @angular-devkit optimizations so the Rx bundle can be t…

### DIFF
--- a/package.json
+++ b/package.json
@@ -156,6 +156,7 @@
   },
   "homepage": "https://github.com/ReactiveX/RxJS",
   "devDependencies": {
+    "@angular-devkit/build-optimizer": "0.0.24",
     "babel-polyfill": "^6.23.0",
     "benchmark": "^2.1.0",
     "benchpress": "2.0.0-beta.1",

--- a/src/operators/toArray.ts
+++ b/src/operators/toArray.ts
@@ -7,5 +7,5 @@ function toArrayReducer<T>(arr: T[], item: T, index: number) {
 }
 
 export function toArray<T>(): OperatorFunction<T, T[]> {
-  return reduce(toArrayReducer, []);
+  return reduce(toArrayReducer, []) as OperatorFunction<T, T[]>;
 }


### PR DESCRIPTION
…ree-shaken

This change will modify the ESM5 output to add annotations used by Uglify in order to treeshake TypeScript downleveled classes.