### PR TITLE
fix(config): expose configuration via rxjs exports

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -78,4 +78,8 @@ describe('index', () => {
     expect(index.using).to.exist;
     expect(index.zip).to.exist;
   });
+
+  it('should expose configuration', () => {
+    expect(index.config).to.exist;
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,3 +67,6 @@ export { NEVER } from './internal/observable/never';
 
 /* Types */
 export * from './internal/types';
+
+/* Config */
+export { config } from './internal/config';


### PR DESCRIPTION
We weren't exposing configuration in a meaningful way from the rxjs module, this remedies that