### PR TITLE
split the method “subscribe” into two steps to get the subscription instance in handle function

### DIFF
--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -19,7 +19,7 @@ export interface Subscribable<T> {
             error?: (error: any) => void,
             complete?: () => void): AnonymousSubscription;
 
-  startSubscription(sink?: AnonymousSubscription): void;
+  startSubscription(sink: AnonymousSubscription<T>): void;
 }
 
 export type SubscribableOrPromise<T> = Subscribable<T> | PromiseLike<T>;
@@ -252,7 +252,7 @@ export class Observable<T> implements Subscribable<T> {
     return toSubscriber(observerOrNext, error, complete);
   }
 
-  startSubscription(sink?: Subscription): void {
+  startSubscription(sink: Subscriber<T>): void {
 
     const { operator } = this;
 

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -19,7 +19,7 @@ export interface Subscribable<T> {
             error?: (error: any) => void,
             complete?: () => void): AnonymousSubscription;
 
-  startSubscription(sink: AnonymousSubscription<T>): void;
+  startSubscription(sink: Subscriber<T>): void;
 }
 
 export type SubscribableOrPromise<T> = Subscribable<T> | PromiseLike<T>;

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -16,8 +16,8 @@ export interface Subscribable<T> {
             complete?: () => void): AnonymousSubscription;
 
   createSubscription(observerOrNext?: PartialObserver<T> | ((value: T) => void),
-            error?: (error: any) => void,
-            complete?: () => void): AnonymousSubscription;
+                     error?: (error: any) => void,
+                     complete?: () => void): AnonymousSubscription;
 
   startSubscription(sink: Subscriber<T>): void;
 }
@@ -227,8 +227,8 @@ export class Observable<T> implements Subscribable<T> {
    *   undefined,
    *   undefined
    * );
-   * 
-   * 
+   *
+   *
    * @example <caption>unsubscribe in the handle function</caption>
    *
    * const stream = Rx.Observable.of(1, 2, 3);
@@ -241,13 +241,13 @@ export class Observable<T> implements Subscribable<T> {
    *   undefined,
    *   undefined
    * );
-   * 
+   *
    * stream.startSubscription(subscription);
    *
    */
   createSubscription(observerOrNext?: PartialObserver<T> | ((value: T) => void),
-            error?: (error: any) => void,
-            complete?: () => void): Subscription {
+                     error?: (error: any) => void,
+                     complete?: () => void): Subscription {
 
     return toSubscriber(observerOrNext, error, complete);
   }

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -212,8 +212,7 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /**
-   *
-   * split the method “subscribe” into two steps
+   * Split the method “subscribe” into two steps
    * for this case: we need to get the subscription instance in the handle function
    *
    * @example <caption>unsubscribe in the handle function</caption>


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
