### PR TITLE
Asap scheduler id fix

### DIFF
--- a/src/internal/scheduler/AsyncScheduler.ts
+++ b/src/internal/scheduler/AsyncScheduler.ts
@@ -11,6 +11,7 @@ export class AsyncScheduler extends Scheduler {
    * A flag to indicate whether the Scheduler is currently executing a batch of
    * queued actions.
    * @type {boolean}
+   * @deprecated internal use only
    */
   public active: boolean = false;
   /**
@@ -18,6 +19,7 @@ export class AsyncScheduler extends Scheduler {
    * coming from `setTimeout`, `setInterval`, `requestAnimationFrame`, and
    * others.
    * @type {any}
+   * @deprecated internal use only
    */
   public scheduled: any = undefined;
 

--- a/src/internal/util/Immediate.ts
+++ b/src/internal/util/Immediate.ts
@@ -1,4 +1,4 @@
-let nextHandle = 0;
+let nextHandle = 1;
 
 const tasksByHandle: { [handle: string]: () => void } = {};
 


### PR DESCRIPTION
- deprecates properties that should only be internally used
- Updates asapScheduler schedule to always return a value > 1