### PR TITLE
fix(config): make sure that Promise config is undefined initially

### DIFF
--- a/spec/config-spec.ts
+++ b/spec/config-spec.ts
@@ -1,0 +1,9 @@
+import { config } from '../src/internal/config';
+import { expect } from 'chai';
+
+describe('config', () => {
+  it('should have a Promise property that defaults to nothing', () => {
+    expect(config).to.have.property('Promise');
+    expect(config.Promise).to.be.undefined;
+  });
+});

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -7,5 +7,5 @@ export const config = {
    * The promise constructor used by default for methods such as
    * {@link toPromise} and {@link forEach}
    */
-  Promise
+  Promise: undefined as PromiseConstructorLike
 };


### PR DESCRIPTION
We need to make sure promise is undefined initially because systems like Zones need to have a chance to pick up Promise and patch it, and we're doing a runtime check for configuration anyhow. This makes the runtime check worthwhile and solves the problem with Zones (without needing to reference Zones in anyway)
