### PR TITLE
docs: update jsdoc examples (operators e through z)

### DIFF
--- a/src/internal/operators/elementAt.ts
+++ b/src/internal/operators/elementAt.ts
@@ -25,8 +25,8 @@ import { take } from './take';
  * ## Example
  * Emit only the third click event
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.elementAt(2);
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(elementAt(2));
  * result.subscribe(x => console.log(x));
  *
  * // Results in:

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -9,9 +9,10 @@ import { Observer, OperatorFunction } from '../types';
  * ## Example
  * A simple example emitting true if all elements are less than 5, false otherwise
  * ```javascript
- *  Observable.of(1, 2, 3, 4, 5, 6)
- *     .every(x => x < 5)
- *     .subscribe(x => console.log(x)); // -> false
+ *  of(1, 2, 3, 4, 5, 6).pipe(
+ *     every(x => x < 5),
+ * )
+ * .subscribe(x => console.log(x)); // -> false
  * ```
  *
  * @param {function} predicate A function for determining if an item meets a specified condition.

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -29,9 +29,11 @@ export function exhaust<R>(): OperatorFunction<any, R>;
  * ## Example
  * Run a finite timer for each click, only if there is no currently active timer
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000).take(5));
- * var result = higherOrder.exhaust();
+ * const clicks = fromEvent(document, 'click');
+ * const higherOrder = clicks.pipe(
+ *   map((ev) => interval(1000).pipe(take(5))),
+ * );
+ * const result = higherOrder.pipe(exhaust());
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -38,8 +38,10 @@ export function exhaustMap<T, I, R>(project: (value: T, index: number) => Observ
  * ## Example
  * Run a finite timer for each click, only if there is no currently active timer
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000).take(5));
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   exhaustMap((ev) => interval(1000).pipe(take(5))),
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -37,11 +37,12 @@ export function expand<T>(project: (value: T, index: number) => ObservableInput<
  * ## Example
  * Start emitting the powers of two on every click, at most 10 of them
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var powersOfTwo = clicks
- *   .mapTo(1)
- *   .expand(x => Rx.Observable.of(2 * x).delay(1000))
- *   .take(10);
+ * const clicks = fromEvent(document, 'click');
+ * const powersOfTwo = clicks.pipe(
+ *   mapTo(1),
+ *   expand(x => of(2 * x).pipe(delay(1000))),
+ *   take(10),
+ * );
  * powersOfTwo.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -27,8 +27,8 @@ export function filter<T>(predicate: (value: T, index: number) => boolean,
  * ## Example
  * Emit only click events whose target was a DIV element
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var clicksOnDivs = clicks.filter(ev => ev.target.tagName === 'DIV');
+ * const clicks = fromEvent(document, 'click');
+ * const clicksOnDivs = clicks.pipe(filter(ev => ev.target.tagName === 'DIV'));
  * clicksOnDivs.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -28,8 +28,8 @@ export function find<T>(predicate: (value: T, index: number) => boolean,
  * ## Example
  * Find and emit the first click that happens on a DIV element
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.find(ev => ev.target.tagName === 'DIV');
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(find(ev => ev.target.tagName === 'DIV'));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -19,8 +19,8 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Emit the index of first click that happens on a DIV element
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.findIndex(ev => ev.target.tagName === 'DIV');
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(findIndex(ev => ev.target.tagName === 'DIV'));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -29,15 +29,15 @@ import { identity } from '../util/identity';
  * ## Examples
  * Emit only the first click that happens on the DOM
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.first();
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(first());
  * result.subscribe(x => console.log(x));
  * ```
  *
  * Emits the first click that happens on a DIV
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.first(ev => ev.target.tagName === 'DIV');
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(first(ev => ev.target.tagName === 'DIV'));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -22,18 +22,20 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  * ##Examples
  * Group objects by id and return as array
  * ```javascript
- * Observable.of<Obj>({id: 1, name: 'aze1'},
- *                    {id: 2, name: 'sf2'},
- *                    {id: 2, name: 'dg2'},
- *                    {id: 1, name: 'erg1'},
- *                    {id: 1, name: 'df1'},
- *                    {id: 2, name: 'sfqfb2'},
- *                    {id: 3, name: 'qfs3'},
- *                    {id: 2, name: 'qsgqsfg2'}
- *     )
- *     .groupBy(p => p.id)
- *     .flatMap( (group$) => group$.reduce((acc, cur) => [...acc, cur], []))
- *     .subscribe(p => console.log(p));
+ * of<Obj>(
+ *   {id: 1, name: 'aze1'},
+ *   {id: 2, name: 'sf2'},
+ *   {id: 2, name: 'dg2'},
+ *   {id: 1, name: 'erg1'},
+ *   {id: 1, name: 'df1'},
+ *   {id: 2, name: 'sfqfb2'},
+ *   {id: 3, name: 'qfs3'},
+ *   {id: 2, name: 'qsgqsfg2'},
+ * ).pipe(
+ *   groupBy(p => p.id),
+ *   flatMap((group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], []))),
+ * )
+ * .subscribe(p => console.log(p));
  *
  * // displays:
  * // [ { id: 1, name: 'aze1' },
@@ -50,19 +52,21 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  *
  * Pivot data on the id field
  * ```javascript
- * Observable.of<Obj>({id: 1, name: 'aze1'},
- *                    {id: 2, name: 'sf2'},
- *                    {id: 2, name: 'dg2'},
- *                    {id: 1, name: 'erg1'},
- *                    {id: 1, name: 'df1'},
- *                    {id: 2, name: 'sfqfb2'},
- *                    {id: 3, name: 'qfs1'},
- *                    {id: 2, name: 'qsgqsfg2'}
- *                   )
- *     .groupBy(p => p.id, p => p.name)
- *     .flatMap( (group$) => group$.reduce((acc, cur) => [...acc, cur], ["" + group$.key]))
- *     .map(arr => ({'id': parseInt(arr[0]), 'values': arr.slice(1)}))
- *     .subscribe(p => console.log(p));
+ * of<Obj>(
+ *   {id: 1, name: 'aze1'},
+ *   {id: 2, name: 'sf2'},
+ *   {id: 2, name: 'dg2'},
+ *   {id: 1, name: 'erg1'},
+ *   {id: 1, name: 'df1'},
+ *   {id: 2, name: 'sfqfb2'},
+ *   {id: 3, name: 'qfs1'},
+ *   {id: 2, name: 'qsgqsfg2'},
+ * ).pipe(
+ *   groupBy(p => p.id, p => p.name),
+ *   flatMap( (group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], ["" + group$.key]))),
+ *   map(arr => ({'id': parseInt(arr[0]), 'values': arr.slice(1)})),
+ * )
+ * .subscribe(p => console.log(p));
  *
  * // displays:
  * // { id: 1, values: [ 'aze1', 'erg1', 'df1' ] }

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -20,8 +20,8 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Map every click to the clientX position of that click
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var positions = clicks.map(ev => ev.clientX);
+ * const clicks = fromEvent(document, 'click');
+ * const positions = clicks.pipe(map(ev => ev.clientX));
  * positions.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -19,8 +19,8 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Map every click to the string 'Hi'
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var greetings = clicks.mapTo('Hi');
+ * const clicks = fromEvent(document, 'click');
+ * const greetings = clicks.pipe(mapTo('Hi'));
  * greetings.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -29,9 +29,9 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Convert a faulty Observable to an Observable of Notifications
  * ```javascript
- * var letters = Rx.Observable.of('a', 'b', 13, 'd');
- * var upperCase = letters.map(x => x.toUpperCase());
- * var materialized = upperCase.materialize();
+ * const letters = of('a', 'b', 13, 'd');
+ * const upperCase = letters.pipe(map(x => x.toUpperCase()));
+ * const materialized = upperCase.pipe(materialize());
  * materialized.subscribe(x => console.log(x));
  *
  * // Results in the following:

--- a/src/internal/operators/max.ts
+++ b/src/internal/operators/max.ts
@@ -10,9 +10,10 @@ import { MonoTypeOperatorFunction } from '../types';
  * ## Examples
  * Get the maximal value of a series of numbers
  * ```javascript
- * Rx.Observable.of(5, 4, 7, 2, 8)
- *   .max()
- *   .subscribe(x => console.log(x)); // -> 8
+ * of(5, 4, 7, 2, 8).pipe(
+ *   max(),
+ * )
+ * .subscribe(x => console.log(x)); // -> 8
  * ```
  *
  * Use a comparer function to get the maximal item
@@ -21,12 +22,14 @@ import { MonoTypeOperatorFunction } from '../types';
  *   age: number,
  *   name: string
  * }
