### PR TITLE
refactor(ignoreElements): ignoreElements now returns Observable<never>

### DIFF
--- a/spec/support/tests2png.opts
+++ b/spec/support/tests2png.opts
@@ -1,4 +1,4 @@
---require spec-js/helpers/polyfills.ts
+--require spec/helpers/polyfills.ts
 --require source-map-support/register
 --require spec/helpers/tests2png/diagram-test-runner.ts
 --require spec/helpers/testScheduler-ui.ts

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -1,7 +1,8 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { MonoTypeOperatorFunction } from '../types';
+import { OperatorFunction } from '../types';
+import { NEVER } from '../observable/never';
 
 /**
  * Ignores all items emitted by the source Observable and only passes calls of `complete` or `error`.
@@ -13,7 +14,7 @@ import { MonoTypeOperatorFunction } from '../types';
  * @method ignoreElements
  * @owner Observable
  */
-export function ignoreElements<T>(): MonoTypeOperatorFunction<T> {
+export function ignoreElements<T>(): OperatorFunction<T, Observable<never> > {
   return function ignoreElementsOperatorFunction(source: Observable<T>) {
     return source.lift(new IgnoreElementsOperator());
   };
@@ -28,10 +29,9 @@ class IgnoreElementsOperator<T, R> implements Operator<T, R> {
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @ignore
- * @extends {Ignored}
  */
 class IgnoreElementsSubscriber<T> extends Subscriber<T> {
-  protected _next(unused: T): void {
-    // Do nothing
+  protected _next(unused: T): Observable<never> {
+    return NEVER;
   }
 }

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -2,7 +2,6 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
-import { NEVER } from '../observable/never';
 
 /**
  * Ignores all items emitted by the source Observable and only passes calls of `complete` or `error`.
@@ -14,8 +13,8 @@ import { NEVER } from '../observable/never';
  * @method ignoreElements
  * @owner Observable
  */
-export function ignoreElements<T>(): OperatorFunction<T, Observable<never> > {
-  return function ignoreElementsOperatorFunction(source: Observable<T>) {
+export function ignoreElements(): OperatorFunction<any, never> {
+  return function ignoreElementsOperatorFunction(source: Observable<any>) {
     return source.lift(new IgnoreElementsOperator());
   };
 }
@@ -29,9 +28,10 @@ class IgnoreElementsOperator<T, R> implements Operator<T, R> {
 /**
  * We need this JSDoc comment for affecting ESDoc.
  * @ignore
+ * @extends {Ignored}
  */
 class IgnoreElementsSubscriber<T> extends Subscriber<T> {
-  protected _next(unused: T): Observable<never> {
-    return NEVER;
+  protected _next(unused: T): void {
+    // Do nothing
   }
 }

--- a/src/internal/patching/operator/ignoreElements.ts
+++ b/src/internal/patching/operator/ignoreElements.ts
@@ -11,6 +11,6 @@ import { ignoreElements as higherOrder } from '../../operators/ignoreElements';
  * @method ignoreElements
  * @owner Observable
  */
-export function ignoreElements<T>(this: Observable<T>): Observable<never> {
-  return higherOrder()(this) as Observable<never>;
+export function ignoreElements(this: Observable<any>): Observable<never> {
+  return higherOrder()(this);
 }

--- a/src/internal/patching/operator/ignoreElements.ts
+++ b/src/internal/patching/operator/ignoreElements.ts
@@ -11,6 +11,6 @@ import { ignoreElements as higherOrder } from '../../operators/ignoreElements';
  * @method ignoreElements
  * @owner Observable
  */
-export function ignoreElements<T>(this: Observable<T>): Observable<T> {
-  return higherOrder()(this) as Observable<T>;
+export function ignoreElements<T>(this: Observable<T>): Observable<never> {
+  return higherOrder()(this) as Observable<never>;
 }


### PR DESCRIPTION
Per #2640 ignoreElements should resolve to Observable<never>, #3340 asks for this explicitly, there was also another issue with tests2png that I fix here (not sure where that came from)

Closes #3340

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

  - Makes ignoreElements return `Observable<never>` instead of whatever you feed into it (for example if you use `Observable<string>` it returns `Observable<string>`, fixing #3340 and #2640 
  - `tests2png` got broken again, fixed that too (see `spec/support/tests2png.opts`)

**Related issue (if exists):**
#3340 and #2640 
