### PR TITLE
fix(subscribe): prevent swallowing of errors when stopped

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -68,7 +68,7 @@ describe('Observable', () => {
     const stubSetTimeout = sinon.stub(global, 'setTimeout');
     Observable.of(1).lift(new OperatorWithBug()).subscribe(
       undefined,
-      err => { throw err; }
+      err => { throw new Error('should not be called'); }
     );
     expect(stubSetTimeout).to.have.property('callCount', 1);
     const [[func]] = stubSetTimeout.args;

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import * as Rx from 'rxjs/Rx';
+import { noop } from '../src/internal/util/noop';
 
 const Subscriber = Rx.Subscriber;
 
@@ -85,5 +87,87 @@ describe('Subscriber', () => {
     sub1.complete();
 
     expect(argument).to.have.lengthOf(0);
+  });
+
+  describe('reportError', () => {
+    it('should call error for an unstopped subscriber', () => {
+      const reported = new Error('Kaboom!');
+      let received: any;
+      const subscriber = new Rx.Subscriber(undefined, err => received = err);
+      subscriber.reportError(reported);
+      expect(received).to.equal(reported);
+    });
+
+    it('should call error for an unstopped destination subscriber', () => {
+      const reported = new Error('Kaboom!');
+      let received: any;
+      const destination = new Rx.Subscriber(undefined, err => received = err);
+      const subscriber = new Rx.Subscriber(destination);
+      subscriber.reportError(reported);
+      expect(received).to.equal(reported);
+    });
+
+    describe('useDeprecatedSynchronousErrorHandling === false', () => {
+      let stubSetTimeout: any;
+      beforeEach(() => {
+        stubSetTimeout = sinon.stub(global, 'setTimeout');
+      });
+
+      it('should call hostReportError for a stopped subscriber', () => {
+        const reported = new Error('Kaboom!');
+        const subscriber = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
+        subscriber.complete();
+        subscriber.reportError(reported);
+        expect(stubSetTimeout).to.have.property('callCount', 1);
+        const [[func]] = stubSetTimeout.args;
+        expect(func).to.throw('Kaboom!');
+      });
+
+      it('should call hostReportError for a stopped destination subscriber', () => {
+        const reported = new Error('Kaboom!');
+        const destination = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
+        const subscriber = new Rx.Subscriber(destination);
+        destination.complete();
+        subscriber.reportError(reported);
+        expect(stubSetTimeout).to.have.property('callCount', 1);
+        const [[func]] = stubSetTimeout.args;
+        expect(func).to.throw('Kaboom!');
+      });
+
+      afterEach(() => {
+        stubSetTimeout.restore();
+      });
+    });
+
+    describe('useDeprecatedSynchronousErrorHandling === true', () => {
+      beforeEach(() => {
+        const _warn = console.warn;
+        console.warn = noop;
+        Rx.config.useDeprecatedSynchronousErrorHandling = true;
+        console.warn = _warn;
+      });
+
+      it('should rethrow the error for a stopped subscriber', () => {
+        const reported = new Error('Kaboom!');
+        const subscriber = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
+        subscriber.complete();
+        expect(() => subscriber.reportError(reported)).to.throw('Kaboom!');
+      });
+
+      it('should rethrow the error for a stopped destination subscriber', () => {
+        const reported = new Error('Kaboom!');
+        const destination = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
+        const subscriber = new Rx.Subscriber(destination);
+        destination.complete();
+        expect(() => subscriber.reportError(reported)).to.throw('Kaboom!');
+      });
+
+      afterEach(() => {
+        const _log = console.log;
+        console.log = noop;
+        Rx.config.useDeprecatedSynchronousErrorHandling = false;
+        console.log = _log;
+      });
+    });
   });
 });

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -1,6 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as Rx from 'rxjs/Rx';
+import { Symbol_reportError } from '../src/internal/Subscriber';
 import { noop } from '../src/internal/util/noop';
 
 const Subscriber = Rx.Subscriber;
@@ -89,12 +90,12 @@ describe('Subscriber', () => {
     expect(argument).to.have.lengthOf(0);
   });
 
