### PR TITLE
fix(fromEvent): Defines toString to fix Closure compilations

### DIFF
--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -2,6 +2,8 @@ import { Observable } from '../Observable';
 import { isFunction } from '../util/isFunction';
 import { Subscriber } from '../Subscriber';
 
+const toString: Function = Object.prototype.toString;
+
 export type NodeStyleEventEmitter = {
   addListener: (eventName: string, handler: Function) => void;
   removeListener: (eventName: string, handler: Function) => void;


### PR DESCRIPTION
**Description:**
Compiling RxJS with Closure currently fails with `rxjs/src/internal/observable/fromEvent.closure.js:204: ERROR - variable toString is undeclared`. This fix is copied from [here](https://github.com/ReactiveX/rxjs/blob/1d100d3c34ebee5d2484a3b664a56f8600cc1f2c/src/observable/FromEventObservable.ts#L8).