### PR TITLE
fix(Subscriber): report or throw internal errors

### DIFF
--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -212,9 +212,20 @@ class SafeSubscriber<T> extends Subscriber<T> {
   }
 
   error(err?: any): void {
-    if (!this.isStopped) {
-      const { _parentSubscriber } = this;
-      const { useDeprecatedSynchronousErrorHandling } = config;
+    const { _parentSubscriber } = this;
+    const { useDeprecatedSynchronousErrorHandling } = config;
+    if (this.isStopped) {
+      if (useDeprecatedSynchronousErrorHandling) {
+        if (!_parentSubscriber || !_parentSubscriber.syncErrorThrowable) {
+          throw err;
+        } else {
+          _parentSubscriber.syncErrorValue = err;
+          _parentSubscriber.syncErrorThrown = true;
+        }
+      } else {
+        hostReportError(err);
+      }
+    } else {
       if (this._error) {
         if (!useDeprecatedSynchronousErrorHandling || !_parentSubscriber.syncErrorThrowable) {
           this.__tryOrUnsub(this._error, err);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

#3444 showed that there are situations in which `error` can be called after `unsubscribe` - see [this comment](https://github.com/ReactiveX/rxjs/issues/3444#issuecomment-375127242) - and in those situations the subscriber's `isStopped` property will be `true` and the error will be swallowed.

With this PR, if `error` is called when the subscriber is stopped, the error will either be reported to the host or rethrown - depending on the `useDeprecatedSynchronousErrorHandling` configuration setting.

**Related issue (if exists):** #3461
