### PR TITLE
fix(AjaxObservable): 1xx,2xx,3xx requests shouldn't error, only 4xx,5xx

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -262,8 +262,9 @@ describe('Observable.ajax', () => {
     expect(error.status).to.equal(404);
   });
 
-  it('should fail on 404', () => {
-    let error;
+  it('should succeed on 300', () => {
+    let result;
+    let complete = false;
     const obj = {
       url: '/flibbertyJibbet',
       normalizeError: (e: any, xhr: any, type: any) => {
@@ -273,13 +274,12 @@ describe('Observable.ajax', () => {
       method: ''
     };
 
-    Rx.Observable.ajax(obj).subscribe(x => {
-      throw 'should not next';
-    }, (err: any) => {
-      error = err;
-    }, () => {
-      throw 'should not complete';
-    });
+    Rx.Observable.ajax(obj)
+      .subscribe((x: any) => {
+        result = x;
+      }, null, () => {
+        complete = true;
+      });
 
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
 
@@ -289,9 +289,9 @@ describe('Observable.ajax', () => {
       'responseText': 'Wee! I am text!'
     });
 
-    expect(error instanceof Rx.AjaxError).to.be.true;
-    expect(error.message).to.equal('ajax error 300');
-    expect(error.status).to.equal(300);
+    expect(result.xhr).exist;
+    expect(result.response).to.deep.equal('Wee! I am text!');
+    expect(complete).to.be.true;
   });
 
   it('should succeed no settings', () => {

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -365,7 +365,8 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
           status = response ? 200 : 0;
         }
 
-        if (200 <= status && status < 300) {
+        // 4xx and 5xx should error (https://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html)
+        if (status < 400) {
           if (progressSubscriber) {
             progressSubscriber.complete();
           }


### PR DESCRIPTION
w3 rfc2616 defines 4xx,5xx status codes as errors, but anything below is a valid response.
AjaxObservable errors when a request status returns 1xx and 3xx, passing only 2xx requests.

#3308

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
w3 rfc2616 defines 4xx,5xx status codes as errors, but anything below is a valid response.
AjaxObservable errors when a request status returns 1xx and 3xx, passing only 2xx requests.

**Related issue (if exists):**
#3308