### PR TITLE
fix(skipUntil): fix skipUntil when innerSubscription is null

### DIFF
--- a/spec/operators/skipUntil-spec.ts
+++ b/spec/operators/skipUntil-spec.ts
@@ -30,6 +30,16 @@ describe('skipUntil', () => {
     expectSubscriptions(skip.subscriptions).toBe(skipSubs);
   });
 
+  it('should emit elements after a synchronous notifier emits', () => {
+    const values: string[] = [];
+
+    of('a', 'b').pipe(skipUntil(of('x'))).subscribe(
+      value => values.push(value),
+      err => { throw err; },
+      () => expect(values).to.deep.equal(['a', 'b'])
+    );
+  });
+
   it('should raise an error if notifier throws and source is hot', () => {
     const e1 =   hot('--a--b--c--d--e--|');
     const e1subs =   '^            !    ';

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -57,7 +57,7 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
              outerIndex: number, innerIndex: number,
              innerSub: InnerSubscriber<T, R>): void {
     this.hasValue = true;
-    if(this.innerSubscription) {
+    if (this.innerSubscription) {
       this.innerSubscription.unsubscribe();
     }
   }

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -57,7 +57,9 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
              outerIndex: number, innerIndex: number,
              innerSub: InnerSubscriber<T, R>): void {
     this.hasValue = true;
-    this.innerSubscription.unsubscribe();
+    if(this.innerSubscription) {
+      this.innerSubscription.unsubscribe();
+    }
   }
 
   notifyComplete() {


### PR DESCRIPTION
**Description:** Fix a minor issue with skipUntil

**Related issue:**
https://github.com/ReactiveX/rxjs/issues/3685
