### PR TITLE
fix(config.useDeprecatedSynchronousErrorThrowing): reentrant error th…

### DIFF
--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -40,6 +40,7 @@ describe('Observable.prototype.repeatWhen', () => {
     let retried = false;
     const expected = [1, 2, 1, 2];
     let i = 0;
+    try {
     Observable.of(1, 2)
       .map((n: number) => {
         return n;
@@ -58,6 +59,9 @@ describe('Observable.prototype.repeatWhen', () => {
         expect(err).to.be.an('error', 'done');
         done();
       });
+    } catch (err) {
+      done(err);
+    }
   });
 
   it('should retry when notified and complete on returned completion', (done: MochaDone) => {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -192,7 +192,7 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink.add(this.source ? this._subscribe(sink) : this._trySubscribe(sink));
+      sink.add(this.source || !sink.syncErrorThrowable ? this._subscribe(sink) : this._trySubscribe(sink));
     }
 
     if (config.useDeprecatedSynchronousErrorHandling) {

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -70,6 +70,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
         }
         if (typeof destinationOrNext === 'object') {
           if (destinationOrNext instanceof Subscriber) {
+            this.syncErrorThrowable = destinationOrNext.syncErrorThrowable;
             this.destination = (<Subscriber<any>> destinationOrNext);
             (<any> this.destination).add(this);
           } else {


### PR DESCRIPTION
…rowing no longer trapped

- Applies a fix from #3161 to prevent some sync errors from being trapped
- Updates tests to not be so noisy when the flag is flipped
- Tests that flipping the flag will console.warn and console.log appropriately
