### PR TITLE
fix(rxjs): make sure esm imports from index.js by default, not Rx.js

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -39,8 +39,8 @@ fs.removeSync(PKG_ROOT);
 
 let rootPackageJson = Object.assign({}, pkg, {
   name: 'rxjs',
-  main: './Rx.js',
-  typings: './Rx.d.ts'
+  main: './index.js',
+  typings: './index.d.ts'
 });
 
 // Get a list of the file names. Sort in reverse order so re-export files


### PR DESCRIPTION
fixes #3315
