### PR TITLE
fix(Node): multiple copies now compatible with each other in Node and TS

### DIFF
--- a/src/AsyncSubject.ts
+++ b/src/AsyncSubject.ts
@@ -10,7 +10,7 @@ export class AsyncSubject<T> extends Subject<T> {
   private hasNext: boolean = false;
   private hasCompleted: boolean = false;
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<any>): Subscription {
     if (this.hasError) {
       subscriber.error(this.thrownError);
       return Subscription.EMPTY;

--- a/src/BehaviorSubject.ts
+++ b/src/BehaviorSubject.ts
@@ -16,7 +16,7 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): Subscription {
     const subscription = super._subscribe(subscriber);
     if (subscription && !(<ISubscription>subscription).closed) {
       subscriber.next(this._value);

--- a/src/Observable.ts
+++ b/src/Observable.ts
@@ -29,7 +29,7 @@ export class Observable<T> implements Subscribable<T> {
 
   public _isScalar: boolean = false;
 
-  protected source: Observable<any>;
+  /** @deprecated internal use only */ public source: Observable<any>;
   protected operator: Operator<any, T>;
 
   /**
@@ -271,7 +271,7 @@ export class Observable<T> implements Subscribable<T> {
     });
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<any>): TeardownLogic {
     return this.source.subscribe(subscriber);
   }
 

--- a/src/ReplaySubject.ts
+++ b/src/ReplaySubject.ts
@@ -29,7 +29,7 @@ export class ReplaySubject<T> extends Subject<T> {
     super.next(value);
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): Subscription {
     const _events = this._trimBufferThenGetEvents();
     const scheduler = this.scheduler;
     let subscription: Subscription;

--- a/src/Subject.ts
+++ b/src/Subject.ts
@@ -107,7 +107,7 @@ export class Subject<T> extends Observable<T> implements ISubscription {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): Subscription {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     } else if (this.hasError) {
@@ -159,7 +159,7 @@ export class AnonymousSubject<T> extends Subject<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {
       return this.source.subscribe(subscriber);

--- a/src/Subscriber.ts
+++ b/src/Subscriber.ts
@@ -149,7 +149,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     this.unsubscribe();
   }
 
-  protected _unsubscribeAndRecycle(): Subscriber<T> {
+  /** @deprecated internal use only */ _unsubscribeAndRecycle(): Subscriber<T> {
     const { _parent, _parents } = this;
     this._parent = null;
     this._parents = null;
@@ -273,7 +273,7 @@ class SafeSubscriber<T> extends Subscriber<T> {
     return false;
   }
 
-  protected _unsubscribe(): void {
+  /** @deprecated internal use only */ _unsubscribe(): void {
     const { _parentSubscriber } = this;
     this._context = null;
     this._parentSubscriber = null;

--- a/src/observable/ArrayLikeObservable.ts
+++ b/src/observable/ArrayLikeObservable.ts
@@ -53,7 +53,7 @@ export class ArrayLikeObservable<T> extends Observable<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     let index = 0;
     const { arrayLike, scheduler } = this;
     const length = arrayLike.length;

--- a/src/observable/ArrayObservable.ts
+++ b/src/observable/ArrayObservable.ts
@@ -109,7 +109,7 @@ export class ArrayObservable<T> extends Observable<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     let index = 0;
     const array = this.array;
     const count = array.length;

--- a/src/observable/BoundCallbackObservable.ts
+++ b/src/observable/BoundCallbackObservable.ts
@@ -185,7 +185,7 @@ export class BoundCallbackObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
     const callbackFunc = this.callbackFunc;
     const args = this.args;
     const scheduler = this.scheduler;

--- a/src/observable/BoundNodeCallbackObservable.ts
+++ b/src/observable/BoundNodeCallbackObservable.ts
@@ -168,7 +168,7 @@ export class BoundNodeCallbackObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T | T[]>): Subscription {
     const callbackFunc = this.callbackFunc;
     const args = this.args;
     const scheduler = this.scheduler;

--- a/src/observable/ConnectableObservable.ts
+++ b/src/observable/ConnectableObservable.ts
@@ -10,21 +10,21 @@ import { refCount as higherOrderRefCount } from '../operators/refCount';
  */
 export class ConnectableObservable<T> extends Observable<T> {
 
-  protected _subject: Subject<T>;
-  protected _refCount: number = 0;
-  protected _connection: Subscription;
+  /** @deprecated internal use only */ public _subject: Subject<T>;
+  /** @deprecated internal use only */ public _refCount: number = 0;
+  /** @deprecated internal use only */ public _connection: Subscription;
   _isComplete = false;
 
-  constructor(protected source: Observable<T>,
-              protected subjectFactory: () => Subject<T>) {
+  constructor(/** @deprecated internal use only */ public source: Observable<T>,
+              /** @deprecated internal use only */ public subjectFactory: () => Subject<T>) {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>) {
     return this.getSubject().subscribe(subscriber);
   }
 
-  protected getSubject(): Subject<T> {
+  /** @deprecated internal use only */ public getSubject(): Subject<T> {
     const subject = this._subject;
     if (!subject || subject.isStopped) {
       this._subject = this.subjectFactory();
@@ -82,7 +82,7 @@ class ConnectableSubscriber<T> extends SubjectSubscriber<T> {
     this._unsubscribe();
     super._complete();
   }
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     const connectable = <any>this.connectable;
     if (connectable) {
       this.connectable = null;
@@ -125,7 +125,7 @@ class RefCountSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
 
     const { connectable } = this;
     if (!connectable) {

--- a/src/observable/DeferObservable.ts
+++ b/src/observable/DeferObservable.ts
@@ -65,7 +65,7 @@ export class DeferObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): Subscription {
     return new DeferSubscriber(subscriber, this.observableFactory);
   }
 }

--- a/src/observable/EmptyObservable.ts
+++ b/src/observable/EmptyObservable.ts
@@ -70,7 +70,7 @@ export class EmptyObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
 
     const scheduler = this.scheduler;
 

--- a/src/observable/ErrorObservable.ts
+++ b/src/observable/ErrorObservable.ts
@@ -68,7 +68,7 @@ export class ErrorObservable extends Observable<any> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<any>): TeardownLogic {
     const error = this.error;
     const scheduler = this.scheduler;
 

--- a/src/observable/ForkJoinObservable.ts
+++ b/src/observable/ForkJoinObservable.ts
@@ -161,7 +161,7 @@ export class ForkJoinObservable<T> extends Observable<T> {
     return new ForkJoinObservable(<Array<SubscribableOrPromise<any>>>sources, resultSelector);
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<any>): Subscription {
     return new ForkJoinSubscriber(subscriber, this.sources, this.resultSelector);
   }
 }

--- a/src/observable/FromEventObservable.ts
+++ b/src/observable/FromEventObservable.ts
@@ -222,7 +222,7 @@ export class FromEventObservable<T> extends Observable<T> {
     subscriber.add(new Subscription(unsubscribe));
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>) {
     const sourceObj = this.sourceObj;
     const eventName = this.eventName;
     const options = this.options;

--- a/src/observable/FromEventPatternObservable.ts
+++ b/src/observable/FromEventPatternObservable.ts
@@ -70,7 +70,7 @@ export class FromEventPatternObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>) {
     const removeHandler = this.removeHandler;
 
     const handler = !!this.selector ? (...args: Array<any>) => {

--- a/src/observable/FromObservable.ts
+++ b/src/observable/FromObservable.ts
@@ -103,7 +103,7 @@ export class FromObservable<T> extends Observable<T> {
     throw new TypeError((ish !== null && typeof ish || ish) + ' is not observable');
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>) {
     const ish = this.ish;
     const scheduler = this.scheduler;
     if (scheduler == null) {

--- a/src/observable/GenerateObservable.ts
+++ b/src/observable/GenerateObservable.ts
@@ -200,7 +200,7 @@ export class GenerateObservable<T, S> extends Observable<T> {
       <IScheduler>scheduler);
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<any>): Subscription | Function | void {
     let state = this.initialState;
     if (this.scheduler) {
       return this.scheduler.schedule<SchedulerState<T, S>>(GenerateObservable.dispatch, 0, {

--- a/src/observable/IfObservable.ts
+++ b/src/observable/IfObservable.ts
@@ -23,7 +23,7 @@ export class IfObservable<T, R> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T|R>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T|R>): TeardownLogic {
     const { condition, thenSource, elseSource } = this;
 
     return new IfSubscriber(subscriber, condition, thenSource, elseSource);

--- a/src/observable/IntervalObservable.ts
+++ b/src/observable/IntervalObservable.ts
@@ -73,7 +73,7 @@ export class IntervalObservable extends Observable<number> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<number>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<number>) {
     const index = 0;
     const period = this.period;
     const scheduler = this.scheduler;

--- a/src/observable/IteratorObservable.ts
+++ b/src/observable/IteratorObservable.ts
@@ -55,7 +55,7 @@ export class IteratorObservable<T> extends Observable<T> {
     this.iterator = getIterator(iterator);
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
 
     let index = 0;
     const { iterator, scheduler } = this;

--- a/src/observable/NeverObservable.ts
+++ b/src/observable/NeverObservable.ts
@@ -47,7 +47,7 @@ export class NeverObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): void {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): void {
     noop();
   }
 }

--- a/src/observable/PairsObservable.ts
+++ b/src/observable/PairsObservable.ts
@@ -76,7 +76,7 @@ export class PairsObservable<T> extends Observable<Array<string | T>> {
     this.keys = Object.keys(obj);
   }
 
-  protected _subscribe(subscriber: Subscriber<Array<string | T>>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<Array<string | T>>): TeardownLogic {
     const {keys, scheduler} = this;
     const length = keys.length;
 

--- a/src/observable/PromiseObservable.ts
+++ b/src/observable/PromiseObservable.ts
@@ -47,7 +47,7 @@ export class PromiseObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     const promise = this.promise;
     const scheduler = this.scheduler;
 

--- a/src/observable/RangeObservable.ts
+++ b/src/observable/RangeObservable.ts
@@ -80,7 +80,7 @@ export class RangeObservable extends Observable<number> {
     this.scheduler = scheduler;
   }
 
-  protected _subscribe(subscriber: Subscriber<number>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<number>): TeardownLogic {
     let index = 0;
     let start = this.start;
     const count = this._count;

--- a/src/observable/ScalarObservable.ts
+++ b/src/observable/ScalarObservable.ts
@@ -39,7 +39,7 @@ export class ScalarObservable<T> extends Observable<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     const value = this.value;
     const scheduler = this.scheduler;
 

--- a/src/observable/SubscribeOnObservable.ts
+++ b/src/observable/SubscribeOnObservable.ts
@@ -38,7 +38,7 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     }
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>) {
     const delay = this.delayTime;
     const source = this.source;
     const scheduler = this.scheduler;

--- a/src/observable/TimerObservable.ts
+++ b/src/observable/TimerObservable.ts
@@ -104,7 +104,7 @@ export class TimerObservable extends Observable<number> {
       (<number> dueTime);
   }
 
-  protected _subscribe(subscriber: Subscriber<number>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<number>): TeardownLogic {
     const index = 0;
     const { period, dueTime, scheduler } = this;
 

--- a/src/observable/UsingObservable.ts
+++ b/src/observable/UsingObservable.ts
@@ -21,7 +21,7 @@ export class UsingObservable<T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     const { resourceFactory, observableFactory } = this;
 
     let resource: AnonymousSubscription;

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -178,7 +178,7 @@ export class AjaxObservable<T> extends Observable<T> {
     this.request = request;
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): TeardownLogic {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     return new AjaxSubscriber(subscriber, this.request);
   }
 }

--- a/src/observable/dom/WebSocketSubject.ts
+++ b/src/observable/dom/WebSocketSubject.ts
@@ -244,7 +244,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     };
   }
 
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {
       return source.subscribe(subscriber);

--- a/src/operators/bufferTime.ts
+++ b/src/operators/bufferTime.ts
@@ -167,7 +167,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     super._complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.contexts = null;
   }
 

--- a/src/operators/bufferWhen.ts
+++ b/src/operators/bufferWhen.ts
@@ -85,7 +85,7 @@ class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
     super._complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.buffer = null;
     this.subscribing = false;
   }

--- a/src/operators/delayWhen.ts
+++ b/src/operators/delayWhen.ts
@@ -161,11 +161,11 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
  * @extends {Ignored}
  */
 class SubscriptionDelayObservable<T> extends Observable<T> {
-  constructor(protected source: Observable<T>, private subscriptionDelay: Observable<any>) {
+  constructor(/** @deprecated internal use only */ public source: Observable<T>, private subscriptionDelay: Observable<any>) {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>) {
     this.subscriptionDelay.subscribe(new SubscriptionDelaySubscriber(subscriber, this.source));
   }
 }

--- a/src/operators/groupBy.ts
+++ b/src/operators/groupBy.ts
@@ -236,7 +236,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
     this.complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     const { parent, key } = this;
     this.key = this.parent = null;
     if (parent) {
@@ -260,7 +260,7 @@ export class GroupedObservable<K, T> extends Observable<T> {
     super();
   }
 
-  protected _subscribe(subscriber: Subscriber<T>) {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<T>) {
     const subscription = new Subscription();
     const {refCountSubscription, groupSubject} = this;
     if (refCountSubscription && !refCountSubscription.closed) {

--- a/src/operators/refCount.ts
+++ b/src/operators/refCount.ts
@@ -39,7 +39,7 @@ class RefCountSubscriber<T> extends Subscriber<T> {
     super(destination);
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
 
     const { connectable } = this;
     if (!connectable) {

--- a/src/operators/repeatWhen.ts
+++ b/src/operators/repeatWhen.ts
@@ -86,7 +86,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     const { notifications, retriesSubscription } = this;
     if (notifications) {
       notifications.unsubscribe();
@@ -99,7 +99,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.retries = null;
   }
 
-  protected _unsubscribeAndRecycle(): Subscriber<T> {
+  /** @deprecated internal use only */ _unsubscribeAndRecycle(): Subscriber<T> {
     const { notifications, retries, retriesSubscription } = this;
     this.notifications = null;
     this.retries = null;

--- a/src/operators/retryWhen.ts
+++ b/src/operators/retryWhen.ts
@@ -32,7 +32,7 @@ export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<a
 
 class RetryWhenOperator<T> implements Operator<T, T> {
   constructor(protected notifier: (errors: Observable<any>) => Observable<any>,
-              protected source: Observable<T>) {
+              public source: Observable<T>) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -86,7 +86,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     const { errors, retriesSubscription } = this;
     if (errors) {
       errors.unsubscribe();

--- a/src/operators/switchMap.ts
+++ b/src/operators/switchMap.ts
@@ -120,7 +120,7 @@ class SwitchMapSubscriber<T, I, R> extends OuterSubscriber<T, I> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.innerSubscription = null;
   }
 

--- a/src/operators/switchMapTo.ts
+++ b/src/operators/switchMapTo.ts
@@ -102,7 +102,7 @@ class SwitchMapToSubscriber<T, I, R> extends OuterSubscriber<T, I> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.innerSubscription = null;
   }
 

--- a/src/operators/throttle.ts
+++ b/src/operators/throttle.ts
@@ -124,7 +124,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     const { throttled, _trailingValue, _hasTrailingValue, _trailing } = this;
 
     this._trailingValue = null;

--- a/src/operators/timeout.ts
+++ b/src/operators/timeout.ts
@@ -140,7 +140,7 @@ class TimeoutSubscriber<T> extends Subscriber<T> {
     super._next(value);
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.action = null;
     this.scheduler = null;
     this.errorInstance = null;

--- a/src/operators/timeoutWith.ts
+++ b/src/operators/timeoutWith.ts
@@ -133,7 +133,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
     super._next(value);
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.action = null;
     this.scheduler = null;
     this.withObservable = null;

--- a/src/operators/window.ts
+++ b/src/operators/window.ts
@@ -106,7 +106,7 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     this.destination.complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.window = null;
   }
 

--- a/src/operators/windowCount.ts
+++ b/src/operators/windowCount.ts
@@ -127,7 +127,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     this.destination.complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     this.count = 0;
     this.windows = null;
   }

--- a/src/operators/windowToggle.ts
+++ b/src/operators/windowToggle.ts
@@ -134,7 +134,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
     super._complete();
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
     const { contexts } = this;
     this.contexts = null;
     if (contexts) {

--- a/src/scheduler/AsyncAction.ts
+++ b/src/scheduler/AsyncAction.ts
@@ -129,7 +129,7 @@ export class AsyncAction<T> extends Action<T> {
     }
   }
 
-  protected _unsubscribe() {
+  /** @deprecated internal use only */ _unsubscribe() {
 
     const id = this.id;
     const scheduler = this.scheduler;

--- a/src/testing/HotObservable.ts
+++ b/src/testing/HotObservable.ts
@@ -24,7 +24,7 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     this.scheduler = scheduler;
   }
 
-  protected _subscribe(subscriber: Subscriber<any>): Subscription {
+  /** @deprecated internal use only */ _subscribe(subscriber: Subscriber<any>): Subscription {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();
     subscriber.add(new Subscription(() => {


### PR DESCRIPTION
This deprecates protected properties that users should not be using when extending types they probably should not be extending. This also makes them public, mostly so in situations where there are multiple copies of rxjs in in a node project, TypeScript is still happy with the resulting dts files

related to #3544
