### PR TITLE
refactor(Observable): remove internal flag on source and operator

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -20,9 +20,16 @@ export class Observable<T> implements Subscribable<T> {
   /** @internal */
   public _isScalar: boolean = false;
 
-  /** @internal */
+  /**
+   * The source observable to get values from. This should only be used when
+   * overriding {@link lift}.
+   */
   protected source: Observable<any>;
-  /** @internal */
+
+  /**
+   * The operator definution to use as part of the operator chain. This should
+   * only be used when overriding {@link lift}.
+   */
   protected operator: Operator<any, T>;
 
   /**


### PR DESCRIPTION
These are normal to access inside of the `lift` method of an extended Observable. They should not be used anywhere else, this also adds some documentation to that effect.
