### PR TITLE
fix(Observable.toArray): Fix Observable.toArray with multiple subscriptions.

### DIFF
--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -65,6 +65,17 @@ describe('Observable.prototype.toArray', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should allow multiple subscriptions', () => {
+    const e1 = hot('-x-^--y--|');
+    const e1subs =    '^     !';
+    const expected =  '------(w|)';
+
+    const result = e1.toArray();
+    expectObservable(result).toBe(expected, { w: ['y'] });
+    expectObservable(result).toBe(expected, { w: ['y'] });
+    expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
+  });
+
   it('should allow unsubscribing explicitly and early', () => {
     const e1 =   hot('--a--b----c-----d----e---|');
     const unsub =    '        !                 ';

--- a/src/operators/toArray.ts
+++ b/src/operators/toArray.ts
@@ -2,6 +2,9 @@ import { reduce } from './reduce';
 import { OperatorFunction } from '../interfaces';
 
 function toArrayReducer<T>(arr: T[], item: T, index: number) {
+  if (index === 0) {
+    return [item];
+  }
   arr.push(item);
   return arr;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The current implementation of `Observable.toArray` reuses the same array instance for multiple subscriptions.

This example clarifies why that's wrong.
```js
const Rx = require('rxjs/Rx');
const observable = Rx.Observable.from([1,2]).toArray();
observable.take(1).subscribe(console.log); // prints [ 1, 2 ]
observable.take(1).subscribe(console.log); // prints [ 1, 2, 1, 2 ]
```