### PR TITLE
fix(typings): the return type of project of mergeScan should be ObservableInput<R>

### DIFF
--- a/src/operator/mergeScan.ts
+++ b/src/operator/mergeScan.ts
@@ -1,5 +1,5 @@
 
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { mergeScan as higherOrder } from '../operators/mergeScan';
 
 /**
@@ -34,7 +34,7 @@ import { mergeScan as higherOrder } from '../operators/mergeScan';
  * @owner Observable
  */
 export function mergeScan<T, R>(this: Observable<T>,
-                                accumulator: (acc: R, value: T) => Observable<R>,
+                                accumulator: (acc: R, value: T) => ObservableInput<R>,
                                 seed: R,
                                 concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
   return higherOrder(accumulator, seed, concurrent)(this);

--- a/src/operators/mergeScan.ts
+++ b/src/operators/mergeScan.ts
@@ -1,5 +1,5 @@
 import { Operator } from '../Operator';
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { tryCatch } from '../util/tryCatch';
@@ -40,14 +40,14 @@ import { OperatorFunction } from '../interfaces';
  * @method mergeScan
  * @owner Observable
  */
-export function mergeScan<T, R>(accumulator: (acc: R, value: T) => Observable<R>,
+export function mergeScan<T, R>(accumulator: (acc: R, value: T) => ObservableInput<R>,
                                 seed: R,
                                 concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<T, R> {
   return (source: Observable<T>) => source.lift(new MergeScanOperator(accumulator, seed, concurrent));
 }
 
 export class MergeScanOperator<T, R> implements Operator<T, R> {
-  constructor(private accumulator: (acc: R, value: T) => Observable<R>,
+  constructor(private accumulator: (acc: R, value: T) => ObservableInput<R>,
               private seed: R,
               private concurrent: number) {
   }
@@ -72,7 +72,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
   protected index: number = 0;
 
   constructor(destination: Subscriber<R>,
-              private accumulator: (acc: R, value: T) => Observable<R>,
+              private accumulator: (acc: R, value: T) => ObservableInput<R>,
               private acc: R,
               private concurrent: number) {
     super(destination);


### PR DESCRIPTION
**Description:**
should be able to use `async await` in `mergeScan`

```ts
Observable.of(1, 2, 3)
  .pipe(
    mergeScan(async (acc, cur) => {
      await sleep(cur)
      acc.push(cur)
      return acc
    }, [])
  )

```
**Related issue (if exists):**
