### PR TITLE
fix(range): Range should be same for every subscriber

### DIFF
--- a/spec/observables/range-spec.ts
+++ b/spec/observables/range-spec.ts
@@ -31,6 +31,21 @@ describe('range', () => {
     expectObservable(e1).toBe(expected, values);
   });
 
+  it('should work for two subscribers', () => {
+    const e1 = range(1, 5)
+      .concatMap((x, i) => Observable.of(x).delay(i === 0 ? 0 : 20, rxTestScheduler));
+    const expected = 'a-b-c-d-(e|)';
+    const values = {
+      a: 1,
+      b: 2,
+      c: 3,
+      d: 4,
+      e: 5
+    };
+    expectObservable(e1).toBe(expected, values);
+    expectObservable(e1).toBe(expected, values);
+  });
+
   it('should synchronously create a range of values by default', () => {
     const results = [] as any[];
     range(12, 4).subscribe(function (x) {

--- a/src/internal/observable/range.ts
+++ b/src/internal/observable/range.ts
@@ -36,6 +36,7 @@ export function range(start: number = 0,
                       scheduler?: SchedulerLike): Observable<number> {
   return new Observable<number>(subscriber => {
     let index = 0;
+    let current = start;
 
     if (scheduler) {
       return scheduler.schedule(dispatch, 0, {
@@ -47,7 +48,7 @@ export function range(start: number = 0,
           subscriber.complete();
           break;
         }
-        subscriber.next(start++);
+        subscriber.next(current++);
         if (subscriber.closed) {
           break;
         }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Range should be same for every subscriber. 

We were mutating the start parameter that was passed in so the second subscriber was starting at the end of the first subscriber.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3706
