### PR TITLE
chore(CI): have CI run in Node current LTS and higher

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,15 +14,15 @@ cache:
 
 env:
   matrix:
-  - NODE_VER=4 FULL_VALIDATE=false
-  - NODE_VER=6 FULL_VALIDATE=true alias grunt=./node_modules/grunt-cli/bin/grunt
-  - NODE_VER=7 FULL_VALIDATE=false
+  - NODE_VER=8 FULL_VALIDATE=true alias grunt=./node_modules/grunt-cli/bin/grunt
+  - NODE_VER=9 FULL_VALIDATE=false
+
 matrix:
   fast_finish: true
 
 before_install:
   - nvm install $NODE_VER
-  - npm install -g npm@5.6.0 && npm install -g npx && node -v && npm -v
+  - npm install -g npm@5.8.0 && npm install -g npx && node -v && npm -v
   - if [ "$FULL_VALIDATE" == "true" ]; then npm install grunt@0.4.1 grunt-cli grunt-contrib-connect grunt-run; fi
 
 install:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,13 @@
 environment:
   matrix:
   # node.js
-    - nodejs_version: "6"
-    - nodejs_version: "7"
     - nodejs_version: "8"
+    - nodejs_version: "9"
 
 install:
   - ps: Install-Product node $env:nodejs_version
   - set PATH=%APPDATA%\npm;%PATH%
-  - npm install -g npm@5.6.0
+  - npm install -g npm@5.8.0
   - node -v && npm -v
   - npm install
 


### PR DESCRIPTION
It's time to update our CI.

This will run the builds in v8 (LTS) and v9 (current) of Node and stop running in 4, 5, and 6.