### PR TITLE
fix(AjaxObservable): Use encodeURIComponent to encode ajax url params

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -487,6 +487,25 @@ describe('Observable.ajax', () => {
       expect(MockXMLHttpRequest.mostRecent.data).to.equal('%F0%9F%8C%9F=%F0%9F%9A%80');
     });
 
+    it('should send by form-urlencoded format with special characters', () => {
+      const body = {
+        'foo=bar': 'foo?bar'
+      };
+      const obj = {
+        url: '/flibbertyJibbet',
+        method: '',
+        headers: {
+          'Content-Type': 'application/x-www-form-urlencoded'
+        },
+        body: body
+      };
+
+      Rx.Observable.ajax(obj).subscribe();
+
+      expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
+      expect(MockXMLHttpRequest.mostRecent.data).to.equal('foo%3Dbar=foo%3Fbar');
+    });
+
     it('should send by JSON', () => {
       const body = {
         '🌟': '🚀'

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -292,7 +292,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
     switch (contentType) {
       case 'application/x-www-form-urlencoded':
-        return Object.keys(body).map(key => `${encodeURI(key)}=${encodeURI(body[key])}`).join('&');
+        return Object.keys(body).map(key => `${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`).join('&');
       case 'application/json':
         return JSON.stringify(body);
       default:


### PR DESCRIPTION
**Description:**
The contentType 'application/x-www-form-urlencoded' was using encodeURI but should be using encodeURIComponent.


**Related issue (if exists):**
closes #2389