### PR TITLE
docs(MIGRATION): remove shareReplay

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -106,7 +106,6 @@ enabling "composite" subscription behavior.
 |`selectMany(observable)`|`mergeMapTo(observable)`|
 |`selectManyObserver` or `flatMapObserver`|No longer implemented|
 |`select`|`map`|
-|`shareReplay`|`publishReplay().refCount()`|
 |`shareValue`|No longer implemented|
 |`singleInstance`|`share`|
 |`skipLastWithTime`|No longer implemented|


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Remove `shareReplay` from the **Operators Renamed or Removed** list in `MIGRATION.md`, as it was implemented in [5.4.0](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#540-2017-05-09) and its listing is causing confusion.

**Related issue (if exists):** #3034
