### PR TITLE
refactor(Symbol_iterator): remove warning

### DIFF
--- a/src/internal/symbol/iterator.ts
+++ b/src/internal/symbol/iterator.ts
@@ -1,10 +1,5 @@
 export function getSymbolIterator(): symbol {
-  /* NOTE: Warning users that they don't have a Symbol.iterator
-     polyfill. We don't want to throw on this, because it's not required
-     by the library. However it will provide clues to users on older
-     browsers why things like `from(iterable)` doesn't work. */
   if (typeof Symbol !== 'function' || !Symbol.iterator) {
-    console.warn('RxJS: Symbol.iterator does not exist, so things like from(iterable) won\'t work');
     return '@@iterator' as any;
   }
 


### PR DESCRIPTION
Removes the console.warn as it's liable to cause more trouble and confusion than it is to help.