### PR TITLE
fix(groupBy): reexporting the GroupedObservable type

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 /* Observable */
 export { Observable } from './internal/Observable';
 export { ConnectableObservable } from './internal/observable/ConnectableObservable';
+export { GroupedObservable } from './internal/operators/groupBy';
 export { Operator } from './internal/Operator';
 export { observable } from './internal/symbol/observable';
 

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -253,6 +253,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
  * @class GroupedObservable<K, T>
  */
 export class GroupedObservable<K, T> extends Observable<T> {
+  /** @deprecated Do not construct this type. Internal use only */
   constructor(public key: K,
               private groupSubject: Subject<T>,
               private refCountSubscription?: RefCountSubscription) {


### PR DESCRIPTION
We are now exporting the GroupedObservable type. This also marked the constructor as deprecated, as it is really for internal use only, and subject to change at any time.

fixes #3551
