### PR TITLE
fix(Subject): make value parameter for next non-optional

### DIFF
--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -49,7 +49,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     return <any>subject;
   }
 
-  next(value?: T) {
+  next(value: T) {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     }

--- a/src/operators/repeatWhen.ts
+++ b/src/operators/repeatWhen.ts
@@ -46,7 +46,7 @@ class RepeatWhenOperator<T> implements Operator<T, T> {
  */
 class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  private notifications: Subject<any>;
+  private notifications: Subject<void>;
   private retries: Observable<any>;
   private retriesSubscription: Subscription;
   private sourceIsBeingSubscribedTo: boolean = true;
@@ -81,7 +81,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
       }
 
       this._unsubscribeAndRecycle();
-      this.notifications.next();
+      this.notifications.next(undefined);
     }
   }
 


### PR DESCRIPTION
Prevents emitting undefined on strictly-typed Subjects

BREAKING CHANGE:
If you are using TypeScript called next() without a value before, TypeScript will error. If the Subject is of type void, explicitely pass undefined to next().

closes #2852

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->
