### PR TITLE
Allow no upper limit on the number of functions passed to a pipe

### DIFF
--- a/spec/util/pipe-spec.ts
+++ b/spec/util/pipe-spec.ts
@@ -16,6 +16,16 @@ describe('pipe', () => {
     expect(c(10)).to.equal(19);
   });
 
+  it('should pipe allow more than 10 functions together', () => {
+    const a = (x: number) => x + x;
+    const b = (x: number) => x - 1;
+
+    const c = pipe(a, b, b, b, b, b, b, b, b, b, b);
+    expect(c).to.be.a('function');
+    expect(c(1)).to.equal(-8);
+    expect(c(10)).to.equal(10);
+  });
+
   it('should return the same function if only one is passed', () => {
     const a = <T>(x: T) => x;
     const c = pipe(a);

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -1,19 +1,6 @@
 import { noop } from './noop';
 import { UnaryFunction } from '../types';
 
-/* tslint:disable:max-line-length */
-export function pipe<T>(): UnaryFunction<T, T>;
-export function pipe<T, A>(op1: UnaryFunction<T, A>): UnaryFunction<T, A>;
-export function pipe<T, A, B>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>): UnaryFunction<T, B>;
-export function pipe<T, A, B, C>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>, op3: UnaryFunction<B, C>): UnaryFunction<T, C>;
-export function pipe<T, A, B, C, D>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>, op3: UnaryFunction<B, C>, op4: UnaryFunction<C, D>): UnaryFunction<T, D>;
-export function pipe<T, A, B, C, D, E>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>, op3: UnaryFunction<B, C>, op4: UnaryFunction<C, D>, op5: UnaryFunction<D, E>): UnaryFunction<T, E>;
-export function pipe<T, A, B, C, D, E, F>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>, op3: UnaryFunction<B, C>, op4: UnaryFunction<C, D>, op5: UnaryFunction<D, E>, op6: UnaryFunction<E, F>): UnaryFunction<T, F>;
-export function pipe<T, A, B, C, D, E, F, G>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>, op3: UnaryFunction<B, C>, op4: UnaryFunction<C, D>, op5: UnaryFunction<D, E>, op6: UnaryFunction<E, F>, op7: UnaryFunction<F, G>): UnaryFunction<T, G>;
-export function pipe<T, A, B, C, D, E, F, G, H>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>, op3: UnaryFunction<B, C>, op4: UnaryFunction<C, D>, op5: UnaryFunction<D, E>, op6: UnaryFunction<E, F>, op7: UnaryFunction<F, G>, op8: UnaryFunction<G, H>): UnaryFunction<T, H>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(op1: UnaryFunction<T, A>, op2: UnaryFunction<A, B>, op3: UnaryFunction<B, C>, op4: UnaryFunction<C, D>, op5: UnaryFunction<D, E>, op6: UnaryFunction<E, F>, op7: UnaryFunction<F, G>, op8: UnaryFunction<G, H>, op9: UnaryFunction<H, I>): UnaryFunction<T, I>;
-/* tslint:enable:max-line-length */
-
 export function pipe<T, R>(...fns: Array<UnaryFunction<T, R>>): UnaryFunction<T, R> {
   return pipeFromArray(fns);
 }


### PR DESCRIPTION
**Description:**

Currently, a pipe could only have 0-10 functions arguments.
It is not clear to me why this arbitrary number (maybe some kind of 'safety' for the user?)

This patch dissables this limitation.

