### PR TITLE
fix(subscribe): ignore syncError when deprecated

### DIFF
--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { of, throwError, EMPTY, from } from 'rxjs';
+import { concat, Observable, of, throwError, EMPTY, from } from 'rxjs';
 import { catchError, map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import * as sinon from 'sinon';
@@ -283,6 +283,21 @@ describe('catchError operator', () => {
     }, () => {
       done();
     });
+  });
+
+  it('should catch errors throw from within the constructor', () => {
+    // See https://github.com/ReactiveX/rxjs/issues/3740
+    const source = concat(
+      new Observable<string>(o => {
+        o.next('a');
+        throw 'kaboom';
+      }).pipe(
+        catchError(_ => of('b'))
+      ),
+      of('c')
+    );
+    const expected = '(abc|)';
+    expectObservable(source).toBe(expected);
   });
 
   context('fromPromise', () => {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -194,7 +194,11 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink.add(this.source || !sink.syncErrorThrowable ? this._subscribe(sink) : this._trySubscribe(sink));
+      sink.add(
+        this.source || (config.useDeprecatedSynchronousErrorHandling && !sink.syncErrorThrowable) ?
+        this._subscribe(sink) :
+        this._trySubscribe(sink)
+      );
     }
 
     if (config.useDeprecatedSynchronousErrorHandling) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing test and fixes the problem with the implementation of `subscribe` that sees the `catchError` operator bypassed in some circumstances.

This will fix the behaviour when `useDeprecatedSynchronousErrorHandling` is `false` - i.e. the default version 6 behaviour.

Elsewhere, the `syncErrorThrowable` flag has no meaning unless `useDeprecatedSynchronousErrorHandling` is `true`.

So, when `useDeprecatedSynchronousErrorHandling` is `false`, it makes no sense to consider `syncErrorThrowable` when deciding between a call to `_subscribe` or `_trySubscribe`.

Whether or not - as discussed in the related issue - a getter should be added to `InnerSubscriber` to attempt to fix the deprecated behaviour is another (more complicated) matter. And one that need not be relevant to this PR. As noted in [this comment](https://github.com/ReactiveX/rxjs/issues/3740#issuecomment-391936393), even with the getter added, the deprecated behaviour is still broken.

**Related issue (if exists):** #3740
