### PR TITLE
docs(single): Describe case where `undefined` is emitted

### DIFF
--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -10,7 +10,8 @@ import { MonoTypeOperatorFunction } from '../../internal/types';
 /**
  * Returns an Observable that emits the single item emitted by the source Observable that matches a specified
  * predicate, if that Observable emits one such item. If the source Observable emits more than one such item or no
- * such items, notify of an IllegalArgumentException or NoSuchElementException respectively.
+ * items, notify of an IllegalArgumentException or NoSuchElementException respectively. If the source Observable
+ * emits items but none match the specified predicate then `undefined` is emiited.
  *
  * <img src="./img/single.png" width="100%">
  *
@@ -18,8 +19,8 @@ import { MonoTypeOperatorFunction } from '../../internal/types';
  * callback if the Observable completes before any `next` notification was sent.
  * @param {Function} predicate - A predicate function to evaluate items emitted by the source Observable.
  * @return {Observable<T>} An Observable that emits the single item emitted by the source Observable that matches
- * the predicate.
- .
+ * the predicate or `undefined` when no items match.
+ *
  * @method single
  * @owner Observable
  */


### PR DESCRIPTION
Expands docs for the Single operator to cover the behaviour where `undefined` is emitted.

Behaviour already has test coverage [test](https://github.com/ReactiveX/rxjs/blob/master/spec/operators/single-spec.ts#L143)

Closes #3182
