### PR TITLE
fix(repeatWhen): support synchronous notifier

### DIFF
--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -95,7 +95,7 @@ describe('Observable.prototype.repeatWhen', () => {
     Observable.prototype.subscribe = function (...args: any[]): any {
       let [subscriber] = args;
       if (!(subscriber instanceof Rx.Subscriber)) {
-        subscriber = new Rx.Subscriber<any>(...args);
+        subscriber = new Rx.Subscriber<any>(args[0], args[1], args[2]);
       }
       subscriber.error = function (err: any): void {
         errors.push(err);
@@ -122,7 +122,7 @@ describe('Observable.prototype.repeatWhen', () => {
     Observable.prototype.subscribe = function (...args: any[]): any {
       let [subscriber] = args;
       if (!(subscriber instanceof Rx.Subscriber)) {
-        subscriber = new Rx.Subscriber<any>(...args);
+        subscriber = new Rx.Subscriber<any>(args[0], args[1], args[2]);
       }
       subscriber.error = function (err: any): void {
         errors.push(err);

--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -40,7 +40,7 @@ describe('Observable.prototype.repeatWhen', () => {
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  it('should retry when notified via returned notifier on complete', (done: MochaDone) => {
+  it('should repeat when notified via returned notifier on complete', (done: MochaDone) => {
     let retried = false;
     const expected = [1, 2, 1, 2];
     let i = 0;
@@ -64,8 +64,9 @@ describe('Observable.prototype.repeatWhen', () => {
       });
   });
 
-  it('should retry when notified and complete on returned completion', (done: MochaDone) => {
-    const expected = [1, 2, 1, 2];
+  it('should not repeat when applying an empty notifier', (done: MochaDone) => {
+    const expected = [1, 2];
+    const nexted: number[] = [];
     Observable.of(1, 2)
       .map((n: number) => {
         return n;
@@ -73,11 +74,67 @@ describe('Observable.prototype.repeatWhen', () => {
       .repeatWhen((notifications: any) => Observable.empty())
       .subscribe((n: number) => {
         expect(n).to.equal(expected.shift());
+        nexted.push(n);
       }, (err: any) => {
         done(new Error('should not be called'));
       }, () => {
+        expect(nexted).to.deep.equal([1, 2]);
         done();
       });
+  });
+
+  it('should not error when applying an empty synchronous notifier', () => {
+    const errors: any[] = [];
+    // The current Subscriber.prototype.error implementation does nothing for
+    // stopped subscribers. This test was written to fail and expose a problem
+    // with synchronous notifiers. However, by the time the error occurs the
+    // subscriber is stopped, so the test logs errors by both patching the
+    // prototype and by using an error callback (for when/if the do-nothing-if-
+    // stopped behaviour is fixed).
+    const originalSubscribe = Observable.prototype.subscribe;
+    Observable.prototype.subscribe = function (...args: any[]): any {
+      let [subscriber] = args;
+      if (!(subscriber instanceof Rx.Subscriber)) {
+        subscriber = new Rx.Subscriber<any>(...args);
+      }
+      subscriber.error = function (err: any): void {
+        errors.push(err);
+        Rx.Subscriber.prototype.error.call(this, err);
+      };
+      return originalSubscribe.call(this, subscriber);
+    };
+    Observable.of(1, 2)
+      .repeatWhen((notifications: any) => Observable.empty())
+      .subscribe(undefined, err => errors.push(err));
+    Observable.prototype.subscribe = originalSubscribe;
+    expect(errors).to.deep.equal([]);
+  });
+
+  it('should not error when applying a non-empty synchronous notifier', () => {
+    const errors: any[] = [];
+    // The current Subscriber.prototype.error implementation does nothing for
+    // stopped subscribers. This test was written to fail and expose a problem
+    // with synchronous notifiers. However, by the time the error occurs the
+    // subscriber is stopped, so the test logs errors by both patching the
+    // prototype and by using an error callback (for when/if the do-nothing-if-
+    // stopped behaviour is fixed).
+    const originalSubscribe = Observable.prototype.subscribe;
+    Observable.prototype.subscribe = function (...args: any[]): any {
+      let [subscriber] = args;
+      if (!(subscriber instanceof Rx.Subscriber)) {
+        subscriber = new Rx.Subscriber<any>(...args);
+      }
+      subscriber.error = function (err: any): void {
+        errors.push(err);
+        Rx.Subscriber.prototype.error.call(this, err);
+      };
+      return originalSubscribe.call(this, subscriber);
+    };
+    Observable.of(1, 2)
+      .repeatWhen((notifications: any) => Observable.of(1))
+      .subscribe(undefined, err => errors.push(err));
+    Observable.prototype.subscribe = originalSubscribe;
+    expect(errors).to.deep.equal([]);
   });
 
   it('should apply an empty notifier on an empty source', () => {

--- a/src/operators/repeatWhen.ts
+++ b/src/operators/repeatWhen.ts
@@ -76,7 +76,8 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (!this.isStopped) {
       if (!this.retries) {
         this.subscribeToRetries();
-      } else if (this.retriesSubscription.closed) {
+      }
+      if (!this.retriesSubscription || this.retriesSubscription.closed) {
         return super.complete();
       }
 


### PR DESCRIPTION
* test(repeatWhen): rename to repeat in descriptions
* test(repeatWhen): align expectations with docs
* test(repeatWhen): add failing empty notifier test
* test(repeatWhen): add failing notifier test
* fix(repeatWhen): support synchronous notifier

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR cherry picks the commits made in #3460 into the `stable` branch.

The problem with the `repeatWhen` operator has been present for sometime, so I guess it should be fixed in `stable`, too.

**Related issue (if exists):** #3444
