### PR TITLE
Update using() to apply to any disposable resource type

### DIFF
--- a/compat/observable/UsingObservable.ts
+++ b/compat/observable/UsingObservable.ts
@@ -1,8 +1,11 @@
-import { Observable, Unsubscribable, SubscribableOrPromise, using } from 'rxjs';
+import { Observable, ObservableInput, Unsubscribable, SubscribableOrPromise, using } from 'rxjs';
 
 export class UsingObservable<T> extends Observable<T> {
-  static create<T>(resourceFactory: () => Unsubscribable | void,
-                   observableFactory: (resource: Unsubscribable | void) => SubscribableOrPromise<T> | void): Observable<T> {
-    return using(resourceFactory, observableFactory);
+  static create<T, Resource>(
+    resourceFactory: () => Resource | void,
+    observableFactory: (resource: Resource | void) => ObservableInput<T> | void,
+    disposeFunction: (resource: Resource | void) => void
+  ): Observable<T> {
+    return using(resourceFactory, observableFactory, disposeFunction);
   }
 }

--- a/spec/observables/using-spec.ts
+++ b/spec/observables/using-spec.ts
@@ -117,7 +117,7 @@ describe('using', () => {
     const source = using(
       () => new Subscription(() => disposed = true),
       (resource) => {
-        throw error;
+        throw expected;
       },
       (resource) => resource && resource.unsubscribe()
     );

--- a/src/internal/observable/using.ts
+++ b/src/internal/observable/using.ts
@@ -31,10 +31,13 @@ import { EMPTY } from './empty';
  * @return {Observable<T>} An Observable that behaves the same as Observable returned by `observableFactory`, but
  * which - when completed, errored or unsubscribed - will also call `unsubscribe` on created resource object.
  */
-export function using<T>(resourceFactory: () => Unsubscribable | void,
-                         observableFactory: (resource: Unsubscribable | void) => ObservableInput<T> | void): Observable<T> {
+export function using<T, Resource>(
+    resourceFactory: () => Resource | void,
+    observableFactory: (resource: Resource | void) => ObservableInput<T> | void,
+    disposeFunction: (resource: Resource | void) => void
+): Observable<T> {
   return new Observable<T>(subscriber => {
-    let resource: Unsubscribable | void;
+    let resource: Resource | void;
 
     try {
       resource = resourceFactory();
@@ -56,7 +59,7 @@ export function using<T>(resourceFactory: () => Unsubscribable | void,
     return () => {
       subscription.unsubscribe();
       if (resource) {
-        resource.unsubscribe();
+        disposeFunction(resource);
       }
     };
   });


### PR DESCRIPTION
**Description:**
The documentation of the _using_ function on reactivex.io indicates that it can be used to dispose of arbitrary resources. (http://reactivex.io/documentation/operators/using.html). The RxJs section has an image indicating that the client should be able to pass in a _disposeFunction_. The provided RxJs in the docs does not work for a couple of reasons:
   * The resource allocated by _using_ is only ever disposed of using _unsubscribe()_, which implies something about its type.
   * The resultant subscription does not have a dispose() method, but the implementation here looks like it provides that capability.