### PR TITLE
fix(closure-compiler): removes bad @params comments that caused issues

### DIFF
--- a/src/internal/util/subscribeToArray.ts
+++ b/src/internal/util/subscribeToArray.ts
@@ -3,7 +3,6 @@ import { Subscriber } from '../Subscriber';
 /**
  * Subscribes to an ArrayLike with a subscriber
  * @param array The array or array-like to subscribe to
- * @param subscriber The subscriber to subscribe with.
  */
 export const subscribeToArray = <T>(array: ArrayLike<T>) => (subscriber: Subscriber<T>) => {
   for (let i = 0, len = array.length; i < len && !subscriber.closed; i++) {

--- a/src/internal/util/subscribeToObservable.ts
+++ b/src/internal/util/subscribeToObservable.ts
@@ -5,7 +5,6 @@ import { observable as Symbol_observable } from '../symbol/observable';
  * Subscribes to an object that implements Symbol.observable with the given
  * Subscriber.
  * @param obj An object that implements Symbol.observable
- * @param subscriber The Subscriber to use to subscribe to the observable
  */
 export const subscribeToObservable = <T>(obj: any) => (subscriber: Subscriber<T>) => {
   const obs = obj[Symbol_observable]();


### PR DESCRIPTION
There were some params comments added that should not have been there, given that they were part of the result of a higher order function, not the initial arguments.
