### PR TITLE
fix(TSC): Fixing TSC errors. Fixes #3020

### DIFF
--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -24,25 +24,27 @@ export function lowerCaseO<T>(...args: Array<any>): Rx.Observable<T> {
   return <any>o;
 };
 
-export const createObservableInputs = <T>(value: T) => Rx.Observable.of<ObservableInput<T>>(
-  Rx.Observable.of<T>(value),
-  Rx.Observable.of<T>(value, Rx.Scheduler.async),
-  [value],
-  Promise.resolve(value),
-  <any>({
-  [$$iterator]: () => {
-    const iteratorResults = [
-      { value, done: false },
-      { done: true }
-    ];
-    return {
-      next: () => {
-        return iteratorResults.shift();
-      }
-    };
-  }
-  }),
-  <any>({ [$$symbolObservable]: () => Rx.Observable.of(value) })
-);
+export function createObservableInputs<T>(value: T): Rx.Observable<ObservableInput<T>> {
+  return Rx.Observable.of<ObservableInput<T>>(
+    Rx.Observable.of<T>(value),
+    Rx.Observable.of<T>(value, Rx.Scheduler.async),
+    [value],
+    Promise.resolve(value),
+    <any>({
+    [$$iterator]: () => {
+      const iteratorResults = [
+        { value, done: false },
+        { done: true }
+      ];
+      return {
+        next: () => {
+          return iteratorResults.shift();
+        }
+      };
+    }
+    }),
+    <any>({ [$$symbolObservable]: () => Rx.Observable.of(value) })
+  );
+}
 
 global.__root__ = root;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,8 @@
       "es2015.collection",
       "es2015.promise",
       "dom"
-    ]
+    ],
+    "types": ["mocha", "node"]
   },
   "formatCodeOptions": {
     "indentSize": 2,


### PR DESCRIPTION
**Description:** This fixes all the warnings output by running `tsc` at the project's root by adding types for `node` and `mocha`, and also fixing a TS4023 issue.

**Related issue (if exists):** https://github.com/ReactiveX/rxjs/issues/3020
