### PR TITLE
🛑 Remove .bind loss of type safety.

### DIFF
--- a/src/scheduler/AnimationFrameAction.ts
+++ b/src/scheduler/AnimationFrameAction.ts
@@ -25,8 +25,7 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     // one. If an animation frame hasn't been requested yet, request one. Return
     // the current animation frame request id.
     return scheduler.scheduled || (scheduler.scheduled = AnimationFrame.requestAnimationFrame(
-      scheduler.flush.bind(scheduler, null)
-    ));
+      () => scheduler.flush(null)));
   }
   protected recycleAsyncId(scheduler: AnimationFrameScheduler, id?: any, delay: number = 0): any {
     // If delay exists and is greater than 0, or if the delay is null (the


### PR DESCRIPTION
When you use .bind in typescript you lose type safety

https://www.typescriptlang.org/play/#src=class%20Person%20%7B%0D%0A%20%20%20%20private%20name%3A%20string%3B%0D%0A%0D%0A%20%20%20%20speak(msg)%20%7B%0D%0A%20%20%20%20%20%20%20%20console.log(%60%24%7Bmsg%7D%20%24%7Bthis.name%7D%60)%0D%0A%0D%0A%20%20%20%20%20%20%20%20%2F%2F%20look%20no%20exceptions!%0D%0A%20%20%20%20%20%20%20%20setTimeout(this.speak.bind(this)%2C%2010)%0D%0A%20%20%20%20%7D%0D%0A%7D%0D%0A%0D%0Aclass%20PersonSafe%20%7B%0D%0A%20%20%20%20private%20name%3A%20string%3B%0D%0A%0D%0A%20%20%20%20speak(msg)%20%7B%0D%0A%20%20%20%20%20%20%20%20console.log(%60%24%7Bmsg%7D%20%24%7Bthis.name%7D%60)%0D%0A%0D%0A%20%20%20%20%20%20%20%20%2F%2F%20look%20no%20exceptions!%0D%0A%20%20%20%20%20%20%20%20setTimeout(()%20%3D%3E%20this.speak()%2C%2010)%0D%0A%20%20%20%20%7D%0D%0A%7D


By switching to an arrow function we get to retain the typescript engines type checking to avoid bugs slipping into releases when function signatures are changed.
