### PR TITLE
docs: use `pipe` method for showing usage of operators as pure functions

### DIFF
--- a/doc/operator-creation.md
+++ b/doc/operator-creation.md
@@ -129,11 +129,11 @@ function mySimpleOperator(someCallback) {
 }
 ```
 
-This can now be used with the `let()` method on the Observable:
+This can now be used with the `pipe()` method on the Observable:
 
 <!-- skip-example -->
 ```js
-const obs = someObservable.let(mySimpleOperator(x => x + '!'));
+const obs = someObservable.pipe(mySimpleOperator(x => x + '!'));
 ```
 
 ## Publish your operator as a separate library


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The operators creation guide was recommending the usage of `let` method in Observables.

But from v5.5, we have lettable operators. Better suggest new users to use `pipe` instead.