### PR TITLE
Multi package issue

### DIFF
--- a/node-tests/run.sh
+++ b/node-tests/run.sh
@@ -1,0 +1,16 @@
+
+rm -rf node-tests/node_modules/
+
+mkdir -p node-tests/node_modules/rxjs
+mkdir -p node-tests/node_modules/rxjs1
+
+cp -R dist/package/. node-tests/node_modules/rxjs
+cp -R dist/package/. node-tests/node_modules/rxjs1
+
+{
+   node node-tests/test.js
+  # node --inspect-brk node-tests/test.js
+} || {
+  echo 'TEST FAILED'
+}
+

--- a/node-tests/test.js
+++ b/node-tests/test.js
@@ -16,7 +16,7 @@ var id = setTimeout(function () {
 }, 200);
 
 of1(0).pipe(
-  mergeMap1(function () { return of(x); }),
+  mergeMap1(function (x) { return of(x); }),
   mergeMap(function () { return from1(Promise.resolve(1)); })
 ).subscribe({
   next: function (value) { actual.push(value); },

--- a/node-tests/test.js
+++ b/node-tests/test.js
@@ -1,0 +1,34 @@
+
+var rxjs = require('rxjs');
+var rxjs1 = require('rxjs1');
+var mergeMap = require('rxjs/operators').mergeMap;
+var mergeMap1 = require('rxjs1/operators').mergeMap;
+
+var of = rxjs.of;
+var of1 = rxjs1.of;
+var from1 = rxjs1.from;
+
+var actual = [];
+var expected = [1];
+
+var id = setTimeout(function () {
+  throw new Error('TIMEOUT: Observable did not complete');
+}, 200);
+
+of1(0).pipe(
+  mergeMap1(function () { return of(x); }),
+  mergeMap(function () { return from1(Promise.resolve(1)); })
+).subscribe({
+  next: function (value) { actual.push(value); },
+  error: function () {
+    throw new Error('should not error');
+  },
+  complete: function () {
+    if (actual.length !== expected.length || actual[0] !== expected[0] || actual[1] !== expected[1]) {
+      throw new Error(actual + ' does not equal ' + expected);
+    } else {
+      clearTimeout(id);
+      console.log('TEST PASSED');
+    }
+  },
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactivex/rxjs",
-  "version": "6.0.0-beta.1",
+  "version": "6.0.0-beta.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
This resolves a very nasty issue that happens when more than one copy of rxjs exists in node_modules. This is something that can organically happen to users if they have a dependency that hard-depends on one version of rxjs, but they try to use another version of rxjs for their app. Sometimes even if they revert back, they end up with, say, 2 or 3 copies of `rxjs@5.5.7` in their node_modules

The problem is that the `Subscriber` constructor was doing an `instanceof` check to see if the `destination` was a known/trusted RxJS subscriber. When that fails, it causes RxJS to treat the destination subscriber as any other POJO would be. Due to optimizations involving lift, InnerSubscriber, and a behavior where we're setting the context of the `next`, `error` and `complete` functions manually, then calling `unsubscribe` for them synchronously in SafeSubscriber, this was causing some asynchronous subscriptions to be unsubscribed prematurely in error.

There will be another patch for 5.5.x stable branch as well.

cc/ @hansl 