### PR TITLE
refactor(config): Move config to a module

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -74,9 +74,7 @@ describe('Observable', () => {
     it('should allow Promise to be globally configured', (done) => {
       let wasCalled = false;
 
-      __root__.Rx = {};
-      __root__.Rx.config = {};
-      __root__.Rx.config.Promise = function MyPromise(callback: any) {
+      Rx.config.Promise = function MyPromise(callback: any) {
         wasCalled = true;
         return new Promise<number>(callback);
       };
@@ -85,7 +83,6 @@ describe('Observable', () => {
         expect(x).to.equal(42);
       }).then(() => {
         expect(wasCalled).to.be.true;
-        delete __root__.Rx;
         done();
       });
     });

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
 import * as Rx from '../../src/internal/Rx';
 
-declare const __root__: any;
 const Observable = Rx.Observable;
 
 /** @test {toPromise} */
@@ -24,18 +23,14 @@ describe('Observable.prototype.toPromise', () => {
 
   it('should allow for global config via Rx.config.Promise', (done: MochaDone) => {
     let wasCalled = false;
-    __root__.Rx = {};
-    __root__.Rx.config = {};
-    __root__.Rx.config.Promise = function MyPromise(callback) {
+    Rx.config.Promise = function MyPromise(callback: Function) {
       wasCalled = true;
-      return new Promise(callback);
-    };
+      return new Promise(callback as any);
+    } as any;
 
     Observable.of(42).toPromise().then((x: number) => {
       expect(wasCalled).to.be.true;
       expect(x).to.equal(42);
-
-      delete __root__.Rx;
       done();
     });
   });

--- a/src/internal/Rx.ts
+++ b/src/internal/Rx.ts
@@ -6,6 +6,8 @@ export {Subject, AnonymousSubject} from './Subject';
 /* tslint:enable:no-unused-variable */
 export {Observable} from './Observable';
 
+export { config } from './config';
+
 // statics
 /* tslint:disable:no-use-before-declare */
 import '../add/observable/bindCallback';

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,0 +1,11 @@
+/**
+ * The global configuration object for RxJS, used to configure things
+ * like what Promise contructor should used to create Promises
+ */
+export const config = {
+  /**
+   * The promise constructor used by default for methods such as
+   * {@link toPromise} and {@link forEach}
+   */
+  Promise
+};


### PR DESCRIPTION
Moves Rx.config to a module so it can be used via any module system as well

This is part of the path to removing `root`.

It also moves some of the duplicate logic for getting the proper Promise constructor to a single function.