### PR TITLE
feat(TestScheduler): Add subscription schedule to expectObservable

### DIFF
--- a/doc/writing-marble-tests.md
+++ b/doc/writing-marble-tests.md
@@ -20,8 +20,9 @@ The unit tests have helper methods that have been added to make creating tests e
   being tested begins.
 - `cold(marbles: string, values?: object, error?: any)` - creates a "cold" observable whose subscription starts when 
   the test begins.
-- `expectObservable(actual: Observable<T>).toBe(marbles: string, values?: object, error?: any)` - schedules an assertion
-  for when the TestScheduler flushes. The TestScheduler will automatically flush at the end of your jasmine `it` block.
+- `expectObservable(actual: Observable<T>, subscriptionMarbles?: string).toBe(marbles: string, values?: object, error?: any)` - schedules an assertion
+  for when the TestScheduler flushes. The TestScheduler will automatically flush at the end of your jasmine `it` block. Give `subscriptionMarbles` as parameter to
+  change the schedule of subscription and unsubscription. If you don't provide the `subscriptionMarbles` parameter it will subscribe at the beginning and never unsubscribe. Read below about subscription marble diagram.
 - `expectSubscriptions(actualSubscriptionLogs: SubscriptionLog[]).toBe(subscriptionMarbles: string)` - like `expectObservable` schedules an assertion for when the testScheduler flushes. Both `cold()` and `hot()` return an observable with a property `subscriptions` of type `SubscriptionLog[]`. Give `subscriptions` as parameter to `expectSubscriptions` to assert whether it matches the `subscriptionsMarbles` marble diagram given in `toBe()`. Subscription marble diagrams are slightly different than Observable marble diagrams. Read more below.
 
 ### Ergonomic defaults for `hot` and `cold`

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -211,6 +211,13 @@ describe('TestScheduler', () => {
         const expected =      '--a';
         expectObservable(source, unsubscribe).toBe(expected);
       });
+
+      it('should accept a subscription marble diagram', () => {
+        const source = hot('-a-b-c|');
+        const subscribe =  '---^';
+        const expected =   '---b-c|';
+        expectObservable(source, subscribe).toBe(expected);
+      });
     });
 
     describe('expectSubscriptions()', () => {

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -72,11 +72,13 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   expectObservable(observable: Observable<any>,
-                   unsubscriptionMarbles: string = null): ({ toBe: observableToBeFn }) {
+                   subscriptionMarbles: string = null): ({ toBe: observableToBeFn }) {
     const actual: TestMessage[] = [];
     const flushTest: FlushableTest = { actual, ready: false };
-    const unsubscriptionFrame = TestScheduler
-      .parseMarblesAsSubscriptions(unsubscriptionMarbles).unsubscribedFrame;
+    const subscriptionParsed = TestScheduler.parseMarblesAsSubscriptions(subscriptionMarbles);
+    const subscriptionFrame = subscriptionParsed.subscribedFrame === Number.POSITIVE_INFINITY ?
+      0 : subscriptionParsed.subscribedFrame;
+    const unsubscriptionFrame = subscriptionParsed.unsubscribedFrame;
     let subscription: Subscription;
 
     this.schedule(() => {
@@ -92,7 +94,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       }, () => {
         actual.push({ frame: this.frame, notification: Notification.createComplete() });
       });
-    }, 0);
+    }, subscriptionFrame);
 
     if (unsubscriptionFrame !== Number.POSITIVE_INFINITY) {
       this.schedule(() => subscription.unsubscribe(), unsubscriptionFrame);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
