### PR TITLE
 fix(TestScheduler): restore run changes upon error

### DIFF
--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
+import { AsyncScheduler } from 'rxjs/internal/scheduler/AsyncScheduler';
 import { TestScheduler } from 'rxjs/testing';
 import { Observable, NEVER, EMPTY, Subject, of, concat, merge, Notification } from 'rxjs';
 import { delay, debounceTime, concatMap } from 'rxjs/operators';
@@ -440,6 +441,26 @@ describe('TestScheduler', () => {
         expect(value).to.equal('foo');
         done();
       });
+    });
+
+    it('should restore changes upon thrown errors', () => {
+      const testScheduler = new TestScheduler(assertDeepEquals);
+
+      const frameTimeFactor = TestScheduler['frameTimeFactor'];
+      const maxFrames = testScheduler.maxFrames;
+      const runMode = testScheduler['runMode'];
+      const delegate = AsyncScheduler.delegate;
+
+      try {
+        testScheduler.run(() => {
+          throw new Error('kaboom!');
+        });
+      } catch { /* empty */ }
+
+      expect(TestScheduler['frameTimeFactor']).to.equal(frameTimeFactor);
+      expect(testScheduler.maxFrames).to.equal(maxFrames);
+      expect(testScheduler['runMode']).to.equal(runMode);
+      expect(AsyncScheduler.delegate).to.equal(delegate);
     });
   });
 });

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -378,14 +378,15 @@ export class TestScheduler extends VirtualTimeScheduler {
       expectObservable: this.expectObservable.bind(this),
       expectSubscriptions: this.expectSubscriptions.bind(this),
     };
-    const ret = callback(helpers);
-    this.flush();
-
-    TestScheduler.frameTimeFactor = prevFrameTimeFactor;
-    this.maxFrames = prevMaxFrames;
-    this.runMode = false;
-    AsyncScheduler.delegate = undefined;
-
-    return ret;
+    try {
+      const ret = callback(helpers);
+      this.flush();
+      return ret;
+    } finally {
+      TestScheduler.frameTimeFactor = prevFrameTimeFactor;
+      this.maxFrames = prevMaxFrames;
+      this.runMode = false;
+      AsyncScheduler.delegate = undefined;
+    }
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing test and a `finally` block to the `TestScheduler`'s `run` method so that `runMode` changes are restored upon an error being thrown by a test.

Without the `finally` block, the `TestScheduler` is left in `runMode` and that breaks tests that depend upon the previous, deprecated behaviour. This is a problem when converting a suite of tests to use the new behaviour: a failing `runMode` test will cause all subsequent non-`runMode` tests to fail with useless messages, as their marble diagrams will be interpreted incorrectly.

/cc @jayphelps

**Related issue (if exists):** None
