### PR TITLE
fix(ajax): RxJS v6 TimeoutError is missing name property

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -273,6 +273,7 @@ describe('Observable.ajax', () => {
     });
 
     expect(error instanceof Rx.AjaxError).to.be.true;
+    expect(error.name).to.equal('AjaxError');
     expect(error.message).to.equal('ajax error 404');
     expect(error.status).to.equal(404);
   });
@@ -843,7 +844,7 @@ describe('Observable.ajax', () => {
     delete root.XMLHttpRequest.prototype.onreadystatechange;
   });
 
-  it('should work fine when XMLHttpRequest ontimeout property is monkey patched', function() {
+  it('should work fine when XMLHttpRequest ontimeout property is monkey patched', function(done) {
     Object.defineProperty(root.XMLHttpRequest.prototype, 'ontimeout', {
       set(fn: (e: ProgressEvent) => any) {
         const wrapFn = (ev: ProgressEvent) => {
@@ -867,7 +868,8 @@ describe('Observable.ajax', () => {
     Rx.Observable.ajax(ajaxRequest)
       .subscribe({
         error(err) {
-          /* expected, ignore */
+          expect(err.name).to.equal('AjaxTimeoutError');
+          done();
         }
       });
 

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -25,14 +25,17 @@ describe('Observable.prototype.timeout', () => {
   it('should emit and error of an instanceof TimeoutError on timeout', () => {
     const e1 =  cold('-------a--b--|');
     const result = e1.timeout(50, rxTestScheduler);
+    let error;
     result.subscribe(() => {
       throw new Error('this should not next');
     }, err => {
-      expect(err).to.be.an.instanceof(Rx.TimeoutError);
+      error = err;
     }, () => {
       throw new Error('this should not complete');
     });
     rxTestScheduler.flush();
+    expect(error).to.be.an.instanceof(Rx.TimeoutError);
+    expect(error.name).to.equal('TimeoutError');
   });
 
   it('should not timeout if source completes within absolute timeout period', () => {

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -490,6 +490,7 @@ function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
 export class AjaxTimeoutError extends AjaxError {
   constructor(xhr: XMLHttpRequest, request: AjaxRequest) {
     super('ajax timeout', xhr, request);
+    this.name = 'AjaxTimeoutError';
     (Object as any).setPrototypeOf(this, AjaxTimeoutError.prototype);
   }
 }

--- a/src/internal/util/TimeoutError.ts
+++ b/src/internal/util/TimeoutError.ts
@@ -8,7 +8,7 @@
 export class TimeoutError extends Error {
   constructor() {
     super('Timeout has occurred');
-
+    this.name = 'TimeoutError';
     (Object as any).setPrototypeOf(this, TimeoutError.prototype);
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Update the `name` property of the `AjaxTimeoutError` to be "AjaxTimeoutError" instead of "AjaxError".

@felixfbecker mentioned the following in the original issue: 
> Why not use instanceof? instanceof breaks when multiple RxJS versions are in play, or even just the same version had to be installed multiple times because deduping wasn't possible. It asserts the implementation, err.name asserts an interface. All browser errors use it (e.g. AbortError).

This still will cause problems if the implementation name changes.  Open to feedback for a more permanent solution.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3602
