### PR TITLE
fix(fromEventPattern): pass multiple arguments of event emitters to subscribe

### DIFF
--- a/spec/observables/fromEventPattern-spec.ts
+++ b/spec/observables/fromEventPattern-spec.ts
@@ -133,4 +133,28 @@ describe('Observable.fromEventPattern', () => {
 
     trigger('test');
   });
+
+  it('should accept and pass multiple parameters from an event emitter', (done: MochaDone) => {
+    let target: Function = () => '';
+    const trigger = (...args: any[]) => {
+      if (target) {
+        target(...args);
+      }
+    };
+
+    const addHandler = (handler: any) => {
+      target = handler;
+    };
+
+    Observable.fromEventPattern(addHandler).take(1)
+      .subscribe((x: any) => {
+        expect(x).eql(['a', 'b', 'c']);
+      }, (err: any) => {
+        done(new Error('should not be called'));
+      }, () => {
+        done();
+      });
+
+    trigger('a', 'b', 'c');
+  });
 });

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -75,7 +75,17 @@ export class FromEventPatternObservable<T> extends Observable<T> {
 
     const handler = !!this.selector ? (...args: Array<any>) => {
       this._callSelector(subscriber, args);
-    } : function(e: any) { subscriber.next(e); };
+    } : function(...args: any[]) { // could be more than one parameters from an event emmiter
+      if (args && args.length > 1) {
+        let value: any = []; // use an array to capsule all parameters
+        for (let elem of args) {
+          value.push(elem);
+        }
+        subscriber.next(value);
+      } else {
+        subscriber.next(...args); // pass 0 or 1 parameter
+      }
+    };
 
     const retValue = this._callAddHandler(handler, subscriber);
 


### PR DESCRIPTION
**Description:**
The situation is like the following code:
```javascript
const EventEmitter = require('events').EventEmitter;
const Observable = require('rxjs').Observable;

const emitter = new EventEmitter();

const obs = Observable.fromEventPattern(function(handler) {
  emitter.on('test', handler);
});

obs.subscribe(args => {
  console.log(args); // expected ['a', 'b', 'c']
});

emitter.emit('test', 'a', 'b', 'c');

```
If multiple arguments are emitted from an event, only the first will be passed to `subscribe`. This PR changes it to pass an array of arguments to `subscribe`. A test case is added to `spec.ts`.

**Related issue (#3048)**
