### PR TITLE
fix(audit): will not crash if duration is synchronous

### DIFF
--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -163,6 +163,18 @@ describe('Observable.prototype.audit', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
+  it('should mirror source if durations are synchronous observables', () => {
+    const e1 =   hot('abcdefabcdefabcdefabcdefa|');
+    const e1subs =   '^                        !';
+    const e2 =  Rx.Observable.of('one single value');
+    const expected = 'abcdefabcdefabcdefabcdefa|';
+
+    const result = e1.audit(() => e2);
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should raise error as soon as just-throw duration is used', () => {
     const e1 =   hot('----abcdefabcdefabcdefabcdefa|');
     const e1subs =   '^   !                         ';

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -89,7 +89,7 @@ class AuditSubscriber<T, R> extends OuterSubscriber<T, R> {
         this.destination.error(errorObject.e);
       } else {
         const innerSubscription = subscribeToResult(this, duration);
-        if (innerSubscription.closed) {
+        if (!innerSubscription || innerSubscription.closed) {
           this.clearThrottle();
         } else {
           this.add(this.throttled = innerSubscription);


### PR DESCRIPTION
closes #2743, but thank you, @jayphelps for "git-blame-someone-else" which allowed me to give commit credit to @asnov, who authored the commit (I just had to redo it for the new file structure).