### PR TITLE
build(docs): remove docs app from published node modules

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,3 +4,4 @@ spec
 yarn.lock
 coverage
 typings/
+docs_app


### PR DESCRIPTION
Due to the publish.sh the docs-app shouldn't published within the rxjs node module. But to ensure that I think it is a good idea to add the docs-app folder to the .npmignore file.