### PR TITLE
fix(sourcemaps): fix mappings for source maps so they will work

### DIFF
--- a/.make-compat-package.js
+++ b/.make-compat-package.js
@@ -6,6 +6,11 @@ let mkdirp = require('mkdirp');
 let path = require('path');
 let klawSync = require('klaw-sync');
 let licenseTool = require('./tools/add-license-to-file');
+let makePackages = require('./.make-helpers');
+let copySources = makePackages.copySources;
+let createImportTargets = makePackages.createImportTargets;
+let cleanSourceMapRoot = makePackages.cleanSourceMapRoot;
+
 let addLicenseToFile = licenseTool.addLicenseToFile;
 let addLicenseTextToFile = licenseTool.addLicenseTextToFile;
 
@@ -19,6 +24,7 @@ const CJS_PKG = PKG_ROOT + '';
 const ESM5_PKG = PKG_ROOT + '_esm5/';
 const ESM2015_PKG = PKG_ROOT + '_esm2015/';
 const UMD_PKG = PKG_ROOT + 'bundles/';
+const SRC_ROOT_PKG = PKG_ROOT +  'src/';
 const TYPE_PKG = PKG_ROOT;
 
 // License info for minified files
@@ -32,22 +38,10 @@ mkdirp.sync(PKG_ROOT);
 // Copy over the sources
 fs.copySync(TYPE_ROOT, TYPE_PKG);
 copySources(CJS_ROOT, CJS_PKG);
+cleanSourceMapRoot(CJS_PKG, SRC_ROOT_PKG);
 copySources(ESM5_ROOT, ESM5_PKG, true);
+cleanSourceMapRoot(ESM5_PKG, SRC_ROOT_PKG);
 copySources(ESM2015_ROOT, ESM2015_PKG, true);
+cleanSourceMapRoot(ESM2015_PKG, SRC_ROOT_PKG);
 
 fs.copySync('compat/package.json', PKG_ROOT + '/package.json');
-
-function copySources(rootDir, packageDir, ignoreMissing) {
-  // If we are ignoring missing directories, early return when source doesn't exist
-  if (!fs.existsSync(rootDir)) {
-    if (ignoreMissing) {
-      return;
-    } else {
-      throw "Source root dir does not exist!";
-    }
-  }
-  // Copy over the CommonJS files
-  fs.copySync(rootDir, packageDir);
-  fs.copySync('./LICENSE.txt', packageDir + 'LICENSE.txt');
-  fs.copySync('./compat/README.md', packageDir + 'README.md');
-}

--- a/.make-helpers.js
+++ b/.make-helpers.js
@@ -1,0 +1,65 @@
+"use strict";
+
+let fs = require('fs-extra');
+let path = require('path');
+let klawSync = require('klaw-sync');
+
+function cleanSourceMapRoot(mapRoot, sourcesRoot) {
+  klawSync(mapRoot, {filter: (item) => item.path.endsWith('.js.map')})
+  .map(f => f.path)
+  .forEach(fName => {
+    const sourceMap = fs.readJsonSync(fName);
+
+    // Get relative path from map file to source file
+    sourceMap.sources = sourceMap.sources.map(s => {
+      const sRel = path.relative(path.parse(fName).dir, path.resolve(path.join(sourcesRoot, s)));
+      return sRel;
+    });
+    delete sourceMap.sourceRoot;
+
+    fs.writeJsonSync(fName, sourceMap);
+  });
+}
+
+function copySources(rootDir, packageDir, ignoreMissing) {
+  // If we are ignoring missing directories, early return when source doesn't exist
+  if (!fs.existsSync(rootDir)) {
+    if (ignoreMissing) {
+      return;
+    } else {
+      throw "Source root dir does not exist!";
+    }
+  }
+  // Copy over the CommonJS files
+  fs.copySync(rootDir, packageDir);
+  fs.copySync('./LICENSE.txt', packageDir + 'LICENSE.txt');
+  fs.copySync('./README.md', packageDir + 'README.md');
+}
+
+// Create a file that exports the importTargets object
+function createImportTargets(importTargets, targetName, targetDirectory) {
+  const importMap = {};
+  for (const x in importTargets) {
+    importMap['rxjs/' + x] = ('rxjs-compat/' + targetName + importTargets[x]).replace(/\.js$/, '');
+  }
+
+  const outputData =
+`
+"use strict"
+
+var path = require('path');
+var dir = path.resolve(__dirname);
+
+module.exports = function() {
+  return ${JSON.stringify(importMap, null, 4)};
+}
+`
+
+  fs.outputFileSync(targetDirectory + 'path-mapping.js', outputData);
+}
+
+module.exports = {
+  copySources,
+  createImportTargets,
+  cleanSourceMapRoot
+}

