### PR TITLE
docs(README): mention lettable operators

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ import { map } from 'rxjs/operator/map';
 Observable::of(1,2,3)::map(x => x + '!!!'); // etc
 ```
 
-Alternatively, you can use the built-in `pipe` method on Observables. See [lettable operators](https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md) for more information.
+Alternatively, you can use the built-in `pipe` method on Observables. See [lettable operators](https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md) for more information.
 
 ### CommonJS via npm
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ import { map } from 'rxjs/operator/map';
 Observable::of(1,2,3)::map(x => x + '!!!'); // etc
 ```
 
-Alternatively, you can use the built-in `pipe` method on Observables. See [lettable operators](https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md) for more information.
+Alternatively, you can use the built-in `pipe` method on Observables. See [pipeable operators](https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md) for more information.
 
 ### CommonJS via npm
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ import { map } from 'rxjs/operator/map';
 Observable::of(1,2,3)::map(x => x + '!!!'); // etc
 ```
 
+Alternatively, you can use the built-in `pipe` method on Observables. See [lettable operators](https://github.com/ReactiveX/rxjs/blob/master/doc/lettable-operators.md) for more information.
+
 ### CommonJS via npm
 
 To install this library for CommonJS (CJS) usage, use the following command:


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
