### PR TITLE
docs(marbles): fix sync group example

### DIFF
--- a/doc/writing-marble-tests.md
+++ b/doc/writing-marble-tests.md
@@ -72,7 +72,7 @@ always represents the "zero frame". A "frame" is somewhat analogous to a virtual
 
 `'-a-^-b--|'`: In a hot observable, on frame -20 emit `a`, then on frame 20 emit `b`, and on frame 50, `complete`.
 
-`'--(abc)-|'`: on frame 20, emit `a`, `b`, and `c`, then on frame 30 `complete`
+`'--(abc)-|'`: on frame 20, emit `a`, `b`, and `c`, then on frame 80 `complete`
 
 `'-----(a|)'`: on frame 50, emit `a` and `complete`.
 


### PR DESCRIPTION
Closes #3581

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes an error introduced in a recent commit. The sync group example's `complete` event occurs at frame 80 - not frame 30.

**Related issue (if exists):** #3581