### PR TITLE
test(take): refactor test use rxsandbox

### DIFF
--- a/package.json
+++ b/package.json
@@ -217,6 +217,7 @@
     "rollup-plugin-inject": "^2.0.0",
     "rollup-plugin-node-resolve": "^2.0.0",
     "rx": "latest",
+    "rx-sandbox": "0.0.10",
     "rxjs": "latest",
     "shx": "^0.2.2",
     "sinon": "^2.1.0",

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -1,140 +1,154 @@
 import { expect } from 'chai';
-import * as Rx from '../../src/Rx';
-import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
-
-declare const { asDiagram };
-declare const hot: typeof marbleTestingSignature.hot;
-declare const cold: typeof marbleTestingSignature.cold;
-declare const expectObservable: typeof marbleTestingSignature.expectObservable;
-declare const expectSubscriptions: typeof marbleTestingSignature.expectSubscriptions;
-
-const Subject = Rx.Subject;
-const Observable = Rx.Observable;
+import { hotObservable, coldObservable, getObservableMessage, expectedObservable, expectedSubscription, rxSandbox } from 'rx-sandbox';
+import { take, mergeMap } from '../../src/operators';
+import { ArgumentOutOfRangeError } from '../../src/internal/util/ArgumentOutOfRangeError';
+import { Observable } from '../../src/internal/Observable';
+import { Subject } from '../../src/internal/Subject';
+import { of } from '../../src/create';
+import { Observer } from '../../src/internal/Observer';
+const { marbleAssert } = rxSandbox;
 
 /** @test {take} */
 describe('Observable.prototype.take', () => {
-  asDiagram('take(2)')('should take two values of an observable with many values', () => {
-    const e1 =  cold('--a-----b----c---d--|');
-    const e1subs =   '^       !            ';
-    const expected = '--a-----(b|)         ';
+  let hot: hotObservable, cold: coldObservable, getMessages: getObservableMessage, e: expectedObservable, s: expectedSubscription;
+  beforeEach(() => ({ hot, cold, e, s, getMessages } = rxSandbox.create(true)));
 
-    expectObservable(e1.take(2)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  it('should take two values of an observable with many values', () => {
+    const e1 = cold('   --a-----b----c---d--|');
+    const e1subs = s('  ^-------!            ');
+    const expected = e('--a-----(b|)         ');
+
+    const value = getMessages(e1.pipe(take(2)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should work with empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    const e1 = cold('|');
+    const e1subs = s('(^!)');
+    const expected = e('|');
 
-    expectObservable(e1.take(42)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(42)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should go on forever on never', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    const e1 = cold('   -');
+    const e1subs = s('  ^');
+    const expected = e('-');
 
-    expectObservable(e1.take(42)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(42)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should be empty on take(0)', () => {
     const e1 = hot('--a--^--b----c---d--|');
     const e1subs = []; // Don't subscribe at all
-    const expected =    '|';
+    const expected = e('|');
 
-    expectObservable(e1.take(0)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(0)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal(e1subs);
   });
 
   it('should take one value of an observable with one value', () => {
-    const e1 =   hot('---(a|)');
-    const e1subs =   '^  !   ';
-    const expected = '---(a|)';
+    const e1 = hot('    ---(a|)');
+    const e1subs = s('  ^--!   ');
+    const expected = e('---(a|)');
 
-    expectObservable(e1.take(1)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(1)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should take one values of an observable with many values', () => {
     const e1 = hot('--a--^--b----c---d--|');
-    const e1subs =      '^  !            ';
-    const expected =    '---(b|)         ';
+    const e1subs = s('   ^--!            ');
+    const expected = e(' ---(b|)         ');
 
-    expectObservable(e1.take(1)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(1)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should error on empty', () => {
     const e1 = hot('--a--^----|');
-    const e1subs =      '^    !';
-    const expected =    '-----|';
+    const e1subs = s('   ^----!');
+    const expected = e(' -----|');
 
-    expectObservable(e1.take(42)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(42)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should propagate error from the source observable', () => {
     const e1 = hot('---^---#', null, 'too bad');
-    const e1subs =    '^   !';
-    const expected =  '----#';
+    const e1subs = s(' ^---!');
+    const expected = e('----#', null, 'too bad');
 
-    expectObservable(e1.take(42)).toBe(expected, null, 'too bad');
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(42)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should propagate error from an observable with values', () => {
-    const e1 = hot('---^--a--b--#');
-    const e1subs =    '^        !';
-    const expected =  '---a--b--#';
+    const e1 = hot(' ---^--a--b--#');
+    const e1subs = s('  ^--------!');
+    const expected = e('---a--b--#');
 
-    expectObservable(e1.take(42)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(42)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 = hot('---^--a--b-----c--d--e--|');
-    const unsub =     '         !            ';
-    const e1subs =    '^        !            ';
-    const expected =  '---a--b---            ';
+    const e1 = hot('    ---^--a--b-----c--d--e--|');
+    const unsub = '        ---------!            ';
+    const e1subs = s('     ^--------!            ');
+    const expected = e('   ---a--b---            ');
 
-    expectObservable(e1.take(42), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(42)), unsub);
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should work with throw', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    const e1 = cold('   #');
+    const e1subs = s('  (^!)');
+    const expected = e('#');
 
-    expectObservable(e1.take(42)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(e1.pipe(take(42)));
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should throw if total is less than zero', () => {
     expect(() => { Observable.range(0, 10).take(-1); })
-      .to.throw(Rx.ArgumentOutOfRangeError);
+      .to.throw(ArgumentOutOfRangeError);
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
     const e1 = hot('---^--a--b-----c--d--e--|');
-    const unsub =     '         !            ';
-    const e1subs =    '^        !            ';
-    const expected =  '---a--b---            ';
+    const unsub = '    ---------!            ';
+    const e1subs = s(' ^--------!            ');
+    const expected = e('---a--b---            ');
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .take(42)
-      .mergeMap((x: string) => Observable.of(x));
+      .pipe(
+      mergeMap((x) => of(x)),
+      take(42),
+      mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    const value = getMessages(result, unsub);
+    marbleAssert(value).to.equal(expected);
+    marbleAssert(e1.subscriptions).to.equal([e1subs]);
   });
 
   it('should unsubscribe from the source when it reaches the limit', () => {
-    const source = Observable.create(observer => {
+    const source = Observable.create((observer: Observer<number>) => {
       expect(observer.closed).to.be.false;
       observer.next(42);
       expect(observer.closed).to.be.true;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**DONOTMERGE** (Test will fail anyway, so can't be merged)
related to #3254, #3231 and https://github.com/ReactiveX/rxjs/pull/3265. 

This PR is poc attempt to move our test assertion to use `rx-sandbox` instead, provides strong type safety around interfaces, as well as fixes some of known issues in current test assertion.

Unfortunately there is one nasty issue - since rx-sandbox has deps to Rx, there are 2 observable object (from source we'd like to assert, and one rx-sandbox uses internally) and it creates some conflict around scheduling, so couple of subscription tests are failing in here.

Not entirely sure how this can be resolved in quick manner - probably best thing is setting up monorepo and use linked pkg to source allows to have same object over, otherwise we may need to port changes of sandbox into core / or try to expose override rxsandbox to import source directly. Opening up as discussion, since @david-driscoll created PR around current test assertion - we may need to decide which way before make actions.

**Related issue (if exists):**
