### PR TITLE
Simplify webpack alias

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -138,9 +138,10 @@ function createImportTargets(importTargets, targetName, targetDirectory) {
 "use strict"
 
 var path = require('path');
+var dir = path.resolve(__dirname);
 
-module.exports = function(PATH_REPLACEMENT) {
-  return ${JSON.stringify(importMap, null, 4).replace(/(: )(".+")(,?)/g, "$1path.resolve(PATH_REPLACEMENT, $2)$3")};
+module.exports = function() {
+  return ${JSON.stringify(importMap, null, 4).replace(/(: )"rxjs\/_esm(5|2015)\/(.+")(,?)/g, "$1path.join(dir, \"$3)$4")};
 }
 `
 

--- a/doc/lettable-operators.md
+++ b/doc/lettable-operators.md
@@ -117,7 +117,7 @@ In order to use the new lettable operators and not gain bundle size, you will ne
 
 Published along with rxjs 5.5 is builds of rxjs in ECMAScript Module format (imports and exports) with both ES5 and ES2015 language level. You can find these distributions in `node_modules/rxjs/_esm5` and `node_modules/rxjs/_esm2015` ("esm" stands for ECMAScript Modules and the number "5" or "2015" is for the ES language level). In your application source code, you should import from `rxjs/operators`, but in your Webpack configuration file you will need to re-map imports to the ESM5 (or ESM2015) version.
 
-If you `require('rxjs/_esm5/path-mapping')`, you will receive a function that takes a path to your node modules (or any directory containing the rxjs distribution) and returns an object of key-value pairs mapping each input to it's file location on disk. Utilize this mapping as follows:
+If you `require('rxjs/_esm5/path-mapping')`, you will receive a function that returns an object of key-value pairs mapping each input to it's file location on disk. Utilize this mapping as follows:
 
 **webpack.config.js**
 
@@ -134,7 +134,7 @@ module.exports = {
   output: 'bundle.js',
   resolve: {
     // Use the "alias" key to resolve to an ESM distribution
-    alias: rxPaths(path.resolve(__dirname, 'node_modules'))
+    alias: rxPaths()
   },
   plugins: [
     new webpack.optimize.ModuleConcatenationPlugin()
@@ -179,7 +179,7 @@ var config = {
     resolve: {
         extensions: [".ts", ".js"],
         modules: [path.resolve('./src'), 'node_modules'],
-        alias: rxPaths(path.resolve(__dirname, 'node_modules'))
+        alias: rxPaths()
     },
     plugins: [
         new webpack.DefinePlugin({


### PR DESCRIPTION
Using `__dirname` directly in the `path-mapping.js` file should be more reliable and should always be accurate. This simplifies setting up the aliases for Webpack to map to the `esm` distribution.

Output in the `path-mapping.js` file will now look like this:

```

"use strict"

var path = require('path');

module.exports = function() {
  return {
    "rxjs/AsyncSubject": path.resolve(__dirname, "AsyncSubject.js"),
    "rxjs/add/observable/interval": path.resolve(__dirname, "add/observable/interval.js"),
    "rxjs/util/tryCatch": path.resolve(__dirname, "util/tryCatch.js"),
    // ...
};
}
```