### PR TITLE
docs: remove html tags from map and mapTo operators

### DIFF
--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -7,9 +7,9 @@ import { OperatorFunction } from '../../internal/types';
  * Applies a given `project` function to each value emitted by the source
  * Observable, and emits the resulting values as an Observable.
  *
- * <span class="informal">Like [Array.prototype.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map),
+ * Like [Array.prototype.map()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map),
  * it passes each source value through a transformation function to get
- * corresponding output values.</span>
+ * corresponding output values.
  *
  * <img src="./img/map.png" width="100%">
  *

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -7,8 +7,8 @@ import { OperatorFunction } from '../../internal/types';
  * Emits the given constant value on the output Observable every time the source
  * Observable emits a value.
  *
- * <span class="informal">Like {@link map}, but it maps every source value to
- * the same output value every time.</span>
+ * Like {@link map}, but it maps every source value to
+ * the same output value every time.
  *
  * <img src="./img/mapTo.png" width="100%">
  *


### PR DESCRIPTION
will fix #3257 

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
html tags are displayed in the docs snippet.

**Related issue (if exists):**
see #3257 