### PR TITLE
fix(ESM): Add operators/package.json for ESM support, fixes #3227

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -40,7 +40,9 @@ fs.removeSync(PKG_ROOT);
 let rootPackageJson = Object.assign({}, pkg, {
   name: 'rxjs',
   main: './index.js',
-  typings: './index.d.ts'
+  typings: './index.d.ts',
+  module: './_esm5/index.js',
+  es2015: './_esm2015/index.js'
 });
 
 // Get a list of the file names. Sort in reverse order so re-export files
@@ -102,6 +104,10 @@ copySources(ESM2015_ROOT, ESM2015_PKG, true);
 fs.copySync('./tsconfig.json', PKG_ROOT + 'src/tsconfig.json');
 
 fs.writeJsonSync(PKG_ROOT + 'package.json', rootPackageJson);
+fs.copySync('src/operators/package.json', PKG_ROOT + '/operators/package.json');
+fs.copySync('src/ajax/package.json', PKG_ROOT + '/ajax/package.json');
+fs.copySync('src/websocket/package.json', PKG_ROOT + '/websocket/package.json');
+fs.copySync('src/testing/package.json', PKG_ROOT + '/testing/package.json');
 
 if (fs.existsSync(UMD_ROOT)) {
   fs.copySync(UMD_ROOT, UMD_PKG);

--- a/src/ajax/package.json
+++ b/src/ajax/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "rxjs/ajax",
+  "typings": "./index.d.ts",
+  "main": "./index.js",
+  "module": "../_esm5/ajax/index.js",
+  "es2015": "../_esm2015/ajax/index.js"
+}

--- a/src/operators/package.json
+++ b/src/operators/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "rxjs/operators",
+  "typings": "./index.d.ts",
+  "main": "./index.js",
+  "module": "../_esm5/operators/index.js",
+  "es2015": "../_esm2015/operators/index.js"
+}

--- a/src/testing/package.json
+++ b/src/testing/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "rxjs/testing",
+  "typings": "./index.d.ts",
+  "main": "./index.js",
+  "module": "../_esm5/testing/index.js",
+  "es2015": "../_esm2015/testing/index.js"
+}

--- a/src/websocket/package.json
+++ b/src/websocket/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "rxjs/websocket",
+  "typings": "./index.d.ts",
+  "main": "./index.js",
+  "module": "../_esm5/websocket/index.js",
+  "es2015": "../_esm2015/websocket/index.js"
+}


### PR DESCRIPTION
See #3227

I didn't do anything for `@reactivex/rxjs` package because I'm hopeful for its elimination (#2916) and I'm not entirely sure how it works lol.