### PR TITLE
fix: Revert "fix(scheduler): prevent unwanted clearInterval (#3044)"

### DIFF
--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -40,59 +40,6 @@ describe('Scheduler.asap', () => {
     sandbox.restore();
   });
 
-  it('should reuse the interval for recursively scheduled actions with the same delay', () => {
-    const sandbox = sinon.sandbox.create();
-    const fakeTimer = sandbox.useFakeTimers();
-    // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sinon.stub(global, 'setInterval')).callThrough();
-    function dispatch(state: any): void {
-      state.index += 1;
-      if (state.index < 3) {
-        (<any> this).schedule(state, state.period);
-      }
-    }
-    const period = 50;
-    const state = { index: 0, period };
-    asap.schedule(dispatch, period, state);
-    expect(state).to.have.property('index', 0);
-    expect(stubSetInterval).to.have.property('callCount', 1);
-    fakeTimer.tick(period);
-    expect(state).to.have.property('index', 1);
-    expect(stubSetInterval).to.have.property('callCount', 1);
-    fakeTimer.tick(period);
-    expect(state).to.have.property('index', 2);
-    expect(stubSetInterval).to.have.property('callCount', 1);
-    stubSetInterval.restore();
-    sandbox.restore();
-  });
-
-  it('should not reuse the interval for recursively scheduled actions with a different delay', () => {
-    const sandbox = sinon.sandbox.create();
-    const fakeTimer = sandbox.useFakeTimers();
-    // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sinon.stub(global, 'setInterval')).callThrough();
-    function dispatch(state: any): void {
-      state.index += 1;
-      state.period -= 1;
-      if (state.index < 3) {
-        (<any> this).schedule(state, state.period);
-      }
-    }
-    const period = 50;
-    const state = { index: 0, period };
-    asap.schedule(dispatch, period, state);
-    expect(state).to.have.property('index', 0);
-    expect(stubSetInterval).to.have.property('callCount', 1);
-    fakeTimer.tick(period);
-    expect(state).to.have.property('index', 1);
-    expect(stubSetInterval).to.have.property('callCount', 2);
-    fakeTimer.tick(period);
-    expect(state).to.have.property('index', 2);
-    expect(stubSetInterval).to.have.property('callCount', 3);
-    stubSetInterval.restore();
-    sandbox.restore();
-  });
-
   it('should schedule an action to happen later', (done: MochaDone) => {
     let actionHappened = false;
     asap.schedule(() => {

--- a/src/scheduler/AsyncAction.ts
+++ b/src/scheduler/AsyncAction.ts
@@ -29,6 +29,10 @@ export class AsyncAction<T> extends Action<T> {
     // Always replace the current state with the new state.
     this.state = state;
 
+    // Set the pending flag indicating that this action has been scheduled, or
+    // has recursively rescheduled itself.
+    this.pending = true;
+
     const id = this.id;
     const scheduler = this.scheduler;
 
@@ -56,10 +60,6 @@ export class AsyncAction<T> extends Action<T> {
     if (id != null) {
       this.id = this.recycleAsyncId(scheduler, id, delay);
     }
-
-    // Set the pending flag indicating that this action has been scheduled, or
-    // has recursively rescheduled itself.
-    this.pending = true;
 
     this.delay = delay;
     // If this action has already an async Id, don't request a new one.


### PR DESCRIPTION
This reverts commit 7d722d4d36debcf5bb79fa4006f455bd72caeee1.


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
fixing regressions.
**Related issue (if exists):**
- closes #3151