### PR TITLE
fix(fromEvent): pass options in unsubscribe

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -132,16 +132,17 @@ describe('fromEvent', () => {
     });
   });
 
-  it('should pass through options to addEventListener', () => {
-    let actualOptions;
+  it('should pass through options to addEventListener and removeEventListener', () => {
+    let onOptions;
+    let offOptions;
     const expectedOptions = { capture: true, passive: true };
 
     const obj = {
       addEventListener: (a: string, b: EventListenerOrEventListenerObject, c?: any) => {
-        actualOptions = c;
+        onOptions = c;
       },
       removeEventListener: (a: string, b: EventListenerOrEventListenerObject, c?: any) => {
-        //noop
+        offOptions = c;
       }
     };
 
@@ -152,7 +153,8 @@ describe('fromEvent', () => {
 
     subscription.unsubscribe();
 
-    expect(actualOptions).to.equal(expectedOptions);
+    expect(onOptions).to.equal(expectedOptions);
+    expect(offOptions).to.equal(expectedOptions);
   });
 
   it('should pass through events that occur', (done: MochaDone) => {

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -166,7 +166,7 @@ function setupSubscription<T>(sourceObj: EventTargetLike, eventName: string,
   } else if (isEventTarget(sourceObj)) {
     const source = sourceObj;
     sourceObj.addEventListener(eventName, handler as EventListener, options);
-    unsubscribe = () => source.removeEventListener(eventName, handler as EventListener);
+    unsubscribe = () => source.removeEventListener(eventName, handler as EventListener, options);
   } else if (isJQueryStyleEventEmitter(sourceObj)) {
     const source = sourceObj;
     sourceObj.on(eventName, handler);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes the problem reported in #3349. In Chrome, at least, if options are passed in the call to `addEventListener`, but not in the call to `removeEventListener`, the listener is not removed.

The PR adds an expectation to an existing test and passes the options in the call to `removeEventListener`, too.

**Related issue (if exists):** #3349
