### PR TITLE
fix(Scheduler): export but deprecate

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ export { async as asyncScheduler } from './internal/scheduler/async';
 export { queue as queueScheduler } from './internal/scheduler/queue';
 export { animationFrame as animationFrameScheduler } from './internal/scheduler/animationFrame';
 export { VirtualTimeScheduler, VirtualAction } from './internal/scheduler/VirtualTimeScheduler';
+export { Scheduler } from './internal/Scheduler';
 
 /* Subscription */
 export { Subscription } from './internal/Subscription';

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -17,6 +17,9 @@ import { SchedulerLike, SchedulerAction } from './types';
  * ```
  *
  * @class Scheduler
+ * @deprecated Scheduler is an internal implementation detail of RxJS, and
+ * should not be used directly. Rather, create your own class and implement
+ * {@link SchedulerLike}
  */
 export class Scheduler implements SchedulerLike {
 


### PR DESCRIPTION
There are a lot of people extending Scheduler, they really should not be, but we can give them time to fix things on their end before removing the reexport of Scheduler. Scheduler is an internal implementation detail.
