### PR TITLE
refactor(mergeMap): readd resultSelector as deprecated

### DIFF
--- a/compat/operator/exhaust.ts
+++ b/compat/operator/exhaust.ts
@@ -37,8 +37,6 @@ export function exhaust<T, R>(this: Observable<T>): Observable<R>;
  *
  * @return {Observable} An Observable that takes a source of Observables and propagates the first observable
  * exclusively until it completes before subscribing to the next.
- * @method exhaust
- * @owner Observable
  */
 export function exhaust<T>(this: Observable<ObservableInput<T>>): Observable<T> {
   return higherOrder<T>()(this);

--- a/compat/operator/exhaustMap.ts
+++ b/compat/operator/exhaustMap.ts
@@ -20,8 +20,8 @@ import { exhaustMap as higherOrder } from 'rxjs/operators';
  * and repeat this process.
  *
  * @example <caption>Run a finite timer for each click, only if there is no currently active timer</caption>
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000).take(5));
+ * var clicks = fromEvent(document, 'click');
+ * var result = clicks.pipe(exhaustMap((ev) => Rx.Observable.interval(1000).take(5)));
  * result.subscribe(x => console.log(x));
  *
  * @see {@link concatMap}
@@ -35,8 +35,6 @@ import { exhaustMap as higherOrder } from 'rxjs/operators';
  * @return {Observable} An Observable containing projected Observables
  * of each item of the source, ignoring projected Observables that start before
  * their preceding Observable has completed.
- * @method exhaustMap
- * @owner Observable
  */
 export function exhaustMap<T, R>(
   this: Observable<T>,

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -78,6 +78,31 @@ describe('mergeMap', () => {
     });
   });
 
