### PR TITLE
build: fix BUILD.bazel specification by excluding all backwards compat code

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -7,7 +7,8 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 ts_library(
   name = "rxjs",
   module_name = "rxjs",
-  srcs = glob(["*.ts", "**/*.ts"]),
+  # exclude all backwards compatibility code because we don't have a bazel target setup for that
+  srcs = glob(["*.ts", "**/*.ts"], exclude = ["internal/Rx.ts", "internal-compatibility/**",  "internal/patching/**", "umd.ts"]),
   tsconfig = "tsconfig.json",
   # Specify the compile-time dependencies to run the compilation (eg. typescript)
   # The default value assumes that the end-user has a target //:node_modules


### PR DESCRIPTION
we have no target setup for this, we should set it up or be ok with not having backwards compat
story for external bazel users. I'll leave it up to @alexeagle and @jasonaden to decide and
potentially fix in a followup PR.