### PR TITLE
feat(umd): UMD now mirrors export schema for ESM and CJS

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -112,10 +112,10 @@ fs.copySync('src/testing/package.json', PKG_ROOT + '/testing/package.json');
 if (fs.existsSync(UMD_ROOT)) {
   fs.copySync(UMD_ROOT, UMD_PKG);
   // Add licenses to tops of bundles
-  addLicenseToFile('LICENSE.txt', UMD_PKG + 'Rx.js');
-  addLicenseTextToFile(license, UMD_PKG + 'Rx.min.js');
-  addLicenseToFile('LICENSE.txt', UMD_PKG + 'Rx.js');
-  addLicenseTextToFile(license, UMD_PKG + 'Rx.min.js');
+  addLicenseToFile('LICENSE.txt', UMD_PKG + 'rxjs.umd.js');
+  addLicenseTextToFile(license, UMD_PKG + 'rxjs.umd.min.js');
+  addLicenseToFile('LICENSE.txt', UMD_PKG + 'rxjs.umd.js');
+  addLicenseTextToFile(license, UMD_PKG + 'rxjs.umd.min.js');
 }
 
 function copySources(rootDir, packageDir, ignoreMissing) {

--- a/dangerfile.js
+++ b/dangerfile.js
@@ -69,72 +69,75 @@ if (!messageConventionValid) {
   markdown('> (' + errorCount + ') : RxJS uses conventional change log to generate changelog automatically. It seems some of commit messages are not following those, please check [contributing guideline](https://github.com/ReactiveX/rxjs/blob/master/CONTRIBUTING.md#commit-message-format) and update commit messages.');
 }
 
-function getKB(size) {
-  return (size / 1024).toFixed(1);
-}
+// TODO(benlesh): update script to run against proper global files
+// The name has changed to `rxjs.umd.js` from `Rx.js`
 
-function getFormattedKB(size) {
-  if (size < 0) {
-    return '-' + size.toString();
-  } else if (size > 0) {
-    return '+' + size.toString();
-  }
-  return size.toString();
-}
+// function getKB(size) {
+//   return (size / 1024).toFixed(1);
+// }
 
-var globalFile = 'Rx.js';
-var minFile = 'Rx.min.js';
+// function getFormattedKB(size) {
+//   if (size < 0) {
+//     return '-' + size.toString();
+//   } else if (size > 0) {
+//     return '+' + size.toString();
+//   }
+//   return size.toString();
+// }
 
-function sizeDiffBadge(name, value) {
-  var color = 'lightgrey';
-  if (value > 0) {
-    color = 'red';
-  } else if (value < 0) {
-    color = 'green';
-  }
-  return 'https://img.shields.io/badge/' + name + '-' + getFormattedKB(getKB(value)) + 'KB-' + color + '.svg?style=flat-square';
-}
+// var globalFile = 'Rx.js';
+// var minFile = 'Rx.min.js';
 
-//post size of build
-schedule(new Promise(function (res) {
-  getSize('./dist/cjs', function (e, result) {
-    var localGlobalFile = path.resolve('./dist/global', globalFile);
-    var localMinFile = path.resolve('./dist/global', minFile);
+// function sizeDiffBadge(name, value) {
+//   var color = 'lightgrey';
+//   if (value > 0) {
+//     color = 'red';
+//   } else if (value < 0) {
+//     color = 'green';
+//   }
+//   return 'https://img.shields.io/badge/' + name + '-' + getFormattedKB(getKB(value)) + 'KB-' + color + '.svg?style=flat-square';
+// }
 
-    //get sizes of PR build
-    var global = fs.statSync(localGlobalFile);
-    var global_gzip = gzipSize.sync(fs.readFileSync(localGlobalFile, 'utf8'));
-    var min = fs.statSync(localMinFile);
-    var min_gzip = gzipSize.sync(fs.readFileSync(localMinFile, 'utf8'));
+// //post size of build
+// schedule(new Promise(function (res) {
+//   getSize('./dist/cjs', function (e, result) {
+//     var localGlobalFile = path.resolve('./dist/global', globalFile);
+//     var localMinFile = path.resolve('./dist/global', minFile);
 
-    //resolve path to release build
-    var releasePath = path.dirname(require.resolve(require.resolve('rxjs')));
-    var bundlePath = path.resolve(releasePath, 'bundles');
-    var bundleGlobalFile = path.resolve(bundlePath, globalFile);
-    var bundleMinFile = path.resolve(bundlePath, minFile);
+//     //get sizes of PR build
+//     var global = fs.statSync(localGlobalFile);
+//     var global_gzip = gzipSize.sync(fs.readFileSync(localGlobalFile, 'utf8'));
+//     var min = fs.statSync(localMinFile);
+//     var min_gzip = gzipSize.sync(fs.readFileSync(localMinFile, 'utf8'));
 
-    var packagePath = path.resolve(releasePath, 'package.json');
-    var releaseVersion = require(packagePath).version;
+//     //resolve path to release build
+//     var releasePath = path.dirname(require.resolve(require.resolve('rxjs')));
+//     var bundlePath = path.resolve(releasePath, 'bundles');
+//     var bundleGlobalFile = path.resolve(bundlePath, globalFile);
+//     var bundleMinFile = path.resolve(bundlePath, minFile);
 
-    //get sizes of release build
-    var bundleGlobal = fs.statSync(bundleGlobalFile);
-    var bundle_global_gzip = gzipSize.sync(fs.readFileSync(bundleGlobalFile, 'utf8'));
-    var bundleMin = fs.statSync(bundleMinFile);
-    var bundle_min_gzip = gzipSize.sync(fs.readFileSync(bundleMinFile, 'utf8'));
+//     var packagePath = path.resolve(releasePath, 'package.json');
+//     var releaseVersion = require(packagePath).version;
 
-    var sizeMessage = '<img src="https://img.shields.io/badge/Size%20Diff%20%28' + releaseVersion + '%29--lightgrey.svg?style=flat-square"/>  ';
-    sizeMessage += '<img src="' + sizeDiffBadge('Global', global.size - bundleGlobal.size) + '"/> ';
-    sizeMessage += '<img src="' + sizeDiffBadge('Global(gzip)', global_gzip - bundle_global_gzip) + '"/> ';
-    sizeMessage += '<img src="' + sizeDiffBadge('Min', min.size - bundleMin.size) + '"/> ';
-    sizeMessage += '<img src="' + sizeDiffBadge('Min (gzip)', min_gzip - bundle_min_gzip) + '"/> ';
-    message(sizeMessage);
+//     //get sizes of release build
+//     var bundleGlobal = fs.statSync(bundleGlobalFile);
+//     var bundle_global_gzip = gzipSize.sync(fs.readFileSync(bundleGlobalFile, 'utf8'));
+//     var bundleMin = fs.statSync(bundleMinFile);
+//     var bundle_min_gzip = gzipSize.sync(fs.readFileSync(bundleMinFile, 'utf8'));
 
-    markdown('> CJS: **' + getKB(result) +
-      '**KB, global: **' + getKB(global.size) +
-      '**KB (gzipped: **' + getKB(global_gzip) +
-      '**KB), min: **' + getKB(min.size) +
-      '**KB (gzipped: **' + getKB(min_gzip) + '**KB)');
+//     var sizeMessage = '<img src="https://img.shields.io/badge/Size%20Diff%20%28' + releaseVersion + '%29--lightgrey.svg?style=flat-square"/>  ';
+//     sizeMessage += '<img src="' + sizeDiffBadge('Global', global.size - bundleGlobal.size) + '"/> ';
+//     sizeMessage += '<img src="' + sizeDiffBadge('Global(gzip)', global_gzip - bundle_global_gzip) + '"/> ';
+//     sizeMessage += '<img src="' + sizeDiffBadge('Min', min.size - bundleMin.size) + '"/> ';
+//     sizeMessage += '<img src="' + sizeDiffBadge('Min (gzip)', min_gzip - bundle_min_gzip) + '"/> ';
+//     message(sizeMessage);
 
-    res();
-  });
-}));
+//     markdown('> CJS: **' + getKB(result) +
+//       '**KB, global: **' + getKB(global.size) +
+//       '**KB (gzipped: **' + getKB(global_gzip) +
+//       '**KB), min: **' + getKB(min.size) +
+//       '**KB (gzipped: **' + getKB(min_gzip) + '**KB)');
+
+//     res();
+//   });
+// }));

--- a/src/internal/umd.ts
+++ b/src/internal/umd.ts
@@ -3,20 +3,20 @@
  */
 
 /* rxjs */
-export * from '../';
+export * from '../index';
 
 /* rxjs.operators */
-import * as _operators from '../operators';
+import * as _operators from '../operators/index';
 export const operators = _operators;
 
 /* rxjs.testing */
-import * as _testing from '../testing';
+import * as _testing from '../testing/index';
 export const testing = _testing;
 
 /* rxjs.ajax */
-import * as _ajax from '../ajax';
+import * as _ajax from '../ajax/index';
 export const ajax = _ajax;
 
 /* rxjs.websocket */
-import * as _websocket from '../websocket';
+import * as _websocket from '../websocket/index';
 export const websocket = _websocket;

--- a/tools/make-closure-core.js
+++ b/tools/make-closure-core.js
@@ -1,7 +1,7 @@
 var compiler = require('google-closure-compiler-js').compile;
 var fs = require('fs');
 
-var source = fs.readFileSync('dist/global/Rx.js', 'utf8');
+var source = fs.readFileSync('dist/global/rxjs.umd.js', 'utf8');
 
 var compilerFlags = {
   jsCode: [{src: source}],
@@ -11,5 +11,5 @@ var compilerFlags = {
 
 var output = compiler(compilerFlags);
 
-fs.writeFileSync('dist/global/Rx.min.js', output.compiledCode, 'utf8');
-fs.writeFileSync('dist/global/Rx.min.js.map', output.sourceMap, 'utf8');
+fs.writeFileSync('dist/global/rxjs.umd.min.js', output.compiledCode, 'utf8');
+fs.writeFileSync('dist/global/rxjs.umd.min.js.map', output.sourceMap, 'utf8');

--- a/tools/make-umd-bundle.js
+++ b/tools/make-umd-bundle.js
@@ -10,7 +10,7 @@ var path = require('path');
 var tslib = require('tslib');
 
 rollup.rollup({
-  entry: 'dist/esm5_for_rollup/internal/Rx.js',
+  entry: 'dist/esm5_for_rollup/internal/umd.js',
   plugins: [
     rollupNodeResolve({
       jsnext: true,
@@ -25,10 +25,10 @@ rollup.rollup({
 }).then(function (bundle) {
   var result = bundle.generate({
     format: 'umd',
-    moduleName: 'Rx',
+    moduleName: 'rxjs',
     sourceMap: true
   });
 
-  fs.writeFileSync('dist/global/Rx.js', result.code);
-  fs.writeFileSync('dist/global/Rx.js.map', result.map);
+  fs.writeFileSync('dist/global/rxjs.umd.js', result.code);
+  fs.writeFileSync('dist/global/rxjs.umd.js.map', result.map);
 });

--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -13,6 +13,9 @@
 
     // legacy entry-points
     "../dist/src/internal/Rx.ts",
-    "../dist/src/add/observable/of.ts"
+    "../dist/src/add/observable/of.ts",
+
+    // umd entry-point
+    "../dist/src/internal/umd.ts",
   ]
 }


### PR DESCRIPTION
For example, if you want to do the same thing as  but using the global file, you would use , If you wanted to do , that will be available at . Thus making the import/access points more predictable between the UMD and the ESM and CJS versions.
