### PR TITLE
Revert "refactor(fromPromise): expose fromPromise through rxjs export"

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -55,7 +55,6 @@ describe('index', () => {
     expect(index.from).to.exist;
     expect(index.fromEvent).to.exist;
     expect(index.fromEventPattern).to.exist;
-    expect(index.fromPromise).to.exist;
     expect(index.generate).to.exist;
     expect(index.iif).to.exist;
     expect(index.interval).to.exist;

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,7 +40,6 @@ export { forkJoin } from './internal/observable/forkJoin';
 export { from } from './internal/observable/from';
 export { fromEvent } from './internal/observable/fromEvent';
 export { fromEventPattern } from './internal/observable/fromEventPattern';
-export { fromPromise } from './internal/observable/fromPromise';
 export { generate } from './internal/observable/generate';
 export { iif } from './internal/observable/iif';
 export { interval } from './internal/observable/interval';


### PR DESCRIPTION
Reverts ReactiveX/rxjs#3375

To decrease the API surface area, we shouldn't export `fromPromise`, as any operator or function that accepts an Observable (such as `mergeMap` or `defer`) will include most of `from`'s logic anyhow.