### PR TITLE
fix(node/TS): eliminate incompatable types to protected properties

### DIFF
--- a/src/internal/AsyncSubject.ts
+++ b/src/internal/AsyncSubject.ts
@@ -10,7 +10,8 @@ export class AsyncSubject<T> extends Subject<T> {
   private hasNext: boolean = false;
   private hasCompleted: boolean = false;
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<any>): Subscription {
     if (this.hasError) {
       subscriber.error(this.thrownError);
       return Subscription.EMPTY;

--- a/src/internal/BehaviorSubject.ts
+++ b/src/internal/BehaviorSubject.ts
@@ -17,7 +17,8 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>): Subscription {
     const subscription = super._subscribe(subscriber);
     if (subscription && !(<SubscriptionLike>subscription).closed) {
       subscriber.next(this._value);

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -21,9 +21,11 @@ export class Observable<T> implements Subscribable<T> {
   /** Internal implementation detail, do not use directly. */
   public _isScalar: boolean = false;
 
-  protected source: Observable<any>;
+  /** @deprecated This is an internal implementation detail, do not use. */
+  source: Observable<any>;
 
-  protected operator: Operator<any, T>;
+  /** @deprecated This is an internal implementation detail, do not use. */
+  operator: Operator<any, T>;
 
   /**
    * @constructor
@@ -208,7 +210,8 @@ export class Observable<T> implements Subscribable<T> {
     return sink;
   }
 
-  protected _trySubscribe(sink: Subscriber<T>): TeardownLogic {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _trySubscribe(sink: Subscriber<T>): TeardownLogic {
     try {
       return this._subscribe(sink);
     } catch (err) {
@@ -247,8 +250,8 @@ export class Observable<T> implements Subscribable<T> {
     }) as Promise<void>;
   }
 
-  /** @internal */
-  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<any>): TeardownLogic {
     const { source } = this;
     return source && source.subscribe(subscriber);
   }

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -49,7 +49,8 @@ export class ReplaySubject<T> extends Subject<T> {
     super.next(value);
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>): Subscription {
     // When `_infiniteTimeWindow === true` then the buffer is already trimmed
     const _infiniteTimeWindow = this._infiniteTimeWindow;
     const _events = _infiniteTimeWindow ? this._events : this._trimBufferThenGetEvents();

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -100,7 +100,8 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     this.observers = null;
   }
 
-  protected _trySubscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _trySubscribe(subscriber: Subscriber<T>): TeardownLogic {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     } else {
@@ -108,7 +109,8 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>): Subscription {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     } else if (this.hasError) {
@@ -160,7 +162,8 @@ export class AnonymousSubject<T> extends Subject<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {
       return this.source.subscribe(subscriber);

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -152,7 +152,8 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     this.unsubscribe();
   }
 
-  protected _unsubscribeAndRecycle(): Subscriber<T> {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribeAndRecycle(): Subscriber<T> {
     const { _parent, _parents } = this;
     this._parent = null;
     this._parents = null;
@@ -296,7 +297,8 @@ class SafeSubscriber<T> extends Subscriber<T> {
     return false;
   }
 
-  protected _unsubscribe(): void {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe(): void {
     const { _parentSubscriber } = this;
     this._context = null;
     this._parentSubscriber = null;

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -17,12 +17,13 @@ export class ConnectableObservable<T> extends Observable<T> {
   /** @internal */
   _isComplete = false;
 
-  constructor(protected source: Observable<T>,
+  constructor(public source: Observable<T>,
               protected subjectFactory: () => Subject<T>) {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>) {
     return this.getSubject().subscribe(subscriber);
   }
 

--- a/src/internal/observable/SubscribeOnObservable.ts
+++ b/src/internal/observable/SubscribeOnObservable.ts
@@ -39,7 +39,8 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>) {
     const delay = this.delayTime;
     const source = this.source;
     const scheduler = this.scheduler;

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -179,7 +179,8 @@ export class AjaxObservable<T> extends Observable<T> {
     this.request = request;
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     return new AjaxSubscriber(subscriber, this.request);
   }
 }

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -68,7 +68,8 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
 
   private _config: WebSocketSubjectConfig<T>;
 
-  protected _output: Subject<T>;
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _output: Subject<T>;
 
   private _socket: WebSocket;
 
@@ -263,7 +264,8 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     };
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {
       return source.subscribe(subscriber);

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -170,7 +170,8 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     super._complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     this.contexts = null;
   }
 

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -85,7 +85,8 @@ class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
     super._complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     this.buffer = null;
     this.subscribing = false;
   }

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -161,11 +161,12 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
  * @extends {Ignored}
  */
 class SubscriptionDelayObservable<T> extends Observable<T> {
-  constructor(protected source: Observable<T>, private subscriptionDelay: Observable<any>) {
+  constructor(public source: Observable<T>, private subscriptionDelay: Observable<any>) {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>) {
     this.subscriptionDelay.subscribe(new SubscriptionDelaySubscriber(subscriber, this.source));
   }
 }

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -234,7 +234,8 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
     this.complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     const { parent, key } = this;
     this.key = this.parent = null;
     if (parent) {
@@ -258,7 +259,8 @@ export class GroupedObservable<K, T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>) {
     const subscription = new Subscription();
     const { refCountSubscription, groupSubject } = this;
     if (refCountSubscription && !refCountSubscription.closed) {

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -86,7 +86,8 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     const { notifications, retriesSubscription } = this;
     if (notifications) {
       notifications.unsubscribe();
@@ -99,7 +100,8 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.retries = null;
   }
 
-  protected _unsubscribeAndRecycle(): Subscriber<T> {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribeAndRecycle(): Subscriber<T> {
     const { _unsubscribe } = this;
 
     this._unsubscribe = null;

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -86,7 +86,8 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     const { errors, retriesSubscription } = this;
     if (errors) {
       errors.unsubscribe();

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -129,7 +129,8 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
     super._next(value);
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     this.action = null;
     this.scheduler = null;
     this.withObservable = null;

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -106,7 +106,8 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     this.destination.complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     this.window = null;
   }
 

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -134,7 +134,8 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
     super._complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
     const { contexts } = this;
     this.contexts = null;
     if (contexts) {

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -129,7 +129,8 @@ export class AsyncAction<T> extends Action<T> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _unsubscribe() {
 
     const id = this.id;
     const scheduler = this.scheduler;

--- a/src/internal/testing/HotObservable.ts
+++ b/src/internal/testing/HotObservable.ts
@@ -24,7 +24,8 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     this.scheduler = scheduler;
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription {
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<any>): Subscription {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
     subscriber.add(new Subscription(() => {


### PR DESCRIPTION
Resolves an issue in Node and TypeScript where if a project had more than one copy of RxJS, even if it was the same version, types would be incompatable between say, Observable and Observable, due to protected fields in the dts files. As all of these fields are really implementation details of the library, and my be removed at any time do to architectural changes, it is prudent to mark them as deprecated. Marking them as public only serves to eliminate the type incompatibilities.
