### PR TITLE
build(typescript): lock TypeScript to 2.7.x to avoid unexpected break…

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "ts-node": "4.1.0",
     "tslint": "5.9.1",
     "tslint-no-unused-expression-chai": "0.0.3",
-    "typescript": "latest",
+    "typescript": "~2.7.2",
     "validate-commit-msg": "2.14.0",
     "watch": "1.0.2",
     "webpack": "1.13.1",


### PR DESCRIPTION
…ing changes

TypeScript should always be locked down because they do not follow semver and make breaking changes in what appears to be feature releases.