### PR TITLE
fix(forkJoin): catch and forward selector errors

### DIFF
--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -331,6 +331,20 @@ describe('Observable.forkJoin', () => {
     expectObservable(e1).toBe(expected);
   });
 
+  it('should raise error when the selector throws', () => {
+    function selector(x, y) {
+      throw 'error';
+    }
+
+    const e1 = Observable.forkJoin(
+               hot('--a-|'),
+               hot('---b-|'),
+               selector);
+    const expected = '-----#';
+
+    expectObservable(e1).toBe(expected);
+  });
+
   it('should allow unsubscribing early and explicitly', () => {
     const e1 =   hot('--a--^--b--c---d-| ');
     const e1subs =        '^        !    ';

--- a/src/internal/observable/ForkJoinObservable.ts
+++ b/src/internal/observable/ForkJoinObservable.ts
@@ -224,7 +224,13 @@ class ForkJoinSubscriber<T> extends OuterSubscriber<T, T> {
     }
 
     if (haveValues === len) {
-      const value = resultSelector ? resultSelector.apply(this, values) : values;
+      let value: any;
+      try {
+        value = resultSelector ? resultSelector.apply(this, values) : values;
+      } catch (err) {
+        destination.error(err);
+        return;
+      }
       destination.next(value);
     }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes `forkJoin` so that errors thrown from within the selector are no longer unhandled.

**Related issue (if exists):** #3216 
