### PR TITLE
docs(pipeable-operators): correct sample output in "takeEveryNth" example

### DIFF
--- a/doc/pipeable-operators.md
+++ b/doc/pipeable-operators.md
@@ -116,7 +116,7 @@ interval(1000).pipe(
   toArray()
 )
 .subscribe(x => console.log(x));
-// [0, 12, 24]
+// [0, 2304, 9216]
 ```
 
 ## Known Issues


### PR DESCRIPTION
**Description:**

An example in `pipepable-operators.md` showed incorrect sample output:

```js
interval(1000).pipe(
  takeEveryNth(2),
  map(x => x + x),
  takeEveryNthSimple(3),
  map(x => x * x),
  takeEveryNthSimplest(4),
  take(3),
  toArray()
)
.subscribe(x => console.log(x));
// [0, 12, 24]
```

The correct result is `[0, 2304, 9216]` and not `[0, 12, 24]`, see the working example on StackBlitz: https://stackblitz.com/edit/rxjs-pipeable-example

`[0, 12, 24]` would be the result if `map(x => x * x)` and `takeEveryNthSimplest(4)` were not in the chain.