### PR TITLE
fix(typings): relax debounce selector type

### DIFF
--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as Rx from '../../src/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
+declare const type;
 declare const { asDiagram };
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
@@ -414,5 +415,21 @@ describe('Observable.prototype.debounce', () => {
     source.next(1);
 
     expect(results).to.deep.equal([1, 2]);
+  });
+
+  type('should support selectors of the same type', () => {
+    /* tslint:disable:no-unused-variable */
+    let o: Rx.Observable<number>;
+    let s: Rx.Observable<number>;
+    let r: Rx.Observable<number> = o.debounce((n) => s);
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type('should support selectors of a different type', () => {
+    /* tslint:disable:no-unused-variable */
+    let o: Rx.Observable<number>;
+    let s: Rx.Observable<string>;
+    let r: Rx.Observable<number> = o.debounce((n) => s);
+    /* tslint:enable:no-unused-variable */
   });
 });

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -50,12 +50,12 @@ import { MonoTypeOperatorFunction } from '../../internal/types';
  * @method debounce
  * @owner Observable
  */
-export function debounce<T>(durationSelector: (value: T) => SubscribableOrPromise<number>): MonoTypeOperatorFunction<T> {
+export function debounce<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new DebounceOperator(durationSelector));
 }
 
 class DebounceOperator<T> implements Operator<T, T> {
-  constructor(private durationSelector: (value: T) => SubscribableOrPromise<number>) {
+  constructor(private durationSelector: (value: T) => SubscribableOrPromise<any>) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -74,7 +74,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
   private durationSubscription: Subscription = null;
 
   constructor(destination: Subscriber<R>,
-              private durationSelector: (value: T) => SubscribableOrPromise<number>) {
+              private durationSelector: (value: T) => SubscribableOrPromise<any>) {
     super(destination);
   }
 
@@ -95,7 +95,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.destination.complete();
   }
 
-  private _tryNext(value: T, duration: SubscribableOrPromise<number>): void {
+  private _tryNext(value: T, duration: SubscribableOrPromise<any>): void {
     let subscription = this.durationSubscription;
     this.value = value;
     this.hasValue = true;

--- a/src/internal/patching/operator/debounce.ts
+++ b/src/internal/patching/operator/debounce.ts
@@ -44,6 +44,6 @@ import { debounce as higherOrder } from '../../operators/debounce';
  * @method debounce
  * @owner Observable
  */
-export function debounce<T>(this: Observable<T>, durationSelector: (value: T) => SubscribableOrPromise<number>): Observable<T> {
+export function debounce<T>(this: Observable<T>, durationSelector: (value: T) => SubscribableOrPromise<any>): Observable<T> {
   return higherOrder(durationSelector)(this);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Changes the typings for the `debounce` method's selected observable to `any` - in line with the typings used for other methods that include selectors for notification observables. E.g. [`audit`](https://github.com/ReactiveX/rxjs/blob/5.5.4/src/operators/audit.ts#L52).

**Related issue (if exists):** #3164
