### PR TITLE
fix(WebSocketSubject): Check if WebSocket exists before using it

### DIFF
--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -80,7 +80,6 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
       this.source = urlConfigOrSource as Observable<T>;
     } else {
       const config = this._config = { ...DEFAULT_WEBSOCKET_CONFIG };
-      config.WebSocketCtor = WebSocket;
       this._output = new Subject<T>();
       if (typeof urlConfigOrSource === 'string') {
         config.url = urlConfigOrSource;
@@ -91,7 +90,10 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
           }
         }
       }
-      if (!config.WebSocketCtor) {
+
+      if (!config.WebSocketCtor && WebSocket) {
+        config.WebSocketCtor = WebSocket;
+      } else if (!config.WebSocketCtor) {
         throw new Error('no WebSocket constructor can be found');
       }
       this.destination = new ReplaySubject();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Check to make sure that the `WebSocket` constructor is in the root before using it.  This is currently breaking in Node.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3692
