### PR TITLE
refactor(race): deprecate race operator in favor of static race

### DIFF
--- a/src/internal/operators/race.ts
+++ b/src/internal/operators/race.ts
@@ -4,19 +4,18 @@ import { MonoTypeOperatorFunction, OperatorFunction } from '../types';
 import { race as raceStatic } from '../observable/race';
 
 /* tslint:disable:max-line-length */
+/** @deprecated Deprecated in favor of static race. */
 export function race<T>(observables: Array<Observable<T>>): MonoTypeOperatorFunction<T>;
+/** @deprecated Deprecated in favor of static race. */
 export function race<T, R>(observables: Array<Observable<T>>): OperatorFunction<T, R>;
+/** @deprecated Deprecated in favor of static race. */
 export function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): MonoTypeOperatorFunction<T>;
+/** @deprecated Deprecated in favor of static race. */
 export function race<T, R>(...observables: Array<Observable<any> | Array<Observable<any>>>): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**
- * Returns an Observable that mirrors the first source Observable to emit an item
- * from the combination of this Observable and supplied Observables.
- * @param {...Observables} ...observables Sources used to race for which Observable emits first.
- * @return {Observable} An Observable that mirrors the output of the first Observable to emit an item.
- * @method race
- * @owner Observable
+ * @deprecated Deprecated in favor of static race.
  */
 export function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): MonoTypeOperatorFunction<T> {
   return function raceOperatorFunction(source: Observable<T>) {


### PR DESCRIPTION
deprecate race operator in favor of static race, similar to other deprecated operators concat,
merge, etc

#3603 
