### PR TITLE
fix(fromEvent): pass options in unsubscribe

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -129,16 +129,17 @@ describe('Observable.fromEvent', () => {
     expect(subscribe).to.throw(TypeError, 'Invalid event target');
   });
 
-  it('should pass through options to addEventListener', () => {
-    let actualOptions;
+  it('should pass through options to addEventListener and removeEventListener', () => {
+    let onOptions;
+    let offOptions;
     const expectedOptions = { capture: true, passive: true };
 
     const obj = {
       addEventListener: (a: string, b: EventListenerOrEventListenerObject, c?: any) => {
-        actualOptions = c;
+        onOptions = c;
       },
       removeEventListener: (a: string, b: EventListenerOrEventListenerObject, c?: any) => {
-        //noop
+        offOptions = c;
       }
     };
 
@@ -149,7 +150,8 @@ describe('Observable.fromEvent', () => {
 
     subscription.unsubscribe();
 
-    expect(actualOptions).to.equal(expectedOptions);
+    expect(onOptions).to.equal(expectedOptions);
+    expect(offOptions).to.equal(expectedOptions);
   });
 
   it('should pass through events that occur', (done: MochaDone) => {

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -206,7 +206,7 @@ export class FromEventObservable<T> extends Observable<T> {
     } else if (isEventTarget(sourceObj)) {
       const source = sourceObj;
       sourceObj.addEventListener(eventName, <EventListener>handler, <boolean>options);
-      unsubscribe = () => source.removeEventListener(eventName, <EventListener>handler);
+      unsubscribe = () => source.removeEventListener(eventName, <EventListener>handler, <boolean>options);
     } else if (isJQueryStyleEventEmitter(sourceObj)) {
       const source = sourceObj;
       sourceObj.on(eventName, handler);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR includes the same fix as #3350, but targets the stable branch.

The PR cherry picks a commit from #3350 (that adds an expectation to a `fromEvent` test) and changes `FromEventObservable` so that the test passes.

The fix in #3350 was rebased to account for refactorings that were made to `fromEvent` after the PR was opened. I guess the issue is something that ought to be fixed in stable, too.

**Related issue (if exists):** #3349
