### PR TITLE
docs(contributing): add guideline not to overwrite commit history

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,8 @@ Before you submit your Pull Request (PR) consider the following guidelines:
     git push -f
     ```
 
+  * When updating your feature branch with the requested changes, please do not overwrite the commit history, but rather contain the changes in new commits. This is for the sake of a clearer and easier review process.
+
 That's it! Thank you for your contribution!
 
 


### PR DESCRIPTION
**Description:**
Based on a conversation with @cartant during my first PR, it turned out that squashing commits containing the requested changes - even though it has the purpose of making the git history clean - makes the github review flow unclear. The original commits appear with annotation of being "outdated", and the PR author is not confident whether the comments they see pertain to the original or updated commits.

My understanding then is that the practice should be to append new commits, thus keeping the history of the feature branch linear and the flow clear. Therefore, I am updating the guidelines in CONTRIBUTING.md with an appropriate info.