### PR TITLE
build: use tsc importHelpers flag to remove duplicate helpers from esm5 and esm2015 builds

### DIFF
--- a/package.json
+++ b/package.json
@@ -166,6 +166,9 @@
     "url": "https://github.com/ReactiveX/RxJS/issues"
   },
   "homepage": "https://github.com/ReactiveX/RxJS",
+  "dependencies": {
+    "tslib": "^1.9.0"
+  },
   "devDependencies": {
     "@angular-devkit/build-optimizer": "0.0.24",
     "@types/chai": "4.1.2",
@@ -224,7 +227,6 @@
     "source-map-support": "0.5.3",
     "symbol-observable": "1.0.1",
     "ts-node": "4.1.0",
-    "tslib": "1.5.0",
     "tslint": "5.9.1",
     "tslint-no-unused-expression-chai": "0.0.3",
     "typescript": "latest",

--- a/tsconfig/tsconfig.esm2015.json
+++ b/tsconfig/tsconfig.esm2015.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "es2015",
+    "importHelpers": true,
+    "moduleResolution": "node",
     "target": "es2015",
     "outDir": "../dist/esm2015"
   }

--- a/tsconfig/tsconfig.esm5.json
+++ b/tsconfig/tsconfig.esm5.json
@@ -2,6 +2,8 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "es2015",
+    "importHelpers": true,
+    "moduleResolution": "node",
     "target": "es5",
     "outDir": "../dist/esm5"
   }


### PR DESCRIPTION
I intentionally didn't use the flag for cjs builds because that would
make cjs builds incompatible with SystemJS without further configuration
on the client-side - this would be highly undesirable.