### PR TITLE
fix(AjaxObservable): notify with error if fails to parse json response

### DIFF
--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -329,7 +329,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       } else {
         subscriber.error(ajaxTimeoutError);
       }
-    };
+    }
     xhr.ontimeout = xhrTimeout;
     (<any>xhrTimeout).request = request;
     (<any>xhrTimeout).subscriber = this;

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -221,8 +221,11 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
     this.done = true;
     const { xhr, request, destination } = this;
     const response = new AjaxResponse(e, xhr, request);
-
-    destination.next(response);
+    if (response.response === errorObject) {
+      destination.error(errorObject.e);
+    } else {
+      destination.next(response);
+    }
   }
 
   private send(): XMLHttpRequest {
@@ -320,8 +323,13 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       if (progressSubscriber) {
         progressSubscriber.error(e);
       }
-      subscriber.error(new AjaxTimeoutError(this, request)); //TODO: Make betterer.
-    }
+      const ajaxTimeoutError = new AjaxTimeoutError(this, request); //TODO: Make betterer.
+      if (ajaxTimeoutError.response === errorObject) {
+        subscriber.error(errorObject.e);
+      } else {
+        subscriber.error(ajaxTimeoutError);
+      }
+    };
     xhr.ontimeout = xhrTimeout;
     (<any>xhrTimeout).request = request;
     (<any>xhrTimeout).subscriber = this;
@@ -346,7 +354,12 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
         if (progressSubscriber) {
           progressSubscriber.error(e);
         }
-        subscriber.error(new AjaxError('ajax error', this, request));
+        const ajaxError = new AjaxError('ajax error', this, request);
+        if (ajaxError.response === errorObject) {
+          subscriber.error(errorObject.e);
+        } else {
+          subscriber.error(ajaxError);
+        }
       };
       xhr.onerror = xhrError;
       (<any>xhrError).request = request;
@@ -388,7 +401,12 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
           if (progressSubscriber) {
             progressSubscriber.error(e);
           }
-          subscriber.error(new AjaxError('ajax error ' + status, this, request));
+          const ajaxError = new AjaxError('ajax error ' + status, this, request);
+          if (ajaxError.response === errorObject) {
+            subscriber.error(errorObject.e);
+          } else {
+            subscriber.error(ajaxError);
+          }
         }
       }
     }
@@ -474,17 +492,21 @@ export class AjaxError extends Error {
   }
 }
 
+function parseJson(xhr: XMLHttpRequest) {
+  // HACK(benlesh): TypeScript shennanigans
+  // tslint:disable-next-line:no-any XMLHttpRequest is defined to always have 'response' inferring xhr as never for the else clause.
+  if ('response' in (xhr as any)) {
+    //IE does not support json as responseType, parse it internally
+    return xhr.responseType ? xhr.response : JSON.parse(xhr.response || xhr.responseText || 'null');
+  } else {
+    return JSON.parse((xhr as any).responseText || 'null');
+  }
+}
+
 function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
   switch (responseType) {
     case 'json':
-        // HACK(benlesh): TypeScript shennanigans
-        // tslint:disable-next-line:no-any XMLHttpRequest is defined to always have 'response' inferring xhr as never for the else clause.
-        if ('response' in (xhr as any)) {
-          //IE does not support json as responseType, parse it internally
-          return xhr.responseType ? xhr.response : JSON.parse(xhr.response || xhr.responseText || 'null');
-        } else {
-          return JSON.parse((xhr as any).responseText || 'null');
-        }
+        return tryCatch(parseJson)(xhr);
       case 'xml':
         return xhr.responseXML;
       case 'text':


### PR DESCRIPTION
Catch error when parsing json response and notify observer with thrown error.
JSON could be invalid if proxy overtakes the response and in IE responseType is empty.

closes #3138

**Description:**
Please find description under the issue. This is my first PR to rxjs, so any feedback is welcome.

**Related issue (if exists):** #3138 
