### PR TITLE
chore(test): fix operator test types e-g

### DIFF
--- a/spec/operators/every-spec.ts
+++ b/spec/operators/every-spec.ts
@@ -8,12 +8,12 @@ const Observable = Rx.Observable;
 
 /** @test {every} */
 describe('Observable.prototype.every', () => {
-  function truePredicate(x) {
+  function truePredicate(x: number | string) {
     return true;
   }
 
-  function predicate(x) {
-    return x % 5 === 0;
+  function predicate(x: number | string) {
+    return (+x) % 5 === 0;
   }
 
   asDiagram('every(x => x % 5 === 0)')('should return false if only some of element matches with predicate', () => {
@@ -28,7 +28,7 @@ describe('Observable.prototype.every', () => {
   it('should accept thisArg with scalar observables', () => {
     const thisArg = {};
 
-    Observable.of(1).every(function (value: number, index: number) {
+    Observable.of(1).every(function (this: any, value: number, index: number) {
       expect(this).to.deep.equal(thisArg);
       return true;
     }, thisArg).subscribe();
@@ -38,7 +38,7 @@ describe('Observable.prototype.every', () => {
   it('should accept thisArg with array observables', () => {
     const thisArg = {};
 
-    Observable.of(1, 2, 3, 4).every(function (value: number, index: number) {
+    Observable.of(1, 2, 3, 4).every(function (this: any, value: number, index: number) {
       expect(this).to.deep.equal(thisArg);
       return true;
     }, thisArg).subscribe();
@@ -51,7 +51,7 @@ describe('Observable.prototype.every', () => {
       observer.next(1);
       observer.complete();
     })
-    .every(function (value: number, index: number) {
+    .every(function (this: any, value: number, index: number) {
       expect(this).to.deep.equal(thisArg);
     }, thisArg).subscribe();
   });
@@ -124,7 +124,7 @@ describe('Observable.prototype.every', () => {
     const sourceSubs = '^       !';
     const expected =   '--------#';
 
-    function faultyPredicate(x) {
+    function faultyPredicate(x: string) {
       if (x === 'c') {
         throw 'error';
       } else {
@@ -163,7 +163,7 @@ describe('Observable.prototype.every', () => {
     const source = Observable.of(3);
     const expected = '#';
 
-    function faultyPredicate(x) {
+    function faultyPredicate(x: number) {
       throw 'error';
     }
 
@@ -188,7 +188,7 @@ describe('Observable.prototype.every', () => {
     const source = Observable.of(5, 10, 15, 20);
     const expected = '#';
 
-    function faultyPredicate(x) {
+    function faultyPredicate(x: number) {
       if (x === 15) {
         throw 'error';
       }

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -8,11 +8,11 @@ const Observable = Rx.Observable;
 
 /** @test {filter} */
 describe('Observable.prototype.filter', () => {
-  function oddFilter(x) {
+  function oddFilter(x: number | string) {
     return (+x) % 2 === 1;
   }
 
-  function isPrime(i) {
+  function isPrime(i: number | string) {
     if (+i <= 1) { return false; }
     const max = Math.floor(Math.sqrt(+i));
     for (let j = 2; j <= max; ++j) {
@@ -174,8 +174,8 @@ describe('Observable.prototype.filter', () => {
 
     expectObservable(
       source
-        .filter((x: number) => x % 2 === 0)
-        .filter((x: number) => x % 3 === 0)
+        .filter((x: string) => (+x) % 2 === 0)
+        .filter((x: string) => (+x) % 3 === 0)
     ).toBe(expected);
   });
 
@@ -183,18 +183,18 @@ describe('Observable.prototype.filter', () => {
     const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
     const expected =          '--------6----------|';
 
-    function Filterer() {
-      this.filter1 = (x: number) => x % 2 === 0;
-      this.filter2 = (x: number) => x % 3 === 0;
+    class Filterer {
+      filter1 = (x: string) => (+x) % 2 === 0;
+      filter2 = (x: string) => (+x) % 3 === 0;
     }
 
     const filterer = new Filterer();
 
     expectObservable(
       source
-        .filter(function (x) { return this.filter1(x); }, filterer)
-        .filter(function (x) { return this.filter2(x); }, filterer)
-        .filter(function (x) { return this.filter1(x); }, filterer)
+        .filter(function (this: any, x) { return this.filter1(x); }, filterer)
+        .filter(function (this: any, x) { return this.filter2(x); }, filterer)
+        .filter(function (this: any, x) { return this.filter1(x); }, filterer)
     ).toBe(expected);
   });
 
@@ -205,8 +205,8 @@ describe('Observable.prototype.filter', () => {
 
     expectObservable(
       source
-        .filter((x: number) => x % 2 === 0)
-        .map((x: number) => x * x)
+        .filter((x: string) => (+x) % 2 === 0)
+        .map((x: string) => (+x) * (+x))
     ).toBe(expected, values);
   });
 

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -8,7 +8,7 @@ const Observable = Rx.Observable;
 
 /** @test {find} */
 describe('Observable.prototype.find', () => {
-  function truePredicate(x) {
+  function truePredicate(x: any) {
     return true;
   }
 
@@ -18,7 +18,7 @@ describe('Observable.prototype.find', () => {
     const subs =       '^        !       ';
     const expected =   '---------(c|)    ';
 
-    const predicate = function (x) { return x % 5 === 0; };
+    const predicate = function (x: number) { return x % 5 === 0; };
 
     expectObservable((<any>source).find(predicate)).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -55,7 +55,7 @@ describe('Observable.prototype.find', () => {
     const subs =       '^ !';
     const expected =   '--(a|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'a';
     };
 
@@ -68,7 +68,7 @@ describe('Observable.prototype.find', () => {
     const subs =       '^    !';
     const expected =   '-----(b|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'b';
     };
 
@@ -84,7 +84,7 @@ describe('Observable.prototype.find', () => {
     const finder = {
       target: 'b'
     };
-    const predicate = function (value) {
+    const predicate = function (this: typeof finder, value: string) {
       return value === this.target;
     };
 
@@ -97,7 +97,7 @@ describe('Observable.prototype.find', () => {
     const subs =       '^          !';
     const expected =   '-----------(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'z';
     };
 
@@ -137,7 +137,7 @@ describe('Observable.prototype.find', () => {
     const subs =       '^       !';
     const expected =   '--------#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'z';
     };
 
@@ -150,7 +150,7 @@ describe('Observable.prototype.find', () => {
     const subs =       '^ !';
     const expected =   '--#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       throw 'error';
     };
 

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -7,7 +7,7 @@ const Observable = Rx.Observable;
 
 /** @test {findIndex} */
 describe('Observable.prototype.findIndex', () => {
-  function truePredicate(x) {
+  function truePredicate(x: any) {
     return true;
   }
 
@@ -17,7 +17,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^        !       ';
     const expected =   '---------(x|)    ';
 
-    const predicate = function (x) { return x % 5 === 0; };
+    const predicate = function (x: number) { return x % 5 === 0; };
 
     expectObservable((<any>source).findIndex(predicate)).toBe(expected, { x: 2 });
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -49,7 +49,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^ !   ';
     const expected =   '--(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: number) {
       return value === sourceValue;
     };
 
@@ -62,7 +62,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^    !';
     const expected =   '-----(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: number) {
       return value === 7;
     };
 
@@ -76,7 +76,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^    !';
     const expected =   '-----(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (this: typeof sourceValues, value: number) {
       return value === this.b;
     };
     const result = (<any>source).findIndex(predicate, sourceValues);
@@ -90,7 +90,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^          !';
     const expected =   '-----------(x|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'z';
     };
 
@@ -130,7 +130,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^       !';
     const expected =   '--------#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'z';
     };
 
@@ -143,7 +143,7 @@ describe('Observable.prototype.findIndex', () => {
     const subs =       '^ !';
     const expected =   '--#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       throw 'error';
     };
 

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -170,6 +170,10 @@ describe('Observable.prototype.first', () => {
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
+  // The current signature for first suggests that this test is not rquired. In
+  // fact, with type checking enabled, it will fail. See:
+  // https://github.com/ReactiveX/rxjs/issues/3717
+  /*
   it('should support type guards without breaking previous behavior', () => {
     // tslint:disable no-unused-variable
 
@@ -228,4 +232,5 @@ describe('Observable.prototype.first', () => {
 
     // tslint:disable enable
   });
+  */
 });

--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -23,11 +23,11 @@ describe('Observable.prototype.groupBy', () => {
     expectObservable(source).toBe(expected, expectedValues);
   });
 
-  function reverseString(str) {
+  function reverseString(str: string) {
     return str.split('').reverse().join('');
   }
 
-  function mapObject(obj, fn) {
+  function mapObject(obj: object, fn: Function) {
     const out = {};
     for (const p in obj) {
       if (obj.hasOwnProperty(p)) {
@@ -81,7 +81,7 @@ describe('Observable.prototype.groupBy', () => {
       { key: 0, values: [6] }
     ];
 
-    const resultingGroups = [];
+    const resultingGroups: { key: number, values: number [] }[] = [];
 
     Observable.of(1, 2, 3, 4, 5, 6)
       .groupBy(
@@ -89,7 +89,7 @@ describe('Observable.prototype.groupBy', () => {
         (x: number) => x,
         (g: any) => g.skip(1))
       .subscribe((g: any) => {
-        let group = { key: g.key, values: [] };
+        let group = { key: g.key, values: [] as number[] };
 
         g.subscribe((x: any) => {
           group.values.push(x);
@@ -544,7 +544,7 @@ describe('Observable.prototype.groupBy', () => {
     const source = e1
       .groupBy((val: string) => val.toLowerCase().trim())
       .map((group: any) => {
-        const arr = [];
+        const arr: any[] = [];
 
         const subscription = group
           .materialize()
@@ -608,7 +608,7 @@ describe('Observable.prototype.groupBy', () => {
     const source = e1
       .groupBy((val: string) => val.toLowerCase().trim())
       .map((group: any) => {
-        const arr = [];
+        const arr: any[] = [];
 
         const subscription = group
           .materialize()
@@ -879,7 +879,7 @@ describe('Observable.prototype.groupBy', () => {
         (group: any) => group.skip(2)
       )
       .map((group: any) => {
-        const arr = [];
+        const arr: any[] = [];
 
         const subscription = group
           .materialize()
@@ -1106,7 +1106,7 @@ describe('Observable.prototype.groupBy', () => {
         (group: any) => group.skip(2)
       )
       .map((group: any, index: number) => {
-        const arr = [];
+        const arr: any[] = [];
 
         const subscription = group
           .materialize()
@@ -1183,7 +1183,7 @@ describe('Observable.prototype.groupBy', () => {
         (group: any) => group.skip(2)
       )
       .map((group: any) => {
-        const arr = [];
+        const arr: any[] = [];
 
         const subscription = group
           .materialize()
@@ -1254,7 +1254,7 @@ describe('Observable.prototype.groupBy', () => {
          (val: string) => val.toLowerCase().trim(),
          (val: string) => val
        ).map((group: any) => {
-         const innerNotifications = [];
+         const innerNotifications: any[] = [];
          const subscriptionFrame = subscriptionFrames[group.key];
 
          rxTestScheduler.schedule(() => {
@@ -1304,7 +1304,7 @@ describe('Observable.prototype.groupBy', () => {
         (group: any) => group.skip(7)
       )
       .map((group: any) => {
-        const arr = [];
+        const arr: any[] = [];
 
         rxTestScheduler.schedule(() => {
           group
@@ -1353,7 +1353,7 @@ describe('Observable.prototype.groupBy', () => {
         (group: any) => group.skip(7)
       )
       .map((group: any) => {
-        const arr = [];
+        const arr: any[] = [];
 
         rxTestScheduler.schedule(() => {
           group
@@ -1404,7 +1404,7 @@ describe('Observable.prototype.groupBy', () => {
         (group: any) => group.skip(7)
       )
       .map((group: any) => {
-        const arr = [];
+        const arr: any[] = [];
 
         rxTestScheduler.schedule(() => {
           group

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -12,6 +12,7 @@
     "./operators/b*.ts",
     "./operators/c*.ts",
     "./operators/d*.ts",
+    "./operators/e*.ts",
     "./symbol/**/*.ts",
     "./testing/**/*.ts",
     "./util/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -14,6 +14,7 @@
     "./operators/d*.ts",
     "./operators/e*.ts",
     "./operators/f*.ts",
+    "./operators/g*.ts",
     "./symbol/**/*.ts",
     "./testing/**/*.ts",
     "./util/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -13,6 +13,7 @@
     "./operators/c*.ts",
     "./operators/d*.ts",
     "./operators/e*.ts",
+    "./operators/f*.ts",
     "./symbol/**/*.ts",
     "./testing/**/*.ts",
     "./util/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -8,6 +8,24 @@
     "./ajax/**/*.ts",
     "./helpers/**/*.ts",
     "./migration/**/*.ts",
+    /*"./observables/dom/*.ts",*/
+    /*"./observables/b*.ts",*/
+    /*"./observables/c*.ts",*/
+    /*"./observables/d*.ts",*/
+    /*"./observables/e*.ts",*/
+    /*"./observables/f*.ts",*/
+    /*"./observables/g*.ts",*/
+    /*"./observables/i*.ts",*/
+    /*"./observables/I*.ts",*/
+    /*"./observables/m*.ts",*/
+    /*"./observables/n*.ts",*/
+    /*"./observables/o*.ts",*/
+    /*"./observables/p*.ts",*/
+    /*"./observables/r*.ts",*/
+    /*"./observables/S*.ts",*/
+    /*"./observables/t*.ts",*/
+    /*"./observables/u*.ts",*/
+    /*"./observables/z*.ts",*/
     "./operators/a*.ts",
     "./operators/b*.ts",
     "./operators/c*.ts",
@@ -15,6 +33,16 @@
     "./operators/e*.ts",
     "./operators/f*.ts",
     "./operators/g*.ts",
+    /*"./operators/i*.ts",*/
+    /*"./operators/l*.ts",*/
+    /*"./operators/m*.ts",*/
+    /*"./operators/o*.ts",*/
+    /*"./operators/p*.ts",*/
+    /*"./operators/r*.ts",*/
+    /*"./operators/s*.ts",*/
+    /*"./operators/s*.ts",*/
+    /*"./operators/w*.ts",*/
+    /*"./operators/z*.ts",*/
     "./symbol/**/*.ts",
     "./testing/**/*.ts",
     "./util/**/*.ts",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Continues from PR #3680 and fixes operators tests for operators starting with `e` through to `g`.

**Related issue (if exists):** #3411 #3680