### PR TITLE
fix(Symbol.observable): make observable declaration readonly (#3697)

### DIFF
--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -5,7 +5,7 @@ import { root } from '../util/root';
   however, we are no longer polyfilling Symbol.observable */
 declare global {
   interface SymbolConstructor {
-    observable: symbol;
+    readonly observable: symbol;
   }
 }
 


### PR DESCRIPTION
rxjs symbol declaration creates error when combined with other packages

closes #3697