### PR TITLE
fix(rxjs): add exports for symbols/interfaces that were missing

### DIFF
--- a/spec/ajax/index-spec.ts
+++ b/spec/ajax/index-spec.ts
@@ -5,4 +5,12 @@ describe('index', () => {
   it('should export static ajax observable creator functions', () => {
     expect(index.ajax).to.exist;
   });
+
+  it('should export Ajax data classes', () => {
+    expect(index.AjaxResponse).to.exist;
+    expect(index.AjaxError).to.exist;
+    expect(index.AjaxTimeoutError).to.exist;
+    // Interfaces can be checked by creating a variable of that type
+    let ajaxRequest: index.AjaxRequest;
+  });
 });

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -4,12 +4,16 @@ import { expect } from 'chai';
 describe('index', () => {
   it('should export Observable', () => {
     expect(index.Observable).to.exist;
+    expect(index.ConnectableObservable).to.exist;
+    // Interfaces can be checked by creating a variable of that type
+    let operator: index.Operator<any, any>;
   });
 
   it('should export the Subject types', () => {
     expect(index.Subject).to.exist;
     expect(index.BehaviorSubject).to.exist;
     expect(index.ReplaySubject).to.exist;
+    expect(index.AsyncSubject).to.exist;
   });
 
   it('should export the schedulers', () => {
@@ -17,10 +21,13 @@ describe('index', () => {
     expect(index.asyncScheduler).to.exist;
     expect(index.queueScheduler).to.exist;
     expect(index.animationFrameScheduler).to.exist;
+    expect(index.VirtualTimeScheduler).to.exist;
+    expect(index.VirtualAction).to.exist;
   });
 
   it('should export Subscription', () => {
     expect(index.Subscription).to.exist;
+    expect(index.Subscriber).to.exist;
   });
 
   it('should export Notification', () => {
@@ -38,6 +45,7 @@ describe('index', () => {
     expect(index.EmptyError).to.exist;
     expect(index.ObjectUnsubscribedError).to.exist;
     expect(index.UnsubscriptionError).to.exist;
+    expect(index.TimeoutError).to.exist;
   });
 
   it('should export constants', () => {

--- a/src/ajax/index.ts
+++ b/src/ajax/index.ts
@@ -1,1 +1,2 @@
 export { ajax } from '../internal/observable/dom/ajax';
+export { AjaxRequest, AjaxResponse, AjaxError, AjaxTimeoutError } from '../internal/observable/dom/AjaxObservable';

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,19 +1,24 @@
 /* Observable */
 export { Observable } from './internal/Observable';
+export { ConnectableObservable } from './internal/observable/ConnectableObservable';
+export { Operator } from './internal/Operator';
 
 /* Subjects */
 export { Subject } from './internal/Subject';
 export { BehaviorSubject } from './internal/BehaviorSubject';
 export { ReplaySubject } from './internal/ReplaySubject';
+export { AsyncSubject } from './internal/AsyncSubject';
 
 /* Schedulers */
 export { asap as asapScheduler } from './internal/scheduler/asap';
 export { async as asyncScheduler } from './internal/scheduler/async';
 export { queue as queueScheduler } from './internal/scheduler/queue';
 export { animationFrame as animationFrameScheduler } from './internal/scheduler/animationFrame';
+export { VirtualTimeScheduler, VirtualAction } from './internal/scheduler/VirtualTimeScheduler';
 
 /* Subscription */
 export { Subscription } from './internal/Subscription';
+export { Subscriber } from './internal/Subscriber';
 
 /* Notification */
 export { Notification } from './internal/Notification';
@@ -28,6 +33,7 @@ export { ArgumentOutOfRangeError } from './internal/util/ArgumentOutOfRangeError
 export { EmptyError } from './internal/util/EmptyError';
 export { ObjectUnsubscribedError } from './internal/util/ObjectUnsubscribedError';
 export { UnsubscriptionError } from './internal/util/UnsubscriptionError';
+export { TimeoutError } from './internal/util/TimeoutError';
 
 /* Static observable creation exports */
 export { bindCallback } from './internal/observable/bindCallback';

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -3,13 +3,13 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { IScheduler } from '../Scheduler';
 import { async } from '../scheduler/async';
-import { OperatorFunction } from '../types';
+import { OperatorFunction, TimeInterval as TimeIntervalInterface } from '../types';
 
 export function timeInterval<T>(scheduler: IScheduler = async): OperatorFunction<T, TimeInterval<T>> {
   return (source: Observable<T>) => source.lift(new TimeIntervalOperator(scheduler));
 }
 
-export class TimeInterval<T> {
+export class TimeInterval<T> implements TimeIntervalInterface<T> {
   constructor(public value: T, public interval: number) {
 
   }

--- a/src/internal/operators/timestamp.ts
+++ b/src/internal/operators/timestamp.ts
@@ -1,7 +1,7 @@
 
 import { IScheduler } from '../Scheduler';
 import { async } from '../scheduler/async';
-import { OperatorFunction } from '../types';
+import { OperatorFunction, Timestamp as TimestampInterface } from '../types';
 import { map } from './map';
 
 /**
@@ -15,7 +15,7 @@ export function timestamp<T>(scheduler: IScheduler = async): OperatorFunction<T,
   // return (source: Observable<T>) => source.lift(new TimestampOperator(scheduler));
 }
 
-export class Timestamp<T> {
+export class Timestamp<T> implements TimestampInterface<T> {
   constructor(public value: T, public timestamp: number) {
   }
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -11,6 +11,16 @@ export type FactoryOrValue<T> = T | (() => T);
 
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}
 
+export interface Timestamp<T> {
+  value: T;
+  timestamp: number;
+}
+
+export interface TimeInterval<T> {
+  value: T;
+  interval: number;
+}
+
 /** SUBSCRIPTION INTERFACES */
 
 export interface Unsubscribable {


### PR DESCRIPTION
Includes:

`rxjs`:

Operator
Subscriber
AsyncSubject
ConnectableObservable
TimeoutError
VirtualTimeScheduler

`rxjs/ajax`:

AjaxRequest
AjaxResponse
AjaxError
AjaxTimeoutError

`rxjs/operators`:

Timestamp (made an interface)
TimeInterval (made an interface)