### PR TITLE
fix(isObservable): Fix throwing error when testing isObservable(null)

### DIFF
--- a/spec/util/isObservable-spec.ts
+++ b/spec/util/isObservable-spec.ts
@@ -23,4 +23,13 @@ describe('isObservable', () => {
 
     expect(isObservable(o)).to.be.false;
   });
+
+  it('should return false for null', () => {
+    expect(isObservable(null)).to.be.false;
+  });
+
+  it('should return false for a number', () => {
+    expect(isObservable(1)).to.be.false;
+  });
+
 });

--- a/src/internal/util/isObservable.ts
+++ b/src/internal/util/isObservable.ts
@@ -1,10 +1,13 @@
 import { Observable } from '../Observable';
 import { ObservableInput } from '../types';
+import { isObject  } from './isObject';
+import { isFunction } from './isFunction';
 
 /**
  * Tests to see if the object is an RxJS {@link Observable}
  * @param obj the object to test
  */
 export function isObservable<T>(obj: any): obj is Observable<T> {
-  return obj && obj instanceof Observable || (typeof obj.lift === 'function' && typeof obj.subscribe === 'function');
+  return obj && obj instanceof Observable ||
+    (isObject(obj) || isFunction(obj)) ? (isFunction(obj.lift) && isFunction(obj.subscribe)) : false;
 }

--- a/src/internal/util/isObservable.ts
+++ b/src/internal/util/isObservable.ts
@@ -1,7 +1,5 @@
 import { Observable } from '../Observable';
 import { ObservableInput } from '../types';
-import { isObject  } from './isObject';
-import { isFunction } from './isFunction';
 
 /**
  * Tests to see if the object is an RxJS {@link Observable}

--- a/src/internal/util/isObservable.ts
+++ b/src/internal/util/isObservable.ts
@@ -8,6 +8,5 @@ import { isFunction } from './isFunction';
  * @param obj the object to test
  */
 export function isObservable<T>(obj: any): obj is Observable<T> {
-  return obj && obj instanceof Observable ||
-    (isObject(obj) || isFunction(obj)) ? (isFunction(obj.lift) && isFunction(obj.subscribe)) : false;
+  return !!obj && (obj instanceof Observable || (typeof obj.lift === 'function' && typeof obj.subscribe === 'function'));
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Fix `isObservable` to test to make sure the test subject is a function or object before attempting to access properties on it.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3687