### PR TITLE
refactor(catchError): add type overloads for functions that do not re…

### DIFF
--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -4,7 +4,19 @@ import { Observable } from '../Observable';
 
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
-import { ObservableInput, OperatorFunction } from '../types';
+import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction } from '../types';
+
+export function catchError<T>(
+  selector: (err: any, caught: Observable<T>) => never
+): MonoTypeOperatorFunction<T>;
+
+export function catchError<T>(
+  selector: (err: any, caught: Observable<T>) => ObservableInput<T>
+): MonoTypeOperatorFunction<T>;
+
+export function catchError<T, R>(
+  selector: (err: any, caught: Observable<T>) => ObservableInput<R>
+): OperatorFunction<T, R>;
 
 /**
  * Catches errors on the observable to be handled by returning a new observable or throwing an error.
@@ -63,7 +75,7 @@ import { ObservableInput, OperatorFunction } from '../types';
  *  catch `selector` function.
  * @name catchError
  */
-export function catchError<T, R>(selector: (err: any, caught: Observable<T>) => ObservableInput<R>): OperatorFunction<T, T | R> {
+export function catchError<T, R>(selector: (err: any, caught: Observable<T>) => ObservableInput<R>|never): OperatorFunction<T, T | R> {
   return function catchErrorOperatorFunction(source: Observable<T>): Observable<T | R> {
     const operator = new CatchOperator(selector);
     const caught = source.lift(operator);


### PR DESCRIPTION
…turn

Added per suggestion of @mprobst [here](https://github.com/ReactiveX/rxjs/issues/3395#issuecomment-371062130), it should provide slightly better type inferrence once other issues with `pipe` type inference are straightened out.

related #3395
