### PR TITLE
build(bazel): adds bazel build files to support building rxjs with bazel from dist

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -98,6 +98,8 @@ fs.copySync(TYPE_ROOT, TYPE_PKG);
 copySources(ESM5_ROOT, ESM5_PKG, true);
 copySources(ESM2015_ROOT, ESM2015_PKG, true);
 
+// Copy over tsconfig.json for bazel build support
+fs.copySync('./tsconfig.json', PKG_ROOT + 'src/tsconfig.json');
 
 fs.writeJsonSync(PKG_ROOT + 'package.json', rootPackageJson);
 

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -1,0 +1,12 @@
+package(default_visibility = ["//visibility:public"])
+
+exports_files(["tsconfig.json"])
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+
+ts_library(
+  name = "rxjs",
+  module_name = "rxjs",
+  srcs = glob(["*.ts", "**/*.ts"]),
+  tsconfig = "tsconfig.json",
+)

--- a/src/WORKSPACE
+++ b/src/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "rxjs")


### PR DESCRIPTION
Adds `WORKSPACE` and `BUILD.bazel` files to `/src` folder so they end up in `/dist/package/src` and copies `/tsconfig.json` to `/dist/packages/src` for external bazel build support.

Bazel built projects that pull in rxjs from npm can build it with Bazel with the following configuration in their WORKSPACE file:

```
local_repository(
    name = "rxjs",
    path = "node_modules/rxjs/src",
)
```

and using the following dependency on targets that depend on rxjs:

```
"@rxjs//:rxjs"
```

An example of this can be found here: https://github.com/gregmagolan/webpack-typescript-benchmarking/tree/bazel-rxjs