### PR TITLE
refactor(types): create SchedulerLike interface to replace IScheduler…

### DIFF
--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -1,5 +1,5 @@
 import { Subject } from './Subject';
-import { IScheduler } from './Scheduler';
+import { SchedulerLike } from './types';
 import { queue } from './scheduler/queue';
 import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
@@ -16,7 +16,7 @@ export class ReplaySubject<T> extends Subject<T> {
 
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
               windowTime: number = Number.POSITIVE_INFINITY,
-              private scheduler?: IScheduler) {
+              private scheduler?: SchedulerLike) {
     super();
     this._bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -1,10 +1,7 @@
 import { Action } from './scheduler/Action';
 import { Subscription } from './Subscription';
+import { SchedulerLike, SchedulerAction } from './types';
 
-export interface IScheduler {
-  now(): number;
-  schedule<T>(work: (this: Action<T>, state?: T) => void, delay?: number, state?: T): Subscription;
-}
 /**
  * An execution context and a data structure to order tasks and schedule their
  * execution. Provides a notion of (potentially virtual) time, through the
@@ -21,7 +18,7 @@ export interface IScheduler {
  *
  * @class Scheduler
  */
-export class Scheduler implements IScheduler {
+export class Scheduler implements SchedulerLike {
 
   public static now: () => number = Date.now ? Date.now : () => +new Date();
 
@@ -57,7 +54,7 @@ export class Scheduler implements IScheduler {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
-  public schedule<T>(work: (this: Action<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
+  public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
     return new this.SchedulerAction<T>(this, work).schedule(state, delay);
   }
 }

--- a/src/internal/observable/SubscribeOnObservable.ts
+++ b/src/internal/observable/SubscribeOnObservable.ts
@@ -1,5 +1,4 @@
-import { Action } from '../scheduler/Action';
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike, SchedulerAction } from '../types';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
@@ -17,18 +16,18 @@ export interface DispatchArg<T> {
  * @hide true
  */
 export class SubscribeOnObservable<T> extends Observable<T> {
-  static create<T>(source: Observable<T>, delay: number = 0, scheduler: IScheduler = asap): Observable<T> {
+  static create<T>(source: Observable<T>, delay: number = 0, scheduler: SchedulerLike = asap): Observable<T> {
     return new SubscribeOnObservable(source, delay, scheduler);
   }
 
-  static dispatch<T>(this: Action<T>, arg: DispatchArg<T>): Subscription {
+  static dispatch<T>(this: SchedulerAction<T>, arg: DispatchArg<T>): Subscription {
     const { source, subscriber } = arg;
     return this.add(source.subscribe(subscriber));
   }
 
   constructor(public source: Observable<T>,
               private delayTime: number = 0,
-              private scheduler: IScheduler = asap) {
+              private scheduler: SchedulerLike = asap) {
     super();
     if (!isNumeric(delayTime) || delayTime < 0) {
       this.delayTime = 0;

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -1,19 +1,18 @@
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike, SchedulerAction } from '../types';
 import { Observable } from '../Observable';
 import { AsyncSubject } from '../AsyncSubject';
 import { Subscriber } from '../Subscriber';
-import { Action } from '../scheduler/Action';
 
 // tslint:disable:max-line-length
-export function bindCallback(callbackFunc: (callback: () => any) => any, scheduler?: IScheduler): () => Observable<void>;
-export function bindCallback<R>(callbackFunc: (callback: (result: R) => any) => any, scheduler?: IScheduler): () => Observable<R>;
-export function bindCallback<T, R>(callbackFunc: (v1: T, callback: (result: R) => any) => any, scheduler?: IScheduler): (v1: T) => Observable<R>;
-export function bindCallback<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2) => Observable<R>;
-export function bindCallback<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
-export function bindCallback<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
-export function bindCallback<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
-export function bindCallback<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
-export function bindCallback<T>(callbackFunc: Function, scheduler?: IScheduler): (...args: any[]) => Observable<T>;
+export function bindCallback(callbackFunc: (callback: () => any) => any, scheduler?: SchedulerLike): () => Observable<void>;
+export function bindCallback<R>(callbackFunc: (callback: (result: R) => any) => any, scheduler?: SchedulerLike): () => Observable<R>;
+export function bindCallback<T, R>(callbackFunc: (v1: T, callback: (result: R) => any) => any, scheduler?: SchedulerLike): (v1: T) => Observable<R>;
+export function bindCallback<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2) => Observable<R>;
+export function bindCallback<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3) => Observable<R>;
+export function bindCallback<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
+export function bindCallback<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
+export function bindCallback<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
+export function bindCallback<T>(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<T>;
 // tslint:enable:max-line-length
 
 /**
@@ -127,7 +126,7 @@ export function bindCallback<T>(callbackFunc: Function, scheduler?: IScheduler):
  * @name bindCallback
  */
 export function bindCallback<T>(callbackFunc: Function,
-                                scheduler?: IScheduler): (...args: any[]) => Observable<T> {
+                                scheduler?: SchedulerLike): (...args: any[]) => Observable<T> {
   return function (this: any, ...args: any[]): Observable<T> {
     const context = this;
     let subject: AsyncSubject<T>;
@@ -171,12 +170,12 @@ interface DispatchState<T> {
 
 interface ParamsContext<T> {
   callbackFunc: Function;
-  scheduler: IScheduler;
+  scheduler: SchedulerLike;
   context: any;
   subject: AsyncSubject<T>;
 }
 
-function dispatch<T>(this: Action<DispatchState<T>>, state: DispatchState<T>) {
+function dispatch<T>(this: SchedulerAction<DispatchState<T>>, state: DispatchState<T>) {
   const self = this;
   const { args, subscriber, params } = state;
   const { callbackFunc, context, scheduler } = params;
@@ -204,7 +203,7 @@ interface NextState<T> {
   value: T;
 }
 
-function dispatchNext<T>(this: Action<NextState<T>>, state: NextState<T>) {
+function dispatchNext<T>(this: SchedulerAction<NextState<T>>, state: NextState<T>) {
   const { value, subject } = state;
   subject.next(value);
   subject.complete();
@@ -215,7 +214,7 @@ interface ErrorState<T> {
   err: any;
 }
 
-function dispatchError<T>(this: Action<ErrorState<T>>, state: ErrorState<T>) {
+function dispatchError<T>(this: SchedulerAction<ErrorState<T>>, state: ErrorState<T>) {
   const { err, subject } = state;
   subject.error(err);
 }

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -1,18 +1,17 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
 import { AsyncSubject } from '../AsyncSubject';
 import { Subscriber } from '../Subscriber';
-import { Action } from '../scheduler/Action';
+import { SchedulerAction, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
-export function bindNodeCallback<R>(callbackFunc: (callback: (err: any, result: R) => any) => any, scheduler?: IScheduler): () => Observable<R>;
-export function bindNodeCallback<T, R>(callbackFunc: (v1: T, callback: (err: any, result: R) => any) => any, scheduler?: IScheduler): (v1: T) => Observable<R>;
-export function bindNodeCallback<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (err: any, result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2) => Observable<R>;
-export function bindNodeCallback<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (err: any, result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3) => Observable<R>;
-export function bindNodeCallback<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (err: any, result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
-export function bindNodeCallback<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (err: any, result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
-export function bindNodeCallback<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (err: any, result: R) => any) => any, scheduler?: IScheduler): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
-export function bindNodeCallback<T>(callbackFunc: Function, scheduler?: IScheduler): (...args: any[]) => Observable<T>;
+export function bindNodeCallback<R>(callbackFunc: (callback: (err: any, result: R) => any) => any, scheduler?: SchedulerLike): () => Observable<R>;
+export function bindNodeCallback<T, R>(callbackFunc: (v1: T, callback: (err: any, result: R) => any) => any, scheduler?: SchedulerLike): (v1: T) => Observable<R>;
+export function bindNodeCallback<T, T2, R>(callbackFunc: (v1: T, v2: T2, callback: (err: any, result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2) => Observable<R>;
+export function bindNodeCallback<T, T2, T3, R>(callbackFunc: (v1: T, v2: T2, v3: T3, callback: (err: any, result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3) => Observable<R>;
+export function bindNodeCallback<T, T2, T3, T4, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, callback: (err: any, result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3, v4: T4) => Observable<R>;
+export function bindNodeCallback<T, T2, T3, T4, T5, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, callback: (err: any, result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => Observable<R>;
+export function bindNodeCallback<T, T2, T3, T4, T5, T6, R>(callbackFunc: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6, callback: (err: any, result: R) => any) => any, scheduler?: SchedulerLike): (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => Observable<R>;
+export function bindNodeCallback<T>(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -118,7 +117,7 @@ export function bindNodeCallback<T>(callbackFunc: Function, scheduler?: ISchedul
  * @name bindNodeCallback
  */
 export function bindNodeCallback<T>(callbackFunc: Function,
-                                    scheduler?: IScheduler): (...args: any[]) => Observable<T> {
+                                    scheduler?: SchedulerLike): (...args: any[]) => Observable<T> {
   return function(this: any, ...args: any[]): Observable<T> {
     const params: ParamsState<T> = {
       subject: undefined,
@@ -168,12 +167,12 @@ interface DispatchState<T> {
 interface ParamsState<T> {
   callbackFunc: Function;
   args: any[];
-  scheduler: IScheduler;
+  scheduler: SchedulerLike;
   subject: AsyncSubject<T>;
   context: any;
 }
 
-function dispatch<T>(this: Action<DispatchState<T>>, state: DispatchState<T>) {
+function dispatch<T>(this: SchedulerAction<DispatchState<T>>, state: DispatchState<T>) {
   const { params, subscriber, context } = state;
   const { callbackFunc, args, scheduler } = params;
   let subject = params.subject;

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -1,6 +1,5 @@
 import { Observable } from '../Observable';
-import { ObservableInput  } from '../types';
-import { IScheduler  } from '../Scheduler';
+import { ObservableInput, SchedulerLike } from '../types';
 import { isScheduler  } from '../util/isScheduler';
 import { isArray  } from '../util/isArray';
 import { Subscriber } from '../Subscriber';
@@ -13,26 +12,26 @@ import { fromArray } from './fromArray';
 const NONE = {};
 
 /* tslint:disable:max-line-length */
-export function combineLatest<T, R>(v1: ObservableInput<T>, project: (v1: T) => R, scheduler?: IScheduler): Observable<R>;
-export function combineLatest<T, T2, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R, scheduler?: IScheduler): Observable<R>;
-export function combineLatest<T, T2, T3, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R, scheduler?: IScheduler): Observable<R>;
-export function combineLatest<T, T2, T3, T4, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R, scheduler?: IScheduler): Observable<R>;
-export function combineLatest<T, T2, T3, T4, T5, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R, scheduler?: IScheduler): Observable<R>;
-export function combineLatest<T, T2, T3, T4, T5, T6, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R, scheduler?: IScheduler): Observable<R>;
+export function combineLatest<T, R>(v1: ObservableInput<T>, project: (v1: T) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<T, T2, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<T, T2, T3, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<T, T2, T3, T4, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<T, T2, T3, T4, T5, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<T, T2, T3, T4, T5, T6, R>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R, scheduler?: SchedulerLike): Observable<R>;
 
-export function combineLatest<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<[T, T2]>;
-export function combineLatest<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<[T, T2, T3]>;
-export function combineLatest<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<[T, T2, T3, T4]>;
-export function combineLatest<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<[T, T2, T3, T4, T5]>;
-export function combineLatest<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<[T, T2, T3, T4, T5, T6]>;
+export function combineLatest<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: SchedulerLike): Observable<[T, T2]>;
+export function combineLatest<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: SchedulerLike): Observable<[T, T2, T3]>;
+export function combineLatest<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: SchedulerLike): Observable<[T, T2, T3, T4]>;
+export function combineLatest<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: SchedulerLike): Observable<[T, T2, T3, T4, T5]>;
+export function combineLatest<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: SchedulerLike): Observable<[T, T2, T3, T4, T5, T6]>;
 
-export function combineLatest<T>(array: ObservableInput<T>[], scheduler?: IScheduler): Observable<T[]>;
-export function combineLatest<R>(array: ObservableInput<any>[], scheduler?: IScheduler): Observable<R>;
-export function combineLatest<T, R>(array: ObservableInput<T>[], project: (...values: Array<T>) => R, scheduler?: IScheduler): Observable<R>;
-export function combineLatest<R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R, scheduler?: IScheduler): Observable<R>;
-export function combineLatest<T>(...observables: Array<ObservableInput<T> | IScheduler>): Observable<T[]>;
-export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R) | IScheduler>): Observable<R>;
-export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | IScheduler>): Observable<R>;
+export function combineLatest<T>(array: ObservableInput<T>[], scheduler?: SchedulerLike): Observable<T[]>;
+export function combineLatest<R>(array: ObservableInput<any>[], scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<T, R>(array: ObservableInput<T>[], project: (...values: Array<T>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<T>(...observables: Array<ObservableInput<T> | SchedulerLike>): Observable<T[]>;
+export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R) | SchedulerLike>): Observable<R>;
+export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -146,12 +145,12 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
 export function combineLatest<T, R>(...observables: Array<any | ObservableInput<any> |
                                                     Array<ObservableInput<any>> |
                                                     (((...values: Array<any>) => R)) |
-                                                    IScheduler>): Observable<R> {
+                                                    SchedulerLike>): Observable<R> {
   let project: (...values: Array<any>) => R =  null;
-  let scheduler: IScheduler = null;
+  let scheduler: SchedulerLike = null;
 
   if (isScheduler(observables[observables.length - 1])) {
-    scheduler = <IScheduler>observables.pop();
+    scheduler = <SchedulerLike>observables.pop();
   }
 
   if (typeof observables[observables.length - 1] === 'function') {

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -1,20 +1,19 @@
 import { Observable } from '../Observable';
-import { ObservableInput } from '../types';
-import { IScheduler } from '../Scheduler';
+import { ObservableInput, SchedulerLike } from '../types';
 import { isScheduler } from '../util/isScheduler';
 import { of } from './of';
 import { from } from './from';
 import { concatAll } from '../../internal/operators/concatAll';
 
 /* tslint:disable:max-line-length */
-export function concat<T>(v1: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
-export function concat<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
-export function concat<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
-export function concat<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
-export function concat<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function concat<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function concat<T>(...observables: (ObservableInput<T> | IScheduler)[]): Observable<T>;
-export function concat<T, R>(...observables: (ObservableInput<any> | IScheduler)[]): Observable<R>;
+export function concat<T>(v1: ObservableInput<T>, scheduler?: SchedulerLike): Observable<T>;
+export function concat<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: SchedulerLike): Observable<T | T2>;
+export function concat<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function concat<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function concat<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function concat<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function concat<T>(...observables: (ObservableInput<T> | SchedulerLike)[]): Observable<T>;
+export function concat<T, R>(...observables: (ObservableInput<any> | SchedulerLike)[]): Observable<R>;
 /* tslint:enable:max-line-length */
 /**
  * Creates an output Observable which sequentially emits all values from given
@@ -109,7 +108,7 @@ export function concat<T, R>(...observables: (ObservableInput<any> | IScheduler)
  * @name concat
  * @owner Observable
  */
-export function concat<T, R>(...observables: Array<ObservableInput<any> | IScheduler>): Observable<R> {
+export function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike>): Observable<R> {
   if (observables.length === 1 || (observables.length === 2 && isScheduler(observables[1]))) {
     return from(<any>observables[0]);
   }

--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike } from '../types';
 
 /**
  * The same Observable instance returned by any call to {@link empty} without a
@@ -50,10 +50,10 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * @name empty
  * @owner Observable
  */
-export function empty(scheduler?: IScheduler) {
+export function empty(scheduler?: SchedulerLike) {
   return scheduler ? emptyScheduled(scheduler) : EMPTY;
 }
 
-export function emptyScheduled(scheduler: IScheduler) {
+export function emptyScheduled(scheduler: SchedulerLike) {
   return new Observable<never>(subscriber => scheduler.schedule(() => subscriber.complete()));
 }

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -1,5 +1,4 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
 import { isPromise } from '../util/isPromise';
 import { isArrayLike } from '../util/isArrayLike';
 import { isObservable } from '../util/isObservable';
@@ -9,11 +8,11 @@ import { fromPromise } from './fromPromise';
 import { fromIterable } from './fromIterable';
 import { fromObservable } from './fromObservable';
 import { subscribeTo } from '../util/subscribeTo';
-import { ObservableInput } from '../types';
+import { ObservableInput, SchedulerLike } from '../types';
 
-export function from<T>(input: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
-export function from<T>(input: ObservableInput<ObservableInput<T>>, scheduler?: IScheduler): Observable<Observable<T>>;
-export function from<T>(input: ObservableInput<T>, scheduler?: IScheduler): Observable<T> {
+export function from<T>(input: ObservableInput<T>, scheduler?: SchedulerLike): Observable<T>;
+export function from<T>(input: ObservableInput<ObservableInput<T>>, scheduler?: SchedulerLike): Observable<Observable<T>>;
+export function from<T>(input: ObservableInput<T>, scheduler?: SchedulerLike): Observable<T> {
   if (!scheduler) {
     if (input instanceof Observable) {
       return input;

--- a/src/internal/observable/fromArray.ts
+++ b/src/internal/observable/fromArray.ts
@@ -1,9 +1,9 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike } from '../types';
 import { Subscription } from '../Subscription';
 import { subscribeToArray } from '../util/subscribeToArray';
 
-export function fromArray<T>(input: ArrayLike<T>, scheduler?: IScheduler) {
+export function fromArray<T>(input: ArrayLike<T>, scheduler?: SchedulerLike) {
   if (!scheduler) {
     return new Observable<T>(subscribeToArray(input));
   } else {

--- a/src/internal/observable/fromIterable.ts
+++ b/src/internal/observable/fromIterable.ts
@@ -1,10 +1,10 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike } from '../types';
 import { Subscription } from '../Subscription';
 import { iterator as Symbol_iterator } from '../symbol/iterator';
 import { subscribeToIterable } from '../util/subscribeToIterable';
 
-export function fromIterable<T>(input: Iterable<T>, scheduler: IScheduler) {
+export function fromIterable<T>(input: Iterable<T>, scheduler: SchedulerLike) {
   if (!input) {
     throw new Error('Iterable cannot be null');
   }

--- a/src/internal/observable/fromObservable.ts
+++ b/src/internal/observable/fromObservable.ts
@@ -1,11 +1,10 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
 import { observable as Symbol_observable } from '../symbol/observable';
 import { subscribeToObservable } from '../util/subscribeToObservable';
-import { ObservableLike, Subscribable } from '../types';
+import { ObservableLike, SchedulerLike, Subscribable } from '../types';
 
-export function fromObservable<T>(input: ObservableLike<T>, scheduler: IScheduler) {
+export function fromObservable<T>(input: ObservableLike<T>, scheduler: SchedulerLike) {
   if (!scheduler) {
     return new Observable<T>(subscribeToObservable(input));
   } else {

--- a/src/internal/observable/fromPromise.ts
+++ b/src/internal/observable/fromPromise.ts
@@ -1,9 +1,9 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike } from '../types';
 import { Subscription } from '../Subscription';
 import { subscribeToPromise } from '../util/subscribeToPromise';
 
-export function fromPromise<T>(input: PromiseLike<T>, scheduler?: IScheduler) {
+export function fromPromise<T>(input: PromiseLike<T>, scheduler?: SchedulerLike) {
   if (!scheduler) {
     return new Observable<T>(subscribeToPromise(input));
   } else {

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -1,9 +1,8 @@
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { identity } from '../util/identity';
-import { IScheduler } from '../Scheduler';
+import { SchedulerAction, SchedulerLike } from '../types';
 import { isScheduler } from '../util/isScheduler';
-import { Action } from '../scheduler/Action';
 
 export type ConditionFunc<S> = (state: S) => boolean;
 export type IterateFunc<S> = (state: S) => S;
@@ -34,10 +33,10 @@ export interface GenerateBaseOptions<S> {
    */
   iterate: IterateFunc<S>;
   /**
-   * IScheduler to use for generation process.
+   * SchedulerLike to use for generation process.
    * By default, a generator starts immediately.
    */
-  scheduler?: IScheduler;
+  scheduler?: SchedulerLike;
 }
 
 export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
@@ -67,14 +66,14 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
  * @param {function (state: S): S} iterate Iteration step function.
  * @param {function (state: S): T} resultSelector Selector function for results produced in the sequence.
- * @param {Scheduler} [scheduler] A {@link IScheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
+ * @param {Scheduler} [scheduler] A {@link SchedulerLike} on which to run the generator loop. If not provided, defaults to emit immediately.
  * @returns {Observable<T>} The generated sequence.
  */
   export function generate<T, S>(initialState: S,
                                  condition: ConditionFunc<S>,
                                  iterate: IterateFunc<S>,
                                  resultSelector: ResultFunc<S, T>,
-                                 scheduler?: IScheduler): Observable<T>;
+                                 scheduler?: SchedulerLike): Observable<T>;
 
 /**
  * Generates an observable sequence by running a state-driven loop
@@ -96,13 +95,13 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  * @param {S} initialState Initial state.
  * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
  * @param {function (state: S): S} iterate Iteration step function.
- * @param {Scheduler} [scheduler] A {@link IScheduler} on which to run the generator loop. If not provided, defaults to emit immediately.
+ * @param {Scheduler} [scheduler] A {@link SchedulerLike} on which to run the generator loop. If not provided, defaults to emit immediately.
  * @returns {Observable<S>} The generated sequence.
  */
 export function generate<S>(initialState: S,
                             condition: ConditionFunc<S>,
                             iterate: IterateFunc<S>,
-                            scheduler?: IScheduler): Observable<S>;
+                            scheduler?: SchedulerLike): Observable<S>;
 
 /**
  * Generates an observable sequence by running a state-driven loop
@@ -156,8 +155,8 @@ export function generate<T, S>(options: GenerateOptions<T, S>): Observable<T>;
 export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
                                condition?: ConditionFunc<S>,
                                iterate?: IterateFunc<S>,
-                               resultSelectorOrObservable?: (ResultFunc<S, T>) | IScheduler,
-                               scheduler?: IScheduler): Observable<T> {
+                               resultSelectorOrObservable?: (ResultFunc<S, T>) | SchedulerLike,
+                               scheduler?: SchedulerLike): Observable<T> {
 
   let resultSelector: ResultFunc<S, T>;
   let initialState: S;
@@ -172,7 +171,7 @@ export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
   } else if (resultSelectorOrObservable === undefined || isScheduler(resultSelectorOrObservable)) {
     initialState = initialStateOrOptions as S;
     resultSelector = identity as ResultFunc<S, T>;
-    scheduler = resultSelectorOrObservable as IScheduler;
+    scheduler = resultSelectorOrObservable as SchedulerLike;
   } else {
     initialState = initialStateOrOptions as S;
     resultSelector = resultSelectorOrObservable as ResultFunc<S, T>;
@@ -227,7 +226,7 @@ export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
   });
 }
 
-function dispatch<T, S>(this: Action<SchedulerState<T, S>>, state: SchedulerState<T, S>) {
+function dispatch<T, S>(this: SchedulerAction<SchedulerState<T, S>>, state: SchedulerState<T, S>) {
   const { subscriber, condition } = state;
   if (subscriber.closed) {
     return undefined;

--- a/src/internal/observable/interval.ts
+++ b/src/internal/observable/interval.ts
@@ -1,9 +1,8 @@
 import { Observable } from '../Observable';
 import { async } from '../scheduler/async';
-import { IScheduler } from '../Scheduler';
+import { SchedulerAction, SchedulerLike } from '../types';
 import { isNumeric } from '../util/isNumeric';
 import { Subscriber } from '../Subscriber';
-import { Action } from '../scheduler/Action';
 
 /**
  * Creates an Observable that emits sequential numbers every specified
@@ -39,7 +38,7 @@ import { Action } from '../scheduler/Action';
  * @owner Observable
  */
 export function interval(period = 0,
-                         scheduler: IScheduler = async): Observable<number> {
+                         scheduler: SchedulerLike = async): Observable<number> {
   if (!isNumeric(period) || period < 0) {
     period = 0;
   }
@@ -56,7 +55,7 @@ export function interval(period = 0,
   });
 }
 
-function dispatch(this: Action<IntervalState>, state: IntervalState) {
+function dispatch(this: SchedulerAction<IntervalState>, state: IntervalState) {
   const { subscriber, counter, period } = state;
   subscriber.next(counter);
   this.schedule({ subscriber, counter: counter + 1, period }, period);

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -1,25 +1,24 @@
 import { Observable } from '../Observable';
-import { ObservableInput } from '../types';
-import { IScheduler } from '../Scheduler';
+import { ObservableInput, SchedulerLike} from '../types';
 import { isScheduler } from '../util/isScheduler';
 import { mergeAll } from '../../internal/operators/mergeAll';
 import { fromArray } from './fromArray';
 
 /* tslint:disable:max-line-length */
-export function merge<T>(v1: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
-export function merge<T>(v1: ObservableInput<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
-export function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
-export function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2>;
-export function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
-export function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3>;
-export function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T>(...observables: (ObservableInput<T> | IScheduler | number)[]): Observable<T>;
-export function merge<T, R>(...observables: (ObservableInput<any> | IScheduler | number)[]): Observable<R>;
+export function merge<T>(v1: ObservableInput<T>, scheduler?: SchedulerLike): Observable<T>;
+export function merge<T>(v1: ObservableInput<T>, concurrent?: number, scheduler?: SchedulerLike): Observable<T>;
+export function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler?: SchedulerLike): Observable<T | T2>;
+export function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2>;
+export function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function merge<T>(...observables: (ObservableInput<T> | SchedulerLike | number)[]): Observable<T>;
+export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLike | number)[]): Observable<R>;
 /* tslint:enable:max-line-length */
 /**
  * Creates an output Observable which concurrently emits all values from every
@@ -81,12 +80,12 @@ export function merge<T, R>(...observables: (ObservableInput<any> | IScheduler |
  * @name merge
  * @owner Observable
  */
-export function merge<T, R>(...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R> {
+export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
- let scheduler: IScheduler = null;
+ let scheduler: SchedulerLike = null;
   let last: any = observables[observables.length - 1];
   if (isScheduler(last)) {
-    scheduler = <IScheduler>observables.pop();
+    scheduler = <SchedulerLike>observables.pop();
     if (observables.length > 1 && typeof observables[observables.length - 1] === 'number') {
       concurrent = <number>observables.pop();
     }

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -1,25 +1,25 @@
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike } from '../types';
 import { isScheduler } from '../util/isScheduler';
 import { fromArray } from './fromArray';
 import { empty } from './empty';
 import { scalar } from './scalar';
 import { Observable } from '../Observable';
 
-export function of<T>(a: T, scheduler?: IScheduler): Observable<T>;
-export function of<T, T2>(a: T, b: T2, scheduler?: IScheduler): Observable<T | T2>;
-export function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler?: IScheduler): Observable<T | T2 | T3>;
-export function of<T, T2, T3, T4>(a: T, b: T2, c: T3, d: T4, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
-export function of<T, T2, T3, T4, T5>(a: T, b: T2, c: T3, d: T4, e: T5, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function of<T, T2, T3, T4, T5, T6>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function of<T, T2, T3, T4, T5, T6, T7>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, scheduler?: IScheduler):
+export function of<T>(a: T, scheduler?: SchedulerLike): Observable<T>;
+export function of<T, T2>(a: T, b: T2, scheduler?: SchedulerLike): Observable<T | T2>;
+export function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function of<T, T2, T3, T4>(a: T, b: T2, c: T3, d: T4, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function of<T, T2, T3, T4, T5>(a: T, b: T2, c: T3, d: T4, e: T5, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function of<T, T2, T3, T4, T5, T6>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function of<T, T2, T3, T4, T5, T6, T7>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, scheduler?: SchedulerLike):
   Observable<T | T2 | T3 | T4 | T5 | T6 | T7>;
-export function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, scheduler?: IScheduler):
+export function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, scheduler?: SchedulerLike):
   Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
-export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler?: IScheduler):
+export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler?: SchedulerLike):
   Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
-export function of<T>(...args: Array<T | IScheduler>): Observable<T>;
-export function of<T>(...args: Array<T | IScheduler>): Observable<T> {
-  let scheduler = args[args.length - 1] as IScheduler;
+export function of<T>(...args: Array<T | SchedulerLike>): Observable<T>;
+export function of<T>(...args: Array<T | SchedulerLike>): Observable<T> {
+  let scheduler = args[args.length - 1] as SchedulerLike;
   if (isScheduler(scheduler)) {
     args.pop();
   } else {

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -1,8 +1,7 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
+import { SchedulerAction, SchedulerLike } from '../types';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
-import { Action } from '../scheduler/Action';
 
 /**
  * Convert an object into an observable sequence of [key, value] pairs
@@ -35,7 +34,7 @@ import { Action } from '../scheduler/Action';
  * @returns {(Observable<[string, T]>)} An observable sequence of
  * [key, value] pairs from the object.
  */
-export function pairs<T>(obj: Object, scheduler?: IScheduler): Observable<[string, T]> {
+export function pairs<T>(obj: Object, scheduler?: SchedulerLike): Observable<[string, T]> {
   if (!scheduler) {
     return new Observable<[string, T]>(subscriber => {
       const keys = Object.keys(obj);
@@ -60,7 +59,7 @@ export function pairs<T>(obj: Object, scheduler?: IScheduler): Observable<[strin
 }
 
 /** @internal */
-export function dispatch<T>(this: Action<any>,
+export function dispatch<T>(this: SchedulerAction<any>,
                             state: { keys: string[], index: number, subscriber: Subscriber<[string, T]>, subscription: Subscription, obj: Object }) {
   const { keys, index, subscriber, subscription, obj } = state;
   if (!subscriber.closed) {

--- a/src/internal/observable/range.ts
+++ b/src/internal/observable/range.ts
@@ -1,6 +1,5 @@
-import { IScheduler } from '../Scheduler';
+import { SchedulerAction, SchedulerLike } from '../types';
 import { Observable } from '../Observable';
-import { Action } from '../scheduler/Action';
 
 /**
  * Creates an Observable that emits a sequence of numbers within a specified
@@ -34,7 +33,7 @@ import { Action } from '../scheduler/Action';
  */
 export function range(start: number = 0,
                       count: number = 0,
-                      scheduler?: IScheduler): Observable<number> {
+                      scheduler?: SchedulerLike): Observable<number> {
   return new Observable<number>(subscriber => {
     let index = 0;
 
@@ -60,7 +59,7 @@ export function range(start: number = 0,
 }
 
 /** @internal */
-export function dispatch(this: Action<any>, state: any) {
+export function dispatch(this: SchedulerAction<any>, state: any) {
   const { start, index, count, subscriber } = state;
 
   if (index >= count) {

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
+import { SchedulerLike } from '../types';
 import { Subscriber } from '../Subscriber';
 
 /**
@@ -46,7 +46,7 @@ import { Subscriber } from '../Subscriber';
  * @name throw
  * @owner Observable
  */
-export function throwError(error: any, scheduler?: IScheduler): Observable<never> {
+export function throwError(error: any, scheduler?: SchedulerLike): Observable<never> {
   if (!scheduler) {
     return new Observable(subscriber => subscriber.error(error));
   } else {

--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -1,9 +1,8 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
+import { SchedulerAction, SchedulerLike } from '../types';
 import { async } from '../scheduler/async';
 import { isNumeric } from '../util/isNumeric';
 import { isScheduler } from '../util/isScheduler';
-import { Action } from '../scheduler/Action';
 import { Subscriber } from '../Subscriber';
 
 /**
@@ -37,9 +36,9 @@ import { Subscriber } from '../Subscriber';
  *
  * @param {number|Date} [dueTime] The initial delay time to wait before
  * emitting the first value of `0`.
- * @param {number|IScheduler} [periodOrScheduler] The period of time between emissions of the
+ * @param {number|SchedulerLike} [periodOrScheduler] The period of time between emissions of the
  * subsequent numbers.
- * @param {IScheduler} [scheduler=async] The IScheduler to use for scheduling
+ * @param {SchedulerLike} [scheduler=async] The IScheduler to use for scheduling
  * the emission of values, and providing a notion of "time".
  * @return {Observable} An Observable that emits a `0` after the
  * `initialDelay` and ever increasing numbers after each `period` of time
@@ -49,8 +48,8 @@ import { Subscriber } from '../Subscriber';
  * @owner Observable
  */
 export function timer(dueTime: number | Date = 0,
-                      periodOrScheduler?: number | IScheduler,
-                      scheduler?: IScheduler): Observable<number> {
+                      periodOrScheduler?: number | SchedulerLike,
+                      scheduler?: SchedulerLike): Observable<number> {
   let period = -1;
   if (isNumeric(periodOrScheduler)) {
     period = Number(periodOrScheduler) < 1 && 1 || Number(periodOrScheduler);
@@ -79,7 +78,7 @@ interface TimerState {
   subscriber: Subscriber<number>;
 }
 
-function dispatch(this: Action<TimerState>, state: TimerState) {
+function dispatch(this: SchedulerAction<TimerState>, state: TimerState) {
   const { index, period, subscriber } = state;
   subscriber.next(index);
 

--- a/src/internal/operators/auditTime.ts
+++ b/src/internal/operators/auditTime.ts
@@ -1,8 +1,7 @@
 import { async } from '../scheduler/async';
-import { IScheduler } from '../Scheduler';
 import { audit } from './audit';
 import { timer } from '../observable/timer';
-import { MonoTypeOperatorFunction } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 
 /**
  * Ignores source values for `duration` milliseconds, then emits the most recent
@@ -46,6 +45,6 @@ import { MonoTypeOperatorFunction } from '../types';
  * @method auditTime
  * @owner Observable
  */
-export function auditTime<T>(duration: number, scheduler: IScheduler = async): MonoTypeOperatorFunction<T> {
+export function auditTime<T>(duration: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
   return audit(() => timer(duration, scheduler));
 }

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -1,10 +1,9 @@
 import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
 import { async } from '../scheduler/async';
-import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types';
 
 /**
  * Emits a value from the source Observable only after a particular time span
@@ -52,12 +51,12 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @method debounceTime
  * @owner Observable
  */
-export function debounceTime<T>(dueTime: number, scheduler: IScheduler = async): MonoTypeOperatorFunction<T> {
+export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new DebounceTimeOperator(dueTime, scheduler));
 }
 
 class DebounceTimeOperator<T> implements Operator<T, T> {
-  constructor(private dueTime: number, private scheduler: IScheduler) {
+  constructor(private dueTime: number, private scheduler: SchedulerLike) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -77,7 +76,7 @@ class DebounceTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private dueTime: number,
-              private scheduler: IScheduler) {
+              private scheduler: SchedulerLike) {
     super(destination);
   }
 

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,5 +1,4 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { tryCatch } from '../util/tryCatch';
@@ -8,11 +7,11 @@ import { Subscription } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
-import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
-export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: IScheduler): OperatorFunction<T, R>;
-export function expand<T>(project: (value: T, index: number) => ObservableInput<T>, concurrent?: number, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
+export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: SchedulerLike): OperatorFunction<T, R>;
+export function expand<T>(project: (value: T, index: number) => ObservableInput<T>, concurrent?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -62,7 +61,7 @@ export function expand<T>(project: (value: T, index: number) => ObservableInput<
  */
 export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,
-                             scheduler: IScheduler = undefined): OperatorFunction<T, R> {
+                             scheduler: SchedulerLike = undefined): OperatorFunction<T, R> {
   concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;
 
   return (source: Observable<T>) => source.lift(new ExpandOperator(project, concurrent, scheduler));
@@ -71,7 +70,7 @@ export function expand<T, R>(project: (value: T, index: number) => ObservableInp
 export class ExpandOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => ObservableInput<R>,
               private concurrent: number,
-              private scheduler: IScheduler) {
+              private scheduler: SchedulerLike) {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
@@ -100,7 +99,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => ObservableInput<R>,
               private concurrent: number,
-              private scheduler: IScheduler) {
+              private scheduler: SchedulerLike) {
     super(destination);
     if (concurrent < Number.POSITIVE_INFINITY) {
       this.buffer = [];

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -1,10 +1,8 @@
 import { Observable } from '../Observable';
-import { IScheduler } from '../Scheduler';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Notification } from '../Notification';
-import { Action } from '../scheduler/Action';
-import { MonoTypeOperatorFunction, PartialObserver, TeardownLogic } from '../types';
+import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
 
 /**
  *
@@ -44,7 +42,7 @@ import { MonoTypeOperatorFunction, PartialObserver, TeardownLogic } from '../typ
  *
  * @see {@link delay}
  *
- * @param {IScheduler} scheduler Scheduler that will be used to reschedule notifications from source Observable.
+ * @param {SchedulerLike} scheduler Scheduler that will be used to reschedule notifications from source Observable.
  * @param {number} [delay] Number of milliseconds that states with what delay every notification should be rescheduled.
  * @return {Observable<T>} Observable that emits the same notifications as the source Observable,
  * but with provided scheduler.
@@ -52,14 +50,14 @@ import { MonoTypeOperatorFunction, PartialObserver, TeardownLogic } from '../typ
  * @method observeOn
  * @owner Observable
  */
-export function observeOn<T>(scheduler: IScheduler, delay: number = 0): MonoTypeOperatorFunction<T> {
+export function observeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return function observeOnOperatorFunction(source: Observable<T>): Observable<T> {
     return source.lift(new ObserveOnOperator(scheduler, delay));
   };
 }
 
 export class ObserveOnOperator<T> implements Operator<T, T> {
-  constructor(private scheduler: IScheduler, private delay: number = 0) {
+  constructor(private scheduler: SchedulerLike, private delay: number = 0) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -73,14 +71,14 @@ export class ObserveOnOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 export class ObserveOnSubscriber<T> extends Subscriber<T> {
-  static dispatch(this: Action<ObserveOnMessage>, arg: ObserveOnMessage) {
+  static dispatch(this: SchedulerAction<ObserveOnMessage>, arg: ObserveOnMessage) {
     const { notification, destination } = arg;
     notification.observe(destination);
     this.unsubscribe();
   }
 
   constructor(destination: Subscriber<T>,
-              private scheduler: IScheduler,
+              private scheduler: SchedulerLike,
               private delay: number = 0) {
     super(destination);
   }

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -1,20 +1,19 @@
 import { Observable } from '../Observable';
 import { ReplaySubject } from '../ReplaySubject';
-import { IScheduler } from '../Scheduler';
 import { multicast } from './multicast';
 import { ConnectableObservable } from '../observable/ConnectableObservable';
-import { UnaryFunction, MonoTypeOperatorFunction, OperatorFunction } from '../types';
+import { UnaryFunction, MonoTypeOperatorFunction, OperatorFunction, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
-export function publishReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: IScheduler): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
-export function publishReplay<T, R>(bufferSize?: number, windowTime?: number, selector?: OperatorFunction<T, R>, scheduler?: IScheduler): OperatorFunction<T, R>;
-export function publishReplay<T>(bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
+export function publishReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
+export function publishReplay<T, R>(bufferSize?: number, windowTime?: number, selector?: OperatorFunction<T, R>, scheduler?: SchedulerLike): OperatorFunction<T, R>;
+export function publishReplay<T>(bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 export function publishReplay<T, R>(bufferSize?: number,
                                     windowTime?: number,
-                                    selectorOrScheduler?: IScheduler | OperatorFunction<T, R>,
-                                    scheduler?: IScheduler): UnaryFunction<Observable<T>, ConnectableObservable<R>> {
+                                    selectorOrScheduler?: SchedulerLike | OperatorFunction<T, R>,
+                                    scheduler?: SchedulerLike): UnaryFunction<Observable<T>, ConnectableObservable<R>> {
 
   if (selectorOrScheduler && typeof selectorOrScheduler !== 'function') {
     scheduler = selectorOrScheduler;

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -1,10 +1,8 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { IScheduler } from '../Scheduler';
-import { Action } from '../scheduler/Action';
 import { async } from '../scheduler/async';
-import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
 
 /**
  * Emits the most recently emitted value from the source Observable within
@@ -42,13 +40,13 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @method sampleTime
  * @owner Observable
  */
-export function sampleTime<T>(period: number, scheduler: IScheduler = async): MonoTypeOperatorFunction<T> {
+export function sampleTime<T>(period: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SampleTimeOperator(period, scheduler));
 }
 
 class SampleTimeOperator<T> implements Operator<T, T> {
   constructor(private period: number,
-              private scheduler: IScheduler) {
+              private scheduler: SchedulerLike) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -67,7 +65,7 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private period: number,
-              private scheduler: IScheduler) {
+              private scheduler: SchedulerLike) {
     super(destination);
     this.add(scheduler.schedule(dispatchNotification, period, { subscriber: this, period }));
   }
@@ -85,7 +83,7 @@ class SampleTimeSubscriber<T> extends Subscriber<T> {
   }
 }
 
-function dispatchNotification<T>(this: Action<any>, state: any) {
+function dispatchNotification<T>(this: SchedulerAction<any>, state: any) {
   let { subscriber, period } = state;
   subscriber.notifyNext();
   this.schedule(state, period);

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -1,19 +1,18 @@
 import { Observable } from '../Observable';
 import { ReplaySubject } from '../ReplaySubject';
-import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
-import { MonoTypeOperatorFunction } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { Subscriber } from '../Subscriber';
 
 /**
  * @method shareReplay
  * @owner Observable
  */
-export function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: IScheduler ): MonoTypeOperatorFunction<T> {
+export function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike ): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(shareReplayOperator(bufferSize, windowTime, scheduler));
 }
 
-function shareReplayOperator<T>(bufferSize?: number, windowTime?: number, scheduler?: IScheduler) {
+function shareReplayOperator<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike) {
   let subject: ReplaySubject<T>;
   let refCount = 0;
   let subscription: Subscription;

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -1,20 +1,19 @@
-import { IScheduler } from '../Scheduler';
 import { Observable } from '../Observable';
 import { fromArray } from '../observable/fromArray';
 import { scalar } from '../observable/scalar';
 import { empty } from '../observable/empty';
 import { concat as concatStatic } from '../observable/concat';
 import { isScheduler } from '../util/isScheduler';
-import { MonoTypeOperatorFunction } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
-export function startWith<T>(v1: T, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, v4: T, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: IScheduler): MonoTypeOperatorFunction<T>;
-export function startWith<T>(...array: Array<T | IScheduler>): MonoTypeOperatorFunction<T>;
+export function startWith<T>(v1: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export function startWith<T>(v1: T, v2: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export function startWith<T>(v1: T, v2: T, v3: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export function startWith<T>(v1: T, v2: T, v3: T, v4: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export function startWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export function startWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export function startWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -31,9 +30,9 @@ export function startWith<T>(...array: Array<T | IScheduler>): MonoTypeOperatorF
  * @method startWith
  * @owner Observable
  */
-export function startWith<T>(...array: Array<T | IScheduler>): MonoTypeOperatorFunction<T> {
+export function startWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => {
-    let scheduler = <IScheduler>array[array.length - 1];
+    let scheduler = <SchedulerLike>array[array.length - 1];
     if (isScheduler(scheduler)) {
       array.pop();
     } else {

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -1,9 +1,8 @@
 import { Operator } from '../Operator';
-import { IScheduler } from '../Scheduler';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { SubscribeOnObservable } from '../observable/SubscribeOnObservable';
-import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types';
 
 /**
  * Asynchronously subscribes Observers to this Observable on the specified IScheduler.
@@ -16,14 +15,14 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @method subscribeOn
  * @owner Observable
  */
-export function subscribeOn<T>(scheduler: IScheduler, delay: number = 0): MonoTypeOperatorFunction<T> {
+export function subscribeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return function subscribeOnOperatorFunction(source: Observable<T>): Observable<T> {
     return source.lift(new SubscribeOnOperator<T>(scheduler, delay));
   };
 }
 
 class SubscribeOnOperator<T> implements Operator<T, T> {
-  constructor(private scheduler: IScheduler,
+  constructor(private scheduler: SchedulerLike,
               private delay: number) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -1,11 +1,10 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { IScheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
 import { async } from '../scheduler/async';
 import { Observable } from '../Observable';
 import { ThrottleConfig, defaultThrottleConfig } from './throttle';
-import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types';
 
 /**
  * Emits a value from the source Observable, then ignores subsequent source
@@ -47,14 +46,14 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @owner Observable
  */
 export function throttleTime<T>(duration: number,
-                                scheduler: IScheduler = async,
+                                scheduler: SchedulerLike = async,
                                 config: ThrottleConfig = defaultThrottleConfig): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new ThrottleTimeOperator(duration, scheduler, config.leading, config.trailing));
 }
 
 class ThrottleTimeOperator<T> implements Operator<T, T> {
   constructor(private duration: number,
-              private scheduler: IScheduler,
+              private scheduler: SchedulerLike,
               private leading: boolean,
               private trailing: boolean) {
   }
@@ -78,7 +77,7 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T>,
               private duration: number,
-              private scheduler: IScheduler,
+              private scheduler: SchedulerLike,
               private leading: boolean,
               private trailing: boolean) {
     super(destination);

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -1,11 +1,10 @@
 import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { IScheduler } from '../Scheduler';
 import { async } from '../scheduler/async';
-import { OperatorFunction, TimeInterval as TimeIntervalInterface } from '../types';
+import { OperatorFunction, SchedulerLike, TimeInterval as TimeIntervalInterface } from '../types';
 
-export function timeInterval<T>(scheduler: IScheduler = async): OperatorFunction<T, TimeInterval<T>> {
+export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunction<T, TimeInterval<T>> {
   return (source: Observable<T>) => source.lift(new TimeIntervalOperator(scheduler));
 }
 
@@ -16,7 +15,7 @@ export class TimeInterval<T> implements TimeIntervalInterface<T> {
 }
 
 class TimeIntervalOperator<T> implements Operator<T, TimeInterval<T>> {
-  constructor(private scheduler: IScheduler) {
+  constructor(private scheduler: SchedulerLike) {
 
   }
 
@@ -33,7 +32,7 @@ class TimeIntervalOperator<T> implements Operator<T, TimeInterval<T>> {
 class TimeIntervalSubscriber<T> extends Subscriber<T> {
   private lastTime: number = 0;
 
-  constructor(destination: Subscriber<TimeInterval<T>>, private scheduler: IScheduler) {
+  constructor(destination: Subscriber<TimeInterval<T>>, private scheduler: SchedulerLike) {
     super(destination);
 
     this.lastTime = scheduler.now();

--- a/src/internal/operators/timestamp.ts
+++ b/src/internal/operators/timestamp.ts
@@ -1,7 +1,6 @@
 
-import { IScheduler } from '../Scheduler';
 import { async } from '../scheduler/async';
-import { OperatorFunction, Timestamp as TimestampInterface } from '../types';
+import { OperatorFunction, SchedulerLike, Timestamp as TimestampInterface } from '../types';
 import { map } from './map';
 
 /**
@@ -10,7 +9,7 @@ import { map } from './map';
  * @method timestamp
  * @owner Observable
  */
-export function timestamp<T>(scheduler: IScheduler = async): OperatorFunction<T, Timestamp<T>> {
+export function timestamp<T>(scheduler: SchedulerLike = async): OperatorFunction<T, Timestamp<T>> {
   return map((value: T) => new Timestamp(value, scheduler.now()));
   // return (source: Observable<T>) => source.lift(new TimestampOperator(scheduler));
 }

--- a/src/internal/patching/operator/auditTime.ts
+++ b/src/internal/patching/operator/auditTime.ts
@@ -1,5 +1,5 @@
 import { async } from '../../scheduler/async';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { Observable } from '../../Observable';
 import { auditTime as higherOrder } from '../../operators/auditTime';
 
@@ -45,6 +45,6 @@ import { auditTime as higherOrder } from '../../operators/auditTime';
  * @method auditTime
  * @owner Observable
  */
-export function auditTime<T>(this: Observable<T>, duration: number, scheduler: IScheduler = async): Observable<T> {
+export function auditTime<T>(this: Observable<T>, duration: number, scheduler: SchedulerLike = async): Observable<T> {
   return higherOrder(duration, scheduler)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/bufferTime.ts
+++ b/src/internal/patching/operator/bufferTime.ts
@@ -1,13 +1,13 @@
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { async } from '../../scheduler/async';
 import { Observable } from '../../Observable';
 import { isScheduler } from '../..//util/isScheduler';
 import { bufferTime as higherOrder } from '../../operators/bufferTime';
 
 /* tslint:disable:max-line-length */
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, scheduler?: IScheduler): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, scheduler?: IScheduler): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, maxBufferSize: number, scheduler?: IScheduler): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, scheduler?: SchedulerLike): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, scheduler?: SchedulerLike): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, maxBufferSize: number, scheduler?: SchedulerLike): Observable<T[]>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -56,7 +56,7 @@ export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, buffe
 export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number): Observable<T[]> {
   let length: number = arguments.length;
 
-  let scheduler: IScheduler = async;
+  let scheduler: SchedulerLike = async;
   if (isScheduler(arguments[arguments.length - 1])) {
     scheduler = arguments[arguments.length - 1];
     length--;

--- a/src/internal/patching/operator/concat.ts
+++ b/src/internal/patching/operator/concat.ts
@@ -1,17 +1,16 @@
 import { Observable } from '../../Observable';
-import { ObservableInput } from '../../types';
-import { IScheduler } from '../../Scheduler';
+import { ObservableInput, SchedulerLike } from '../../types';
 import { concat as concatStatic } from '../../observable/concat';
 
 /* tslint:disable:max-line-length */
-export function concat<T>(this: Observable<T>, scheduler?: IScheduler): Observable<T>;
-export function concat<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
-export function concat<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
-export function concat<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
-export function concat<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function concat<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function concat<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | IScheduler>): Observable<T>;
-export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler>): Observable<R>;
+export function concat<T>(this: Observable<T>, scheduler?: SchedulerLike): Observable<T>;
+export function concat<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: SchedulerLike): Observable<T | T2>;
+export function concat<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function concat<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function concat<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function concat<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function concat<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | SchedulerLike>): Observable<T>;
+export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | SchedulerLike>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -63,6 +62,6 @@ export function concat<T, R>(this: Observable<T>, ...observables: Array<Observab
  * @method concat
  * @owner Observable
  */
-export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler>): Observable<R> {
+export function concat<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | SchedulerLike>): Observable<R> {
   return this.lift.call(concatStatic(this, ...observables));
 }

--- a/src/internal/patching/operator/debounceTime.ts
+++ b/src/internal/patching/operator/debounceTime.ts
@@ -1,6 +1,6 @@
 
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { async } from '../../scheduler/async';
 import { debounceTime as higherOrder } from '../../operators/debounceTime';
 
@@ -50,6 +50,6 @@ import { debounceTime as higherOrder } from '../../operators/debounceTime';
  * @method debounceTime
  * @owner Observable
  */
-export function debounceTime<T>(this: Observable<T>, dueTime: number, scheduler: IScheduler = async): Observable<T> {
+export function debounceTime<T>(this: Observable<T>, dueTime: number, scheduler: SchedulerLike = async): Observable<T> {
   return higherOrder(dueTime, scheduler)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/delay.ts
+++ b/src/internal/patching/operator/delay.ts
@@ -1,5 +1,5 @@
 import { async } from '../../scheduler/async';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { Observable } from '../../Observable';
 import { delay as higherOrder } from '../../operators/delay';
 
@@ -43,6 +43,6 @@ import { delay as higherOrder } from '../../operators/delay';
  * @owner Observable
  */
 export function delay<T>(this: Observable<T>, delay: number|Date,
-                         scheduler: IScheduler = async): Observable<T> {
+                         scheduler: SchedulerLike = async): Observable<T> {
   return higherOrder<T>(delay, scheduler)(this);
 }

--- a/src/internal/patching/operator/expand.ts
+++ b/src/internal/patching/operator/expand.ts
@@ -1,11 +1,10 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
 import { expand as higherOrder } from '../../operators/expand';
-import { ObservableInput } from '../../types';
+import { ObservableInput, SchedulerLike } from '../../types';
 
 /* tslint:disable:max-line-length */
-export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: IScheduler): Observable<R>;
-export function expand<T>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
+export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: SchedulerLike): Observable<R>;
+export function expand<T>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<T>, concurrent?: number, scheduler?: SchedulerLike): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -55,7 +54,7 @@ export function expand<T>(this: Observable<T>, project: (value: T, index: number
  */
 export function expand<T, R>(this: Observable<T>, project: (value: T, index: number) => ObservableInput<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,
-                             scheduler: IScheduler = undefined): Observable<R> {
+                             scheduler: SchedulerLike = undefined): Observable<R> {
   concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;
 
   return higherOrder(project, concurrent, scheduler)(this);

--- a/src/internal/patching/operator/merge.ts
+++ b/src/internal/patching/operator/merge.ts
@@ -1,23 +1,22 @@
 import { Observable } from '../../Observable';
-import { ObservableInput } from '../../types';
-import { IScheduler } from '../../Scheduler';
+import { ObservableInput, SchedulerLike } from '../../types';
 import { merge as mergeStatic } from '../../observable/merge';
 
 /* tslint:disable:max-line-length */
-export function merge<T>(this: Observable<T>, scheduler?: IScheduler): Observable<T>;
-export function merge<T>(this: Observable<T>, concurrent?: number, scheduler?: IScheduler): Observable<T>;
-export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: IScheduler): Observable<T | T2>;
-export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2>;
-export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: IScheduler): Observable<T | T2 | T3>;
-export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3>;
-export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: IScheduler): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | IScheduler | number>): Observable<T>;
-export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R>;
+export function merge<T>(this: Observable<T>, scheduler?: SchedulerLike): Observable<T>;
+export function merge<T>(this: Observable<T>, concurrent?: number, scheduler?: SchedulerLike): Observable<T>;
+export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, scheduler?: SchedulerLike): Observable<T | T2>;
+export function merge<T, T2>(this: Observable<T>, v2: ObservableInput<T2>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2>;
+export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function merge<T, T2, T3>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function merge<T, T2, T3, T4>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function merge<T, T2, T3, T4, T5>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function merge<T, T2, T3, T4, T5, T6>(this: Observable<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent?: number, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function merge<T>(this: Observable<T>, ...observables: Array<ObservableInput<T> | SchedulerLike | number>): Observable<T>;
+export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | SchedulerLike | number>): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -66,6 +65,6 @@ export function merge<T, R>(this: Observable<T>, ...observables: Array<Observabl
  * @method merge
  * @owner Observable
  */
-export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | IScheduler | number>): Observable<R> {
+export function merge<T, R>(this: Observable<T>, ...observables: Array<ObservableInput<any> | SchedulerLike | number>): Observable<R> {
   return this.lift.call(mergeStatic(this, ...observables));
 }

--- a/src/internal/patching/operator/observeOn.ts
+++ b/src/internal/patching/operator/observeOn.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { observeOn as higherOrder } from '../../operators/observeOn';
 
 /**
@@ -40,7 +40,7 @@ import { observeOn as higherOrder } from '../../operators/observeOn';
  *
  * @see {@link delay}
  *
- * @param {IScheduler} scheduler Scheduler that will be used to reschedule notifications from source Observable.
+ * @param {SchedulerLike} scheduler Scheduler that will be used to reschedule notifications from source Observable.
  * @param {number} [delay] Number of milliseconds that states with what delay every notification should be rescheduled.
  * @return {Observable<T>} Observable that emits the same notifications as the source Observable,
  * but with provided scheduler.
@@ -48,6 +48,6 @@ import { observeOn as higherOrder } from '../../operators/observeOn';
  * @method observeOn
  * @owner Observable
  */
-export function observeOn<T>(this: Observable<T>, scheduler: IScheduler, delay: number = 0): Observable<T> {
+export function observeOn<T>(this: Observable<T>, scheduler: SchedulerLike, delay: number = 0): Observable<T> {
   return higherOrder(scheduler, delay)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/publishReplay.ts
+++ b/src/internal/patching/operator/publishReplay.ts
@@ -1,13 +1,12 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
 import { ConnectableObservable } from '../../observable/ConnectableObservable';
 import { publishReplay as higherOrder } from '../../operators/publishReplay';
-import { OperatorFunction, MonoTypeOperatorFunction } from '../../../internal/types';
+import { OperatorFunction, MonoTypeOperatorFunction, SchedulerLike } from '../../../internal/types';
 
 /* tslint:disable:max-line-length */
-export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, scheduler?: IScheduler): ConnectableObservable<T>;
+export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): ConnectableObservable<T>;
 export function publishReplay<T, R>(this: Observable<T>, bufferSize?: number, windowTime?: number, selector?: OperatorFunction<T, R>): Observable<R>;
-export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: IScheduler): Observable<T>;
+export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, selector?: MonoTypeOperatorFunction<T>, scheduler?: SchedulerLike): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -21,8 +20,8 @@ export function publishReplay<T>(this: Observable<T>, bufferSize?: number, windo
  */
 export function publishReplay<T, R>(this: Observable<T>, bufferSize?: number,
                                     windowTime?: number,
-                                    selectorOrScheduler?: IScheduler | OperatorFunction<T, R>,
-                                    scheduler?: IScheduler): Observable<R> | ConnectableObservable<R> {
+                                    selectorOrScheduler?: SchedulerLike | OperatorFunction<T, R>,
+                                    scheduler?: SchedulerLike): Observable<R> | ConnectableObservable<R> {
 
   return higherOrder<T, R>(bufferSize, windowTime, selectorOrScheduler as any, scheduler)(this);
 }

--- a/src/internal/patching/operator/sampleTime.ts
+++ b/src/internal/patching/operator/sampleTime.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { async } from '../../scheduler/async';
 import { sampleTime as higherOrder } from '../../operators/sampleTime';
 
@@ -39,6 +39,6 @@ import { sampleTime as higherOrder } from '../../operators/sampleTime';
  * @method sampleTime
  * @owner Observable
  */
-export function sampleTime<T>(this: Observable<T>, period: number, scheduler: IScheduler = async): Observable<T> {
+export function sampleTime<T>(this: Observable<T>, period: number, scheduler: SchedulerLike = async): Observable<T> {
   return higherOrder(period, scheduler)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/shareReplay.ts
+++ b/src/internal/patching/operator/shareReplay.ts
@@ -1,12 +1,12 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { shareReplay as higherOrder } from '../../operators/shareReplay';
 
 /**
  * @method shareReplay
  * @owner Observable
  */
-export function shareReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, scheduler?: IScheduler):
+export function shareReplay<T>(this: Observable<T>, bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike):
   Observable<T> {
   return higherOrder(bufferSize, windowTime, scheduler)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/startWith.ts
+++ b/src/internal/patching/operator/startWith.ts
@@ -1,15 +1,15 @@
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { Observable } from '../../Observable';
 import { startWith as higherOrder } from '../../operators/startWith';
 
 /* tslint:disable:max-line-length */
-export function startWith<T>(this: Observable<T>, v1: T, scheduler?: IScheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, scheduler?: IScheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, scheduler?: IScheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, scheduler?: IScheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: IScheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: IScheduler): Observable<T>;
-export function startWith<T>(this: Observable<T>, ...array: Array<T | IScheduler>): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, scheduler?: SchedulerLike): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, scheduler?: SchedulerLike): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, scheduler?: SchedulerLike): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, scheduler?: SchedulerLike): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: SchedulerLike): Observable<T>;
+export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: SchedulerLike): Observable<T>;
+export function startWith<T>(this: Observable<T>, ...array: Array<T | SchedulerLike>): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -26,6 +26,6 @@ export function startWith<T>(this: Observable<T>, ...array: Array<T | IScheduler
  * @method startWith
  * @owner Observable
  */
-export function startWith<T>(this: Observable<T>, ...array: Array<T | IScheduler>): Observable<T> {
+export function startWith<T>(this: Observable<T>, ...array: Array<T | SchedulerLike>): Observable<T> {
   return higherOrder(...array)(this);
 }

--- a/src/internal/patching/operator/subscribeOn.ts
+++ b/src/internal/patching/operator/subscribeOn.ts
@@ -1,5 +1,5 @@
 
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { Observable } from '../../Observable';
 import { subscribeOn as higherOrder } from '../../operators/subscribeOn';
 
@@ -14,6 +14,6 @@ import { subscribeOn as higherOrder } from '../../operators/subscribeOn';
  * @method subscribeOn
  * @owner Observable
  */
-export function subscribeOn<T>(this: Observable<T>, scheduler: IScheduler, delay: number = 0): Observable<T> {
+export function subscribeOn<T>(this: Observable<T>, scheduler: SchedulerLike, delay: number = 0): Observable<T> {
   return higherOrder(scheduler, delay)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/throttleTime.ts
+++ b/src/internal/patching/operator/throttleTime.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { async } from '../../scheduler/async';
 import { ThrottleConfig, defaultThrottleConfig } from '../../operators/throttle';
 import { throttleTime as higherOrder } from '../../operators/throttleTime';
@@ -45,7 +45,7 @@ import { throttleTime as higherOrder } from '../../operators/throttleTime';
  */
 export function throttleTime<T>(this: Observable<T>,
                                 duration: number,
-                                scheduler: IScheduler = async,
+                                scheduler: SchedulerLike = async,
                                 config: ThrottleConfig = defaultThrottleConfig): Observable<T> {
   return higherOrder(duration, scheduler, config)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/timeInterval.ts
+++ b/src/internal/patching/operator/timeInterval.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { async } from '../../scheduler/async';
 import { timeInterval as higherOrder, TimeInterval } from '../../operators/timeInterval';
 export {TimeInterval};
@@ -10,6 +10,6 @@ export {TimeInterval};
  * @method timeInterval
  * @owner Observable
  */
-export function timeInterval<T>(this: Observable<T>, scheduler: IScheduler = async): Observable<TimeInterval<T>> {
+export function timeInterval<T>(this: Observable<T>, scheduler: SchedulerLike = async): Observable<TimeInterval<T>> {
   return higherOrder(scheduler)(this) as Observable<TimeInterval<T>>;
 }

--- a/src/internal/patching/operator/timeout.ts
+++ b/src/internal/patching/operator/timeout.ts
@@ -1,5 +1,5 @@
 import { async } from '../../scheduler/async';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { Observable } from '../../Observable';
 import { timeout as higherOrder } from '../../operators/timeout';
 
@@ -70,6 +70,6 @@ import { timeout as higherOrder } from '../../operators/timeout';
  */
 export function timeout<T>(this: Observable<T>,
                            due: number | Date,
-                           scheduler: IScheduler = async): Observable<T> {
+                           scheduler: SchedulerLike = async): Observable<T> {
   return higherOrder(due, scheduler)(this) as Observable<T>;
 }

--- a/src/internal/patching/operator/timeoutWith.ts
+++ b/src/internal/patching/operator/timeoutWith.ts
@@ -1,12 +1,11 @@
-import { IScheduler } from '../../Scheduler';
 import { async } from '../../scheduler/async';
 import { Observable } from '../../Observable';
-import { ObservableInput } from '../../types';
+import { ObservableInput, SchedulerLike } from '../../types';
 import { timeoutWith as higherOrder } from '../../operators/timeoutWith';
 
 /* tslint:disable:max-line-length */
-export function timeoutWith<T>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<T>, scheduler?: IScheduler): Observable<T>;
-export function timeoutWith<T, R>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<R>, scheduler?: IScheduler): Observable<T | R>;
+export function timeoutWith<T>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<T>, scheduler?: SchedulerLike): Observable<T>;
+export function timeoutWith<T, R>(this: Observable<T>, due: number | Date, withObservable: ObservableInput<R>, scheduler?: SchedulerLike): Observable<T | R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -58,6 +57,6 @@ export function timeoutWith<T, R>(this: Observable<T>, due: number | Date, withO
  */
 export function timeoutWith<T, R>(this: Observable<T>, due: number | Date,
                                   withObservable: ObservableInput<R>,
-                                  scheduler: IScheduler = async): Observable<T | R> {
+                                  scheduler: SchedulerLike = async): Observable<T | R> {
   return higherOrder(due, withObservable, scheduler)(this as any);
 }

--- a/src/internal/patching/operator/timestamp.ts
+++ b/src/internal/patching/operator/timestamp.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../../Observable';
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { async } from '../../scheduler/async';
 import { timestamp as higherOrder, Timestamp } from '../../operators/timestamp';
 /**
@@ -8,6 +8,6 @@ import { timestamp as higherOrder, Timestamp } from '../../operators/timestamp';
  * @method timestamp
  * @owner Observable
  */
-export function timestamp<T>(this: Observable<T>, scheduler: IScheduler = async): Observable<Timestamp<T>> {
+export function timestamp<T>(this: Observable<T>, scheduler: SchedulerLike = async): Observable<Timestamp<T>> {
   return higherOrder(scheduler)(this) as Observable<Timestamp<T>>;
 }

--- a/src/internal/patching/operator/windowTime.ts
+++ b/src/internal/patching/operator/windowTime.ts
@@ -1,4 +1,4 @@
-import { IScheduler } from '../../Scheduler';
+import { SchedulerLike } from '../../types';
 import { async } from '../../scheduler/async';
 import { Observable } from '../../Observable';
 import { isNumeric } from '../..//util/isNumeric';
@@ -66,19 +66,19 @@ import { windowTime as higherOrder } from '../../operators/windowTime';
  * @owner Observable
  */
 export function windowTime<T>(this: Observable<T>, windowTimeSpan: number,
-                              scheduler?: IScheduler): Observable<Observable<T>>;
+                              scheduler?: SchedulerLike): Observable<Observable<T>>;
 export function windowTime<T>(this: Observable<T>, windowTimeSpan: number,
                               windowCreationInterval: number,
-                              scheduler?: IScheduler): Observable<Observable<T>>;
+                              scheduler?: SchedulerLike): Observable<Observable<T>>;
 export function windowTime<T>(this: Observable<T>, windowTimeSpan: number,
                               windowCreationInterval: number,
                               maxWindowSize: number,
-                              scheduler?: IScheduler): Observable<Observable<T>>;
+                              scheduler?: SchedulerLike): Observable<Observable<T>>;
 
 export function windowTime<T>(this: Observable<T>,
                               windowTimeSpan: number): Observable<Observable<T>> {
 
-  let scheduler: IScheduler = async;
+  let scheduler: SchedulerLike = async;
   let windowCreationInterval: number = null;
   let maxWindowSize: number = Number.POSITIVE_INFINITY;
 

--- a/src/internal/scheduler/Action.ts
+++ b/src/internal/scheduler/Action.ts
@@ -1,5 +1,6 @@
 import { Scheduler } from '../Scheduler';
 import { Subscription } from '../Subscription';
+import { SchedulerAction } from '../types';
 
 /**
  * A unit of work to be executed in a {@link Scheduler}. An action is typically
@@ -16,7 +17,7 @@ import { Subscription } from '../Subscription';
  * @class Action<T>
  */
 export class Action<T> extends Subscription {
-  constructor(scheduler: Scheduler, work: (this: Action<T>, state?: T) => void) {
+  constructor(scheduler: Scheduler, work: (this: SchedulerAction<T>, state?: T) => void) {
     super();
   }
   /**

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -1,6 +1,6 @@
 import { AsyncAction } from './AsyncAction';
 import { AnimationFrameScheduler } from './AnimationFrameScheduler';
-import { Action } from './Action';
+import { SchedulerAction } from '../types';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -10,7 +10,7 @@ import { Action } from './Action';
 export class AnimationFrameAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AnimationFrameScheduler,
-              protected work: (this: Action<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -1,8 +1,7 @@
 import { Immediate } from '../util/Immediate';
 import { AsyncAction } from './AsyncAction';
 import { AsapScheduler } from './AsapScheduler';
-import { Action } from './Action';
-
+import { SchedulerAction } from '../types';
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @ignore
@@ -11,7 +10,7 @@ import { Action } from './Action';
 export class AsapAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AsapScheduler,
-              protected work: (this: Action<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -1,4 +1,5 @@
 import { Action } from './Action';
+import { SchedulerAction } from '../types';
 import { Subscription } from '../Subscription';
 import { AsyncScheduler } from './AsyncScheduler';
 
@@ -15,7 +16,7 @@ export class AsyncAction<T> extends Action<T> {
   protected pending: boolean = false;
 
   constructor(protected scheduler: AsyncScheduler,
-              protected work: (this: Action<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/QueueAction.ts
+++ b/src/internal/scheduler/QueueAction.ts
@@ -1,7 +1,7 @@
 import { AsyncAction } from './AsyncAction';
 import { Subscription } from '../Subscription';
 import { QueueScheduler } from './QueueScheduler';
-import { Action } from './Action';
+import { SchedulerAction } from '../types';
 
 /**
  * We need this JSDoc comment for affecting ESDoc.
@@ -11,7 +11,7 @@ import { Action } from './Action';
 export class QueueAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: QueueScheduler,
-              protected work: (this: Action<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -1,7 +1,7 @@
 import { AsyncAction } from './AsyncAction';
 import { Subscription } from '../Subscription';
 import { AsyncScheduler } from './AsyncScheduler';
-import { Action } from './Action';
+import { SchedulerAction } from '../types';
 
 export class VirtualTimeScheduler extends AsyncScheduler {
 
@@ -50,7 +50,7 @@ export class VirtualAction<T> extends AsyncAction<T> {
   protected active: boolean = true;
 
   constructor(protected scheduler: VirtualTimeScheduler,
-              protected work: (this: Action<T>, state?: T) => void,
+              protected work: (this: SchedulerAction<T>, state?: T) => void,
               protected index: number = scheduler.index += 1) {
     super(scheduler, work);
     this.index = scheduler.index = index;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,6 @@
 import { Observable } from './Observable';
+import { Action as _Action } from './scheduler/Action';
+import { Subscription } from './Subscription';
 
 /** OPERATOR INTERFACES */
 
@@ -82,4 +84,15 @@ export interface Observer<T> {
   next: (value: T) => void;
   error: (err: any) => void;
   complete: () => void;
+}
+
+/** SCHEDULER INTERFACES */
+
+export interface SchedulerLike {
+  now(): number;
+  schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay?: number, state?: T): Subscription;
+}
+
+export interface SchedulerAction<T> extends Subscription {
+  schedule(state?: T, delay?: number): Subscription;
 }


### PR DESCRIPTION
… and expose publically

This avoids the need to expose `IScheduler`.