### PR TITLE
fix(Observable): expose pipe rest parameter overload

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -278,6 +278,7 @@ export class Observable<T> implements Subscribable<T> {
   pipe<A, B, C, D, E, F, G>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>): Observable<G>
   pipe<A, B, C, D, E, F, G, H>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>): Observable<H>
   pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): Observable<I>
+  pipe<R>(...operations: OperatorFunction<T, R>[]): Observable<R>
   /* tslint:enable:max-line-length */
 
   /**


### PR DESCRIPTION
**Description:**
The spread overload of the `pipe` method was not present in the typings for `Observable`.  This PR corrects this.  This is required for TS 2.7 compatibility as it provides stricter parameter checking.

**Related issue (if exists):**