### PR TITLE
 chore(test): fix operator test types p-z

### DIFF
--- a/spec/helpers/marble-testing.ts
+++ b/spec/helpers/marble-testing.ts
@@ -7,8 +7,6 @@ import { observableToBeFn, subscriptionLogsToBeFn } from '../../src/internal/tes
 
 declare const global: any;
 
-export const rxTestScheduler: TestScheduler = global.rxTestScheduler;
-
 export const emptySubs: any[] = [];
 
 export function hot(marbles: string, values?: void, error?: any): HotObservable<string>;

--- a/spec/operators/partition-spec.ts
+++ b/spec/operators/partition-spec.ts
@@ -8,7 +8,7 @@ const Observable = Rx.Observable;
 
 /** @test {partition} */
 describe('Observable.prototype.partition', () => {
-  function expectObservableArray(result, expected) {
+  function expectObservableArray(result: Rx.Observable<string>[], expected: string[]) {
     for (let idx = 0; idx < result.length; idx++ ) {
       expectObservable(result[idx]).toBe(expected[idx]);
     }
@@ -33,7 +33,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----a---------a------|',
                     '----b----------d------c--|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -47,7 +47,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----a---------e------|',
                       '----b----------d------c--|'];
 
-    function predicate(value, index: number) {
+    function predicate(value: string, index: number) {
       return index % 2 === 0;
     }
 
@@ -61,7 +61,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----a---------a------|',
                     '----b----------d------c--|'];
 
-    function predicate(x) {
+    function predicate(this: any, x: string) {
       return x === this.value;
     }
 
@@ -75,7 +75,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----#',
                     '----b---#'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -89,7 +89,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['#',
                     '#'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -105,7 +105,7 @@ describe('Observable.prototype.partition', () => {
 
     let index = 0;
     const error = 'error';
-    function predicate(x) {
+    function predicate(x: string) {
       const match = x === 'a';
       if (match && index++ > 1) {
         throw error;
@@ -123,7 +123,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['----|',
                     '----|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'x';
     }
 
@@ -137,7 +137,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['|',
                     '|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'x';
     }
 
@@ -151,7 +151,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a--|',
                     '-----|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -165,7 +165,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a--a--a--a--a--a--a--|',
                     '-----------------------|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -179,7 +179,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['-----------------------|',
                     '--b--b--b--b--b--b--b--|'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -193,7 +193,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----a-----------',
                     '----b----------d----'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -207,7 +207,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['-',
                     '-'];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
 
@@ -222,7 +222,7 @@ describe('Observable.prototype.partition', () => {
     const expected = ['--a-----          ',
                     '----b---          '];
 
-    function predicate(x) {
+    function predicate(x: string) {
       return x === 'a';
     }
     const result = e1.partition(predicate);
@@ -254,7 +254,7 @@ describe('Observable.prototype.partition', () => {
   it('should accept thisArg', () => {
     const thisArg = {};
 
-    Observable.of(1).partition(function (value: number) {
+    Observable.of(1).partition(function (this: any, value: number) {
       expect(this).to.deep.equal(thisArg);
       return true;
     }, thisArg)

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -78,7 +78,7 @@ describe('Observable.prototype.pluck', () => {
     const a =   cold('--a-b--c-d---e-|', inputs);
     const asubs =    '^              !';
     const expected = '--r-x--y-z---w-|';
-    const values = {r: 1, x: undefined, y: undefined, z: undefined, w: 5};
+    const values: { [key: string]: number | undefined } = {r: 1, x: undefined, y: undefined, z: undefined, w: 5};
 
     const r = a.pluck('a', 'b', 'c');
     expectObservable(r).toBe(expected, values);
@@ -162,8 +162,8 @@ describe('Observable.prototype.pluck', () => {
     const expected = '--1--2-     ';
 
     const r = a
-      .mergeMap((x: string) => Observable.of(x))
-      .pluck('prop')
+      .mergeMap((x: { prop: string }) => Observable.of(x))
+      .pluck<{ prop: string }, string>('prop')
       .mergeMap((x: string) => Observable.of(x));
 
     expectObservable(r, unsub).toBe(expected);

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -498,13 +498,13 @@ describe('Observable.prototype.publishReplay', () => {
     /* tslint:enable:no-unused-variable */
   });
 
-  type('should infer the type for the pipeable operator', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of<number>(1, 2, 3);
-    // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: ConnectableObservable<number> = publishReplay<number>(1)(source);
-    /* tslint:enable:no-unused-variable */
-  });
+  // TODO: https://github.com/ReactiveX/rxjs/issues/2972
+  // type('should infer the type for the pipeable operator', () => {
+  //   /* tslint:disable:no-unused-variable */
+  //   const source = of<number>(1, 2, 3);
+  //   const result: ConnectableObservable<number> = publishReplay<number>(1)(source);
+  //   /* tslint:enable:no-unused-variable */
+  // });
 
   type('should infer the type for the pipeable operator with a selector', () => {
     /* tslint:disable:no-unused-variable */

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -17,7 +17,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =     '^          !';
     const expected =   '-----------(x|)';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: number, x: number) {
       return o + x;
     };
 
@@ -31,7 +31,7 @@ describe('Observable.prototype.reduce', () => {
     const expected =   '--------(x|)';
 
     const seed = 'n';
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -99,7 +99,7 @@ describe('Observable.prototype.reduce', () => {
     const expected =    '--------(x|)';
 
     const expectedValue = '42';
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -112,7 +112,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =     '^    !   ';
     const expected =   '-----#   ';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       throw 'error';
     };
 
@@ -126,7 +126,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =     '^     !  ';
     const expected =   '-------  ';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -142,7 +142,7 @@ describe('Observable.prototype.reduce', () => {
     const expected =   '-------  ';
     const unsub =      '      !  ';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -161,7 +161,7 @@ describe('Observable.prototype.reduce', () => {
     const expected = '--------#';
 
     const expectedValue = '42';
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -175,7 +175,7 @@ describe('Observable.prototype.reduce', () => {
     const expected = '----#';
 
     const expectedValue = '42';
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -189,7 +189,7 @@ describe('Observable.prototype.reduce', () => {
     const expected =   '--#     ';
 
     const seed = 'n';
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       throw 'error';
     };
 
@@ -203,7 +203,7 @@ describe('Observable.prototype.reduce', () => {
     const expected =   '-----';
 
     const seed = 'n';
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -217,7 +217,7 @@ describe('Observable.prototype.reduce', () => {
     const expected = '-';
 
     const seed = 'n';
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -230,7 +230,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =   '^       ';
     const expected = '--------';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -243,7 +243,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -256,7 +256,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =      '^       !';
     const expected =    '--------|';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -269,7 +269,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =   '^       !';
     const expected = '--------#';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -282,7 +282,7 @@ describe('Observable.prototype.reduce', () => {
     const e1subs =   '^   !';
     const expected = '----#';
 
-    const reduceFunction = function (o, x) {
+    const reduceFunction = function (o: string, x: string) {
       return o + x;
     };
 
@@ -338,7 +338,7 @@ describe('Observable.prototype.reduce', () => {
       value.a = acc.a;
       value.b = acc.b;
       return acc;
-    }, {});
+    }, {} as { a?: number; b?: string });
 
     reduced.subscribe(r => {
       r.a.toExponential();

--- a/spec/operators/repeat-spec.ts
+++ b/spec/operators/repeat-spec.ts
@@ -34,7 +34,7 @@ describe('Observable.prototype.repeat', () => {
 
   it('should complete without emit when count is zero', () => {
     const e1 =  cold('--a--b--|');
-    const subs = [];
+    const subs: string[] = [];
     const expected = '|';
 
     expectObservable(e1.repeat(0)).toBe(expected);
@@ -132,7 +132,7 @@ describe('Observable.prototype.repeat', () => {
 
   it('should complete immediately when source does not complete without emit but count is zero', () => {
     const e1 =  cold('-');
-    const subs = [];
+    const subs: string[] = [];
     const expected = '|';
 
     expectObservable(e1.repeat(0)).toBe(expected);
@@ -141,7 +141,7 @@ describe('Observable.prototype.repeat', () => {
 
   it('should complete immediately when source does not complete but count is zero', () => {
     const e1 =   cold('--a--b--');
-    const subs = [];
+    const subs: string[] = [];
     const expected = '|';
 
     expectObservable(e1.repeat(0)).toBe(expected);
@@ -179,7 +179,7 @@ describe('Observable.prototype.repeat', () => {
 
   it('should complete immediately when source does not emit but count is zero', () => {
     const e1 =  cold('----|');
-    const subs = [];
+    const subs: string[] = [];
     const expected = '|';
 
     expectObservable(e1.repeat(0)).toBe(expected);

--- a/spec/operators/sample-spec.ts
+++ b/spec/operators/sample-spec.ts
@@ -34,8 +34,8 @@ describe('Observable.prototype.sample', () => {
   });
 
   it('should behave properly when notified by the same observable as the source (issue #2075)', () => {
-    const item$ = new Rx.Subject();
-    const results = [];
+    const item$ = new Rx.Subject<number>();
+    const results: number[] = [];
 
     item$
       .sample(item$)

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -18,7 +18,7 @@ describe('Observable.prototype.scan', () => {
     const e1subs =     '^          !';
     const expected =   '--x--y--z--|';
 
-    const scanFunction = function (o, x) {
+    const scanFunction = function (o: number, x: number) {
       return o + x;
     };
 
@@ -195,7 +195,7 @@ describe('Observable.prototype.scan', () => {
     const source = e1
       .mergeMap((x: string) => Observable.of(x))
       .scan((acc: any, x: string) => [].concat(acc, x), [])
-      .mergeMap((x: string) => Observable.of(x));
+      .mergeMap((x: string[]) => Observable.of(x));
 
     expectObservable(source, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -236,7 +236,7 @@ describe('Observable.prototype.scan', () => {
       value.a = acc.a;
       value.b = acc.b;
       return acc;
-    }, {});
+    }, {} as { a?: number; b?: string });
   });
 
   type('should accept R typed reducers', () => {

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
+import { hot, cold, expectObservable, expectSubscriptions, time, rxTestScheduler } from '../helpers/marble-testing';
 
 declare const type: Function;
 declare const asDiagram: Function;
@@ -186,7 +186,7 @@ describe('Observable.prototype.sequenceEqual', () => {
       return a.value === b.value;
     });
 
-    const values = {
+    const values: { [key: string]: any } = {
       a: null,
       b: { value: 'bees knees' },
       c: { value: 'carpy dumb' },
@@ -210,7 +210,7 @@ describe('Observable.prototype.sequenceEqual', () => {
 
     const source = s1.sequenceEqual(s2, (a: any, b: any) => a.value === b.value);
 
-    const values = {
+    const values: { [key: string]: any } = {
       a: null,
       b: { value: 'bees knees' },
       c: { value: 'carpy dumb' },

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -1,8 +1,10 @@
 import * as _ from 'lodash';
-import { hot, cold, expectObservable, expectSubscriptions, time, rxTestScheduler } from '../helpers/marble-testing';
+import * as Rx from 'rxjs/Rx';
+import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
 
 declare const type: Function;
 declare const asDiagram: Function;
+declare const rxTestScheduler: Rx.TestScheduler;
 const booleans = { T: true, F: false };
 
 /** @test {sequenceEqual} */

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as Rx from 'rxjs/Rx';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { hot, cold, expectObservable, expectSubscriptions, rxTestScheduler } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
 
@@ -162,7 +162,7 @@ describe('Observable.prototype.shareReplay', () => {
   });
 
   it('should not restart if refCount hits 0 due to unsubscriptions', () => {
-    const results = [];
+    const results: number[] = [];
     const source = Rx.Observable.interval(10, rxTestScheduler)
       .take(10)
       .shareReplay(1);

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import * as Rx from 'rxjs/Rx';
-import { hot, cold, expectObservable, expectSubscriptions, rxTestScheduler } from '../helpers/marble-testing';
+import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
-
+declare const rxTestScheduler: Rx.TestScheduler;
 const Observable = Rx.Observable;
 
 /** @test {shareReplay} */

--- a/spec/operators/single-spec.ts
+++ b/spec/operators/single-spec.ts
@@ -74,7 +74,7 @@ describe('Observable.prototype.single', () => {
     const e1subs =          '^  !';
     const expected =        '---#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'c';
     };
 
@@ -87,7 +87,7 @@ describe('Observable.prototype.single', () => {
     const e1subs =    '^          !   ';
     const expected =  '-----------#   ';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       if (value !== 'd') {
         return false;
       }
@@ -103,7 +103,7 @@ describe('Observable.prototype.single', () => {
     const e1subs =    '^          !';
     const expected =  '-----------(b|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'b';
     };
 
@@ -116,7 +116,7 @@ describe('Observable.prototype.single', () => {
     const e1subs =    '^          !      ';
     const expected =  '-----------#      ';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'b';
     };
 
@@ -129,7 +129,7 @@ describe('Observable.prototype.single', () => {
     const e1subs =      '^  !';
     const expected =    '---#';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'a';
     };
 
@@ -142,7 +142,7 @@ describe('Observable.prototype.single', () => {
     const e1subs =    '^          !';
     const expected =  '-----------(z|)';
 
-    const predicate = function (value) {
+    const predicate = function (value: string) {
       return value === 'x';
     };
 
@@ -155,8 +155,8 @@ describe('Observable.prototype.single', () => {
     const e1subs =    '^          !';
     const expected =  '-----------(b|)';
 
-    let indices = [];
-    const predicate = function(value, index) {
+    let indices: number[] = [];
+    const predicate = function(value: string, index: number) {
       indices.push(index);
       return value === 'b';
     };

--- a/spec/operators/skipUntil-spec.ts
+++ b/spec/operators/skipUntil-spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { Observable, of, Subject } from 'rxjs';
 import { skipUntil, mergeMap } from 'rxjs/operators';

--- a/spec/operators/skipWhile-spec.ts
+++ b/spec/operators/skipWhile-spec.ts
@@ -13,7 +13,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =    '^               !';
     const expected =      '-------4--5--6--|';
 
-    const predicate = function (v) {
+    const predicate = function (v: string) {
       return +v < 4;
     };
 
@@ -62,7 +62,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =        '^                   ';
     const expected =          '--------5--6--7--8--';
 
-    const predicate = function (v) {
+    const predicate = function (v: string) {
       return +v < 5;
     };
 
@@ -75,7 +75,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =        '^                   !';
     const expected =          '--------e--f--g--h--|';
 
-    const predicate = function (v, index) {
+    const predicate = function (v: string, index: number) {
       return index < 2;
     };
 
@@ -89,7 +89,7 @@ describe('Observable.prototype.skipWhile', () => {
     const unsub =             '-----------!';
     const expected =          '-----d--e---';
 
-    const predicate = function (v, index) {
+    const predicate = function (v: string, index: number) {
       return index < 1;
     };
 
@@ -103,7 +103,7 @@ describe('Observable.prototype.skipWhile', () => {
     const expected =          '-----d--e---';
     const unsub =             '           !';
 
-    const predicate = function (v, index) {
+    const predicate = function (v: string, index: number) {
       return index < 1;
     };
 
@@ -121,7 +121,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =        '^                   !';
     const expected =          '-----d--e--f--g--h--#';
 
-    const predicate = function (v) {
+    const predicate = function (v: string) {
       return v !== 'd';
     };
 
@@ -135,7 +135,7 @@ describe('Observable.prototype.skipWhile', () => {
     const expected =          '--------e--f--g--h--|';
 
     let invoked = 0;
-    const predicate = function (v) {
+    const predicate = function (v: string) {
       invoked++;
       return v !== 'e';
     };
@@ -153,7 +153,7 @@ describe('Observable.prototype.skipWhile', () => {
     const sourceSubs =        '^       !';
     const expected =          '--------#';
 
-    const predicate = function (v) {
+    const predicate = function (v: string) {
       if (v === 'e') {
         throw new Error('nom d\'une pipe !');
       }

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -38,7 +38,7 @@ describe('Observable.prototype.take', () => {
 
   it('should be empty on take(0)', () => {
     const e1 = hot('--a--^--b----c---d--|');
-    const e1subs = []; // Don't subscribe at all
+    const e1subs: string[] = []; // Don't subscribe at all
     const expected =    '|';
 
     expectObservable(e1.take(0)).toBe(expected);
@@ -130,7 +130,7 @@ describe('Observable.prototype.take', () => {
   });
 
   it('should unsubscribe from the source when it reaches the limit', () => {
-    const source = Observable.create(observer => {
+    const source = new Observable<number>(observer => {
       expect(observer.closed).to.be.false;
       observer.next(42);
       expect(observer.closed).to.be.true;

--- a/spec/operators/takeLast-spec.ts
+++ b/spec/operators/takeLast-spec.ts
@@ -71,7 +71,7 @@ describe('Observable.prototype.takeLast', () => {
 
   it('should be empty on takeLast(0)', () => {
     const e1 = hot('--a--^--b----c---d--|');
-    const e1subs = []; // Don't subscribe at all
+    const e1subs: string[] = []; // Don't subscribe at all
     const expected =    '|';
 
     expectObservable(e1.takeLast(0)).toBe(expected);

--- a/spec/operators/takeWhile-spec.ts
+++ b/spec/operators/takeWhile-spec.ts
@@ -59,7 +59,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^       !      ';
     const expected =   '--b--c--|      ';
 
-    function predicate(value) {
+    function predicate(value: string) {
       return value !== 'd';
     }
 
@@ -112,7 +112,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^       !      ';
     const expected =   '--b--c--|      ';
 
-    function predicate(value, index) {
+    function predicate(value: string, index: number) {
       return index < 2;
     }
 
@@ -144,7 +144,7 @@ describe('Observable.prototype.takeWhile', () => {
     const expected =   '--b--c--|      ';
 
     let invoked = 0;
-    function predicate(value) {
+    function predicate(value: string) {
       invoked++;
       return value !== 'd';
     }
@@ -161,7 +161,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^ !            ';
     const expected =   '--#            ';
 
-    function predicate(value) {
+    function predicate(value: string) {
       throw 'error';
     }
 
@@ -175,7 +175,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^    !         ';
     const expected =   '--b---         ';
 
-    function predicate(value) {
+    function predicate(value: string) {
       return value !== 'd';
     }
 
@@ -189,7 +189,7 @@ describe('Observable.prototype.takeWhile', () => {
     const e1subs =     '^    !         ';
     const expected =   '--b---         ';
 
-    function predicate(value) {
+    function predicate(value: string) {
       return value !== 'd';
     }
 

--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as Rx from 'rxjs/Rx';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
-declare const type;
+declare const type: Function;
 declare function asDiagram(arg: string): Function;
 
 const Observable = Rx.Observable;

--- a/spec/operators/throttleTime-spec.ts
+++ b/spec/operators/throttleTime-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as Rx from 'rxjs/Rx';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
 

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -35,7 +35,7 @@ describe('Observable.prototype.timeout', () => {
     });
     rxTestScheduler.flush();
     expect(error).to.be.an.instanceof(Rx.TimeoutError);
-    expect(error.name).to.equal('TimeoutError');
+    expect(error).to.have.property('name', 'TimeoutError');
   });
 
   it('should not timeout if source completes within absolute timeout period', () => {

--- a/spec/operators/timeoutWith-spec.ts
+++ b/spec/operators/timeoutWith-spec.ts
@@ -88,7 +88,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e1 =  cold('---a------b------');
     const e1subs =   '^    !           ';
     const e2 =  cold(        'i---j---|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected = '---a--           ';
     const unsub =    '     !           ';
 
@@ -166,7 +166,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e1 =   hot('-----|');
     const e1subs =   '^    !';
     const e2 = cold(           '----x----');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected = '-----|';
 
     const result = e1.timeoutWith(100, e2, rxTestScheduler);
@@ -180,7 +180,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e1 =   hot('-----#');
     const e1subs =   '^    !';
     const e2 = cold(           '----x----|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected = '-----#';
 
     const result = e1.timeoutWith(100, e2, rxTestScheduler);
@@ -194,7 +194,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e1 =   hot('--a--b--c--d--e--|');
     const e1subs =   '^                !';
     const e2 =  cold('----x----|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected = '--a--b--c--d--e--|';
 
     const result = e1.timeoutWith(50, e2, rxTestScheduler);
@@ -222,7 +222,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e1 =   hot('--a--b--c--d--e--|');
     const e1subs =   '^                !';
     const e2 =  cold('--x--|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected = '--a--b--c--d--e--|';
 
     const timeoutValue = new Date(Date.now() + (expected.length + 2) * 10);
@@ -238,7 +238,7 @@ describe('Observable.prototype.timeoutWith', () => {
     const e1 =   hot('---a---#');
     const e1subs =   '^      !';
     const e2 =  cold('--x--|');
-    const e2subs = [];
+    const e2subs: string[] = [];
     const expected = '---a---#';
 
     const result = e1.timeoutWith(new Date(Date.now() + 100), e2, rxTestScheduler);

--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -1,8 +1,9 @@
 import * as Rx from 'rxjs/Rx';
-import { hot, cold, expectObservable, expectSubscriptions, rxTestScheduler, time } from '../helpers/marble-testing';
+import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
 
 declare const type: Function;
 declare const asDiagram: Function;
+declare const rxTestScheduler: Rx.TestScheduler;
 const Observable = Rx.Observable;
 
 /** @test {windowTime} */

--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -1,5 +1,5 @@
 import * as Rx from 'rxjs/Rx';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { hot, cold, expectObservable, expectSubscriptions, rxTestScheduler, time } from '../helpers/marble-testing';
 
 declare const type: Function;
 declare const asDiagram: Function;

--- a/spec/operators/withLatestFrom-spec.ts
+++ b/spec/operators/withLatestFrom-spec.ts
@@ -55,7 +55,7 @@ describe('Observable.prototype.withLatestFrom', () => {
       y: 'cgk',
       z: 'dhl'
     };
-    const project = function (a, b, c) { return a + b + c; };
+    const project = function (a: string, b: string, c: string) { return a + b + c; };
 
     const result = e1.withLatestFrom(e2, e3, project);
 
@@ -79,7 +79,7 @@ describe('Observable.prototype.withLatestFrom', () => {
       y: 'cgk',
       z: 'dhl'
     };
-    const project = function (a, b, c) { return a + b + c; };
+    const project = function (a: string, b: string, c: string) { return a + b + c; };
 
     const result = e1.withLatestFrom(e2, e3, project);
 
@@ -103,7 +103,7 @@ describe('Observable.prototype.withLatestFrom', () => {
       y: 'cgk',
       z: 'dhl'
     };
-    const project = function (a, b, c) { return a + b + c; };
+    const project = function (a: string, b: string, c: string) { return a + b + c; };
 
     const result = e1
       .mergeMap((x: string) => Observable.of(x))
@@ -198,7 +198,7 @@ describe('Observable.prototype.withLatestFrom', () => {
     const values = {
       x: 'bfj'
     };
-    const project = function (a, b, c) { return a + b + c; };
+    const project = function (a: string, b: string, c: string) { return a + b + c; };
 
     const result = e1.withLatestFrom(e2, e3, project);
 

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -41,6 +41,7 @@
     "./operators/r*.ts",
     "./operators/s*.ts",
     "./operators/s*.ts",
+    "./operators/t*.ts",
     /*"./operators/w*.ts",*/
     /*"./operators/z*.ts",*/
     "./symbol/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -42,7 +42,7 @@
     "./operators/s*.ts",
     "./operators/s*.ts",
     "./operators/t*.ts",
-    /*"./operators/w*.ts",*/
+    "./operators/w*.ts",
     /*"./operators/z*.ts",*/
     "./symbol/**/*.ts",
     "./testing/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -43,7 +43,7 @@
     "./operators/s*.ts",
     "./operators/t*.ts",
     "./operators/w*.ts",
-    /*"./operators/z*.ts",*/
+    "./operators/z*.ts",
     "./symbol/**/*.ts",
     "./testing/**/*.ts",
     "./util/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -38,7 +38,7 @@
     /*"./operators/m*.ts",*/
     /*"./operators/o*.ts",*/
     "./operators/p*.ts",
-    /*"./operators/r*.ts",*/
+    "./operators/r*.ts",
     /*"./operators/s*.ts",*/
     /*"./operators/s*.ts",*/
     /*"./operators/w*.ts",*/

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -39,8 +39,8 @@
     /*"./operators/o*.ts",*/
     "./operators/p*.ts",
     "./operators/r*.ts",
-    /*"./operators/s*.ts",*/
-    /*"./operators/s*.ts",*/
+    "./operators/s*.ts",
+    "./operators/s*.ts",
     /*"./operators/w*.ts",*/
     /*"./operators/z*.ts",*/
     "./symbol/**/*.ts",

--- a/spec/tsconfig.check.json
+++ b/spec/tsconfig.check.json
@@ -37,7 +37,7 @@
     /*"./operators/l*.ts",*/
     /*"./operators/m*.ts",*/
     /*"./operators/o*.ts",*/
-    /*"./operators/p*.ts",*/
+    "./operators/p*.ts",
     /*"./operators/r*.ts",*/
     /*"./operators/s*.ts",*/
     /*"./operators/s*.ts",*/


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Continues from PR #3680 and fixes operators tests for operators starting with `p` through to `z`.

**Related issue (if exists):** #3411 #3680