--- a/.make-packages.js
+++ b/.make-packages.js
@@ -8,6 +8,10 @@ let klawSync = require('klaw-sync');
 let licenseTool = require('./tools/add-license-to-file');
 let addLicenseToFile = licenseTool.addLicenseToFile;
 let addLicenseTextToFile = licenseTool.addLicenseTextToFile;
+let makePackages = require('./.make-helpers');
+let copySources = makePackages.copySources;
+let createImportTargets = makePackages.createImportTargets;
+let cleanSourceMapRoot = makePackages.cleanSourceMapRoot;
 let bo = null;
 // Build Optimizer is not available on Node 4.x. Using a try/catch
 // here to make sure the build passes on Travis using Node 4, but
@@ -22,13 +26,15 @@ const CJS_ROOT = ROOT + 'cjs/';
 const ESM5_ROOT = ROOT + 'esm5/';
 const ESM2015_ROOT = ROOT + 'esm2015/';
 const UMD_ROOT = ROOT + 'global/';
-const LEGACY_REEXPORT_ROOT = ROOT + "legacy-reexport/"
+const ESM5_FOR_ROLLUP_ROOT = ROOT + 'esm5_for_rollup/';
+const LEGACY_REEXPORT_ROOT = ROOT + 'legacy-reexport/';
 const TYPE_ROOT = ROOT + 'typings/';
 const PKG_ROOT = ROOT + 'package/';
 const CJS_PKG = PKG_ROOT + '';
 const ESM5_PKG = PKG_ROOT + '_esm5/';
 const ESM2015_PKG = PKG_ROOT + '_esm2015/';
 const UMD_PKG = PKG_ROOT + 'bundles/';
+const SRC_ROOT_PKG = PKG_ROOT +  'src/';
 const TYPE_PKG = PKG_ROOT;
 
 // License info for minified files
@@ -106,13 +112,21 @@ createImportTargets(importTargets, "_esm2015/", ESM2015_PKG);
 mkdirp.sync(PKG_ROOT);
 
 // Copy over the sources
-copySources('src/', PKG_ROOT + 'src/');
+copySources('src/', SRC_ROOT_PKG);
+// Copy legacy-reexport sources
+copySources('legacy-reexport/', SRC_ROOT_PKG);
+
 copySources(CJS_ROOT, CJS_PKG);
-fs.copySync(TYPE_ROOT, TYPE_PKG);
 fs.copySync(LEGACY_REEXPORT_ROOT, CJS_PKG, {overwrite: false, errorOnExist: true});
 
+// Clean up the source maps for CJS sources
+cleanSourceMapRoot(PKG_ROOT, SRC_ROOT_PKG);
+fs.copySync(TYPE_ROOT, TYPE_PKG);
+
 copySources(ESM5_ROOT, ESM5_PKG, true);
+cleanSourceMapRoot(ESM5_PKG, SRC_ROOT_PKG);
 copySources(ESM2015_ROOT, ESM2015_PKG, true);
+cleanSourceMapRoot(ESM2015_PKG, SRC_ROOT_PKG);
 
 // Copy over tsconfig.json for bazel build support
 fs.copySync('./tsconfig.base.json', PKG_ROOT + 'src/tsconfig.json');
