### PR TITLE
Update MIGRATION.md

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -64,7 +64,7 @@ enabling "composite" subscription behavior.
 |`concatMapObserver`|No longer implemented|
 |`controlled`|No longer implemented|
 |`delaySubscription`|No longer implemented|
-|`do`|`do`|
+|`do`|Use `tap`|
 |`doAction`|`do`|
 |`doOnCompleted`|`do(null, null, fn)`|
 |`doOnError`|`do(null, fn)`|
@@ -122,7 +122,7 @@ enabling "composite" subscription behavior.
 |`tapOnCompleted(fn)`|`do(null, null, fn)`|
 |`tapOnError(fn)`|`do(null, fn)`|
 |`tapOnNext(fn)`|`do(fn)`|
-|`tap`|`do`|
+|`tap`|`tap`|
 |`timestamp`|`map(v => ({ value: v, timestamp: Date.now() }))`|
 |`toMap(keySelector)`|`reduce((map, v, i) => map.set(keySelector(v, i), v), new Map())`|
 |`toMap(keySelector, elmentSelector)`|`reduce((map, v, i) => map.set(keySelector(v, i), elementSelector(v)), new Map())`|


### PR DESCRIPTION
`do` is `tap` nowadays

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
