### PR TITLE
 fix(repeatWhen): support synchronous notifier

### DIFF
--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -36,7 +36,7 @@ describe('Observable.prototype.repeatWhen', () => {
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  it('should retry when notified via returned notifier on complete', (done: MochaDone) => {
+  it('should repeat when notified via returned notifier on complete', (done: MochaDone) => {
     let retried = false;
     const expected = [1, 2, 1, 2];
     let i = 0;
@@ -64,7 +64,7 @@ describe('Observable.prototype.repeatWhen', () => {
     }
   });
 
-  it('should retry when notified and complete on returned completion', (done: MochaDone) => {
+  it('should repeat when notified and complete on returned completion', (done: MochaDone) => {
     const expected = [1, 2, 1, 2];
     Observable.of(1, 2)
       .map((n: number) => {

--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -64,8 +64,9 @@ describe('Observable.prototype.repeatWhen', () => {
     }
   });
 
-  it('should repeat when notified and complete on returned completion', (done: MochaDone) => {
-    const expected = [1, 2, 1, 2];
+  it('should not repeat when applying an empty notifier', (done: MochaDone) => {
+    const expected = [1, 2];
+    const nexted: number[] = [];
     Observable.of(1, 2)
       .map((n: number) => {
         return n;
@@ -73,9 +74,11 @@ describe('Observable.prototype.repeatWhen', () => {
       .repeatWhen((notifications: any) => Observable.empty())
       .subscribe((n: number) => {
         expect(n).to.equal(expected.shift());
+        nexted.push(n);
       }, (err: any) => {
         done(new Error('should not be called'));
       }, () => {
+        expect(nexted).to.deep.equal([1, 2]);
         done();
       });
   });

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -76,7 +76,8 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (!this.isStopped) {
       if (!this.retries) {
         this.subscribeToRetries();
-      } else if (this.retriesSubscription.closed) {
+      }
+      if (!this.retriesSubscription || this.retriesSubscription.closed) {
         return super.complete();
       }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR is an attempt at fixing #3444. However, in making the changes, I found some conflict between a test, the documentation and the current behaviour. My changes were made in favour of the docs and the behaviour. In particular, [this test](https://github.com/ReactiveX/rxjs/blob/master/spec/operators/repeatWhen-spec.ts#L67-L81) attempts to assert that the observable repeats when an empty notifier is used:

```ts
it('should retry when notified and complete on returned completion', (done: MochaDone) => {
  const expected = [1, 2, 1, 2];
  Observable.of(1, 2)
    .map((n: number) => {
      return n;
    })
    .repeatWhen((notifications: any) => Observable.empty())
    .subscribe((n: number) => {
      expect(n).to.equal(expected.shift());
    }, (err: any) => {
      done(new Error('should not be called'));
    }, () => {
      done();
    });
});
```

However, it does not repeat. The test still passes, as there is no expectation to assert that all four values are received. [The docs](http://reactivex.io/rxjs/class/es6/Observable.js~Observable.html#instance-method-repeatWhen) have this to say:

> If the source Observable calls `complete`, this method will emit to the Observable returned from `notifier`. If that Observable calls `complete` or `error`, then this method will call `complete` or `error` on the child subscription.

I read that as meaning that an empty notifier that completes should not effect a repeat.

The change itself is trivial, it just checks to see whether or not the subscriber `isStopped` as it's possible for it to become so during the subscription to the notifier. See the explanation in [this comment](https://github.com/ReactiveX/rxjs/issues/3444#issuecomment-375127242).

Given the conflict between the docs - at least by my reading of them - and the tests, it will be interesting to hear opinions as to whether or not this is a breaking change. Fun stuff. At any rate, the changes I've made to the tests should be useful, even if the solution is not appropriate.

**Related issue (if exists):** #3444
