### PR TITLE
docs(issue): update issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,32 @@
+---
+name: Bug report
+about: If rxjs does not behave as expected
+
+---
+
+## Bug Report
+
+**Current Behavior**
+A clear and concise description of the behavior.
+
+**Reproduction**
+- REPL or Repo link:
+(you can use https://stackblitz.com/ to create one to attach here)
+
+```js
+var your => (code) => here;
+```
+
+**Expected behavior**
+A clear and concise description of what you expected to happen (or code).
+
+**Environment**
+- Runtime: [e.g. Node v${x}, Chrome v${x}]
+- RxJS version:
+- (If bug is related) Loader, build configuration: [e.g webpack, angular-cli version, config]
+
+**Possible Solution**
+<!--- Only if you have suggestions on a fix for the bug -->
+
+**Additional context/Screenshots**
+Add any other context about the problem here. If applicable, add screenshots to help explain.

--- a/.github/ISSUE_TEMPLATE/documentation.md
+++ b/.github/ISSUE_TEMPLATE/documentation.md
@@ -1,0 +1,7 @@
+---
+name: Documentation
+about: Issues around documentation
+
+---
+
+Please check out our documentation repo https://github.com/ReactiveX/rxjs-docs and file issues there.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest new operator or features
+
+---
+
+## Feature Request
+
+With pipable operator, RxJS strongly recommends to create new features via pipable function and publish it as user-land module. If this feature request is
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Describe alternatives you've considered**
+A clear and concise description of any alternative solutions or features you've considered.
+
+**(If this is new operator request) describe reason it should be core operator**
+A clear and concise description of reason it can't be achieved via user-land module.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -1,0 +1,14 @@
+---
+name: Support Question
+about: 'If you have a question, please check out our StackOverflow! '
+
+---
+
+We primarily use GitHub as an issue tracker; for usage and support questions, please check out these resources below. Thanks! 
+
+---
+* StackOverflow: https://stackoverflow.com/questions/tagged/rxjs using the tag `rxjs`
+* Also have a look at the readme for more information, possibly can have some answers already:
+- https://github.com/ReactiveX/rxjs/blob/master/README.md
+- https://github.com/ReactiveX/rxjs/blob/master/MIGRATION.md
+- https://github.com/ReactiveX/rxjs/blob/master/doc/pipeable-operators.md


### PR DESCRIPTION
This PR utilizes issue template feature from github, categorize templates based on cases. I've limited major category in 3 (bug / feature / support question, documentation is just let redirect) for now, while I was tempting to have one another category around `setup` (i.e loader, browser, framework config can't import rx correctly), not sure how much needed though.

Probably need to discuss to handle support questions separately (i.e still need to followup or either close it similar to other project like electron does), but for now template just suggest to check other places first.