### PR TITLE
chore(Error): Make error name part of visible api contract

### DIFF
--- a/spec/util/ArgumentOutOfRangeError-spec.ts
+++ b/spec/util/ArgumentOutOfRangeError-spec.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { ArgumentOutOfRangeError } from 'rxjs/util/ArgumentOutOfRangeError';
+
+/** @test {ArgumentOutOfRangeError} */
+describe('ArgumentOutOfRangeError', () => {
+  const error = new ArgumentOutOfRangeError();
+  it('Should have a name', () => {
+    expect(error.name).to.be.equal('ArgumentOutOfRangeError');
+  });
+  it('Should have a message', () => {
+    expect(error.message).to.be.equal('argument out of range');
+  });
+});

--- a/spec/util/EmptyError-spec.ts
+++ b/spec/util/EmptyError-spec.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { EmptyError } from 'rxjs/util/EmptyError';
+
+/** @test {EmptyError} */
+describe('EmptyError', () => {
+  const error = new EmptyError();
+  it('Should have a name', () => {
+    expect(error.name).to.be.equal('EmptyError');
+  });
+  it('Should have a message', () => {
+    expect(error.message).to.be.equal('no elements in sequence');
+  });
+});

--- a/spec/util/ObjectUnsubscribedError-spec.ts
+++ b/spec/util/ObjectUnsubscribedError-spec.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { ObjectUnsubscribedError } from 'rxjs/util/ObjectUnsubscribedError';
+
+/** @test {ObjectUnsubscribedError} */
+describe('ObjectUnsubscribedError', () => {
+  const error = new ObjectUnsubscribedError();
+  it('Should have a name', () => {
+    expect(error.name).to.be.equal('ObjectUnsubscribedError');
+  });
+  it('Should have a message', () => {
+    expect(error.message).to.be.equal('object unsubscribed');
+  });
+});

--- a/spec/util/TimeoutError-spec.ts
+++ b/spec/util/TimeoutError-spec.ts
@@ -1,0 +1,13 @@
+import { expect } from 'chai';
+import { TimeoutError } from 'rxjs/util/TimeoutError';
+
+/** @test {TimeoutError} */
+describe('TimeoutError', () => {
+  const error = new TimeoutError();
+  it('Should have a name', () => {
+    expect(error.name).to.be.equal('TimeoutError');
+  });
+  it('Should have a message', () => {
+    expect(error.message).to.be.equal('Timeout has occurred');
+  });
+});

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -424,6 +424,8 @@ export class AjaxResponse {
   }
 }
 
+type AjaxErrors = 'AjaxError' | 'AjaxTimeoutError';
+
 /**
  * A normalized AJAX error.
  *
@@ -447,7 +449,7 @@ export class AjaxError extends Error {
   /** @type {string|ArrayBuffer|Document|object|any} The response data */
   response: any;
 
