### PR TITLE
fix(rxjs): once again exports custom error types

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -33,6 +33,13 @@ describe('index', () => {
     expect(index.identity).to.exist;
   });
 
+  it('should export error types', () => {
+    expect(index.ArgumentOutOfRangeError).to.exist;
+    expect(index.EmptyError).to.exist;
+    expect(index.ObjectUnsubscribedError).to.exist;
+    expect(index.UnsubscriptionError).to.exist;
+  });
+
   it('should export constants', () => {
     expect(index.EMPTY).to.exist;
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,6 +23,12 @@ export { pipe } from './internal/util/pipe';
 export { noop } from './internal/util/noop';
 export { identity } from './internal/util/identity';
 
+/* Error types */
+export { ArgumentOutOfRangeError } from './internal/util/ArgumentOutOfRangeError';
+export { EmptyError } from './internal/util/EmptyError';
+export { ObjectUnsubscribedError } from './internal/util/ObjectUnsubscribedError';
+export { UnsubscriptionError } from './internal/util/UnsubscriptionError';
+
 /* Static observable creation exports */
 export { bindCallback } from './internal/observable/bindCallback';
 export { bindNodeCallback } from './internal/observable/bindNodeCallback';


### PR DESCRIPTION
Realized we weren't exporting custom error types so people couldn't do `instanceof` checks.