### PR TITLE
refactor(types): enable strict fntype compiler option

### DIFF
--- a/src/internal/observable/BoundCallbackObservable.ts
+++ b/src/internal/observable/BoundCallbackObservable.ts
@@ -172,7 +172,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
   static create<T>(func: Function,
                    selector: Function | void = undefined,
                    scheduler?: IScheduler): (...args: any[]) => Observable<T> {
-    return function(this: any, ...args: any[]): Observable<T> {
+    return function (this: any, ...args: any[]): Observable<T> {
       return new BoundCallbackObservable<T>(func, <any>selector, args, this, scheduler);
     };
   }
@@ -201,7 +201,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
             const result = tryCatch(selector).apply(this, innerArgs);
             if (result === errorObject) {
               subject.error(errorObject.e);
-          } else {
+            } else {
               subject.next(result);
               subject.complete();
             }
@@ -220,7 +220,8 @@ export class BoundCallbackObservable<T> extends Observable<T> {
       }
       return subject.subscribe(subscriber);
     } else {
-      return scheduler.schedule(BoundCallbackObservable.dispatch, 0, { source: this, subscriber, context: this.context });
+      return scheduler.schedule<{ source: BoundCallbackObservable<T>, subscriber: Subscriber<T>, context: any }>
+        (BoundCallbackObservable.dispatch, 0, { source: this, subscriber, context: this.context });
     }
   }
 
@@ -239,13 +240,13 @@ export class BoundCallbackObservable<T> extends Observable<T> {
         if (selector) {
           const result = tryCatch(selector).apply(this, innerArgs);
           if (result === errorObject) {
-            self.add(scheduler.schedule(dispatchError, 0, { err: errorObject.e, subject }));
+            self.add(scheduler.schedule<DispatchErrorArg<T>>(dispatchError, 0, { err: errorObject.e, subject }));
           } else {
-            self.add(scheduler.schedule(dispatchNext, 0, { value: result, subject }));
+            self.add(scheduler.schedule<DispatchNextArg<T>>(dispatchNext, 0, { value: result, subject }));
           }
         } else {
           const value = innerArgs.length <= 1 ? innerArgs[0] : innerArgs;
-          self.add(scheduler.schedule(dispatchNext, 0, { value, subject }));
+          self.add(scheduler.schedule<DispatchNextArg<T>>(dispatchNext, 0, { value, subject }));
         }
       };
       // use named function to pass values in without closure

--- a/src/internal/observable/BoundNodeCallbackObservable.ts
+++ b/src/internal/observable/BoundNodeCallbackObservable.ts
@@ -207,7 +207,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
       }
       return subject.subscribe(subscriber);
     } else {
-      return scheduler.schedule(dispatch, 0, { source: this, subscriber, context: this.context });
+      return scheduler.schedule<DispatchState<T>>(dispatch, 0, { source: this, subscriber, context: this.context });
     }
   }
 }

--- a/src/internal/observable/SubscribeOnObservable.ts
+++ b/src/internal/observable/SubscribeOnObservable.ts
@@ -43,7 +43,7 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     const source = this.source;
     const scheduler = this.scheduler;
 
-    return scheduler.schedule(SubscribeOnObservable.dispatch, delay, {
+    return scheduler.schedule<DispatchArg<any>>(SubscribeOnObservable.dispatch, delay, {
       source, subscriber
     });
   }

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -350,7 +350,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       (<any>xhrError).progressSubscriber = progressSubscriber;
     }
 
