### PR TITLE
Minor optimization in ignoreElements operator

### DIFF
--- a/src/operators/ignoreElements.ts
+++ b/src/operators/ignoreElements.ts
@@ -1,7 +1,6 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { noop } from '../util/noop';
 import { MonoTypeOperatorFunction } from '../interfaces';
 
 /**
@@ -33,6 +32,6 @@ class IgnoreElementsOperator<T, R> implements Operator<T, R> {
  */
 class IgnoreElementsSubscriber<T> extends Subscriber<T> {
   protected _next(unused: T): void {
-    noop();
+    // Do nothing
   }
 }


### PR DESCRIPTION
**Description:**
Minor optimization in `ignoreElements` operator.
We don't need to call any kind of `noop` function, simply do not call anything.
I mean, sure, it's not a bottleneck by no means, but better without, right?