### PR TITLE
refactor(Observable): toPromise and forEach return Promise not Promis…

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -213,7 +213,7 @@ export class Observable<T> implements Subscribable<T> {
    * @return {Promise} a promise that either resolves on observable completion or
    *  rejects with the handled error
    */
-  forEach(next: (value: T) => void, promiseCtor?: PromiseConstructorLike): PromiseLike<void> {
+  forEach(next: (value: T) => void, promiseCtor?: PromiseConstructorLike): Promise<void> {
     promiseCtor = getPromiseCtor(promiseCtor);
 
     return new promiseCtor<void>((resolve, reject) => {
@@ -230,7 +230,7 @@ export class Observable<T> implements Subscribable<T> {
           }
         }
       }, reject, resolve);
-    });
+    }) as Promise<void>;
   }
 
   /** @internal */
@@ -297,13 +297,13 @@ export class Observable<T> implements Subscribable<T> {
   toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T>;
   /* tslint:enable:max-line-length */
 
-  toPromise(promiseCtor?: PromiseConstructorLike): PromiseLike<T> {
+  toPromise(promiseCtor?: PromiseConstructorLike): Promise<T> {
     promiseCtor = getPromiseCtor(promiseCtor);
 
     return new promiseCtor((resolve, reject) => {
       let value: any;
       this.subscribe((x: T) => value = x, (err: any) => reject(err), () => resolve(value));
-    });
+    }) as Promise<T>;
   }
 }
 


### PR DESCRIPTION
…eLike

Unfortunately this requires a cast because we don't want to specify PromiseConstructor, because that comes with a bunch of statics that are optional, so we use PromiseConstructorLike, however that returns a PromiseLike, and we want to ensure that the returned promise also has a `catch` method and isn't just a thennable.


Unfortunately the previous change I made was to avoid the afformentioned cast, but I don't think it can be avoided. Or we'll break people using `catch` after `forEach`.