-    function xhrReadyStateChange(this: XMLHttpRequest, e: ProgressEvent) {
+    function xhrReadyStateChange(this: XMLHttpRequest, e: Event) {
       const { subscriber, progressSubscriber, request } = (<any>xhrReadyStateChange);
       if (this.readyState === 4) {
         // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -51,7 +51,9 @@ export function pairs<T>(obj: Object, scheduler?: IScheduler): Observable<[strin
     return new Observable<[string, T]>(subscriber => {
       const keys = Object.keys(obj);
       const subscription = new Subscription();
-      subscription.add(scheduler.schedule(dispatch, 0, { keys, index: 0, subscriber, subscription, obj }));
+      subscription.add(
+        scheduler.schedule<{ keys: string[], index: number, subscriber: Subscriber<[string, T]>, subscription: Subscription, obj: Object }>
+          (dispatch, 0, { keys, index: 0, subscriber, subscription, obj }));
       return subscription;
     });
   }

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -66,7 +66,7 @@ export class RaceSubscriber<T> extends OuterSubscriber<T, T> {
     } else {
       for (let i = 0; i < len && !this.hasFirst; i++) {
         let observable = observables[i];
-        let subscription = subscribeToResult(this, observable, observable, i);
+        let subscription = subscribeToResult(this, observable, observable as any, i);
 
         if (this.subscriptions) {
           this.subscriptions.push(subscription);

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -64,7 +64,7 @@ export function concatMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * @owner Observable
  */
 export function concatMapTo<T, I, R>(
-  innerObservable: Observable<I>,
+  innerObservable: ObservableInput<I>,
   resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, R> {
   return concatMap(() => innerObservable, resultSelector);

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -130,7 +130,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
         this.subscribeToProjection(result, value, index);
       } else {
         const state: DispatchArg<T, R> = { subscriber: this, result, value, index };
-        this.add(this.scheduler.schedule(ExpandSubscriber.dispatch, 0, state));
+        this.add(this.scheduler.schedule<DispatchArg<T, R>>(ExpandSubscriber.dispatch, 0, state));
       }
     } else {
       this.buffer.push(value);

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -119,7 +119,7 @@ class GroupByOperator<T, K, R> implements Operator<T, GroupedObservable<K, R>> {
  * @extends {Ignored}
  */
 class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscription {
-  private groups: Map<K, Subject<T|R>> = null;
+  private groups: Map<K, Subject<T | R>> = null;
   public attemptedToUnsubscribe: boolean = false;
   public count: number = 0;
 
@@ -147,7 +147,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
     let groups = this.groups;
 
     if (!groups) {
-      groups = this.groups = new Map<K, Subject<T|R>>();
+      groups = this.groups = new Map<K, Subject<T | R>>();
     }
 
     let group = groups.get(key);
@@ -164,7 +164,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
     }
 
     if (!group) {
-      group = this.subjectSelector ? this.subjectSelector() : new Subject<R>();
+      group = (this.subjectSelector ? this.subjectSelector() : new Subject<R>()) as Subject<T | R>;
       groups.set(key, group);
       const groupedObservable = new GroupedObservable(key, group, this);
       this.destination.next(groupedObservable);
@@ -231,7 +231,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
 class GroupDurationSubscriber<K, T> extends Subscriber<T> {
   constructor(private key: K,
               private group: Subject<T>,
-              private parent: GroupBySubscriber<any, K, T>) {
+              private parent: GroupBySubscriber<any, K, T | any>) {
     super(group);
   }
 
@@ -265,7 +265,7 @@ export class GroupedObservable<K, T> extends Observable<T> {
 
   protected _subscribe(subscriber: Subscriber<T>) {
     const subscription = new Subscription();
-    const {refCountSubscription, groupSubject} = this;
+    const { refCountSubscription, groupSubject } = this;
     if (refCountSubscription && !refCountSubscription.closed) {
       subscription.add(new InnerRefCountSubscription(refCountSubscription));
     }

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -56,7 +56,7 @@ export function mergeMapTo<T, I, R>(observable: ObservableInput<I>, resultSelect
  * @method mergeMapTo
  * @owner Observable
  */
-export function mergeMapTo<T, I, R>(innerObservable: Observable<I>,
+export function mergeMapTo<T, I, R>(innerObservable: ObservableInput<I>,
                                     resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
                                     concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<T, R> {
   if (typeof resultSelector === 'number') {

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -8,7 +8,7 @@ import { Observable } from '../Observable';
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return function refCountOperatorFunction(source: ConnectableObservable<T>): Observable<T> {
     return source.lift(new RefCountOperator(source));
-  };
+  } as MonoTypeOperatorFunction<T>;
 }
 
 class RefCountOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -46,7 +46,7 @@ export function startWith<T>(...array: Array<T | IScheduler>): MonoTypeOperatorF
     } else if (len > 0) {
       return concatStatic(fromArray(array as T[], scheduler), source);
     } else {
-      return concatStatic<T>(empty(scheduler), source);
+      return concatStatic<T>(empty(scheduler) as any, source);
     }
   };
 }

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -28,7 +28,7 @@ class SubscribeOnOperator<T> implements Operator<T, T> {
               private delay: number) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return new SubscribeOnObservable(
+    return new SubscribeOnObservable<T>(
       source, this.delay, this.scheduler
     ).subscribe(subscriber);
   }

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -54,7 +54,7 @@ export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * @method switchMapTo
  * @owner Observable
  */
-export function switchMapTo<T, I, R>(innerObservable: Observable<I>,
+export function switchMapTo<T, I, R>(innerObservable: ObservableInput<I>,
                                      resultSelector?: (outerValue: T,
                                                        innerValue: I,
                                                        outerIndex: number,
@@ -63,7 +63,7 @@ export function switchMapTo<T, I, R>(innerObservable: Observable<I>,
 }
 
 class SwitchMapToOperator<T, I, R> implements Operator<T, I> {
-  constructor(private observable: Observable<I>,
+  constructor(private observable: ObservableInput<I>,
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
   }
 
@@ -82,7 +82,7 @@ class SwitchMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
   private innerSubscription: Subscription;
 
   constructor(destination: Subscriber<I>,
-              private inner: Observable<I>,
+              private inner: ObservableInput<I>,
               private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
     super(destination);
   }

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -91,7 +91,7 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
         this._hasTrailingValue = true;
       }
     } else {
-      this.add(this.throttled = this.scheduler.schedule(dispatchNext, this.duration, { subscriber: this }));
+      this.add(this.throttled = this.scheduler.schedule<DispatchArg<T>>(dispatchNext, this.duration, { subscriber: this }));
       if (this.leading) {
         this.destination.next(value);
       }

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -127,7 +127,7 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
       // to ensure that's the one we clone from next time.
       this.action = (<Action<TimeoutSubscriber<T>>> action.schedule(this, this.waitFor));
     } else {
-      this.add(this.action = (<Action<TimeoutSubscriber<T>>> this.scheduler.schedule(
+      this.add(this.action = (<Action<TimeoutSubscriber<T>>> this.scheduler.schedule<TimeoutSubscriber<T>>(
         TimeoutSubscriber.dispatchTimeout, this.waitFor, this
       )));
     }

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -120,7 +120,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
       // to ensure that's the one we clone from next time.
       this.action = (<Action<TimeoutWithSubscriber<T, R>>> action.schedule(this, this.waitFor));
     } else {
-      this.add(this.action = (<Action<TimeoutWithSubscriber<T, R>>> this.scheduler.schedule(
+      this.add(this.action = (<Action<TimeoutWithSubscriber<T, R>>> this.scheduler.schedule<TimeoutWithSubscriber<T, R>>(
         TimeoutWithSubscriber.dispatchTimeout, this.waitFor, this
       )));
     }

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -177,11 +177,11 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
       const closeState: CloseState<T> = { subscriber: this, window, context: <any>null };
       const creationState: CreationState<T> = { windowTimeSpan, windowCreationInterval, subscriber: this, scheduler };
-      this.add(scheduler.schedule(dispatchWindowClose, windowTimeSpan, closeState));
-      this.add(scheduler.schedule(dispatchWindowCreation, windowCreationInterval, creationState));
+      this.add(scheduler.schedule<CloseState<T>>(dispatchWindowClose, windowTimeSpan, closeState));
+      this.add(scheduler.schedule<CreationState<T>>(dispatchWindowCreation, windowCreationInterval, creationState));
     } else {
       const timeSpanOnlyState: TimeSpanOnlyState<T> = { subscriber: this, window, windowTimeSpan };
-      this.add(scheduler.schedule(dispatchWindowTimeSpanOnly, windowTimeSpan, timeSpanOnlyState));
+      this.add(scheduler.schedule<TimeSpanOnlyState<T>>(dispatchWindowTimeSpanOnly, windowTimeSpan, timeSpanOnlyState));
     }
   }
 
@@ -248,7 +248,7 @@ function dispatchWindowCreation<T>(this: Action<CreationState<T>>, state: Creati
   const action = this;
   let context: CloseWindowContext<T> = { action, subscription: <any>null };
   const timeSpanState: CloseState<T> = { subscriber, window, context };
-  context.subscription = scheduler.schedule(dispatchWindowClose, windowTimeSpan, timeSpanState);
+  context.subscription = scheduler.schedule<CloseState<T>>(dispatchWindowClose, windowTimeSpan, timeSpanState);
   action.add(context.subscription);
   action.schedule(state, windowCreationInterval);
 }

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -87,7 +87,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
               private openings: Observable<O>,
               private closingSelector: (openValue: O) => Observable<any>) {
     super(destination);
-    this.add(this.openSubscription = subscribeToResult(this, openings, openings));
+    this.add(this.openSubscription = subscribeToResult(this, openings, openings as any));
   }
 
   protected _next(value: T) {
@@ -164,7 +164,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
         const subscription = new Subscription();
         const context = { window, subscription };
         this.contexts.push(context);
-        const innerSubscription = subscribeToResult(this, closingNotifier, context);
+        const innerSubscription = subscribeToResult(this, closingNotifier, context as any);
 
         if (innerSubscription.closed) {
           this.closeWindow(this.contexts.length - 1);

--- a/src/internal/patching/operator/combineLatest.ts
+++ b/src/internal/patching/operator/combineLatest.ts
@@ -77,5 +77,5 @@ export function combineLatest<T, R>(this: Observable<T>, ...observables: Array<O
     observables = (<any>observables[0]).slice();
   }
 
-  return this.lift.call(of(this, ...observables), new CombineLatestOperator(project));
+  return this.lift.call(of(this, ...observables as Array<Observable<any>>), new CombineLatestOperator(project));
 }

--- a/src/internal/patching/operator/concatMapTo.ts
+++ b/src/internal/patching/operator/concatMapTo.ts
@@ -62,7 +62,7 @@ export function concatMapTo<T, I, R>(this: Observable<T>, observable: Observable
  * @method concatMapTo
  * @owner Observable
  */
-export function concatMapTo<T, I, R>(this: Observable<T>, innerObservable: Observable<I>,
+export function concatMapTo<T, I, R>(this: Observable<T>, innerObservable: ObservableInput<I>,
                                      resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {
   return higherOrder(innerObservable, resultSelector)(this);
 }

--- a/src/internal/patching/operator/mergeMapTo.ts
+++ b/src/internal/patching/operator/mergeMapTo.ts
@@ -49,7 +49,7 @@ export function mergeMapTo<T, I, R>(this: Observable<T>, observable: ObservableI
  * @method mergeMapTo
  * @owner Observable
  */
-export function mergeMapTo<T, I, R>(this: Observable<T>, innerObservable: Observable<I>,
+export function mergeMapTo<T, I, R>(this: Observable<T>, innerObservable: ObservableInput<I>,
                                     resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
                                     concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
   return higherOrder(innerObservable, resultSelector as any, concurrent)(this) as Observable<R>;

--- a/src/internal/patching/operator/publishLast.ts
+++ b/src/internal/patching/operator/publishLast.ts
@@ -8,5 +8,5 @@ import { publishLast as higherOrder } from '../../operators/publishLast';
  */
 export function publishLast<T>(this: Observable<T>): ConnectableObservable<T> {
   //TODO(benlesh): correct type-flow through here.
-  return higherOrder()(this) as ConnectableObservable<T>;
+  return higherOrder<T>()(this) as ConnectableObservable<T>;
 }

--- a/src/internal/patching/operator/scan.ts
+++ b/src/internal/patching/operator/scan.ts
@@ -45,9 +45,11 @@ export function scan<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, 
  * @method scan
  * @owner Observable
  */
-export function scan<T, R>(this: Observable<T>, accumulator: (acc: R, value: T, index: number) => R, seed?: T | R): Observable<R> {
+export function scan<T, R>(this: Observable<T>,
+                           accumulator: (acc: T | Array<T> | R, value: T, index: number) => T | Array<T> | R,
+                           seed?: T | R): Observable<R> {
   if (arguments.length >= 2) {
     return higherOrderScan(accumulator, seed)(this) as Observable<R>;
   }
-  return higherOrderScan(accumulator)(this);
+  return higherOrderScan(accumulator)(this) as Observable<R>;
 }

--- a/src/internal/patching/operator/switchMapTo.ts
+++ b/src/internal/patching/operator/switchMapTo.ts
@@ -48,7 +48,7 @@ export function switchMapTo<T, I, R>(this: Observable<T>, observable: Observable
  * @method switchMapTo
  * @owner Observable
  */
-export function switchMapTo<T, I, R>(this: Observable<T>, innerObservable: Observable<I>,
+export function switchMapTo<T, I, R>(this: Observable<T>, innerObservable: ObservableInput<I>,
                                      resultSelector?: (outerValue: T,
                                                        innerValue: I,
                                                        outerIndex: number,

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -1,6 +1,7 @@
 import { AsyncAction } from './AsyncAction';
 import { AnimationFrame } from '..//util/AnimationFrame';
 import { AnimationFrameScheduler } from './AnimationFrameScheduler';
+import { Action } from './Action';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -10,7 +11,7 @@ import { AnimationFrameScheduler } from './AnimationFrameScheduler';
 export class AnimationFrameAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AnimationFrameScheduler,
-              protected work: (this: AnimationFrameAction<T>, state?: T) => void) {
+              protected work: (this: Action<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -1,6 +1,7 @@
 import { Immediate } from '..//util/Immediate';
 import { AsyncAction } from './AsyncAction';
 import { AsapScheduler } from './AsapScheduler';
+import { Action } from './Action';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -10,7 +11,7 @@ import { AsapScheduler } from './AsapScheduler';
 export class AsapAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AsapScheduler,
-              protected work: (this: AsapAction<T>, state?: T) => void) {
+              protected work: (this: Action<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -16,7 +16,7 @@ export class AsyncAction<T> extends Action<T> {
   protected pending: boolean = false;
 
   constructor(protected scheduler: AsyncScheduler,
-              protected work: (this: AsyncAction<T>, state?: T) => void) {
+              protected work: (this: Action<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/QueueAction.ts
+++ b/src/internal/scheduler/QueueAction.ts
@@ -1,6 +1,7 @@
 import { AsyncAction } from './AsyncAction';
 import { Subscription } from '../Subscription';
 import { QueueScheduler } from './QueueScheduler';
+import { Action } from './Action';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -10,7 +11,7 @@ import { QueueScheduler } from './QueueScheduler';
 export class QueueAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: QueueScheduler,
-              protected work: (this: QueueAction<T>, state?: T) => void) {
+              protected work: (this: Action<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -1,6 +1,7 @@
 import { AsyncAction } from './AsyncAction';
 import { Subscription } from '../Subscription';
 import { AsyncScheduler } from './AsyncScheduler';
+import { Action } from './Action';
 
 export class VirtualTimeScheduler extends AsyncScheduler {
 
@@ -9,7 +10,7 @@ export class VirtualTimeScheduler extends AsyncScheduler {
   public frame: number = 0;
   public index: number = -1;
 
-  constructor(SchedulerAction: typeof AsyncAction = VirtualAction,
+  constructor(SchedulerAction: typeof AsyncAction = VirtualAction as any,
               public maxFrames: number = Number.POSITIVE_INFINITY) {
     super(SchedulerAction, () => this.frame);
   }
@@ -49,7 +50,7 @@ export class VirtualAction<T> extends AsyncAction<T> {
   protected active: boolean = true;
 
   constructor(protected scheduler: VirtualTimeScheduler,
-              protected work: (this: VirtualAction<T>, state?: T) => void,
+              protected work: (this: Action<T>, state?: T) => void,
               protected index: number = scheduler.index += 1) {
     super(scheduler, work);
     this.index = scheduler.index = index;
@@ -73,7 +74,7 @@ export class VirtualAction<T> extends AsyncAction<T> {
     this.delay = scheduler.frame + delay;
     const {actions} = scheduler;
     actions.push(this);
-    actions.sort(VirtualAction.sortActions);
+    (actions as Array<VirtualAction<T>>).sort(VirtualAction.sortActions);
     return true;
   }
 

--- a/src/internal/testing/ColdObservable.ts
+++ b/src/internal/testing/ColdObservable.ts
@@ -20,8 +20,8 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
 
   constructor(public messages: TestMessage[],
               scheduler: Scheduler) {
-    super(function (this: ColdObservable<T>, subscriber: Subscriber<any>) {
-      const observable: ColdObservable<T> = this;
+    super(function (this: Observable<T>, subscriber: Subscriber<any>) {
+      const observable: ColdObservable<T> = this as any;
       const index = observable.logSubscribedFrame();
       subscriber.add(new Subscription(() => {
         observable.logUnsubscribedFrame(index);
@@ -37,9 +37,9 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
     for (let i = 0; i < messagesLength; i++) {
       const message = this.messages[i];
       subscriber.add(
-        this.scheduler.schedule(({message, subscriber}) => { message.notification.observe(subscriber); },
+        this.scheduler.schedule(({ message, subscriber }) => { message.notification.observe(subscriber); },
           message.frame,
-          {message, subscriber})
+          { message, subscriber })
       );
     }
   }

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -29,6 +29,6 @@ export function pipeFromArray<T, R>(fns: Array<UnaryFunction<T, R>>): UnaryFunct
   }
 
   return function piped(input: T): R {
-    return fns.reduce((prev: any, fn: UnaryFunction<T, R>) => fn(prev), input);
+    return fns.reduce((prev: any, fn: UnaryFunction<T, R>) => fn(prev), input as any);
   };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,6 +3,7 @@
     "removeComments": false,
     "preserveConstEnums": true,
     "sourceMap": true,
+    "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,
     "noImplicitThis": true,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR enables `strictFnType` in master branch resolves build error with 2.6 version of tsc. (related with https://github.com/ReactiveX/rxjs/issues/3031) . due to our inheritance structure, there are some types are actually loosened (mostly around `Action`'s `work` types). 

This is targeting master intentionally due to scope of change is relatively large, include (probably) unnecessary part to close issue itself. Some change need to be cherrypicked into `stable` though.

**Related issue (if exists):**
