### PR TITLE
chore(typings): improve toPromise typings

### DIFF
--- a/src/operator/toPromise.ts
+++ b/src/operator/toPromise.ts
@@ -4,6 +4,7 @@ import { toPromise as higherOrder } from '../operators/toPromise';
 /* tslint:disable:max-line-length */
 export function toPromise<T>(this: Observable<T>): Promise<T>;
 export function toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T>;
+export function toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -55,6 +56,6 @@ export function toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): 
  * @method toPromise
  * @owner Observable
  */
-export function toPromise<T>(this: Observable<T>, PromiseCtor?: typeof Promise): Promise<T> {
+export function toPromise<T>(this: Observable<T>, PromiseCtor?: PromiseConstructorLike): Promise<T> {
   return higherOrder(PromiseCtor)(this) as Promise<T>;
 }

--- a/src/operators/toPromise.ts
+++ b/src/operators/toPromise.ts
@@ -5,6 +5,7 @@ import { UnaryFunction } from '../interfaces';
 /* tslint:disable:max-line-length */
 export function toPromise<T>(): UnaryFunction<Observable<T>, Promise<T>>;
 export function toPromise<T>(PromiseCtor: typeof Promise): UnaryFunction<Observable<T>, Promise<T>>;
+export function toPromise<T>(PromiseCtor: PromiseConstructorLike): UnaryFunction<Observable<T>, Promise<T>>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -56,7 +57,7 @@ export function toPromise<T>(PromiseCtor: typeof Promise): UnaryFunction<Observa
  * @method toPromise
  * @owner Observable
  */
-export function toPromise<T>(PromiseCtor?: typeof Promise): UnaryFunction<Observable<T>, Promise<T>> {
+export function toPromise<T>(PromiseCtor?: PromiseConstructorLike): UnaryFunction<Observable<T>, Promise<T>> {
   return (source: Observable<T>) => {
     if (!PromiseCtor) {
       if (root.Rx && root.Rx.config && root.Rx.config.Promise) {
@@ -73,6 +74,6 @@ export function toPromise<T>(PromiseCtor?: typeof Promise): UnaryFunction<Observ
     return new PromiseCtor((resolve, reject) => {
       let value: any;
       source.subscribe((x: T) => value = x, (err: any) => reject(err), () => resolve(value));
-    });
+    }) as Promise<T>;
   };
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Add overload signatures that use TypeScript's built-in `PromiseConstructorLike` and
`PromiseLike` types.

**Related issue (if exists):** #2904