### PR TITLE
feat(observable): observable can be augmented with a then method and therefore awaitable

### DIFF
--- a/spec/extensions/awaitable-spec.ts
+++ b/spec/extensions/awaitable-spec.ts
@@ -1,0 +1,21 @@
+import { expect } from 'chai';
+import { Observable } from '../../src/awaitable';
+
+declare const __root__: any;
+
+/** @test {awaitable} */
+describe('Observable.prototype.toPromise', () => {
+  it('should convert an Observable to a promise of its last value', async () => {
+    const x = await Observable.of(1, 2, 3);
+    expect(x).to.equal(3);
+  });
+
+  it('should handle errors properly', async () => {
+    try {
+      return await Observable.throwError('bad');
+    } catch (err) {
+      expect(err).to.equal('bad');
+      return err;
+    }
+  });
+});

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -1,8 +1,7 @@
 import { expect } from 'chai';
-import * as Rx from '../../src/Rx';
+import { Observable } from '../../src/internal/Observable';
 
 declare const __root__: any;
-const Observable = Rx.Observable;
 
 /** @test {toPromise} */
 describe('Observable.prototype.toPromise', () => {

--- a/src/awaitable.ts
+++ b/src/awaitable.ts
@@ -1,0 +1,2 @@
+export * from './index';
+import './extensions/awaitable';

--- a/src/extensions/awaitable.ts
+++ b/src/extensions/awaitable.ts
@@ -1,0 +1,9 @@
+import { Observable } from '../internal/Observable';
+
+Observable.prototype.then = function(this: Observable<any>, resolve, reject) {
+    return this.toPromise().then(resolve, reject);
+};
+
+declare module '../internal/Observable' {
+  interface Observable<T> extends PromiseLike<T> {}
+}

--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -6,6 +6,7 @@
   "files": [
     "../dist/src/Rx.ts",
     "../dist/src/add/observable/of.ts",
+    "../dist/src/awaitable.ts",
     "../dist/src/index.ts",
     "../dist/src/operators/index.ts",
     "../dist/src/ajax/index.ts",


### PR DESCRIPTION
**Description:**
Add a new import targets `rxjs/awaitable` as well as `rxjs/extensions/awaitable` that will augment
the observable prototype with a then method, and also make `Observable<T>` extend `PromiseLike<T>`.

I realize we closed #556 but this keeps getting stuck in my head, imo if someone wants to shoot themselves in the foot let them.  Right now, as designed, this would be an optional import that has to be made on the consumer side.

As far as naming 🚲🏘 away.

**Related issue (if exists):**
#556