### PR TITLE
Export froms

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -53,6 +53,7 @@ describe('index', () => {
     expect(index.empty).to.exist;
     expect(index.forkJoin).to.exist;
     expect(index.from).to.exist;
+    expect(index.fromArray).to.exist;
     expect(index.fromEvent).to.exist;
     expect(index.fromEventPattern).to.exist;
     expect(index.fromPromise).to.exist;

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -57,6 +57,7 @@ describe('index', () => {
     expect(index.fromEvent).to.exist;
     expect(index.fromEventPattern).to.exist;
     expect(index.fromIterable).to.exist;
+    expect(index.fromObservable).to.exist;
     expect(index.fromPromise).to.exist;
     expect(index.generate).to.exist;
     expect(index.iif).to.exist;

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -56,6 +56,7 @@ describe('index', () => {
     expect(index.fromArray).to.exist;
     expect(index.fromEvent).to.exist;
     expect(index.fromEventPattern).to.exist;
+    expect(index.fromIterable).to.exist;
     expect(index.fromPromise).to.exist;
     expect(index.generate).to.exist;
     expect(index.iif).to.exist;

--- a/src/index.ts
+++ b/src/index.ts
@@ -41,6 +41,7 @@ export { from } from './internal/observable/from';
 export { fromArray } from './internal/observable/fromArray';
 export { fromEvent } from './internal/observable/fromEvent';
 export { fromEventPattern } from './internal/observable/fromEventPattern';
+export { fromIterable } from './internal/observable/fromIterable';
 export { fromPromise } from './internal/observable/fromPromise';
 export { generate } from './internal/observable/generate';
 export { iif } from './internal/observable/iif';

--- a/src/index.ts
+++ b/src/index.ts
@@ -38,6 +38,7 @@ export { defer } from './internal/observable/defer';
 export { empty } from './internal/observable/empty';
 export { forkJoin } from './internal/observable/forkJoin';
 export { from } from './internal/observable/from';
+export { fromArray } from './internal/observable/fromArray';
 export { fromEvent } from './internal/observable/fromEvent';
 export { fromEventPattern } from './internal/observable/fromEventPattern';
 export { fromPromise } from './internal/observable/fromPromise';

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,6 +42,7 @@ export { fromArray } from './internal/observable/fromArray';
 export { fromEvent } from './internal/observable/fromEvent';
 export { fromEventPattern } from './internal/observable/fromEventPattern';
 export { fromIterable } from './internal/observable/fromIterable';
+export { fromObservable } from './internal/observable/fromObservable';
 export { fromPromise } from './internal/observable/fromPromise';
 export { generate } from './internal/observable/generate';
 export { iif } from './internal/observable/iif';


### PR DESCRIPTION
In this spirit of #3374, if we're exporting `fromPromise`, we should export these as well.


HOWEVER: I still find the "smallness" of fromPromise to be dubious, as things like `defer`, `switchMap`, `concatMap`, `mergeMap`, `exhaustMap`, `forkJoin`, etc, all pull in the majority of `from`'s logic.

cc @IgorMinar @jasonaden @kwonoj 

... this is, of course, at the _expense_ of more API surface area.