### PR TITLE
fix(rxjs): remove types.ts importing from itself.

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,4 @@
 import { Observable } from './Observable';
-import { PartialObserver } from './types';
 
 /** OPERATOR INTERFACES */
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
[`PartialObserver` is defined in `types.ts`](https://github.com/ReactiveX/rxjs/blob/1e4ca05ab247eedc3d7db233874e650439f09fbd/src/internal/types.ts#L69) . Importing it again causes a build error in google3.

**Related issue (if exists):**
