### PR TITLE
fix(throttleTime): emit throttled values when complete if trailing=true

### DIFF
--- a/spec/operators/throttleTime-spec.ts
+++ b/spec/operators/throttleTime-spec.ts
@@ -164,5 +164,17 @@ describe('Observable.prototype.throttleTime', () => {
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
+
+    asDiagram('throttleTime(fn, { leading: false, trailing: true })')('should emit the last throttled value when complete', () => {
+      const e1 =   hot('-a-xy-----b--x--cxx|');
+      const e1subs =   '^                  !';
+      const t =   time('----|              ');
+      const expected = '-----y--------x----(x|)';
+
+      const result = e1.throttleTime(t, rxTestScheduler, { leading: false, trailing: true });
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 });

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -97,6 +97,15 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
     }
   }
 
+  protected _complete() {
+    if (this._hasTrailingValue) {
+      this.destination.next(this._trailingValue);
+      this.destination.complete();
+    } else {
+      this.destination.complete();
+    }
+  }
+
   clearThrottle() {
     const throttled = this.throttled;
     if (throttled) {


### PR DESCRIPTION
**Description:**
BREAKING CHANGE: This changes the behavior of throttleTime, in particular when throttling with trailing set to true. Throttling now treats observable complete as a trailing edge in addition to the timer and emits the last throttled value when observable completes before the current timer is up.

**Related issue (if exists):**
closes #3351