### PR TITLE
docs(takeUntil): update docs to match operator's behavior

### DIFF
--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -43,7 +43,7 @@ children:
         - label: based on a given amount
           children:
           - label: takeLast
-      - label: until another Observable emits a value or completes
+      - label: until another Observable emits a value
         children:
         - label: takeUntil
     - label: I want to ignore values

--- a/src/operator/takeUntil.ts
+++ b/src/operator/takeUntil.ts
@@ -6,14 +6,15 @@ import { takeUntil as higherOrder } from '../operators/takeUntil';
  * Observable emits a value.
  *
  * <span class="informal">Lets values pass until a second Observable,
- * `notifier`, emits something. Then, it completes.</span>
+ * `notifier`, emits a value. Then, it completes.</span>
  *
  * <img src="./img/takeUntil.png" width="100%">
  *
  * `takeUntil` subscribes and begins mirroring the source Observable. It also
  * monitors a second Observable, `notifier` that you provide. If the `notifier`
  * emits a value, the output Observable stops mirroring the source Observable
- * and completes.
+ * and completes. If the `notifier` doesn't emit any value and completes
+ * then `takeUntil` will pass all values.
  *
  * @example <caption>Tick every second until the first click happens</caption>
  * var interval = Rx.Observable.interval(1000);

--- a/src/operators/takeUntil.ts
+++ b/src/operators/takeUntil.ts
@@ -14,14 +14,15 @@ import { MonoTypeOperatorFunction } from '../interfaces';
  * Observable emits a value.
  *
  * <span class="informal">Lets values pass until a second Observable,
- * `notifier`, emits something. Then, it completes.</span>
+ * `notifier`, emits a value. Then, it completes.</span>
  *
  * <img src="./img/takeUntil.png" width="100%">
  *
  * `takeUntil` subscribes and begins mirroring the source Observable. It also
  * monitors a second Observable, `notifier` that you provide. If the `notifier`
- * emits a value or a complete notification, the output Observable stops
- * mirroring the source Observable and completes.
+ * emits a value, the output Observable stops mirroring the source Observable
+ * and completes. If the `notifier` doesn't emit any value and completes
+ * then `takeUntil` will pass all values.
  *
  * @example <caption>Tick every second until the first click happens</caption>
  * var interval = Rx.Observable.interval(1000);


### PR DESCRIPTION
**Description:**

This PR only updates `takeUntil` docs to reflect its functionality.

**Related issue (if exists):**

#2160 
