### PR TITLE
refactor(count-spec): update count operator tests to use pipeable operators

### DIFF
--- a/spec/operators/count-spec.ts
+++ b/spec/operators/count-spec.ts
@@ -1,19 +1,18 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
+import { of, range } from 'rxjs';
+import { count, skip, take, mergeMap } from 'rxjs/operators';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
 
-const Observable = Rx.Observable;
-
 /** @test {count} */
-describe('Observable.prototype.count', () => {
+describe('count operator', () => {
   asDiagram('count')('should count the values of an observable', () => {
     const source = hot('--a--b--c--|');
     const subs =       '^          !';
     const expected =   '-----------(x|)';
 
-    expectObservable(source.count()).toBe(expected, {x: 3});
+    expectObservable(source.pipe(count())).toBe(expected, {x: 3});
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -22,7 +21,7 @@ describe('Observable.prototype.count', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable(e1.count()).toBe(expected);
+    expectObservable(e1.pipe(count())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -31,7 +30,7 @@ describe('Observable.prototype.count', () => {
     const e1subs =   '(^!)';
     const expected = '(w|)';
 
-    expectObservable(e1.count()).toBe(expected, { w: 0 });
+    expectObservable(e1.pipe(count())).toBe(expected, { w: 0 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -40,7 +39,7 @@ describe('Observable.prototype.count', () => {
     const e1subs =      '^     ';
     const expected =    '------';
 
-    expectObservable(e1.count()).toBe(expected);
+    expectObservable(e1.pipe(count())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -49,7 +48,7 @@ describe('Observable.prototype.count', () => {
     const e1subs =    '^   !';
     const expected =  '----(w|)';
 
-    expectObservable(e1.count()).toBe(expected, { w: 0 });
+    expectObservable(e1.pipe(count())).toBe(expected, { w: 0 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -58,7 +57,7 @@ describe('Observable.prototype.count', () => {
     const e1subs =    '^     !';
     const expected =  '------(w|)';
 
-    expectObservable(e1.count()).toBe(expected, { w: 1 });
+    expectObservable(e1.pipe(count())).toBe(expected, { w: 1 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -67,12 +66,12 @@ describe('Observable.prototype.count', () => {
     const subs =           '^          !';
     const expected =       '-----------(x|)';
 
-    expectObservable(source.count()).toBe(expected, {x: 3});
+    expectObservable(source.pipe(count())).toBe(expected, {x: 3});
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should count a range() source observable', (done: MochaDone) => {
-    Rx.Observable.range(1, 10).count().subscribe(
+    range(1, 10).pipe(count()).subscribe(
       (value: number) => {
         expect(value).to.equal(10);
       }, (x) => {
@@ -83,7 +82,10 @@ describe('Observable.prototype.count', () => {
   });
 
   it('should count a range().skip(1) source observable', (done: MochaDone) => {
-    Rx.Observable.range(1, 10).skip(1).count().subscribe(
+    range(1, 10).pipe(
+      skip(1),
+      count()
+    ).subscribe(
       (value: number) => {
         expect(value).to.equal(9);
       }, (x) => {
@@ -94,7 +96,10 @@ describe('Observable.prototype.count', () => {
   });
 
   it('should count a range().take(1) source observable', (done: MochaDone) => {
-    Rx.Observable.range(1, 10).take(1).count().subscribe(
+    range(1, 10).pipe(
+      take(1),
+      count()
+    ).subscribe(
       (value: number) => {
         expect(value).to.equal(1);
       }, (x) => {
@@ -109,7 +114,7 @@ describe('Observable.prototype.count', () => {
     const e1subs =    '^        !';
     const expected =  '---------#';
 
-    expectObservable(e1.count()).toBe(expected, null, 'too bad');
+    expectObservable(e1.pipe(count())).toBe(expected, null, 'too bad');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -118,7 +123,7 @@ describe('Observable.prototype.count', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable(e1.count()).toBe(expected);
+    expectObservable(e1.pipe(count())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -130,7 +135,7 @@ describe('Observable.prototype.count', () => {
       return true;
     };
 
-    expectObservable(e1.count(predicate)).toBe(expected, { w: 0 });
+    expectObservable(e1.pipe(count(predicate))).toBe(expected, { w: 0 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -142,7 +147,7 @@ describe('Observable.prototype.count', () => {
       return false;
     };
 
-    expectObservable(e1.count(predicate)).toBe(expected, { w: 0 });
+    expectObservable(e1.pipe(count(predicate))).toBe(expected, { w: 0 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -154,7 +159,7 @@ describe('Observable.prototype.count', () => {
       return true;
     };
 
-    expectObservable(e1.count(predicate)).toBe(expected, { w: 1 });
+    expectObservable(e1.pipe(count(predicate))).toBe(expected, { w: 1 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -166,7 +171,7 @@ describe('Observable.prototype.count', () => {
       return false;
     };
 
-    expectObservable(e1.count(predicate)).toBe(expected, { w: 0 });
+    expectObservable(e1.pipe(count(predicate))).toBe(expected, { w: 0 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -176,7 +181,7 @@ describe('Observable.prototype.count', () => {
     const expected =  '-------    ';
     const unsub =     '      !    ';
 
-    const result = e1.count((value: string) => parseInt(value) < 10);
+    const result = e1.pipe(count((value: string) => parseInt(value) < 10));
 
     expectObservable(result, unsub).toBe(expected, { w: 3 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -188,10 +193,11 @@ describe('Observable.prototype.count', () => {
     const expected =  '-------    ';
     const unsub =     '      !    ';
 
-    const result = e1
-      .mergeMap((x: string) => Observable.of(x))
-      .count((value: string) => parseInt(value) < 10)
-      .mergeMap((x: number) => Observable.of(x));
+    const result = e1.pipe(
+      mergeMap((x: string) => of(x)),
+      count((value: string) => parseInt(value) < 10),
+      mergeMap((x: number) => of(x))
+    );
 
     expectObservable(result, unsub).toBe(expected, { w: 3 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -203,7 +209,7 @@ describe('Observable.prototype.count', () => {
     const expected =  '----------(w|)';
     const predicate = (value: string) => parseInt(value) < 10;
 
-    expectObservable(e1.count(predicate)).toBe(expected, { w: 3 });
+    expectObservable(e1.pipe(count(predicate))).toBe(expected, { w: 3 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -213,7 +219,7 @@ describe('Observable.prototype.count', () => {
     const expected =  '----------(w|)';
     const predicate = (value: string) => parseInt(value) > 10;
 
-    expectObservable(e1.count(predicate)).toBe(expected, { w: 0 });
+    expectObservable(e1.pipe(count(predicate))).toBe(expected, { w: 0 });
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -223,7 +229,7 @@ describe('Observable.prototype.count', () => {
     const expected =  '----#';
     const predicate = () => true;
 
-    expectObservable(e1.count(predicate)).toBe(expected);
+    expectObservable(e1.pipe(count(predicate))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -233,7 +239,7 @@ describe('Observable.prototype.count', () => {
     const expected =  '----#';
     const predicate = () => false;
 
-    expectObservable(e1.count(predicate)).toBe(expected);
+    expectObservable(e1.pipe(count(predicate))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -243,7 +249,7 @@ describe('Observable.prototype.count', () => {
     const expected =  '-----';
     const predicate = () => true;
 
-    expectObservable(e1.count(predicate)).toBe(expected);
+    expectObservable(e1.pipe(count(predicate))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -258,7 +264,7 @@ describe('Observable.prototype.count', () => {
       return true;
     };
 
-    expectObservable(e1.count(predicate)).toBe(expected);
+    expectObservable(e1.pipe(count(predicate))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });


### PR DESCRIPTION
update count spec to use updated import sites and pipeable operators
