### PR TITLE
refactor(typings): updated typings to support symbol observables and iterables

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,1 @@
 # no eol conversions!
-* -text

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -24,8 +24,8 @@ function expectFullObserver(val: any) {
 
 /** @test {Observable} */
 describe('Observable', () => {
-  it('should be constructed with a subscriber function', (done: MochaDone) => {
-    const source = new Observable(function (observer) {
+  it('should be constructed with a subscriber function', (done) => {
+    const source = new Observable<number>(function (observer) {
       expectFullObserver(observer);
       observer.next(1);
       observer.complete();
@@ -35,7 +35,7 @@ describe('Observable', () => {
   });
 
   it('should send errors thrown in the constructor down the error path', (done) => {
-    new Observable((observer) => {
+    new Observable<number>((observer) => {
       throw new Error('this should be handled');
     })
     .subscribe({
@@ -49,7 +49,7 @@ describe('Observable', () => {
   });
 
   describe('forEach', () => {
-    it('should iterate and return a Promise', (done: MochaDone) => {
+    it('should iterate and return a Promise', (done) => {
       const expected = [1, 2, 3];
       const result = Observable.of(1, 2, 3).forEach(function (x) {
         expect(x).to.equal(expected.shift());
@@ -61,28 +61,28 @@ describe('Observable', () => {
       expect(result.then).to.be.a('function');
     });
 
-    it('should reject promise when in error', (done: MochaDone) => {
-      Observable.throw('bad').forEach((x: any) => {
+    it('should reject promise when in error', (done) => {
+      Observable.throwError('bad').forEach((x) => {
         done(new Error('should not be called'));
       }, Promise).then(() => {
         done(new Error('should not complete'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.equal('bad');
         done();
       });
     });
 
-    it('should allow Promise to be globally configured', (done: MochaDone) => {
+    it('should allow Promise to be globally configured', (done) => {
       let wasCalled = false;
 
       __root__.Rx = {};
       __root__.Rx.config = {};
       __root__.Rx.config.Promise = function MyPromise(callback: any) {
         wasCalled = true;
-        return new Promise(callback);
+        return new Promise<number>(callback);
       };
 
-      Observable.of(42).forEach((x: number) => {
+      Observable.of(42).forEach((x) => {
         expect(x).to.equal(42);
       }).then(() => {
         expect(wasCalled).to.be.true;
@@ -91,10 +91,10 @@ describe('Observable', () => {
       });
     });
 
-    it('should reject promise if nextHandler throws', (done: MochaDone) => {
+    it('should reject promise if nextHandler throws', (done) => {
       const results: number[] = [];
 
-      Observable.of(1, 2, 3).forEach((x: number) => {
+      Observable.of(1, 2, 3).forEach((x) => {
         if (x === 3) {
           throw new Error('NO THREES!');
         }
@@ -112,7 +112,7 @@ describe('Observable', () => {
 
     it('should handle a synchronous throw from the next handler', () => {
       const expected = new Error('I told, you Bobby Boucher, threes are the debil!');
-      const syncObservable = new Observable<number>((observer: Rx.Observer<number>) => {
+      const syncObservable = new Observable<number>((observer) => {
         observer.next(1);
         observer.next(2);
         observer.next(3);
@@ -141,7 +141,7 @@ describe('Observable', () => {
 
     it('should handle an asynchronous throw from the next handler and tear down', () => {
       const expected = new Error('I told, you Bobby Boucher, twos are the debil!');
-      const asyncObservable = new Observable<number>((observer: Rx.Observer<number>) => {
+      const asyncObservable = new Observable<number>((observer) => {
         let i = 1;
         const id = setInterval(() => observer.next(i++), 1);
 
@@ -174,7 +174,7 @@ describe('Observable', () => {
       let subscribed = false;
       let nexted: string;
       let completed: boolean;
-      const source = new Observable((observer: Rx.Observer<string>) => {
+      const source = new Observable<string>((observer) => {
         subscribed = true;
         observer.next('wee');
         expect(nexted).to.equal('wee');
@@ -187,7 +187,7 @@ describe('Observable', () => {
       let mutatedByNext = false;
       let mutatedByComplete = false;
 
-      source.subscribe((x: string) => {
+      source.subscribe((x) => {
         nexted = x;
         mutatedByNext = true;
       }, null, () => {
@@ -200,7 +200,7 @@ describe('Observable', () => {
     });
 
     it('should work when subscribe is called with no arguments', () => {
-      const source = new Observable((subscriber: Rx.Subscriber<string>) => {
+      const source = new Observable<string>((subscriber) => {
         subscriber.next('foo');
         subscriber.complete();
       });
@@ -210,7 +210,7 @@ describe('Observable', () => {
 
     it('should not be unsubscribed when other empty subscription completes', () => {
       let unsubscribeCalled = false;
-      const source = new Observable(() => {
+      const source = new Observable<number>(() => {
         return () => {
           unsubscribeCalled = true;
         };
@@ -227,7 +227,7 @@ describe('Observable', () => {
 
     it('should not be unsubscribed when other subscription with same observer completes', () => {
       let unsubscribeCalled = false;
-      const source = new Observable(() => {
+      const source = new Observable<number>(() => {
         return () => {
           unsubscribeCalled = true;
         };
@@ -246,7 +246,7 @@ describe('Observable', () => {
       expect(unsubscribeCalled).to.be.false;
     });
 
-    it('should run unsubscription logic when an error is sent asynchronously and subscribe is called with no arguments', (done: MochaDone) => {
+    it('should run unsubscription logic when an error is sent asynchronously and subscribe is called with no arguments', (done) => {
       const sandbox = sinon.sandbox.create();
       const fakeTimer = sandbox.useFakeTimers();
 
@@ -291,7 +291,7 @@ describe('Observable', () => {
     it('should return a Subscription that calls the unsubscribe function returned by the subscriber', () => {
       let unsubscribeCalled = false;
 
-      const source = new Observable(() => {
+      const source = new Observable<number>(() => {
         return () => {
           unsubscribeCalled = true;
         };
@@ -311,7 +311,7 @@ describe('Observable', () => {
     it('should ignore next messages after unsubscription', (done) => {
       let times = 0;
 
-      const subscription = new Observable((observer: Rx.Observer<number>) => {
+      const subscription = new Observable<number>((observer) => {
         let i = 0;
         const id = setInterval(() => {
           observer.next(i++);
@@ -338,7 +338,7 @@ describe('Observable', () => {
       let times = 0;
       let errorCalled = false;
 
-      const subscription = new Observable((observer: Rx.Observer<number>) => {
+      const subscription = new Observable<number>((observer) => {
         let i = 0;
         const id = setInterval(() => {
           observer.next(i++);
@@ -369,7 +369,7 @@ describe('Observable', () => {
       let times = 0;
       let completeCalled = false;
 
-      const subscription = new Observable((observer: Rx.Observer<number>) => {
+      const subscription = new Observable<number>((observer) => {
         let i = 0;
         const id = setInterval(() => {
           observer.next(i++);
@@ -399,11 +399,11 @@ describe('Observable', () => {
 
     describe('when called with an anonymous observer', () => {
       it('should accept an anonymous observer with just a next function and call the next function in the context' +
-        ' of the anonymous observer', (done: MochaDone) => {
+        ' of the anonymous observer', (done) => {
         //intentionally not using lambda to avoid typescript's this context capture
         const o = {
           myValue: 'foo',
-          next: function next(x: number) {
+          next(x: any) {
             expect(this.myValue).to.equal('foo');
             expect(x).to.equal(1);
             done();
@@ -414,22 +414,22 @@ describe('Observable', () => {
       });
 
       it('should accept an anonymous observer with just an error function and call the error function in the context' +
-        ' of the anonymous observer', (done: MochaDone) => {
+        ' of the anonymous observer', (done) => {
         //intentionally not using lambda to avoid typescript's this context capture
         const o = {
           myValue: 'foo',
-          error: function error(err: string) {
+          error(err: any) {
             expect(this.myValue).to.equal('foo');
             expect(err).to.equal('bad');
             done();
           }
         };
 
-        Observable.throw('bad').subscribe(o);
+        Observable.throwError('bad').subscribe(o);
       });
 
       it('should accept an anonymous observer with just a complete function and call the complete function in the' +
-        ' context of the anonymous observer', (done: MochaDone) => {
+        ' context of the anonymous observer', (done) => {
         //intentionally not using lambda to avoid typescript's this context capture
          const o = {
           myValue: 'foo',
@@ -451,7 +451,7 @@ describe('Observable', () => {
       it('should ignore next messages after unsubscription', (done) => {
         let times = 0;
 
-        const subscription = new Observable((observer: Rx.Observer<number>) => {
+        const subscription = new Observable<number>((observer) => {
           let i = 0;
           const id = setInterval(() => {
             observer.next(i++);
@@ -477,7 +477,7 @@ describe('Observable', () => {
         let times = 0;
         let errorCalled = false;
 
-        const subscription = new Observable((observer: Rx.Observer<number>) => {
+        const subscription = new Observable<number>((observer) => {
           let i = 0;
           const id = setInterval(() => {
             observer.next(i++);
@@ -507,7 +507,7 @@ describe('Observable', () => {
         let times = 0;
         let completeCalled = false;
 
-        const subscription = new Observable((observer: Rx.Observer<number>) => {
+        const subscription = new Observable<number>((observer) => {
           let i = 0;
           const id = setInterval(() => {
             observer.next(i++);
@@ -546,8 +546,8 @@ describe('Observable', () => {
     it('should pipe multiple operations', (done) => {
       Observable.of('test')
         .pipe(
-          map((x: string) => x + x),
-          map((x: string) => x + '!!!')
+          map((x) => x + x),
+          map((x) => x + '!!!')
         )
         .subscribe(
           x => {
@@ -629,13 +629,13 @@ describe('Observable.lift', () => {
     }
   }
 
-  it('should be overrideable in a custom Observable type that composes', (done: MochaDone) => {
-    const result = new MyCustomObservable((observer: Rx.Observer<number>) => {
+  it('should be overrideable in a custom Observable type that composes', (done) => {
+    const result = new MyCustomObservable<number>((observer) => {
       observer.next(1);
       observer.next(2);
       observer.next(3);
       observer.complete();
-    }).map((x: number) => { return 10 * x; });
+    }).map((x) => { return 10 * x; });
 
     expect(result instanceof MyCustomObservable).to.be.true;
 
@@ -651,16 +651,16 @@ describe('Observable.lift', () => {
       });
   });
 
-  it('should compose through multicast and refCount', (done: MochaDone) => {
-    const result = new MyCustomObservable((observer: Rx.Observer<number>) => {
+  it('should compose through multicast and refCount', (done) => {
+    const result = new MyCustomObservable((observer) => {
       observer.next(1);
       observer.next(2);
       observer.next(3);
       observer.complete();
     })
-    .multicast(() => new Rx.Subject())
+    .multicast(() => new Rx.Subject<number>())
     .refCount()
-    .map((x: number) => { return 10 * x; });
+    .map((x) => { return 10 * x; });
 
     expect(result instanceof MyCustomObservable).to.be.true;
 
@@ -676,14 +676,14 @@ describe('Observable.lift', () => {
       });
   });
 
-  it('should compose through multicast with selector function', (done: MochaDone) => {
-    const result = new MyCustomObservable((observer: Rx.Observer<number>) => {
+  it('should compose through multicast with selector function', (done) => {
+    const result = new MyCustomObservable((observer) => {
       observer.next(1);
       observer.next(2);
       observer.next(3);
       observer.complete();
     })
-    .multicast(() => new Rx.Subject(), (shared) => shared.map((x: number) => { return 10 * x; }));
+    .multicast(() => new Rx.Subject<number>(), (shared) => shared.map((x) => { return 10 * x; }));
 
     expect(result instanceof MyCustomObservable).to.be.true;
 
@@ -704,7 +704,7 @@ describe('Observable.lift', () => {
     const e2 =   cold('--1--2-3-4---|   ');
     const expected = '--A-BC-D-EF-G-H-|';
 
-    const result = MyCustomObservable.from(e1).combineLatest(e2, (a: any, b: any) => String(a) + String(b));
+    const result = MyCustomObservable.from(e1).combineLatest(e2, (a, b) => String(a) + String(b));
 
     expect(result instanceof MyCustomObservable).to.be.true;
 
@@ -758,7 +758,7 @@ describe('Observable.lift', () => {
     const e2 =   cold('--1--2-3-4---|   ');
     const expected = ('--A--B----C-D|   ');
 
-    const result = MyCustomObservable.from(e1).zip(e2, (a: any, b: any) => String(a) + String(b));
+    const result = MyCustomObservable.from(e1).zip(e2, (a, b) => String(a) + String(b));
 
     expect(result instanceof MyCustomObservable).to.be.true;
 
@@ -768,7 +768,7 @@ describe('Observable.lift', () => {
   });
 
   it('should allow injecting behaviors into all subscribers in an operator ' +
-  'chain when overridden', (done: MochaDone) => {
+  'chain when overridden', (done) => {
     // The custom Subscriber
     const log: Array<string> = [];
 
@@ -802,14 +802,14 @@ describe('Observable.lift', () => {
     }
 
     // Use the LogObservable
-    const result = new LogObservable((observer: Rx.Observer<number>) => {
+    const result = new LogObservable<number>((observer) => {
       observer.next(1);
       observer.next(2);
       observer.next(3);
       observer.complete();
     })
-    .map((x: number) => { return 10 * x; })
-    .filter((x: number) => { return x > 15; })
+    .map((x) => { return 10 * x; })
+    .filter((x) => { return x > 15; })
     .count();
 
     expect(result instanceof LogObservable).to.be.true;

--- a/spec/observables/IteratorObservable-spec.ts
+++ b/spec/observables/IteratorObservable-spec.ts
@@ -16,11 +16,11 @@ describe('fromIterable', () => {
     }).to.throw(Error, 'Iterable cannot be null');
   });
 
-  it('should emit members of an array iterator', (done: MochaDone) => {
+  it('should emit members of an array iterator', (done) => {
     const expected = [10, 20, 30, 40];
     fromIterable([10, 20, 30, 40], undefined)
       .subscribe(
-        (x: number) => { expect(x).to.equal(expected.shift()); },
+        (x) => { expect(x).to.equal(expected.shift()); },
         (x) => {
           done(new Error('should not be called'));
         }, () => {
@@ -122,7 +122,7 @@ describe('fromIterable', () => {
   });
 
   it('should emit members of an array iterator on a particular scheduler, ' +
-  'but is unsubscribed early', (done: MochaDone) => {
+  'but is unsubscribed early', (done) => {
     const expected = [10, 20, 30, 40];
 
     const source = fromIterable(
@@ -131,7 +131,7 @@ describe('fromIterable', () => {
     );
 
     const subscriber = Rx.Subscriber.create(
-      (x: number) => {
+      (x) => {
         expect(x).to.equal(expected.shift());
         if (x === 30) {
           subscriber.unsubscribe();
@@ -146,11 +146,11 @@ describe('fromIterable', () => {
     source.subscribe(subscriber);
   });
 
-  it('should emit characters of a string iterator', (done: MochaDone) => {
+  it('should emit characters of a string iterator', (done) => {
     const expected = ['f', 'o', 'o'];
     fromIterable('foo', undefined)
       .subscribe(
-        (x: string) => { expect(x).to.equal(expected.shift()); },
+        (x) => { expect(x).to.equal(expected.shift()); },
         (x) => {
           done(new Error('should not be called'));
         }, () => {
@@ -160,11 +160,11 @@ describe('fromIterable', () => {
       );
   });
 
-  it('should be possible to unsubscribe in the middle of the iteration', (done: MochaDone) => {
+  it('should be possible to unsubscribe in the middle of the iteration', (done) => {
     const expected = [10, 20, 30];
 
     const subscriber = Rx.Subscriber.create(
-      (x: number) => {
+      (x) => {
         expect(x).to.equal(expected.shift());
         if (x === 30) {
           subscriber.unsubscribe();

--- a/spec/observables/empty-spec.ts
+++ b/spec/observables/empty-spec.ts
@@ -1,10 +1,11 @@
+import { expect } from 'chai';
 import { expectObservable } from '../helpers/marble-testing';
 import { empty } from '../../src/';
 import { EMPTY } from '../../src';
-import { expect } from 'chai';
+import { TestScheduler } from '../../src/testing';
 
 declare const asDiagram: any;
-declare const rxTestScheduler: any;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {empty} */
 describe('empty', () => {

--- a/spec/observables/from-promise-spec.ts
+++ b/spec/observables/from-promise-spec.ts
@@ -7,11 +7,11 @@ const Observable = Rx.Observable;
 
 /** @test {fromPromise} */
 describe('Observable.fromPromise', () => {
-  it('should emit one value from a resolved promise', (done: MochaDone) => {
+  it('should emit one value from a resolved promise', (done) => {
     const promise = Promise.resolve(42);
     Observable.fromPromise(promise)
       .subscribe(
-        (x: number) => { expect(x).to.equal(42); },
+        (x) => { expect(x).to.equal(42); },
         (x) => {
           done(new Error('should not be called'));
         }, () => {
@@ -19,13 +19,13 @@ describe('Observable.fromPromise', () => {
         });
   });
 
-  it('should raise error from a rejected promise', (done: MochaDone) => {
+  it('should raise error from a rejected promise', (done) => {
     const promise = Promise.reject('bad');
     Observable.fromPromise(promise)
-      .subscribe((x: any) => {
+      .subscribe((x) => {
           done(new Error('should not be called'));
         },
-        (e: any) => {
+        (e) => {
           expect(e).to.equal('bad');
           done();
         }, () => {
@@ -33,20 +33,20 @@ describe('Observable.fromPromise', () => {
        });
   });
 
-  it('should share the underlying promise with multiple subscribers', (done: MochaDone) => {
+  it('should share the underlying promise with multiple subscribers', (done) => {
     const promise = Promise.resolve(42);
     const observable = Observable.fromPromise(promise);
 
     observable
       .subscribe(
-        (x: number) => { expect(x).to.equal(42); },
+        (x) => { expect(x).to.equal(42); },
         (x) => {
           done(new Error('should not be called'));
         }, null);
     setTimeout(() => {
       observable
         .subscribe(
-          (x: number) => { expect(x).to.equal(42); },
+          (x) => { expect(x).to.equal(42); },
           (x) => {
             done(new Error('should not be called'));
           }, () => {
@@ -55,13 +55,13 @@ describe('Observable.fromPromise', () => {
     });
   });
 
-  it('should accept already-resolved Promise', (done: MochaDone) => {
+  it('should accept already-resolved Promise', (done) => {
     const promise = Promise.resolve(42);
-    promise.then((x: number) => {
+    promise.then((x) => {
       expect(x).to.equal(42);
       Observable.fromPromise(promise)
         .subscribe(
-          (y: number) => { expect(y).to.equal(42); },
+          (y) => { expect(y).to.equal(42); },
           (x) => {
             done(new Error('should not be called'));
           }, () => {
@@ -72,18 +72,20 @@ describe('Observable.fromPromise', () => {
     });
   });
 
-  it('should accept PromiseLike object for interoperability', (done: MochaDone) => {
+  it('should accept PromiseLike object for interoperability', (done) => {
     class CustomPromise<T> implements PromiseLike<T> {
       constructor(private promise: PromiseLike<T>) {
       }
-      then(onFulfilled?, onRejected?): PromiseLike<T> {
+      then<TResult1 = T, TResult2 = T>(
+        onFulfilled?: ((value: T) => TResult1 | PromiseLike<TResult1>) | undefined | null,
+        onRejected?: ((reason: any) => TResult2 | PromiseLike<TResult2>) | undefined | null): PromiseLike<TResult1 | TResult2> {
         return new CustomPromise(this.promise.then(onFulfilled, onRejected));
       }
     }
     const promise = new CustomPromise(Promise.resolve(42));
     Observable.fromPromise(promise)
       .subscribe(
-        (x: number) => { expect(x).to.equal(42); },
+        (x) => { expect(x).to.equal(42); },
         () => {
           done(new Error('should not be called'));
         }, () => {
@@ -91,11 +93,11 @@ describe('Observable.fromPromise', () => {
         });
   });
 
-  it('should emit a value from a resolved promise on a separate scheduler', (done: MochaDone) => {
+  it('should emit a value from a resolved promise on a separate scheduler', (done) => {
     const promise = Promise.resolve(42);
     Observable.fromPromise(promise, Rx.Scheduler.asap)
       .subscribe(
-        (x: number) => { expect(x).to.equal(42); },
+        (x) => { expect(x).to.equal(42); },
         (x) => {
           done(new Error('should not be called'));
         }, () => {
@@ -103,12 +105,12 @@ describe('Observable.fromPromise', () => {
         });
   });
 
-  it('should raise error from a rejected promise on a separate scheduler', (done: MochaDone) => {
+  it('should raise error from a rejected promise on a separate scheduler', (done) => {
     const promise = Promise.reject('bad');
     Observable.fromPromise(promise, Rx.Scheduler.asap)
       .subscribe(
-        (x: any) => { done(new Error('should not be called')); },
-        (e: any) => {
+        (x) => { done(new Error('should not be called')); },
+        (e) => {
           expect(e).to.equal('bad');
           done();
         }, () => {
@@ -116,13 +118,13 @@ describe('Observable.fromPromise', () => {
         });
   });
 
-  it('should share the underlying promise with multiple subscribers on a separate scheduler', (done: MochaDone) => {
+  it('should share the underlying promise with multiple subscribers on a separate scheduler', (done) => {
     const promise = Promise.resolve(42);
     const observable = Observable.fromPromise(promise, Rx.Scheduler.asap);
 
     observable
       .subscribe(
-        (x: number) => { expect(x).to.equal(42); },
+        (x) => { expect(x).to.equal(42); },
         (x) => {
           done(new Error('should not be called'));
         },
@@ -130,7 +132,7 @@ describe('Observable.fromPromise', () => {
     setTimeout(() => {
       observable
         .subscribe(
-          (x: number) => { expect(x).to.equal(42); },
+          (x) => { expect(x).to.equal(42); },
           (x) => {
             done(new Error('should not be called'));
           }, () => {
@@ -139,7 +141,7 @@ describe('Observable.fromPromise', () => {
     });
   });
 
-  it('should not emit, throw or complete if immediately unsubscribed', (done: MochaDone) => {
+  it('should not emit, throw or complete if immediately unsubscribed', (done) => {
     const nextSpy = sinon.spy();
     const throwSpy = sinon.spy();
     const completeSpy = sinon.spy();

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -6,7 +6,6 @@ import { of, from } from '../../src/';
 // tslint:disable:no-any
 declare const asDiagram: any;
 declare const expectObservable: any;
-declare const Symbol: any;
 declare const type: any;
 declare const rxTestScheduler: TestScheduler;
 // tslint:enable:no-any
@@ -38,7 +37,7 @@ describe('from', () => {
   type('should return T for ObservableLike objects', () => {
     /* tslint:disable:no-unused-variable */
     const o1: Observable<number> = from([] as number[], asapScheduler);
-    const o2: Observable<{ a: string }> = from(Observable.empty<{ a: string }>());
+    const o2: Observable<{ a: string }> = from(Observable.empty());
     const o3: Observable<{ b: number }> = from(new Promise<{b: number}>(resolve => resolve()));
     /* tslint:enable:no-unused-variable */
   });
@@ -50,7 +49,7 @@ describe('from', () => {
   });
 
   const fakervable = <T>(...values: T[]) => ({
-    [Symbol.observable as symbol]: () => ({
+    [Symbol.observable]: () => ({
       subscribe: (observer: Observer<T>) => {
         for (const value of values) {
           observer.next(value);
@@ -85,11 +84,11 @@ describe('from', () => {
   ];
 
   for (const source of sources) {
-    it(`should accept ${source.name}`, (done: MochaDone) => {
+    it(`should accept ${source.name}`, (done) => {
       let nextInvoked = false;
       from(source.value)
         .subscribe(
-          (x: string) => {
+          (x) => {
             nextInvoked = true;
             expect(x).to.equal('x');
           },
@@ -102,11 +101,11 @@ describe('from', () => {
           }
         );
     });
-    it(`should accept ${source.name} and scheduler`, (done: MochaDone) => {
+    it(`should accept ${source.name} and scheduler`, (done) => {
       let nextInvoked = false;
       from(source.value, asyncScheduler)
         .subscribe(
-          (x: string) => {
+          (x) => {
             nextInvoked = true;
             expect(x).to.equal('x');
           },

--- a/spec/observables/of-spec.ts
+++ b/spec/observables/of-spec.ts
@@ -2,9 +2,7 @@ import { expect } from 'chai';
 import * as Rx from '../../src/Rx';
 import { empty } from '../../src/internal/observable/empty';
 import { expectObservable } from '../helpers/marble-testing';
-
-declare function asDiagram(arg: string): Function;
-
+declare const asDiagram: any;
 declare const rxTestScheduler: Rx.TestScheduler;
 const Observable = Rx.Observable;
 

--- a/spec/observables/onErrorResumeNext-spec.ts
+++ b/spec/observables/onErrorResumeNext-spec.ts
@@ -1,3 +1,4 @@
+
 import { onErrorResumeNext } from '../../src/';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 

--- a/spec/observables/throwError-spec.ts
+++ b/spec/observables/throwError-spec.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai';
-import * as Rx from '../../src/Rx';
-import { throwError } from '../../src/internal/observable/throwError';
+import { TestScheduler } from '../../src/internal/testing/TestScheduler';
+import { throwError } from '../../src/';
 import { expectObservable } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
-
-declare const rxTestScheduler: Rx.TestScheduler;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {throw} */
 describe('throwError', () => {
@@ -15,11 +14,11 @@ describe('throwError', () => {
     expectObservable(e1).toBe(expected);
   });
 
-  it('should emit one value', (done: MochaDone) => {
+  it('should emit one value', (done) => {
     let calls = 0;
     throwError('bad').subscribe(() => {
       done(new Error('should not be called'));
-    }, (err: any) => {
+    }, (err) => {
       expect(++calls).to.equal(1);
       expect(err).to.equal('bad');
       done();

--- a/spec/observables/timer-spec.ts
+++ b/spec/observables/timer-spec.ts
@@ -1,4 +1,4 @@
-import { cold, expectObservable } from '../helpers/marble-testing';
+import { cold, expectObservable, time } from '../helpers/marble-testing';
 import { timer, never, merge } from '../../src/';
 import { TestScheduler } from '../../src/testing';
 import { mergeMap } from '../../src/operators';

--- a/spec/symbol/iterator-spec.ts
+++ b/spec/symbol/iterator-spec.ts
@@ -23,7 +23,7 @@ describe('symbolIteratorPonyfill', () => {
         const SYMBOL_RETURN = {};
         let passedDescription: string;
         const root = {
-          Symbol: function (description) {
+          Symbol: function (description: string) {
             passedDescription = description;
             return SYMBOL_RETURN;
           }

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -1,6 +1,5 @@
 {
   "extends": "../tsconfig.json",
   "compilerOptions": {
-    "noImplicitAny": false
   }
 }

--- a/spec/util/pipe-spec.ts
+++ b/spec/util/pipe-spec.ts
@@ -7,8 +7,8 @@ describe('pipe', () => {
   });
 
   it('should pipe two functions together', () => {
-    const a = x => x + x;
-    const b = x => x - 1;
+    const a = (x: number) => x + x;
+    const b = (x: number) => x - 1;
 
     const c = pipe(a, b);
     expect(c).to.be.a('function');
@@ -17,7 +17,7 @@ describe('pipe', () => {
   });
 
   it('should return the same function if only one is passed', () => {
-    const a = x => x;
+    const a = <T>(x: T) => x;
     const c = pipe(a);
 
     expect(c).to.equal(a);

--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -9,7 +9,7 @@ describe('subscribeToResult', () => {
   it('should synchronously complete when subscribe to scalarObservable', () => {
     const result = Rx.Observable.of(42);
     let expected: number;
-    const subscriber = new OuterSubscriber((x: number) => expected = x);
+    const subscriber = new OuterSubscriber<number, number>((x) => expected = x);
 
     const subscription = subscribeToResult(subscriber, result);
 
@@ -17,11 +17,11 @@ describe('subscribeToResult', () => {
     expect(subscription).to.not.exist;
   });
 
-  it('should subscribe to observables that are an instanceof Rx.Observable', (done: MochaDone) => {
+  it('should subscribe to observables that are an instanceof Rx.Observable', (done) => {
     const expected = [1, 2, 3];
     const result = Rx.Observable.range(1, 3);
 
-    const subscriber = new OuterSubscriber(x => {
+    const subscriber = new OuterSubscriber<number, number>(x => {
       expect(expected.shift()).to.be.equal(x);
     }, () => {
       done(new Error('should not be called'));
@@ -33,8 +33,8 @@ describe('subscribeToResult', () => {
     subscribeToResult(subscriber, result);
   });
 
-  it('should emit error when observable emits error', (done: MochaDone) => {
-    const result = Rx.Observable.throw(new Error('error'));
+  it('should emit error when observable emits error', (done) => {
+    const result = Rx.Observable.throwError(new Error('error'));
     const subscriber = new OuterSubscriber(x => {
       done(new Error('should not be called'));
     }, (err) => {
@@ -49,9 +49,9 @@ describe('subscribeToResult', () => {
 
   it('should subscribe to an array and emit synchronously', () => {
     const result = [1, 2, 3];
-    const expected = [];
+    const expected: number[] = [];
 
-    const subscriber = new OuterSubscriber(x => expected.push(x));
+    const subscriber = new OuterSubscriber<number, number>(x => expected.push(x));
 
     subscribeToResult(subscriber, result);
 
@@ -60,19 +60,19 @@ describe('subscribeToResult', () => {
 
   it('should subscribe to an array-like and emit synchronously', () => {
     const result = { 0: 0, 1: 1, 2: 2, length: 3 };
-    const expected = [];
+    const expected: number[] = [];
 
-    const subscriber = new OuterSubscriber(x => expected.push(x));
+    const subscriber = new OuterSubscriber<number, number>(x => expected.push(x));
 
     subscribeToResult(subscriber, result);
 
     expect(expected).to.be.deep.equal([0, 1, 2]);
   });
 
-  it('should subscribe to a promise', (done: MochaDone) => {
+  it('should subscribe to a promise', (done) => {
     const result = Promise.resolve(42);
 
-    const subscriber = new OuterSubscriber(x => {
+    const subscriber = new OuterSubscriber<number, number>(x => {
       expect(x).to.be.equal(42);
     }, () => {
       done(new Error('should not be called'));
@@ -81,10 +81,10 @@ describe('subscribeToResult', () => {
     subscribeToResult(subscriber, result);
   });
 
-  it('should emits error when the promise rejects', (done: MochaDone) => {
+  it('should emits error when the promise rejects', (done) => {
     const result = Promise.reject(42);
 
-    const subscriber = new OuterSubscriber(x => {
+    const subscriber = new OuterSubscriber<number, number>(x => {
       done(new Error('should not be called'));
     }, (x) => {
       expect(x).to.be.equal(42);
@@ -119,7 +119,7 @@ describe('subscribeToResult', () => {
     expect(expected).to.be.equal(42);
   });
 
-  it('should subscribe to to an object that implements Symbol.observable', (done: MochaDone) => {
+  it('should subscribe to to an object that implements Symbol.observable', (done) => {
     const observableSymbolObject = { [$$symbolObservable]: () => Rx.Observable.of(42) };
 
     const subscriber = new OuterSubscriber(x => {

--- a/src/add/observable/throw.ts
+++ b/src/add/observable/throw.ts
@@ -1,4 +1,11 @@
 import { Observable } from '../../internal/Observable';
-import { throwError } from '../../internal/observable/throwError';
+import { throwError as staticThrowError } from '../../internal/observable/throwError';
 
-(Observable as any).throw = throwError;
+(Observable as any).throw = staticThrowError;
+(Observable as any).throwError = staticThrowError;
+
+declare module '../../internal/Observable' {
+  namespace Observable {
+    export let throwError: typeof staticThrowError;
+  }
+}

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -6,17 +6,11 @@ import { root } from './util/root';
 import { toSubscriber } from './util/toSubscriber';
 import { IfObservable } from './observable/IfObservable';
 import { observable as Symbol_observable } from '../internal/symbol/observable';
-import { OperatorFunction } from '../internal/types';
+import { OperatorFunction, Subscribable } from '../internal/types';
 import { pipeFromArray } from './util/pipe';
 
-export interface Subscribable<T> {
-  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
-            error?: (error: any) => void,
-            complete?: () => void): AnonymousSubscription;
-}
-
-export type SubscribableOrPromise<T> = Subscribable<T> | PromiseLike<T>;
-export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T>;
+//TODO(davidd): refactor all references to these to use types instead
+export { Subscribable, ObservableLike, SubscribableOrPromise, ObservableInput } from '../internal/types';
 
 /**
  * A representation of any set of values over any amount of time. This is the most basic building block

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -1,15 +1,19 @@
-import { Observable, ObservableInput} from '../Observable';
+import { Observable } from '../Observable';
 import { IScheduler } from '../Scheduler';
 import { isPromise } from '../util/isPromise';
 import { isArrayLike } from '../util/isArrayLike';
 import { isObservable } from '../util/isObservable';
+import { isIterable } from '../util/isIterable';
 import { iterator as Symbol_iterator } from '../symbol/iterator';
 import { fromArray } from './fromArray';
 import { fromPromise } from './fromPromise';
 import { fromIterable } from './fromIterable';
 import { fromObservable } from './fromObservable';
 import { subscribeTo } from '../util/subscribeTo';
+import { ObservableInput } from '../types';
 
+export function from<T>(input: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
+export function from<T>(input: ObservableInput<ObservableInput<T>>, scheduler?: IScheduler): Observable<Observable<T>>;
 export function from<T>(input: ObservableInput<T>, scheduler?: IScheduler): Observable<T> {
   if (!scheduler) {
     if (input instanceof Observable) {
@@ -22,11 +26,11 @@ export function from<T>(input: ObservableInput<T>, scheduler?: IScheduler): Obse
     if (isObservable(input)) {
       return fromObservable(input, scheduler);
     } else if (isPromise(input)) {
-      return fromPromise<T>(input as any, scheduler);
+      return fromPromise(input, scheduler);
     } else if (isArrayLike(input)) {
       return fromArray(input, scheduler);
-    }  else if (typeof input[Symbol_iterator] === 'function' || typeof input === 'string') {
-      return fromIterable(input as any, scheduler);
+    }  else if (isIterable(input) || typeof input === 'string') {
+      return fromIterable(input, scheduler);
     }
   }
 

--- a/src/internal/observable/fromObservable.ts
+++ b/src/internal/observable/fromObservable.ts
@@ -1,11 +1,11 @@
-import { Observable, Subscribable } from '../Observable';
+import { Observable } from '../Observable';
 import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
 import { observable as Symbol_observable } from '../symbol/observable';
 import { subscribeToObservable } from '../util/subscribeToObservable';
+import { ObservableLike, Subscribable } from '../types';
 
-// tslint:disable-next-line:no-any TS is unable to type [Symbol.observable]
-export function fromObservable<T>(input: any, scheduler: IScheduler) {
+export function fromObservable<T>(input: ObservableLike<T>, scheduler: IScheduler) {
   if (!scheduler) {
     return new Observable<T>(subscribeToObservable(input));
   } else {

--- a/src/internal/observable/fromPromise.ts
+++ b/src/internal/observable/fromPromise.ts
@@ -3,7 +3,7 @@ import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
 import { subscribeToPromise } from '../util/subscribeToPromise';
 
-export function fromPromise<T>(input: Promise<T>, scheduler: IScheduler) {
+export function fromPromise<T>(input: PromiseLike<T>, scheduler?: IScheduler) {
   if (!scheduler) {
     return new Observable<T>(subscribeToPromise(input));
   } else {

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -5,6 +5,19 @@ import { empty } from './empty';
 import { scalar } from './scalar';
 import { Observable } from '../Observable';
 
+export function of<T>(a: T, scheduler?: IScheduler): Observable<T>;
+export function of<T, T2>(a: T, b: T2, scheduler?: IScheduler): Observable<T | T2>;
+export function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler?: IScheduler): Observable<T | T2 | T3>;
+export function of<T, T2, T3, T4>(a: T, b: T2, c: T3, d: T4, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
+export function of<T, T2, T3, T4, T5>(a: T, b: T2, c: T3, d: T4, e: T5, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
+export function of<T, T2, T3, T4, T5, T6>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function of<T, T2, T3, T4, T5, T6, T7>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, scheduler?: IScheduler):
+  Observable<T | T2 | T3 | T4 | T5 | T6 | T7>;
+export function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, scheduler?: IScheduler):
+  Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler?: IScheduler):
+  Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+export function of<T>(...args: Array<T | IScheduler>): Observable<T>;
 export function of<T>(...args: Array<T | IScheduler>): Observable<T> {
   let scheduler = args[args.length - 1] as IScheduler;
   if (isScheduler(scheduler)) {

--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,18 +1,18 @@
 import { root } from '..//util/root';
 
-export function getSymbolObservable(context: any) {
-  let $$observable: any;
+export function getSymbolObservable(context: { Symbol: SymbolConstructor; }): symbol {
+  let $$observable: symbol;
   let Symbol = context.Symbol;
 
   if (typeof Symbol === 'function') {
     if (Symbol.observable) {
       $$observable = Symbol.observable;
     } else {
-        $$observable = Symbol('observable');
-        Symbol.observable = $$observable;
+      $$observable = Symbol('observable');
+      Symbol.observable = $$observable;
     }
   } else {
-    $$observable = '@@observable';
+    $$observable = <any>'@@observable';
   }
 
   return $$observable;
@@ -24,3 +24,9 @@ export const observable = getSymbolObservable(root);
  * @deprecated use observable instead
  */
 export const $$observable = observable;
+
+declare global {
+  interface SymbolConstructor {
+    observable: symbol;
+  }
+}

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,6 @@
 import { Observable } from './Observable';
+import { PartialObserver } from './Observer';
+import { AnonymousSubscription } from './Subscription';
 
 export interface UnaryFunction<T, R> { (source: T): R; }
 
@@ -7,6 +9,16 @@ export interface OperatorFunction<T, R> extends UnaryFunction<Observable<T>, Obs
 export type FactoryOrValue<T> = T | (() => T);
 
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}
+
+export interface Subscribable<T> {
+  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
+            error?: (error: any) => void,
+            complete?: () => void): AnonymousSubscription;
+}
+
+export type ObservableLike<T> = { [Symbol.observable]: () => Subscribable<T>; };
+export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | PromiseLike<T> | ObservableLike<T>;
+export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Iterable<T>;
 
 //TODO(benlesh): eventually we need to move all Observer interfaces to types.ts
 export * from './Observer';

--- a/src/internal/util/isIterable.ts
+++ b/src/internal/util/isIterable.ts
@@ -1,6 +1,6 @@
 import { iterator as Symbol_iterator } from '../symbol/iterator';
 
 /** Identifies an input as being an Iterable */
-export function isIterable<T>(input: T) {
+export function isIterable(input: any): input is Iterable<any> {
   return input && typeof input[Symbol_iterator] === 'function';
 }

--- a/src/internal/util/isObservable.ts
+++ b/src/internal/util/isObservable.ts
@@ -1,6 +1,7 @@
+import { ObservableLike, Subscribable } from '../types';
 import { observable as Symbol_observable } from '../symbol/observable';
 
 /** Identifies an input as being Observable (but not necessary an Rx Observable) */
-export function isObservable<T>(input: T) {
+export function isObservable(input: any): input is ObservableLike<any> {
   return input && typeof input[Symbol_observable] === 'function';
 }

--- a/src/internal/util/isPromise.ts
+++ b/src/internal/util/isPromise.ts
@@ -1,3 +1,3 @@
-export function isPromise<T>(value: any | Promise<T>): value is Promise<T> {
+export function isPromise(value: any): value is PromiseLike<any> {
   return value && typeof (<any>value).subscribe !== 'function' && typeof (value as any).then === 'function';
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,8 @@
       "es2015.iterable",
       "es2015.collection",
       "es2015.promise",
+      "es2015.symbol",
+      "es2015.symbol.wellknown",
       "dom"
     ]
   },

--- a/tsconfig.vscode.json
+++ b/tsconfig.vscode.json
@@ -1,0 +1,13 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "noEmit": true
+  },
+  "exclude": [
+    "dist"
+  ],
+  "formatCodeOptions": {
+    "indentSize": 2,
+    "tabSize": 2
+  }
+}

--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -1,5 +1,8 @@
 {
   "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "noEmit": false
+  },
   "files": [
     "../dist/src/Rx.ts",
     "../dist/src/add/observable/of.ts",


### PR DESCRIPTION
**Description:**
Follow up to #3265 (merge/rebase after the above is done).  The best commit to compare against is https://github.com/ReactiveX/rxjs/pull/3317/commits/43fdddc03a9459a19a853534686aa10be2133a1b

* Moved `Subscribable<T>`, `SubscribableOrPromise<T>` and `ObservableInput<T>` to `types.ts`.
* Added `ObservableLike<T>` using `[Symbol.observable]()`
* Added augmentation to make `Symbol.observable` resolve properly.
* `fromObservable` now requires `ObservableLike<T>`
* `of` now creates a type union for the first few overloads of the method.
* `isIterable` now returns `input is Iterable<any>`
* `isObservable` now returns `input is ObservableLike<any>`
* `isPromise` now returns `value is PromiseLike<any>` instead of `Promise<T>`
* Cleaned up tests for the related specs that were touched with this PR
* Added `tsconfig.vscode.json`, this can be used to get errors back in VSCode's problems window
  * NOTE: There are lots of errors for the `spec` folder still.
  * Almost all of the tests have been updated @ https://github.com/david-driscoll/RxJS-1/tree/compiled-tests
* `add/observable/throw` now adds `throwError` to `Observable.prototype` (`throw` cannot be augmented because it's a keyword)

**Related issue (if exists):**
#3265
