### PR TITLE
refactory: improve hack for XMLHttpRequest usage with TypeScript 2.7

### DIFF
--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -461,12 +461,12 @@ export class AjaxError extends Error {
 function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
   switch (responseType) {
     case 'json':
-        if ('response' in xhr) {
+        // HACK(benlesh): TypeScript shennanigans
+        // tslint:disable-next-line:no-any XMLHttpRequest is defined to always have 'response' inferring xhr as never for the else clause.
+        if ('response' in (xhr as any)) {
           //IE does not support json as responseType, parse it internally
           return xhr.responseType ? xhr.response : JSON.parse(xhr.response || xhr.responseText || 'null');
         } else {
-          // HACK(benlesh): TypeScript shennanigans
-          // tslint:disable-next-line:no-any latest TS seems to think xhr is "never" here.
           return JSON.parse((xhr as any).responseText || 'null');
         }
       case 'xml':
@@ -474,8 +474,8 @@ function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
       case 'text':
       default:
           // HACK(benlesh): TypeScript shennanigans
-          // tslint:disable-next-line:no-any latest TS seems to think xhr is "never" here.
-          return  ('response' in xhr) ? xhr.response : (xhr as any).responseText;
+          // tslint:disable-next-line:no-any XMLHttpRequest is defined to always have 'response' inferring xhr as never for the else sub-expression.
+          return  ('response' in (xhr as any)) ? xhr.response : xhr.responseText;
   }
 }
 


### PR DESCRIPTION
The XMLHttpRequest type is defined to always have the `request`
property. This will lead 2.7 to infer `never` for the else
part of any test of the form `'request' in xhr` as this, as far
as the declarations are concerned, is always true and TypeScript
then infers the else part will `never` run.

This change prevents this inference wihtout removing the type
checking of the other members of xhr such as `responseText`.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
See commit text above.

**Related issue (if exists):**
