### PR TITLE
fix(onErrorResumeNext): no longer holds onto subscriptions too long

### DIFF
--- a/spec/observables/onErrorResumeNext-spec.ts
+++ b/spec/observables/onErrorResumeNext-spec.ts
@@ -1,4 +1,4 @@
-import * as Rx from '../../src/Rx';
+import { onErrorResumeNext } from '../../src/create';
 import marbleTestingSignature = require('../helpers/marble-testing'); // tslint:disable-line:no-require-imports
 
 declare const hot: typeof marbleTestingSignature.hot;
@@ -6,32 +6,41 @@ declare const cold: typeof marbleTestingSignature.cold;
 declare const expectObservable: typeof marbleTestingSignature.expectObservable;
 declare const expectSubscriptions: typeof marbleTestingSignature.expectSubscriptions;
 
-const Observable = Rx.Observable;
-
-describe('Observable.onErrorResumeNext', () => {
+describe('onErrorResumeNext', () => {
   it('should continue with observables', () => {
-    const source =   hot('--a--b--#');
-    const next1  =  cold(        '--c--d--#');
-    const next2  =  cold(                '--e--#');
-    const next3  =  cold(                     '--f--g--|');
-    const subs =         '^                            !';
-    const expected =     '--a--b----c--d----e----f--g--|';
+    const s1 =   hot('--a--b--#');
+    const s2  =  cold(       '--c--d--#');
+    const s3  =  cold(               '--e--#');
+    const s4  =  cold(                    '--f--g--|');
+    const subs1 =    '^       !';
+    const subs2 =    '        ^       !';
+    const subs3 =    '                ^    !';
+    const subs4 =    '                     ^       !';
+    const expected = '--a--b----c--d----e----f--g--|';
 
-    expectObservable(Observable.onErrorResumeNext(source, next1, next2, next3)).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectObservable(onErrorResumeNext(s1, s2, s3, s4)).toBe(expected);
+    expectSubscriptions(s1.subscriptions).toBe(subs1);
+    expectSubscriptions(s2.subscriptions).toBe(subs2);
+    expectSubscriptions(s3.subscriptions).toBe(subs3);
+    expectSubscriptions(s4.subscriptions).toBe(subs4);
   });
 
   it('should continue array of observables', () => {
-    const source = hot('--a--b--#');
-    const next  = [ source,
-                   cold(        '--c--d--#'),
-                   cold(                '--e--#'),
-                   cold(                     '--f--g--|')];
-    const subs =        '^                            !';
-    const expected =    '--a--b----c--d----e----f--g--|';
+    const s1 =   hot('--a--b--#');
+    const s2  =  cold(       '--c--d--#');
+    const s3  =  cold(               '--e--#');
+    const s4  =  cold(                    '--f--g--|');
+    const subs1 =    '^       !';
+    const subs2 =    '        ^       !';
+    const subs3 =    '                ^    !';
+    const subs4 =    '                     ^       !';
+    const expected = '--a--b----c--d----e----f--g--|';
 
-    expectObservable(Observable.onErrorResumeNext(next)).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectObservable(onErrorResumeNext([s1, s2, s3, s4])).toBe(expected);
+    expectSubscriptions(s1.subscriptions).toBe(subs1);
+    expectSubscriptions(s2.subscriptions).toBe(subs2);
+    expectSubscriptions(s3.subscriptions).toBe(subs3);
+    expectSubscriptions(s4.subscriptions).toBe(subs4);
   });
 
   it('should complete single observable throws', () => {
@@ -39,7 +48,7 @@ describe('Observable.onErrorResumeNext', () => {
     const subs =         '(^!)';
     const expected =     '|';
 
-    expectObservable(Observable.onErrorResumeNext(source)).toBe(expected);
+    expectObservable(onErrorResumeNext(source)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 });


### PR DESCRIPTION
Reduces the size of onErrorResumeNext. 

Fixes an issue where `onErrorResumeNext` was holding onto all inner subscriptions for the lifetime of the resulting observable.

Updates documentation

related #2459
closes #3178
