### PR TITLE
fix(Observable): empty ctor returns valid Observable

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -50,6 +50,11 @@ describe('Observable', () => {
     });
   });
 
+  it('should allow empty ctor, which is effectively a never-observable', () => {
+    const result = new Observable<any>();
+    expectObservable(result).toBe('-');
+  });
+
   describe('forEach', () => {
     it('should iterate and return a Promise', (done) => {
       const expected = [1, 2, 3];

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -20,9 +20,8 @@ export class Observable<T> implements Subscribable<T> {
   /** @internal */
   public _isScalar: boolean = false;
 
-  /** @internal */
   protected source: Observable<any>;
-  /** @internal */
+
   protected operator: Operator<any, T>;
 
   /**
@@ -248,7 +247,8 @@ export class Observable<T> implements Subscribable<T> {
 
   /** @internal */
   protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
-    return this.source.subscribe(subscriber);
+    const { source } = this;
+    return source && source.subscribe(subscriber);
   }
 
   // TODO(benlesh): determine if this is still necessary


### PR DESCRIPTION
Before if you subscribed such as `(new Observable()).subscribe()` it would throw an error, this remedies that and will effectively return a never observable, however _not_ the same instance as `NEVER`
