### PR TITLE
fix(websocket): no longer throws errors in operators applied to it

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@reactivex/rxjs",
-  "version": "6.0.0-turbo-rc.4",
+  "version": "6.0.0-uncanny-rc.7",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -101,6 +101,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   lift<R>(operator: Operator<T, R>): WebSocketSubject<R> {
     const sock = new WebSocketSubject<R>(this._config as WebSocketSubjectConfig<any>, <any> this.destination);
     sock.operator = operator;
+    sock.source = this;
     return sock;
   }
 


### PR DESCRIPTION
There was an issue where using operators on a WebSocketSubject resulted in errors being thrown
because the source was not set in lift.

This also updates the tests to use pipeable operators.
