### PR TITLE
docs(readme): fix link to CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ range(1, 200)
 
 For CDN, you can use [unpkg](https://unpkg.com/):
 
-https://unpkg.com/rxjs/bundles/Rx.min.js
+https://unpkg.com/rxjs@rc/bundles/rxjs.umd.min.js
 
 The global namespace for rxjs is `rxjs`:
 

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ range(1, 200)
 
 For CDN, you can use [unpkg](https://unpkg.com/):
 
-https://unpkg.com/rxjs/bundles/rxjs.umd.min.js
+https://unpkg.com/rxjs/bundles/Rx.min.js
 
 The global namespace for rxjs is `rxjs`:
 


### PR DESCRIPTION
**Description:**

Fixes the link to the Rx.js bundle on the unpkg CDN in the README.
