### PR TITLE
chore: add @nocollapse to static members.

### DIFF
--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -105,6 +105,7 @@ export class Notification<T> {
    * @param {T} value The `next` value.
    * @return {Notification<T>} The "next" Notification representing the
    * argument.
+   * @nocollapse
    */
   static createNext<T>(value: T): Notification<T> {
     if (typeof value !== 'undefined') {
@@ -119,6 +120,7 @@ export class Notification<T> {
    * @param {any} [err] The `error` error.
    * @return {Notification<T>} The "error" Notification representing the
    * argument.
+   * @nocollapse
    */
   static createError<T>(err?: any): Notification<T> {
     return new Notification('E', undefined, err);
@@ -127,6 +129,7 @@ export class Notification<T> {
   /**
    * A shortcut to create a Notification instance of the type `complete`.
    * @return {Notification<any>} The valueless "complete" Notification.
+   * @nocollapse
    */
   static createComplete(): Notification<any> {
     return Notification.completeNotification;

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -47,6 +47,7 @@ export class Observable<T> implements Subscribable<T> {
    * @method create
    * @param {Function} subscribe? the subscriber function to be passed to the Observable constructor
    * @return {Observable} a new cold observable
+   * @nocollapse
    */
   static create: Function = <T>(subscribe?: (subscriber: Subscriber<T>) => TeardownLogic) => {
     return new Observable<T>(subscribe);
@@ -253,6 +254,7 @@ export class Observable<T> implements Subscribable<T> {
 
   // TODO(benlesh): determine if this is still necessary
   // `if` and `throw` are special snow flakes, the compiler sees them as reserved words
+  /** @nocollapse */
   static if: typeof iif;
 
   /**

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -20,6 +20,7 @@ import { SchedulerLike, SchedulerAction } from './types';
  */
 export class Scheduler implements SchedulerLike {
 
+  /** @nocollapse */
   public static now: () => number = Date.now ? Date.now : () => +new Date();
 
   constructor(private SchedulerAction: typeof Action,

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -39,6 +39,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     super();
   }
 
+  /**@nocollapse */
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
   }

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -30,6 +30,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
    * Observer.
    * @return {Subscriber<T>} A Subscriber wrapping the (partially defined)
    * Observer represented by the given arguments.
+   * @nocollapse
    */
   static create<T>(next?: (x?: T) => void,
                    error?: (e?: any) => void,

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -19,6 +19,7 @@ import { SubscriptionLike, TeardownLogic } from './types';
  * @class Subscription
  */
 export class Subscription implements SubscriptionLike {
+  /** @nocollapse */
   public static EMPTY: Subscription = (function(empty: any) {
     empty.closed = true;
     return empty;


### PR DESCRIPTION
**Description:**

Add @nocollapse to prevent closure compiler from dropping static members that are reexported
twice.  The static members are kept in the first export, but if that symbol is then exported
again the static members are not kept.

**Related issue (if exists):**
