### PR TITLE
docs(dom): Updated to include missing withCredentials property on AjaxRequest

### DIFF
--- a/src/internal/observable/dom/MiscJSDoc.ts
+++ b/src/internal/observable/dom/MiscJSDoc.ts
@@ -50,6 +50,10 @@ export class AjaxRequestDoc {
    */
   crossDomain: boolean = false;
   /**
+   * @type {boolean}
+   */
+  withCredentials: boolean = false;
+  /**
    * @return {XMLHttpRequest}
    */
   createXHR(): XMLHttpRequest {


### PR DESCRIPTION
**Description:** Documentation for AjaxRequest missing `withCredentials` property

**Related issue (if exists):** https://github.com/ReactiveX/rxjs/issues/3448