-  public readonly name: string = 'AjaxError';
+  public readonly name: AjaxErrors = 'AjaxError';
 
   constructor(message: string, xhr: XMLHttpRequest, request: AjaxRequest) {
     super(message);
@@ -490,7 +492,7 @@ function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
  */
 export class AjaxTimeoutError extends AjaxError {
 
-  public readonly name: string = 'AjaxTimeoutError';
+  public readonly name: AjaxErrors = 'AjaxTimeoutError';
 
   constructor(xhr: XMLHttpRequest, request: AjaxRequest) {
     super('ajax timeout', xhr, request);

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -424,7 +424,7 @@ export class AjaxResponse {
   }
 }
 
-type AjaxErrors = 'AjaxError' | 'AjaxTimeoutError';
+export type AjaxErrorNames = 'AjaxError' | 'AjaxTimeoutError';
 
 /**
  * A normalized AJAX error.
@@ -449,7 +449,7 @@ export class AjaxError extends Error {
   /** @type {string|ArrayBuffer|Document|object|any} The response data */
   response: any;
 
-  public readonly name: AjaxErrors = 'AjaxError';
+  public readonly name: AjaxErrorNames = 'AjaxError';
 
   constructor(message: string, xhr: XMLHttpRequest, request: AjaxRequest) {
     super(message);
@@ -492,7 +492,7 @@ function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
  */
 export class AjaxTimeoutError extends AjaxError {
 
-  public readonly name: AjaxErrors = 'AjaxTimeoutError';
+  public readonly name: AjaxErrorNames = 'AjaxTimeoutError';
 
   constructor(xhr: XMLHttpRequest, request: AjaxRequest) {
     super('ajax timeout', xhr, request);

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -447,6 +447,8 @@ export class AjaxError extends Error {
   /** @type {string|ArrayBuffer|Document|object|any} The response data */
   response: any;
 
+  public readonly name: string = 'AjaxError';
+
   constructor(message: string, xhr: XMLHttpRequest, request: AjaxRequest) {
     super(message);
     this.message = message;
@@ -456,7 +458,6 @@ export class AjaxError extends Error {
     this.responseType = xhr.responseType || request.responseType;
     this.response = parseXhrResponse(this.responseType, xhr);
 
-    this.name = 'AjaxError';
     (Object as any).setPrototypeOf(this, AjaxError.prototype);
   }
 }
@@ -488,9 +489,11 @@ function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
  * @class AjaxTimeoutError
  */
 export class AjaxTimeoutError extends AjaxError {
+
+  public readonly name: string = 'AjaxTimeoutError';
+
   constructor(xhr: XMLHttpRequest, request: AjaxRequest) {
     super('ajax timeout', xhr, request);
-    this.name = 'AjaxTimeoutError';
     (Object as any).setPrototypeOf(this, AjaxTimeoutError.prototype);
   }
 }

--- a/src/internal/util/ArgumentOutOfRangeError.ts
+++ b/src/internal/util/ArgumentOutOfRangeError.ts
@@ -9,9 +9,11 @@
  * @class ArgumentOutOfRangeError
  */
 export class ArgumentOutOfRangeError extends Error {
+
+  public readonly name: 'ArgumentOutOfRangeError' = 'ArgumentOutOfRangeError';
+
   constructor() {
     super('argument out of range');
-    this.name = 'ArgumentOutOfRangeError';
     (Object as any).setPrototypeOf(this, ArgumentOutOfRangeError.prototype);
   }
 }

--- a/src/internal/util/ArgumentOutOfRangeError.ts
+++ b/src/internal/util/ArgumentOutOfRangeError.ts
@@ -10,7 +10,7 @@
  */
 export class ArgumentOutOfRangeError extends Error {
 
-  public readonly name: 'ArgumentOutOfRangeError' = 'ArgumentOutOfRangeError';
+  public readonly name = 'ArgumentOutOfRangeError';
 
   constructor() {
     super('argument out of range');

--- a/src/internal/util/EmptyError.ts
+++ b/src/internal/util/EmptyError.ts
@@ -10,7 +10,7 @@
  */
 export class EmptyError extends Error {
 
-  public readonly name: 'EmptyError' = 'EmptyError';
+  public readonly name = 'EmptyError';
 
   constructor() {
     super('no elements in sequence');

--- a/src/internal/util/EmptyError.ts
+++ b/src/internal/util/EmptyError.ts
@@ -9,9 +9,11 @@
  * @class EmptyError
  */
 export class EmptyError extends Error {
+
+  public readonly name: 'EmptyError' = 'EmptyError';
+
   constructor() {
     super('no elements in sequence');
-    this.name = 'EmptyError';
     (Object as any).setPrototypeOf(this, EmptyError.prototype);
   }
 }

--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -9,7 +9,7 @@
  */
 export class ObjectUnsubscribedError extends Error {
 
-  public readonly name: 'ObjectUnsubscribedError' = 'ObjectUnsubscribedError';
+  public readonly name = 'ObjectUnsubscribedError';
 
   constructor() {
     super('object unsubscribed');

--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -8,9 +8,11 @@
  * @class ObjectUnsubscribedError
  */
 export class ObjectUnsubscribedError extends Error {
+
+  public readonly name: 'ObjectUnsubscribedError' = 'ObjectUnsubscribedError';
+
   constructor() {
     super('object unsubscribed');
-    this.name = 'ObjectUnsubscribedError';
     (Object as any).setPrototypeOf(this, ObjectUnsubscribedError.prototype);
   }
 }

--- a/src/internal/util/TimeoutError.ts
+++ b/src/internal/util/TimeoutError.ts
@@ -6,9 +6,11 @@
  * @class TimeoutError
  */
 export class TimeoutError extends Error {
+
+  public readonly name: 'TimeoutError' = 'TimeoutError';
+
   constructor() {
     super('Timeout has occurred');
-    this.name = 'TimeoutError';
     (Object as any).setPrototypeOf(this, TimeoutError.prototype);
   }
 }

--- a/src/internal/util/TimeoutError.ts
+++ b/src/internal/util/TimeoutError.ts
@@ -7,7 +7,7 @@
  */
 export class TimeoutError extends Error {
 
-  public readonly name: 'TimeoutError' = 'TimeoutError';
+  public readonly name = 'TimeoutError';
 
   constructor() {
     super('Timeout has occurred');

--- a/src/internal/util/UnsubscriptionError.ts
+++ b/src/internal/util/UnsubscriptionError.ts
@@ -3,11 +3,13 @@
  * `unsubscribe` of a {@link Subscription}.
  */
 export class UnsubscriptionError extends Error {
+
+  public readonly name: 'UnsubscriptionError' = 'UnsubscriptionError';
+
   constructor(public errors: any[]) {
     super(errors ?
       `${errors.length} errors occurred during unsubscription:
   ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '');
-    this.name = 'UnsubscriptionError';
     (Object as any).setPrototypeOf(this, UnsubscriptionError.prototype);
   }
 }

--- a/src/internal/util/UnsubscriptionError.ts
+++ b/src/internal/util/UnsubscriptionError.ts
@@ -4,7 +4,7 @@
  */
 export class UnsubscriptionError extends Error {
 
-  public readonly name: 'UnsubscriptionError' = 'UnsubscriptionError';
+  public readonly name = 'UnsubscriptionError';
 
   constructor(public errors: any[]) {
     super(errors ?


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Add `Error.name` to all custom errors.  Add tests for name and description. 
 
**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3602
https://github.com/ReactiveX/rxjs/pull/3656