### PR TITLE
fix(typings): relax throttle selector type

### DIFF
--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import * as Rx from '../../src/Rx';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
+declare const type;
 declare const { asDiagram };
 declare const hot: typeof marbleTestingSignature.hot;
 declare const cold: typeof marbleTestingSignature.cold;
@@ -336,6 +337,22 @@ describe('Observable.prototype.throttle', () =>  {
         done(new Error('should not be called'));
       }
     );
+  });
+
+  type('should support selectors of the same type', () => {
+    /* tslint:disable:no-unused-variable */
+    let o: Rx.Observable<number>;
+    let s: Rx.Observable<number>;
+    let r: Rx.Observable<number> = o.throttle((n) => s);
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type('should support selectors of a different type', () => {
+    /* tslint:disable:no-unused-variable */
+    let o: Rx.Observable<number>;
+    let s: Rx.Observable<string>;
+    let r: Rx.Observable<number> = o.throttle((n) => s);
+    /* tslint:enable:no-unused-variable */
   });
 
   describe('throttle(fn, { leading: true, trailing: true })', () => {

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -59,13 +59,13 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * @method throttle
  * @owner Observable
  */
-export function throttle<T>(durationSelector: (value: T) => SubscribableOrPromise<number>,
+export function throttle<T>(durationSelector: (value: T) => SubscribableOrPromise<any>,
                             config: ThrottleConfig = defaultThrottleConfig): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new ThrottleOperator(durationSelector, config.leading, config.trailing));
 }
 
 class ThrottleOperator<T> implements Operator<T, T> {
-  constructor(private durationSelector: (value: T) => SubscribableOrPromise<number>,
+  constructor(private durationSelector: (value: T) => SubscribableOrPromise<any>,
               private leading: boolean,
               private trailing: boolean) {
   }
@@ -88,7 +88,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
   private _hasTrailingValue = false;
 
   constructor(protected destination: Subscriber<T>,
-              private durationSelector: (value: T) => SubscribableOrPromise<number>,
+              private durationSelector: (value: T) => SubscribableOrPromise<any>,
               private _leading: boolean,
               private _trailing: boolean) {
     super(destination);

--- a/src/internal/patching/operator/throttle.ts
+++ b/src/internal/patching/operator/throttle.ts
@@ -42,7 +42,7 @@ import { throttle as higherOrder, ThrottleConfig, defaultThrottleConfig } from '
  * @owner Observable
  */
 export function throttle<T>(this: Observable<T>,
-                            durationSelector: (value: T) => SubscribableOrPromise<number>,
+                            durationSelector: (value: T) => SubscribableOrPromise<any>,
                             config: ThrottleConfig = defaultThrottleConfig): Observable<T> {
   return higherOrder(durationSelector, config)(this);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Changes the typings for the `throttle` method's selected observable to `any` - in line with the typings used for other methods that include selectors for notification observables. E.g. [`audit`](https://github.com/ReactiveX/rxjs/blob/5.5.4/src/operators/audit.ts#L52).

**Related issue (if exists):** #3204 (also see PR #3169)
