### PR TITLE
fix(compat): export TeardownLogic

### DIFF
--- a/compat/Subscription.ts
+++ b/compat/Subscription.ts
@@ -1,1 +1,1 @@
-export {Subscription, Unsubscribable as AnonymousSubscription, SubscriptionLike as ISubscription} from 'rxjs';
+export {Subscription, Unsubscribable as AnonymousSubscription, SubscriptionLike as ISubscription, TeardownLogic} from 'rxjs';


### PR DESCRIPTION
Closes #3531

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adds a `TeardownLogic` export to `compat/Subscription` for 5.5.8 compatibility - see [this export](https://github.com/ReactiveX/rxjs/blob/5.5.8/src/Subscription.ts#L12) in 5.5.8.

**Related issue (if exists):** #3531
