### PR TITLE
fix(build): fix make_packages to not error when running build_test

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -60,6 +60,8 @@ const fileNames = klawSync(CJS_ROOT, {
 fileNames.map(fileName => {
   if (!bo) return fileName;
   let fullPath = path.resolve(__dirname, ESM5_ROOT, fileName);
+  // The file won't exist when running build_test as we don't create the ESM5 sources
+  if (!fs.existsSync(fullPath)) return fileName;
   let content = fs.readFileSync(fullPath).toString();
   let transformed = bo.transformJavascript({
     content: content,


### PR DESCRIPTION
When running `build_test` we don't create the ESM sources. `.make_packages.js` was looking for ESM sources in all cases. This change doesn't error when the ESM sources don't exist.