### PR TITLE
fix(ajax): Handle timeouts as errors

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -2,8 +2,10 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import * as Rx from 'rxjs/Rx';
 import { root } from 'rxjs/util/root';
+import { TestScheduler } from 'rxjs/testing';
 
 declare const global: any;
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {ajax} */
 describe('Observable.ajax', () => {
@@ -380,7 +382,7 @@ describe('Observable.ajax', () => {
     });
   });
 
-  it('should error on timeout of asynchronous request', (done) => {
+  it('should error on timeout of asynchronous request', () => {
     const obj: Rx.AjaxRequest = {
       url: '/flibbertyJibbet',
       responseType: 'text',
@@ -402,14 +404,15 @@ describe('Observable.ajax', () => {
 
     expect(request.url).to.equal('/flibbertyJibbet');
 
-    setTimeout(() => {
+    rxTestScheduler.schedule(() => {
       request.respondWith({
         'status': 200,
         'contentType': 'text/plain',
         'responseText': 'Wee! I am text!'
       });
-      done();
     }, 1000);
+
+    rxTestScheduler.flush();
   });
 
   it('should create a synchronous request', () => {

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -353,7 +353,15 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
     }
 
     function xhrReadyStateChange(this: XMLHttpRequest, e: Event) {
-      const { subscriber, progressSubscriber, request } = (<any>xhrReadyStateChange);
+      return;
+    }
+    xhr.onreadystatechange = xhrReadyStateChange;
+    (<any>xhrReadyStateChange).subscriber = this;
+    (<any>xhrReadyStateChange).progressSubscriber = progressSubscriber;
+    (<any>xhrReadyStateChange).request = request;
+
+    function xhrLoad(this: XMLHttpRequest, e: Event) {
+      const { subscriber, progressSubscriber, request } = (<any>xhrLoad);
       if (this.readyState === 4) {
         // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)
         let status: number = this.status === 1223 ? 204 : this.status;
@@ -382,10 +390,10 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
         }
       }
     }
-    xhr.onreadystatechange = xhrReadyStateChange;
-    (<any>xhrReadyStateChange).subscriber = this;
-    (<any>xhrReadyStateChange).progressSubscriber = progressSubscriber;
-    (<any>xhrReadyStateChange).request = request;
+    xhr.onload = xhrLoad;
+    (<any>xhrLoad).subscriber = this;
+    (<any>xhrLoad).progressSubscriber = progressSubscriber;
+    (<any>xhrLoad).request = request;
   }
 
   unsubscribe() {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
XHR Timeouts are not being handled properly.

It turns out the XHR timeouts fire the `readystatechange` event (with status=0, readyState=4) and then the `timeout` event.  This is causing `next` to be called before `error`.

Confirmed this behavior in Chrome, added a test for timeouts and fixed the behavior by pointing the main event handler to fire on `load`.  Definitely recommend confirming this behavior and compatibility in other browsers.

Fixed up our `MockXMLHttpRequest` to cause timeouts after the `send` method is called.  
Overall, I want to recommend moving away from this `MockXMLHttpRequest` so that we aren't re-implementing browser functionality in the tests.  I saw that the current browser tests are broken, wanted to take a stab at either fixing those or porting over some integration tests to Karma.  Totally open to suggestions there. 

This is my first contribution to rxjs, really open to feedback and suggestions! 

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3606
