### PR TITLE
docs(README): remove google docs URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,7 @@
 
 Find out how up update to v6, **automatically update your TypeScript code**, and more!
 
-- [Current home is a Google Doc](https://goo.gl/osWFzo)
-- [Future home is MIGRATION.md](./MIGRATION.md)
+- [Current home is MIGRATION.md](./MIGRATION.md)
 
 ### FOR V 5.X PLEASE GO TO [THE 5.0 BRANCH](https://github.com/ReactiveX/rxjs/tree/stable)
 


### PR DESCRIPTION
The Google Doc's documentation has moved to MIGRATION.md

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The Google Doc's documentation has moved to MIGRATION.md
**Related issue (if exists):**
