### PR TITLE
feat(typings): updated typings for combineAll, mergeAll, concatAll, switch, exhaust, zipAll

### DIFF
--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -15,18 +15,18 @@ describe('Observable.combineLatest', () => {
     const expected =         '----uv--wx-y--z----|';
 
     const combined = Observable.combineLatest(firstSource, secondSource,
-      (a: any, b: any) => '' + a + b);
+      (a, b) => '' + a + b);
 
     expectObservable(combined).toBe(expected, {u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg'});
   });
 
-  it('should combine an immediately-scheduled source with an immediately-scheduled second', (done: MochaDone) => {
+  it('should combine an immediately-scheduled source with an immediately-scheduled second', (done) => {
     const a = Observable.of<number>(1, 2, 3, queueScheduler);
     const b = Observable.of<number>(4, 5, 6, 7, 8, queueScheduler);
     const r = [[1, 4], [2, 4], [2, 5], [3, 5], [3, 6], [3, 7], [3, 8]];
 
     //type definition need to be updated
-    Observable.combineLatest(a, b, queueScheduler).subscribe((vals: any) => {
+    Observable.combineLatest(a, b, queueScheduler).subscribe((vals) => {
       expect(vals).to.deep.equal(r.shift());
     }, (x) => {
       done(new Error('should not be called'));
@@ -42,7 +42,7 @@ describe('Observable.combineLatest', () => {
     const expected =         '----uv--wx-y--z----|';
 
     const combined = Observable.combineLatest([firstSource, secondSource],
-      (a: any, b: any) => '' + a + b);
+      (a: string, b: string) => '' + a + b);
 
     expectObservable(combined).toBe(expected, {u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg'});
   });
@@ -54,7 +54,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -68,7 +68,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =   '(^!)';
     const expected = '-';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -82,7 +82,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -96,7 +96,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =  '(^!)';
     const expected = '|';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -116,7 +116,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -133,7 +133,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.combineLatest(e2, e1, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e2, e1, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -150,7 +150,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =           '^  ';
     const expected =         '-'; //never
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -167,7 +167,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =           '^   !';
     const expected =         '-----'; //never
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -181,7 +181,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =        '^         !';
     const expected =      '----x-yz--|';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -195,7 +195,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =   '^     !';
     const expected = '------#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'shazbot!');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -209,7 +209,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =     '^   !';
     const expected =   '----#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'too bad, honk');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -223,7 +223,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -237,7 +237,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -251,7 +251,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -265,7 +265,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -279,7 +279,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -293,7 +293,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^     !';
     const expected =     '------#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -307,7 +307,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^    !';
     const expected =     '-----#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -321,7 +321,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { a: 1, b: 2}, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -335,7 +335,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { a: 1, b: 2}, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -349,7 +349,7 @@ describe('Observable.combineLatest', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.combineLatest(left, right, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(left, right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -363,7 +363,7 @@ describe('Observable.combineLatest', () => {
     const rightSubs =       '^      !';
     const expected =        '---------#';
 
-    const result = Observable.combineLatest(left, right, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(left, right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -377,7 +377,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =     '^           !';
     const expected =   '-----x-y-z--|';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'be', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -391,7 +391,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =      '^                   !';
     const expected =    '-----------x--y--z--|';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -405,7 +405,7 @@ describe('Observable.combineLatest', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.combineLatest(left, right, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(left, right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'jenga');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -419,7 +419,7 @@ describe('Observable.combineLatest', () => {
     const rightSubs =      '^                   !';
     const expected =       '-----------x--y--z--#';
 
-    const result = Observable.combineLatest(left, right, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(left, right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' }, 'dun dun dun');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -433,7 +433,7 @@ describe('Observable.combineLatest', () => {
     const e2subs =      '^  !';
     const expected =    '---#';
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => { throw 'ha ha ' + x + ', ' + y; });
+    const result = Observable.combineLatest(e1, e2, (x, y) => { throw 'ha ha ' + x + ', ' + y; });
 
     expectObservable(result).toBe(expected, null, 'ha ha 2, 4');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -449,7 +449,7 @@ describe('Observable.combineLatest', () => {
     const unsub =         '         !    ';
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-    const result = Observable.combineLatest(e1, e2, (x: any, y: any) => x + y);
+    const result = Observable.combineLatest(e1, e2, (x, y) => x + y);
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -466,10 +466,10 @@ describe('Observable.combineLatest', () => {
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
     const result = Observable.combineLatest(
-        e1.mergeMap((x: string) => Observable.of(x)),
-        e2.mergeMap((x: string) => Observable.of(x)),
-        (x: any, y: any) => x + y
-    ).mergeMap((x: any) => Observable.of(x));
+        e1.mergeMap((x) => Observable.of(x)),
+        e2.mergeMap((x) => Observable.of(x)),
+        (x, y) => x + y
+    ).mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/observables/concat-spec.ts
+++ b/spec/observables/concat-spec.ts
@@ -58,10 +58,10 @@ describe('Observable.concat', () => {
     const expected =    '--i-j-k-l---i-j-';
     const unsub =       '               !';
 
-    const innerWrapped = inner.mergeMap((x: string) => Observable.of(x));
+    const innerWrapped = inner.mergeMap((x) => Observable.of(x));
     const result = Observable
       .concat(innerWrapped, innerWrapped, innerWrapped, innerWrapped)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -334,17 +334,17 @@ describe('Observable.concat', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should concat an immediately-scheduled source with an immediately-scheduled second', (done: MochaDone) => {
+  it('should concat an immediately-scheduled source with an immediately-scheduled second', (done) => {
     const a = Observable.of<number>(1, 2, 3, queueScheduler);
     const b = Observable.of<number>(4, 5, 6, 7, 8, queueScheduler);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    Observable.concat(a, b, queueScheduler).subscribe((vals: number) => {
+    Observable.concat(a, b, queueScheduler).subscribe((vals) => {
       expect(vals).to.equal(r.shift());
     }, null, done);
   });
 
-  it('should use the scheduler even when one Observable is concat\'d', (done: MochaDone) => {
+  it('should use the scheduler even when one Observable is concat\'d', (done) => {
     let e1Subscribed = false;
     const e1 = Observable.defer(() => {
       e1Subscribed = true;

--- a/spec/observables/merge-spec.ts
+++ b/spec/observables/merge-spec.ts
@@ -263,7 +263,7 @@ describe('Observable.merge(...observables, Scheduler, number)', () => {
     expectObservable(Observable.merge(e1, e2, e3, 2, rxTestScheduler)).toBe(expected);
   });
 
-  it('should use the scheduler even when one Observable is merged', (done: MochaDone) => {
+  it('should use the scheduler even when one Observable is merged', (done) => {
     let e1Subscribed = false;
     const e1 = Observable.defer(() => {
       e1Subscribed = true;

--- a/spec/operators/combineAll-spec.ts
+++ b/spec/operators/combineAll-spec.ts
@@ -3,6 +3,7 @@ import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
+declare const type: Function;
 
 const Observable = Rx.Observable;
 const queueScheduler = Rx.Scheduler.queue;
@@ -15,7 +16,7 @@ describe('Observable.prototype.combineAll', () => {
     const outer = hot('-x----y--------|           ', { x: x, y: y });
     const expected =  '-----------------A-B--C---|';
 
-    const result = outer.combineAll((a: any, b: any) => String(a) + String(b));
+    const result = outer.combineAll((a, b) => String(a) + String(b));
 
     expectObservable(result).toBe(expected, { A: 'a1', B: 'a2', C: 'b2' });
   });
@@ -27,7 +28,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -41,7 +42,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '(^!)';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -55,7 +56,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -69,7 +70,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =  '(^!)';
     const expected = '|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -83,7 +84,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -97,7 +98,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = Observable.of(e2, e1).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e2, e1).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -111,7 +112,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^  ';
     const expected =         '-'; //never
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -125,7 +126,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =           '^   !';
     const expected =         '-----'; //never
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -139,7 +140,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =        '^         !';
     const expected =      '----x-yz--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -155,7 +156,7 @@ describe('Observable.prototype.combineAll', () => {
     const unsub =         '         !    ';
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -172,9 +173,9 @@ describe('Observable.prototype.combineAll', () => {
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
     const result = Observable.of(e1, e2)
-      .mergeMap((x: any) => Observable.of(x))
-      .combineAll((x: any, y: any) => x + y)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x))
+      .combineAll((x, y) => x + y)
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -190,7 +191,7 @@ describe('Observable.prototype.combineAll', () => {
     const e3subs =        '^         !';
     const expected =      '-----wxyz-|';
 
-    const result = Observable.of(e1, e2, e3).combineAll((x: string, y: string, z: string) => x + y + z);
+    const result = Observable.of(e1, e2, e3).combineAll((x, y, z) => x + y + z);
 
     expectObservable(result).toBe(expected, { w: 'bfi', x: 'cfi', y: 'cgi', z: 'cgj' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -205,7 +206,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =   '^     !';
     const expected = '------#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'shazbot!');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -219,7 +220,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =     '^   !';
     const expected =   '----#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'too bad, honk');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -233,7 +234,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -247,7 +248,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -261,7 +262,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -275,7 +276,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -289,7 +290,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -303,7 +304,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^     !';
     const expected =     '------#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -317,7 +318,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^    !';
     const expected =     '-----#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -331,7 +332,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { a: 1, b: 2}, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -345,7 +346,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -359,7 +360,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -373,7 +374,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =       '^      !';
     const expected =        '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -387,7 +388,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =     '^           !';
     const expected =   '-----x-y-z--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'be', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -401,7 +402,7 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =      '^                   !';
     const expected =    '-----------x--y--z--|';
 
-    const result = Observable.of(e1, e2).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(e1, e2).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -415,7 +416,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'jenga');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -429,7 +430,7 @@ describe('Observable.prototype.combineAll', () => {
     const rightSubs =      '^                   !';
     const expected =       '-----------x--y--z--#';
 
-    const result = Observable.of(left, right).combineAll((x: any, y: any) => x + y);
+    const result = Observable.of(left, right).combineAll((x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' }, 'dun dun dun');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -443,18 +444,18 @@ describe('Observable.prototype.combineAll', () => {
     const e2subs =      '^  !';
     const expected =    '---#';
 
-    const result = Observable.of(e1, e2).combineAll(<any>((x: string, y: string) => { throw 'ha ha ' + x + ', ' + y; }));
+    const result = Observable.of(e1, e2).combineAll((x, y) => { throw 'ha ha ' + x + ', ' + y; });
 
     expectObservable(result).toBe(expected, null, 'ha ha b, d');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should combine two observables', (done: MochaDone) => {
+  it('should combine two observables', (done) => {
     const a = Observable.of(1, 2, 3);
     const b = Observable.of(4, 5, 6, 7, 8);
     const expected = [[3, 4], [3, 5], [3, 6], [3, 7], [3, 8]];
-    Observable.of(a, b).combineAll().subscribe((vals: any) => {
+    Observable.of(a, b).combineAll().subscribe((vals) => {
       expect(vals).to.deep.equal(expected.shift());
     }, null, () => {
       expect(expected.length).to.equal(0);
@@ -462,17 +463,117 @@ describe('Observable.prototype.combineAll', () => {
     });
   });
 
-  it('should combine two immediately-scheduled observables', (done: MochaDone) => {
+  it('should combine two immediately-scheduled observables', (done) => {
     const a = Observable.of<number>(1, 2, 3, queueScheduler);
     const b = Observable.of<number>(4, 5, 6, 7, 8, queueScheduler);
     const r = [[1, 4], [2, 4], [2, 5], [3, 5], [3, 6], [3, 7], [3, 8]];
 
-    Observable.of<Rx.Observable<number>>(a, b, queueScheduler).combineAll()
-      .subscribe((vals: any) => {
+    Observable.of(a, b, queueScheduler).combineAll()
+      .subscribe((vals) => {
         expect(vals).to.deep.equal(r.shift());
     }, null, () => {
       expect(r.length).to.equal(0);
       done();
     });
+  });
+
+  type(() => {
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<number[]> = Rx.Observable
+      .of(source1, source2, source3)
+      .pipe(Rx.operators.combineAll());
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<number> = Rx.Observable
+      .of(source1, source2, source3)
+      .pipe(Rx.operators.combineAll((...args) => args.reduce((acc, x) => acc + x, 0)));
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<number[]> = Rx.Observable
+      .of(source1, source2, source3)
+      .combineAll();
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<number> = Rx.Observable
+      .of(source1, source2, source3)
+      .combineAll((...args) => args.reduce((acc, x) => acc + x, 0));
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    // coerce type to a specific type
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<string[]> = Rx.Observable
+      .of(<any>source1, <any>source2, <any>source3)
+      .pipe(Rx.operators.combineAll<string>());
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    // coerce type to a specific type
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<string> = Rx.Observable
+      .of(<any>source1, <any>source2, <any>source3)
+      .pipe(Rx.operators.combineAll<string>((...args) => args.reduce((acc, x) => acc + x, 0)));
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    // coerce type to a specific type
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<string[]> = Rx.Observable
+      .of(<any>source1, <any>source2, <any>source3)
+      .combineAll<string>();
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    // coerce type to a specific type
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<string> = Rx.Observable
+      .of(<any>source1, <any>source2, <any>source3)
+      .combineAll<string>((...args) => args.reduce((acc, x) => acc + x, 0));
+    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/combineLatest-spec.ts
+++ b/spec/operators/combineLatest-spec.ts
@@ -12,7 +12,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2 =   cold('--1--2-3-4---|   ');
     const expected = '--A-BC-D-EF-G-H-|';
 
-    const result = e1.combineLatest(e2, (a: any, b: any) => String(a) + String(b));
+    const result = e1.combineLatest(e2, (a, b) => String(a) + String(b));
 
     expectObservable(result).toBe(expected, {
       A: 'a1', B: 'b1', C: 'b2', D: 'b3', E: 'b4', F: 'c4', G: 'd4', H: 'e4'
@@ -26,7 +26,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -40,7 +40,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =   '(^!)';
     const expected = '-';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -54,7 +54,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =   '^';
     const expected = '-';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -68,7 +68,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =  '(^!)';
     const expected = '|';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -88,7 +88,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -105,7 +105,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =           '^   !';
     const expected =         '----|';
 
-    const result = e2.combineLatest(e1, (x: any, y: any) => x + y);
+    const result = e2.combineLatest(e1, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -122,7 +122,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =           '^  ';
     const expected =         '-'; //never
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -139,7 +139,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =           '^   !';
     const expected =         '-----'; //never
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -153,7 +153,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =        '^         !';
     const expected =      '----x-yz--|';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -184,7 +184,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =   '^     !';
     const expected = '------#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'shazbot!');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -198,7 +198,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =     '^   !';
     const expected =   '----#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'too bad, honk');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -212,7 +212,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -226,7 +226,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -240,7 +240,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bazinga');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -254,7 +254,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -268,7 +268,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^ !';
     const expected =     '--#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'flurp');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -282,7 +282,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^     !';
     const expected =     '------#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -296,7 +296,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^    !';
     const expected =     '-----#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -310,7 +310,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { a: 1, b: 2}, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -324,7 +324,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =       '^  !';
     const expected =     '---#';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { a: 1, b: 2}, 'wokka wokka');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -338,7 +338,7 @@ describe('Observable.prototype.combineLatest', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = left.combineLatest(right, (x: any, y: any) => x + y);
+    const result = left.combineLatest(right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -352,7 +352,7 @@ describe('Observable.prototype.combineLatest', () => {
     const rightSubs =       '^      !';
     const expected =        '---------#';
 
-    const result = left.combineLatest(right, (x: any, y: any) => x + y);
+    const result = left.combineLatest(right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'bad things');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -366,7 +366,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =     '^           !';
     const expected =   '-----x-y-z--|';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'be', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -380,7 +380,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =      '^                   !';
     const expected =    '-----------x--y--z--|';
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -394,7 +394,7 @@ describe('Observable.prototype.combineLatest', () => {
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
-    const result = left.combineLatest(right, (x: any, y: any) => x + y);
+    const result = left.combineLatest(right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, null, 'jenga');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -408,7 +408,7 @@ describe('Observable.prototype.combineLatest', () => {
     const rightSubs =      '^                   !';
     const expected =       '-----------x--y--z--#';
 
-    const result = left.combineLatest(right, (x: any, y: any) => x + y);
+    const result = left.combineLatest(right, (x, y) => x + y);
 
     expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' }, 'dun dun dun');
     expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -422,7 +422,7 @@ describe('Observable.prototype.combineLatest', () => {
     const e2subs =      '^  !';
     const expected =    '---#';
 
-    const result = e1.combineLatest(e2, (x: number, y: number) => { throw 'ha ha ' + x + ', ' + y; });
+    const result = e1.combineLatest(e2, (x, y) => { throw 'ha ha ' + x + ', ' + y; });
 
     expectObservable(result).toBe(expected, null, 'ha ha 2, 4');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -438,7 +438,7 @@ describe('Observable.prototype.combineLatest', () => {
     const unsub =         '         !    ';
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-    const result = e1.combineLatest(e2, (x: any, y: any) => x + y);
+    const result = e1.combineLatest(e2, (x, y) => x + y);
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -455,9 +455,9 @@ describe('Observable.prototype.combineLatest', () => {
     const values = { x: 'bf', y: 'cf', z: 'cg' };
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
-      .combineLatest(e2, (x: any, y: any) => x + y)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x))
+      .combineLatest(e2, (x, y) => x + y)
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/concat-spec.ts
+++ b/spec/operators/concat-spec.ts
@@ -17,11 +17,10 @@ describe('Observable.prototype.concat', () => {
     expectObservable(e1.concat(e2, rxTestScheduler)).toBe(expected);
   });
 
-  it('should work properly with scalar observables', (done: MochaDone) => {
-    const results = [];
+  it('should work properly with scalar observables', (done) => {
+    const results: string[] = [];
 
-    const s1 = Observable
-      .create((observer: Rx.Observer<number>) => {
+    const s1 = new Observable<number>((observer) => {
         setTimeout(() => {
           observer.next(1);
           observer.complete();
@@ -29,7 +28,7 @@ describe('Observable.prototype.concat', () => {
       })
       .concat(Observable.of(2));
 
-    s1.subscribe((x: number) => {
+    s1.subscribe((x) => {
           results.push('Next: ' + x);
         }, (x) => {
           done(new Error('should not be called'));
@@ -57,7 +56,7 @@ describe('Observable.prototype.concat', () => {
     const e1 =   cold('-');
     const e1subs =    '^';
     const e2 =   cold('--|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected =  '-';
 
     expectObservable(e1.concat(e2)).toBe(expected);
@@ -81,7 +80,7 @@ describe('Observable.prototype.concat', () => {
     const e1 =   cold('-');
     const e1subs =    '^';
     const e2 =   cold('-');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected =  '-';
 
     expectObservable(e1.concat(e2)).toBe(expected);
@@ -105,7 +104,7 @@ describe('Observable.prototype.concat', () => {
     const e1 =   cold('---#');
     const e1subs =    '^  !';
     const e2 =   cold('----|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected =  '---#';
 
     expectObservable(e1.concat(e2)).toBe(expected);
@@ -117,7 +116,7 @@ describe('Observable.prototype.concat', () => {
     const e1 =   cold('---#');
     const e1subs =    '^  !';
     const e2 =   cold('------#');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected =  '---#';
 
     expectObservable(e1.concat(e2)).toBe(expected);
@@ -166,7 +165,7 @@ describe('Observable.prototype.concat', () => {
     const e1 =   cold('-');
     const e1subs =    '^';
     const e2 =   cold('--a--|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected =  '-';
 
     expectObservable(e1.concat(e2)).toBe(expected);
@@ -208,9 +207,9 @@ describe('Observable.prototype.concat', () => {
     const unsub =     '                 !    ';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .concat(e2)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -221,7 +220,7 @@ describe('Observable.prototype.concat', () => {
     const e1 =   cold('--#');
     const e1subs =    '^ !';
     const e2 =   cold('----a--|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected =  '--#';
 
     expectObservable(e1.concat(e2)).toBe(expected);

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -16,7 +16,7 @@ describe('Observable.prototype.concatMap', () => {
     const expected =  '--x-x-x-y-y-yz-z-z-|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.concatMap(x => e2.map(i => i * x));
+    const result = e1.concatMap(x => e2.map(i => i * parseInt(x)));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -36,7 +36,7 @@ describe('Observable.prototype.concatMap', () => {
     const expected = '--a-a-a-a---b--b--b-------c-c-c-----(d|)';
 
     const observableLookup = { a: a, b: b, c: c, d: d };
-    const source = e1.concatMap((value: any) => observableLookup[value]);
+    const source = e1.concatMap((value) => observableLookup[value]);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -57,7 +57,7 @@ describe('Observable.prototype.concatMap', () => {
                      '                               ^         !'];
     const expected =   '---i-j-k-l---i-j-k-l---i-j-k-l---i-j-k-l-|';
 
-    const result = e1.concatMap((value: any) => inner);
+    const result = e1.concatMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -68,7 +68,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 = cold( '|');
     const e1subs =   '(^!)';
     const inner = cold('-1-2-3|');
-    const innersubs = [];
+    const innersubs: string[] = [];
     const expected = '|';
 
     const result = e1.concatMap(() => inner);
@@ -82,7 +82,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 = cold( '-');
     const e1subs =   '^';
     const inner = cold('-1-2-3|');
-    const innersubs = [];
+    const innersubs: string[] = [];
     const expected = '-';
 
     const result = e1.concatMap(() => { return inner; });
@@ -96,7 +96,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 = cold( '#');
     const e1subs =   '(^!)';
     const inner = cold('-1-2-3|');
-    const innersubs = [];
+    const innersubs: string[] = [];
     const expected = '#';
 
     const result = e1.concatMap(() => { return inner; });
@@ -161,7 +161,7 @@ describe('Observable.prototype.concatMap', () => {
                      '                               ^         !       '];
     const expected =   '---i-j-k-l---i-j-k-l---i-j-k-l---i-j-k-l--------|';
 
-    const result = e1.concatMap((value: any) => inner);
+    const result = e1.concatMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -179,7 +179,7 @@ describe('Observable.prototype.concatMap', () => {
                      '                               ^         !       '];
     const expected =   '---i-j-k-l---i-j-k-l---i-j-k-l---i-j-k-l---------';
 
-    const result = e1.concatMap((value: any) => inner);
+    const result = e1.concatMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -194,7 +194,7 @@ describe('Observable.prototype.concatMap', () => {
     const innersubs =  ' ^                ';
     const expected =   '---i-j-k-l--------';
 
-    const result = e1.concatMap((value: any) => inner);
+    const result = e1.concatMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -209,7 +209,7 @@ describe('Observable.prototype.concatMap', () => {
     const innersubs =  ' ^         !      ';
     const expected =   '---i-j-k-l-#      ';
 
-    const result = e1.concatMap((value: any) => inner);
+    const result = e1.concatMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -225,7 +225,7 @@ describe('Observable.prototype.concatMap', () => {
                      '           ^     !'];
     const expected =   '---i-j-k-l---i-j-#';
 
-    const result = e1.concatMap((value: any) => inner);
+    const result = e1.concatMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -240,7 +240,7 @@ describe('Observable.prototype.concatMap', () => {
     const innersubs =  ' ^         !      ';
     const expected =   '---i-j-k-l-#      ';
 
-    const result = e1.concatMap((value: any) => inner);
+    const result = e1.concatMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -249,9 +249,9 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should concatMap many complex, where all inners are finite', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-|                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3|                           ');
@@ -267,7 +267,7 @@ describe('Observable.prototype.concatMap', () => {
     const expected =       '---2--3--4--5----6-----2--3-1------2--3-4-5--------1-2|';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.concatMap((value: any) => observableLookup[value]);
+    const result = e1.concatMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -282,25 +282,25 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should concatMap many complex, all inners finite except one', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-|                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3-                           ');
     const dsubs =          '                   ^                                   ';
     const e =   cold(                                 '-1------2--3-4-5---|        ');
-    const esubs = [];
+    const esubs: string[] = [];
     const f =   cold(                                                    '--|      ');
-    const fsubs = [];
+    const fsubs: string[] = [];
     const g =   cold(                                                      '---1-2|');
-    const gsubs = [];
+    const gsubs: string[] = [];
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                                                      ';
     const expected =       '---2--3--4--5----6-----2--3----------------------------';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.concatMap((value: any) => observableLookup[value]);
+    const result = e1.concatMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -315,9 +315,9 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should concatMap many complex, inners finite, outer does not complete', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-|                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3|                           ');
@@ -333,7 +333,7 @@ describe('Observable.prototype.concatMap', () => {
     const expected =       '---2--3--4--5----6-----2--3-1------2--3-4-5--------1-2-';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.concatMap((value: any) => observableLookup[value]);
+    const result = e1.concatMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -348,9 +348,9 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should concatMap many complex, all inners finite, and outer throws', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-|                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3|                           ');
@@ -358,15 +358,15 @@ describe('Observable.prototype.concatMap', () => {
     const e =   cold(                                 '-1------2--3-4-5---|        ');
     const esubs =          '                           ^           !               ';
     const f =   cold(                                                    '--|      ');
-    const fsubs = [];
+    const fsubs: string[] = [];
     const g =   cold(                                                      '---1-2|');
-    const gsubs = [];
+    const gsubs: string[] = [];
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g#               ');
     const e1subs =         '^                                      !               ';
     const expected =       '---2--3--4--5----6-----2--3-1------2--3#               ';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.concatMap((value: any) => observableLookup[value]);
+    const result = e1.concatMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -381,25 +381,25 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should concatMap many complex, all inners complete except one throws', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-#                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3|                           ');
-    const dsubs = [];
+    const dsubs: string[] = [];
     const e =   cold(                                 '-1------2--3-4-5---|        ');
-    const esubs = [];
+    const esubs: string[] = [];
     const f =   cold(                                                    '--|      ');
-    const fsubs = [];
+    const fsubs: string[] = [];
     const g =   cold(                                                      '---1-2|');
-    const gsubs = [];
+    const gsubs: string[] = [];
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                  !                                   ';
     const expected =       '---2--3--4--5----6-#                                   ';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.concatMap((value: any) => observableLookup[value]);
+    const result = e1.concatMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -414,9 +414,9 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should concatMap many complex, all inners finite, outer is unsubscribed early', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-|                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3|                           ');
@@ -424,16 +424,16 @@ describe('Observable.prototype.concatMap', () => {
     const e =   cold(                                 '-1------2--3-4-5---|        ');
     const esubs =          '                           ^  !                        ';
     const f =   cold(                                                    '--|      ');
-    const fsubs = [];
+    const fsubs: string[] = [];
     const g =   cold(                                                      '---1-2|');
-    const gsubs = [];
+    const gsubs: string[] = [];
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                             !                        ';
     const unsub =          '                              !                        ';
     const expected =       '---2--3--4--5----6-----2--3-1--                        ';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.concatMap((value: any) => observableLookup[value]);
+    const result = e1.concatMap((value) => observableLookup[value]);
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -448,9 +448,9 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-|                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3|                           ');
@@ -458,9 +458,9 @@ describe('Observable.prototype.concatMap', () => {
     const e =   cold(                                 '-1------2--3-4-5---|        ');
     const esubs =          '                           ^  !                        ';
     const f =   cold(                                                    '--|      ');
-    const fsubs = [];
+    const fsubs: string[] = [];
     const g =   cold(                                                      '---1-2|');
-    const gsubs = [];
+    const gsubs: string[] = [];
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                             !                        ';
     const unsub =          '                              !                        ';
@@ -468,9 +468,9 @@ describe('Observable.prototype.concatMap', () => {
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
-      .concatMap((value: any) => observableLookup[value])
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x))
+      .concatMap((value) => observableLookup[value])
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -485,25 +485,25 @@ describe('Observable.prototype.concatMap', () => {
 
   it('should concatMap many complex, all inners finite, project throws', () => {
     const a =   cold( '-#                                                          ');
-    const asubs = [];
+    const asubs: string[] = [];
     const b =   cold(   '-#                                                        ');
-    const bsubs = [];
+    const bsubs: string[] = [];
     const c =   cold(        '-2--3--4--5----6-|                                   ');
     const csubs =          '  ^                !                                   ';
     const d =   cold(                         '----2--3|                           ');
     const dsubs =          '                   ^       !                           ';
     const e =   cold(                                 '-1------2--3-4-5---|        ');
-    const esubs = [];
+    const esubs: string[] = [];
     const f =   cold(                                                    '--|      ');
-    const fsubs = [];
+    const fsubs: string[] = [];
     const g =   cold(                                                      '---1-2|');
-    const gsubs = [];
+    const gsubs: string[] = [];
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                          !                           ';
     const expected =       '---2--3--4--5----6-----2--3#                           ';
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.concatMap((value: string) => {
+    const result = e1.concatMap((value) => {
       if (value === 'e') { throw 'error'; }
       return observableLookup[value];
     });
@@ -519,7 +519,7 @@ describe('Observable.prototype.concatMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  function arrayRepeat(value, times) {
+  function arrayRepeat(value: string, times: number) {
     let results = [];
     for (let i = 0; i < times; i++) {
       results.push(value);
@@ -532,7 +532,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =   '^                               !';
     const expected = '(22)--(4444)---(333)----(22)----|';
 
-    const result = e1.concatMap(<any>((value: any) => arrayRepeat(value, value)));
+    const result = e1.concatMap((value) => arrayRepeat(value, +value));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -543,8 +543,8 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =   '^                               !';
     const expected = '(44)--(8888)---(666)----(44)----|';
 
-    const result = e1.concatMap(<any>((value: any) => arrayRepeat(value, value)),
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const result = e1.concatMap((value) => arrayRepeat(value, +value),
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -555,7 +555,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =   '^                               !';
     const expected = '(22)--(4444)---(333)----(22)----#';
 
-    const result = e1.concatMap(<any>((value: any) => arrayRepeat(value, value)));
+    const result = e1.concatMap((value) => arrayRepeat(value, +value));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -566,8 +566,8 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =   '^                               !';
     const expected = '(44)--(8888)---(666)----(44)----#';
 
-    const result = e1.concatMap(<any>((value: any) => arrayRepeat(value, value)),
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const result = e1.concatMap((value) => arrayRepeat(value, +value),
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -579,7 +579,7 @@ describe('Observable.prototype.concatMap', () => {
     const unsub =    '             !                   ';
     const expected = '(22)--(4444)--                   ';
 
-    const result = e1.concatMap(<any>((value: any) => arrayRepeat(value, value)));
+    const result = e1.concatMap((value) => arrayRepeat(value, +value));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -591,8 +591,8 @@ describe('Observable.prototype.concatMap', () => {
     const unsub =    '             !                   ';
     const expected = '(44)--(8888)--                   ';
 
-    const result = e1.concatMap(<any>((value: any) => arrayRepeat(value, value)),
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const result = e1.concatMap((value) => arrayRepeat(value, +value),
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -604,13 +604,13 @@ describe('Observable.prototype.concatMap', () => {
     const expected = '(22)--(4444)---#                 ';
 
     let invoked = 0;
-    const result = e1.concatMap(<any>((value: any) => {
+    const result = e1.concatMap((value) => {
       invoked++;
       if (invoked === 3) {
         throw 'error';
       }
-      return arrayRepeat(value, value);
-    }));
+      return arrayRepeat(value, +value);
+    });
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -621,8 +621,8 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =   '^              !                 ';
     const expected = '(44)--(8888)---#                 ';
 
-    const result = e1.concatMap(<any>((value: any) => arrayRepeat(value, value)),
-      (inner: any, outer: any) => {
+    const result = e1.concatMap((value) => arrayRepeat(value, +value),
+      (inner, outer) => {
         if (outer === '3') {
           throw 'error';
         }
@@ -639,13 +639,13 @@ describe('Observable.prototype.concatMap', () => {
     const expected = '(44)--(8888)---#                 ';
 
     let invoked = 0;
-    const result = e1.concatMap(<any>((value: any) => {
+    const result = e1.concatMap((value) => {
       invoked++;
       if (invoked === 3) {
         throw 'error';
       }
-      return arrayRepeat(value, value);
-    }), (inner: string, outer: string) => {
+      return arrayRepeat(value, +value);
+    }, (inner, outer) => {
       return String(parseInt(outer) + parseInt(inner));
     });
 
@@ -653,15 +653,15 @@ describe('Observable.prototype.concatMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should map values to constant resolved promises and concatenate', (done: MochaDone) => {
+  it('should map values to constant resolved promises and concatenate', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const project = (value: any) => Observable.from(Promise.resolve(42));
+    const project = (value: number) => Observable.from(Promise.resolve(42));
 
-    const results = [];
+    const results: number[] = [];
     source.concatMap(project).subscribe(
-      (x: any) => {
+      (x) => {
         results.push(x);
-      }, (err: any) => {
+      }, (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       }, () => {
         expect(results).to.deep.equal([42, 42, 42, 42]);
@@ -669,14 +669,14 @@ describe('Observable.prototype.concatMap', () => {
       });
   });
 
-  it('should map values to constant rejected promises and concatenate', (done: MochaDone) => {
+  it('should map values to constant rejected promises and concatenate', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const project = (value: any) => Observable.from(Promise.reject(42));
 
     source.concatMap(project).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.deep.equal(42);
         done();
       }, () => {
@@ -684,15 +684,15 @@ describe('Observable.prototype.concatMap', () => {
       });
   });
 
-  it('should map values to resolved promises and concatenate', (done: MochaDone) => {
+  it('should map values to resolved promises and concatenate', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const project = (value: number, index: number) => Observable.from(Promise.resolve(value + index));
 
-    const results = [];
+    const results: number[] = [];
     source.concatMap(project).subscribe(
-      (x: any) => {
+      (x) => {
         results.push(x);
-      }, (err: any) => {
+      }, (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       }, () => {
         expect(results).to.deep.equal([4, 4, 4, 4]);
@@ -700,14 +700,14 @@ describe('Observable.prototype.concatMap', () => {
       });
   });
 
-  it('should map values to rejected promises and concatenate', (done: MochaDone) => {
+  it('should map values to rejected promises and concatenate', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const project = (value: number, index: number) => Observable.from(Promise.reject('' + value + '-' + index));
 
     source.concatMap(project).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.deep.equal('4-0');
         done();
       }, () => {
@@ -715,17 +715,17 @@ describe('Observable.prototype.concatMap', () => {
       });
   });
 
-  it('should concatMap values to resolved promises with resultSelector', (done: MochaDone) => {
+  it('should concatMap values to resolved promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const resultSelectorCalledWith = [];
+    const resultSelectorCalledWith: number[][] = [];
     const project = (value: number, index: number) => Observable.from((Promise.resolve([value, index])));
 
-    const resultSelector = function (outerVal, innerVal, outerIndex, innerIndex) {
+    const resultSelector = function (outerVal: any, innerVal: any, outerIndex: any, innerIndex: any): number {
       resultSelectorCalledWith.push([].slice.call(arguments));
       return 8;
     };
 
-    const results = [];
+    const results: number[] = [];
     const expectedCalls = [
       [4, [4, 0], 0, 0],
       [3, [3, 1], 1, 0],
@@ -733,9 +733,9 @@ describe('Observable.prototype.concatMap', () => {
       [1, [1, 3], 3, 0]
     ];
     source.concatMap(project, resultSelector).subscribe(
-      (x: any) => {
+      (x) => {
         results.push(x);
-      }, (err: any) => {
+      }, (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       }, () => {
         expect(results).to.deep.equal([8, 8, 8, 8]);
@@ -744,7 +744,7 @@ describe('Observable.prototype.concatMap', () => {
       });
   });
 
-  it('should concatMap values to rejected promises with resultSelector', (done: MochaDone) => {
+  it('should concatMap values to rejected promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const project = (value: number, index: number) => Observable.from(Promise.reject('' + value + '-' + index));
 
@@ -753,9 +753,9 @@ describe('Observable.prototype.concatMap', () => {
     };
 
     source.concatMap(project, resultSelector).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.deep.equal('4-0');
         done();
       }, () => {

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -44,7 +44,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 = cold( '|');
     const e1subs =   '(^!)';
     const inner = cold('-1-2-3|');
-    const innersubs = [];
+    const innersubs: string[] = [];
     const expected = '|';
 
     const result = e1.concatMapTo(inner);
@@ -58,7 +58,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 = cold( '-');
     const e1subs =   '^';
     const inner = cold('-1-2-3|');
-    const innersubs = [];
+    const innersubs: string[] = [];
     const expected = '-';
 
     const result = e1.concatMapTo(inner);
@@ -72,7 +72,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 = cold( '#');
     const e1subs =   '(^!)';
     const inner = cold('-1-2-3|');
-    const innersubs = [];
+    const innersubs: string[] = [];
     const expected = '#';
 
     const result = e1.concatMapTo(inner);
@@ -173,9 +173,9 @@ describe('Observable.prototype.concatMapTo', () => {
     const unsub =      '                  !';
 
     const result = e1
-      .mergeMap((x: any) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .concatMapTo(inner)
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -257,7 +257,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const expected = '(2345)(4567)---(3456)---(2345)--|';
 
     const result = e1.concatMapTo(['0', '1', '2', '3'],
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result).toBe(expected);
   });
@@ -276,7 +276,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const expected = '(2345)(4567)---(3456)---(2345)--#';
 
     const result = e1.concatMapTo(['0', '1', '2', '3'],
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result).toBe(expected);
   });
@@ -297,7 +297,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const expected = '(2345)(4567)--';
 
     const result = e1.concatMapTo(['0', '1', '2', '3'],
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(result, unsub).toBe(expected);
   });
@@ -306,7 +306,7 @@ describe('Observable.prototype.concatMapTo', () => {
     const e1 =   hot('2-----4--------3--------2-------|');
     const expected = '(2345)(4567)---#';
 
-    const result = e1.concatMapTo(['0', '1', '2', '3'], (x: string, y: string) => {
+    const result = e1.concatMapTo(['0', '1', '2', '3'], (x, y) => {
       if (x === '3') {
         throw 'error';
       }
@@ -316,15 +316,15 @@ describe('Observable.prototype.concatMapTo', () => {
     expectObservable(result).toBe(expected);
   });
 
-  it('should map values to constant resolved promises and concatenate', (done: MochaDone) => {
+  it('should map values to constant resolved promises and concatenate', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
 
-    const results = [];
+    const results: number[] = [];
     source.concatMapTo(Observable.from(Promise.resolve(42))).subscribe(
-      (x: any) => {
+      (x) => {
         results.push(x);
       },
-      (err: any) => {
+      (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
       () => {
@@ -333,14 +333,14 @@ describe('Observable.prototype.concatMapTo', () => {
       });
   });
 
-  it('should map values to constant rejected promises and concatenate', (done: MochaDone) => {
+  it('should map values to constant rejected promises and concatenate', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
 
     source.concatMapTo(Observable.from(Promise.reject(42))).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err: any) => {
+      (err) => {
         expect(err).to.equal(42);
         done();
       },
@@ -349,16 +349,16 @@ describe('Observable.prototype.concatMapTo', () => {
       });
   });
 
-  it('should concatMapTo values to resolved promises with resultSelector', (done: MochaDone) => {
+  it('should concatMapTo values to resolved promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const resultSelectorCalledWith = [];
+    const resultSelectorCalledWith: number[][] = [];
     const inner = Observable.from(Promise.resolve(42));
-    const resultSelector = function (outerVal, innerVal, outerIndex, innerIndex) {
+    const resultSelector = function (outerVal: number, innerVal: number, outerIndex: number, innerIndex: number) {
       resultSelectorCalledWith.push([].slice.call(arguments));
       return 8;
     };
 
-    const results = [];
+    const results: number[] = [];
     const expectedCalls = [
       [4, 42, 0, 0],
       [3, 42, 1, 0],
@@ -366,10 +366,10 @@ describe('Observable.prototype.concatMapTo', () => {
       [1, 42, 3, 0]
     ];
     source.concatMapTo(inner, resultSelector).subscribe(
-      (x: any) => {
+      (x) => {
         results.push(x);
       },
-      (err: any) => {
+      (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
       () => {
@@ -379,7 +379,7 @@ describe('Observable.prototype.concatMapTo', () => {
       });
   });
 
-  it('should concatMapTo values to rejected promises with resultSelector', (done: MochaDone) => {
+  it('should concatMapTo values to rejected promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const inner = Observable.from(Promise.reject(42));
     const resultSelector = () => {
@@ -387,10 +387,10 @@ describe('Observable.prototype.concatMapTo', () => {
     };
 
     source.concatMapTo(inner, resultSelector).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err: any) => {
+      (err) => {
         expect(err).to.equal(42);
         done();
       },

--- a/spec/operators/exhaust-spec.ts
+++ b/spec/operators/exhaust-spec.ts
@@ -3,6 +3,7 @@ import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
+declare const type: Function;
 
 const Observable = Rx.Observable;
 
@@ -15,17 +16,17 @@ describe('Observable.prototype.exhaust', () => {
     const e1 = hot(  '------x-------y-----z-------------|', { x: x, y: y, z: z });
     const expected = '--------a---b---c------g--h---i---|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
   });
 
   it('should switch to first immediately-scheduled inner Observable', () => {
     const e1 = cold( '(ab|)');
     const e1subs =   '(^!)';
     const e2 = cold( '(cd|)');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected = '(ab|)';
 
-    expectObservable((<any>Observable.of(e1, e2)).exhaust()).toBe(expected);
+    expectObservable(Observable.of(e1, e2).exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -35,7 +36,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -44,7 +45,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -53,7 +54,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -61,13 +62,13 @@ describe('Observable.prototype.exhaust', () => {
     const x = cold(        '--a---b---c--|               ');
     const xsubs =    '      ^            !               ';
     const y = cold(                '---d--e---f---|      ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const z = cold(                      '---g--h---i---|');
     const zsubs =    '                    ^             !';
     const e1 = hot(  '------x-------y-----z-------------|', { x: x, y: y, z: z });
     const expected = '--------a---b---c------g--h---i---|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(z.subscriptions).toBe(zsubs);
@@ -77,12 +78,12 @@ describe('Observable.prototype.exhaust', () => {
     const x = cold(        '--a---b---c--|         ');
     const xsubs =    '      ^         !           ';
     const y = cold(                '---d--e---f---|');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
     const unsub =    '                !            ';
     const expected = '--------a---b---             ';
 
-    expectObservable((<any>e1).exhaust(), unsub).toBe(expected);
+    expectObservable(e1.exhaust(), unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -91,15 +92,15 @@ describe('Observable.prototype.exhaust', () => {
     const x = cold(        '--a---b---c--|         ');
     const xsubs =    '      ^         !           ';
     const y = cold(                '---d--e---f---|');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
     const unsub =    '                !            ';
     const expected = '--------a---b----            ';
 
-    const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
+    const result = e1
+      .mergeMap((x) => Observable.of(x))
       .exhaust()
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -110,13 +111,13 @@ describe('Observable.prototype.exhaust', () => {
     const x = cold(     '--a---b--|              ');
     const xsubs =    '   ^        !              ';
     const y = cold(          '-d---e-            ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const z = cold(                '---f--g---h--');
     const zsubs =    '              ^            ';
     const e1 = hot(  '---x---y------z----------| ', { x: x, y: y, z: z });
     const expected = '-----a---b-------f--g---h--';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(z.subscriptions).toBe(zsubs);
@@ -126,11 +127,11 @@ describe('Observable.prototype.exhaust', () => {
     const x = cold(        '--a---b---c--|   ');
     const xsubs =    '      ^            !   ';
     const y = cold(        '---d--e---f---|  ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 = hot(  '------(xy)------------|', { x: x, y: y });
     const expected = '--------a---b---c-----|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -139,11 +140,11 @@ describe('Observable.prototype.exhaust', () => {
     const x = cold(        '--a---#                ');
     const xsubs =    '      ^     !                ';
     const y = cold(                '---d--e---f---|');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 = hot(  '------x-------y------|       ', { x: x, y: y });
     const expected = '--------a---#                ';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -152,11 +153,11 @@ describe('Observable.prototype.exhaust', () => {
     const x = cold(        '--a---b---c--|         ');
     const xsubs =    '      ^            !         ';
     const y = cold(                '---d--e---f---|');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 = hot(  '------x-------y-------#      ', { x: x, y: y });
     const expected = '--------a---b---c-----#      ';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
   });
@@ -166,7 +167,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '^     !';
     const expected = '------|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -175,7 +176,7 @@ describe('Observable.prototype.exhaust', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -185,16 +186,16 @@ describe('Observable.prototype.exhaust', () => {
     const e1 = hot(  '------x---------------|', { x: x });
     const expected = '--------a---b---c-----|';
 
-    expectObservable((<any>e1).exhaust()).toBe(expected);
+    expectObservable(e1.exhaust()).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
   });
 
-  it('should handle an observable of promises', (done: MochaDone) => {
+  it('should handle an observable of promises', (done) => {
     const expected = [1];
 
-    (<any>Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3)))
+    Observable.of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3))
       .exhaust()
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, () => {
         expect(expected.length).to.equal(0);
@@ -202,16 +203,66 @@ describe('Observable.prototype.exhaust', () => {
       });
   });
 
-  it('should handle an observable of promises, where one rejects', (done: MochaDone) => {
-    (<any>Observable.of<any>(Promise.reject(2), Promise.resolve(1)))
+  it('should handle an observable of promises, where one rejects', (done) => {
+    Observable.of(Promise.reject(2), Promise.resolve(1))
       .exhaust()
-      .subscribe((x: any) => {
+      .subscribe((x) => {
         done(new Error('should not be called'));
-      }, (err: any) => {
+      }, (err) => {
         expect(err).to.equal(2);
         done();
       }, () => {
         done(new Error('should not be called'));
       });
+  });
+
+  type(() => {
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<number> = Rx.Observable
+      .of(source1, source2, source3)
+      .pipe(Rx.operators.exhaust());
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<number> = Rx.Observable
+      .of(source1, source2, source3)
+      .exhaust();
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    // coerce type to a specific type
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<string> = Rx.Observable
+      .of(<any>source1, <any>source2, <any>source3)
+      .pipe(Rx.operators.exhaust<string>());
+    /* tslint:enable:no-unused-variable */
+  });
+
+  type(() => {
+    // coerce type to a specific type
+    /* tslint:disable:no-unused-variable */
+    const source1 = Rx.Observable.of(1, 2, 3);
+    const source2 = [1, 2, 3];
+    const source3 = new Promise<number>(d => d(1));
+
+    let result: Rx.Observable<string> = Rx.Observable
+      .of(<any>source1, <any>source2, <any>source3)
+      .exhaust<string>();
+    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -15,7 +15,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const expected =  '--x-x-x-y-y-y------|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.exhaustMap(x => e2.map(i => i * x));
+    const result = e1.exhaustMap(x => e2.map(i => i * +x));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -23,12 +23,12 @@ describe('Observable.prototype.exhaustMap', () => {
 
   it('should handle outer throw', () => {
     const x =   cold('--a--b--c--|');
-    const xsubs = [];
+    const xsubs: string[] = [];
     const e1 =  cold('#');
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const result = (<any>e1).exhaustMap(() => x);
+    const result = e1.exhaustMap(() => x);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -37,12 +37,12 @@ describe('Observable.prototype.exhaustMap', () => {
 
   it('should handle outer empty', () => {
     const x =   cold('--a--b--c--|');
-    const xsubs = [];
+    const xsubs: string[] = [];
     const e1 =  cold('|');
     const e1subs =   '(^!)';
     const expected = '|';
 
-    const result = (<any>e1).exhaustMap(() => x);
+    const result = e1.exhaustMap(() => x);
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -50,12 +50,12 @@ describe('Observable.prototype.exhaustMap', () => {
 
   it('should handle outer never', () => {
     const x =   cold('--a--b--c--|');
-    const xsubs = [];
+    const xsubs: string[] = [];
     const e1 =  cold('-');
     const e1subs =   '^';
     const expected = '-';
 
-    const result = (<any>e1).exhaustMap(() => x);
+    const result = e1.exhaustMap(() => x);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -67,7 +67,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const e1subs =   '^  !';
     const expected = '---#';
 
-    const result = (<any>e1).exhaustMap((value: any) => {
+    const result = e1.exhaustMap((value) => {
       throw 'error';
     });
 
@@ -82,7 +82,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const e1subs =   '^    !                  ';
     const expected = '-----#                  ';
 
-    const result = (<any>e1).exhaustMap((value: any) => x,
+    const result = e1.exhaustMap((value) => x,
       () => {
         throw 'error';
       });
@@ -96,7 +96,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const x = cold(     '--a--b--c--|                              ');
     const xsubs =    '   ^          !                              ';
     const y = cold(               '--d--e--f--|                    ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const z = cold(                                 '--g--h--i--|  ');
     const zsubs =    '                               ^          !  ';
     const e1 =   hot('---x---------y-----------------z-------------|');
@@ -105,7 +105,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y, z: z };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -118,7 +118,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const x = cold(     '--a--b--c--|                               ');
     const xsubs =    '   ^          !                               ';
     const y = cold(               '--d--e--f--|                     ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const z = cold(                                 '--g--h--i--|   ');
     const zsubs =    '                               ^  !           ';
     const e1 =   hot('---x---------y-----------------z-------------|');
@@ -128,7 +128,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y, z: z };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -141,7 +141,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const x = cold(     '--a--b--c--|                               ');
     const xsubs =    '   ^          !                               ';
     const y = cold(               '--d--e--f--|                     ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const z = cold(                                 '--g--h--i--|   ');
     const zsubs =    '                               ^  !           ';
     const e1 =   hot('---x---------y-----------------z-------------|');
@@ -151,10 +151,10 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y, z: z };
 
-    const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
-      .exhaustMap((value: any) => observableLookup[value])
-      .mergeMap((x: any) => Observable.of(x));
+    const result = e1
+      .mergeMap((x) => Observable.of(x))
+      .exhaustMap((value) => observableLookup[value])
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -167,7 +167,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const x = cold(     '--a--b--c--|                              ');
     const xsubs =    '   ^          !                              ';
     const y = cold(               '--d--e--f--|                    ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const z = cold(                                 '--g--h--i-----');
     const zsubs =    '                               ^             ';
     const e1 =   hot('---x---------y-----------------z---------|   ');
@@ -176,7 +176,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y, z: z };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -189,14 +189,14 @@ describe('Observable.prototype.exhaustMap', () => {
     const x =   cold(         '--a--b--c--d--e--|   ');
     const xsubs =    '         ^                !   ';
     const y =   cold(         '---f---g---h---i--|  ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 =   hot('---------(xy)----------------|');
     const e1subs =   '^                            !';
     const expected = '-----------a--b--c--d--e-----|';
 
     const observableLookup = { x: x, y: y };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -208,14 +208,14 @@ describe('Observable.prototype.exhaustMap', () => {
     const x =   cold(         '--a--b--c--d--#             ');
     const xsubs =    '         ^             !             ';
     const y =   cold(                   '---f---g---h---i--');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 =   hot('---------x---------y---------|       ');
     const e1subs =   '^                      !             ';
     const expected = '-----------a--b--c--d--#             ';
 
     const observableLookup = { x: x, y: y };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -227,7 +227,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const x =    hot('-----a--b--c--d--e--|                  ');
     const xsubs =    '         ^          !                  ';
     const y =    hot('--p-o-o-p-------f---g---h---i--|       ');
-    const ysubs =  [];
+    const ysubs: string[] = [];
     const z =    hot('---z-o-o-m-------------j---k---l---m--|');
     const zsubs =    '                    ^                 !';
     const e1 =   hot('---------x----y-----z--------|         ');
@@ -236,7 +236,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y, z: z };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -256,7 +256,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -275,7 +275,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -287,14 +287,14 @@ describe('Observable.prototype.exhaustMap', () => {
     const x = cold('-');
     const y = cold('#');
     const xsubs =    '         ^                     ';
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 =   hot('---------x---------y----------|');
     const e1subs =   '^                              ';
     const expected = '-------------------------------';
 
     const observableLookup = { x: x, y: y };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -313,7 +313,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -330,7 +330,7 @@ describe('Observable.prototype.exhaustMap', () => {
 
     const observableLookup = { x: x };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value]);
+    const result = e1.exhaustMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -341,7 +341,7 @@ describe('Observable.prototype.exhaustMap', () => {
     const x =   cold(  '--a--b--c--d--e-|                   ');
     const xsubs =    '  ^               !                   ';
     const y =   cold(            '---f---g---h---i--|       ');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const z =   cold(                   '---k---l---m---n--|');
     const zsubs =    '                   ^                 !';
     const e1 =   hot('--x---------y------z-|                ');
@@ -362,7 +362,7 @@ describe('Observable.prototype.exhaustMap', () => {
       n: ['z', 'n', 1, 3],
     };
 
-    const result = (<any>e1).exhaustMap((value: any) => observableLookup[value],
+    const result = e1.exhaustMap((value) => observableLookup[value],
     (innerValue, outerValue, innerIndex, outerIndex) => [innerValue, outerValue, innerIndex, outerIndex]);
 
     expectObservable(result).toBe(expected, expectedValues);

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -1,10 +1,11 @@
 import { expect } from 'chai';
 import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { Subscribable } from '../../src/internal/Observable';
 
 declare function asDiagram(arg: string): Function;
+declare const type: Function;
 
-declare const Symbol: any;
 declare const rxTestScheduler: Rx.TestScheduler;
 const Observable = Rx.Observable;
 
@@ -64,7 +65,7 @@ describe('Observable.prototype.expand', () => {
       a--b--c--d--(e|)
     */
 
-    const result = e1.expand((x: any, index: number): Rx.Observable<any> => {
+    const result = e1.expand((x, index): Rx.Observable<any> => {
       if (x === 16) {
         return Observable.empty();
       } else {
@@ -89,9 +90,9 @@ describe('Observable.prototype.expand', () => {
     const e2shape =  '---(z|)      ';
     const expected = 'a--b--c--(d#)';
 
-    const result = e1.expand((x: number) => {
+    const result = e1.expand((x) => {
       if (x === 8) {
-        return cold('#');
+        return cold<number>('#');
       }
       return cold(e2shape, { z: x + x });
     });
@@ -113,7 +114,7 @@ describe('Observable.prototype.expand', () => {
     const e2shape =  '---(z|)      ';
     const expected = 'a--b--c--(d#)';
 
-    const result = e1.expand((x: number) => {
+    const result = e1.expand((x) => {
       if (x === 8) {
         throw 'error';
       }
@@ -138,7 +139,7 @@ describe('Observable.prototype.expand', () => {
     const e2shape =  '---(z|)   ';
     const expected = 'a--b--c-  ';
 
-    const result = e1.expand((x: number): Rx.Observable<any> => {
+    const result = e1.expand((x): Rx.Observable<any> => {
       if (x === 16) {
         return Observable.empty();
       }
@@ -163,15 +164,15 @@ describe('Observable.prototype.expand', () => {
     const expected = 'a--b--c-  ';
     const unsub =    '       !  ';
 
-    const result = (<any>e1)
-      .mergeMap((x: any) => Observable.of(x))
-      .expand((x: number): Rx.Observable<any> => {
+    const result = e1
+      .mergeMap((x) => Observable.of(x))
+      .expand((x): Rx.Observable<any> => {
         if (x === 16) {
           return Observable.empty();
         }
         return cold(e2shape, { z: x + x });
       })
-      .mergeMap((x: any) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -190,7 +191,7 @@ describe('Observable.prototype.expand', () => {
     const e2shape =  '---(z|)           ';
     const expected = 'a-ab-bc-cd-de-(e|)';
 
-    const result = e1.expand((x: number): Rx.Observable<any> => {
+    const result = e1.expand((x): Rx.Observable<any> => {
       if (x === 16) {
         return Observable.empty();
       }
@@ -228,7 +229,7 @@ describe('Observable.prototype.expand', () => {
     const expected = 'a--u--b--v--c--x--d--y--(ez|)';
     const concurrencyLimit = 1;
 
-    const result = e1.expand((x: number): Rx.Observable<any> => {
+    const result = e1.expand((x): Rx.Observable<any> => {
       if (x === 16 || x === 160) {
         return Observable.empty();
       }
@@ -261,7 +262,7 @@ describe('Observable.prototype.expand', () => {
     const expected = 'a---a-u---b-b---v-(cc)(x|)';
     const concurrencyLimit = 2;
 
-    const result = e1.expand((x: number): Rx.Observable<any> => {
+    const result = e1.expand((x): Rx.Observable<any> => {
       if (x === 4 || x === 40) {
         return Observable.empty();
       }
@@ -291,7 +292,7 @@ describe('Observable.prototype.expand', () => {
     const expected = 'a-ub-vc-xd-ye-(z|)';
     const concurrencyLimit = 100;
 
-    const result = e1.expand((x: number): Rx.Observable<any> => {
+    const result = e1.expand((x): Rx.Observable<any> => {
       if (x === 16 || x === 160) {
         return Observable.empty();
       }
@@ -314,7 +315,7 @@ describe('Observable.prototype.expand', () => {
     const e1subs =   '(^!)';
     const expected = '(abcde|)';
 
-    const result = e1.expand((x: number) => {
+    const result = e1.expand((x) => {
       if (x === 16) {
         return Observable.empty();
       }
@@ -325,16 +326,16 @@ describe('Observable.prototype.expand', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should recursively flatten promises', (done: MochaDone) => {
+  it('should recursively flatten promises', (done) => {
     const expected = [1, 2, 4, 8, 16];
     Observable.of(1)
-      .expand((x: number): any => {
+      .expand((x): any => {
         if (x === 16) {
           return Observable.empty();
         }
         return Promise.resolve(x + x);
       })
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, () => {
         expect(expected.length).to.equal(0);
@@ -342,16 +343,16 @@ describe('Observable.prototype.expand', () => {
       });
   });
 
-  it('should recursively flatten Arrays', (done: MochaDone) => {
+  it('should recursively flatten Arrays', (done) => {
     const expected = [1, 2, 4, 8, 16];
     Observable.of(1)
-      .expand((x: number): any => {
+      .expand((x): any => {
         if (x === 16) {
           return Observable.empty();
         }
         return [x + x];
       })
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, () => {
         expect(expected.length).to.equal(0);
@@ -359,11 +360,11 @@ describe('Observable.prototype.expand', () => {
       });
   });
 
-  it('should recursively flatten lowercase-o observables', (done: MochaDone) => {
+  it('should recursively flatten lowercase-o observables', (done) => {
     const expected = [1, 2, 4, 8, 16];
-    const project = (x: any, index: number) => {
+    const project = (x: number, index: number): Subscribable<number> => {
       if (x === 16) {
-        return Observable.empty();
+        return <any>Observable.empty();
       }
 
       const ish = {
@@ -376,12 +377,12 @@ describe('Observable.prototype.expand', () => {
       ish[Symbol.observable] = function () {
         return this;
       };
-      return ish;
+      return <Subscribable<number>> ish;
     };
 
-    (<any>Observable.of(1))
+    Observable.of(1)
       .expand(project)
-      .subscribe((x: number) => {
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, () => {
         expect(expected.length).to.equal(0);

--- a/spec/operators/merge-spec.ts
+++ b/spec/operators/merge-spec.ts
@@ -24,12 +24,12 @@ describe('Observable.prototype.merge', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should merge a source with a second', (done: MochaDone) => {
+  it('should merge a source with a second', (done) => {
     const a = Observable.of(1, 2, 3);
     const b = Observable.of(4, 5, 6, 7, 8);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    a.merge(b).subscribe((val: number) => {
+    a.merge(b).subscribe((val) => {
       expect(val).to.equal(r.shift());
     }, (x) => {
       done(new Error('should not be called'));
@@ -38,12 +38,12 @@ describe('Observable.prototype.merge', () => {
     });
   });
 
-  it('should merge an immediately-scheduled source with an immediately-scheduled second', (done: MochaDone) => {
+  it('should merge an immediately-scheduled source with an immediately-scheduled second', (done) => {
     const a = Observable.of<number>(1, 2, 3, queueScheduler);
     const b = Observable.of<number>(4, 5, 6, 7, 8, queueScheduler);
     const r = [1, 2, 4, 3, 5, 6, 7, 8];
 
-    a.merge(b, queueScheduler).subscribe((val: number) => {
+    a.merge(b, queueScheduler).subscribe((val) => {
       expect(val).to.equal(r.shift());
     }, (x) => {
       done(new Error('should not be called'));
@@ -132,9 +132,9 @@ describe('Observable.prototype.merge', () => {
     const unsub =     '          !           ';
 
     const result = e1
-      .map((x: string) => x)
+      .map((x) => x)
       .merge(e2, rxTestScheduler)
-      .map((x: string) => x);
+      .map((x) => x);
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -279,22 +279,22 @@ describe('Observable.prototype.merge', () => {
 });
 
 describe('Observable.prototype.mergeAll', () => {
-  it('should merge two observables', (done: MochaDone) => {
+  it('should merge two observables', (done) => {
     const a = Observable.of(1, 2, 3);
     const b = Observable.of(4, 5, 6, 7, 8);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    Observable.of(a, b).mergeAll().subscribe((val: number) => {
+    Observable.of(a, b).mergeAll().subscribe((val) => {
       expect(val).to.equal(r.shift());
     }, null, done);
   });
 
-  it('should merge two immediately-scheduled observables', (done: MochaDone) => {
+  it('should merge two immediately-scheduled observables', (done) => {
     const a = Observable.of<number>(1, 2, 3, queueScheduler);
     const b = Observable.of<number>(4, 5, 6, 7, 8, queueScheduler);
     const r = [1, 2, 4, 3, 5, 6, 7, 8];
 
-    Observable.of<Rx.Observable<number>>(a, b, queueScheduler).mergeAll().subscribe((val: number) => {
+    Observable.of(a, b, queueScheduler).mergeAll().subscribe((val) => {
       expect(val).to.equal(r.shift());
     }, null, done);
   });

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -17,7 +17,7 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =  '--x-x-x-y-yzyz-z---|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.mergeMap(x => e2.map(i => i * x));
+    const result = e1.mergeMap(x => e2.map(i => i * +x));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -33,22 +33,22 @@ describe('Observable.prototype.mergeMap', () => {
     const expected = '----a---(ab)(ab)(ab)c---c---(cd)c---(c|)';
 
     const observableLookup = { a: a, b: b, c: c, d: d };
-    const source = e1.mergeMap((value: any) => observableLookup[value]);
+    const source = e1.mergeMap((value) => observableLookup[value]);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should map values to constant resolved promises and merge', (done: MochaDone) => {
+  it('should map values to constant resolved promises and merge', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const project = (value: any) => Observable.from(Promise.resolve(42));
 
-    const results = [];
+    const results: number[] = [];
     source.mergeMap(project).subscribe(
-      (x: number) => {
+      (x) => {
         results.push(x);
       },
-      (err: any) => {
+      (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
       () => {
@@ -57,17 +57,17 @@ describe('Observable.prototype.mergeMap', () => {
       });
   });
 
-  it('should map values to constant rejected promises and merge', (done: MochaDone) => {
+  it('should map values to constant rejected promises and merge', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const project = function (value) {
+    const project = function (value: any) {
       return Observable.from(Promise.reject<number>(42));
     };
 
     source.mergeMap(project).subscribe(
-      (x: number) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err: any) => {
+      (err) => {
         expect(err).to.equal(42);
         done();
       },
@@ -76,18 +76,18 @@ describe('Observable.prototype.mergeMap', () => {
       });
   });
 
-  it('should map values to resolved promises and merge', (done: MochaDone) => {
+  it('should map values to resolved promises and merge', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const project = function (value, index) {
+    const project = function (value: number, index: number) {
       return Observable.from(Promise.resolve(value + index));
     };
 
-    const results = [];
+    const results: number[] = [];
     source.mergeMap(project).subscribe(
-      (x: number) => {
+      (x) => {
         results.push(x);
       },
-      (err: any) => {
+      (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
       () => {
@@ -96,17 +96,17 @@ describe('Observable.prototype.mergeMap', () => {
       });
   });
 
-  it('should map values to rejected promises and merge', (done: MochaDone) => {
+  it('should map values to rejected promises and merge', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const project = function (value, index) {
+    const project = function (value: number, index: number) {
       return Observable.from(Promise.reject<string>('' + value + '-' + index));
     };
 
     source.mergeMap(project).subscribe(
-      (x: string) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err: any) => {
+      (err) => {
         expect(err).to.equal('4-0');
         done();
       },
@@ -115,18 +115,18 @@ describe('Observable.prototype.mergeMap', () => {
       });
   });
 
-  it('should mergeMap values to resolved promises with resultSelector', (done: MochaDone) => {
+  it('should mergeMap values to resolved promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const resultSelectorCalledWith = [];
-    const project = function (value, index) {
+    const resultSelectorCalledWith: number[][] = [];
+    const project = function (value: number, index: number) {
       return Observable.from(Promise.resolve([value, index]));
     };
-    const resultSelector = function (outerVal, innerVal, outerIndex, innerIndex) {
+    const resultSelector = function (outerVal: number, innerVal: number[], outerIndex: number, innerIndex: number) {
       resultSelectorCalledWith.push([].slice.call(arguments));
       return 8;
     };
 
-    const results = [];
+    const results: number[] = [];
     const expectedCalls = [
       [4, [4, 0], 0, 0],
       [3, [3, 1], 1, 0],
@@ -134,10 +134,10 @@ describe('Observable.prototype.mergeMap', () => {
       [1, [1, 3], 3, 0],
     ];
     source.mergeMap(project, resultSelector).subscribe(
-      (x: number) => {
+      (x) => {
         results.push(x);
       },
-      (err: any) => {
+      (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
       () => {
@@ -147,9 +147,9 @@ describe('Observable.prototype.mergeMap', () => {
       });
   });
 
-  it('should mergeMap values to rejected promises with resultSelector', (done: MochaDone) => {
+  it('should mergeMap values to rejected promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const project = function (value, index) {
+    const project = function (value: number, index: number) {
       return Observable.from(Promise.reject('' + value + '-' + index));
     };
     const resultSelector = () => {
@@ -157,10 +157,10 @@ describe('Observable.prototype.mergeMap', () => {
     };
 
     source.mergeMap(project, resultSelector).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err: any) => {
+      (err) => {
         expect(err).to.equal('4-0');
         done();
       },
@@ -180,7 +180,7 @@ describe('Observable.prototype.mergeMap', () => {
                      '                         ^                   !'];
     const expected =   '-----i---j---(ki)(lj)(ki)(lj)(ki)(lj)k---l---|';
 
-    const result = e1.mergeMap((value: any) => inner);
+    const result = e1.mergeMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(inner.subscriptions).toBe(innersubs);
@@ -194,7 +194,7 @@ describe('Observable.prototype.mergeMap', () => {
     const inner = cold('----i---j---k---l---|                            ', values);
     const expected =  '-----i---j---(ki)(lj)(ki)(lj)(ki)(lj)k---l-------|';
 
-    const result = e1.mergeMap((value: any) => inner);
+    const result = e1.mergeMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -208,7 +208,7 @@ describe('Observable.prototype.mergeMap', () => {
     const inner = cold('----i---j---k---l---|                                  ', values);
     const expected =  '-----i---j---(ki)(lj)(ki)(lj)(ki)(lj)(ki)(lj)k---l---i--';
 
-    const source = e1.mergeMap((value: any) => inner);
+    const source = e1.mergeMap((value) => inner);
 
     expectObservable(source, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -224,7 +224,7 @@ describe('Observable.prototype.mergeMap', () => {
 
     const source = e1
       .map(function (x) { return x; })
-      .mergeMap((value: any) => inner)
+      .mergeMap((value) => inner)
       .map(function (x) { return x; });
 
     expectObservable(source, unsub).toBe(expected, values);
@@ -238,7 +238,7 @@ describe('Observable.prototype.mergeMap', () => {
     const inner = cold('----i---j---k---l-------------------------', values);
     const expected =  '-----i---j---(ki)(lj)(ki)(lj)(ki)(lj)k---l-';
 
-    const result = e1.mergeMap((value: any) => inner);
+    const result = e1.mergeMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -251,7 +251,7 @@ describe('Observable.prototype.mergeMap', () => {
     const inner = cold('----i---j---k---l-------#        ', values);
     const expected =  '-----i---j---(ki)(lj)(ki)#        ';
 
-    const result = e1.mergeMap((value: any) => inner);
+    const result = e1.mergeMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -264,7 +264,7 @@ describe('Observable.prototype.mergeMap', () => {
     const inner = cold('----i---j---k---l---|            ', values);
     const expected =  '-----i---j---(ki)(lj)(ki)(lj)(ki)#';
 
-    const result = e1.mergeMap((value: any) => inner);
+    const result = e1.mergeMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -277,7 +277,7 @@ describe('Observable.prototype.mergeMap', () => {
     const inner = cold('----i---j---k---l---#            ', values);
     const expected =  '-----i---j---(ki)(lj)#            ';
 
-    const result = e1.mergeMap((value: any) => inner);
+    const result = e1.mergeMap((value) => inner);
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -294,7 +294,7 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
 
     function project() { return inner; }
-    function resultSelector(oV, iV, oI, iI) { return iV; }
+    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
     const result = e1.mergeMap(project, resultSelector, 1);
 
     expectObservable(result).toBe(expected, values);
@@ -313,7 +313,7 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
 
     function project() { return inner; }
-    function resultSelector(oV, iV, oI, iI) { return iV; }
+    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
     const result = e1.mergeMap(project, resultSelector, 2);
 
     expectObservable(result).toBe(expected, values);
@@ -334,8 +334,8 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
     const inners = { a: hotA, b: hotB, c: hotC };
 
-    function project(x) { return inners[x]; }
-    function resultSelector(oV, iV, oI, iI) { return iV; }
+    function project(x: string) { return inners[x]; }
+    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
     const result = e1.mergeMap(project, resultSelector, 1);
 
     expectObservable(result).toBe(expected, values);
@@ -358,8 +358,8 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
     const inners = { a: hotA, b: hotB, c: hotC };
 
-    function project(x) { return inners[x]; }
-    function resultSelector(oV, iV, oI, iI) { return iV; }
+    function project(x: string) { return inners[x]; }
+    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
     const result = e1.mergeMap(project, resultSelector, 2);
 
     expectObservable(result).toBe(expected, values);
@@ -418,7 +418,7 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
     const inners = { a: hotA, b: hotB, c: hotC };
 
-    function project(x) { return inners[x]; }
+    function project(x: string) { return inners[x]; }
     const result = e1.mergeMap(project, 1);
 
     expectObservable(result).toBe(expected, values);
@@ -441,7 +441,7 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
     const inners = { a: hotA, b: hotB, c: hotC };
 
-    function project(x) { return inners[x]; }
+    function project(x: string) { return inners[x]; }
     const result = e1.mergeMap(project, 2);
 
     expectObservable(result).toBe(expected, values);
@@ -465,7 +465,7 @@ describe('Observable.prototype.mergeMap', () => {
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.mergeMap((value: any) => observableLookup[value]);
+    const result = e1.mergeMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -485,7 +485,7 @@ describe('Observable.prototype.mergeMap', () => {
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.mergeMap((value: any) => observableLookup[value]);
+    const result = e1.mergeMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -505,7 +505,7 @@ describe('Observable.prototype.mergeMap', () => {
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.mergeMap((value: any) => observableLookup[value]);
+    const result = e1.mergeMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -525,7 +525,7 @@ describe('Observable.prototype.mergeMap', () => {
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.mergeMap((value: any) => observableLookup[value]);
+    const result = e1.mergeMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -545,7 +545,7 @@ describe('Observable.prototype.mergeMap', () => {
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
-    const result = e1.mergeMap((value: any) => observableLookup[value]);
+    const result = e1.mergeMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -565,7 +565,7 @@ describe('Observable.prototype.mergeMap', () => {
     const expected =       '---2--3--4--5---1--2--3--2--3--                ';
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
-    const source = e1.mergeMap((value: any) => observableLookup[value]);
+    const source = e1.mergeMap((value) => observableLookup[value]);
 
     expectObservable(source, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -585,7 +585,7 @@ describe('Observable.prototype.mergeMap', () => {
 
     const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
     let invoked = 0;
-    const source = e1.mergeMap((value: any) => {
+    const source = e1.mergeMap((value) => {
       invoked++;
       if (invoked === 3) {
         throw 'error';
@@ -597,7 +597,7 @@ describe('Observable.prototype.mergeMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  function arrayRepeat(value, times): any {
+  function arrayRepeat(value: any, times: number): any {
     const results = [];
     for (let i = 0; i < times; i++) {
       results.push(value);
@@ -610,7 +610,7 @@ describe('Observable.prototype.mergeMap', () => {
     const e1subs =   '^                               !';
     const expected = '(22)--(4444)---(333)----(22)----|';
 
-    const source = e1.mergeMap((value: any) => arrayRepeat(value, value));
+    const source = e1.mergeMap((value) => arrayRepeat(value, +value));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -621,8 +621,8 @@ describe('Observable.prototype.mergeMap', () => {
     const e1subs =   '^                               !';
     const expected = '(44)--(8888)---(666)----(44)----|';
 
-    const source = e1.mergeMap((value: any) => arrayRepeat(value, value),
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const source = e1.mergeMap((value) => arrayRepeat(value, +value),
+      (x, y) => String(parseInt(x) + (+y)));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -633,7 +633,7 @@ describe('Observable.prototype.mergeMap', () => {
     const e1subs =   '^                               !';
     const expected = '(22)--(4444)---(333)----(22)----#';
 
-    const source = e1.mergeMap((value: any) => arrayRepeat(value, value));
+    const source = e1.mergeMap((value) => arrayRepeat(value, +value));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -644,8 +644,8 @@ describe('Observable.prototype.mergeMap', () => {
     const e1subs =   '^                               !';
     const expected = '(44)--(8888)---(666)----(44)----#';
 
-    const source = e1.mergeMap((value: any) => arrayRepeat(value, value),
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const source = e1.mergeMap((value) => arrayRepeat(value, +value),
+      (x, y) => String(parseInt(x) + (+y)));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -657,7 +657,7 @@ describe('Observable.prototype.mergeMap', () => {
     const e1subs  =  '^            !                   ';
     const expected = '(22)--(4444)--                   ';
 
-    const source = e1.mergeMap((value: any) => arrayRepeat(value, value));
+    const source = e1.mergeMap((value) => arrayRepeat(value, +value));
 
     expectObservable(source, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -669,8 +669,8 @@ describe('Observable.prototype.mergeMap', () => {
     const e1subs =   '^            !                   ';
     const expected = '(44)--(8888)--                   ';
 
-     const source = e1.mergeMap((value: any) => arrayRepeat(value, value),
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+     const source = e1.mergeMap((value) => arrayRepeat(value, +value),
+      (x, y) => String(parseInt(x) + (+y)));
 
     expectObservable(source, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -682,12 +682,12 @@ describe('Observable.prototype.mergeMap', () => {
     const expected = '(22)--(4444)---#                 ';
 
     let invoked = 0;
-    const source = e1.mergeMap((value: any) => {
+    const source = e1.mergeMap((value) => {
       invoked++;
       if (invoked === 3) {
         throw 'error';
       }
-      return arrayRepeat(value, value);
+      return arrayRepeat(value, +value);
     });
 
     expectObservable(source).toBe(expected);
@@ -699,12 +699,12 @@ describe('Observable.prototype.mergeMap', () => {
     const e1subs  =  '^              !                 ';
     const expected = '(44)--(8888)---#                 ';
 
-    const source = e1.mergeMap((value: any) => arrayRepeat(value, value),
-      (inner: string, outer: string) => {
+    const source = e1.mergeMap((value) => arrayRepeat(value, +value),
+      (inner, outer) => {
         if (outer === '3') {
           throw 'error';
         }
-        return String(parseInt(outer) + parseInt(inner));
+        return String((+outer) + parseInt(inner));
     });
 
     expectObservable(source).toBe(expected);
@@ -717,14 +717,14 @@ describe('Observable.prototype.mergeMap', () => {
     const expected = '(44)--(8888)---#                 ';
 
     let invoked = 0;
-    const source = e1.mergeMap((value: any) => {
+    const source = e1.mergeMap((value) => {
       invoked++;
       if (invoked === 3) {
         throw 'error';
       }
-      return arrayRepeat(value, value);
-    }, (inner: string, outer: string) => {
-      return String(parseInt(outer) + parseInt(inner));
+      return arrayRepeat(value, +value);
+    }, (inner, outer) => {
+      return String((+outer) + parseInt(inner));
     });
 
     expectObservable(source).toBe(expected);
@@ -732,12 +732,12 @@ describe('Observable.prototype.mergeMap', () => {
   });
 
   it('should map and flatten', () => {
-    const source = Observable.of(1, 2, 3, 4).mergeMap((x: number) => Observable.of(x + '!'));
+    const source = Observable.of(1, 2, 3, 4).mergeMap((x) => Observable.of(x + '!'));
 
     const expected = ['1!', '2!', '3!', '4!'];
     let completed = false;
 
-    source.subscribe((x: string) => {
+    source.subscribe((x) => {
       expect(x).to.equal(expected.shift());
     }, null, () => {
       expect(expected.length).to.equal(0);
@@ -748,12 +748,12 @@ describe('Observable.prototype.mergeMap', () => {
   });
 
   it('should map and flatten an Array', () => {
-    const source = Observable.of(1, 2, 3, 4).mergeMap((x: number): any => [x + '!']);
+    const source = Observable.of(1, 2, 3, 4).mergeMap((x): any => [x + '!']);
 
     const expected = ['1!', '2!', '3!', '4!'];
     let completed = false;
 
-    source.subscribe((x: string) => {
+    source.subscribe((x) => {
       expect(x).to.equal(expected.shift());
     }, null, () => {
       expect(expected.length).to.equal(0);

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -42,15 +42,15 @@ describe('Observable.prototype.mergeMapTo', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should map values to constant resolved promises and merge', (done: MochaDone) => {
+  it('should map values to constant resolved promises and merge', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
 
-    const results = [];
+    const results: number[] = [];
     source.mergeMapTo(Observable.from(Promise.resolve(42))).subscribe(
-      (x: any) => {
+      (x) => {
         results.push(x);
       },
-      (err: any) => {
+      (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
       () => {
@@ -59,14 +59,14 @@ describe('Observable.prototype.mergeMapTo', () => {
       });
   });
 
-  it('should map values to constant rejected promises and merge', (done: MochaDone) => {
+  it('should map values to constant rejected promises and merge', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
 
     source.mergeMapTo(Observable.from(Promise.reject(42))).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err: any) => {
+      (err) => {
         expect(err).to.equal(42);
         done();
       },
@@ -75,16 +75,16 @@ describe('Observable.prototype.mergeMapTo', () => {
       });
   });
 
-  it('should mergeMapTo values to resolved promises with resultSelector', (done: MochaDone) => {
+  it('should mergeMapTo values to resolved promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
-    const resultSelectorCalledWith = [];
+    const resultSelectorCalledWith: number[][] = [];
     const inner = Observable.from(Promise.resolve(42));
-    const resultSelector = function (outerVal, innerVal, outerIndex, innerIndex) {
+    const resultSelector = function (outerVal: number, innerVal: number, outerIndex: number, innerIndex: number) {
       resultSelectorCalledWith.push([].slice.call(arguments));
       return 8;
     };
 
-    const results = [];
+    const results: number[] = [];
     const expectedCalls = [
       [4, 42, 0, 0],
       [3, 42, 1, 0],
@@ -92,10 +92,10 @@ describe('Observable.prototype.mergeMapTo', () => {
       [1, 42, 3, 0],
     ];
     source.mergeMapTo(inner, resultSelector).subscribe(
-      (x: any) => {
+      (x) => {
         results.push(x);
       },
-      (err: any) => {
+      (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
       () => {
@@ -105,7 +105,7 @@ describe('Observable.prototype.mergeMapTo', () => {
       });
   });
 
-  it('should mergeMapTo values to rejected promises with resultSelector', (done: MochaDone) => {
+  it('should mergeMapTo values to rejected promises with resultSelector', (done) => {
     const source = Rx.Observable.from([4, 3, 2, 1]);
     const inner = Observable.from(Promise.reject(42));
     const resultSelector = () => {
@@ -113,10 +113,10 @@ describe('Observable.prototype.mergeMapTo', () => {
     };
 
     source.mergeMapTo(inner, resultSelector).subscribe(
-      (x: any) => {
+      (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err: any) => {
+      (err) => {
         expect(err).to.equal(42);
         done();
       },
@@ -274,7 +274,7 @@ describe('Observable.prototype.mergeMapTo', () => {
                      '                                         ^                   !'];
     const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
 
-    function resultSelector(oV, iV, oI, iI) { return iV; }
+    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
     const result = e1.mergeMapTo(inner, resultSelector, 1);
 
     expectObservable(result).toBe(expected, values);
@@ -292,7 +292,7 @@ describe('Observable.prototype.mergeMapTo', () => {
                      '                     ^                   !'];
     const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
 
-    function resultSelector(oV, iV, oI, iI) { return iV; }
+    function resultSelector(oV: string, iV: string, oI: number, iI: number) { return iV; }
     const result = e1.mergeMapTo(inner, resultSelector, 2);
 
     expectObservable(result).toBe(expected, values);
@@ -339,7 +339,7 @@ describe('Observable.prototype.mergeMapTo', () => {
     const e1subs =   '^                               !';
     const expected = '(0123)(0123)---(0123)---(0123)--|';
 
-    const source = e1.mergeMapTo(<any>['0', '1', '2', '3']);
+    const source = e1.mergeMapTo(['0', '1', '2', '3']);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -350,8 +350,8 @@ describe('Observable.prototype.mergeMapTo', () => {
     const e1subs =   '^                               !';
     const expected = '(2345)(4567)---(3456)---(2345)--|';
 
-    const source = e1.mergeMapTo(<any>['0', '1', '2', '3'],
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const source = e1.mergeMapTo(['0', '1', '2', '3'],
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -362,7 +362,7 @@ describe('Observable.prototype.mergeMapTo', () => {
     const e1subs =   '^                               !';
     const expected = '(0123)(0123)---(0123)---(0123)--#';
 
-    const source = e1.mergeMapTo(<any>['0', '1', '2', '3']);
+    const source = e1.mergeMapTo(['0', '1', '2', '3']);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -373,8 +373,8 @@ describe('Observable.prototype.mergeMapTo', () => {
     const e1subs =   '^                               !';
     const expected = '(2345)(4567)---(3456)---(2345)--#';
 
-    const source = e1.mergeMapTo(<any>['0', '1', '2', '3'],
-    (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const source = e1.mergeMapTo(['0', '1', '2', '3'],
+    (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -386,7 +386,7 @@ describe('Observable.prototype.mergeMapTo', () => {
     const unsub =    '             !';
     const expected = '(0123)(0123)--';
 
-    const source = e1.mergeMapTo(<any>['0', '1', '2', '3']);
+    const source = e1.mergeMapTo(['0', '1', '2', '3']);
 
     expectObservable(source, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -398,8 +398,8 @@ describe('Observable.prototype.mergeMapTo', () => {
     const unsub =    '             !';
     const expected = '(2345)(4567)--';
 
-    const source = e1.mergeMapTo(<any>['0', '1', '2', '3'],
-      (x: string, y: string) => String(parseInt(x) + parseInt(y)));
+    const source = e1.mergeMapTo(['0', '1', '2', '3'],
+      (x, y) => String(parseInt(x) + parseInt(y)));
 
     expectObservable(source, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -410,7 +410,7 @@ describe('Observable.prototype.mergeMapTo', () => {
     const e1subs =   '^              !';
     const expected = '(2345)(4567)---#';
 
-    const source = e1.mergeMapTo(<any>['0', '1', '2', '3'], (outer: string, inner: string) => {
+    const source = e1.mergeMapTo(['0', '1', '2', '3'], (outer, inner) => {
       if (outer === '3') {
         throw 'error';
       }
@@ -427,7 +427,7 @@ describe('Observable.prototype.mergeMapTo', () => {
     const expected = ['!', '!', '!', '!'];
     let completed = false;
 
-    source.subscribe((x: string) => {
+    source.subscribe((x) => {
       expect(x).to.equal(expected.shift());
     }, null, () => {
       expect(expected.length).to.equal(0);
@@ -438,12 +438,12 @@ describe('Observable.prototype.mergeMapTo', () => {
   });
 
   it('should map and flatten an Array', () => {
-    const source = Observable.of(1, 2, 3, 4).mergeMapTo(<any>['!']);
+    const source = Observable.of(1, 2, 3, 4).mergeMapTo(['!']);
 
     const expected = ['!', '!', '!', '!'];
     let completed = false;
 
-    source.subscribe((x: string) => {
+    source.subscribe((x) => {
       expect(x).to.equal(expected.shift());
     }, null, () => {
       expect(expected.length).to.equal(0);

--- a/spec/operators/mergeScan-spec.ts
+++ b/spec/operators/mergeScan-spec.ts
@@ -1,5 +1,6 @@
 import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { throwError } from '../../src/internal/observable/throwError';
 
 declare const rxTestScheduler: Rx.TestScheduler;
 const Observable = Rx.Observable;
@@ -20,7 +21,7 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = e1.mergeScan((acc, x) => Observable.of(acc.concat(x)), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -37,7 +38,7 @@ describe('Observable.prototype.mergeScan', () => {
       w: ['b', 'c', 'd']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = e1.mergeScan((acc, x) => Observable.of(acc.concat(x)), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -57,7 +58,7 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) =>
+    const source = e1.mergeScan((acc, x) =>
       Observable.of(acc.concat(x)).delay(20, rxTestScheduler), []);
 
     expectObservable(source).toBe(expected, values);
@@ -78,7 +79,7 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['c', 'e', 'g'],
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) =>
+    const source = e1.mergeScan((acc, x) =>
       Observable.of(acc.concat(x)).delay(50, rxTestScheduler), []);
 
     expectObservable(source).toBe(expected, values);
@@ -99,7 +100,7 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['c', 'e', 'g'],
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) =>
+    const source = e1.mergeScan((acc, x) =>
       Observable.of(acc.concat(x)).delay(50, rxTestScheduler), []);
 
     expectObservable(source, e1subs).toBe(expected, values);
@@ -121,9 +122,9 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['c', 'e', 'g'],
     };
 
-    const source = (<any>e1)
-      .mergeMap((x: string) => Observable.of(x))
-      .mergeScan((acc: any, x: string) =>
+    const source = e1
+      .mergeMap((x) => Observable.of(x))
+      .mergeScan((acc, x) =>
         Observable.of(acc.concat(x)).delay(50, rxTestScheduler), [])
       .mergeMap(function (x) { return Observable.of(x); });
 
@@ -141,7 +142,7 @@ describe('Observable.prototype.mergeScan', () => {
       v: ['b', 'c']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => {
+    const source = e1.mergeScan((acc, x) => {
       if (x === 'd') {
         throw 'bad!';
       }
@@ -157,7 +158,7 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =      '^  !';
     const expected =    '---#';
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.throw('bad!'), []);
+    const source = e1.mergeScan((acc, x) => throwError('bad!'), []);
 
     expectObservable(source).toBe(expected, undefined, 'bad!');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -168,9 +169,9 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =      '^                    !';
     const expected =    '---------------------(x|)';
 
-    const values = { x: [] };
+    const values = { x: <string[]>[] };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.empty(), []);
+    const source = e1.mergeScan((acc, x) => Observable.empty(), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -181,9 +182,9 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =      '^                     ';
     const expected =    '----------------------';
 
-    const values = { x: [] };
+    const values = { x: <string[]>[] };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.never(), []);
+    const source = e1.mergeScan((acc, x) => Observable.never(), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -195,10 +196,10 @@ describe('Observable.prototype.mergeScan', () => {
     const expected = '(u|)';
 
     const values = {
-      u: []
+      u: <string[]>[]
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = e1.mergeScan((acc, x) => Observable.of(acc.concat(x)), []);
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -209,7 +210,7 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = e1.mergeScan((acc, x) => Observable.of(acc.concat(x)), []);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -220,7 +221,7 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = e1.mergeScan((acc, x) => Observable.of(acc.concat(x)), []);
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -239,7 +240,7 @@ describe('Observable.prototype.mergeScan', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.of(acc.concat(x)), []);
+    const source = e1.mergeScan((acc, x) => Observable.of(acc.concat(x)), []);
 
     expectObservable(source, sub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(sub);
@@ -262,7 +263,7 @@ describe('Observable.prototype.mergeScan', () => {
     const expected = '--x-d--e--f--f-g--h--i--i-j--k--l--|';
 
     let index = 0;
-    const source = (<any>e1).mergeScan((acc: any, x: string) => {
+    const source = e1.mergeScan((acc, x) => {
       const value = inner[index++];
       return value.startWith(acc);
     }, 'x', 1);
@@ -280,7 +281,7 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =      '^                    !';
     const expected =    '---------------------(x|)';
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) => Observable.empty(), ['1']);
+    const source = e1.mergeScan((acc, x) => Observable.empty(), ['1']);
 
     expectObservable(source).toBe(expected, {x: ['1']});
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -291,7 +292,7 @@ describe('Observable.prototype.mergeScan', () => {
     const e1subs =      '^                      !';
     const expected =    '-----------------------(x|)';
 
-    const source = (<any>e1).mergeScan((acc: any, x: string) =>
+    const source = e1.mergeScan((acc, x) =>
       Observable.empty().delay(50, rxTestScheduler), ['1']);
 
     expectObservable(source).toBe(expected, {x: ['1']});
@@ -315,7 +316,7 @@ describe('Observable.prototype.mergeScan', () => {
     const expected = '---x-e--f--f--i----i-l------|';
 
     let index = 0;
-    const source = (<any>e1).mergeScan((acc: any, x: string) => {
+    const source = e1.mergeScan((acc, x) => {
       const value = inner[index++];
       return value.startWith(acc);
     }, 'x', 1);
@@ -345,7 +346,7 @@ describe('Observable.prototype.mergeScan', () => {
     const expected = '----x--d-d-eg--fh--hi-j---k---l---|';
 
     let index = 0;
-    const source = (<any>e1).mergeScan((acc: any, x: string) => {
+    const source = e1.mergeScan((acc, x) => {
       const value = inner[index++];
       return value.startWith(acc);
     }, 'x', 2);
@@ -375,7 +376,7 @@ describe('Observable.prototype.mergeScan', () => {
     const expected = '---x-e-efh-h-ki------l------|';
 
     let index = 0;
-    const source = (<any>e1).mergeScan((acc: any, x: string) => {
+    const source = e1.mergeScan((acc, x) => {
       const value = inner[index++];
       return value.startWith(acc);
     }, 'x', 2);

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -16,26 +16,26 @@ describe('Observable.prototype.switchMap', () => {
     const expected =  '--x-x-x-y-yz-z-z---|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.switchMap(x => e2.map(i => i * x));
+    const result = e1.switchMap(x => e2.map(i => i * +x));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should switch with a selector function', (done: MochaDone) => {
+  it('should switch with a selector function', (done) => {
     const a = Observable.of(1, 2, 3);
     const expected = ['a1', 'b1', 'c1', 'a2', 'b2', 'c2', 'a3', 'b3', 'c3'];
-    a.switchMap((x: number) => Observable.of('a' + x, 'b' + x, 'c' + x))
-      .subscribe((x: string) => {
+    a.switchMap((x) => Observable.of('a' + x, 'b' + x, 'c' + x))
+      .subscribe((x) => {
         expect(x).to.equal(expected.shift());
       }, null, done);
   });
 
   it('should unsub inner observables', () => {
-    const unsubbed = [];
+    const unsubbed: string[] = [];
 
-    Observable.of('a', 'b').switchMap((x: string) =>
-      Observable.create((subscriber: Rx.Subscriber<string>) => {
+    Observable.of('a', 'b').switchMap((x) =>
+      new Observable<string>((subscriber) => {
         subscriber.complete();
         return () => {
           unsubbed.push(x);
@@ -56,7 +56,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -68,11 +68,11 @@ describe('Observable.prototype.switchMap', () => {
     const e1 =   hot('-------x-----y---|');
     const e1subs =   '^      !          ';
     const expected = '-------#          ';
-    function project() {
+    function project(): any[] {
       throw 'error';
     }
 
-    expectObservable(e1.switchMap(<any>project)).toBe(expected);
+    expectObservable(e1.switchMap(project)).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -87,7 +87,7 @@ describe('Observable.prototype.switchMap', () => {
       throw 'error';
     }
 
-    const result = e1.switchMap((value: string) => x, selector);
+    const result = e1.switchMap((value) => x, selector);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -106,7 +106,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -127,9 +127,9 @@ describe('Observable.prototype.switchMap', () => {
     const observableLookup = { x: x, y: y };
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .switchMap((value: string) => observableLookup[value])
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x))
+      .switchMap((value) => observableLookup[value])
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -148,7 +148,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -167,7 +167,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -179,14 +179,14 @@ describe('Observable.prototype.switchMap', () => {
     const x =   cold(         '--a--b--#--d--e--|          ');
     const xsubs =    '         ^       !                   ';
     const y =   cold(                   '---f---g---h---i--');
-    const ysubs = [];
+    const ysubs: string[] = [];
     const e1 =   hot('---------x---------y---------|       ');
     const e1subs =   '^                !                   ';
     const expected = '-----------a--b--#                   ';
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -205,7 +205,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -224,7 +224,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -243,7 +243,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -262,7 +262,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -281,7 +281,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected, undefined, 'sad');
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -300,7 +300,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected, undefined, 'sad');
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -313,7 +313,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    const result = e1.switchMap((value: any) => Observable.of(value));
+    const result = e1.switchMap((value) => Observable.of(value));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -324,7 +324,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const result = e1.switchMap((value: any) => Observable.of(value));
+    const result = e1.switchMap((value) => Observable.of(value));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -335,7 +335,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const result = e1.switchMap((value: any) => Observable.of(value));
+    const result = e1.switchMap((value) => Observable.of(value));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -350,7 +350,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x };
 
-    const result = e1.switchMap((value: string) => observableLookup[value]);
+    const result = e1.switchMap((value) => observableLookup[value]);
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -378,7 +378,7 @@ describe('Observable.prototype.switchMap', () => {
       i: ['y', 'i', 1, 3]
     };
 
-    const result = e1.switchMap((value: string) => observableLookup[value],
+    const result = e1.switchMap((value) => observableLookup[value],
       (innerValue, outerValue, innerIndex, outerIndex) => [innerValue, outerValue, innerIndex, outerIndex]);
 
     expectObservable(result).toBe(expected, expectedValues);

--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -22,10 +22,10 @@ describe('Observable.prototype.switchMapTo', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should switch a synchronous many outer to a synchronous many inner', (done: MochaDone) => {
+  it('should switch a synchronous many outer to a synchronous many inner', (done) => {
     const a = Observable.of(1, 2, 3);
     const expected = ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
-    a.switchMapTo(Observable.of('a', 'b', 'c')).subscribe((x: string) => {
+    a.switchMapTo(Observable.of('a', 'b', 'c')).subscribe((x) => {
       expect(x).to.equal(expected.shift());
     }, null, done);
   });
@@ -34,7 +34,7 @@ describe('Observable.prototype.switchMapTo', () => {
     let unsubbed = 0;
 
     Observable.of('a', 'b').switchMapTo(
-      Observable.create((subscriber: Rx.Subscriber<string>) => {
+      new Observable<string>((subscriber) => {
         subscriber.complete();
         return () => {
           unsubbed++;
@@ -97,9 +97,9 @@ describe('Observable.prototype.switchMapTo', () => {
     const unsub =    '                      !       ';
 
     const result = e1
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .switchMapTo(x)
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);

--- a/spec/operators/zip-spec.ts
+++ b/spec/operators/zip-spec.ts
@@ -2,9 +2,8 @@ import { expect } from 'chai';
 import * as Rx from '../../src/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
-declare const type;
+declare const type: Function;
 
-declare const Symbol: any;
 const Observable = Rx.Observable;
 const queueScheduler = Rx.Scheduler.queue;
 
@@ -23,13 +22,13 @@ describe('Observable.prototype.zip', () => {
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
 
-  it('should zip the provided observables', (done: MochaDone) => {
+  it('should zip the provided observables', (done) => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
 
     Observable.from(['a', 'b', 'c']).zip(
       Observable.from([1, 2, 3]),
-      (a: string, b: number): string => a + b
+      (a, b): string => a + b
     )
     .subscribe(function (x) {
       expect(x).to.equal(expected[i++]);
@@ -124,7 +123,7 @@ describe('Observable.prototype.zip', () => {
     it('should work with never observable and empty iterable', () => {
       const a = cold(  '-');
       const asubs =    '^';
-      const b = [];
+      const b: string[] = [];
       const expected = '-';
 
       expectObservable(a.zip(b)).toBe(expected);
@@ -134,7 +133,7 @@ describe('Observable.prototype.zip', () => {
     it('should work with empty observable and empty iterable', () => {
       const a = cold('|');
       const asubs = '(^!)';
-      const b = [];
+      const b: string[] = [];
       const expected = '|';
 
       expectObservable(a.zip(b)).toBe(expected);
@@ -154,7 +153,7 @@ describe('Observable.prototype.zip', () => {
     it('should work with non-empty observable and empty iterable', () => {
       const a = hot('---^----a--|');
       const asubs =    '^       !';
-      const b = [];
+      const b: string[] = [];
       const expected = '--------|';
 
       expectObservable(a.zip(b)).toBe(expected);
@@ -184,7 +183,7 @@ describe('Observable.prototype.zip', () => {
     it('should work with non-empty observable and empty iterable', () => {
       const a = hot('---^----#');
       const asubs =    '^    !';
-      const b = [];
+      const b: string[] = [];
       const expected = '-----#';
 
       expectObservable(a.zip(b)).toBe(expected);
@@ -218,7 +217,7 @@ describe('Observable.prototype.zip', () => {
       const b = [4, 5, 6];
       const expected = '---x--#';
 
-      const selector = function (x, y) {
+      const selector = function (x: string, y: number) {
         if (y === 5) {
           throw new Error('too bad');
         } else {
@@ -335,7 +334,7 @@ describe('Observable.prototype.zip', () => {
     const bsubs =      '^       !     ';
     const expected =   '---x----#     ';
 
-    const selector = function (x, y) {
+    const selector = function (x: string, y: string) {
       if (y === '5') {
         throw new Error('too bad');
       } else {
@@ -564,7 +563,7 @@ describe('Observable.prototype.zip', () => {
     expectSubscriptions(b.subscriptions).toBe(bsubs);
   });
 
-  it('should combine an immediately-scheduled source with an immediately-scheduled second', (done: MochaDone) => {
+  it('should combine an immediately-scheduled source with an immediately-scheduled second', (done) => {
     const a = Observable.of<number>(1, 2, 3, queueScheduler);
     const b = Observable.of<number>(4, 5, 6, 7, 8, queueScheduler);
     const r = [[1, 4], [2, 5], [3, 6]];
@@ -584,9 +583,9 @@ describe('Observable.prototype.zip', () => {
     const expected = '---x---y--';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
+      .mergeMap((x) => Observable.of(x))
       .zip(b)
-      .mergeMap((x: Array<any>) => Observable.of(x));
+      .mergeMap((x) => Observable.of(x));
 
     expectObservable(r, unsub).toBe(expected, { x: ['1', '4'], y: ['2', '5']});
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -613,7 +612,7 @@ describe('Observable.prototype.zip', () => {
     /* tslint:disable:no-unused-variable */
     let o: Rx.Observable<number>;
     let z: Rx.Observable<number>[];
-    let a: Rx.Observable<string[]> = o.zip(z, (...r) => r.map(v => v.toString()));
+    let a: Rx.Observable<string[]> = o.zip(z, (...r: any[]) => r.map(v => v.toString()));
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -112,5 +112,5 @@ export function concat<T, R>(...observables: Array<ObservableInput<any> | ISched
   if (observables.length === 1 || (observables.length === 2 && isScheduler(observables[1]))) {
     return from(<any>observables[0]);
   }
-  return concatAll()(of(...observables)) as Observable<R>;
+  return concatAll<R>()(of(...observables));
 }

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -97,5 +97,5 @@ export function merge<T, R>(...observables: Array<ObservableInput<any> | ISchedu
     return <Observable<R>>observables[0];
   }
 
-  return mergeAll(concurrent)(fromArray(observables, scheduler)) as Observable<R>;
+  return mergeAll<R>(concurrent)(fromArray<any>(observables, scheduler));
 }

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -1,7 +1,11 @@
 import { CombineLatestOperator } from '../observable/combineLatest';
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { OperatorFunction } from '../../internal/types';
 
+export function combineAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
+export function combineAll<T>(): OperatorFunction<any, T[]>;
+export function combineAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
+export function combineAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 export function combineAll<T, R>(project?: (...values: Array<any>) => R): OperatorFunction<T, R> {
   return (source: Observable<T>) => source.lift(new CombineLatestOperator(project));
 }

--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -1,6 +1,10 @@
 
 import { mergeAll } from './mergeAll';
-import { MonoTypeOperatorFunction } from '../../internal/types';
+import { OperatorFunction } from '../../internal/types';
+import { ObservableInput, Observable } from '../Observable';
+
+export function concatAll<T>(): OperatorFunction<ObservableInput<T>, T>;
+export function concatAll<R>(): OperatorFunction<any, R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable by
@@ -50,6 +54,6 @@ import { MonoTypeOperatorFunction } from '../../internal/types';
  * @method concatAll
  * @owner Observable
  */
-export function concatAll<T>(): MonoTypeOperatorFunction<T> {
-  return mergeAll(1);
+export function concatAll<T>(): OperatorFunction<ObservableInput<T>, T> {
+  return mergeAll<T>(1);
 }

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -1,10 +1,13 @@
 import { Operator } from '../Operator';
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription, TeardownLogic } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '..//util/subscribeToResult';
-import { MonoTypeOperatorFunction } from '../../internal/types';
+import { OperatorFunction } from '../../internal/types';
+
+export function exhaust<T>(): OperatorFunction<ObservableInput<T>, T>;
+export function exhaust<R>(): OperatorFunction<any, R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable by dropping
@@ -41,7 +44,7 @@ import { MonoTypeOperatorFunction } from '../../internal/types';
  * @method exhaust
  * @owner Observable
  */
-export function exhaust<T>(): MonoTypeOperatorFunction<T> {
+export function exhaust<T>(): OperatorFunction<any, T> {
   return (source: Observable<T>) => source.lift(new SwitchFirstOperator<T>());
 }
 

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,4 +1,4 @@
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { IScheduler } from '../Scheduler';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
@@ -11,8 +11,8 @@ import { subscribeToResult } from '..//util/subscribeToResult';
 import { MonoTypeOperatorFunction, OperatorFunction } from '../../internal/types';
 
 /* tslint:disable:max-line-length */
-export function expand<T>(project: (value: T, index: number) => Observable<T>, concurrent?: number, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
-export function expand<T, R>(project: (value: T, index: number) => Observable<R>, concurrent?: number, scheduler?: IScheduler): OperatorFunction<T, R>;
+export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: IScheduler): OperatorFunction<T, R>;
+export function expand<T>(project: (value: T, index: number) => ObservableInput<T>, concurrent?: number, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -60,7 +60,7 @@ export function expand<T, R>(project: (value: T, index: number) => Observable<R>
  * @method expand
  * @owner Observable
  */
-export function expand<T, R>(project: (value: T, index: number) => Observable<R>,
+export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,
                              scheduler: IScheduler = undefined): OperatorFunction<T, R> {
   concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;
@@ -69,7 +69,7 @@ export function expand<T, R>(project: (value: T, index: number) => Observable<R>
 }
 
 export class ExpandOperator<T, R> implements Operator<T, R> {
-  constructor(private project: (value: T, index: number) => Observable<R>,
+  constructor(private project: (value: T, index: number) => ObservableInput<R>,
               private concurrent: number,
               private scheduler: IScheduler) {
   }
@@ -81,7 +81,7 @@ export class ExpandOperator<T, R> implements Operator<T, R> {
 
 interface DispatchArg<T, R> {
   subscriber: ExpandSubscriber<T, R>;
-  result: Observable<R>;
+  result: ObservableInput<R>;
   value: any;
   index: number;
 }
@@ -98,7 +98,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   private buffer: any[];
 
   constructor(destination: Subscriber<R>,
-              private project: (value: T, index: number) => Observable<R>,
+              private project: (value: T, index: number) => ObservableInput<R>,
               private concurrent: number,
               private scheduler: IScheduler) {
     super(destination);

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -1,8 +1,11 @@
 
-import { ObservableInput } from '../Observable';
+import { ObservableInput, Observable } from '../Observable';
 import { mergeMap } from './mergeMap';
 import { identity } from '..//util/identity';
-import { MonoTypeOperatorFunction } from '../../internal/types';
+import { OperatorFunction } from '../../internal/types';
+
+export function mergeAll<T>(concurrent?: number): OperatorFunction<ObservableInput<T>, T>;
+export function mergeAll<R>(concurrent?: number): OperatorFunction<any, R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable which
@@ -48,6 +51,6 @@ import { MonoTypeOperatorFunction } from '../../internal/types';
  * @method mergeAll
  * @owner Observable
  */
-export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): MonoTypeOperatorFunction<T> {
+export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<any, T> {
   return mergeMap(identity as (value: T, index: number) => ObservableInput<{}>, null, concurrent);
 }

--- a/src/internal/operators/switchAll.ts
+++ b/src/internal/operators/switchAll.ts
@@ -1,8 +1,11 @@
 import { OperatorFunction } from '../../internal/types';
-import { Observable } from '../Observable';
+import { ObservableInput } from '../Observable';
 import { switchMap } from './switchMap';
 import { identity } from '..//util/identity';
 
-export function switchAll<T>(): OperatorFunction<Observable<T>, T> {
+export function switchAll<T>(): OperatorFunction<ObservableInput<T>, T>;
+export function switchAll<R>(): OperatorFunction<any, R>;
+
+export function switchAll<T>(): OperatorFunction<ObservableInput<T>, T> {
   return switchMap(identity);
 }

--- a/src/internal/operators/zipAll.ts
+++ b/src/internal/operators/zipAll.ts
@@ -1,6 +1,11 @@
 import { ZipOperator } from '../observable/zip';
-import { Observable } from '../Observable';
+import { Observable, ObservableInput } from '../Observable';
 import { OperatorFunction } from '../../internal/types';
+
+export function zipAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
+export function zipAll<T>(): OperatorFunction<any, T[]>;
+export function zipAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
+export function zipAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 
 export function zipAll<T, R>(project?: (...values: Array<any>) => R): OperatorFunction<T, R> {
   return (source: Observable<T>) => source.lift(new ZipOperator(project));

--- a/src/internal/patching/operator/combineAll.ts
+++ b/src/internal/patching/operator/combineAll.ts
@@ -1,6 +1,12 @@
 
-import { Observable } from '../../Observable';
+import { Observable, ObservableInput } from '../../Observable';
 import { combineAll as higherOrder } from '../../operators/combineAll';
+
+export function combineAll<T>(this: Observable<ObservableInput<T>>): Observable<T[]>;
+export function combineAll<T, R>(this: Observable<T>): Observable<R[]>;
+export function combineAll<T, R>(this: Observable<ObservableInput<T>>, project: (...values: T[]) => R): Observable<R>;
+export function combineAll<T, R>(this: Observable<T>, project: (...values: T[]) => R): Observable<R>;
+export function combineAll<R>(this: Observable<any>, project: (...values: any[]) => R): Observable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable by waiting
@@ -42,6 +48,6 @@ import { combineAll as higherOrder } from '../../operators/combineAll';
  * @method combineAll
  * @owner Observable
  */
-export function combineAll<T, R>(this: Observable<T>, project?: (...values: Array<any>) => R): Observable<R> {
+export function combineAll<T, R>(this: Observable<ObservableInput<T>>, project?: (...values: Array<T>) => R): Observable<R> {
   return higherOrder(project)(this);
 }

--- a/src/internal/patching/operator/concatAll.ts
+++ b/src/internal/patching/operator/concatAll.ts
@@ -1,11 +1,8 @@
-import { Observable } from '../../Observable';
-import { Subscribable } from '../../Observable';
+import { Observable, ObservableInput } from '../../Observable';
 import { concatAll as higherOrder } from '../../operators/concatAll';
 
-/* tslint:disable:max-line-length */
-export function concatAll<T>(this: Observable<T>): T;
-export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
-/* tslint:enable:max-line-length */
+export function concatAll<T>(this: Observable<ObservableInput<T>>): Observable<T>;
+export function concatAll<T, R>(this: Observable<T>): Observable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable by
@@ -55,6 +52,6 @@ export function concatAll<T, R>(this: Observable<T>): Subscribable<R>;
  * @method concatAll
  * @owner Observable
  */
-export function concatAll<T>(this: Observable<T>): T {
-  return <any>higherOrder()(this);
+export function concatAll<T>(this: Observable<ObservableInput<T>>): Observable<T> {
+  return <any>higherOrder<T>()(this);
 }

--- a/src/internal/patching/operator/exhaust.ts
+++ b/src/internal/patching/operator/exhaust.ts
@@ -1,6 +1,9 @@
 
-import { Observable } from '../../Observable';
+import { Observable, ObservableInput } from '../../Observable';
 import { exhaust as higherOrder } from '../../operators/exhaust';
+
+export function exhaust<T>(this: Observable<ObservableInput<T>>): Observable<T>;
+export function exhaust<T, R>(this: Observable<T>): Observable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable by dropping
@@ -37,6 +40,6 @@ import { exhaust as higherOrder } from '../../operators/exhaust';
  * @method exhaust
  * @owner Observable
  */
-export function exhaust<T>(this: Observable<T>): Observable<T> {
-  return higherOrder()(this) as Observable<T>;
+export function exhaust<T>(this: Observable<ObservableInput<T>>): Observable<T> {
+  return higherOrder<T>()(this);
 }

--- a/src/internal/patching/operator/expand.ts
+++ b/src/internal/patching/operator/expand.ts
@@ -1,10 +1,10 @@
-import { Observable } from '../../Observable';
+import { Observable, ObservableInput } from '../../Observable';
 import { IScheduler } from '../../Scheduler';
 import { expand as higherOrder } from '../../operators/expand';
 
 /* tslint:disable:max-line-length */
-export function expand<T>(this: Observable<T>, project: (value: T, index: number) => Observable<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
-export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => Observable<R>, concurrent?: number, scheduler?: IScheduler): Observable<R>;
+export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: IScheduler): Observable<R>;
+export function expand<T>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -52,7 +52,7 @@ export function expand<T, R>(this: Observable<T>, project: (value: T, index: num
  * @method expand
  * @owner Observable
  */
-export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => Observable<R>,
+export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,
                              scheduler: IScheduler = undefined): Observable<R> {
   concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;

--- a/src/internal/patching/operator/mergeAll.ts
+++ b/src/internal/patching/operator/mergeAll.ts
@@ -1,9 +1,8 @@
-import { Observable } from '../../Observable';
-import { Subscribable } from '../../Observable';
+import { Observable, ObservableInput } from '../../Observable';
 import { mergeAll as higherOrder } from '../../operators/mergeAll';
 
-export function mergeAll<T>(this: Observable<T>, concurrent?: number): T;
-export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscribable<R>;
+export function mergeAll<T>(this: Observable<ObservableInput<T>>, concurrent?: number): Observable<T>;
+export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Observable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable which
@@ -49,6 +48,6 @@ export function mergeAll<T, R>(this: Observable<T>, concurrent?: number): Subscr
  * @method mergeAll
  * @owner Observable
  */
-export function mergeAll<T>(this: Observable<T>, concurrent: number = Number.POSITIVE_INFINITY): Observable<T> {
-  return higherOrder(concurrent)(this) as Observable<T>;
+export function mergeAll<T>(this: Observable<ObservableInput<T>>, concurrent: number = Number.POSITIVE_INFINITY): Observable<T> {
+  return higherOrder<T>(concurrent)(this);
 }

--- a/src/internal/patching/operator/switch.ts
+++ b/src/internal/patching/operator/switch.ts
@@ -1,5 +1,8 @@
-import { Observable } from '../../Observable';
+import { Observable, ObservableInput } from '../../Observable';
 import { switchAll as higherOrder } from '../../operators/switchAll';
+
+export function _switch<T>(this: Observable<ObservableInput<T>>): Observable<T>;
+export function _switch<T, R>(this: Observable<T>): Observable<R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable by
@@ -43,6 +46,6 @@ import { switchAll as higherOrder } from '../../operators/switchAll';
  * @name switch
  * @owner Observable
  */
-export function _switch<T>(this: Observable<Observable<T>>): Observable<T> {
+export function _switch<T>(this: Observable<ObservableInput<T>>): Observable<T> {
   return higherOrder()(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/zipAll.ts
+++ b/src/internal/patching/operator/zipAll.ts
@@ -1,12 +1,17 @@
-import { Observable } from '../../Observable';
+import { Observable, ObservableInput } from '../../Observable';
 import { zipAll as higherOrder } from '../../operators/zipAll';
 
+export function zipAll<T>(this: Observable<ObservableInput<T>>): Observable<T[]>;
+export function zipAll<T, R>(this: Observable<T>): Observable<R[]>;
+export function zipAll<T, R>(this: Observable<ObservableInput<T>>, project: (...values: T[]) => R): Observable<R>;
+export function zipAll<T, R>(this: Observable<T>, project: (...values: T[]) => R): Observable<R>;
+export function zipAll<R>(this: Observable<any>, project: (...values: any[]) => R): Observable<R>;
 /**
  * @param project
  * @return {Observable<R>|WebSocketSubject<T>|Observable<T>}
  * @method zipAll
  * @owner Observable
  */
-export function zipAll<T, R>(this: Observable<T>, project?: (...values: Array<any>) => R): Observable<R> {
-  return higherOrder(project)(this);
+export function zipAll<T, R>(this: Observable<ObservableInput<T>>, project?: (...values: Array<any>) => R): Observable<R> {
+  return higherOrder<T, R>(project)(this);
 }


### PR DESCRIPTION
**Description:**

This adds support for nested observables using some of the newest features of the TypeScript
compiler.  Things like like the following that were impossible before will now work correctly!
```
const source1 = Rx.Observable.of(1, 2, 3);
const source2 = [1, 2, 3];
const source3 = new Promise<number>(d => d(1));

let result: Rx.Observable<number[]> = Rx.Observable
      .of(source1, source2, source3)
      .zipAll();

// or

let result: Rx.Observable<number[]> = Rx.Observable
  .of(source1, source2, source3)
  .pipe(Rx.operators.zipAll());
```

Also updated tests in related areas.