### PR TITLE
fix: fix type mismatch in `NodeStyleEventEmitter`

### DIFF
--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -6,10 +6,12 @@ import { map } from '../operators/map';
 
 const toString: Function = Object.prototype.toString;
 
-export type NodeStyleEventEmitter = {
-  addListener: (eventName: string, handler: Function) => void;
-  removeListener: (eventName: string, handler: Function) => void;
-};
+export interface NodeStyleEventEmitter {
+  addListener: (eventName: string | symbol, handler: NodeEventHandler) => this;
+  removeListener: (eventName: string | symbol, handler: NodeEventHandler) => this;
+}
+
+export type NodeEventHandler = (...args: any[]) => void;
 
 export type JQueryStyleEventEmitter = {
   on: (eventName: string, handler: Function) => void;
@@ -193,8 +195,8 @@ function setupSubscription<T>(sourceObj: EventTargetLike, eventName: string,
     unsubscribe = () => source.off(eventName, handler);
   } else if (isNodeStyleEventEmitter(sourceObj)) {
     const source = sourceObj;
-    sourceObj.addListener(eventName, handler);
-    unsubscribe = () => source.removeListener(eventName, handler);
+    sourceObj.addListener(eventName, handler as NodeEventHandler);
+    unsubscribe = () => source.removeListener(eventName, handler as NodeEventHandler);
   } else {
     throw new TypeError('Invalid event target');
   }


### PR DESCRIPTION
**Description:**
There was a type mismatch in `observable/fromEvent.ts` which causes `tsc` compile error when I tried to compile the following.
```
Observable.fromEvent(new EventEmitter(), "foo")
```
Error I've got is below
```
src/my-library/index.ts:41:5 - error TS2352: Type 'EventEmitter' cannot be converted to type 'NodeStyleEventEmitter'.
  Types of property 'addListener' are incompatible.
    Type '(event: string | symbol, listener: (...args: any[]) => void) => EventEmitter' is not comparable to type '(eventName: string, handler: Function) => void'.
      Types of parameters 'listener' and 'handler' are incompatible.
        Type 'Function' is not comparable to type '(...args: any[]) => void'.
          Type 'Function' provides no match for the signature '(...args: any[]): void'.
```

NOTE: There was also a same problem in stable branch. Please tell me what should I do for it.
https://github.com/ReactiveX/rxjs/blob/stable/src/observable/FromEventObservable.ts