### PR TITLE
feat: allow TestScheduler to accept comparison functions

### DIFF
--- a/spec/helpers/marble-testing.ts
+++ b/spec/helpers/marble-testing.ts
@@ -2,7 +2,7 @@ import { Observable } from '../../src/Observable';
 import { SubscriptionLog } from '../../src/testing/SubscriptionLog';
 import { ColdObservable } from '../../src/testing/ColdObservable';
 import { HotObservable } from '../../src/testing/HotObservable';
-import { TestScheduler, observableToBeFn, subscriptionLogsToBeFn } from '../../src/testing/TestScheduler';
+import { TestScheduler, observableToBeFn, observableToFn, subscriptionLogsToBeFn } from '../../src/testing/TestScheduler';
 
 declare const global: any;
 
@@ -23,7 +23,7 @@ export function cold(marbles: string, values?: any, error?: any): ColdObservable
 }
 
 export function expectObservable(observable: Observable<any>,
-                                 unsubscriptionMarbles: string = null): ({ toBe: observableToBeFn }) {
+                                 unsubscriptionMarbles: string = null): ({ toBe: observableToBeFn, to: observableToFn }) {
   if (!global.rxTestScheduler) {
     throw 'tried to use expectObservable() in async test';
   }

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -197,6 +197,10 @@ describe('TestScheduler', () => {
         expect(expectObservable(Rx.Observable.of(1)).toBe).to.be.a('function');
       });
 
+      it('should return an object with a to function', () => {
+        expect(expectObservable(Rx.Observable.of(1)).to).to.be.a('function');
+      });
+
       it('should append to flushTests array', () => {
         expectObservable(Rx.Observable.empty());
         expect((<any>rxTestScheduler).flushTests.length).to.equal(1);
@@ -216,6 +220,11 @@ describe('TestScheduler', () => {
         const unsubscribe  =  '---!';
         const expected =      '--a';
         expectObservable(source, unsubscribe).toBe(expected);
+      });
+
+      it('should accept a comparison function', () => {
+        const source = hot('--a-b-|', { a: 6, b: 12});
+        expectObservable(source).to((actual) => { expect(actual).greaterThan(5); }, '--a-b-|');
       });
     });
 


### PR DESCRIPTION
TestScheduler is an invaluable tool when testing observables, however, in practice, the singular reliance on deepEqual can make for a burdensome and rigid testing experience. This change adds the ability for users to specify their own comparison functions. These user supplied comparisons can open the door to testing conveniences like property-value assertions that developers may be accustomed to.

The first step to make this a reality was to step away from comparing observables as a whole and compare each individual emission. This allowed me to write up some (what I believe to be) more helpful error messages when tests fail, but the downside is test failures no longer provide "whole stream" context.

**The Good**
- User Supplied Comparison Functions (allow a developer to run propVal, greaterThan, hasMembers, etc. on an observable's values)
- Targeted specific error messages about failures, no more (potentially giant) deep equal monster for test failures 

**The Bad**
- TestScheduler needs to do a handful of comparisons now, which I'm doing with lodash, I could pass this function in, but that would require a BC break on the scheduler constructor, which I didn't want to do unless I got feedback to do so.
- I stole the error stack normalization and stringify functions from testscheduler-ui for use in this class, open to suggestions on how I should appropriately remove that duplication.