### PR TITLE
fix(from): properly subscribe to Observables with no Symbol.observabl…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "requires": {
         "loader-utils": "1.1.0",
         "source-map": "0.5.7",
-        "typescript": "2.7.1",
+        "typescript": "2.7.2",
         "webpack-sources": "1.1.0"
       }
     },
@@ -6948,7 +6948,7 @@
         "log-symbols": "1.0.2",
         "log-update": "1.0.2",
         "ora": "0.2.3",
-        "rxjs": "5.5.6",
+        "rxjs": "5.5.7",
         "stream-to-observable": "0.1.0",
         "strip-ansi": "3.0.1"
       }
@@ -11076,9 +11076,9 @@
       }
     },
     "rxjs": {
-      "version": "5.5.6",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.6.tgz",
-      "integrity": "sha512-v4Q5HDC0FHAQ7zcBX7T2IL6O5ltl1a2GX4ENjPXg6SjDY69Cmx9v4113C99a4wGF16ClPv5Z8mghuYorVkg/kg==",
+      "version": "5.5.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.7.tgz",
+      "integrity": "sha512-Hxo2ac8gRQjwjtKgukMIwBRbq5+KAeEV5hXM4obYBOAghev41bDQWgFH4svYiU9UnQ5kNww2LgfyBdevCd2HXA==",
       "dev": true,
       "requires": {
         "symbol-observable": "1.0.1"
@@ -11757,6 +11757,12 @@
       "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
       "dev": true
     },
+    "systemjs": {
+      "version": "0.21.0",
+      "resolved": "https://registry.npmjs.org/systemjs/-/systemjs-0.21.0.tgz",
+      "integrity": "sha512-Ly/H3MUDaxl5OzMJ/loGFLWPao0h6WHcN6LHlI2HdsTJfZY9sYyn5B2SDnifuBlOUFlTr65rLAP+vSAXDsxOtg==",
+      "dev": true
+    },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
@@ -12111,10 +12117,9 @@
       }
     },
     "tslib": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.5.0.tgz",
-      "integrity": "sha1-O7UPhx5f35pFVan/I3tzCGAEj+o=",
-      "dev": true
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.0.tgz",
+      "integrity": "sha512-f/qGG2tUkrISBlQZEjEqoZ3B2+npJjIf04H1wuAv9iA8i04Icp+61KRXxFdha22670NJopsZCIjhC3SnjPRKrQ=="
     },
     "tslint": {
       "version": "5.9.1",
@@ -12277,9 +12282,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.7.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.1.tgz",
-      "integrity": "sha512-bqB1yS6o9TNA9ZC/MJxM0FZzPnZdtHj0xWK/IZ5khzVqdpGul/R/EIiHRgFXlwTD7PSIaYVnGKq1QgMCu2mnqw==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.7.2.tgz",
+      "integrity": "sha512-p5TCYZDAO0m4G344hD+wx/LATebLWZNkkh2asWUFqSsD2OrDNhbAHuSjobrmsUmdzjJjEeZVU9g1h3O6vpstnw==",
       "dev": true
     },
     "uglify-js": {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -1,7 +1,7 @@
 import { Operator } from './Operator';
 import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
-import { TeardownLogic } from './types';
+import { TeardownLogic, ObservableLike } from './types';
 import { toSubscriber } from './util/toSubscriber';
 import { iif } from './observable/iif';
 import { observable as Symbol_observable } from '../internal/symbol/observable';

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -1,14 +1,14 @@
 import { Observable } from '../Observable';
 import { isPromise } from '../util/isPromise';
 import { isArrayLike } from '../util/isArrayLike';
-import { isObservable } from '../util/isObservable';
+import { isObservableLike } from '../util/isObservableLike';
 import { isIterable } from '../util/isIterable';
 import { fromArray } from './fromArray';
 import { fromPromise } from './fromPromise';
 import { fromIterable } from './fromIterable';
-import { fromObservable } from './fromObservable';
+import { fromObservableLike } from './fromObservable';
 import { subscribeTo } from '../util/subscribeTo';
-import { ObservableInput, SchedulerLike } from '../types';
+import { ObservableInput, SchedulerLike, ObservableLike } from '../types';
 
 export function from<T>(input: ObservableInput<T>, scheduler?: SchedulerLike): Observable<T>;
 export function from<T>(input: ObservableInput<ObservableInput<T>>, scheduler?: SchedulerLike): Observable<Observable<T>>;
@@ -21,8 +21,11 @@ export function from<T>(input: ObservableInput<T>, scheduler?: SchedulerLike): O
   }
 
   if (input != null) {
-    if (isObservable(input)) {
-      return fromObservable(input, scheduler);
+    // We need to check both instanceof and isObservableLike because
+    // Symbol.observable might not be polyfilled.
+    if (input instanceof Observable || isObservableLike(input)) {
+      // HACK(benlesh): Typings around Symbol.observable get tricky here.
+      return fromObservableLike(input as ObservableLike<T>, scheduler);
     } else if (isPromise(input)) {
       return fromPromise(input, scheduler);
     } else if (isArrayLike(input)) {

--- a/src/internal/observable/fromObservable.ts
+++ b/src/internal/observable/fromObservable.ts
@@ -4,7 +4,7 @@ import { observable as Symbol_observable } from '../symbol/observable';
 import { subscribeToObservable } from '../util/subscribeToObservable';
 import { ObservableLike, SchedulerLike, Subscribable } from '../types';
 
-export function fromObservable<T>(input: ObservableLike<T>, scheduler: SchedulerLike) {
+export function fromObservableLike<T>(input: ObservableLike<T>, scheduler: SchedulerLike) {
   if (!scheduler) {
     return new Observable<T>(subscribeToObservable(input));
   } else {

--- a/src/internal/util/isObservableLike.ts
+++ b/src/internal/util/isObservableLike.ts
@@ -2,6 +2,6 @@ import { ObservableLike } from '../types';
 import { observable as Symbol_observable } from '../symbol/observable';
 
 /** Identifies an input as being Observable (but not necessary an Rx Observable) */
-export function isObservable(input: any): input is ObservableLike<any> {
+export function isObservableLike(input: any): input is ObservableLike<any> {
   return input && typeof input[Symbol_observable] === 'function';
 }


### PR DESCRIPTION
…e polyfill

- Renames `isObservable` to `isObservableLike`
- Updates `from` to check both `instanceof Observable` and `isObservableLike` in the event that `Symbol.observable` is not polyfilled.

cc @IgorMinar