### PR TITLE
operator/publishReplay.ts:give type arguments to higherOrder call

### DIFF
--- a/src/operator/publishReplay.ts
+++ b/src/operator/publishReplay.ts
@@ -24,5 +24,5 @@ export function publishReplay<T, R>(this: Observable<T>, bufferSize?: number,
                                     selectorOrScheduler?: IScheduler | OperatorFunction<T, R>,
                                     scheduler?: IScheduler): Observable<R> | ConnectableObservable<R> {
 
-  return higherOrder(bufferSize, windowTime, selectorOrScheduler as any, scheduler)(this);
+  return higherOrder<T, R>(bufferSize, windowTime, selectorOrScheduler as any, scheduler)(this);
 }


### PR DESCRIPTION
**Description:**
In src/operator/publishReplay.ts, the delegating call to higherOrder (which is an alias for publishReplay in src/operators/publishReplay.ts), has arguments that don't provide enough information to infer type arguments. That's because the third argument is cast to any, which is because it's just a delegation; a call to publishReplay could delegate to any of the three overloads of higherOrder. The compiler has to choose one, however, and it chooses the wrong one in Typescript 2.6.

This change provides the type arguments explicitly so that the most general overload gets called. This results in the the correct return type, `OperatorFunction<T, R>`.

**Related issue (if exists):**
#2991