### PR TITLE
fix(flatMap): reexport flatMap as alias of mergeMap

### DIFF
--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -43,6 +43,7 @@ export { max } from './max';
 export { merge } from './merge';
 export { mergeAll } from './mergeAll';
 export { mergeMap } from './mergeMap';
+export { mergeMap as flatMap } from './mergeMap';
 export { mergeMapTo } from './mergeMapTo';
 export { mergeScan } from './mergeScan';
 export { min } from './min';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [x] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adding `flatMap` alias.