### PR TITLE
refactor(webSocket): rename back to webSocket ala 5.0

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -135,7 +135,7 @@ fs.copySync('./tsconfig.base.json', PKG_ROOT + 'src/tsconfig.json');
 fs.writeJsonSync(PKG_ROOT + 'package.json', rootPackageJson, {spaces: 2});
 fs.copySync('src/operators/package.json', PKG_ROOT + '/operators/package.json');
 fs.copySync('src/ajax/package.json', PKG_ROOT + '/ajax/package.json');
-fs.copySync('src/websocket/package.json', PKG_ROOT + '/websocket/package.json');
+fs.copySync('src/webSocket/package.json', PKG_ROOT + '/webSocket/package.json');
 fs.copySync('src/testing/package.json', PKG_ROOT + '/testing/package.json');
 fs.copySync('src/internal-compatibility/package.json', PKG_ROOT + '/internal-compatibility/package.json');
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -36,7 +36,7 @@ Other export points:
 
 - `rxjs/testing`: The `TestScheduler` and friends can be found here
 - `rxjs/ajax`: This is the new home for the rxjs AJAX implementation
-- `rxjs/websocket`: This is the home for the rxjs web socket implementation.
+- `rxjs/webSocket`: This is the home for the rxjs web socket implementation.
 
 
 ### Import Migration Table

--- a/compat/add/observable/dom/webSocket.ts
+++ b/compat/add/observable/dom/webSocket.ts
@@ -1,5 +1,5 @@
 import { Observable } from 'rxjs';
-import { websocket as staticWebSocket } from 'rxjs/websocket';
+import { webSocket as staticWebSocket } from 'rxjs/webSocket';
 
 Observable.webSocket = staticWebSocket;
 

--- a/integration/systemjs/systemjs-compatibility-spec.js
+++ b/integration/systemjs/systemjs-compatibility-spec.js
@@ -8,7 +8,7 @@ System.config({
     'rxjs/ajax': {main: 'index.js', defaultExtension: 'js' },
     'rxjs/operators': {main: 'index.js', defaultExtension: 'js' },
     'rxjs/testing': {main: 'index.js', defaultExtension: 'js' },
-    'rxjs/websocket': {main: 'index.js', defaultExtension: 'js' }
+    'rxjs/webSocket': {main: 'index.js', defaultExtension: 'js' }
   }
 });
 
