### PR TITLE
refactor(shareReplay): align logic with var names

### DIFF
--- a/src/operators/shareReplay.ts
+++ b/src/operators/shareReplay.ts
@@ -12,7 +12,7 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
   let refCount = 0;
   let subscription: Subscription;
   let hasError = false;
-  let isComplete = true;
+  let isComplete = false;
 
   return (source: Observable<T>) => new Observable<T>(observer => {
     refCount++;
@@ -37,7 +37,7 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
     return () => {
       refCount--;
       innerSub.unsubscribe();
-      if (subscription && refCount === 0 && !isComplete) {
+      if (subscription && refCount === 0 && isComplete) {
         subscription.unsubscribe();
       }
     };


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes `isComplete` from being always `true` to representing whether or not
the source is actually complete and changes the logical test accordingly.

Without the change, `isComplete` is always `true` and the `unsubscribe` call made using the subscription to the source can never occur - regardless of the `refCount`.

With the change, the call will happen, but only if the `refCount` is zero and the source has completed.

If the source has completed, the `unsubscribe` call is redundant and the `refCount` is irrelevant. If you want, the implementation could be simplified to take that into account, like this:

```ts
export function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: IScheduler ): MonoTypeOperatorFunction<T> {
  let subject: ReplaySubject<T>;
  let hasError = false;

  return (source: Observable<T>) => new Observable<T>(observer => {
    if (!subject || hasError) {
      hasError = false;
      subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
      source.subscribe({
        next(value) { subject.next(value); },
        error(err) {
          hasError = true;
          subject.error(err);
        },
        complete() {
          subject.complete();
        },
      });
    }

    const innerSub = subject.subscribe(observer);

    return () => {
      innerSub.unsubscribe();
    };
  });
};
```

**Related issue (if exists):** None