- * Observable.of<Person>({age: 7, name: 'Foo'},
- *                       {age: 5, name: 'Bar'},
- *                       {age: 9, name: 'Beer'})
- *           .max<Person>((a: Person, b: Person) => a.age < b.age ? -1 : 1)
- *           .subscribe((x: Person) => console.log(x.name)); // -> 'Beer'
- * }
+ * of<Person>(
+ *   {age: 7, name: 'Foo'},
+ *   {age: 5, name: 'Bar'},
+ *   {age: 9, name: 'Beer'},
+ * ).pipe(
+ *   max<Person>((a: Person, b: Person) => a.age < b.age ? -1 : 1),
+ * )
+ * .subscribe((x: Person) => console.log(x.name)); // -> 'Beer'
  * ```
  *
  * @see {@link min}

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -23,17 +23,19 @@ export function mergeAll<T>(concurrent?: number): OperatorFunction<ObservableInp
  * ## Examples
  * Spawn a new interval Observable for each click event, and blend their outputs as one Observable
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000));
- * var firstOrder = higherOrder.mergeAll();
+ * const clicks = fromEvent(document, 'click');
+ * const higherOrder = clicks.pipe(map((ev) => interval(1000)));
+ * const firstOrder = higherOrder.pipe(mergeAll());
  * firstOrder.subscribe(x => console.log(x));
  * ```
  *
  * Count from 0 to 9 every second for each click, but only allow 2 concurrent timers
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000).take(10));
- * var firstOrder = higherOrder.mergeAll(2);
+ * const clicks = fromEvent(document, 'click');
+ * const higherOrder = clicks.pipe(
+ *   map((ev) => interval(1000).pipe(take(10))),
+ * );
+ * const firstOrder = higherOrder.pipe(mergeAll(2));
  * firstOrder.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -34,9 +34,9 @@ export function mergeMap<T, I, R>(project: (value: T, index: number) => Observab
  * ## Example
  * Map and flatten each letter to an Observable ticking every 1 second
  * ```javascript
- * var letters = Rx.Observable.of('a', 'b', 'c');
- * var result = letters.mergeMap(x =>
- *   Rx.Observable.interval(1000).map(i => x+i)
+ * const letters = of('a', 'b', 'c');
+ * const result = letters.pipe(
+ *   mergeMap(x => interval(1000).pipe(map(i => x+i))),
  * );
  * result.subscribe(x => console.log(x));
  *

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -25,8 +25,8 @@ export function mergeMapTo<T, I, R>(innerObservable: ObservableInput<I>, resultS
  * ## Example
  * For each click event, start an interval Observable ticking every 1 second
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.mergeMapTo(Rx.Observable.interval(1000));
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(mergeMapTo(interval(1000)));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -20,10 +20,12 @@ import { ObservableInput, OperatorFunction } from '../types';
  * ## Example
  * Count the number of click events
  * ```javascript
- * const click$ = Rx.Observable.fromEvent(document, 'click');
- * const one$ = click$.mapTo(1);
+ * const click$ = fromEvent(document, 'click');
+ * const one$ = click$.pipe(mapTo(1));
  * const seed = 0;
- * const count$ = one$.mergeScan((acc, one) => Rx.Observable.of(acc + one), seed);
+ * const count$ = one$.pipe(
+ *   mergeScan((acc, one) => of(acc + one), seed),
+ * );
  * count$.subscribe(x => console.log(x));
  *
  * // Results:

--- a/src/internal/operators/min.ts
+++ b/src/internal/operators/min.ts
@@ -10,9 +10,10 @@ import { MonoTypeOperatorFunction } from '../types';
  * ## Examples
  * Get the minimal value of a series of numbers
  * ```javascript
- * Rx.Observable.of(5, 4, 7, 2, 8)
- *   .min()
- *   .subscribe(x => console.log(x)); // -> 2
+ * of(5, 4, 7, 2, 8).pipe(
+ *   min(),
+ * )
+ * .subscribe(x => console.log(x)); // -> 2
  * ```
  *
  * Use a comparer function to get the minimal item
@@ -21,14 +22,15 @@ import { MonoTypeOperatorFunction } from '../types';
  *   age: number,
  *   name: string
  * }