@@ -127,11 +141,30 @@ fs.copySync('src/internal-compatibility/package.json', PKG_ROOT + '/internal-com
 
 if (fs.existsSync(UMD_ROOT)) {
   fs.copySync(UMD_ROOT, UMD_PKG);
+  // Clean up source map paths so they can be re-mapped
+  klawSync(UMD_PKG, {filter: (item) => item.path.endsWith('.js.map')})
+  .map(f => f.path)
+  .forEach(fName => {
+    const sourceMap = fs.readJsonSync(fName);
+    sourceMap.sources = sourceMap.sources.map(s => {
+      const nm = 'node_modules/';
+      const rr = path.resolve(ESM5_FOR_ROLLUP_ROOT);
+      if (s.includes(nm)) {
+        return s.substring(s.indexOf(nm) + nm.length);
+      } else if (s.includes(rr)) {
+        return s.substring(s.indexOf(rr) + rr.length);
+      }
+      return s;
+    });
+    fs.writeJsonSync(fName, sourceMap);
+  });
+
   // Add licenses to tops of bundles
   addLicenseToFile('LICENSE.txt', UMD_PKG + 'rxjs.umd.js');
   addLicenseTextToFile(license, UMD_PKG + 'rxjs.umd.min.js');
   addLicenseToFile('LICENSE.txt', UMD_PKG + 'rxjs.umd.js');
   addLicenseTextToFile(license, UMD_PKG + 'rxjs.umd.min.js');
+  cleanSourceMapRoot(UMD_PKG, PKG_ROOT);
 }
 
 // remove umd.js/umd.d.ts files that are only needed for creation of the umd bundle
@@ -142,40 +175,3 @@ fs.removeSync(ESM5_PKG + '/internal/umd.js.map');
 fs.removeSync(ESM2015_PKG + '/internal/umd.js');
 fs.removeSync(ESM2015_PKG + '/internal/umd.js.map');
 fs.removeSync(TYPE_PKG + '/internal/umd.d.ts');
-
-function copySources(rootDir, packageDir, ignoreMissing) {
-  // If we are ignoring missing directories, early return when source doesn't exist
-  if (!fs.existsSync(rootDir)) {
-    if (ignoreMissing) {
-      return;
-    } else {
-      throw "Source root dir does not exist!";
-    }
-  }
-  // Copy over the CommonJS files
-  fs.copySync(rootDir, packageDir);
-  fs.copySync('./LICENSE.txt', packageDir + 'LICENSE.txt');
-  fs.copySync('./README.md', packageDir + 'README.md');
-}
-
-// Create a file that exports the importTargets object
-function createImportTargets(importTargets, targetName, targetDirectory) {
-  const importMap = {};
-  for (const x in importTargets) {
-    importMap['rxjs/' + x] = ('rxjs-compat/' + targetName + importTargets[x]).replace(/\.js$/, '');
-  }
-
-  const outputData =
-`
-"use strict"
-
-var path = require('path');
-var dir = path.resolve(__dirname);
-
-module.exports = function() {
-  return ${JSON.stringify(importMap, null, 4)};
-}
-`
-
-  fs.outputFileSync(targetDirectory + 'path-mapping.js', outputData);
-}

--- a/tsconfig/compat/tsconfig.base.json
+++ b/tsconfig/compat/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "baseUrl": "../../compat",
+    "sourceRoot": "../../compat",
     "paths": {
       "rxjs": ["../src/index"],
       "rxjs/*": ["../src/*"],

--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "noEmit": false,
     "baseUrl": "../src",
+    "sourceRoot": "../src",
     "paths": {
       "rxjs": ["./"],
       "rxjs/*": ["./*"]

--- a/tsconfig/tsconfig.legacy-reexport.json
+++ b/tsconfig/tsconfig.legacy-reexport.json
@@ -8,6 +8,7 @@
     "outDir": "../dist/legacy-reexport",
     "rootDir": "../legacy-reexport",
     "baseUrl": "../legacy-reexport",
+    "sourceRoot": "../legacy-reexport",
     "paths": {
       "rxjs": ["../dist/typings/index"],
       "rxjs/*": ["../dist/typings/*"],


### PR DESCRIPTION
This PR basically just adjusts the `sources` property of the `.js.map` files to point to the right places.

Fixes #3479