### PR TITLE
test(forkJoin): Add forkJoin diagram, fix tests2png

### DIFF
--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
     "test": "cross-env TS_NODE_FAST=true mocha --compilers ts:ts-node/register --opts spec/support/coverage.opts \"spec/**/*-spec.ts\"",
     "test:cover": "cross-env TS_NODE_FAST=true nyc npm test",
     "test:circular": "dependency-cruise --validate .dependency-cruiser.json -x \"^node_modules\" src",
-    "tests2png": "tsc && mkdirp tmp/docs/img && mkdirp spec-js/support && shx cp spec/support/*.opts spec-js/support/ && mocha --opts spec/support/tests2png.opts spec-js",
+    "tests2png": "mkdirp tmp/docs/img && cross-env TS_NODE_FAST=true mocha --compilers ts:ts-node/register --opts spec/support/tests2png.opts \"spec/**/*-spec.ts\"",
     "watch": "watch \"echo triggering build && npm run test && echo build completed\" src -d -u -w=15"
   },
   "repository": {

--- a/spec/helpers/tests2png/types.ts
+++ b/spec/helpers/tests2png/types.ts
@@ -1,0 +1,44 @@
+import { TestMessage } from '../../../src/internal/testing/TestMessage';
+import { ColdObservable } from '../../../src/internal/testing/ColdObservable';
+
+export interface TestStream {
+  messages: TestMessage[];
+  cold?: ColdObservable<any>;
+  subscription?: {
+    start: number;
+    end: string | number;
+  };
+  isGhost?: boolean;
+}
+
+export type MarbleContent = string[] | boolean | string | object;
+
+export interface GMObject {
+  size: (cb: Function) => GMObject;
+  format: (cb: Function) => GMObject;
+  depth: (cb: Function) => GMObject;
+  color: (cb: Function) => GMObject;
+  res: (cb: Function) => GMObject;
+  filesize: (cb: Function) => GMObject;
+  identify: (cb: Function) => GMObject;
+  orientation: (cb: Function) => GMObject;
+
+  draw: Function;
+  drawArc: Function;
+  drawBezier: Function;
+  drawCircle: Function;
+  drawEllipse: Function;
+  drawLine: Function;
+  drawPoint: Function;
+  drawPolygon: Function;
+  drawPolyline: Function;
+  drawRectangle: Function;
+  drawText: Function;
+  fill: Function;
+  font: Function;
+  fontSize: Function;
+  stroke: Function;
+  strokeWidth: Function;
+  setDraw: Function;
+  write: Function;
+}

--- a/spec/operators/forkJoin-spec.ts
+++ b/spec/operators/forkJoin-spec.ts
@@ -1,0 +1,46 @@
+import * as Rx from '../../src/Rx';
+import { expect } from 'chai';
+import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { forkJoin } from '../../src/internal/observable/forkJoin';
+
+declare function asDiagram(arg: string): Function;
+
+const Observable = Rx.Observable;
+
+/** @test {forkJoin} */
+describe('Observable.prototype.forkJoin', () => {
+  asDiagram('forkJoin')('should emit the last emitted value from each observable', () => {
+    const e1 =   hot('-a--b-----c-d-e-|');
+    const e2 =   cold('--1--2-3-4---|   ');
+    const e3 =   hot('--------f--g-h-i--j-|');
+    const expected = '--------------------(z|)';
+    const expectedValue = {
+      z: ['e', '4', 'j']
+    };
+    const result = forkJoin(e1, e2, e3);
+    expectObservable(result).toBe(expected, expectedValue);
+  });
+
+  it('should work with two nevers', () => {
+    const e1 = cold( '-');
+    const e1subs =   '^';
+    const e2 = cold( '-');
+    const e2subs =   '^';
+    const expected = '-';
+
+    const result = forkJoin(e1, e2);
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+  });
+
+  it('should work with never and empty', () => {
+    const e1 = cold( '-');
+    const e2 = cold( '|');
+    const expected = '|';
+
+    const result = forkJoin(e1, e2);
+    expectObservable(result).toBe(expected);
+  });
+
+});

--- a/spec/support/tests2png.opts
+++ b/spec/support/tests2png.opts
@@ -1,7 +1,7 @@
 --require source-map-support/register
---require spec-js/helpers/tests2png/diagram-test-runner.js
---require spec-js/helpers/testScheduler-ui.js
---ui spec-js/helpers/testScheduler-ui.js
+--require spec/helpers/tests2png/diagram-test-runner.ts
+--require spec/helpers/testScheduler-ui.ts
+--ui spec/helpers/testScheduler-ui.ts
 
 --reporter dot
 

--- a/src/internal/testing/TestMessage.ts
+++ b/src/internal/testing/TestMessage.ts
@@ -3,4 +3,5 @@ import { Notification } from '../Notification';
 export interface TestMessage {
   frame: number;
   notification: Notification<any>;
+  isGhost?: boolean;
 }

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -19,8 +19,8 @@ export type observableToBeFn = (marbles: string, values?: any, errorValue?: any)
 export type subscriptionLogsToBeFn = (marbles: string | string[]) => void;
 
 export class TestScheduler extends VirtualTimeScheduler {
-  private hotObservables: HotObservable<any>[] = [];
-  private coldObservables: ColdObservable<any>[] = [];
+  public readonly hotObservables: HotObservable<any>[] = [];
+  public readonly coldObservables: ColdObservable<any>[] = [];
   private flushTests: FlushableTest[] = [];
 
   constructor(public assertDeepEqual: (actual: any, expected: any) => boolean | void) {


### PR DESCRIPTION
forkJoin diagram is missing, to add this I added Tests and fixed some issues with tests2png to make
it work again

tests2png uses ts now instead of creating a new dist copy

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
`tests2png` wasn't working and there we're some files migrated to `*.ts` (`testScheduler-ui.ts`), so I migrated `diagram-test-runner.js` and `painter.js` to typescript and ran tests2png using the same way `npm run test` works. 

**Related issue (if exists):**
Fixes #3352 