### PR TITLE
[Fix] Pluck overload signature

### DIFF
--- a/src/operator/pluck.ts
+++ b/src/operator/pluck.ts
@@ -27,7 +27,9 @@ import { map } from './map';
  * @method pluck
  * @owner Observable
  */
-export function pluck<T, R>(this: Observable<T>, ...properties: string[]): Observable<R> {
+export function pluck<T, R extends keyof T>(this: Observable<T>, property: R): Observable<T[R]>;
+export function pluck<T, R>(this: Observable<T>, ...properties: string[]): Observable<R>;
+export function pluck<T, R, U extends keyof T>(this: Observable<T>, ...properties: string[]): Observable<T[U] | R> {
   const length = properties.length;
   if (length === 0) {
     throw new Error('list of properties cannot be empty.');


### PR DESCRIPTION
**Description:** With new version of typescript and new keyword `keyof` it is possible now to add type safety to the signature of `pluck` operator.

But because nature of pluck is quite dynamic it is impossible to completely describe statically return type of this operator however for single argument version it's feasible.

This change yields the next result:
```ts
const obs = Observable.of({ a: 1, b: { c: '2' } });

const a = obs.pluck('a');
// 'a' has type Observable<number> <-- This is new safer behavior

const b = obs.pluck('b', 'c');
// 'b' has type Observable<{}> <-- 2 or more arguments version still works as before

const c = obs.pluck<any, string>('b', 'c');
// 'c' has type Observable<string> <-- And it is still possible to manually specify the return type
```

Thanks