### PR TITLE
chore(test): fix operator test types a-d

### DIFF
--- a/spec/operators/bufferTime-spec.ts
+++ b/spec/operators/bufferTime-spec.ts
@@ -18,7 +18,7 @@ describe('bufferTime operator', () => {
       w: ['a', 'b'],
       x: ['c', 'd', 'e'],
       y: ['f', 'g'],
-      z: []
+      z: [] as string[]
     };
 
     const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, rxTestScheduler));
@@ -34,7 +34,7 @@ describe('bufferTime operator', () => {
     const values = {
       x: ['a', 'b', 'c'],
       y: ['d', 'e', 'g'],
-      z: []
+      z: [] as string[]
     };
 
     const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, rxTestScheduler));
@@ -69,7 +69,7 @@ describe('bufferTime operator', () => {
       w: ['a', 'b'],
       x: ['c', 'd', 'e'],
       y: ['f', 'g'],
-      z: []
+      z: [] as string[]
     };
 
     const result = e1.pipe(bufferTime(t, null, 3, rxTestScheduler));
@@ -137,8 +137,8 @@ describe('bufferTime operator', () => {
       b: ['4', '5', '6'],
       c: ['6', '7', '8'],
       d: ['8', '9'],
-      e: [],
-      f: []
+      e: [] as string[],
+      f: [] as string[]
     };
 
     const result = e1.pipe(bufferTime(t, interval, Number.POSITIVE_INFINITY, rxTestScheduler));
@@ -164,7 +164,7 @@ describe('bufferTime operator', () => {
       b: ['4', '5', '6'],
       c: ['6', '7', '8'],
       d: ['8', '9'],
-      e: []
+      e: [] as string[]
     };
 
     const result = e1.pipe(bufferTime(t, interval, Number.POSITIVE_INFINITY, rxTestScheduler));
@@ -222,7 +222,7 @@ describe('bufferTime operator', () => {
     const e1 = cold( '|');
     const e1subs =   '(^!)';
     const expected = '(b|)';
-    const values = { b: [] };
+    const values = { b: [] as string[] };
     const t = time('----------|');
 
     const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, rxTestScheduler));

--- a/spec/operators/bufferToggle-spec.ts
+++ b/spec/operators/bufferToggle-spec.ts
@@ -274,7 +274,7 @@ describe('bufferToggle operator', () => {
     const e2 =  cold('--o-----|');
     const e3 =  cold(  '-----c--|');
     const expected = '|';
-    const values = { x: [] };
+    const values = { x: [] as string[] };
 
     const result = e1.pipe(bufferToggle(e2, () => e3));
 
@@ -286,7 +286,7 @@ describe('bufferToggle operator', () => {
     const e2 =  cold('--o-----|');
     const e3 =  cold(  '-----c--|');
     const expected = '#';
-    const values = { x: [] };
+    const values = { x: [] as string[] };
 
     const result = e1.pipe(bufferToggle(e2, () => e3));
 
@@ -300,7 +300,7 @@ describe('bufferToggle operator', () => {
     const unsub =    '                                            !';
     const subs =     '^                                           !';
     const expected = '----x-----x------x-----x---x-----------------';
-    const values = { x: [] };
+    const values = { x: [] as string[] };
 
     const result = e1.pipe(bufferToggle(e2, () => e3));
 

--- a/spec/operators/bufferWhen-spec.ts
+++ b/spec/operators/bufferWhen-spec.ts
@@ -15,7 +15,7 @@ describe('bufferWhen operator', () => {
     const values = {
       x: ['b', 'c', 'd'],
       y: ['e', 'f', 'g'],
-      z: []
+      z: [] as string[]
     };
 
     expectObservable(e1.pipe(bufferWhen(() => e2))).toBe(expected, values);
@@ -239,7 +239,7 @@ describe('bufferWhen operator', () => {
     const e1subs =   '(^!)';
     const expected = '(x|)';
     const values = {
-      x: []
+      x: [] as string[]
     };
 
     const result = e1.pipe(bufferWhen(() => e2));
@@ -254,7 +254,7 @@ describe('bufferWhen operator', () => {
     const e1subs =   '(^!)';
     const expected = '#';
     const values = {
-      x: []
+      x: [] as string[]
     };
 
     const result = e1.pipe(bufferWhen(() => e2));
@@ -276,7 +276,7 @@ describe('bufferWhen operator', () => {
                    '                                        ^   !'];
     const expected = '--------x-------x-------x-------x-------x----';
     const values = {
-      x: []
+      x: [] as string[]
     };
 
     const source = e1.pipe(bufferWhen(() => e2));
@@ -346,7 +346,7 @@ describe('bufferWhen operator', () => {
     const values = {
       x: ['b', 'c', 'd'],
       y: ['e', 'f', 'g', 'h'],
-      z: []
+      z: [] as string[]
     };
 
     const source = e1.pipe(bufferWhen(() => e2));

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -4,14 +4,14 @@ import { debounce, mergeMap, mapTo } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
-declare const type;
+declare const type: Function;
 declare function asDiagram(arg: string): Function;
 
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {debounce} */
 describe('debounce operator', () => {
-  function getTimerSelector(x) {
+  function getTimerSelector(x: number) {
     return () => timer(x, rxTestScheduler);
   }
 
@@ -287,7 +287,7 @@ describe('debounce operator', () => {
                   ['        ^!                            ',
                    '                 ^ !                  '];
 
-    function selectorFunction(x) {
+    function selectorFunction(x: string) {
       if (x !== 'c') {
         return selector.shift();
       } else {
@@ -307,7 +307,7 @@ describe('debounce operator', () => {
     const e1subs =   '^                                   !';
     const expected = '--------a-x-yz---bxy---z--c--x--y--z|';
 
-    function selectorFunction(x) { return EMPTY; }
+    function selectorFunction(x: string) { return EMPTY; }
 
     expectObservable(e1.pipe(debounce(selectorFunction))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -420,8 +420,8 @@ describe('debounce operator', () => {
   });
 
   it('should debounce correctly when synchronously reentered', () => {
-    const results = [];
-    const source = new Subject();
+    const results: number[] = [];
+    const source = new Subject<number>();
 
     source.pipe(debounce(() => of(null))).subscribe(value => {
       results.push(value);

--- a/spec/operators/debounceTime-spec.ts
+++ b/spec/operators/debounceTime-spec.ts
@@ -155,8 +155,8 @@ describe('debounceTime operator', () => {
   });
 
   it('should debounce correctly when synchronously reentered', () => {
-    const results = [];
-    const source = new Subject();
+    const results: number[] = [];
+    const source = new Subject<number>();
     const scheduler = new VirtualTimeScheduler();
 
     source.pipe(debounceTime(0, scheduler)).subscribe(value => {

--- a/spec/operators/do-spec.ts
+++ b/spec/operators/do-spec.ts
@@ -46,7 +46,7 @@ describe('Observable.prototype.do', () => {
 
   it('should handle everything with an observer', (done: MochaDone) => {
     const expected = [1, 2, 3];
-    const results = [];
+    const results: number[] = [];
 
     Observable.of(1, 2, 3)
       .do(<Rx.Observer<number>>{
@@ -101,7 +101,7 @@ describe('Observable.prototype.do', () => {
 
   it('should handle an error with observer', () => {
     let errored = false;
-    Observable.throw('bad').do(<any>{ error: function (err) {
+    Observable.throw('bad').do(<any>{ error: function (err: string) {
       expect(err).to.equal('bad');
     } })
     .subscribe(null, function (err) {

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -8,6 +8,8 @@
     "./ajax/**/*.ts",
     "./helpers/**/*.ts",
     "./migration/**/*.ts",
+    "./operators/a*.ts",
+    "./operators/b*.ts",
     "./symbol/**/*.ts",
     "./testing/**/*.ts",
     "./util/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -10,6 +10,8 @@
     "./migration/**/*.ts",
     "./operators/a*.ts",
     "./operators/b*.ts",
+    "./operators/c*.ts",
+    "./operators/d*.ts",
     "./symbol/**/*.ts",
     "./testing/**/*.ts",
     "./util/**/*.ts",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Continues from PR #3680 and fixes operators tests for operators starting with `a` through to `d`.

**Related issue (if exists):** #3411 #3680
