### PR TITLE
 fix(fromEvent): don't enumerate valid sources

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -119,6 +119,37 @@ describe('fromEvent', () => {
     expect(offHandler).to.equal(onHandler);
   });
 
+  it('should setup an event observable on objects with "addListener" and "removeListener" and "length" ', () => {
+    let onEventName;
+    let onHandler;
+    let offEventName;
+    let offHandler;
+
+    const obj = {
+      addListener: (a: string, b: Function) => {
+        onEventName = a;
+        onHandler = b;
+      },
+      removeListener: (a: string, b: Function) => {
+        offEventName = a;
+        offHandler = b;
+      },
+      length: 1
+    };
+
+    const subscription = fromEvent(obj, 'click')
+      .subscribe(() => {
+        //noop
+       });
+
+    subscription.unsubscribe();
+
+    expect(onEventName).to.equal('click');
+    expect(typeof onHandler).to.equal('function');
+    expect(offEventName).to.equal(onEventName);
+    expect(offHandler).to.equal(onHandler);
+  });
+
   it('should error on invalid event targets', () => {
     const obj = {
       addListener: () => {

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -193,11 +193,7 @@ function setupSubscription<T>(sourceObj: FromEventTarget<T>, eventName: string,
                               handler: (...args: any[]) => void, subscriber: Subscriber<T>,
                               options?: EventListenerOptions) {
   let unsubscribe: () => void;
-  if (sourceObj && (sourceObj as any).length) {
-    for (let i = 0, len = (sourceObj as any).length; i < len; i++) {
-      setupSubscription(sourceObj[i], eventName, handler, subscriber, options);
-    }
-  } else if (isEventTarget(sourceObj)) {
+  if (isEventTarget(sourceObj)) {
     const source = sourceObj;
     sourceObj.addEventListener(eventName, handler, options);
     unsubscribe = () => source.removeEventListener(eventName, handler, options);
@@ -209,6 +205,10 @@ function setupSubscription<T>(sourceObj: FromEventTarget<T>, eventName: string,
     const source = sourceObj;
     sourceObj.addListener(eventName, handler as NodeEventHandler);
     unsubscribe = () => source.removeListener(eventName, handler as NodeEventHandler);
+  } else if (sourceObj && (sourceObj as any).length) {
+    for (let i = 0, len = (sourceObj as any).length; i < len; i++) {
+      setupSubscription(sourceObj[i], eventName, handler, subscriber, options);
+    }
   } else {
     throw new TypeError('Invalid event target');
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing test and moves the check for a `length` property on the event source to last place - after the checks for DOM, JQuery and Node event sources.

It fixes the problem with using `fromEvent` on `window` - which has a `length` property.

**Related issue (if exists):** #3578
