### PR TITLE
chore(gitignore): ignore IntelliJ IDEA module files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Editor-specific
 .idea/
+*.iml
 *.sublime-project
 *.sublime-workspace
 .settings


### PR DESCRIPTION
Make Git ignore IntelliJ IDEA module (*.iml) files.

**Description:**

Depending on the personal preferences user can keep IntelliJ IDEA module (*.iml) files  in project root directory. This change makes Git ignore these files.

**Related issue (if exists):**

N/A