@@ -17,7 +17,7 @@ Promise.all([
   System.import('rxjs/ajax'),
   System.import('rxjs/operators'),
   System.import('rxjs/testing'),
-  System.import('rxjs/websocket'),
+  System.import('rxjs/webSocket'),
 ]).then(
   function () { console.log('Successfully tested all entry-points with SystemJS!'); },
   function (error) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4333,7 +4333,8 @@
         "jsbn": {
           "version": "0.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "json-schema": {
           "version": "0.2.3",

--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -1,12 +1,12 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { websocket } from 'rxjs/websocket';
+import { webSocket } from 'rxjs/webSocket';
 import { map, retry, take, repeat, takeWhile } from 'rxjs/operators';
 
 declare const __root__: any;
 
 /** @test {webSocket} */
-describe('websocket', () => {
+describe('webSocket', () => {
   let __ws: any;
 
   function setupMockWebSocket() {
@@ -30,7 +30,7 @@ describe('websocket', () => {
 
     it('should send and receive messages', () => {
       let messageReceived = false;
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
 
       subject.next('ping');
 
@@ -52,7 +52,7 @@ describe('websocket', () => {
     });
 
     it('should allow use of operators and subscribe', () => {
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
       const results: any[] = [];
 
       subject.pipe(
@@ -68,7 +68,7 @@ describe('websocket', () => {
     it('receive multiple messages', () => {
       const expected = ['what', 'do', 'you', 'do', 'with', 'a', 'drunken', 'sailor?'];
       const results: string[] = [];
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
 
       subject.subscribe(x => {
         results.push(x);
@@ -89,7 +89,7 @@ describe('websocket', () => {
 
     it('should queue messages prior to subscription', () => {
       const expected = ['make', 'him', 'walk', 'the', 'plank'];
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
 
       expected.forEach(x => {
         subject.next(x);
@@ -110,7 +110,7 @@ describe('websocket', () => {
     });
 
     it('should send messages immediately if already open', () => {
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
       subject.subscribe();
       const socket = MockWebSocket.lastSocket;
       socket.open();
@@ -124,7 +124,7 @@ describe('websocket', () => {
     });
 
     it('should close the socket when completed', () => {
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
       subject.subscribe();
       const socket = MockWebSocket.lastSocket;
       socket.open();
@@ -144,7 +144,7 @@ describe('websocket', () => {
     });
 
     it('should close the socket with a code and a reason when errored', () => {
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
       subject.subscribe();
       const socket = MockWebSocket.lastSocket;
       socket.open();
@@ -160,7 +160,7 @@ describe('websocket', () => {
     });
 
     it('should allow resubscription after closure via complete', () => {
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
       subject.subscribe();
       const socket1 = MockWebSocket.lastSocket;
       socket1.open();
@@ -178,7 +178,7 @@ describe('websocket', () => {
     });
 
     it('should allow resubscription after closure via error', () => {
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
       subject.subscribe();
       const socket1 = MockWebSocket.lastSocket;
       socket1.open();
@@ -198,7 +198,7 @@ describe('websocket', () => {
     it('should have a default resultSelector that parses message data as JSON', () => {
       let result;
       const expected = { mork: 'shazbot!' };
-      const subject = websocket<string>('ws://mysocket');
+      const subject = webSocket<string>('ws://mysocket');
 
       subject.subscribe((x: any) => {
         result = x;
@@ -226,7 +226,7 @@ describe('websocket', () => {
 
     it('should send and receive messages', () => {
       let messageReceived = false;
-      const subject = websocket<string>({ url: 'ws://mysocket' });
+      const subject = webSocket<string>({ url: 'ws://mysocket' });
 
       subject.next('ping');
 
@@ -248,7 +248,7 @@ describe('websocket', () => {
     });
 
     it('should take a protocol and set it properly on the web socket', () => {
-      const subject = websocket<string>({
+      const subject = webSocket<string>({
         url: 'ws://mysocket',
         protocol: 'someprotocol'
       });
@@ -262,7 +262,7 @@ describe('websocket', () => {
     });
 
     it('should take a binaryType and set it properly on the web socket', () => {
-      const subject = websocket<string>({
+      const subject = webSocket<string>({
         url: 'ws://mysocket',
         binaryType: 'blob'
       });
@@ -278,7 +278,7 @@ describe('websocket', () => {
     it('should take a deserializer', () => {
       const results = [] as string[];
 
-      const subject = websocket<string>({
+      const subject = webSocket<string>({
         url: 'ws://mysocket',
         deserializer: (e: any) => {
           return e.data + '!';
@@ -301,7 +301,7 @@ describe('websocket', () => {
     });
 
     it('if the deserializer fails it should go down the error path', () => {
-      const subject = websocket<string>({
+      const subject = webSocket<string>({
         url: 'ws://mysocket',
         deserializer: (e: any) => {
           throw new Error('I am a bad error');
@@ -323,7 +323,7 @@ describe('websocket', () => {
 
     it('should accept a closingObserver', () => {
       let calls = 0;
-      const subject = websocket<string>(<any>{
+      const subject = webSocket<string>(<any>{
         url: 'ws://mysocket',
         closingObserver: {
           next(x: any) {
@@ -355,7 +355,7 @@ describe('websocket', () => {
     it('should accept a closeObserver', () => {
       const expected = [{ wasClean: true }, { wasClean: false }];
       const closes = [] as any[];
-      const subject = websocket<string>(<any>{
+      const subject = webSocket<string>(<any>{
         url: 'ws://mysocket',
         closeObserver: {
           next(e: any) {
@@ -390,7 +390,7 @@ describe('websocket', () => {
     });
 
     it('should handle constructor errors', () => {
-      const subject = websocket<string>(<any>{
+      const subject = webSocket<string>(<any>{
         url: 'bad_url',
         WebSocketCtor: (url: string, protocol?: string | string[]): WebSocket => {
           throw new Error(`connection refused`);
@@ -419,7 +419,7 @@ describe('websocket', () => {
 
     it('should be retryable', () => {
       const results = [] as string[];
-      const subject = websocket<{ name: string, value: string }>('ws://websocket');
+      const subject = webSocket<{ name: string, value: string }>('ws://websocket');
       const source = subject.multiplex(
         () => ({ sub: 'foo' }),
         () => ({ unsub: 'foo' }),
@@ -454,7 +454,7 @@ describe('websocket', () => {
 
     it('should be repeatable', () => {
       const results = [] as string[];
-      const subject = websocket<{ name: string, value: string }>('ws://websocket');
+      const subject = webSocket<{ name: string, value: string }>('ws://websocket');
       const source = subject.multiplex(
         () => ({ sub: 'foo' }),
         () => ({ unsub: 'foo' }),
@@ -490,9 +490,9 @@ describe('websocket', () => {
       expect(results).to.deep.equal(['test', 'this', 'test', 'this'], 'results were not equal');
     });
 
-    it('should multiplex over the websocket', () => {
+    it('should multiplex over the webSocket', () => {
       const results = [] as Array<{ value: number, name: string }>;
-      const subject = websocket<{ value: number, name: string }>('ws://websocket');
+      const subject = webSocket<{ value: number, name: string }>('ws://websocket');
       const source = subject.multiplex(
         () => ({ sub: 'foo'}),
         () => ({ unsub: 'foo' }),
@@ -527,7 +527,7 @@ describe('websocket', () => {
     });
 
     it('should keep the same socket for multiple multiplex subscriptions', () => {
-      const socketSubject = websocket<string>({url: 'ws://mysocket'});
+      const socketSubject = webSocket<string>({url: 'ws://mysocket'});
       const results = [] as string[];
       const socketMessages = [
         {id: 'A'},
@@ -584,7 +584,7 @@ describe('websocket', () => {
     });
 
     it('should not close the socket until all subscriptions complete', () => {
-      const socketSubject = websocket<{ id: string, complete: boolean }>({url: 'ws://mysocket'});
+      const socketSubject = webSocket<{ id: string, complete: boolean }>({url: 'ws://mysocket'});
       const results = [] as string[];
       const socketMessages = [
         {id: 'A'},

--- a/spec/websocket/index-spec.ts
+++ b/spec/websocket/index-spec.ts
@@ -1,8 +1,8 @@
-import * as index from 'rxjs/websocket';
+import * as index from 'rxjs/webSocket';
 import { expect } from 'chai';
 
 describe('index', () => {
   it('should export static websocket subject creator functions', () => {
-    expect(index.websocket).to.exist;
+    expect(index.webSocket).to.exist;
   });
 });

--- a/src/BUILD.bazel
+++ b/src/BUILD.bazel
@@ -38,6 +38,6 @@ ts_library(
         "//ajax",
         "//operators",
         "//testing",
-        "//websocket",
+        "//webSocket",
     ],
 )

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -30,7 +30,7 @@ export interface WebSocketSubjectConfig<T> {
    */
   openObserver?: NextObserver<Event>;
   /**
-   * An Observer than watches when close events occur on the underlying websocket
+   * An Observer than watches when close events occur on the underlying webSocket
    */
   closeObserver?: NextObserver<CloseEvent>;
   /**

--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -5,7 +5,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  *
  * @example <caption>Wraps browser WebSocket</caption>
  *
- * import { webSocket } from 'rxjs/websocket';
+ * import { webSocket } from 'rxjs/webSocket';
  *
  * let socket$ = webSocket('ws://localhost:8081');
  *
@@ -17,14 +17,14 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  *
  * socket$.next(JSON.stringify({ op: 'hello' }));
  *
- * @example <caption>Wraps WebSocket from nodejs-websocket (using node.js)</caption>
+ * @example <caption>Wraps WebSocket from nodejs-webSocket (using node.js)</caption>
  *
- * import { webSocket } from 'rxjs/websocket';
- * import { w3cwebsocket } from 'websocket';
+ * import { webSocket } from 'rxjs/webSocket';
+ * import { w3cwebSocket } from 'webSocket';
  *
  * let socket$ = webSocket({
  *   url: 'ws://localhost:8081',
- *   WebSocketCtor: w3cwebsocket
+ *   WebSocketCtor: w3cwebSocket
  * });
  *
  * socket$.subscribe(
@@ -35,7 +35,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  *
  * socket$.next(JSON.stringify({ op: 'hello' }));
  *
- * @param {string | WebSocketSubjectConfig} urlConfigOrSource the source of the websocket as an url or a structure defining the websocket object
+ * @param {string | WebSocketSubjectConfig} urlConfigOrSource the source of the webSocket as an url or a structure defining the webSocket object
  * @return {WebSocketSubject}
  */
 export function webSocket<T>(urlConfigOrSource: string | WebSocketSubjectConfig<T>): WebSocketSubject<T> {

--- a/src/internal/umd.ts
+++ b/src/internal/umd.ts
@@ -17,6 +17,6 @@ export const testing = _testing;
 import * as _ajax from '../ajax/index';
 export const ajax = _ajax;
 
-/* rxjs.websocket */
-import * as _websocket from '../websocket/index';
-export const websocket = _websocket;
+/* rxjs.webSocket */
+import * as _webSocket from '../webSocket/index';
+export const webSocket = _webSocket;

--- a/src/webSocket/BUILD.bazel
+++ b/src/webSocket/BUILD.bazel
@@ -3,9 +3,9 @@ package(default_visibility = ["//visibility:public"])
 load("@build_bazel_rules_typescript//:defs.bzl", "ts_library")
 
 ts_library(
-    name = "websocket",
+    name = "webSocket",
     srcs = ["index.ts"],
-    module_name = "rxjs/websocket",
+    module_name = "rxjs/webSocket",
     module_root = "index.d.ts",
     node_modules = "@build_bazel_rules_typescript_tsc_wrapped_deps//:node_modules",
     tsconfig = "//:tsconfig.json",

--- a/src/webSocket/index.ts
+++ b/src/webSocket/index.ts
@@ -1,2 +1,2 @@
-export { webSocket as websocket } from '../internal/observable/dom/webSocket';
+export { webSocket as webSocket } from '../internal/observable/dom/webSocket';
 export { WebSocketSubject, WebSocketSubjectConfig } from '../internal/observable/dom/WebSocketSubject';

--- a/src/webSocket/package.json
+++ b/src/webSocket/package.json
@@ -1,0 +1,8 @@
+{
+  "name": "rxjs/webSocket",
+  "typings": "./index.d.ts",
+  "main": "./index.js",
+  "module": "../_esm5/webSocket/index.js",
+  "es2015": "../_esm2015/webSocket/index.js",
+  "sideEffects": false
+}

--- a/src/websocket/package.json
+++ b/src/websocket/package.json
@@ -1,8 +1,0 @@
-{
-  "name": "rxjs/websocket",
-  "typings": "./index.d.ts",
-  "main": "./index.js",
-  "module": "../_esm5/websocket/index.js",
-  "es2015": "../_esm2015/websocket/index.js",
-  "sideEffects": false
-}

--- a/tsconfig/compat/tsconfig.base.json
+++ b/tsconfig/compat/tsconfig.base.json
@@ -11,7 +11,7 @@
       "rxjs/testing": ["../src/testing/index"],
       "rxjs/ajax": ["../src/ajax/index"],
       "rxjs/operators": ["../src/operators/index"],
-      "rxjs/websocket": ["../src/websocket/index"]
+      "rxjs/websocket": ["../src/webSocket/index"]
     }
   },
   "include": [

--- a/tsconfig/compat/tsconfig.base.json
+++ b/tsconfig/compat/tsconfig.base.json
@@ -11,7 +11,7 @@
       "rxjs/testing": ["../src/testing/index"],
       "rxjs/ajax": ["../src/ajax/index"],
       "rxjs/operators": ["../src/operators/index"],
-      "rxjs/websocket": ["../src/webSocket/index"]
+      "rxjs/webSocket": ["../src/webSocket/index"]
     }
   },
   "include": [

--- a/tsconfig/tsconfig.base.json
+++ b/tsconfig/tsconfig.base.json
@@ -15,7 +15,7 @@
     "../src/ajax/index.ts",
     "../src/operators/index.ts",
     "../src/testing/index.ts",
-    "../src/websocket/index.ts",
+    "../src/webSocket/index.ts",
     "../src/internal-compatibility/index.ts",
 
     // legacy entry-points

--- a/tsconfig/tsconfig.legacy-reexport.json
+++ b/tsconfig/tsconfig.legacy-reexport.json
@@ -16,7 +16,7 @@
       "rxjs/testing": ["../dist/typings/testing/index"],
       "rxjs/ajax": ["../dist/typings/ajax/index"],
       "rxjs/operators": ["../dist/typings/operators/index"],
-      "rxjs/websocket": ["../dist/typings/websocket/index"],
+      "rxjs/websocket": ["../dist/typings/webSocket/index"],
       "rxjs-compat": ["../dist-compat/typings/compat/Rx"],
       "rxjs-compat/*": ["../dist-compat/typings/compat/*"]
     }

--- a/tsconfig/tsconfig.legacy-reexport.json
+++ b/tsconfig/tsconfig.legacy-reexport.json
@@ -16,7 +16,7 @@
       "rxjs/testing": ["../dist/typings/testing/index"],
       "rxjs/ajax": ["../dist/typings/ajax/index"],
       "rxjs/operators": ["../dist/typings/operators/index"],
-      "rxjs/websocket": ["../dist/typings/webSocket/index"],
+      "rxjs/webSocket": ["../dist/typings/webSocket/index"],
       "rxjs-compat": ["../dist-compat/typings/compat/Rx"],
       "rxjs-compat/*": ["../dist-compat/typings/compat/*"]
     }


### PR DESCRIPTION
BREAKING CHANGE: UNBREAKING websocket to be named `webSocket` again, just like it was in 5.0. Now you should import from `rxjs/webSocket`
