### PR TITLE
fix(subscribeOn): remove subscribeOn from reexport to support treesha…

### DIFF
--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -75,7 +75,13 @@ export { skipLast } from './skipLast';
 export { skipUntil } from './skipUntil';
 export { skipWhile } from './skipWhile';
 export { startWith } from './startWith';
-export { subscribeOn } from './subscribeOn';
+/**
+ * TODO(jasonaden): Add back subscribeOn once it can be
+ * treeshaken. Currently if this export is added back, it
+ * forces apps to bring in asap scheduler along with
+ * Immediate, root, and other supporting code.
+ */
+// export { subscribeOn } from './subscribeOn';
 export { switchAll } from './switchAll';
 export { switchMap } from './switchMap';
 export { switchMapTo } from './switchMapTo';

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -76,7 +76,7 @@ export { skipUntil } from './skipUntil';
 export { skipWhile } from './skipWhile';
 export { startWith } from './startWith';
 /**
- * TODO(jasonaden): Add back subscribeOn once it can be
+ * TODO(https://github.com/ReactiveX/rxjs/issues/2900): Add back subscribeOn once it can be
  * treeshaken. Currently if this export is added back, it
  * forces apps to bring in asap scheduler along with
  * Immediate, root, and other supporting code.


### PR DESCRIPTION
…kability

There is more research to be done (see #2900), but right now `subscribeOn` needs to be removed from `operators/index.ts`. Having it in there pulls in a tree totaling around 20k unminified. The tree that gets pulled in includes subscribeOn, schedulers/asap, AsapAction, ImmediateDefiniton, root, and a bit more.