-  describe('_reportError', () => {
+  describe('reportError', () => {
     it('should call error for an unstopped subscriber', () => {
       const reported = new Error('Kaboom!');
       let received: any;
       const subscriber = new Rx.Subscriber(undefined, err => received = err);
-      (subscriber as any)._reportError(reported);
+      subscriber[Symbol_reportError](reported);
       expect(received).to.equal(reported);
       expect(subscriber).to.have.property('isStopped', true);
     });
@@ -105,7 +106,7 @@ describe('Subscriber', () => {
       const destination = new Rx.Subscriber(undefined, err => received = err);
       const subscriber = new Rx.Subscriber(destination);
       const spy = sinon.spy(subscriber, 'error');
-      (subscriber as any)._reportError(reported);
+      subscriber[Symbol_reportError](reported);
       expect(received).to.equal(reported);
       expect(subscriber).to.have.property('isStopped', true);
       expect(destination).to.have.property('isStopped', true);
@@ -123,7 +124,7 @@ describe('Subscriber', () => {
         const reported = new Error('Kaboom!');
         const subscriber = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
         subscriber.complete();
-        (subscriber as any)._reportError(reported);
+        subscriber[Symbol_reportError](reported);
         expect(stubSetTimeout).to.have.property('callCount', 1);
         const [[func]] = stubSetTimeout.args;
         expect(func).to.throw('Kaboom!');
@@ -135,7 +136,7 @@ describe('Subscriber', () => {
         const destination = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
         const subscriber = new Rx.Subscriber(destination);
         destination.complete();
-        (subscriber as any)._reportError(reported);
+        subscriber[Symbol_reportError](reported);
         expect(stubSetTimeout).to.have.property('callCount', 1);
         const [[func]] = stubSetTimeout.args;
         expect(func).to.throw('Kaboom!');
@@ -160,7 +161,7 @@ describe('Subscriber', () => {
         const reported = new Error('Kaboom!');
         const subscriber = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
         subscriber.complete();
-        expect(() => (subscriber as any)._reportError(reported)).to.throw('Kaboom!');
+        expect(() => subscriber[Symbol_reportError](reported)).to.throw('Kaboom!');
         expect(subscriber).to.have.property('isStopped', true);
       });
 
@@ -169,7 +170,7 @@ describe('Subscriber', () => {
         const destination = new Rx.Subscriber(undefined, err => { throw new Error('should not be called'); });
         const subscriber = new Rx.Subscriber(destination);
         destination.complete();
-        expect(() => (subscriber as any)._reportError(reported)).to.throw('Kaboom!');
+        expect(() => subscriber[Symbol_reportError](reported)).to.throw('Kaboom!');
         expect(subscriber).to.have.property('isStopped', true);
         expect(destination).to.have.property('isStopped', true);
       });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -215,7 +215,7 @@ export class Observable<T> implements Subscribable<T> {
         sink.syncErrorThrown = true;
         sink.syncErrorValue = err;
       }
-      sink.error(err);
+      sink.reportError(err);
     }
   }
 

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -215,7 +215,7 @@ export class Observable<T> implements Subscribable<T> {
         sink.syncErrorThrown = true;
         sink.syncErrorValue = err;
       }
-      sink.reportError(err);
+      (sink as any)._reportError(err);
     }
   }
 

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -1,5 +1,5 @@
 import { Operator } from './Operator';
-import { Subscriber } from './Subscriber';
+import { Subscriber, Symbol_reportError } from './Subscriber';
 import { Subscription } from './Subscription';
 import { TeardownLogic } from './types';
 import { toSubscriber } from './util/toSubscriber';
@@ -215,7 +215,7 @@ export class Observable<T> implements Subscribable<T> {
         sink.syncErrorThrown = true;
         sink.syncErrorValue = err;
       }
-      (sink as any)._reportError(err);
+      sink[Symbol_reportError](err);
     }
   }
 

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -181,7 +181,10 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   [Symbol_reportError](err?: any): void {
     let observer: PartialObserver<T> = this;
     while (observer) {
-      if (observer instanceof Subscriber) {
+      // `observer` will either be a subscriber or an empty observer, but for
+      // the reasons outlined in the constructor, `instanceof Subscriber`
+      // cannot be used.
+      if (isTrustedSubscriber(observer)) {
         const { destination, isStopped } = observer;
         if (isStopped) {
           if (config.useDeprecatedSynchronousErrorHandling) {

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -118,39 +118,6 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   }
 
   /**
-   * @ignore
-   * @internal
-   * Synchronous errors thrown within `subscribe` and caught by `_trySubscribe`
-   * can only be reported using a subscriber's `error` method if the subscriber
-   * is not stopped. This method traverses the `destination` chain of
-   * subscribers and uses the appropriate unhandled mechanism to report the
-   * error if a stopped subscriber is found.
-   */
-  reportError(err?: any): void {
-    let observer: PartialObserver<T> = this;
-    while (observer) {
-      if (observer instanceof Subscriber) {
-        const { destination } = observer;
-        if (observer.isStopped) {
-          if (config.useDeprecatedSynchronousErrorHandling) {
-            throw err;
-          } else {
-            hostReportError(err);
-            return;
-          }
-        } else if (destination === emptyObserver) {
-          observer.error(err);
-          return;
-        }
-        observer = destination;
-      } else {
-        observer.error(err);
-        return;
-      }
-    }
-  }
-
-  /**
    * The {@link Observer} callback to receive a valueless notification of type
    * `complete` from the Observable. Notifies the Observer that the Observable
    * has finished sending push-based notifications.
@@ -195,6 +162,36 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     this._parent = _parent;
     this._parents = _parents;
     return this;
+  }
+
+  /**
+   * @ignore
+   * @internal
+   * Synchronous errors thrown within `subscribe` and caught by `_trySubscribe`
+   * can only be reported using a subscriber's `error` method if the subscriber
+   * is not stopped. This method traverses the `destination` chain of
+   * subscribers and uses the appropriate unhandled mechanism to report the
+   * error if a stopped subscriber is found.
+   */
+  private _reportError(err?: any): void {
+    let observer: PartialObserver<T> = this;
+    while (observer) {
+      if (observer instanceof Subscriber) {
+        const { destination, isStopped } = observer;
+        if (isStopped) {
+          if (config.useDeprecatedSynchronousErrorHandling) {
+            throw err;
+          } else {
+            hostReportError(err);
+            return;
+          }
+        }
+        observer = destination;
+      } else {
+        this.error(err);
+        return;
+      }
+    }
   }
 }
 

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -6,6 +6,11 @@ import { rxSubscriber as rxSubscriberSymbol } from '../internal/symbol/rxSubscri
 import { config } from './config';
 import { hostReportError } from './util/hostReportError';
 
+export const Symbol_reportError =
+  (typeof Symbol === 'function' && typeof Symbol.for === 'function')
+    ? Symbol.for('reportError')
+    : '@@reportError';
+
 /**
  * Implements the {@link Observer} interface and extends the
  * {@link Subscription} class. While the {@link Observer} is the public API for
@@ -173,7 +178,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
    * subscribers and uses the appropriate unhandled mechanism to report the
    * error if a stopped subscriber is found.
    */
-  private _reportError(err?: any): void {
+  [Symbol_reportError](err?: any): void {
     let observer: PartialObserver<T> = this;
     while (observer) {
       if (observer instanceof Subscriber) {

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -339,6 +339,6 @@ class SafeSubscriber<T> extends Subscriber<T> {
   }
 }
 
-function isTrustedSubscriber(obj: any) {
+function isTrustedSubscriber(obj: any): obj is Subscriber<any> {
   return obj instanceof Subscriber || ('syncErrorThrowable' in obj && obj[rxSubscriberSymbol]);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

If `_trySubscribe` catches an error and the sink - or one of its destinations - is stopped and the sink's `error` method is called, the error is swallowed - as it cannot be reported via the observer's callback. This commit adds an internal `reportError` method to `Subscriber`. The method defers to the appropriate error reporting mechanism if a stopped subscriber is found.

For an example scenario of an error being swallowed due to a bug and a closed subscriber (that has not previously been notified of any error) see #3444.

**Related issue (if exists):** #3461
