### PR TITLE
refactor(distinct-spec): update distinct operator tests to use pipeable operators

### DIFF
--- a/spec/operators/distinct-spec.ts
+++ b/spec/operators/distinct-spec.ts
@@ -1,16 +1,15 @@
-import * as Rx from 'rxjs/Rx';
+import { distinct, mergeMap } from 'rxjs/operators';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-
-const Observable = Rx.Observable;
+import { of } from 'rxjs';
 
 /** @test {distinct} */
-describe('Observable.prototype.distinct', () => {
+describe('distinct operator', () => {
   it('should distinguish between values', () => {
     const e1 =   hot('--a--a--a--b--b--a--|');
     const e1subs =   '^                   !';
     const expected = '--a--------b--------|';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -19,7 +18,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^                  ';
     const expected = '--a--------b-------';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -28,7 +27,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -37,7 +36,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -46,7 +45,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -55,7 +54,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^     !';
     const expected = '------|';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -64,15 +63,15 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^    !';
     const expected = '--a--|';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
   it('should emit if source is scalar', () => {
-    const e1 = Observable.of('a');
+    const e1 = of('a');
     const expected = '(a|)';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
   });
 
   it('should raises error if source raises error', () => {
@@ -80,7 +79,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^       !';
     const expected = '--a-----#';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -89,7 +88,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -98,7 +97,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^                   !';
     const expected = '--a--b--c--d--e--f--|';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -108,7 +107,7 @@ describe('Observable.prototype.distinct', () => {
     const expected = '--a--b-----          ';
     const unsub =    '          !          ';
 
-    const result = (<any>e1).distinct();
+    const result = (<any>e1).pipe(distinct());
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -120,10 +119,11 @@ describe('Observable.prototype.distinct', () => {
     const expected = '--a--b-----          ';
     const unsub =    '          !          ';
 
-    const result = (<any>e1
-      .mergeMap((x: any) => Observable.of(x)))
-      .distinct()
-      .mergeMap((x: any) => Observable.of(x));
+    const result = (<any>e1).pipe(
+      mergeMap((x: any) => of(x)),
+      distinct(),
+      mergeMap((x: any) => of(x)),
+    );
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -134,7 +134,7 @@ describe('Observable.prototype.distinct', () => {
     const e1subs =   '^                   !';
     const expected = '--a-----------------|';
 
-    expectObservable((<any>e1).distinct()).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -145,7 +145,7 @@ describe('Observable.prototype.distinct', () => {
     const expected = '--a--b--c-----------|';
     const selector = (value: number) => value % 3;
 
-    expectObservable((<any>e1).distinct(selector)).toBe(expected, values);
+    expectObservable((<any>e1).pipe(distinct(selector))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -160,7 +160,7 @@ describe('Observable.prototype.distinct', () => {
       return value;
     };
 
-    expectObservable((<any>e1).distinct(selector)).toBe(expected, undefined, new Error('d is for dumb'));
+    expectObservable((<any>e1).pipe(distinct(selector))).toBe(expected, undefined, new Error('d is for dumb'));
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -171,7 +171,7 @@ describe('Observable.prototype.distinct', () => {
     const e2subs =   '^                   !';
     const expected = '--a--b--------a--b--|';
 
-    expectObservable((<any>e1).distinct(null, e2)).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null, e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -183,7 +183,7 @@ describe('Observable.prototype.distinct', () => {
     const e2subs =   '^            !';
     const expected = '--a--b-------#';
 
-    expectObservable((<any>e1).distinct(null, e2)).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null, e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -196,7 +196,7 @@ describe('Observable.prototype.distinct', () => {
     const unsub =    '           !         ';
     const expected = '--a--b------';
 
-    expectObservable((<any>e1).distinct(null, e2), unsub).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null, e2)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -208,7 +208,7 @@ describe('Observable.prototype.distinct', () => {
     const e2subs =   '^                   !';
     const expected = '--a--b--------a--b--|';
 
-    expectObservable((<any>e1).distinct(null, e2)).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null, e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });


### PR DESCRIPTION
update distinct spec to use updated import sites and pipeable operators