### PR TITLE
docs(documentation): reference the rxjs-doc repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ If your PR is the addition of a new operator, please make sure all these boxes a
 - [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
 - [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
 - [ ] The operator should be listed in `doc/operators.md` in a category of operators
-- [ ] The operator should also be documented in 'rxjs-docs'. Please reference the pr for the new operator in your pr.
+- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
 - [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
 - [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,6 +9,7 @@ If your PR is the addition of a new operator, please make sure all these boxes a
 - [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
 - [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
 - [ ] The operator should be listed in `doc/operators.md` in a category of operators
+- [ ] The operator should also be documented in 'rxjs-docs'. Please reference the pr for the new operator in your pr.
 - [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
 - [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
 -->

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,6 +12,7 @@ Contents
 - [Submitting a Pull Request (PR)](#submitting-a-pull-request-pr)
   - [After your pull request is merged](#after-your-pull-request-is-merged)
 - [Coding Style Guidelines](#coding-style-guidelines)
+- [Documentation](#documentation)
 - [Unit Tests](#unit-tests)
   - [CI Tests](#ci-tests)
 - [Performance Tests](#performance-tests)
@@ -119,6 +120,11 @@ from the main (upstream) repository:
 
 (TBD): For now try to follow the style that exists elsewhere in the source, and use your best judgment.
 
+## Documentation
+
+- Documentation of RxJs will be shortly inline and more detailed in [rxjs-docs](https://github.com/ReactiveX/rxjs-docs)
+- The [Documentation Guidelines](https://github.com/ReactiveX/rxjs-docs/blob/master/DOCUMENTATION_GUIDELINES.md) will support you
+- Please keep both documents up to date
 
 ## Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -117,6 +117,10 @@ Run `npm run perf_micro [operator]` to run micro performance test benchmarking o
 ## Adding documentation
 RxNext uses [ESDoc](https://esdoc.org/) to generate API documentation. Refer to ESDoc's documentation for syntax. Run `npm run build_docs` to generate.
 
+At the moment we are trying to improve the documentation. For this purpose the Documentation is in a seperate [GitHub Repostory](https://github.com/ReactiveX/rxjs-docs).
+For a quick instruction take a look at the [documentation guidelines](https://github.com/ReactiveX/rxjs-docs/blob/master/DOCUMENTATION_GUIDELINES.md).
+We are really happy about any type of contributions! 
+
 ## Generating PNG marble diagrams
 
 The script `npm run tests2png` requires some native packages installed locally: `imagemagick`, `graphicsmagick`, and `ghostscript`.


### PR DESCRIPTION
[ReactiveX/rxjs-docs#249](https://github.com/ReactiveX/rxjs-docs/issues/249)

hey @benlesh and @ladyleet, like discussed here is the pr to reference to documentation project. If there is another file where I should add a reminder, please let me know :)