### PR TITLE
Removing resultSelectors (WIP)

### DIFF
--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -42,22 +42,6 @@ describe('forkJoin', () => {
     expectObservable(e2).toBe(expected2, {x: [null, 'b', '3', undefined]});
   });
 
-  it('should join the last values of the provided observables with selector', () => {
-    function selector(x: string, y: string, z: string) {
-      return x + y + z;
-    }
-
-    const e1 = forkJoin(
-                hot('--a--b--c--d--|'),
-                hot('(b|)'),
-                hot('--1--2--3--|'),
-                selector
-            );
-    const expected = '--------------(x|)';
-
-    expectObservable(e1).toBe(expected, {x: 'db3'});
-  });
-
   it('should accept single observable', () => {
     const e1 = forkJoin(
                hot('--a--b--c--d--|')
@@ -74,34 +58,6 @@ describe('forkJoin', () => {
     const expected = '--------------(x|)';
 
     expectObservable(e1).toBe(expected, {x: ['d']});
-  });
-
-  it('should accept single observable with selector', () => {
-    function selector(x: string) {
-      return x + x;
-    }
-
-    const e1 = forkJoin(
-               hot('--a--b--c--d--|'),
-               selector
-            );
-    const expected = '--------------(x|)';
-
-    expectObservable(e1).toBe(expected, {x: 'dd'});
-  });
-
-  it('should accept array of observable contains single with selector', () => {
-    function selector(x: string) {
-      return x + x;
-    }
-
-    const e1 = forkJoin(
-               [hot('--a--b--c--d--|')],
-               selector
-            );
-    const expected = '--------------(x|)';
-
-    expectObservable(e1).toBe(expected, {x: 'dd'});
   });
 
   it('should accept lowercase-o observables', () => {
@@ -151,22 +107,6 @@ describe('forkJoin', () => {
     const expected = '--------------(x|)';
 
     expectObservable(e1).toBe(expected, {x: ['d', 'b', '3']});
-  });
-
-  it('should accept array of observables with selector', () => {
-    function selector(x: string, y: string, z: string) {
-      return x + y + z;
-    }
-
-    const e1 = forkJoin(
-               [hot('--a--b--c--d--|'),
-                hot('(b|)'),
-                hot('--1--2--3--|')],
-                selector
-             );
-    const expected = '--------------(x|)';
-
-    expectObservable(e1).toBe(expected, {x: 'db3'});
   });
 
   it('should not emit if any of source observable is empty', () => {
@@ -244,34 +184,6 @@ describe('forkJoin', () => {
     expectObservable(e1).toBe(expected);
   });
 
-  it('should complete when any of source is empty with selector', () => {
-    function selector(x: string, y: string) {
-      return x + y;
-    }
-
-    const e1 = forkJoin(
-               hot('--a--b--c--d--|'),
-               hot('---------|'),
-               selector);
-    const expected = '---------|';
-
-    expectObservable(e1).toBe(expected);
-  });
-
-  it('should emit results by resultselector', () => {
-    function selector(x: string, y: string) {
-      return x + y;
-    }
-
-    const e1 = forkJoin(
-               hot('--a--b--c--d--|'),
-               hot('---2-----|'),
-               selector);
-    const expected = '--------------(x|)';
-
-    expectObservable(e1).toBe(expected, {x: 'd2'});
-  });
-
   it('should raise error when any of source raises error with empty observable', () => {
     const e1 = forkJoin(
                hot('------#'),
@@ -290,53 +202,11 @@ describe('forkJoin', () => {
     expectObservable(e1).toBe(expected);
   });
 
-  it('should raise error when any of source raises error with selector with empty observable', () => {
-    function selector(x: string, y: string) {
-      return x + y;
-    }
-
-    const e1 = forkJoin(
-               hot('------#'),
-               hot('---------|'),
-               selector);
-    const expected = '------#';
-
-    expectObservable(e1).toBe(expected);
-  });
-
   it('should raise error when source raises error', () => {
     const e1 = forkJoin(
                hot('------#'),
                hot('---a-----|'));
     const expected = '------#';
-
-    expectObservable(e1).toBe(expected);
-  });
-
-  it('should raise error when source raises error with selector', () => {
-    function selector(x: string, y: string) {
-      return x + y;
-    }
-
-    const e1 = forkJoin(
-               hot('------#'),
-               hot('-------b-|'),
-               selector);
-    const expected = '------#';
-
-    expectObservable(e1).toBe(expected);
-  });
-
-  it('should raise error when the selector throws', () => {
-    function selector(x: string, y: string) {
-      throw 'error';
-    }
-
-    const e1 = forkJoin(
-               hot('--a-|'),
-               hot('---b-|'),
-               selector);
-    const expected = '-----#';
 
     expectObservable(e1).toBe(expected);
   });
@@ -397,7 +267,6 @@ describe('forkJoin', () => {
     let c: Promise<boolean>;
     let d: Observable<string[]>;
     let o1: Observable<[number, string, boolean, string[]]> = forkJoin(a, b, c, d);
-    let o2: Observable<boolean> = forkJoin(a, b, c, d, (aa, bb, cc, dd) => !!aa && !!bb && cc && !!dd.length);
     /* tslint:enable:no-unused-variable */
   });
 
@@ -406,7 +275,6 @@ describe('forkJoin', () => {
     let a: Promise<number>[];
     let o1: Observable<number[]> = forkJoin(a);
     let o2: Observable<number[]> = forkJoin(...a);
-    let o3: Observable<number> = forkJoin(a, (...x) => x.length);
     /* tslint:enable:no-unused-variable */
   });
 
@@ -415,7 +283,6 @@ describe('forkJoin', () => {
     let a: Observable<number>[];
     let o1: Observable<number[]> = forkJoin(a);
     let o2: Observable<number[]> = forkJoin(...a);
-    let o3: Observable<number> = forkJoin(a, (...x) => x.length);
     /* tslint:enable:no-unused-variable */
   });
 

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -538,44 +538,6 @@ describe('Observable.prototype.concatMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-<<<<<<< HEAD
-  it('should concatMap many outer to inner arrays, using resultSelector', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const e1subs =   '^                               !';
-    const expected = '(44)--(8888)---(666)----(44)----|';
-
-    const result = e1.concatMap((value) => arrayRepeat(value, +value),
-      (x, y) => String(parseInt(x) + parseInt(y)));
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should concatMap many outer to inner arrays, and outer throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------#');
-    const e1subs =   '^                               !';
-    const expected = '(22)--(4444)---(333)----(22)----#';
-
-    const result = e1.concatMap((value) => arrayRepeat(value, +value));
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should concatMap many outer to inner arrays, resultSelector, outer throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------#');
-    const e1subs =   '^                               !';
-    const expected = '(44)--(8888)---(666)----(44)----#';
-
-    const result = e1.concatMap((value) => arrayRepeat(value, +value),
-      (x, y) => String(parseInt(x) + parseInt(y)));
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-=======
->>>>>>> feat(mergeMap|concatMap|concatMapTo): simplified the signatures
   it('should mergeMap many outer to inner arrays, outer unsubscribed early', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const e1subs =   '^            !                   ';

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -538,6 +538,7 @@ describe('Observable.prototype.concatMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+<<<<<<< HEAD
   it('should concatMap many outer to inner arrays, using resultSelector', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const e1subs =   '^                               !';
@@ -573,6 +574,8 @@ describe('Observable.prototype.concatMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+=======
+>>>>>>> feat(mergeMap|concatMap|concatMapTo): simplified the signatures
   it('should mergeMap many outer to inner arrays, outer unsubscribed early', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const e1subs =   '^            !                   ';
@@ -580,19 +583,6 @@ describe('Observable.prototype.concatMap', () => {
     const expected = '(22)--(4444)--                   ';
 
     const result = e1.concatMap((value) => arrayRepeat(value, +value));
-
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should concatMap many outer to inner arrays, resultSelector, outer unsubscribed', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const e1subs =   '^            !                   ';
-    const unsub =    '             !                   ';
-    const expected = '(44)--(8888)--                   ';
-
-    const result = e1.concatMap((value) => arrayRepeat(value, +value),
-      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -615,45 +605,7 @@ describe('Observable.prototype.concatMap', () => {
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
-
-  it('should concatMap many outer to inner arrays, resultSelector throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const e1subs =   '^              !                 ';
-    const expected = '(44)--(8888)---#                 ';
-
-    const result = e1.concatMap((value) => arrayRepeat(value, +value),
-      (inner, outer) => {
-        if (outer === '3') {
-          throw 'error';
-        }
-        return String(parseInt(outer) + parseInt(inner));
-      });
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should concatMap many outer to inner arrays, resultSelector, project throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const e1subs =   '^              !                 ';
-    const expected = '(44)--(8888)---#                 ';
-
-    let invoked = 0;
-    const result = e1.concatMap((value) => {
-      invoked++;
-      if (invoked === 3) {
-        throw 'error';
-      }
-      return arrayRepeat(value, +value);
-    }, (inner, outer) => {
-      return String(parseInt(outer) + parseInt(inner));
-    });
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should map values to constant resolved promises and concatenate', (done) => {
+  it('should map values to constant resolved promises and concatenate', (done: MochaDone) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const project = (value: number) => Observable.from(Promise.resolve(42));
 
@@ -705,54 +657,6 @@ describe('Observable.prototype.concatMap', () => {
     const project = (value: number, index: number) => Observable.from(Promise.reject('' + value + '-' + index));
 
     source.concatMap(project).subscribe(
-      (x) => {
-        done(new Error('Subscriber next handler not supposed to be called.'));
-      }, (err) => {
-        expect(err).to.deep.equal('4-0');
-        done();
-      }, () => {
-        done(new Error('Subscriber complete handler not supposed to be called.'));
-      });
-  });
-
-  it('should concatMap values to resolved promises with resultSelector', (done) => {
-    const source = Rx.Observable.from([4, 3, 2, 1]);
-    const resultSelectorCalledWith: number[][] = [];
-    const project = (value: number, index: number) => Observable.from((Promise.resolve([value, index])));
-
-    const resultSelector = function (outerVal: any, innerVal: any, outerIndex: any, innerIndex: any): number {
-      resultSelectorCalledWith.push([].slice.call(arguments));
-      return 8;
-    };
-
-    const results: number[] = [];
-    const expectedCalls = [
-      [4, [4, 0], 0, 0],
-      [3, [3, 1], 1, 0],
-      [2, [2, 2], 2, 0],
-      [1, [1, 3], 3, 0]
-    ];
-    source.concatMap(project, resultSelector).subscribe(
-      (x) => {
-        results.push(x);
-      }, (err) => {
-        done(new Error('Subscriber error handler not supposed to be called.'));
-      }, () => {
-        expect(results).to.deep.equal([8, 8, 8, 8]);
-        expect(resultSelectorCalledWith).to.deep.equal(expectedCalls);
-        done();
-      });
-  });
-
-  it('should concatMap values to rejected promises with resultSelector', (done) => {
-    const source = Rx.Observable.from([4, 3, 2, 1]);
-    const project = (value: number, index: number) => Observable.from(Promise.reject('' + value + '-' + index));
-
-    const resultSelector = () => {
-      throw 'this should not be called';
-    };
-
-    source.concatMap(project, resultSelector).subscribe(
       (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       }, (err) => {

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -252,31 +252,11 @@ describe('Observable.prototype.concatMapTo', () => {
     expectObservable(result).toBe(expected);
   });
 
-  it('should concatMapTo many outer to inner arrays, using resultSelector', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const expected = '(2345)(4567)---(3456)---(2345)--|';
-
-    const result = e1.concatMapTo(['0', '1', '2', '3'],
-      (x, y) => String(parseInt(x) + parseInt(y)));
-
-    expectObservable(result).toBe(expected);
-  });
-
   it('should concatMapTo many outer to inner arrays, and outer throws', () => {
     const e1 =   hot('2-----4--------3--------2-------#');
     const expected = '(0123)(0123)---(0123)---(0123)--#';
 
     const result = e1.concatMapTo(['0', '1', '2', '3']);
-
-    expectObservable(result).toBe(expected);
-  });
-
-  it('should concatMapTo many outer to inner arrays, resultSelector, outer throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------#');
-    const expected = '(2345)(4567)---(3456)---(2345)--#';
-
-    const result = e1.concatMapTo(['0', '1', '2', '3'],
-      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result).toBe(expected);
   });
@@ -291,32 +271,7 @@ describe('Observable.prototype.concatMapTo', () => {
     expectObservable(result, unsub).toBe(expected);
   });
 
-  it('should concatMapTo many outer to inner arrays, resultSelector, outer unsubscribed', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const unsub =    '             !';
-    const expected = '(2345)(4567)--';
-
-    const result = e1.concatMapTo(['0', '1', '2', '3'],
-      (x, y) => String(parseInt(x) + parseInt(y)));
-
-    expectObservable(result, unsub).toBe(expected);
-  });
-
-  it('should concatMapTo many outer to inner arrays, resultSelector throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const expected = '(2345)(4567)---#';
-
-    const result = e1.concatMapTo(['0', '1', '2', '3'], (x, y) => {
-      if (x === '3') {
-        throw 'error';
-      }
-      return String(parseInt(x) + parseInt(y));
-    });
-
-    expectObservable(result).toBe(expected);
-  });
-
-  it('should map values to constant resolved promises and concatenate', (done) => {
+  it('should map values to constant resolved promises and concatenate', (done: MochaDone) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
 
     const results: number[] = [];
@@ -337,56 +292,6 @@ describe('Observable.prototype.concatMapTo', () => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
 
     source.concatMapTo(Observable.from(Promise.reject(42))).subscribe(
-      (x) => {
-        done(new Error('Subscriber next handler not supposed to be called.'));
-      },
-      (err) => {
-        expect(err).to.equal(42);
-        done();
-      },
-      () => {
-        done(new Error('Subscriber complete handler not supposed to be called.'));
-      });
-  });
-
-  it('should concatMapTo values to resolved promises with resultSelector', (done) => {
-    const source = Rx.Observable.from([4, 3, 2, 1]);
-    const resultSelectorCalledWith: number[][] = [];
-    const inner = Observable.from(Promise.resolve(42));
-    const resultSelector = function (outerVal: number, innerVal: number, outerIndex: number, innerIndex: number) {
-      resultSelectorCalledWith.push([].slice.call(arguments));
-      return 8;
-    };
-
-    const results: number[] = [];
-    const expectedCalls = [
-      [4, 42, 0, 0],
-      [3, 42, 1, 0],
-      [2, 42, 2, 0],
-      [1, 42, 3, 0]
-    ];
-    source.concatMapTo(inner, resultSelector).subscribe(
-      (x) => {
-        results.push(x);
-      },
-      (err) => {
-        done(new Error('Subscriber error handler not supposed to be called.'));
-      },
-      () => {
-        expect(results).to.deep.equal([8, 8, 8, 8]);
-        expect(resultSelectorCalledWith).to.deep.equal(expectedCalls);
-        done();
-      });
-  });
-
-  it('should concatMapTo values to rejected promises with resultSelector', (done) => {
-    const source = Rx.Observable.from([4, 3, 2, 1]);
-    const inner = Observable.from(Promise.reject(42));
-    const resultSelector = () => {
-      throw 'this should not be called';
-    };
-
-    source.concatMapTo(inner, resultSelector).subscribe(
       (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -75,23 +75,6 @@ describe('Observable.prototype.exhaustMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should raise error if selector throws', () => {
-    const x = cold(     '--a--b--c--|         ');
-    const xsubs =    '   ^ !                  ';
-    const e1 =   hot('---x---------y----z----|');
-    const e1subs =   '^    !                  ';
-    const expected = '-----#                  ';
-
-    const result = e1.exhaustMap((value) => x,
-      () => {
-        throw 'error';
-      });
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
   it('should switch with a selector function', () => {
     const x = cold(     '--a--b--c--|                              ');
     const xsubs =    '   ^          !                              ';
@@ -334,41 +317,6 @@ describe('Observable.prototype.exhaustMap', () => {
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should switch with resultSelector goodness', () => {
-    const x =   cold(  '--a--b--c--d--e-|                   ');
-    const xsubs =    '  ^               !                   ';
-    const y =   cold(            '---f---g---h---i--|       ');
-    const ysubs: string[] = [];
-    const z =   cold(                   '---k---l---m---n--|');
-    const zsubs =    '                   ^                 !';
-    const e1 =   hot('--x---------y------z-|                ');
-    const e1subs =   '^                                    !';
-    const expected = '----a--b--c--d--e-----k---l---m---n--|';
-
-    const observableLookup = { x: x, y: y, z: z };
-
-    const expectedValues = {
-      a: ['x', 'a', 0, 0],
-      b: ['x', 'b', 0, 1],
-      c: ['x', 'c', 0, 2],
-      d: ['x', 'd', 0, 3],
-      e: ['x', 'e', 0, 4],
-      k: ['z', 'k', 1, 0],
-      l: ['z', 'l', 1, 1],
-      m: ['z', 'm', 1, 2],
-      n: ['z', 'n', 1, 3],
-    };
-
-    const result = e1.exhaustMap((value) => observableLookup[value],
-    (innerValue, outerValue, innerIndex, outerIndex) => [innerValue, outerValue, innerIndex, outerIndex]);
-
-    expectObservable(result).toBe(expected, expectedValues);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(z.subscriptions).toBe(zsubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -40,7 +40,7 @@ describe('Observable.prototype.first', () => {
     const expected =    '-----(a|)';
     const sub =         '^    !';
 
-    expectObservable(e1.first(null, null, 'a')).toBe(expected);
+    expectObservable(e1.first(null, 'a')).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -145,7 +145,7 @@ describe('Observable.prototype.first', () => {
       return value === 's';
     };
 
-    expectObservable(e1.first(predicate, null, 'd')).toBe(expected);
+    expectObservable(e1.first(predicate, 'd')).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -186,34 +186,6 @@ describe('Observable.prototype.first', () => {
     };
 
     expectObservable(e1.first(predicate)).toBe(expected, null, 'error');
-    expectSubscriptions(e1.subscriptions).toBe(sub);
-  });
-
-  it('should support a result selector argument', () => {
-    const e1 = hot('--a--^---b---c---d---e--|');
-    const expected =    '--------(x|)';
-    const sub =         '^       !';
-    const predicate = function (x) { return x === 'c'; };
-    const resultSelector = function (x, i) {
-      expect(i).to.equal(1);
-      expect(x).to.equal('c');
-      return 'x';
-    };
-
-    expectObservable(e1.first(predicate, resultSelector)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
-  });
-
-  it('should raise error when result selector throws', () => {
-    const e1 = hot('--a--^---b---c---d---e--|');
-    const expected =    '--------#';
-    const sub =         '^       !';
-    const predicate = function (x) { return x === 'c'; };
-    const resultSelector = function (x, i) {
-      throw 'error';
-    };
-
-    expectObservable(e1.first(predicate, resultSelector)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
@@ -267,22 +239,10 @@ describe('Observable.prototype.first', () => {
       // After the type guard `first` predicates, the type is narrowed to string
       xs.first(isString)
         .subscribe(s => s.length); // s is string
-      xs.first(isString, s => s.substr(0)) // s is string in predicate
-        .subscribe(s => s.length); // s is string
 
       // boolean predicates preserve the type
       xs.first(x => typeof x === 'string')
         .subscribe(x => x); // x is still string | number
-      xs.first(x => !!x, x => x)
-        .subscribe(x => x); // x is still string | number
-      xs.first(x => typeof x === 'string', x => x, '') // default is string; x remains string | number
-        .subscribe(x => x); // x is still string | number
-
-      // `first` still uses the `resultSelector` return type, if it exists.
-      xs.first(x => typeof x === 'string', x => ({ str: `${x}` })) // x remains string | number
-        .subscribe(o => o.str); // o is { str: string }
-      xs.first(x => typeof x === 'string', x => ({ str: `${x}` }), { str: '' })
-        .subscribe(o => o.str); // o is { str: string }
     }
 
     // tslint:disable enable

--- a/spec/operators/last-spec.ts
+++ b/spec/operators/last-spec.ts
@@ -1,4 +1,4 @@
-import { expect } from 'chai';
+
 import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
@@ -87,7 +87,7 @@ describe('Observable.prototype.last', () => {
     const e1subs =   '(^!)';
     const expected = '(a|)';
 
-    expectObservable(e1.last(null, null, 'a')).toBe(expected);
+    expectObservable(e1.last(null, 'a')).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -96,23 +96,7 @@ describe('Observable.prototype.last', () => {
     const e1subs =       '^               !';
     const expected =     '----------------(d|)';
 
-    expectObservable(e1.last(null, null, 'x')).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should support a result selector argument', () => {
-    const e1 = hot('--a--^---b---c---d---e--|');
-    const e1subs =      '^                  !';
-    const expected =    '-------------------(x|)';
-
-    const predicate = function (x) { return x === 'c'; };
-    const resultSelector = function (x, i) {
-      expect(i).to.equal(1);
-      expect(x).to.equal('c');
-      return 'x';
-    };
-
-    expectObservable(e1.last(predicate, resultSelector)).toBe(expected);
+    expectObservable(e1.last(null, 'x')).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -130,20 +114,6 @@ describe('Observable.prototype.last', () => {
     };
 
     expectObservable(e1.last(predicate)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should raise error when result selector throws', () => {
-    const e1 = hot('--a--^---b---c---d---e--|');
-    const e1subs =      '^       !           ';
-    const expected =    '--------#           ';
-
-    const predicate = function (x) { return x === 'c'; };
-    const resultSelector = function (x, i) {
-      throw 'error';
-    };
-
-    expectObservable(e1.last(predicate, resultSelector)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -203,16 +173,6 @@ describe('Observable.prototype.last', () => {
       // boolean predicates preserve the type
       xs.last(x => typeof x === 'string')
         .subscribe(x => x); // x is still string | number
-      xs.last(x => !!x, x => x)
-        .subscribe(x => x); // x is still string | number
-      xs.last(x => typeof x === 'string', x => x, '') // default is string; x remains string | number
-        .subscribe(x => x); // x is still string | number
-
-      // `last` still uses the `resultSelector` return type, if it exists.
-      xs.last(x => typeof x === 'string', x => ({ str: `${x}` })) // x remains string | number
-        .subscribe(o => o.str); // o is { str: string }
-      xs.last(x => typeof x === 'string', x => ({ str: `${x}` }), { str: '' })
-        .subscribe(o => o.str); // o is { str: string }
     }
 
     // tslint:disable enable

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -115,60 +115,6 @@ describe('Observable.prototype.mergeMap', () => {
       });
   });
 
-  it('should mergeMap values to resolved promises with resultSelector', (done) => {
-    const source = Rx.Observable.from([4, 3, 2, 1]);
-    const resultSelectorCalledWith: number[][] = [];
-    const project = function (value: number, index: number) {
-      return Observable.from(Promise.resolve([value, index]));
-    };
-    const resultSelector = function (outerVal: number, innerVal: number[], outerIndex: number, innerIndex: number) {
-      resultSelectorCalledWith.push([].slice.call(arguments));
-      return 8;
-    };
-
-    const results: number[] = [];
-    const expectedCalls = [
-      [4, [4, 0], 0, 0],
-      [3, [3, 1], 1, 0],
-      [2, [2, 2], 2, 0],
-      [1, [1, 3], 3, 0],
-    ];
-    source.mergeMap(project, resultSelector).subscribe(
-      (x) => {
-        results.push(x);
-      },
-      (err) => {
-        done(new Error('Subscriber error handler not supposed to be called.'));
-      },
-      () => {
-        expect(results).to.deep.equal([8, 8, 8, 8]);
-        expect(resultSelectorCalledWith).to.deep.equal(expectedCalls);
-        done();
-      });
-  });
-
-  it('should mergeMap values to rejected promises with resultSelector', (done) => {
-    const source = Rx.Observable.from([4, 3, 2, 1]);
-    const project = function (value: number, index: number) {
-      return Observable.from(Promise.reject('' + value + '-' + index));
-    };
-    const resultSelector = () => {
-      throw 'this should not be called';
-    };
-
-    source.mergeMap(project, resultSelector).subscribe(
-      (x) => {
-        done(new Error('Subscriber next handler not supposed to be called.'));
-      },
-      (err) => {
-        expect(err).to.equal('4-0');
-        done();
-      },
-      () => {
-        done(new Error('Subscriber complete handler not supposed to be called.'));
-      });
-  });
-
   it('should mergeMap many outer values to many inner values', () => {
     const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
     const e1 =     hot('-a-------b-------c-------d-------|            ');
@@ -281,92 +227,6 @@ describe('Observable.prototype.mergeMap', () => {
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should mergeMap to many cold Observable, with parameter concurrency=1', () => {
-    const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
-    const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
-    const inner =  cold('----i---j---k---l---|                                        ', values);
-    const innersubs = [' ^                   !                                        ',
-                     '                     ^                   !                    ',
-                     '                                         ^                   !'];
-    const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
-
-    function project() { return inner; }
-    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
-    const result = e1.mergeMap(project, resultSelector, 1);
-
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(inner.subscriptions).toBe(innersubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should mergeMap to many cold Observable, with parameter concurrency=2', () => {
-    const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
-    const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
-    const inner =  cold('----i---j---k---l---|                    ', values);
-    const innersubs = [' ^                   !                    ',
-                     '         ^                   !            ',
-                     '                     ^                   !'];
-    const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
-
-    function project() { return inner; }
-    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
-    const result = e1.mergeMap(project, resultSelector, 2);
-
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(inner.subscriptions).toBe(innersubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should mergeMap to many hot Observable, with parameter concurrency=1', () => {
-    const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
-    const e1 =     hot('-a-------b-------c---|                                        ');
-    const e1subs =     '^                                                            !';
-    const hotA =   hot('x----i---j---k---l---|                                        ', values);
-    const hotB =   hot('-x-x-xxxx-x-x-xxxxx-x----i---j---k---l---|                    ', values);
-    const hotC =   hot('x-xxxx---x-x-x-x-x-xx--x--x-x--x--xxxx-x-----i---j---k---l---|', values);
-    const asubs =      ' ^                   !                                        ';
-    const bsubs =      '                     ^                   !                    ';
-    const csubs =      '                                         ^                   !';
-    const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
-    const inners = { a: hotA, b: hotB, c: hotC };
-
-    function project(x: string) { return inners[x]; }
-    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
-    const result = e1.mergeMap(project, resultSelector, 1);
-
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(hotA.subscriptions).toBe(asubs);
-    expectSubscriptions(hotB.subscriptions).toBe(bsubs);
-    expectSubscriptions(hotC.subscriptions).toBe(csubs);
-  });
-
-  it('should mergeMap to many hot Observable, with parameter concurrency=2', () => {
-    const values = {i: 'foo', j: 'bar', k: 'baz', l: 'qux'};
-    const e1 =     hot('-a-------b-------c---|                    ');
-    const e1subs =     '^                                        !';
-    const hotA =   hot('x----i---j---k---l---|                    ', values);
-    const hotB =   hot('-x-x-xxxx----i---j---k---l---|            ', values);
-    const hotC =   hot('x-xxxx---x-x-x-x-x-xx----i---j---k---l---|', values);
-    const asubs =      ' ^                   !                    ';
-    const bsubs =      '         ^                   !            ';
-    const csubs =      '                     ^                   !';
-    const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
-    const inners = { a: hotA, b: hotB, c: hotC };
-
-    function project(x: string) { return inners[x]; }
-    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
-    const result = e1.mergeMap(project, resultSelector, 2);
-
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(hotA.subscriptions).toBe(asubs);
-    expectSubscriptions(hotB.subscriptions).toBe(bsubs);
-    expectSubscriptions(hotC.subscriptions).toBe(csubs);
   });
 
   it('should mergeMap to many cold Observable, with parameter concurrency=1, without resultSelector', () => {
@@ -616,36 +476,12 @@ describe('Observable.prototype.mergeMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should mergeMap many outer to inner arrays, using resultSelector', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const e1subs =   '^                               !';
-    const expected = '(44)--(8888)---(666)----(44)----|';
-
-    const source = e1.mergeMap((value) => arrayRepeat(value, +value),
-      (x, y) => String(parseInt(x) + (+y)));
-
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
   it('should mergeMap many outer to inner arrays, and outer throws', () => {
     const e1 =   hot('2-----4--------3--------2-------#');
     const e1subs =   '^                               !';
     const expected = '(22)--(4444)---(333)----(22)----#';
 
     const source = e1.mergeMap((value) => arrayRepeat(value, +value));
-
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should mergeMap many outer to inner arrays, resultSelector, outer throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------#');
-    const e1subs =   '^                               !';
-    const expected = '(44)--(8888)---(666)----(44)----#';
-
-    const source = e1.mergeMap((value) => arrayRepeat(value, +value),
-      (x, y) => String(parseInt(x) + (+y)));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -663,19 +499,6 @@ describe('Observable.prototype.mergeMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should mergeMap many outer to inner arrays, resultSelector, outer unsubscribed', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const unsub =    '             !                   ';
-    const e1subs =   '^            !                   ';
-    const expected = '(44)--(8888)--                   ';
-
-     const source = e1.mergeMap((value) => arrayRepeat(value, +value),
-      (x, y) => String(parseInt(x) + (+y)));
-
-    expectObservable(source, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
   it('should mergeMap many outer to inner arrays, project throws', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const e1subs =   '^              !                 ';
@@ -688,43 +511,6 @@ describe('Observable.prototype.mergeMap', () => {
         throw 'error';
       }
       return arrayRepeat(value, +value);
-    });
-
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should mergeMap many outer to inner arrays, resultSelector throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const e1subs  =  '^              !                 ';
-    const expected = '(44)--(8888)---#                 ';
-
-    const source = e1.mergeMap((value) => arrayRepeat(value, +value),
-      (inner, outer) => {
-        if (outer === '3') {
-          throw 'error';
-        }
-        return String((+outer) + parseInt(inner));
-    });
-
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should mergeMap many outer to inner arrays, resultSelector, project throws', () => {
-    const e1 =   hot('2-----4--------3--------2-------|');
-    const e1subs  =  '^              !                 ';
-    const expected = '(44)--(8888)---#                 ';
-
-    let invoked = 0;
-    const source = e1.mergeMap((value) => {
-      invoked++;
-      if (invoked === 3) {
-        throw 'error';
-      }
-      return arrayRepeat(value, +value);
-    }, (inner, outer) => {
-      return String((+outer) + parseInt(inner));
     });
 
     expectObservable(source).toBe(expected);
@@ -769,8 +555,6 @@ describe('Observable.prototype.mergeMap', () => {
     /* tslint:disable:no-unused-variable */
     let a1: Rx.Observable<string> = o.mergeMap(x => x.toString());
     let a2: Rx.Observable<string> = o.mergeMap(x => x.toString(), 3);
-    let a3: Rx.Observable<{ o: number; i: string; }> = o.mergeMap(x => x.toString(), (o, i) => ({ o, i }));
-    let a4: Rx.Observable<{ o: number; i: string; }> = o.mergeMap(x => x.toString(), (o, i) => ({ o, i }), 3);
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -22,15 +22,6 @@ describe('Observable.prototype.switchMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should switch with a selector function', (done) => {
-    const a = Observable.of(1, 2, 3);
-    const expected = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'a3', 'b3', 'c3'];
-    a.switchMap((x) => Observable.of('a' + x, 'b' + x, 'c' + x))
-      .subscribe((x) => {
-        expect(x).to.equal(expected.shift());
-      }, null, done);
-  });
-
   it('should unsub inner observables', () => {
     const unsubbed: string[] = [];
 
@@ -73,24 +64,6 @@ describe('Observable.prototype.switchMap', () => {
     }
 
     expectObservable(e1.switchMap(project)).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should raise error when resultSelector throws', () => {
-    const x =   cold(         '--a--b--c--d--e--|   ');
-    const xsubs =    '         ^ !                  ';
-    const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^          !                  ';
-    const expected = '-----------#                  ';
-
-    function selector() {
-      throw 'error';
-    }
-
-    const result = e1.switchMap((value) => x, selector);
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -354,36 +327,6 @@ describe('Observable.prototype.switchMap', () => {
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should switch with resultSelector goodness', () => {
-    const x =   cold(         '--a--b--c--d--e--|           ');
-    const xsubs =    '         ^         !                  ';
-    const y =   cold(                   '---f---g---h---i--|');
-    const ysubs =    '                   ^                 !';
-    const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                                    !';
-    const expected = '-----------a--b--c----f---g---h---i--|';
-
-    const observableLookup = { x: x, y: y };
-
-    const expectedValues = {
-      a: ['x', 'a', 0, 0],
-      b: ['x', 'b', 0, 1],
-      c: ['x', 'c', 0, 2],
-      f: ['y', 'f', 1, 0],
-      g: ['y', 'g', 1, 1],
-      h: ['y', 'h', 1, 2],
-      i: ['y', 'i', 1, 3]
-    };
-
-    const result = e1.switchMap((value) => observableLookup[value],
-      (innerValue, outerValue, innerIndex, outerIndex) => [innerValue, outerValue, innerIndex, outerIndex]);
-
-    expectObservable(result).toBe(expected, expectedValues);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -222,46 +222,4 @@ describe('Observable.prototype.switchMapTo', () => {
     expectObservable(e1.switchMapTo(Observable.of('foo'))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
-
-  it('should switch with resultSelector goodness', () => {
-    const x =   cold(         '--1--2--3--4--5--|          ');
-    const xsubs =   ['         ^         !                 ',
-    //                                 --1--2--3--4--5--|
-                   '                   ^                !'];
-    const e1 =   hot('---------x---------y---------|       ');
-    const e1subs =   '^                                   !';
-    const expected = '-----------a--b--c---d--e--f--g--h--|';
-    const expectedValues = {
-      a: ['x', '1', 0, 0],
-      b: ['x', '2', 0, 1],
-      c: ['x', '3', 0, 2],
-      d: ['y', '1', 1, 0],
-      e: ['y', '2', 1, 1],
-      f: ['y', '3', 1, 2],
-      g: ['y', '4', 1, 3],
-      h: ['y', '5', 1, 4]
-    };
-
-    const result = e1.switchMapTo(x, (a, b, ai, bi) => [a, b, ai, bi]);
-
-    expectObservable(result).toBe(expected, expectedValues);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should raise error when resultSelector throws', () => {
-    const x =   cold(         '--1--2--3--4--5--|   ');
-    const xsubs =    '         ^ !                  ';
-    const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^          !';
-    const expected = '-----------#';
-
-    const result = e1.switchMapTo(x, () => {
-      throw 'error';
-    });
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
 });

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -1,11 +1,6 @@
 import { mergeMap } from './mergeMap';
 import { ObservableInput, OperatorFunction } from '../types';
 
-/* tslint:disable:max-line-length */
-export function concatMap<T, R>(project: (value: T, index: number) =>  ObservableInput<R>): OperatorFunction<T, R>;
-export function concatMap<T, I, R>(project: (value: T, index: number) =>  ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to an Observable which is merged in the output
  * Observable, in a serialized fashion waiting for each one to complete before
@@ -50,14 +45,6 @@ export function concatMap<T, I, R>(project: (value: T, index: number) =>  Observ
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An Observable that emits the result of applying the
  * projection function (and the optional `resultSelector`) to each item emitted
  * by the source Observable and taking values from each projected inner
@@ -65,7 +52,6 @@ export function concatMap<T, I, R>(project: (value: T, index: number) =>  Observ
  * @method concatMap
  * @owner Observable
  */
-export function concatMap<T, I, R>(project: (value: T, index: number) =>  ObservableInput<I>,
-                                   resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
-  return mergeMap(project, resultSelector, 1);
+export function concatMap<T, R>(project: (value: T, index: number) =>  ObservableInput<R>): OperatorFunction<T, R> {
+  return mergeMap(project, 1);
 }

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -1,11 +1,6 @@
 import { concatMap } from './concatMap';
 import { ObservableInput, OperatorFunction } from '../types';
 
-/* tslint:disable:max-line-length */
-export function concatMapTo<T, R>(observable: ObservableInput<R>): OperatorFunction<T, R>;
-export function concatMapTo<T, I, R>(observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to the same Observable which is merged multiple
  * times in a serialized fashion on the output Observable.
@@ -48,23 +43,14 @@ export function concatMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An observable of values merged together by joining the
  * passed observable with itself, one after the other, for each value emitted
  * from the source.
  * @method concatMapTo
  * @owner Observable
  */
-export function concatMapTo<T, I, R>(
-  innerObservable: ObservableInput<I>,
-  resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R
+export function concatMapTo<T, R>(
+  innerObservable: ObservableInput<R>
 ): OperatorFunction<T, R> {
-  return concatMap(() => innerObservable, resultSelector);
+  return concatMap(() => innerObservable);
 }

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -1,10 +1,9 @@
 
 import { mergeMap } from './mergeMap';
 import { identity } from '../util/identity';
-import { OperatorFunction, ObservableInput } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput } from '../types';
 
 export function mergeAll<T>(concurrent?: number): OperatorFunction<ObservableInput<T>, T>;
-export function mergeAll<R>(concurrent?: number): OperatorFunction<any, R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable which
@@ -50,6 +49,6 @@ export function mergeAll<R>(concurrent?: number): OperatorFunction<any, R>;
  * @method mergeAll
  * @owner Observable
  */
-export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<any, T> {
-  return mergeMap(identity as (value: T, index: number) => ObservableInput<{}>, null, concurrent);
+export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): MonoTypeOperatorFunction<T> {
+  return mergeMap<T, T>(identity as (value: T, index: number) => ObservableInput<T>, concurrent);
 }

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -1,16 +1,6 @@
-import { Observable } from '../Observable';
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
-import { Subscription } from '../Subscription';
-import { OuterSubscriber } from '../OuterSubscriber';
-import { InnerSubscriber } from '../InnerSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
-import { ObservableInput, OperatorFunction, PartialObserver } from '../types';
-
-/* tslint:disable:max-line-length */
-export function mergeMapTo<T, R>(observable: ObservableInput<R>, concurrent?: number): OperatorFunction<T, R>;
-export function mergeMapTo<T, I, R>(observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
+import { Observable, ObservableInput } from '../Observable';
+import { OperatorFunction } from '../../internal/types';
+import { mergeMap } from './mergeMap';
 
 /**
  * Projects each source value to the same Observable which is merged multiple
@@ -39,129 +29,14 @@ export function mergeMapTo<T, I, R>(observable: ObservableInput<I>, resultSelect
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits items from the given
- * `innerObservable` (and optionally transformed through `resultSelector`) every
- * time a value is emitted on the source Observable.
+ * `innerObservable`
  * @method mergeMapTo
  * @owner Observable
  */
-export function mergeMapTo<T, I, R>(innerObservable: ObservableInput<I>,
-                                    resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
-                                    concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<T, R> {
-  if (typeof resultSelector === 'number') {
-    concurrent = <number>resultSelector;
-    resultSelector = null;
-  }
-  return (source: Observable<T>) => source.lift(new MergeMapToOperator(innerObservable, <any>resultSelector, concurrent));
-}
-
-// TODO: Figure out correct signature here: an Operator<Observable<T>, R>
-//       needs to implement call(observer: Subscriber<R>): Subscriber<Observable<T>>
-export class MergeMapToOperator<T, I, R> implements Operator<Observable<T>, R> {
-  constructor(private ish: ObservableInput<I>,
-              private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
-              private concurrent: number = Number.POSITIVE_INFINITY) {
-  }
-
-  call(observer: Subscriber<R>, source: any): any {
-    return source.subscribe(new MergeMapToSubscriber(observer, this.ish, this.resultSelector, this.concurrent));
-  }
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-export class MergeMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
-  private hasCompleted: boolean = false;
-  private buffer: T[] = [];
-  private active: number = 0;
-  protected index: number = 0;
-
-  constructor(destination: Subscriber<R>,
-              private ish: ObservableInput<I>,
-              private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
-              private concurrent: number = Number.POSITIVE_INFINITY) {
-    super(destination);
-  }
-
-  protected _next(value: T): void {
-    if (this.active < this.concurrent) {
-      const resultSelector = this.resultSelector;
-      const index = this.index++;
-      const ish = this.ish;
-      const destination = this.destination;
-
-      this.active++;
-      this._innerSub(ish, destination, resultSelector, value, index);
-    } else {
-      this.buffer.push(value);
-    }
-  }
-
-  private _innerSub(ish: ObservableInput<I>,
-                    destination: PartialObserver<I>,
-                    resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R,
-                    value: T,
-                    index: number): void {
-    this.add(subscribeToResult<T, I>(this, ish, value, index));
-  }
-
-  protected _complete(): void {
-    this.hasCompleted = true;
-    if (this.active === 0 && this.buffer.length === 0) {
-      this.destination.complete();
-    }
-  }
-
-  notifyNext(outerValue: T, innerValue: I,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, I>): void {
-    const { resultSelector, destination } = this;
-    if (resultSelector) {
-      this.trySelectResult(outerValue, innerValue, outerIndex, innerIndex);
-    } else {
-      destination.next(innerValue);
-    }
-  }
-
-  private trySelectResult(outerValue: T, innerValue: I,
-                          outerIndex: number, innerIndex: number): void {
-    const { resultSelector, destination } = this;
-    let result: R;
-    try {
-      result = resultSelector(outerValue, innerValue, outerIndex, innerIndex);
-    } catch (err) {
-      destination.error(err);
-      return;
-    }
-
-    destination.next(result);
-  }
-
-  notifyError(err: any): void {
-    this.destination.error(err);
-  }
-
-  notifyComplete(innerSub: Subscription): void {
-    const buffer = this.buffer;
-    this.remove(innerSub);
-    this.active--;
-    if (buffer.length > 0) {
-      this._next(buffer.shift());
-    } else if (this.active === 0 && this.hasCompleted) {
-      this.destination.complete();
-    }
-  }
+export function mergeMapTo<T, R>(innerObservable: ObservableInput<R>,
+                                 concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<T, R> {
+  return mergeMap(() => innerObservable, concurrent);
 }

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -1,6 +1,7 @@
-import { Observable, ObservableInput } from '../Observable';
+import { Observable } from '../Observable';
 import { OperatorFunction } from '../../internal/types';
 import { mergeMap } from './mergeMap';
+import { ObservableInput } from '../types';
 
 /**
  * Projects each source value to the same Observable which is merged multiple

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -49,7 +49,7 @@ import { ObservableInput, OperatorFunction } from '../types';
 export function switchMap<T, R>(
   project: (value: T, index: number) => ObservableInput<R>
 ): OperatorFunction<T, R> {
-  return function switchMapOperatorFunction(source: Observable<T>): Observable<R | R> {
+  return function switchMapOperatorFunction(source: Observable<T>): Observable<R> {
     return source.lift(new SwitchMapOperator(project));
   };
 }

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -7,11 +7,6 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction } from '../types';
 
-/* tslint:disable:max-line-length */
-export function switchMap<T, R>(project: (value: T, index: number) => ObservableInput<R>): OperatorFunction<T, R>;
-export function switchMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to an Observable which is merged in the output
  * Observable, emitting values only from the most recently projected Observable.
@@ -44,14 +39,6 @@ export function switchMap<T, I, R>(project: (value: T, index: number) => Observa
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An Observable that emits the result of applying the
  * projection function (and the optional `resultSelector`) to each item emitted
  * by the source Observable and taking only the values from the most recently
@@ -59,22 +46,20 @@ export function switchMap<T, I, R>(project: (value: T, index: number) => Observa
  * @method switchMap
  * @owner Observable
  */
-export function switchMap<T, I, R>(
-  project: (value: T, index: number) => ObservableInput<I>,
-  resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R
-): OperatorFunction<T, I | R> {
-  return function switchMapOperatorFunction(source: Observable<T>): Observable<I | R> {
-    return source.lift(new SwitchMapOperator(project, resultSelector));
+export function switchMap<T, R>(
+  project: (value: T, index: number) => ObservableInput<R>
+): OperatorFunction<T, R> {
+  return function switchMapOperatorFunction(source: Observable<T>): Observable<R | R> {
+    return source.lift(new SwitchMapOperator(project));
   };
 }
 
-class SwitchMapOperator<T, I, R> implements Operator<T, I> {
-  constructor(private project: (value: T, index: number) => ObservableInput<I>,
-              private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
+class SwitchMapOperator<T, R> implements Operator<T, R> {
+  constructor(private project: (value: T, index: number) => ObservableInput<R>) {
   }
 
-  call(subscriber: Subscriber<I>, source: any): any {
-    return source.subscribe(new SwitchMapSubscriber(subscriber, this.project, this.resultSelector));
+  call(subscriber: Subscriber<R>, source: any): any {
+    return source.subscribe(new SwitchMapSubscriber(subscriber, this.project));
   }
 }
 
@@ -83,18 +68,17 @@ class SwitchMapOperator<T, I, R> implements Operator<T, I> {
  * @ignore
  * @extends {Ignored}
  */
-class SwitchMapSubscriber<T, I, R> extends OuterSubscriber<T, I> {
+class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   private index: number = 0;
   private innerSubscription: Subscription;
 
-  constructor(destination: Subscriber<I>,
-              private project: (value: T, index: number) => ObservableInput<I>,
-              private resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
+  constructor(destination: Subscriber<R>,
+              private project: (value: T, index: number) => ObservableInput<R>) {
     super(destination);
   }
 
   protected _next(value: T) {
-    let result: ObservableInput<I>;
+    let result: ObservableInput<R>;
     const index = this.index++;
     try {
       result = this.project(value, index);
@@ -105,7 +89,7 @@ class SwitchMapSubscriber<T, I, R> extends OuterSubscriber<T, I> {
     this._innerSub(result, value, index);
   }
 
-  private _innerSub(result: ObservableInput<I>, value: T, index: number) {
+  private _innerSub(result: ObservableInput<R>, value: T, index: number) {
     const innerSubscription = this.innerSubscription;
     if (innerSubscription) {
       innerSubscription.unsubscribe();
@@ -132,24 +116,9 @@ class SwitchMapSubscriber<T, I, R> extends OuterSubscriber<T, I> {
     }
   }
 
-  notifyNext(outerValue: T, innerValue: I,
+  notifyNext(outerValue: T, innerValue: R,
              outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, I>): void {
-    if (this.resultSelector) {
-      this._tryNotifyNext(outerValue, innerValue, outerIndex, innerIndex);
-    } else {
+             innerSub: InnerSubscriber<T, R>): void {
       this.destination.next(innerValue);
-    }
-  }
-
-  private _tryNotifyNext(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): void {
-    let result: R;
-    try {
-      result = this.resultSelector(outerValue, innerValue, outerIndex, innerIndex);
-    } catch (err) {
-      this.destination.error(err);
-      return;
-    }
-    this.destination.next(result);
   }
 }

--- a/src/internal/patching/operator/concatMap.ts
+++ b/src/internal/patching/operator/concatMap.ts
@@ -2,11 +2,6 @@ import { concatMap as higherOrderConcatMap } from '../../operators/concatMap';
 import { Observable } from '../../Observable';
 import { ObservableInput } from '../../types';
 
-/* tslint:disable:max-line-length */
-export function concatMap<T, R>(this: Observable<T>, project: (value: T, index: number) =>  ObservableInput<R>): Observable<R>;
-export function concatMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) =>  ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to an Observable which is merged in the output
  * Observable, in a serialized fashion waiting for each one to complete before
@@ -51,14 +46,6 @@ export function concatMap<T, I, R>(this: Observable<T>, project: (value: T, inde
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An Observable that emits the result of applying the
  * projection function (and the optional `resultSelector`) to each item emitted
  * by the source Observable and taking values from each projected inner
@@ -66,7 +53,6 @@ export function concatMap<T, I, R>(this: Observable<T>, project: (value: T, inde
  * @method concatMap
  * @owner Observable
  */
-export function concatMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) =>  ObservableInput<I>,
-                                   resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) {
-  return higherOrderConcatMap(project, resultSelector)(this);
+export function concatMap<T, R>(this: Observable<T>, project: (value: T, index: number) =>  ObservableInput<R>) {
+  return higherOrderConcatMap(project)(this);
 }

--- a/src/internal/patching/operator/concatMapTo.ts
+++ b/src/internal/patching/operator/concatMapTo.ts
@@ -2,11 +2,6 @@ import { Observable } from '../../Observable';
 import { ObservableInput } from '../../types';
 import { concatMapTo as higherOrder } from '../../operators/concatMapTo';
 
-/* tslint:disable:max-line-length */
-export function concatMapTo<T, R>(this: Observable<T>, observable: ObservableInput<R>): Observable<R>;
-export function concatMapTo<T, I, R>(this: Observable<T>, observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to the same Observable which is merged multiple
  * times in a serialized fashion on the output Observable.
@@ -49,21 +44,12 @@ export function concatMapTo<T, I, R>(this: Observable<T>, observable: Observable
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An observable of values merged together by joining the
  * passed observable with itself, one after the other, for each value emitted
  * from the source.
  * @method concatMapTo
  * @owner Observable
  */
-export function concatMapTo<T, I, R>(this: Observable<T>, innerObservable: ObservableInput<I>,
-                                     resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {
-  return higherOrder(innerObservable, resultSelector)(this);
+export function concatMapTo<T, R>(this: Observable<T>, innerObservable: Observable<R>): Observable<R> {
+  return higherOrder(innerObservable)(this);
 }

--- a/src/internal/patching/operator/exhaustMap.ts
+++ b/src/internal/patching/operator/exhaustMap.ts
@@ -2,12 +2,6 @@
 import { Observable } from '../../Observable';
 import { ObservableInput } from '../../types';
 import { exhaustMap as higherOrder } from '../../operators/exhaustMap';
-
-/* tslint:disable:max-line-length */
-export function exhaustMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>): Observable<R>;
-export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to an Observable which is merged in the output
  * Observable only if the previous projected Observable has completed.
@@ -39,21 +33,15 @@ export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, ind
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An Observable containing projected Observables
  * of each item of the source, ignoring projected Observables that start before
  * their preceding Observable has completed.
  * @method exhaustMap
  * @owner Observable
  */
-export function exhaustMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>,
-                                    resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R> {
-  return higherOrder(project, resultSelector)(this);
+export function exhaustMap<T, R>(
+  this: Observable<T>,
+  project: (value: T, index: number) => ObservableInput<R>
+): Observable<R> {
+  return higherOrder(project)(this);
 }

--- a/src/internal/patching/operator/first.ts
+++ b/src/internal/patching/operator/first.ts
@@ -1,27 +1,6 @@
 import { Observable } from '../../Observable';
 import { first as higherOrder } from '../../operators/first';
 
-/* tslint:disable:max-line-length */
-export function first<T, S extends T>(this: Observable<T>,
-                                      predicate: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
-export function first<T, S extends T, R>(this: Observable<T>,
-                                         predicate: (value: T | S, index: number, source: Observable<T>) => value is S,
-                                         resultSelector: (value: S, index: number) => R, defaultValue?: R): Observable<R>;
-export function first<T, S extends T>(this: Observable<T>,
-                                      predicate: (value: T, index: number, source: Observable<T>) => value is S,
-                                      resultSelector: void,
-                                      defaultValue?: S): Observable<S>;
-export function first<T>(this: Observable<T>,
-                         predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
-export function first<T, R>(this: Observable<T>,
-                            predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                            resultSelector?: (value: T, index: number) => R,
-                            defaultValue?: R): Observable<R>;
-export function first<T>(this: Observable<T>,
-                         predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                         resultSelector: void,
-                         defaultValue?: T): Observable<T>;
-
 /**
  * Emits only the first value (or the first value that meets some condition)
  * emitted by the source Observable.
@@ -58,21 +37,14 @@ export function first<T>(this: Observable<T>,
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} [predicate]
  * An optional function called with each item to test for condition matching.
- * @param {function(value: T, index: number): R} [resultSelector] A function to
- * produce the value on the output Observable based on the values
- * and the indices of the source Observable. The arguments passed to this
- * function are:
- * - `value`: the value that was emitted on the source.
- * - `index`: the "index" of the value from the source.
- * @param {R} [defaultValue] The default value emitted in case no valid value
+ * @param {T} [defaultValue] The default value emitted in case no valid value
  * was found on the source.
- * @return {Observable<T|R>} An Observable of the first item that matches the
+ * @return {Observable<T>} An Observable of the first item that matches the
  * condition.
  * @method first
  * @owner Observable
  */
-export function first<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-                            resultSelector?: ((value: T, index: number) => R) | void,
-                            defaultValue?: R): Observable<T | R> {
-  return higherOrder(predicate, resultSelector as any, defaultValue)(this);
-}
+export function first<T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+                         defaultValue?: T): Observable<T> {
+    return higherOrder(predicate, defaultValue)(this);
+  }

--- a/src/internal/patching/operator/last.ts
+++ b/src/internal/patching/operator/last.ts
@@ -21,6 +21,6 @@ import { last as higherOrder } from '../../operators/last';
  * @owner Observable
  */
 export function last<T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-                        defaultValue?: T): Observable<T | T> {
+                        defaultValue?: T): Observable<T> {
   return higherOrder(predicate, defaultValue)(this);
 }

--- a/src/internal/patching/operator/last.ts
+++ b/src/internal/patching/operator/last.ts
@@ -1,28 +1,6 @@
 import { Observable } from '../../Observable';
 import { last as higherOrder } from '../../operators/last';
 
-/* tslint:disable:max-line-length */
-export function last<T, S extends T>(this: Observable<T>,
-                                     predicate: (value: T, index: number, source: Observable<T>) => value is S): Observable<S>;
-export function last<T, S extends T, R>(this: Observable<T>,
-                                        predicate: (value: T | S, index: number, source: Observable<T>) => value is S,
-                                        resultSelector: (value: S, index: number) => R, defaultValue?: R): Observable<R>;
-export function last<T, S extends T>(this: Observable<T>,
-                                     predicate: (value: T, index: number, source: Observable<T>) => value is S,
-                                     resultSelector: void,
-                                     defaultValue?: S): Observable<S>;
-export function last<T>(this: Observable<T>,
-                        predicate?: (value: T, index: number, source: Observable<T>) => boolean): Observable<T>;
-export function last<T, R>(this: Observable<T>,
-                           predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                           resultSelector?: (value: T, index: number) => R,
-                           defaultValue?: R): Observable<R>;
-export function last<T>(this: Observable<T>,
-                        predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                        resultSelector: void,
-                        defaultValue?: T): Observable<T>;
-/* tslint:enable:max-line-length */
-
 /**
  * Returns an Observable that emits only the last item emitted by the source Observable.
  * It optionally takes a predicate function as a parameter, in which case, rather than emitting
@@ -33,15 +11,16 @@ export function last<T>(this: Observable<T>,
  *
  * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
- * @param {function} predicate - The condition any source emitted item has to satisfy.
+ * @param {function} [predicate] - The condition any source emitted item has to satisfy.
+ * @param {any} [defaultValue] - The default value to use if the predicate isn't
+ * satisfied, or no values were emitted (if no predicate).
  * @return {Observable} An Observable that emits only the last item satisfying the given condition
  * from the source, or an NoSuchElementException if no such items are emitted.
  * @throws - Throws if no items that match the predicate are emitted by the source Observable.
  * @method last
  * @owner Observable
  */
-export function last<T, R>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-                           resultSelector?: ((value: T, index: number) => R) | void,
-                           defaultValue?: R): Observable<T | R> {
-  return higherOrder(predicate, resultSelector as any, defaultValue)(this);
+export function last<T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+                        defaultValue?: T): Observable<T | T> {
+  return higherOrder(predicate, defaultValue)(this);
 }

--- a/src/internal/patching/operator/mergeMap.ts
+++ b/src/internal/patching/operator/mergeMap.ts
@@ -53,6 +53,6 @@ import { mergeMap as higherOrderMergeMap } from '../../operators/mergeMap';
  * @owner Observable
  */
 export function mergeMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>,
-                               concurrent: number = Number.POSITIVE_INFINITY): Observable<R | R> {
-  return higherOrderMergeMap(project, concurrent)(this) as Observable<R | R>;
+                               concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
+  return higherOrderMergeMap(project, concurrent)(this) as Observable<R>;
 }

--- a/src/internal/patching/operator/mergeMap.ts
+++ b/src/internal/patching/operator/mergeMap.ts
@@ -2,11 +2,6 @@ import { Observable } from '../../Observable';
 import { ObservableInput } from '../../types';
 import { mergeMap as higherOrderMergeMap } from '../../operators/mergeMap';
 
-/* tslint:disable:max-line-length */
-export function mergeMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>, concurrent?: number): Observable<R>;
-export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): Observable<R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to an Observable which is merged in the output
  * Observable.
@@ -48,14 +43,6 @@ export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits the result of applying the
@@ -65,8 +52,7 @@ export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index
  * @method mergeMap
  * @owner Observable
  */
-export function mergeMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>,
-                                  resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
-                                  concurrent: number = Number.POSITIVE_INFINITY): Observable<I | R> {
-  return higherOrderMergeMap(project, <any>resultSelector, concurrent)(this) as Observable<I | R>;
+export function mergeMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>,
+                               concurrent: number = Number.POSITIVE_INFINITY): Observable<R | R> {
+  return higherOrderMergeMap(project, concurrent)(this) as Observable<R | R>;
 }

--- a/src/internal/patching/operator/mergeMapTo.ts
+++ b/src/internal/patching/operator/mergeMapTo.ts
@@ -2,11 +2,6 @@ import { Observable } from '../../Observable';
 import { ObservableInput } from '../../types';
 import { mergeMapTo as higherOrder } from '../../operators/mergeMapTo';
 
-/* tslint:disable:max-line-length */
-export function mergeMapTo<T, R>(this: Observable<T>, observable: ObservableInput<R>, concurrent?: number): Observable<R>;
-export function mergeMapTo<T, I, R>(this: Observable<T>, observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): Observable<R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to the same Observable which is merged multiple
  * times in the output Observable.
@@ -34,24 +29,14 @@ export function mergeMapTo<T, I, R>(this: Observable<T>, observable: ObservableI
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits items from the given
- * `innerObservable` (and optionally transformed through `resultSelector`) every
- * time a value is emitted on the source Observable.
+ * `innerObservable`.
  * @method mergeMapTo
  * @owner Observable
  */
-export function mergeMapTo<T, I, R>(this: Observable<T>, innerObservable: ObservableInput<I>,
-                                    resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
-                                    concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
-  return higherOrder(innerObservable, resultSelector as any, concurrent)(this) as Observable<R>;
+export function mergeMapTo<T, R>(this: Observable<T>, innerObservable: ObservableInput<R>,
+                                 concurrent: number = Number.POSITIVE_INFINITY): Observable<R> {
+  return higherOrder(innerObservable, concurrent)(this) as Observable<R>;
 }

--- a/src/internal/patching/operator/switchMap.ts
+++ b/src/internal/patching/operator/switchMap.ts
@@ -3,11 +3,6 @@ import { Observable } from '../../Observable';
 import { ObservableInput } from '../../types';
 import { switchMap as higherOrderSwitchMap } from '../../operators/switchMap';
 
-/* tslint:disable:max-line-length */
-export function switchMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>): Observable<R>;
-export function switchMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<R>;
-/* tslint:enable:max-line-length */
-
 /**
  * Projects each source value to an Observable which is merged in the output
  * Observable, emitting values only from the most recently projected Observable.
@@ -40,14 +35,6 @@ export function switchMap<T, I, R>(this: Observable<T>, project: (value: T, inde
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An Observable that emits the result of applying the
  * projection function (and the optional `resultSelector`) to each item emitted
  * by the source Observable and taking only the values from the most recently
@@ -55,7 +42,6 @@ export function switchMap<T, I, R>(this: Observable<T>, project: (value: T, inde
  * @method switchMap
  * @owner Observable
  */
-export function switchMap<T, I, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<I>,
-                                   resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): Observable<I | R> {
-  return higherOrderSwitchMap(project, resultSelector)(this);
+export function switchMap<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>): Observable<R> {
+  return higherOrderSwitchMap(project)(this);
 }

--- a/src/internal/patching/operator/switchMapTo.ts
+++ b/src/internal/patching/operator/switchMapTo.ts
@@ -34,14 +34,6 @@ export function switchMapTo<T, I, R>(this: Observable<T>, observable: Observable
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @param {function(outerValue: T, innerValue: I, outerIndex: number, innerIndex: number): any} [resultSelector]
- * A function to produce the value on the output Observable based on the values
- * and the indices of the source (outer) emission and the inner Observable
- * emission. The arguments passed to this function are:
- * - `outerValue`: the value that came from the source
- * - `innerValue`: the value that came from the projected Observable
- * - `outerIndex`: the "index" of the value that came from the source
- * - `innerIndex`: the "index" of the value from the projected Observable
  * @return {Observable} An Observable that emits items from the given
  * `innerObservable` (and optionally transformed through `resultSelector`) every
  * time a value is emitted on the source Observable, and taking only the values
@@ -49,10 +41,6 @@ export function switchMapTo<T, I, R>(this: Observable<T>, observable: Observable
  * @method switchMapTo
  * @owner Observable
  */
-export function switchMapTo<T, I, R>(this: Observable<T>, innerObservable: ObservableInput<I>,
-                                     resultSelector?: (outerValue: T,
-                                                       innerValue: I,
-                                                       outerIndex: number,
-                                                       innerIndex: number) => R): Observable<I | R> {
-  return higherOrder(innerObservable, resultSelector)(this);
+export function switchMapTo<T, R>(this: Observable<T>, innerObservable: ObservableInput<R>): Observable<R> {
+  return higherOrder(innerObservable)(this);
 }


### PR DESCRIPTION
This is an experimental PR that is aiming to remove all superfluous resultSelector arguments from operators and observable creators.

To start with I've done `mergeMap`, `mergeMapTo`, `switchMap`, `switchMapTo`, `concatMap`, `concatMapTo` and `forkJoin`.

See commit messages for more detail.

This is aimed at smaller size, simplifying the API, simplifying the code base, and simplifying TypeScript typings. 

Just doing it makes it clear that it's a solid decision, as the code cleans up substantially everywhere it's done.

Relates to #2929 