### PR TITLE
fix(closure-compiler): remove internal flag from _isScalar

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -17,7 +17,7 @@ import { config } from './config';
  */
 export class Observable<T> implements Subscribable<T> {
 
-  /** @internal */
+  /** Internal implementation detail, do not use directly. */
   public _isScalar: boolean = false;
 
   protected source: Observable<any>;


### PR DESCRIPTION
the internal flag was causing issues with _isScalar checks when combined with closure compiler, removing it and opting for a comment and an obviously internal _name
