### PR TITLE
build(bazel): exclude backwards compat code

### DIFF
--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -7,10 +7,9 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 ts_library(
     name = "lib",
     srcs = glob(
-        ["**/*.ts"],
+        ["internal/**/*.ts"],
         # exclude all backwards compatibility code because we don't have a bazel target setup for that
         exclude = [
-            "index.ts",
             "internal/Rx.ts",
             "internal-compatibility/**",
             "internal/patching/**",

--- a/src/operators/BUILD.bazel
+++ b/src/operators/BUILD.bazel
@@ -4,7 +4,7 @@ load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
     name = "operators",
-    srcs = glob(["*.ts"]),
+    srcs = ["index.ts"],
     module_name = "rxjs/operators",
     module_root = "index.d.ts",
     node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",


### PR DESCRIPTION
Excludes backward compat code introduced in 6.0.0-rc.1 from Bazel build