### PR TITLE
docs(lettable-operators): add missing quote

### DIFF
--- a/doc/lettable-operators.md
+++ b/doc/lettable-operators.md
@@ -24,7 +24,7 @@ because an operator returns an `Observable`,
 not a `Promise`.
 There is now an `Observable.toPromise()`instance method.
 
-Because `throw` is a key word you could use `_throw` after `import { _throw } from 'rxjs/observable/throw`.
+Because `throw` is a key word you could use `_throw` after `import { _throw } from 'rxjs/observable/throw'`.
 
 If the leading `_` bothers you (because a leading `_` typically means "_Internal - Do not use_"), you can do as follows:
 ```


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
