### PR TITLE
Fix menu item hover and active in light theme

### DIFF
--- a/doc/styles/main.css
+++ b/doc/styles/main.css
@@ -74,7 +74,7 @@ body.light-theme.layout-container > header {
 .layout-container > header a:hover, .layout-container > header a:active {
   color: #FFF;
 }
-body.light-theme .layout-container > header a:hover, .layout-container > header a:active {
+.light-theme.layout-container > header a:hover, .layout-container > header a:active {
   color: #EC0C8E;
 }
 


### PR DESCRIPTION
**Description:**
The selector in body.light-theme. layout-container doens't work, because the class light-theme is apply with layout-container in same element
Example ![Example](https://i.imgur.com/W21titb.jpg)