### PR TITLE
build: Fix AMD module names generated by bazel

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -5,15 +5,36 @@ exports_files(["tsconfig.json"])
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
-  name = "rxjs",
-  module_name = "rxjs",
-  # exclude all backwards compatibility code because we don't have a bazel target setup for that
-  srcs = glob(["*.ts", "**/*.ts"], exclude = ["internal/Rx.ts", "internal-compatibility/**",  "internal/patching/**", "umd.ts"]),
-  tsconfig = "tsconfig.json",
-  # Specify the compile-time dependencies to run the compilation (eg. typescript)
-  # The default value assumes that the end-user has a target //:node_modules
-  # but not all users do.
-  # This also makes the build more reproducible, in case the user's TypeScript
-  # version isn't compatible.
-  node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
+    name = "lib",
+    srcs = glob(
+        ["**/*.ts"],
+        exclude = [
+            "index.ts",
+            "internal/Rx.ts",
+            "internal-compatibility/**",
+            "internal/patching/**",
+            "internal/umd.ts",
+        ],
+    ),
+    # Specify the compile-time dependencies to run the compilation (eg. typescript)
+    # The default value assumes that the end-user has a target //:node_modules
+    # but not all users do.
+    # This also makes the build more reproducible, in case the user's TypeScript
+    # version isn't compatible.
+    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
+    tsconfig = "tsconfig.json",
+)
+
+ts_library(
+    name = "rxjs",
+    srcs = ["index.ts"],
+    module_name = "rxjs",
+    module_root = "index.d.ts",
+    # See comment above
+    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
+    tsconfig = "tsconfig.json",
+    deps = [
+        ":lib",
+        "//operators",
+    ],
 )

--- a/src/operators/BUILD.bazel
+++ b/src/operators/BUILD.bazel
@@ -1,0 +1,13 @@
+package(default_visibility = ["//visibility:public"])
+
+load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
+
+ts_library(
+    name = "operators",
+    srcs = glob(["*.ts"]),
+    module_name = "rxjs/operators",
+    module_root = "index.d.ts",
+    node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
+    tsconfig = "//:tsconfig.json",
+    deps = ["//:lib"],
+)


### PR DESCRIPTION
Downstream users expect to require('rxjs') and require('rxjs/operators')
