### PR TITLE
fix(Observable): Another attempt at fixing error rethrows in v5

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -59,6 +59,20 @@ describe('Observable', () => {
     }).to.throw();
   });
 
+  it('should rethrow if sink has syncErrorThrowable = false', () => {
+    const observable = new Observable(observer => {
+      observer.next(1);
+    });
+
+    const sink = Subscriber.create(() => {
+      throw 'error!';
+    });
+
+    expect(() => {
+      observable.subscribe(sink);
+    }).to.throw('error!');
+  });
+
   describe('forEach', () => {
     it('should iterate and return a Promise', (done: MochaDone) => {
       const expected = [1, 2, 3];

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -199,7 +199,7 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink.add(this.source ? this._subscribe(sink) : this._trySubscribe(sink));
+      sink.add(this.source || !sink.syncErrorThrowable ? this._subscribe(sink) : this._trySubscribe(sink));
     }
 
     if (sink.syncErrorThrowable) {

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -68,6 +68,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
         }
         if (typeof destinationOrNext === 'object') {
           if (destinationOrNext instanceof Subscriber) {
+            this.syncErrorThrowable = destinationOrNext.syncErrorThrowable;
             this.destination = (<Subscriber<any>> destinationOrNext);
             (<any> this.destination).add(this);
           } else {


### PR DESCRIPTION
This is an attempt at fixing the rethrow issues in #2813. Some of them have been fixed by previous PRs, but other cases still remain. _So far_ every one I've seen has been fixed by this PR.

I'll be totally honest though, why this works isn't 100% clear. The `syncErrorThrowable` stuff is pretty hairy. I tried to map out what `syncErrorThrowable` is being used for, when its set correctly, when its not, etc and noticed a pattern that errors were going down the `_trySubscribe` when there was a `this.source` but that **always** expected `syncErrorThrowable = true` otherwise the [condition right after](https://github.com/jayphelps/rxjs/blob/541b49db0ca4079760f92f670a49a8f06dc83dd2/src/Observable.ts#L205-L210) wouldn't do the rethrowing.

Mostly what's not clear is why this only happens with Subject, timer, interval, etc combined with a nested Observable via merge/concat/etc. Seemed like it might be related to the fact that these override `_subscribe` but others do too and I couldn't find a pattern otherwise.

The minimum reproduction here is, somewhat strangely, the inverse of what most often the problem seems to be. I tried to also find a minimum reproduction for what I think is the issue most often found (swallowing instead of rethrowing) I couldn't. The closest I could find was this:

```js
const input = new Subject();
const result = input
  .mergeMapTo(Observable.of(1).mapTo(1));

result.subscribe(value => {
  throw 'error!';
});
        
try {
  input.next(1);
} catch (e) {
  console.log('does not get caught, without this PR');
}
```

I'm hoping that either this is _good enough_ or perhaps this will help someone get a more clear understanding of the problem.

Fixes #3183, #2813