### PR TITLE
fix(typings): allow bufferCreationInterval null for bufferTime

### DIFF
--- a/compat/operator/bufferTime.ts
+++ b/compat/operator/bufferTime.ts
@@ -4,8 +4,8 @@ import { bufferTime as higherOrder } from 'rxjs/operators';
 
 /* tslint:disable:max-line-length */
 export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, scheduler?: SchedulerLike): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number | null, scheduler?: SchedulerLike): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number | null, maxBufferSize: number, scheduler?: SchedulerLike): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, scheduler?: SchedulerLike): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, maxBufferSize: number, scheduler?: SchedulerLike): Observable<T[]>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/compat/operator/bufferTime.ts
+++ b/compat/operator/bufferTime.ts
@@ -4,8 +4,8 @@ import { bufferTime as higherOrder } from 'rxjs/operators';
 
 /* tslint:disable:max-line-length */
 export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, scheduler?: SchedulerLike): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, scheduler?: SchedulerLike): Observable<T[]>;
-export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number, maxBufferSize: number, scheduler?: SchedulerLike): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number | null, scheduler?: SchedulerLike): Observable<T[]>;
+export function bufferTime<T>(this: Observable<T>, bufferTimeSpan: number, bufferCreationInterval: number | null, maxBufferSize: number, scheduler?: SchedulerLike): Observable<T[]>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -8,8 +8,8 @@ import { OperatorFunction, SchedulerAction, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
 export function bufferTime<T>(bufferTimeSpan: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
-export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
-export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null, maxBufferSize: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
+export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
+export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, maxBufferSize: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -8,8 +8,8 @@ import { OperatorFunction, SchedulerAction, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
 export function bufferTime<T>(bufferTimeSpan: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
-export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
-export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number, maxBufferSize: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
+export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
+export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null, maxBufferSize: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
 /* tslint:enable:max-line-length */
 
 /**


### PR DESCRIPTION
**Description:**

The tests for bufferTime verifies that it is possible to set
bufferCreationInterval to null, but the typings did not allow it
when strictNullChecks were set to true.

**Related issue (if exists):**

Fixes #3728