### PR TITLE
refactor(concat-spec): update concat operator tests to use pipeable operators

### DIFF
--- a/spec/operators/concat-spec.ts
+++ b/spec/operators/concat-spec.ts
@@ -1,20 +1,21 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
+import { of, Observable } from 'rxjs';
+import { concat, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
 
-declare const rxTestScheduler: Rx.TestScheduler;
-const Observable = Rx.Observable;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {concat} */
-describe('Observable.prototype.concat', () => {
+describe('concat operator', () => {
   asDiagram('concat')('should concatenate two cold observables', () => {
     const e1 =   cold('--a--b-|');
     const e2 =   cold(       '--x---y--|');
     const expected =  '--a--b---x---y--|';
 
-    expectObservable(e1.concat(e2, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2, rxTestScheduler))).toBe(expected);
   });
 
   it('should work properly with scalar observables', (done) => {
@@ -26,7 +27,7 @@ describe('Observable.prototype.concat', () => {
           observer.complete();
         });
       })
-      .concat(Observable.of(2));
+      .pipe(concat(of(2)));
 
     s1.subscribe((x) => {
           results.push('Next: ' + x);
@@ -47,7 +48,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '  ^   !';
     const expected =  '------|';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -59,7 +60,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs: string[] = [];
     const expected =  '-';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -71,7 +72,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '  ^';
     const expected =  '---';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -83,7 +84,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs: string[] = [];
     const expected =  '-';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -95,7 +96,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '  ^   !';
     const expected =  '------#';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -107,7 +108,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs: string[] = [];
     const expected =  '---#';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -119,7 +120,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs: string[] = [];
     const expected =  '---#';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -131,7 +132,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '     ^       !';
     const expected =  '--a----------|';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -143,7 +144,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '  ^    !';
     const expected =  '----a--|';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -156,7 +157,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '     ^';
     const expected =  '--a---';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -168,7 +169,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs: string[] = [];
     const expected =  '-';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -180,7 +181,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '    ^       !';
     const expected =  '---a-----b--|';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -193,7 +194,7 @@ describe('Observable.prototype.concat', () => {
     const unsub =     '                 !    ';
     const expected =  '---a-a--a-----b-b     ';
 
-    expectObservable(e1.concat(e2), unsub).toBe(expected);
+    expectObservable(e1.pipe(concat(e2)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -206,10 +207,11 @@ describe('Observable.prototype.concat', () => {
     const expected =  '---a-a--a-----b-b-    ';
     const unsub =     '                 !    ';
 
-    const result = e1
-      .mergeMap((x) => Observable.of(x))
-      .concat(e2)
-      .mergeMap((x) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x) => of(x)),
+      concat(e2),
+      mergeMap((x) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -223,7 +225,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs: string[] = [];
     const expected =  '--#';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -235,7 +237,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =    '     ^      !';
     const expected =  '--a---------#';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -248,7 +250,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =   '       ^      !';
     const expected = '--a--b--x--y--|';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -261,7 +263,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =   '            ^      !';
     const expected = '--a--b--c----x-y-z-|';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -273,7 +275,7 @@ describe('Observable.prototype.concat', () => {
     const e2subs =   '           ^     !';
     const expected = '--a--b--c--y--z--|';
 
-    expectObservable(e1.concat(e2)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -287,7 +289,7 @@ describe('Observable.prototype.concat', () => {
     const e3subs =    '          ^     !';
     const expected =  '---a---b-----c--|';
 
-    expectObservable(e1.concat(e2, e3, rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(concat(e2, e3, rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
     expectSubscriptions(e3.subscriptions).toBe(e3subs);
@@ -298,7 +300,7 @@ describe('Observable.prototype.concat', () => {
     const e1subs =    '^    !';
     const expected =  '---a-|';
 
-    expectObservable(e1.concat(rxTestScheduler)).toBe(expected);
+    expectObservable(e1.pipe(concat(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -307,7 +309,7 @@ describe('Observable.prototype.concat', () => {
     const e1subs =    '^    !';
     const expected =  '---a-|';
 
-    expectObservable(e1.concat()).toBe(expected);
+    expectObservable(e1.pipe(concat())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });


### PR DESCRIPTION
update concat spec to use updated import sites and pipeable operators