### PR TITLE
fix(debounceTime): synchronous reentrancy of debounceTime no longer swallows the second value

### DIFF
--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -399,4 +399,20 @@ describe('Observable.prototype.debounce', () => {
         done(new Error('should not be called'));
       });
   });
+
+  it('should debounce correctly when synchronously reentered', () => {
+    const results = [];
+    const source = new Rx.Subject();
+
+    source.debounce(() => Observable.of(null)).subscribe(value => {
+      results.push(value);
+
+      if (value === 1) {
+        source.next(2);
+      }
+    });
+    source.next(1);
+
+    expect(results).to.deep.equal([1, 2]);
+  });
 });

--- a/src/operators/debounce.ts
+++ b/src/operators/debounce.ts
@@ -129,6 +129,11 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
         subscription.unsubscribe();
         this.remove(subscription);
       }
+      // This must be done *before* passing the value
+      // along to the destination because it's possible for
+      // the value to synchronously re-enter this operator
+      // recursively if the duration selector Observable
+      // emits synchronously
       this.value = null;
       this.hasValue = false;
       super._next(value);

--- a/src/operators/debounceTime.ts
+++ b/src/operators/debounceTime.ts
@@ -97,9 +97,15 @@ class DebounceTimeSubscriber<T> extends Subscriber<T> {
     this.clearDebounce();
 
     if (this.hasValue) {
-      this.destination.next(this.lastValue);
+      const { lastValue } = this;
+      // This must be done *before* passing the value
+      // along to the destination because it's possible for
+      // the value to synchronously re-enter this operator
+      // recursively when scheduled with things like
+      // VirtualScheduler/TestScheduler.
       this.lastValue = null;
       this.hasValue = false;
+      this.destination.next(lastValue);
     }
   }
 


### PR DESCRIPTION
Currently the second value is swallowed because `hasValue` is set to `false` in between the scheduling of the second and its execution.

fixes #2748


```js
const results = [];
const source = new Rx.Subject();
const scheduler = new VirtualTimeScheduler();

source.debounceTime(0, scheduler).subscribe(value => {
  results.push(value);

  if (value === 1) {
    source.next(2);
  }
});
source.next(1);
scheduler.flush();

expect(results).to.deep.equal([1, 2]);
```

@kwonoj you had mentioned in #2748 that rxjs doesn't guarantee reentrancy, though I think in this case the fix is simple. Are there reasons to explicitly not do it in this case?

FWIW the regular `debounce` operator [already supports reentrancy](https://github.com/ReactiveX/rxjs/blob/master/src/operators/debounce.ts#L132-L134), so I added a test for it too. This all seems so familiar so perhaps we discussed this years ago and fixed only debounce lol