### PR TITLE
chore(rxjs): add new rexport file that will be used to build the UMD …

### DIFF
--- a/spec/internal/rxjs-spec.ts
+++ b/spec/internal/rxjs-spec.ts
@@ -1,0 +1,39 @@
+import { expect } from 'chai';
+import * as umd from '../../src/internal/umd';
+import * as rx_index from '../../src';
+import * as rx_operators from '../../src/operators';
+import * as rx_testing from '../../src/testing';
+import * as rx_ajax from '../../src/ajax';
+import * as rx_websocket from '../../src/websocket';
+
+describe('rxjs exports', () => {
+  Object.keys(rx_index).forEach(key => {
+    it(`should export rxjs.${key}`, () => {
+      expect(umd[key]).to.equal(rx_index[key]);
+    });
+  });
+
+  Object.keys(rx_operators).forEach(key => {
+    it(`should export rxjs.operators.${key}`, () => {
+      expect(umd.operators[key]).to.equal(rx_operators[key]);
+    });
+  });
+
+  Object.keys(rx_testing).forEach(key => {
+    it(`should export rxjs.testing.${key}`, () => {
+      expect(umd.testing[key]).to.equal(rx_testing[key]);
+    });
+  });
+
+  Object.keys(rx_ajax).forEach(key => {
+    it(`should export rxjs.ajax.${key}`, () => {
+      expect(umd.ajax[key]).to.equal(rx_ajax[key]);
+    });
+  });
+
+  Object.keys(rx_websocket).forEach(key => {
+    it(`should export rxjs.websocket.${key}`, () => {
+      expect(umd.websocket[key]).to.equal(rx_websocket[key]);
+    });
+  });
+});

--- a/src/internal/umd.ts
+++ b/src/internal/umd.ts
@@ -1,0 +1,22 @@
+/*
+  NOTE: This is the global export file for rxjs v6 and higher.
+ */
+
+/* rxjs */
+export * from '../';
+
+/* rxjs/operators */
+import * as _operators from '../operators';
+export const operators = _operators;
+
+/* rxjs/testing */
+import * as _testing from '../testing';
+export const testing = _testing;
+
+/* rxjs/ajax */
+import * as _ajax from '../ajax';
+export const ajax = _ajax;
+
+/* rxjs/websocket */
+import * as _websocket from '../websocket';
+export const websocket = _websocket;

--- a/src/internal/umd.ts
+++ b/src/internal/umd.ts
@@ -5,18 +5,18 @@
 /* rxjs */
 export * from '../';
 
-/* rxjs/operators */
+/* rxjs.operators */
 import * as _operators from '../operators';
 export const operators = _operators;
 
-/* rxjs/testing */
+/* rxjs.testing */
 import * as _testing from '../testing';
 export const testing = _testing;
 
-/* rxjs/ajax */
+/* rxjs.ajax */
 import * as _ajax from '../ajax';
 export const ajax = _ajax;
 
-/* rxjs/websocket */
+/* rxjs.websocket */
 import * as _websocket from '../websocket';
 export const websocket = _websocket;


### PR DESCRIPTION
This is an incremental step towards a new global UMD output, such that we'll be registering `rxjs` instead of `Rx` on the global to provide symmetry with the rest of the library's usage:


```js
/* For example, the following will exist on `window` or `global` */
rxjs.Observable
rxjs.fromEvent
rxjs.operators.map
rxjs.operators.mergeMap
rxjs.Subject

/* such that this will work... */
const { Observable, Subject, fromEvent } = rxjs;
const { map, mergeMap } = rxjs.operators;
```

This makes it congruent with our modules usage:

```ts
import { Observable, Subject, fromEvent } from 'rxjs';
import { map, mergeMap } from 'rxjs/operators';
```

Additionally, it will keep `rxjs` from trampling older versions of `Rx` if someone really wanted to have both globals. (for better or worse)