### PR TITLE
fix(closure-compiler): remove top level throws

### DIFF
--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -6,10 +6,6 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 
-if (!Set) {
-  throw new Error('Set is not present, please polyfill');
-}
-
 /**
  * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from previous items.
  *

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -5,11 +5,6 @@ import { Operator } from '../Operator';
 import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';
 
-/** Assert that map is present for this operator */
-if (!Map) {
-  throw new Error('Map not found, please polyfill');
-}
-
 /* tslint:disable:max-line-length */
 export function groupBy<T, K>(keySelector: (value: T) => K): OperatorFunction<T, GroupedObservable<K, T>>;
 export function groupBy<T, K>(keySelector: (value: T) => K, elementSelector: void, durationSelector: (grouped: GroupedObservable<K, T>) => Observable<any>): OperatorFunction<T, GroupedObservable<K, T>>;


### PR DESCRIPTION
This fixes closure compiler issues, and also removes the only side-effect from these modules. We want our modules to be side-effect free. This was an oversight in that regard
