### PR TITLE
Functional refactor of `from` and `subscribeToResult`

### DIFF
--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -131,21 +131,21 @@ describe('subscribeToResult', () => {
     subscribeToResult(subscriber, observableSymbolObject);
   });
 
-  it('should emit an error if value returned by Symbol.observable call is not a valid observable', (done: MochaDone) => {
-    const observableSymbolObject = { [$$symbolObservable]: () => ({}) };
+  it('should throw an error if value returned by Symbol.observable call is not ' +
+    'a valid observable', () => {
+      const observableSymbolObject = { [$$symbolObservable]: () => ({}) };
 
-    const subscriber = new OuterSubscriber(x => {
-      done(new Error('should not be called'));
-    }, (x) => {
-      expect(x).to.be.an('error');
-      expect(x.message).to.be.equal('Provided object does not correctly implement Symbol.observable');
-      done();
-    }, () => {
-      done(new Error('should not be called'));
+      const subscriber = new OuterSubscriber(x => {
+        throw new Error('should not be called');
+      }, (x) => {
+        throw new Error('should not be called');
+      }, () => {
+        throw new Error('should not be called');
+      });
+
+      expect(() => subscribeToResult(subscriber, observableSymbolObject))
+        .to.throw(TypeError, 'Provided object does not correctly implement Symbol.observable');
     });
-
-    subscribeToResult(subscriber, observableSymbolObject);
-  });
 
   it('should emit an error when trying to subscribe to an unknown type of object', (done: MochaDone) => {
     const subscriber = new OuterSubscriber(x => {

--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -14,7 +14,7 @@ describe('subscribeToResult', () => {
     const subscription = subscribeToResult(subscriber, result);
 
     expect(expected).to.be.equal(42);
-    expect(subscription).to.be.null;
+    expect(subscription).to.be.empty;
   });
 
   it('should subscribe to observables that are an instanceof Rx.Observable', (done: MochaDone) => {
@@ -147,35 +147,29 @@ describe('subscribeToResult', () => {
         .to.throw(TypeError, 'Provided object does not correctly implement Symbol.observable');
     });
 
-  it('should emit an error when trying to subscribe to an unknown type of object', (done: MochaDone) => {
+  it('should emit an error when trying to subscribe to an unknown type of object', () => {
     const subscriber = new OuterSubscriber(x => {
-      done(new Error('should not be called'));
+      throw new Error('should not be called');
     }, (x) => {
-      expect(x).to.be.an('error');
-      const msg = 'You provided an invalid object where a stream was expected.'
-        + ' You can provide an Observable, Promise, Array, or Iterable.';
-      expect(x.message).to.be.equal(msg);
-      done();
+      throw new Error('should not be called');
     }, () => {
-      done(new Error('should not be called'));
+      throw new Error('should not be called');
     });
 
-    subscribeToResult(subscriber, {});
+    expect(() => subscribeToResult(subscriber, {}))
+      .to.throw(TypeError, 'You provided an invalid object where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.');
   });
 
-  it('should emit an error when trying to subscribe to a non-object', (done: MochaDone) => {
+  it('should emit an error when trying to subscribe to a non-object', () => {
     const subscriber = new OuterSubscriber(x => {
-      done(new Error('should not be called'));
+      throw new Error('should not be called');
     }, (x) => {
-      expect(x).to.be.an('error');
-      const msg = 'You provided \'null\' where a stream was expected.'
-        + ' You can provide an Observable, Promise, Array, or Iterable.';
-      expect(x.message).to.be.equal(msg);
-      done();
+      throw new Error('should not be called');
     }, () => {
-      done(new Error('should not be called'));
+      throw new Error('should not be called');
     });
 
-    subscribeToResult(subscriber, null);
+    expect(() => subscribeToResult(subscriber, null))
+      .to.throw(TypeError, `You provided 'null' where a stream was expected. You can provide an Observable, Promise, Array, or Iterable.`);
   });
 });

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -8,20 +8,25 @@ import { fromArray } from './fromArray';
 import { fromPromise } from './fromPromise';
 import { fromIterable } from './fromIterable';
 import { fromObservable } from './fromObservable';
+import { subscribeTo } from '../util/subscribeTo';
 
-export function from<T>(input: ObservableInput<T> | Promise<T> | Iterable<T>, scheduler?: IScheduler): Observable<T> {
+export function from<T>(input: ObservableInput<T>, scheduler?: IScheduler): Observable<T> {
+  if (!scheduler) {
+    if (input instanceof Observable) {
+      return input;
+    }
+    return new Observable(subscribeTo(input));
+  }
+
   if (input != null) {
     if (isObservable(input)) {
-      if (input instanceof Observable && !scheduler) {
-        return input;
-      }
       return fromObservable(input, scheduler);
     } else if (isPromise(input)) {
-      return fromPromise(input, scheduler);
+      return fromPromise<T>(input as any, scheduler);
     } else if (isArrayLike(input)) {
       return fromArray(input, scheduler);
     }  else if (typeof input[Symbol_iterator] === 'function' || typeof input === 'string') {
-      return fromIterable(input as Iterable<T>, scheduler);
+      return fromIterable(input as any, scheduler);
     }
   }
 

--- a/src/internal/observable/fromArray.ts
+++ b/src/internal/observable/fromArray.ts
@@ -1,15 +1,11 @@
 import { Observable } from '../Observable';
 import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
+import { subscribeToArray } from '../util/subscribeToArray';
 
 export function fromArray<T>(input: ArrayLike<T>, scheduler: IScheduler) {
   if (!scheduler) {
-    return new Observable<T>(subscriber => {
-      for (let i = 0; i < input.length && !subscriber.closed; i++) {
-        subscriber.next(input[i]);
-      }
-      subscriber.complete();
-    });
+    return new Observable<T>(subscribeToArray(input));
   } else {
     return new Observable<T>(subscriber => {
       const sub = new Subscription();

--- a/src/internal/observable/fromIterable.ts
+++ b/src/internal/observable/fromIterable.ts
@@ -2,35 +2,14 @@ import { Observable } from '../Observable';
 import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
 import { iterator as Symbol_iterator } from '../symbol/iterator';
+import { subscribeToIterable } from '../util/subscribeToIterable';
 
 export function fromIterable<T>(input: Iterable<T>, scheduler: IScheduler) {
   if (!input) {
     throw new Error('Iterable cannot be null');
   }
   if (!scheduler) {
-    return new Observable<T>(subscriber => {
-      const iterator = input[Symbol_iterator]();
-      let result: IteratorResult<T>;
-      const nextResult = (): boolean => {
-        try {
-          result = iterator.next();
-        } catch (err) {
-          subscriber.error(err);
-          return false;
-        }
-        return true;
-      };
-      while (nextResult() && !result.done && !subscriber.closed) {
-        subscriber.next(result.value);
-      }
-      subscriber.complete();
-      return () => {
-        // Finalize generators if it happens to be a generator
-        if (iterator && typeof (iterator as any).return === 'function') {
-          iterator.return();
-        }
-      };
-    });
+    return new Observable<T>(subscribeToIterable(input));
   } else {
     return new Observable<T>(subscriber => {
       const sub = new Subscription();

--- a/src/internal/observable/fromObservable.ts
+++ b/src/internal/observable/fromObservable.ts
@@ -2,15 +2,12 @@ import { Observable, Subscribable } from '../Observable';
 import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
 import { observable as Symbol_observable } from '../symbol/observable';
+import { subscribeToObservable } from '../util/subscribeToObservable';
 
 // tslint:disable-next-line:no-any TS is unable to type [Symbol.observable]
 export function fromObservable<T>(input: any, scheduler: IScheduler) {
   if (!scheduler) {
-    return new Observable<T>(subscriber => {
-      const observable: Subscribable<T> = input[Symbol_observable]();
-      const sub = observable.subscribe(subscriber);
-      return () => sub && sub.unsubscribe();
-    });
+    return new Observable<T>(subscribeToObservable(input));
   } else {
     return new Observable<T>(subscriber => {
       const sub = new Subscription();

--- a/src/internal/observable/fromPromise.ts
+++ b/src/internal/observable/fromPromise.ts
@@ -1,15 +1,11 @@
 import { Observable } from '../Observable';
 import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
+import { subscribeToPromise } from '../util/subscribeToPromise';
 
 export function fromPromise<T>(input: Promise<T>, scheduler: IScheduler) {
   if (!scheduler) {
-    return new Observable<T>(subscriber => {
-      input.then(value => {
-        subscriber.next(value);
-        subscriber.complete();
-      }, err => subscriber.error(err));
-    });
+    return new Observable<T>(subscribeToPromise(input));
   } else {
     return new Observable<T>(subscriber => {
       const sub = new Subscription();

--- a/src/internal/util/subscribeTo.ts
+++ b/src/internal/util/subscribeTo.ts
@@ -1,0 +1,38 @@
+import { Observable, ObservableInput } from '../Observable';
+import { subscribeToArray } from './subscribeToArray';
+import { subscribeToPromise } from './subscribeToPromise';
+import { subscribeToIterable } from './subscribeToIterable';
+import { subscribeToObservable } from './subscribeToObservable';
+import { isArrayLike } from './isArrayLike';
+import { isPromise } from './isPromise';
+import { isObject } from './isObject';
+import { iterator as Symbol_iterator } from '../symbol/iterator';
+import { observable as Symbol_observable } from '../symbol/observable';
+import { Subscriber } from '../Subscriber';
+
+export const subscribeTo = <T>(result: ObservableInput<T>) => {
+  if (result instanceof Observable) {
+    return (subscriber: Subscriber<T>) => {
+        if (result._isScalar) {
+        subscriber.next((result as any).value);
+        subscriber.complete();
+        return undefined;
+      } else {
+        return result.subscribe(subscriber);
+      }
+    };
+  } else if (isArrayLike(result)) {
+    return subscribeToArray(result);
+  } else if (isPromise(result)) {
+    return subscribeToPromise(result as Promise<any>);
+  } else if (result && typeof result[Symbol_iterator] === 'function') {
+    return subscribeToIterable(result as any);
+  } else if (result && typeof result[Symbol_observable] === 'function') {
+    return subscribeToObservable(result as any);
+  } else {
+    const value = isObject(result) ? 'an invalid object' : `'${result}'`;
+    const msg = `You provided ${value} where a stream was expected.`
+      + ' You can provide an Observable, Promise, Array, or Iterable.';
+    throw new TypeError(msg);
+  }
+};

--- a/src/internal/util/subscribeToArray.ts
+++ b/src/internal/util/subscribeToArray.ts
@@ -1,0 +1,15 @@
+import { Subscriber } from '../Subscriber';
+
+/**
+ * Subscribes to an ArrayLike with a subscriber
+ * @param array The array or array-like to subscribe to
+ * @param subscriber The subscriber to subscribe with.
+ */
+export const subscribeToArray = <T>(array: ArrayLike<T>) => (subscriber: Subscriber<T>) => {
+  for (let i = 0, len = array.length; i < len && !subscriber.closed; i++) {
+    subscriber.next(array[i]);
+  }
+  if (!subscriber.closed) {
+    subscriber.complete();
+  }
+};

--- a/src/internal/util/subscribeToIterable.ts
+++ b/src/internal/util/subscribeToIterable.ts
@@ -1,0 +1,28 @@
+import { Subscriber } from '../Subscriber';
+import { iterator as Symbol_iterator } from '../symbol/iterator';
+
+export const subscribeToIterable = <T>(iterable: Iterable<T>) => (subscriber: Subscriber<T>) => {
+  const iterator = iterable[Symbol_iterator]();
+  do {
+    const item = iterator.next();
+    if (item.done) {
+      subscriber.complete();
+      break;
+    }
+    subscriber.next(item.value);
+    if (subscriber.closed) {
+      break;
+    }
+  } while (true);
+
+  // Finalize the iterator if it happens to be a Generator
+  if (typeof iterator.return === 'function') {
+    subscriber.add(() => {
+      if (iterator.return) {
+        iterator.return();
+      }
+    });
+  }
+
+  return subscriber;
+};

--- a/src/internal/util/subscribeToObservable.ts
+++ b/src/internal/util/subscribeToObservable.ts
@@ -1,0 +1,18 @@
+import { Subscriber } from '../Subscriber';
+import { observable as Symbol_observable } from '../symbol/observable';
+
+/**
+ * Subscribes to an object that implements Symbol.observable with the given
+ * Subscriber.
+ * @param obj An object that implements Symbol.observable
+ * @param subscriber The Subscriber to use to subscribe to the observable
+ */
+export const subscribeToObservable = <T>(obj: any) => (subscriber: Subscriber<T>) => {
+  const obs = obj[Symbol_observable]();
+  if (typeof obs.subscribe !== 'function') {
+    // Should be caught by observable subscribe function error handling.
+    throw new TypeError('Provided object does not correctly implement Symbol.observable');
+  } else {
+    return obs.subscribe(subscriber);
+  }
+};

--- a/src/internal/util/subscribeToPromise.ts
+++ b/src/internal/util/subscribeToPromise.ts
@@ -1,0 +1,19 @@
+import { root } from './root';
+import { Subscriber } from '../Subscriber';
+
+export const subscribeToPromise = <T>(promise: PromiseLike<T>) => (subscriber: Subscriber<T>) => {
+  promise.then(
+    (value) => {
+      if (!subscriber.closed) {
+        subscriber.next(value);
+        subscriber.complete();
+      }
+    },
+    (err: any) => subscriber.error(err)
+  )
+  .then(null, (err: any) => {
+    // Escaping the Promise trap: globally throw unhandled errors
+    root.setTimeout(() => { throw err; });
+  });
+  return subscriber;
+};

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -9,6 +9,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { observable as Symbol_observable } from '../symbol/observable';
 import { Subscriber } from '../Subscriber';
+import { subscribeToObservable } from './subscribeToObservable';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,
@@ -37,7 +38,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
   } else if (result && typeof result[Symbol_iterator] === 'function') {
     return subscribeToIteratable(result as any, destination);
   } else if (result && typeof result[Symbol_observable] === 'function') {
-    return subscribeToObservable(result as any, new InnerSubscriber(outerSubscriber, outerValue, outerIndex));
+    return subscribeToObservable(result as any)(new InnerSubscriber(outerSubscriber, outerValue, outerIndex));
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;
     const msg = `You provided ${value} where a stream was expected.`
@@ -92,14 +93,4 @@ function subscribeToIteratable<T>(iterable: Iterable<T>, subscriber: Subscriber<
       break;
     }
   } while (true);
-}
-
-function subscribeToObservable<T>(obj: any, subscriber: Subscriber<T>) {
-  const obs = obj[Symbol_observable]();
-  if (typeof obs.subscribe !== 'function') {
-    // Should be caught by observable subscribe function error handling.
-    throw new TypeError('Provided object does not correctly implement Symbol.observable');
-  } else {
-    return obs.subscribe(subscriber);
-  }
 }

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -38,7 +38,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
   } else if (isPromise(result)) {
     return subscribeToPromise(result as Promise<any>)(destination);
   } else if (result && typeof result[Symbol_iterator] === 'function') {
-    return subscribeToIteratable(result as any, destination);
+    return subscribeToIterable(result as any, destination);
   } else if (result && typeof result[Symbol_observable] === 'function') {
     return subscribeToObservable(result as any)(new InnerSubscriber(outerSubscriber, outerValue, outerIndex));
   } else {
@@ -56,7 +56,7 @@ function subscribeToScalar<T>(scalar: { value: T }, subscriber: Subscriber<T>): 
   return null;
 }
 
-function subscribeToIteratable<T>(iterable: Iterable<T>, subscriber: Subscriber<T>) {
+function subscribeToIterable<T>(iterable: Iterable<T>, subscriber: Subscriber<T>) {
   const iterator = iterable[Symbol_iterator]();
   do {
     let item = iterator.next();

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -12,6 +12,7 @@ import { Subscriber } from '../Subscriber';
 import { subscribeToObservable } from './subscribeToObservable';
 import { subscribeToArray } from './subscribeToArray';
 import { subscribeToPromise } from './subscribeToPromise';
+import { subscribeToIterable } from './subscribeToIterable';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,
@@ -38,7 +39,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
   } else if (isPromise(result)) {
     return subscribeToPromise(result as Promise<any>)(destination);
   } else if (result && typeof result[Symbol_iterator] === 'function') {
-    return subscribeToIterable(result as any, destination);
+    return subscribeToIterable(result as any)(destination);
   } else if (result && typeof result[Symbol_observable] === 'function') {
     return subscribeToObservable(result as any)(new InnerSubscriber(outerSubscriber, outerValue, outerIndex));
   } else {
@@ -54,19 +55,4 @@ function subscribeToScalar<T>(scalar: { value: T }, subscriber: Subscriber<T>): 
   subscriber.next(scalar.value);
   subscriber.complete();
   return null;
-}
-
-function subscribeToIterable<T>(iterable: Iterable<T>, subscriber: Subscriber<T>) {
-  const iterator = iterable[Symbol_iterator]();
-  do {
-    let item = iterator.next();
-    if (item.done) {
-      subscriber.complete();
-      break;
-    }
-    subscriber.next(item.value);
-    if (subscriber.closed) {
-      break;
-    }
-  } while (true);
 }

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -8,6 +8,7 @@ import { Subscription } from '../Subscription';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { observable as Symbol_observable } from '../symbol/observable';
+import { Subscriber } from '../Subscriber';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,
@@ -16,7 +17,7 @@ export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
 export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
                                      result: ObservableInput<T>,
                                      outerValue?: T,
-                                     outerIndex?: number): Subscription {
+                                     outerIndex?: number): Subscription | void {
   const destination = new InnerSubscriber(outerSubscriber, outerValue, outerIndex);
 
   if (destination.closed) {
@@ -25,54 +26,18 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
 
   if (result instanceof Observable) {
     if (result._isScalar) {
-      destination.next((result as any).value);
-      destination.complete();
-      return null;
+      return subscribeToScalar(result as any, destination);
     } else {
       return result.subscribe(destination);
     }
   } else if (isArrayLike(result)) {
-    for (let i = 0, len = result.length; i < len && !destination.closed; i++) {
-      destination.next(result[i]);
-    }
-    if (!destination.closed) {
-      destination.complete();
-    }
+    return subscribeToArray(result as ArrayLike<any>, destination);
   } else if (isPromise(result)) {
-    result.then(
-      (value) => {
-        if (!destination.closed) {
-          destination.next(value);
-          destination.complete();
-        }
-      },
-      (err: any) => destination.error(err)
-    )
-    .then(null, (err: any) => {
-      // Escaping the Promise trap: globally throw unhandled errors
-      root.setTimeout(() => { throw err; });
-    });
-    return destination;
+    return subscribeToPromise(result as Promise<any>, destination);
   } else if (result && typeof result[Symbol_iterator] === 'function') {
-    const iterator = result[Symbol_iterator]();
-    do {
-      let item = iterator.next();
-      if (item.done) {
-        destination.complete();
-        break;
-      }
-      destination.next(item.value);
-      if (destination.closed) {
-        break;
-      }
-    } while (true);
+    return subscribeToIteratable(result as any, destination);
   } else if (result && typeof result[Symbol_observable] === 'function') {
-    const obs = result[Symbol_observable]();
-    if (typeof obs.subscribe !== 'function') {
-      destination.error(new TypeError('Provided object does not correctly implement Symbol.observable'));
-    } else {
-      return obs.subscribe(new InnerSubscriber(outerSubscriber, outerValue, outerIndex));
-    }
+    return subscribeToObservable(result as any, new InnerSubscriber(outerSubscriber, outerValue, outerIndex));
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;
     const msg = `You provided ${value} where a stream was expected.`
@@ -80,4 +45,61 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
     destination.error(new TypeError(msg));
   }
   return null;
+}
+
+function subscribeToScalar<T>(scalar: { value: T }, subscriber: Subscriber<T>): null {
+  subscriber.next(scalar.value);
+  subscriber.complete();
+  return null;
+}
+
+function subscribeToArray<T>(array: ArrayLike<T>, subscriber: Subscriber<T>) {
+  for (let i = 0, len = array.length; i < len && !subscriber.closed; i++) {
+    subscriber.next(array[i]);
+  }
+  if (!subscriber.closed) {
+    subscriber.complete();
+  }
+}
+
+function subscribeToPromise<T>(promise: PromiseLike<T>, subscriber: Subscriber<T>): Subscription {
+  promise.then(
+    (value) => {
+      if (!subscriber.closed) {
+        subscriber.next(value);
+        subscriber.complete();
+      }
+    },
+    (err: any) => subscriber.error(err)
+  )
+  .then(null, (err: any) => {
+    // Escaping the Promise trap: globally throw unhandled errors
+    root.setTimeout(() => { throw err; });
+  });
+  return subscriber;
+}
+
+function subscribeToIteratable<T>(iterable: Iterable<T>, subscriber: Subscriber<T>) {
+  const iterator = iterable[Symbol_iterator]();
+  do {
+    let item = iterator.next();
+    if (item.done) {
+      subscriber.complete();
+      break;
+    }
+    subscriber.next(item.value);
+    if (subscriber.closed) {
+      break;
+    }
+  } while (true);
+}
+
+function subscribeToObservable<T>(obj: any, subscriber: Subscriber<T>) {
+  const obs = obj[Symbol_observable]();
+  if (typeof obs.subscribe !== 'function') {
+    // Should be caught by observable subscribe function error handling.
+    throw new TypeError('Provided object does not correctly implement Symbol.observable');
+  } else {
+    return obs.subscribe(subscriber);
+  }
 }

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -10,6 +10,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { observable as Symbol_observable } from '../symbol/observable';
 import { Subscriber } from '../Subscriber';
 import { subscribeToObservable } from './subscribeToObservable';
+import { subscribeToArray } from './subscribeToArray';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,
@@ -32,7 +33,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
       return result.subscribe(destination);
     }
   } else if (isArrayLike(result)) {
-    return subscribeToArray(result as ArrayLike<any>, destination);
+    return subscribeToArray(result)(destination);
   } else if (isPromise(result)) {
     return subscribeToPromise(result as Promise<any>, destination);
   } else if (result && typeof result[Symbol_iterator] === 'function') {
@@ -52,15 +53,6 @@ function subscribeToScalar<T>(scalar: { value: T }, subscriber: Subscriber<T>): 
   subscriber.next(scalar.value);
   subscriber.complete();
   return null;
-}
-
-function subscribeToArray<T>(array: ArrayLike<T>, subscriber: Subscriber<T>) {
-  for (let i = 0, len = array.length; i < len && !subscriber.closed; i++) {
-    subscriber.next(array[i]);
-  }
-  if (!subscriber.closed) {
-    subscriber.complete();
-  }
 }
 
 function subscribeToPromise<T>(promise: PromiseLike<T>, subscriber: Subscriber<T>): Subscription {

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -8,7 +8,6 @@ import { Subscription } from '../Subscription';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { observable as Symbol_observable } from '../symbol/observable';
-import { Subscriber } from '../Subscriber';
 import { subscribeToObservable } from './subscribeToObservable';
 import { subscribeToArray } from './subscribeToArray';
 import { subscribeToPromise } from './subscribeToPromise';
@@ -30,7 +29,9 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
 
   if (result instanceof Observable) {
     if (result._isScalar) {
-      return subscribeToScalar(result as any, destination);
+      destination.next((result as any).value);
+      destination.complete();
+      return null;
     } else {
       return result.subscribe(destination);
     }
@@ -48,11 +49,5 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
       + ' You can provide an Observable, Promise, Array, or Iterable.';
     destination.error(new TypeError(msg));
   }
-  return null;
-}
-
-function subscribeToScalar<T>(scalar: { value: T }, subscriber: Subscriber<T>): null {
-  subscriber.next(scalar.value);
-  subscriber.complete();
   return null;
 }

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -2,7 +2,6 @@ import { root } from './root';
 import { isArrayLike } from './isArrayLike';
 import { isPromise } from './isPromise';
 import { isObject } from './isObject';
-import { Subscriber } from '../Subscriber';
 import { Observable, ObservableInput } from '../Observable';
 import { iterator as Symbol_iterator } from '../symbol/iterator';
 import { Subscription } from '../Subscription';
@@ -18,7 +17,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
                                      result: ObservableInput<T>,
                                      outerValue?: T,
                                      outerIndex?: number): Subscription {
-  let destination: Subscriber<any> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex);
+  const destination = new InnerSubscriber(outerSubscriber, outerValue, outerIndex);
 
   if (destination.closed) {
     return null;
@@ -26,7 +25,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
 
   if (result instanceof Observable) {
     if (result._isScalar) {
-      destination.next((<any>result).value);
+      destination.next((result as any).value);
       destination.complete();
       return null;
     } else {
@@ -43,7 +42,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
     result.then(
       (value) => {
         if (!destination.closed) {
-          destination.next(<any>value);
+          destination.next(value);
           destination.complete();
         }
       },
@@ -55,7 +54,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
     });
     return destination;
   } else if (result && typeof result[Symbol_iterator] === 'function') {
-    const iterator = <any>result[Symbol_iterator]();
+    const iterator = result[Symbol_iterator]();
     do {
       let item = iterator.next();
       if (item.done) {

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -42,7 +42,7 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
   } else if (result && typeof result[Symbol_iterator] === 'function') {
     return subscribeToIterable(result as any)(destination);
   } else if (result && typeof result[Symbol_observable] === 'function') {
-    return subscribeToObservable(result as any)(new InnerSubscriber(outerSubscriber, outerValue, outerIndex));
+    return subscribeToObservable(result as any)(destination);
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;
     const msg = `You provided ${value} where a stream was expected.`

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -1,17 +1,9 @@
 
-import { isArrayLike } from './isArrayLike';
-import { isPromise } from './isPromise';
-import { isObject } from './isObject';
-import { Observable, ObservableInput } from '../Observable';
-import { iterator as Symbol_iterator } from '../symbol/iterator';
+import { ObservableInput } from '../Observable';
 import { Subscription } from '../Subscription';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { OuterSubscriber } from '../OuterSubscriber';
-import { observable as Symbol_observable } from '../symbol/observable';
-import { subscribeToObservable } from './subscribeToObservable';
-import { subscribeToArray } from './subscribeToArray';
-import { subscribeToPromise } from './subscribeToPromise';
-import { subscribeToIterable } from './subscribeToIterable';
+import { subscribeTo } from './subscribeTo';
 
 export function subscribeToResult<T, R>(outerSubscriber: OuterSubscriber<T, R>,
                                         result: any,
@@ -23,31 +15,5 @@ export function subscribeToResult<T>(outerSubscriber: OuterSubscriber<any, any>,
                                      outerIndex?: number): Subscription | void {
   const destination = new InnerSubscriber(outerSubscriber, outerValue, outerIndex);
 
-  if (destination.closed) {
-    return null;
-  }
-
-  if (result instanceof Observable) {
-    if (result._isScalar) {
-      destination.next((result as any).value);
-      destination.complete();
-      return null;
-    } else {
-      return result.subscribe(destination);
-    }
-  } else if (isArrayLike(result)) {
-    return subscribeToArray(result)(destination);
-  } else if (isPromise(result)) {
-    return subscribeToPromise(result as Promise<any>)(destination);
-  } else if (result && typeof result[Symbol_iterator] === 'function') {
-    return subscribeToIterable(result as any)(destination);
-  } else if (result && typeof result[Symbol_observable] === 'function') {
-    return subscribeToObservable(result as any)(destination);
-  } else {
-    const value = isObject(result) ? 'an invalid object' : `'${result}'`;
-    const msg = `You provided ${value} where a stream was expected.`
-      + ' You can provide an Observable, Promise, Array, or Iterable.';
-    destination.error(new TypeError(msg));
-  }
-  return null;
+  return subscribeTo(result)(destination);
 }


### PR DESCRIPTION
This is a multistep refactor, please review each commit separately to help you grok the refactor.

`subscribeToResult` was responsible for optimizations when subscribing to inner observables in operators like `mergeMap`, `switchMap`, et al.

`from` is... well... `from`.

This PR unifies the logic from `subscribeToResult` and `from`, because they were basically doing exactly the same thing. The former was taking some object and tying a Subscriber to it.. the later was returning an Observable, which in subscription, takes some object and ties a Subscriber to it.

Notes:

- Error messages are now also unified, so they have changed slightly for `from(wrongThingHere)`