### PR TITLE
fix(dependency): move symbol-observable into devdependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ matrix:
 
 before_install:
   - nvm install $NODE_VER
-  - npm install -g npm@4 && npm install -g npx && node -v && npm -v
+  - npm install -g npm@5.6.0 && npm install -g npx && node -v && npm -v
   - if [ "$FULL_VALIDATE" == "true" ]; then npm install grunt@0.4.1 grunt-cli grunt-contrib-connect grunt-run; fi
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -8,7 +8,7 @@ environment:
 install:
   - ps: Install-Product node $env:nodejs_version
   - set PATH=%APPDATA%\npm;%PATH%
-  - npm install -g npm@4
+  - npm install -g npm@5.6.0
   - node -v && npm -v
   - npm install
 

--- a/package.json
+++ b/package.json
@@ -224,6 +224,7 @@
     "sinon": "^2.1.0",
     "sinon-chai": "^2.9.0",
     "source-map-support": "^0.4.0",
+    "symbol-observable": "^1.0.1",
     "ts-node": "^3.3.0",
     "tslib": "^1.5.0",
     "tslint": "^4.4.2",
@@ -236,8 +237,5 @@
   "engines": {
     "npm": ">=2.0.0"
   },
-  "typings": "./dist/package/Rx.d.ts",
-  "dependencies": {
-    "symbol-observable": "^1.0.1"
-  }
+  "typings": "./dist/package/Rx.d.ts"
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
We don't use `symbol-observable` for dependency anywhere, moving it into devdep.

**Related issue (if exists):**
