### PR TITLE
chore(TypeScript): locked to 2.8.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -249,7 +249,7 @@
     "ts-node": "4.1.0",
     "tslint": "5.9.1",
     "tslint-no-unused-expression-chai": "0.0.3",
-    "typescript": "latest",
+    "typescript": "~2.8.1",
     "validate-commit-msg": "2.14.0",
     "watch": "1.0.2",
     "webpack": "1.13.1",


### PR DESCRIPTION
Now that we're nearing release, locking TypeScript down to 2.8.x to prevent further breakage.

(For those of you who don't know, TypeScript does _not_ adhere to semver, and publishes breaking changes in minor releases)