### PR TITLE
fix(debounce): support scalar selectors

### DIFF
--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -44,6 +44,15 @@ describe('Observable.prototype.debounce', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should debounce by scalar selector observable', () => {
+    const e1 =   hot('--a--bc--d----|');
+    const e1subs =   '^             !';
+    const expected = '--a--bc--d----|';
+
+    expectObservable(e1.debounce(() => Rx.Observable.of(0))).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should complete when source does not emit', () => {
     const e1 =   hot('-----|');
     const e1subs =   '^    !';

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -44,7 +44,11 @@ describe('Observable.prototype.debounce', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should debounce by scalar selector observable', () => {
+  it('should support a scalar selector observable', () => {
+
+    // If the selector returns a scalar observable, the debounce operator
+    // should emit the value immediately.
+
     const e1 =   hot('--a--bc--d----|');
     const e1subs =   '^             !';
     const expected = '--a--bc--d----|';

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -105,7 +105,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
 
     subscription = subscribeToResult(this, duration);
-    if (!subscription.closed) {
+    if (subscription && !subscription.closed) {
       this.add(this.durationSubscription = subscription);
     }
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adds a failing test and then fixes `debounce` so that selectors returning scalar observables are supported.

**Related issue (if exists):** #3232
