### PR TITLE
fix(forkJoin): fix forkJoin typings for forkJoin(Observable<any>[])

### DIFF
--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -8,13 +8,22 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { Subscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
+// forkJoin([a$, b$, c$]);
+export function forkJoin<T>(sources: [ObservableInput<T>]): Observable<T[]>;
+export function forkJoin<T, T2>(sources: [ObservableInput<T>, ObservableInput<T2>]): Observable<[T, T2]>;
+export function forkJoin<T, T2, T3>(sources: [ObservableInput<T>, ObservableInput<T2>, ObservableInput<T3>]): Observable<[T, T2, T3]>;
+export function forkJoin<T, T2, T3, T4>(sources: [ObservableInput<T>, ObservableInput<T2>, ObservableInput<T3>, ObservableInput<T4>]): Observable<[T, T2, T3, T4]>;
+export function forkJoin<T, T2, T3, T4, T5>(sources: [ObservableInput<T>, ObservableInput<T2>, ObservableInput<T3>, ObservableInput<T4>, ObservableInput<T5>]): Observable<[T, T2, T3, T4, T5]>;
+export function forkJoin<T, T2, T3, T4, T5, T6>(sources: [ObservableInput<T>, ObservableInput<T2>, ObservableInput<T3>, ObservableInput<T4>, ObservableInput<T5>, ObservableInput<T6>]): Observable<[T, T2, T3, T4, T5, T6]>;
+export function forkJoin<T>(sources: Array<ObservableInput<T>>): Observable<T[]>;
+
+// forkJoin(a$, b$, c$)
+export function forkJoin<T>(v1: ObservableInput<T>): Observable<T[]>;
 export function forkJoin<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>): Observable<[T, T2]>;
 export function forkJoin<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<[T, T2, T3]>;
 export function forkJoin<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<[T, T2, T3, T4]>;
 export function forkJoin<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<[T, T2, T3, T4, T5]>;
 export function forkJoin<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<[T, T2, T3, T4, T5, T6]>;
-export function forkJoin<T>(v1: ObservableInput<T>): Observable<T[]>;
-export function forkJoin<T>(sources: Array<ObservableInput<T>>): Observable<T[]>;
 export function forkJoin<T>(...sources: Array<ObservableInput<T>>): Observable<T[]>;
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
Solves an issue where we were hitting the wrong typings for forkJoin if passed an Array of observables.