### PR TITLE
fix(compat): deprecate Observable.if/throw

### DIFF
--- a/compat/add/observable/if.ts
+++ b/compat/add/observable/if.ts
@@ -1,4 +1,3 @@
 import { Observable, iif } from 'rxjs';
 
-//tslint:disable-next-line:no-any TypeScript doesn't like `if`
-(Observable as any).if = iif;
+Observable.if = iif;

--- a/compat/add/observable/throw.ts
+++ b/compat/add/observable/throw.ts
@@ -1,6 +1,6 @@
 import { Observable, throwError as staticThrowError } from 'rxjs';
 
-(Observable as any).throw = staticThrowError;
+Observable.throw = staticThrowError;
 Observable.throwError = staticThrowError;
 
 declare module 'rxjs/internal/Observable' {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -4,6 +4,7 @@ import { Subscription } from './Subscription';
 import { TeardownLogic } from './types';
 import { toSubscriber } from './util/toSubscriber';
 import { iif } from './observable/iif';
+import { throwError } from './observable/throwError';
 import { observable as Symbol_observable } from '../internal/symbol/observable';
 import { OperatorFunction, PartialObserver, Subscribable } from '../internal/types';
 import { pipeFromArray } from './util/pipe';
@@ -252,10 +253,18 @@ export class Observable<T> implements Subscribable<T> {
     return source && source.subscribe(subscriber);
   }
 
-  // TODO(benlesh): determine if this is still necessary
-  // `if` and `throw` are special snow flakes, the compiler sees them as reserved words
-  /** @nocollapse */
+  // `if` and `throw` are special snow flakes, the compiler sees them as reserved words. Deprecated in
+  // favor of iif and throwError functions.
+  /**
+   * @nocollapse
+   * @deprecated In favor of iif creation function: import { iif } from 'rxjs';
+   */
   static if: typeof iif;
+  /**
+   * @nocollapse
+   * @deprecated In favor of throwError creation function: import { throwError } from 'rxjs';
+   */
+  static throw: typeof throwError;
 
   /**
    * An interop point defined by the es7-observable spec https://github.com/zenparsing/es-observable


### PR DESCRIPTION
We need to put these back as deprecated. Will cause fewer broken apps.