### PR TITLE
feat(typings): fixed some cases where multicast and publish would not return a ConnectableObservable

### DIFF
--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -3,7 +3,7 @@ import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
-declare const type;
+declare const type: Function;
 
 const Observable = Rx.Observable;
 
@@ -31,7 +31,7 @@ describe('Observable.prototype.publish', () => {
 
   it('should do nothing if connect is not called, despite subscriptions', () => {
     const source = cold('--1-2---3-4--5-|');
-    const sourceSubs = [];
+    const sourceSubs: string[] = [];
     const published = source.publish();
     const expected =    '-';
 
@@ -115,7 +115,7 @@ describe('Observable.prototype.publish', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -127,7 +127,7 @@ describe('Observable.prototype.publish', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .publish();
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '-1-2-3----   ';
@@ -143,7 +143,7 @@ describe('Observable.prototype.publish', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -220,12 +220,12 @@ describe('Observable.prototype.publish', () => {
     });
   });
 
-  it('should emit completed when subscribed after completed', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should emit completed when subscribed after completed', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -236,7 +236,7 @@ describe('Observable.prototype.publish', () => {
 
     const connectable = source.publish();
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results1.push(x);
     });
 
@@ -249,7 +249,7 @@ describe('Observable.prototype.publish', () => {
     expect(results2).to.deep.equal([]);
     expect(subscriptions).to.equal(1);
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results2.push(x);
     }, (x) => {
       done(new Error('should not be called'));
@@ -295,12 +295,12 @@ describe('Observable.prototype.publish', () => {
     published.connect();
   });
 
-  it('should multicast one observable to multiple observers', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should multicast one observable to multiple observers', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -311,11 +311,11 @@ describe('Observable.prototype.publish', () => {
 
     const connectable = source.publish();
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results1.push(x);
     });
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results2.push(x);
     });
 
@@ -355,7 +355,7 @@ describe('Observable.prototype.publish', () => {
     /* tslint:disable:no-unused-variable */
     const source = Rx.Observable.of<number>(1, 2, 3);
     // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: Rx.ConnectableObservable<number> = Rx.operators.publish()(source);
+    const result: Rx.ConnectableObservable<number> = Rx.operators.publish<number>()(source);
     /* tslint:enable:no-unused-variable */
   });
 

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -3,7 +3,7 @@ import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
-declare const type;
+declare const type: Function;
 
 const Observable = Rx.Observable;
 
@@ -31,7 +31,7 @@ describe('Observable.prototype.publishBehavior', () => {
 
   it('should only emit default value if connect is not called, despite subscriptions', () => {
     const source = cold('--1-2---3-4--5-|');
-    const sourceSubs = [];
+    const sourceSubs: string[] = [];
     const published = source.publishBehavior('0');
     const expected =    '0';
 
@@ -96,7 +96,7 @@ describe('Observable.prototype.publishBehavior', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -108,7 +108,7 @@ describe('Observable.prototype.publishBehavior', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .publishBehavior('0');
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '01-2-3----   ';
@@ -124,7 +124,7 @@ describe('Observable.prototype.publishBehavior', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -201,12 +201,12 @@ describe('Observable.prototype.publishBehavior', () => {
     });
   });
 
-  it('should emit completed when subscribed after completed', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should emit completed when subscribed after completed', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -276,12 +276,12 @@ describe('Observable.prototype.publishBehavior', () => {
     published.connect();
   });
 
-  it('should multicast one observable to multiple observers', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should multicast one observable to multiple observers', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -291,7 +291,7 @@ describe('Observable.prototype.publishBehavior', () => {
 
     const connectable = source.publishBehavior(0);
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results1.push(x);
     });
 
@@ -301,7 +301,7 @@ describe('Observable.prototype.publishBehavior', () => {
 
     expect(results2).to.deep.equal([]);
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results2.push(x);
     });
 
@@ -311,10 +311,10 @@ describe('Observable.prototype.publishBehavior', () => {
     done();
   });
 
-  it('should follow the RxJS 4 behavior and emit nothing to observer after completed', (done: MochaDone) => {
-    const results = [];
+  it('should follow the RxJS 4 behavior and emit nothing to observer after completed', (done) => {
+    const results: number[] = [];
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       observer.next(1);
       observer.next(2);
       observer.next(3);
@@ -326,7 +326,7 @@ describe('Observable.prototype.publishBehavior', () => {
 
     connectable.connect();
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results.push(x);
     });
 

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -3,7 +3,7 @@ import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
-declare const type;
+declare const type: Function;
 
 const Observable = Rx.Observable;
 
@@ -31,7 +31,7 @@ describe('Observable.prototype.publishLast', () => {
 
   it('should do nothing if connect is not called, despite subscriptions', () => {
     const source = cold('--1-2---3-4--5-|');
-    const sourceSubs = [];
+    const sourceSubs: string[] = [];
     const published = source.publishLast();
     const expected =    '-';
 
@@ -96,7 +96,7 @@ describe('Observable.prototype.publishLast', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -108,7 +108,7 @@ describe('Observable.prototype.publishLast', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .publishLast();
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '----------   ';
@@ -124,7 +124,7 @@ describe('Observable.prototype.publishLast', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -220,12 +220,12 @@ describe('Observable.prototype.publishLast', () => {
     published.connect();
   });
 
-  it('should multicast one observable to multiple observers', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should multicast one observable to multiple observers', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -236,11 +236,11 @@ describe('Observable.prototype.publishLast', () => {
 
     const connectable = source.publishLast();
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results1.push(x);
     });
 
-    connectable.subscribe((x: any) => {
+    connectable.subscribe((x) => {
       results2.push(x);
     });
 
@@ -266,7 +266,7 @@ describe('Observable.prototype.publishLast', () => {
     /* tslint:disable:no-unused-variable */
     const source = Rx.Observable.of<number>(1, 2, 3);
     // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: Rx.ConnectableObservable<number> = Rx.operators.publishLast()(source);
+    const result: Rx.ConnectableObservable<{}> = Rx.operators.publishLast()(source);
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -1,9 +1,10 @@
 import { expect } from 'chai';
 import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { throwError } from '../../src/internal/observable/throwError';
 
 declare function asDiagram(arg: string): Function;
-declare const type;
+declare const type: Function;
 
 const Observable = Rx.Observable;
 
@@ -31,7 +32,7 @@ describe('Observable.prototype.publishReplay', () => {
 
   it('should do nothing if connect is not called, despite subscriptions', () => {
     const source = cold('--1-2---3-4--5-|');
-    const sourceSubs = [];
+    const sourceSubs: string[] = [];
     const published = source.publishReplay(1);
     const expected =    '-';
 
@@ -115,7 +116,7 @@ describe('Observable.prototype.publishReplay', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -127,7 +128,7 @@ describe('Observable.prototype.publishReplay', () => {
     const source =     cold('-1-2-3----4-|');
     const sourceSubs =      '^        !   ';
     const published = source
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .publishReplay(1);
     const subscriber1 = hot('a|           ').mergeMapTo(published);
     const expected1   =     '-1-2-3----   ';
@@ -143,7 +144,7 @@ describe('Observable.prototype.publishReplay', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
     // Set up unsubscription action
-    let connection;
+    let connection: Rx.Subscription;
     expectObservable(hot(unsub).do(() => {
       connection.unsubscribe();
     })).toBe(unsub);
@@ -220,12 +221,12 @@ describe('Observable.prototype.publishReplay', () => {
     });
   });
 
-  it('should multicast one observable to multiple observers', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should multicast one observable to multiple observers', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -236,10 +237,10 @@ describe('Observable.prototype.publishReplay', () => {
 
     const connectable = source.publishReplay();
 
-    connectable.subscribe((x: number) => {
+    connectable.subscribe((x) => {
       results1.push(x);
     });
-    connectable.subscribe((x: number) => {
+    connectable.subscribe((x) => {
       results2.push(x);
     });
 
@@ -254,12 +255,12 @@ describe('Observable.prototype.publishReplay', () => {
     done();
   });
 
-  it('should replay as many events as specified by the bufferSize', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should replay as many events as specified by the bufferSize', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -270,7 +271,7 @@ describe('Observable.prototype.publishReplay', () => {
 
     const connectable = source.publishReplay(2);
 
-    connectable.subscribe((x: number) => {
+    connectable.subscribe((x) => {
       results1.push(x);
     });
 
@@ -279,7 +280,7 @@ describe('Observable.prototype.publishReplay', () => {
 
     connectable.connect();
 
-    connectable.subscribe((x: number) => {
+    connectable.subscribe((x) => {
       results2.push(x);
     });
 
@@ -291,11 +292,11 @@ describe('Observable.prototype.publishReplay', () => {
 
   it('should emit replayed values and resubscribe to the source when ' +
     'reconnected without source completion', () => {
-    const results1 = [];
-    const results2 = [];
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -305,7 +306,7 @@ describe('Observable.prototype.publishReplay', () => {
     });
 
     const connectable = source.publishReplay(2);
-    const subscription1 = connectable.subscribe((x: number) => {
+    const subscription1 = connectable.subscribe((x) => {
       results1.push(x);
     });
 
@@ -319,7 +320,7 @@ describe('Observable.prototype.publishReplay', () => {
     expect(results2).to.deep.equal([]);
     expect(subscriptions).to.equal(1);
 
-    const subscription2 = connectable.subscribe((x: number) => {
+    const subscription2 = connectable.subscribe((x) => {
       results2.push(x);
     });
 
@@ -331,12 +332,12 @@ describe('Observable.prototype.publishReplay', () => {
     expect(subscriptions).to.equal(2);
   });
 
-  it('should emit replayed values plus completed when subscribed after completed', (done: MochaDone) => {
-    const results1 = [];
-    const results2 = [];
+  it('should emit replayed values plus completed when subscribed after completed', (done) => {
+    const results1: number[] = [];
+    const results2: number[] = [];
     let subscriptions = 0;
 
-    const source = new Observable((observer: Rx.Observer<number>) => {
+    const source = new Observable<number>((observer) => {
       subscriptions++;
       observer.next(1);
       observer.next(2);
@@ -347,7 +348,7 @@ describe('Observable.prototype.publishReplay', () => {
 
     const connectable = source.publishReplay(2);
 
-    connectable.subscribe((x: number) => {
+    connectable.subscribe((x) => {
       results1.push(x);
     });
 
@@ -360,7 +361,7 @@ describe('Observable.prototype.publishReplay', () => {
     expect(results2).to.deep.equal([]);
     expect(subscriptions).to.equal(1);
 
-    connectable.subscribe((x: number) => {
+    connectable.subscribe((x) => {
       results2.push(x);
     }, (x) => {
       done(new Error('should not be called'));
@@ -409,7 +410,7 @@ describe('Observable.prototype.publishReplay', () => {
 
   it('should mirror a simple source Observable with selector', () => {
     const values = {a: 2, b: 4, c: 6, d: 8};
-    const selector = observable => observable.map(v => 2 * v);
+    const selector = (observable: Rx.Observable<string>) => observable.map(v => 2 * +v);
     const source = cold('--1-2---3-4---|');
     const sourceSubs =  '^             !';
     const published = source.publishReplay(1, Number.POSITIVE_INFINITY, selector);
@@ -434,7 +435,7 @@ describe('Observable.prototype.publishReplay', () => {
   it('should emit an error when the selector returns an Observable that emits an error', () => {
     const error = "It's broken";
     const innerObservable = cold('--5-6----#', undefined, error);
-    const selector = observable => observable.mergeMapTo(innerObservable);
+    const selector = (observable: Rx.Observable<string>) => observable.mergeMapTo(innerObservable);
     const source = cold('--1--2---3---|');
     const sourceSubs =  '^          !';
     const published = source.publishReplay(1, Number.POSITIVE_INFINITY, selector);
@@ -468,7 +469,7 @@ describe('Observable.prototype.publishReplay', () => {
 
   it('should emit error when the selector returns Observable.throw', () => {
     const error = "It's broken";
-    const selector = () => Observable.throw(error);
+    const selector = () => throwError(error);
     const source = cold('--1--2---3---|');
     const sourceSubs =  '(^!)';
     const published = source.publishReplay(1, Number.POSITIVE_INFINITY, selector);
@@ -503,7 +504,7 @@ describe('Observable.prototype.publishReplay', () => {
     /* tslint:disable:no-unused-variable */
     const source = Rx.Observable.of<number>(1, 2, 3);
     // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: Rx.ConnectableObservable<number> = Rx.operators.publishReplay(1)(source);
+    const result: Rx.ConnectableObservable<number> = Rx.operators.publishReplay<number>(1)(source);
     /* tslint:enable:no-unused-variable */
   });
 

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -7,7 +7,9 @@ import { FactoryOrValue, MonoTypeOperatorFunction, OperatorFunction, UnaryFuncti
 
 /* tslint:disable:max-line-length */
 export function multicast<T>(subjectOrSubjectFactory: FactoryOrValue<Subject<T>>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
+export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
+export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<R>>;
 export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: OperatorFunction<T, R>): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -6,8 +6,8 @@ import { MonoTypeOperatorFunction, OperatorFunction, UnaryFunction } from '../..
 
 /* tslint:disable:max-line-length */
 export function publish<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
-export function publish<T>(selector: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
 export function publish<T, R>(selector: OperatorFunction<T, R>): OperatorFunction<T, R>;
+export function publish<T>(selector: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -7,14 +7,14 @@ import { UnaryFunction, MonoTypeOperatorFunction, OperatorFunction } from '../..
 
 /* tslint:disable:max-line-length */
 export function publishReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: IScheduler): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
-export function publishReplay<T>(bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
 export function publishReplay<T, R>(bufferSize?: number, windowTime?: number, selector?: OperatorFunction<T, R>, scheduler?: IScheduler): OperatorFunction<T, R>;
+export function publishReplay<T>(bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 export function publishReplay<T, R>(bufferSize?: number,
                                     windowTime?: number,
                                     selectorOrScheduler?: IScheduler | OperatorFunction<T, R>,
-                                    scheduler?: IScheduler): UnaryFunction<Observable<T>, ConnectableObservable<R> | Observable<R>> {
+                                    scheduler?: IScheduler): UnaryFunction<Observable<T>, ConnectableObservable<R>> {
 
   if (selectorOrScheduler && typeof selectorOrScheduler !== 'function') {
     scheduler = selectorOrScheduler;
@@ -23,5 +23,5 @@ export function publishReplay<T, R>(bufferSize?: number,
   const selector = typeof selectorOrScheduler === 'function' ? selectorOrScheduler : undefined;
   const subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
 
-  return (source: Observable<T>) => multicast(() => subject, selector)(source) as Observable<R> | ConnectableObservable<R>;
+  return (source: Observable<T>) => multicast(() => subject, selector)(source) as ConnectableObservable<R>;
 }

--- a/src/internal/patching/operator/multicast.ts
+++ b/src/internal/patching/operator/multicast.ts
@@ -6,8 +6,10 @@ import { FactoryOrValue, MonoTypeOperatorFunction, OperatorFunction } from '../.
 
 /* tslint:disable:max-line-length */
 export function multicast<T>(this: Observable<T>, subjectOrSubjectFactory: FactoryOrValue<Subject<T>>): ConnectableObservable<T>;
-export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: MonoTypeOperatorFunction<T>): Observable<T>;
-export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: OperatorFunction<T, R>): Observable<R>;
+export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>): ConnectableObservable<T>;
+export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector: MonoTypeOperatorFunction<T>): Observable<T>;
+export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>): ConnectableObservable<R>;
+export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector: OperatorFunction<T, R>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -105,6 +107,6 @@ export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject
  * @owner Observable
  */
 export function multicast<T, R>(this: Observable<T>, subjectOrSubjectFactory: Subject<T> | (() => Subject<T>),
-                                selector?: (source: Observable<T>) => Observable<R>): Observable<R> | ConnectableObservable<R> {
+                                selector?: (source: Observable<T>) => Observable<R>): ConnectableObservable<R> | Observable<R> {
   return higherOrder(<any>subjectOrSubjectFactory, selector)(this);
 }

--- a/src/internal/patching/operator/publish.ts
+++ b/src/internal/patching/operator/publish.ts
@@ -5,8 +5,8 @@ import { publish as higherOrder } from '../../operators/publish';
 
 /* tslint:disable:max-line-length */
 export function publish<T>(this: Observable<T>): ConnectableObservable<T>;
-export function publish<T>(this: Observable<T>, selector: (source: Observable<T>) => Observable<T>): Observable<T>;
 export function publish<T, R>(this: Observable<T>, selector: (source: Observable<T>) => Observable<R>): Observable<R>;
+export function publish<T>(this: Observable<T>, selector: (source: Observable<T>) => Observable<T>): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/patching/operator/publishReplay.ts
+++ b/src/internal/patching/operator/publishReplay.ts
@@ -6,8 +6,8 @@ import { OperatorFunction, MonoTypeOperatorFunction } from '../../../internal/ty
 
 /* tslint:disable:max-line-length */
 export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, scheduler?: IScheduler): ConnectableObservable<T>;
-export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: IScheduler): Observable<T>;
 export function publishReplay<T, R>(this: Observable<T>, bufferSize?: number, windowTime?: number, selector?: OperatorFunction<T, R>): Observable<R>;
+export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: IScheduler): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**


### PR DESCRIPTION
**Description:**
* `multicast` now returns ConnectableObservable when not given a selector.
* `publish` had an issue with overload resolution
* Fixes typing errors in related spec files

**Related issue (if exists):**
