### PR TITLE
fix(closure-compiler): adds nocollapse to static members

### DIFF
--- a/src/MiscJSDoc.ts
+++ b/src/MiscJSDoc.ts
@@ -133,6 +133,7 @@ export class ObservableDoc {
    * @static true
    * @name create
    * @owner Observable
+   * @nocollapse
    */
   static create<T>(onSubscription: <R>(observer: Observer<R>) => TeardownLogic): Observable<T> {
     return new Observable<T>(onSubscription);

--- a/src/internal/observable/SubscribeOnObservable.ts
+++ b/src/internal/observable/SubscribeOnObservable.ts
@@ -16,10 +16,12 @@ export interface DispatchArg<T> {
  * @hide true
  */
 export class SubscribeOnObservable<T> extends Observable<T> {
+  /** @nocollapse */
   static create<T>(source: Observable<T>, delay: number = 0, scheduler: SchedulerLike = asap): Observable<T> {
     return new SubscribeOnObservable(source, delay, scheduler);
   }
 
+  /** @nocollapse */
   static dispatch<T>(this: SchedulerAction<T>, arg: DispatchArg<T>): Subscription {
     const { source, subscriber } = arg;
     return this.add(source.subscribe(subscriber));

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -131,6 +131,7 @@ export class AjaxObservable<T> extends Observable<T> {
    * @static true
    * @name ajax
    * @owner Observable
+   * @nocollapse
   */
   static create: AjaxCreationMethod = (() => {
     const create: any = (urlOrRequest: string | AjaxRequest) => {

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -71,6 +71,7 @@ export class ObserveOnOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 export class ObserveOnSubscriber<T> extends Subscriber<T> {
+  /** @nocollapse */
   static dispatch(this: SchedulerAction<ObserveOnMessage>, arg: ObserveOnMessage) {
     const { notification, destination } = arg;
     notification.observe(destination);

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -136,6 +136,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     }
   }
 
+  /** @nocollapse */
   static parseMarblesAsSubscriptions(marbles: string): SubscriptionLog {
     if (typeof marbles !== 'string') {
       return new SubscriptionLog(Number.POSITIVE_INFINITY);
@@ -185,6 +186,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     }
   }
 
+  /** @nocollapse */
   static parseMarbles(marbles: string,
                       values?: any,
                       errorValue?: any,


### PR DESCRIPTION
There are a few issues with closure compiler and static members not flagged with nocollapse. This change is non-invasive.