### PR TITLE
fix(rxjs): no longer requires `dom` lib

### DIFF
--- a/compat/observable/FromEventObservable.ts
+++ b/compat/observable/FromEventObservable.ts
@@ -3,13 +3,13 @@ import { EventTargetLike } from 'rxjs/internal-compatibility';
 
 export class FromEventObservable<T> extends Observable<T> {
   /* tslint:disable:max-line-length */
-  static create<T>(target: EventTargetLike, eventName: string): Observable<T>;
-  static create<T>(target: EventTargetLike, eventName: string, selector: ((...args: any[]) => T)): Observable<T>;
-  static create<T>(target: EventTargetLike, eventName: string, options: EventListenerOptions): Observable<T>;
-  static create<T>(target: EventTargetLike, eventName: string, options: EventListenerOptions, selector: ((...args: any[]) => T)): Observable<T>;
+  static create<T>(target: EventTargetLike<T>, eventName: string): Observable<T>;
+  static create<T>(target: EventTargetLike<T>, eventName: string, selector: ((...args: any[]) => T)): Observable<T>;
+  static create<T>(target: EventTargetLike<T>, eventName: string, options: EventListenerOptions): Observable<T>;
+  static create<T>(target: EventTargetLike<T>, eventName: string, options: EventListenerOptions, selector: ((...args: any[]) => T)): Observable<T>;
   /* tslint:enable:max-line-length */
 
-  static create<T>(target: EventTargetLike,
+  static create<T>(target: EventTargetLike<T>,
                    eventName: string,
                    options?: EventListenerOptions | ((...args: any[]) => T),
                    selector?: ((...args: any[]) => T)): Observable<T> {


### PR DESCRIPTION
Adds interfaces to cover what is used from DOM in `fromEvent` so that types are carried through, but `dom` lib isn not required by default even if you are not using `fromEvent`

fixes: #3558
