### PR TITLE
refactor(groupBy): put back export of GroupedObservable so-as not to …

### DIFF
--- a/src/operator/groupBy.ts
+++ b/src/operator/groupBy.ts
@@ -2,6 +2,7 @@
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { groupBy as higherOrder, GroupedObservable } from '../operators/groupBy';
+export { GroupedObservable };
 
 /* tslint:disable:max-line-length */
 export function groupBy<T, K>(this: Observable<T>, keySelector: (value: T) => K): Observable<GroupedObservable<K, T>>;


### PR DESCRIPTION
…break existing API