- * Observable.of<Person>({age: 7, name: 'Foo'},
- *                       {age: 5, name: 'Bar'},
- *                       {age: 9, name: 'Beer'})
- *           .min<Person>( (a: Person, b: Person) => a.age < b.age ? -1 : 1)
- *           .subscribe((x: Person) => console.log(x.name)); // -> 'Bar'
- * }
+ * of<Person>(
+ *   {age: 7, name: 'Foo'},
+ *   {age: 5, name: 'Bar'},
+ *   {age: 9, name: 'Beer'},
+ * ).pipe(
+ *   min<Person>( (a: Person, b: Person) => a.age < b.age ? -1 : 1),
+ * )
+ * .subscribe((x: Person) => console.log(x.name)); // -> 'Bar'
  * ```
- *
  * @see {@link max}
  *
  * @param {Function} [comparer] - Optional comparer function that it will use instead of its default to compare the

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -33,12 +33,12 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  * ## Example
  * Ensure values in subscribe are called just before browser repaint.
  * ```javascript
- * const intervals = Rx.Observable.interval(10); // Intervals are scheduled
- *                                               // with async scheduler by default...
- *
- * intervals
- * .observeOn(Rx.Scheduler.animationFrame)       // ...but we will observe on animationFrame
- * .subscribe(val => {                           // scheduler to ensure smooth animation.
+ * const intervals = interval(10);                // Intervals are scheduled
+ *                                                // with async scheduler by default...
+ * intervals.pipe(
+ *   observeOn(animationFrameScheduler),          // ...but we will observe on animationFrame
+ * )                                              // scheduler to ensure smooth animation.
+ * .subscribe(val => {
  *   someDiv.style.height = val + 'px';
  * });
  * ```

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -51,17 +51,18 @@ export function onErrorResumeNext<T, R>(array: ObservableInput<any>[]): Operator
  * ## Example
  * Subscribe to the next Observable after map fails
  * ```javascript
- * Rx.Observable.of(1, 2, 3, 0)
- *   .map(x => {
+ * of(1, 2, 3, 0).pipe(
+ *   map(x => {
  *       if (x === 0) { throw Error(); }
          return 10 / x;
- *   })
- *   .onErrorResumeNext(Rx.Observable.of(1, 2, 3))
- *   .subscribe(
- *     val => console.log(val),
- *     err => console.log(err),          // Will never be called.
- *     () => console.log('that\'s it!')
- *   );
+ *   }),
+ *   onErrorResumeNext(of(1, 2, 3)),
+ * )
+ * .subscribe(
+ *   val => console.log(val),
+ *   err => console.log(err),          // Will never be called.
+ *   () => console.log('that\'s it!')
+ * );
  *
  * // Logs:
  * // 10

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -21,15 +21,17 @@ import { OperatorFunction } from '../types';
  * ## Example
  * On every click (starting from the second), emit the relative distance to the previous click
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var pairs = clicks.pairwise();
- * var distance = pairs.map(pair => {
- *   var x0 = pair[0].clientX;
- *   var y0 = pair[0].clientY;
- *   var x1 = pair[1].clientX;
- *   var y1 = pair[1].clientY;
- *   return Math.sqrt(Math.pow(x0 - x1, 2) + Math.pow(y0 - y1, 2));
- * });
+ * const clicks = fromEvent(document, 'click');
+ * const pairs = clicks.pipe(pairwise());
+ * const distance = pairs.pipe(
+ *   map(pair => {
+ *     const x0 = pair[0].clientX;
+ *     const y0 = pair[0].clientY;
+ *     const x1 = pair[1].clientX;
+ *     const y1 = pair[1].clientY;
+ *     return Math.sqrt(Math.pow(x0 - x1, 2) + Math.pow(y0 - y1, 2));
+ *   }),
+ * );
  * distance.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/partition.ts
+++ b/src/internal/operators/partition.ts
@@ -23,10 +23,10 @@ import { UnaryFunction } from '../types';
  * ## Example
  * Partition click events into those on DIV elements and those elsewhere
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var parts = clicks.partition(ev => ev.target.tagName === 'DIV');
- * var clicksOnDivs = parts[0];
- * var clicksElsewhere = parts[1];
+ * const clicks = fromEvent(document, 'click');
+ * const parts = clicks.pipe(partition(ev => ev.target.tagName === 'DIV'));
+ * const clicksOnDivs = parts[0];
+ * const clicksElsewhere = parts[1];
  * clicksOnDivs.subscribe(x => console.log('DIV clicked: ', x));
  * clicksElsewhere.subscribe(x => console.log('Other clicked: ', x));
  * ```

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -18,8 +18,8 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Map every click to the tagName of the clicked target element
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var tagNames = clicks.pluck('target', 'tagName');
+ * const clicks = fromEvent(document, 'click');
+ * const tagNames = clicks.pipe(pluck('target', 'tagName'));
  * tagNames.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/reduce.ts
+++ b/src/internal/operators/reduce.ts
@@ -37,11 +37,12 @@ export function reduce<T, R>(accumulator: (acc: R, value: T, index: number) => R
  * ## Example
  * Count the number of click events that happened in 5 seconds
  * ```javascript
- * var clicksInFiveSeconds = Rx.Observable.fromEvent(document, 'click')
- *   .takeUntil(Rx.Observable.interval(5000));
- * var ones = clicksInFiveSeconds.mapTo(1);
- * var seed = 0;
- * var count = ones.reduce((acc, one) => acc + one, seed);
+ * const clicksInFiveSeconds = fromEvent(document, 'click').pipe(
+ *   takeUntil(interval(5000)),
+ * );
+ * const ones = clicksInFiveSeconds.pipe(mapTo(1));
+ * const seed = 0;
+ * const count = ones.reduce((acc, one) => acc + one, seed);
  * count.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -69,11 +69,12 @@ class RefCountSubscriber<T> extends Subscriber<T> {
     // supply the RefCountSubscriber with the shared connection Subscription.
     // For example:
     // ```
-    // Observable.range(0, 10)
-    //   .publish()
-    //   .refCount()
-    //   .take(5)
-    //   .subscribe();
+    // range(0, 10).pipe(
+    //   publish(),
+    //   refCount(),
+    //   take(5),
+    // )
+    // .subscribe();
     // ```
     // In order to account for this case, RefCountSubscriber should only dispose
     // the ConnectableObservable's shared connection Subscription if the

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -25,9 +25,9 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * On every click, sample the most recent "seconds" timer
  * ```javascript
- * var seconds = Rx.Observable.interval(1000);
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = seconds.sample(clicks);
+ * const seconds = interval(1000);
+ * const clicks = fromEvent(document, 'click');
+ * const result = seconds.pipe(sample(clicks));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -23,8 +23,8 @@ import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic
  * ## Example
  * Every second, emit the most recent click at most once
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.sampleTime(1000);
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(sampleTime(1000));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -31,10 +31,10 @@ export function scan<T, R>(accumulator: (acc: R, value: T, index: number) => R, 
  * ## Example
  * Count the number of click events
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var ones = clicks.mapTo(1);
- * var seed = 0;
- * var count = ones.scan((acc, one) => acc + one, seed);
+ * const clicks = fromEvent(document, 'click');
+ * const ones = clicks.pipe(mapTo(1));
+ * const seed = 0;
+ * const count = ones.pipe(scan((acc, one) => acc + one, seed));
  * count.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -25,28 +25,27 @@ import { Observer, OperatorFunction } from '../types';
  * ## Example
  * figure out if the Konami code matches
  * ```javascript
- * var code = Rx.Observable.from([
- *  "ArrowUp",
- *  "ArrowUp",
- *  "ArrowDown",
- *  "ArrowDown",
- *  "ArrowLeft",
- *  "ArrowRight",
- *  "ArrowLeft",
- *  "ArrowRight",
- *  "KeyB",
- *  "KeyA",
- *  "Enter" // no start key, clearly.
+ * const codes = from([
+ *   'ArrowUp',
+ *   'ArrowUp',
+ *   'ArrowDown',
+ *   'ArrowDown',
+ *   'ArrowLeft',
+ *   'ArrowRight',
+ *   'ArrowLeft',
+ *   'ArrowRight',
+ *   'KeyB',
+ *   'KeyA',
+ *   'Enter', // no start key, clearly.
  * ]);
  *
- * var keys = Rx.Observable.fromEvent(document, 'keyup')
- *  .map(e => e.code);
- * var matches = keys.bufferCount(11, 1)
- *  .mergeMap(
- *    last11 =>
- *      Rx.Observable.from(last11)
- *        .sequenceEqual(code)
- *   );
+ * const keys = fromEvent(document, 'keyup').pipe(map(e => e.code));
+ * const matches = keys.pipe(
+ *   bufferCount(11, 1),
+ *   mergeMap(
+ *     last11 => from(last11).pipe(sequenceEqual(codes)),
+ *   ),
+ * );
  * matches.subscribe(matched => console.log('Successful cheat at Contra? ', matched));
  * ```
  *

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -13,7 +13,7 @@ function shareSubjectFactory() {
  * Returns a new Observable that multicasts (shares) the original Observable. As long as there is at least one
  * Subscriber this Observable will be subscribed and emitting data. When all subscribers have unsubscribed it will
  * unsubscribe from the source Observable. Because the Observable is multicasting it makes the stream `hot`.
- * This is an alias for .multicast(() => new Subject()).refCount().
+ * This is an alias for `multicast(() => new Subject()), refCount()`.
  *
  * <img src="./img/share.png" width="100%">
  *

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -17,8 +17,8 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Skip the last 2 values of an Observable with many values
  * ```javascript
- * var many = Rx.Observable.range(1, 5);
- * var skipLastTwo = many.skipLast(2);
+ * const many = range(1, 5);
+ * const skipLastTwo = many.pipe(skipLast(2));
  * skipLastTwo.subscribe(x => console.log(x));
  *
  * // Results in:

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -38,8 +38,8 @@ export function switchMap<T, I, R>(project: (value: T, index: number) => Observa
  * ## Example
  * Rerun an interval Observable on every click event
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.switchMap((ev) => Rx.Observable.interval(1000));
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(switchMap((ev) => interval(1000)));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -34,8 +34,8 @@ export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * ## Example
  * Rerun an interval Observable on every click event
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.switchMapTo(Rx.Observable.interval(1000));
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(switchMapTo(interval(1000)));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -21,8 +21,8 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Take the first 5 seconds of an infinite 1-second interval Observable
  * ```javascript
- * var interval = Rx.Observable.interval(1000);
- * var five = interval.take(5);
+ * const interval = interval(1000);
+ * const five = interval.pipe(take(5));
  * five.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -24,8 +24,8 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Take the last 3 values of an Observable with many values
  * ```javascript
- * var many = Rx.Observable.range(1, 100);
- * var lastThree = many.pipe(takeLast(3));
+ * const many = range(1, 100);
+ * const lastThree = many.pipe(takeLast(3));
  * lastThree.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -26,9 +26,9 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Tick every second until the first click happens
  * ```javascript
- * var interval = Rx.Observable.interval(1000);
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = interval.takeUntil(clicks);
+ * const interval = interval(1000);
+ * const clicks = fromEvent(document, 'click');
+ * const result = interval.pipe(takeUntil(clicks));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -23,8 +23,8 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Emit click events only while the clientX property is greater than 200
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.takeWhile(ev => ev.clientX > 200);
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(takeWhile(ev => ev.clientX > 200));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -29,17 +29,18 @@ export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T
  * or performing other side effects.
  *
  * Note: this is different to a `subscribe` on the Observable. If the Observable
- * returned by `do` is not subscribed, the side effects specified by the
- * Observer will never happen. `do` therefore simply spies on existing
+ * returned by `tap` is not subscribed, the side effects specified by the
+ * Observer will never happen. `tap` therefore simply spies on existing
  * execution, it does not trigger an execution to happen like `subscribe` does.
  *
  * ## Example
  * Map every click to the clientX position of that click, while also logging the click event
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var positions = clicks
- *   .do(ev => console.log(ev))
- *   .map(ev => ev.clientX);
+ * const clicks = fromEvent(document, 'click');
+ * const positions = clicks.pipe(
+ *   tap(ev => console.log(ev)),
+ *   map(ev => ev.clientX),
+ * );
  * positions.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -41,8 +41,8 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * ## Example
  * Emit clicks at a rate of at most one click per second
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.throttle(ev => Rx.Observable.interval(1000));
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(throttle(ev => interval(1000)));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -27,8 +27,8 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * ## Example
  * Emit clicks at a rate of at most one click per second
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.throttleTime(1000);
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(throttleTime(1000));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -40,32 +40,35 @@ import { throwError } from '../observable/throwError';
  * ## Examples
  * Check if ticks are emitted within certain timespan
  * ```javascript
- * const seconds = Rx.Observable.interval(1000);
+ * const seconds = interval(1000);
  *
- * seconds.timeout(1100) // Let's use bigger timespan to be safe,
- *                       // since `interval` might fire a bit later then scheduled.
+ * seconds.pipe(timeout(1100))      // Let's use bigger timespan to be safe,
+ *                                  // since `interval` might fire a bit later then scheduled.
  * .subscribe(
  *     value => console.log(value), // Will emit numbers just as regular `interval` would.
- *     err => console.log(err) // Will never be called.
+ *     err => console.log(err),     // Will never be called.
  * );
  *
- * seconds.timeout(900).subscribe(
+ * seconds.pipe(timeout(900))
+ * .subscribe(
  *     value => console.log(value), // Will never be called.
- *     err => console.log(err) // Will emit error before even first value is emitted,
- *                             // since it did not arrive within 900ms period.
+ *     err => console.log(err),     // Will emit error before even first value is emitted,
+ *                                  // since it did not arrive within 900ms period.
  * );
  * ```
  *
  * Use Date to check if Observable completed
  * ```javascript
- * const seconds = Rx.Observable.interval(1000);
+ * const seconds = interval(1000);
  *
- * seconds.timeout(new Date("December 17, 2020 03:24:00"))
+ * seconds.pipe(
+ *   timeout(new Date("December 17, 2020 03:24:00")),
+ * )
  * .subscribe(
  *     value => console.log(value), // Will emit values as regular `interval` would
  *                                  // until December 17, 2020 at 03:24:00.
- *     err => console.log(err) // On December 17, 2020 at 03:24:00 it will emit an error,
- *                             // since Observable did not complete by then.
+ *     err => console.log(err)      // On December 17, 2020 at 03:24:00 it will emit an error,
+ *                                  // since Observable did not complete by then.
  * );
  * ```
  * @see {@link timeoutWith}

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -40,16 +40,16 @@ export function timeoutWith<T, R>(due: number | Date, withObservable: Observable
  * ## Example
  * Add fallback observable
  * ```javascript
- * const seconds = Rx.Observable.interval(1000);
- * const minutes = Rx.Observable.interval(60 * 1000);
+ * const seconds = interval(1000);
+ * const minutes = interval(60 * 1000);
  *
- * seconds.timeoutWith(900, minutes)
- *     .subscribe(
- *         value => console.log(value), // After 900ms, will start emitting `minutes`,
- *                                      // since first value of `seconds` will not arrive fast enough.
- *         err => console.log(err) // Would be called after 900ms in case of `timeout`,
- *                                 // but here will never be called.
- *     );
+ * seconds.pipe(timeoutWith(900, minutes))
+ *   .subscribe(
+ *     value => console.log(value), // After 900ms, will start emitting `minutes`,
+ *                                  // since first value of `seconds` will not arrive fast enough.
+ *     err => console.log(err),     // Would be called after 900ms in case of `timeout`,
+ *                                  // but here will never be called.
+ *   );
  * ```
  *
  * @param {number|Date} due Number specifying period within which Observable must emit values

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -25,11 +25,13 @@ import { Operator } from '../Operator';
  * ## Example
  * In every window of 1 second each, emit at most 2 click events
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var interval = Rx.Observable.interval(1000);
- * var result = clicks.window(interval)
- *   .map(win => win.take(2)) // each window has at most 2 emissions
- *   .mergeAll(); // flatten the Observable-of-Observables
+ * const clicks = fromEvent(document, 'click');
+ * const interval = interval(1000);
+ * const result = clicks.pipe(
+ *   window(interval),
+ *   map(win => win.take(2)), // each window has at most 2 emissions
+ *   mergeAll(),              // flatten the Observable-of-Observables
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  * @see {@link windowCount}

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -25,18 +25,22 @@ import { OperatorFunction } from '../types';
  * ## Examples
  * Ignore every 3rd click event, starting from the first one
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.windowCount(3)
- *   .map(win => win.skip(1)) // skip first of every 3 clicks
- *   .mergeAll(); // flatten the Observable-of-Observables
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   windowCount(3)),
+ *   map(win => win.skip(1)), // skip first of every 3 clicks
+ *   mergeAll(),              // flatten the Observable-of-Observables
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *
  * Ignore every 3rd click event, starting from the third one
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.windowCount(2, 3)
- *   .mergeAll(); // flatten the Observable-of-Observables
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   windowCount(2, 3),
+ *   mergeAll(),              // flatten the Observable-of-Observables
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -33,27 +33,33 @@ import { OperatorFunction, SchedulerLike, SchedulerAction } from '../types';
  * ## Examples
  * In every window of 1 second each, emit at most 2 click events
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.windowTime(1000)
- *   .map(win => win.take(2)) // each window has at most 2 emissions
- *   .mergeAll(); // flatten the Observable-of-Observables
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   windowTime(1000),
+ *   map(win => win.take(2)),   // each window has at most 2 emissions
+ *   mergeAll(),                // flatten the Observable-of-Observables
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *
  * Every 5 seconds start a window 1 second long, and emit at most 2 click events per window
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.windowTime(1000, 5000)
- *   .map(win => win.take(2)) // each window has at most 2 emissions
- *   .mergeAll(); // flatten the Observable-of-Observables
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   windowTime(1000, 5000),
+ *   map(win => win.take(2)),   // each window has at most 2 emissions
+ *   mergeAll(),                // flatten the Observable-of-Observables
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *
  * Same as example above but with maxWindowCount instead of take
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks.windowTime(1000, 5000, 2) // each window has still at most 2 emissions
- *   .mergeAll(); // flatten the Observable-of-Observables
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   windowTime(1000, 5000, 2), // each window has still at most 2 emissions
+ *   mergeAll(),                // flatten the Observable-of-Observables
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -29,11 +29,12 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Every other second, emit the click events from the next 500ms
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var openings = Rx.Observable.interval(1000);
- * var result = clicks.windowToggle(openings, i =>
- *   i % 2 ? Rx.Observable.interval(500) : Rx.Observable.empty()
- * ).mergeAll();
+ * const clicks = fromEvent(document, 'click');
+ * const openings = interval(1000);
+ * const result = clicks.pipe(
+ *   windowToggle(openings, i => i % 2 ? interval(500) : empty()),
+ *   mergeAll(),
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -29,11 +29,12 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Emit only the first two clicks events in every window of [1-5] random seconds
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var result = clicks
- *   .windowWhen(() => Rx.Observable.interval(1000 + Math.random() * 4000))
- *   .map(win => win.take(2)) // each window has at most 2 emissions
- *   .mergeAll(); // flatten the Observable-of-Observables
+ * const clicks = fromEvent(document, 'click');
+ * const result = clicks.pipe(
+ *   windowWhen(() => interval(1000 + Math.random() * 4000)),
+ *   map(win => win.pipe(take(2))),     // each window has at most 2 emissions
+ *   mergeAll(),                        // flatten the Observable-of-Observables
+ * );
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -43,9 +43,9 @@ export function withLatestFrom<T, R>(array: ObservableInput<any>[], project: (..
  * ## Example
  * On every click event, emit an array with the latest timer event plus the click event
  * ```javascript
- * var clicks = Rx.Observable.fromEvent(document, 'click');
- * var timer = Rx.Observable.interval(1000);
- * var result = clicks.withLatestFrom(timer);
+ * const clicks = fromEvent(document, 'click');
+ * const timer = interval(1000);
+ * const result = clicks.pipe(withLatestFrom(timer));
  * result.subscribe(x => console.log(x));
  * ```
  *
@@ -56,7 +56,7 @@ export function withLatestFrom<T, R>(array: ObservableInput<any>[], project: (..
  * @param {Function} [project] Projection function for combining values
  * together. Receives all values in order of the Observables passed, where the
  * first parameter is a value from the source Observable. (e.g.
- * `a.withLatestFrom(b, c, (a1, b1, c1) => a1 + b1 + c1)`). If this is not
+ * `a.pipe(withLatestFrom(b, c), map(([a1, b1, c1]) => a1 + b1 + c1))`). If this is not
  * passed, arrays will be emitted on the output Observable.
  * @return {Observable} An Observable of projected values from the most recent
  * values from each input Observable, or an array of the most recent values from


### PR DESCRIPTION
**Description:** Continuation of #3768 - jsdoc examples: new pipe syntax (remaining operators)
**Related issue (if exists):** #3768

Noticed and not sure about:
- observeOn - `observeOn(Rx.Scheduler.animationFrame),` - is `animationFrame` a creation method, just like `fromEvent`? never used it before.
- some operators are still missing their examples (eg. `endsWith`, `repeat`, `race`)
- do/tap operator - is the do.png link still valid?
- share.ts: `.multicast(() => new Subject()).refCount()` - should this be changed to:
  `.pipe(multicast(() => new Subject()), refCount())` ?
- withLatestFrom - uses chaining + result selector in the description. The description might require a complete makeover though: * `a.withLatestFrom(b, c, (a1, b1, c1) => a1 + b1 + c1)`).

Code style:
- callbacks - single untyped parameters might do without parens around it - example would gain on readability where there is a lot of parens floating around (eg. `groupBy`)
- some examples (eg. `groupBy`) use Finnish notation for streams. Even though it is my personal preference as well in apps, I think it is not necessary in short examples. Unless there is a deeper reason behind that I am unaware of.