+  it('should support a void resultSelector (still deprecated) and concurrency limit', () => {
+    const results: number[] = [];
+
+    of(1, 2, 3).pipe(
+      mergeMap(
+        x => of(x, x + 1, x + 2),
+        void 0,
+        1,
+      )
+    )
+    .subscribe({
+      next (value) {
+        results.push(value);
+      },
+      error(err) {
+        throw err;
+      },
+      complete() {
+        expect(results).to.deep.equal([
+          1, 2, 3, 2, 3, 4, 3, 4, 5
+        ]);
+      }
+    });
+  });
+
   it('should mergeMap many regular interval inners', () => {
     const a =   cold('----a---a---a---(a|)                    ');
     const b =   cold(    '----b---b---(b|)                    ');

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -22,6 +22,62 @@ describe('mergeMap', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should support the deprecated resultSelector', () => {
+    const results: Array<number[]> = [];
+
+    of(1, 2, 3).pipe(
+      mergeMap(
+        x => of(x, x + 1, x + 2),
+        (a, b, i, ii) => [a, b, i, ii]
+      )
+    )
+    .subscribe({
+      next (value) {
+        results.push(value);
+      },
+      error(err) {
+        throw err;
+      },
+      complete() {
+        expect(results).to.deep.equal([
+          [1, 1, 0, 0],
+          [1, 2, 0, 1],
+          [1, 3, 0, 2],
+          [2, 2, 1, 0],
+          [2, 3, 1, 1],
+          [2, 4, 1, 2],
+          [3, 3, 2, 0],
+          [3, 4, 2, 1],
+          [3, 5, 2, 2],
+        ]);
+      }
+    });
+  });
+
+  it('should support a void resultSelector (still deprecated)', () => {
+    const results: number[] = [];
+
+    of(1, 2, 3).pipe(
+      mergeMap(
+        x => of(x, x + 1, x + 2),
+        void 0
+      )
+    )
+    .subscribe({
+      next (value) {
+        results.push(value);
+      },
+      error(err) {
+        throw err;
+      },
+      complete() {
+        expect(results).to.deep.equal([
+          1, 2, 3, 2, 3, 4, 3, 4, 5
+        ]);
+      }
+    });
+  });
+
   it('should mergeMap many regular interval inners', () => {
     const a =   cold('----a---a---a---(a|)                    ');
     const b =   cold(    '----b---b---(b|)                    ');

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -22,6 +22,62 @@ describe('mergeMapTo', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should support the deprecated resultSelector', () => {
+    const results: Array<number[]> = [];
+
+    of(1, 2, 3).pipe(
+      mergeMapTo(
+        of(4, 5, 6),
+        (a, b, i, ii) => [a, b, i, ii]
+      )
+    )
+    .subscribe({
+      next (value) {
+        results.push(value);
+      },
+      error(err) {
+        throw err;
+      },
+      complete() {
+        expect(results).to.deep.equal([
+          [1, 4, 0, 0],
+          [1, 5, 0, 1],
+          [1, 6, 0, 2],
+          [2, 4, 1, 0],
+          [2, 5, 1, 1],
+          [2, 6, 1, 2],
+          [3, 4, 2, 0],
+          [3, 5, 2, 1],
+          [3, 6, 2, 2],
+        ]);
+      }
+    });
+  });
+
+  it('should support a void resultSelector (still deprecated)', () => {
+    const results: number[] = [];
+
+    of(1, 2, 3).pipe(
+      mergeMapTo(
+        of(4, 5, 6),
+        void 0
+      )
+    )
+    .subscribe({
+      next (value) {
+        results.push(value);
+      },
+      error(err) {
+        throw err;
+      },
+      complete() {
+        expect(results).to.deep.equal([
+          4, 5, 6, 4, 5, 6, 4, 5, 6
+        ]);
+      }
+    });
+  });
+
   it('should mergeMapTo many regular interval inners', () => {
     const x =   cold('----1---2---3---(4|)                        ');
     const xsubs =   ['^               !                           ',

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { switchMap, mergeMap } from 'rxjs/operators';
+import { of, Observable } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {switchMap} */
-describe('Observable.prototype.switchMap', () => {
+describe('switchMap', () => {
   asDiagram('switchMap(i => 10*i\u2014\u201410*i\u2014\u201410*i\u2014| )')
   ('should map-and-flatten each item to an Observable', () => {
     const e1 =    hot('--1-----3--5-------|');
@@ -16,22 +15,81 @@ describe('Observable.prototype.switchMap', () => {
     const expected =  '--x-x-x-y-yz-z-z---|';
     const values = {x: 10, y: 30, z: 50};
 
-    const result = e1.switchMap(x => e2.map(i => i * +x));
+    const result = e1.pipe(switchMap(x => e2.map(i => i * +x)));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should support the deprecated resultSelector', () => {
+    const results: Array<number[]> = [];
+
+    of(1, 2, 3).pipe(
+      switchMap(
+        x => of(x, x + 1, x + 2),
+        (a, b, i, ii) => [a, b, i, ii]
+      )
+    )
+    .subscribe({
+      next (value) {
+        results.push(value);
+      },
+      error(err) {
+        throw err;
+      },
+      complete() {
+        expect(results).to.deep.equal([
+          [1, 1, 0, 0],
+          [1, 2, 0, 1],
+          [1, 3, 0, 2],
+          [2, 2, 1, 0],
+          [2, 3, 1, 1],
+          [2, 4, 1, 2],
+          [3, 3, 2, 0],
+          [3, 4, 2, 1],
+          [3, 5, 2, 2],
+        ]);
+      }
+    });
+  });
+
+  it('should support a void resultSelector (still deprecated)', () => {
+    const results: number[] = [];
+
+    of(1, 2, 3).pipe(
+      switchMap(
+        x => of(x, x + 1, x + 2),
+        void 0
+      )
+    )
+    .subscribe({
+      next (value) {
+        results.push(value);
+      },
+      error(err) {
+        throw err;
+      },
+      complete() {
+        expect(results).to.deep.equal([
+          1, 2, 3, 2, 3, 4, 3, 4, 5
+        ]);
+      }
+    });
+  });
+
   it('should unsub inner observables', () => {
     const unsubbed: string[] = [];
 
-    Observable.of('a', 'b').switchMap((x) =>
-      new Observable<string>((subscriber) => {
-        subscriber.complete();
-        return () => {
-          unsubbed.push(x);
-        };
-      })).subscribe();
+    of('a', 'b').pipe(
+      switchMap(x =>
+        new Observable<string>((subscriber) => {
+          subscriber.complete();
+          return () => {
+            unsubbed.push(x);
+          };
+        })
+      )
+    ).subscribe();
 
     expect(unsubbed).to.deep.equal(['a', 'b']);
   });
@@ -47,7 +105,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -63,7 +121,7 @@ describe('Observable.prototype.switchMap', () => {
       throw 'error';
     }
 
-    expectObservable(e1.switchMap(project)).toBe(expected);
+    expectObservable(e1.pipe(switchMap(project))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -79,7 +137,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -99,10 +157,11 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1
-      .mergeMap((x) => Observable.of(x))
-      .switchMap((value) => observableLookup[value])
-      .mergeMap((x) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap(x => of(x)),
+      switchMap(value => observableLookup[value]),
+      mergeMap(x => of(x)),
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -121,7 +180,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -140,7 +199,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -159,7 +218,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -178,7 +237,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -197,7 +256,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -216,7 +275,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -235,7 +294,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -254,7 +313,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected, undefined, 'sad');
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -273,7 +332,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected, undefined, 'sad');
     expectSubscriptions(x.subscriptions).toBe(xsubs);
@@ -286,7 +345,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    const result = e1.switchMap((value) => Observable.of(value));
+    const result = e1.pipe(switchMap(value => of(value)));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -297,7 +356,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const result = e1.switchMap((value) => Observable.of(value));
+    const result = e1.pipe(switchMap(value => of(value)));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -308,7 +367,7 @@ describe('Observable.prototype.switchMap', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const result = e1.switchMap((value) => Observable.of(value));
+    const result = e1.pipe(switchMap(value => of(value)));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -323,7 +382,7 @@ describe('Observable.prototype.switchMap', () => {
 
     const observableLookup = { x: x };
 
-    const result = e1.switchMap((value) => observableLookup[value]);
+    const result = e1.pipe(switchMap(value => observableLookup[value]));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(x.subscriptions).toBe(xsubs);

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -1,6 +1,14 @@
 import { mergeMap } from './mergeMap';
 import { ObservableInput, OperatorFunction } from '../types';
 
+/* tslint:disable:max-line-length */
+export function concatMap<T, R>(project: (value: T, index: number) =>  ObservableInput<R>): OperatorFunction<T, R>;
+/** @deprecated */
+export function concatMap<T, R>(project: (value: T, index: number) => ObservableInput<R>, resultSelector: undefined): OperatorFunction<T, R>;
+/** @deprecated */
+export function concatMap<T, I, R>(project: (value: T, index: number) =>  ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
+/* tslint:enable:max-line-length */
+
 /**
  * Projects each source value to an Observable which is merged in the output
  * Observable, in a serialized fashion waiting for each one to complete before
@@ -52,6 +60,9 @@ import { ObservableInput, OperatorFunction } from '../types';
  * @method concatMap
  * @owner Observable
  */
-export function concatMap<T, R>(project: (value: T, index: number) =>  ObservableInput<R>): OperatorFunction<T, R> {
-  return mergeMap(project, 1);
+export function concatMap<T, I, R>(
+  project: (value: T, index: number) =>  ObservableInput<I>,
+  resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R
+): OperatorFunction<T, I|R> {
+  return mergeMap(project, resultSelector, 1);
 }

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -3,9 +3,9 @@ import { ObservableInput, OperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
 export function concatMap<T, R>(project: (value: T, index: number) =>  ObservableInput<R>): OperatorFunction<T, R>;
-/** @deprecated */
+/** @deprecated resultSelector no longer supported, use inner map instead */
 export function concatMap<T, R>(project: (value: T, index: number) => ObservableInput<R>, resultSelector: undefined): OperatorFunction<T, R>;
-/** @deprecated */
+/** @deprecated resultSelector no longer supported, use inner map instead */
 export function concatMap<T, I, R>(project: (value: T, index: number) =>  ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -1,6 +1,14 @@
 import { concatMap } from './concatMap';
 import { ObservableInput, OperatorFunction } from '../types';
 
+/* tslint:disable:max-line-length */
+export function concatMapTo<T>(observable: ObservableInput<T>): OperatorFunction<any, T>;
+/** @deprecated */
+export function concatMapTo<T>(observable: ObservableInput<T>, resultSelector: undefined): OperatorFunction<any, T>;
+/** @deprecated */
+export function concatMapTo<T, I, R>(observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
+/* tslint:enable:max-line-length */
+
 /**
  * Projects each source value to the same Observable which is merged multiple
  * times in a serialized fashion on the output Observable.
@@ -49,8 +57,9 @@ import { ObservableInput, OperatorFunction } from '../types';
  * @method concatMapTo
  * @owner Observable
  */
-export function concatMapTo<T, R>(
-  innerObservable: ObservableInput<R>
+export function concatMapTo<T, I, R>(
+  innerObservable: ObservableInput<I>,
+  resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, R> {
-  return concatMap(() => innerObservable);
+  return concatMap(() => innerObservable, resultSelector);
 }

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -11,7 +11,9 @@ import { from } from '../observable/from';
 
 /* tslint:disable:max-line-length */
 export function mergeMap<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number): OperatorFunction<T, R>;
-/** @deprecated use inner map instead. */
+/** @deprecated resultSelector no longer supported, use inner map instead */
+export function mergeMap<T, R>(project: (value: T, index: number) => ObservableInput<R>, resultSelector: undefined, concurrent?: number): OperatorFunction<T, R>;
+/** @deprecated resultSelector no longer supported, use inner map instead */
 export function mergeMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -6,9 +6,13 @@ import { subscribeToResult } from '../util/subscribeToResult';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { ObservableInput, OperatorFunction } from '../types';
+import { map } from './map';
+import { from } from '../observable/from';
 
 /* tslint:disable:max-line-length */
 export function mergeMap<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number): OperatorFunction<T, R>;
+/** @deprecated use inner map instead. */
+export function mergeMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -61,11 +65,22 @@ export function mergeMap<T, R>(project: (value: T, index: number) => ObservableI
  * @method mergeMap
  * @owner Observable
  */
-export function mergeMap<T, R>(project: (value: T, index: number) => ObservableInput<R>,
-                               concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<T, R> {
-  return function mergeMapOperatorFunction(source: Observable<T>) {
-    return source.lift(new MergeMapOperator(project, concurrent));
-  };
+export function mergeMap<T, I, R>(
+  project: (value: T, index: number) => ObservableInput<I>,
+  resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
+  concurrent: number = Number.POSITIVE_INFINITY
+): OperatorFunction<T, I|R> {
+  if (typeof resultSelector === 'function') {
+    // DEPRECATED PATH
+    return (source: Observable<T>) => source.pipe(
+      mergeMap((a, i) => from(project(a, i)).pipe(
+        map((b, ii) => resultSelector(a, b, i, ii)),
+      ), concurrent)
+    );
+  } else if (typeof resultSelector === 'number') {
+    concurrent = resultSelector;
+  }
+  return (source: Observable<T>) => source.lift(new MergeMapOperator(project, concurrent));
 }
 
 export class MergeMapOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -3,6 +3,12 @@ import { OperatorFunction } from '../../internal/types';
 import { mergeMap } from './mergeMap';
 import { ObservableInput } from '../types';
 
+/* tslint:disable:max-line-length */
+export function mergeMapTo<T>(innerObservable: ObservableInput<T>, concurrent?: number): OperatorFunction<any, T>;
+/** @deprecated */
+export function mergeMapTo<T, I, R>(innerObservable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
+/* tslint:enable:max-line-length */
+
 /**
  * Projects each source value to the same Observable which is merged multiple
  * times in the output Observable.
@@ -37,7 +43,16 @@ import { ObservableInput } from '../types';
  * @method mergeMapTo
  * @owner Observable
  */
-export function mergeMapTo<T, R>(innerObservable: ObservableInput<R>,
-                                 concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<T, R> {
+export function mergeMapTo<T, I, R>(
+  innerObservable: ObservableInput<I>,
+  resultSelector?: ((outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R) | number,
+  concurrent: number = Number.POSITIVE_INFINITY
+): OperatorFunction<T, I|R> {
+  if (typeof resultSelector === 'function') {
+    return mergeMap(() => innerObservable, resultSelector, concurrent);
+  }
+  if (typeof resultSelector === 'number') {
+    concurrent = resultSelector;
+  }
   return mergeMap(() => innerObservable, concurrent);
 }


### PR DESCRIPTION
Readds the resultSelector, as deprecated, to 

- mergeMap
- mergeMapTo
- switchMap
- switchMapTo
- concatMap
- concatMapTo
- exhaustMap

... relies on map tests for error handling