### PR TITLE
fix(docs): fix code examples

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -110,7 +110,9 @@ export class Observable<T> implements Subscribable<T> {
    * by default emits all its values synchronously. Always check documentation for how given Observable
    * will behave when subscribed and if its default behavior can be modified with a {@link Scheduler}.
    *
-   * @example <caption>Subscribe with an Observer</caption>
+   * ## Example
+   * ### Subscribe with an Observer
+   * ```javascript
    * const sumObserver = {
    *   sum: 0,
    *   next(value) {
@@ -132,9 +134,10 @@ export class Observable<T> implements Subscribable<T> {
    * // "Adding: 2"
    * // "Adding: 3"
    * // "Sum equals: 6"
+   * ```
    *
-   *
-   * @example <caption>Subscribe with functions</caption>
+   * ### Subscribe with functions
+   * ```javascript
    * let sum = 0;
    *
    * Rx.Observable.of(1, 2, 3)
@@ -154,9 +157,10 @@ export class Observable<T> implements Subscribable<T> {
    * // "Adding: 2"
    * // "Adding: 3"
    * // "Sum equals: 6"
+   * ```
    *
-   *
-   * @example <caption>Cancel a subscription</caption>
+   * ### Cancel a subscription
+   * ```javascript
    * const subscription = Rx.Observable.interval(1000).subscribe(
    *   num => console.log(num),
    *   undefined,
@@ -173,7 +177,7 @@ export class Observable<T> implements Subscribable<T> {
    * // 0 after 1s
    * // 1 after 2s
    * // "unsubscribed!" after 2.5s
-   *
+   * ```
    *
    * @param {Observer|Function} observerOrNext (optional) Either an observer with methods to be called,
    *  or the first of three possible handlers, which is the handler for each value emitted from the subscribed
@@ -301,8 +305,8 @@ export class Observable<T> implements Subscribable<T> {
    * @return {Observable} the Observable result of all of the operators having
    * been called in the order they were passed in.
    *
-   * @example
-   *
+   * ### Example
+   * ```javascript
    * import { map, filter, scan } from 'rxjs/operators';
    *
    * Rx.Observable.interval(1000)
@@ -312,6 +316,7 @@ export class Observable<T> implements Subscribable<T> {
    *     scan((acc, x) => acc + x)
    *   )
    *   .subscribe(x => console.log(x))
+   * ```
    */
   pipe<R>(...operations: OperatorFunction<T, R>[]): Observable<R> {
     if (operations.length === 0) {

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -107,15 +107,18 @@ export function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike):
  * `bindCallback` will treat such functions the same as any other and error parameters
  * (whether passed or not) will always be interpreted as regular callback argument.
  *
+ * ## Examples
  *
- * @example <caption>Convert jQuery's getJSON to an Observable API</caption>
+ * ### Convert jQuery's getJSON to an Observable API
+ * ```javascript
  * // Suppose we have jQuery.getJSON('/my/url', callback)
  * var getJSONAsObservable = bindCallback(jQuery.getJSON);
  * var result = getJSONAsObservable('/my/url');
  * result.subscribe(x => console.log(x), e => console.error(e));
+ * ```
  *
- *
- * @example <caption>Receive an array of arguments passed to a callback</caption>
+ * ### Receive an array of arguments passed to a callback
+ * ```javascript
  * someFunction((a, b, c) => {
  *   console.log(a); // 5
  *   console.log(b); // 'some string'
@@ -126,9 +129,10 @@ export function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike):
  * boundSomeFunction().subscribe(values => {
  *   console.log(values) // [5, 'some string', {someProperty: 'someValue'}]
  * });
+ * ```
  *
- *
- * @example <caption>Compare behaviour with and without async Scheduler</caption>
+ * ### Compare behaviour with and without async Scheduler
+ * ```javascript
  * function iCallMyCallbackSynchronously(cb) {
  *   cb();
  * }
@@ -144,13 +148,14 @@ export function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike):
  * // I was sync!
  * // This happened...
  * // I was async!
+ * ```
  *
- *
- * @example <caption>Use bindCallback on an object method</caption>
+ * ### Use bindCallback on an object method
+ * ```javascript
  * const boundMethod = bindCallback(someObject.methodWithCallback);
  * boundMethod.call(someObject) // make sure methodWithCallback has access to someObject
  * .subscribe(subscriber);
- *
+ * ```
  *
  * @see {@link bindNodeCallback}
  * @see {@link from}

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -105,15 +105,17 @@ export function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLi
  * Note that even if error parameter is technically present in callback, but its value
  * is falsy, it still won't appear in array emitted by Observable.
  *
- *
- * @example <caption>Read a file from the filesystem and get the data as an Observable</caption>
+ * ## Examples
+ * ###  Read a file from the filesystem and get the data as an Observable
+ * ```javascript
  * import * as fs from 'fs';
  * var readFileAsObservable = bindNodeCallback(fs.readFile);
  * var result = readFileAsObservable('./roadNames.txt', 'utf8');
  * result.subscribe(x => console.log(x), e => console.error(e));
+ * ```
  *
- *
- * @example <caption>Use on function calling callback with multiple arguments</caption>
+ * ### Use on function calling callback with multiple arguments
+ * ```javascript
  * someFunction((err, a, b) => {
  *   console.log(err); // null
  *   console.log(a); // 5
@@ -124,8 +126,10 @@ export function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLi
  * .subscribe(value => {
  *   console.log(value); // [5, "some string"]
  * });
+ * ```
  *
- * @example <caption>Use on function calling callback in regular style</caption>
+ * ### Use on function calling callback in regular style
+ * ```javascript
  * someFunction(a => {
  *   console.log(a); // 5
  * });
@@ -135,7 +139,7 @@ export function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLi
  *   value => {}             // never gets called
  *   err => console.log(err) // 5
  * );
- *
+ * ```
  *
  * @see {@link bindCallback}
  * @see {@link from}

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -93,8 +93,9 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * of values, but values themselves. That means default `project` can be imagined
  * as function that takes all its arguments and puts them into an array.
  *
- *
- * @example <caption>Combine two timer Observables</caption>
+ * ## Examples
+ * ### Combine two timer Observables
+ * ```javascript
  * const firstTimer = Rx.Observable.timer(0, 1000); // emit 0, 1, 2... after every second, starting from now
  * const secondTimer = Rx.Observable.timer(500, 1000); // emit 0, 1, 2... after every second, starting 0,5s from now
  * const combinedTimers = Rx.Observable.combineLatest(firstTimer, secondTimer);
@@ -104,9 +105,10 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * // [1, 0] after 1s
  * // [1, 1] after 1.5s
  * // [2, 1] after 2s
+ * ```
  *
- *
- * @example <caption>Combine an array of Observables</caption>
+ * ### Combine an array of Observables
+ * ```javascript
  * const observables = [1, 5, 10].map(
  *   n => Rx.Observable.of(n).delay(n * 1000).startWith(0) // emit 0 and then emit n after n seconds
  * );
@@ -117,9 +119,10 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * // [1, 0, 0] after 1s
  * // [1, 5, 0] after 5s
  * // [1, 5, 10] after 10s
+ * ```
  *
- *
- * @example <caption>Use project function to dynamically calculate the Body-Mass Index</caption>
+ * ### Use project function to dynamically calculate the Body-Mass Index
+ * ```javascript
  * var weight = Rx.Observable.of(70, 72, 76, 79, 75);
  * var height = Rx.Observable.of(1.76, 1.77, 1.78);
  * var bmi = Rx.Observable.combineLatest(weight, height, (w, h) => w / (h * h));
@@ -129,7 +132,7 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * // BMI is 24.212293388429753
  * // BMI is 23.93948099205209
  * // BMI is 23.671253629592222
- *
+ * ```
  *
  * @see {@link combineAll}
  * @see {@link merge}

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -52,7 +52,9 @@ export function concat<T, R>(...observables: (ObservableInput<any> | SchedulerLi
  * as many times as you like. If passing the same Observable to `concat` 1000 times becomes tedious,
  * you can always use {@link repeat}.
  *
- * @example <caption>Concatenate a timer counting from 0 to 3 with a synchronous sequence from 1 to 10</caption>
+ * ## Examples
+ * ### Concatenate a timer counting from 0 to 3 with a synchronous sequence from 1 to 10
+ * ```javascript
  * var timer = Rx.Observable.interval(1000).take(4);
  * var sequence = Rx.Observable.range(1, 10);
  * var result = Rx.Observable.concat(timer, sequence);
@@ -60,9 +62,9 @@ export function concat<T, R>(...observables: (ObservableInput<any> | SchedulerLi
  *
  * // results in:
  * // 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3 -immediate-> 1 ... 10
+ * ```
  *
- *
- * @example <caption>Concatenate an array of 3 Observables</caption>
+ * ### Concatenate an array of 3 Observables
  * var timer1 = Rx.Observable.interval(1000).take(10);
  * var timer2 = Rx.Observable.interval(2000).take(6);
  * var timer3 = Rx.Observable.interval(500).take(10);
@@ -74,9 +76,10 @@ export function concat<T, R>(...observables: (ObservableInput<any> | SchedulerLi
  * // -1000ms-> 0 -1000ms-> 1 -1000ms-> ... 9
  * // -2000ms-> 0 -2000ms-> 1 -2000ms-> ... 5
  * // -500ms-> 0 -500ms-> 1 -500ms-> ... 9
+ * ```
  *
- *
- * @example <caption>Concatenate the same Observable to repeat it</caption>
+ * ### Concatenate the same Observable to repeat it
+ * ```javascript
  * const timer = Rx.Observable.interval(1000).take(2);
  *
  * Rx.Observable.concat(timer, timer) // concating the same Observable!
@@ -92,6 +95,7 @@ export function concat<T, R>(...observables: (ObservableInput<any> | SchedulerLi
  * // 0 after 3s
  * // 1 after 4s
  * // "...and it is done!" also after 4s
+ * ```
  *
  * @see {@link concatAll}
  * @see {@link concatMap}

--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -21,7 +21,9 @@ import { empty } from './empty';
  * same Observable, in fact each subscriber gets its own individual
  * Observable.
  *
- * @example <caption>Subscribe to either an Observable of clicks or an Observable of interval, at random</caption>
+ * ## Example
+ * ### Subscribe to either an Observable of clicks or an Observable of interval, at random
+ * ```javascript
  * var clicksOrInterval = Rx.Observable.defer(function () {
  *   if (Math.random() > 0.5) {
  *     return Rx.Observable.fromEvent(document, 'click');
@@ -36,6 +38,7 @@ import { empty } from './empty';
  * // for clicks anywhere on the "document"; when document is clicked it
  * // will log a MouseEvent object to the console. If the result is less
  * // than 0.5 it will emit ascending numbers, one every second(1000ms).
+ * ```
  *
  * @see {@link create}
  *

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -110,9 +110,11 @@ export class AjaxObservable<T> extends Observable<T> {
    * Creates an observable for an Ajax request with either a request object with
    * url, headers, etc or a string for a URL.
    *
-   * @example
+   * ## Example
+   * ```javascript
    * source = Rx.Observable.ajax('/products');
    * source = Rx.Observable.ajax({ url: 'products', method: 'GET' });
+   * ```
    *
    * @param {string|Object} request Can be one of the following:
    *   A string of the URL to make the Ajax call.

--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -3,8 +3,9 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
 /**
  * Wrapper around the w3c-compatible WebSocket object provided by the browser.
  *
- * @example <caption>Wraps browser WebSocket</caption>
- *
+ * ## Examples
+ * ### Wrapping browser WebSocket
+ * ```javascript
  * import { webSocket } from 'rxjs/webSocket';
  *
  * let socket$ = webSocket('ws://localhost:8081');
@@ -16,9 +17,10 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * );
  *
  * socket$.next(JSON.stringify({ op: 'hello' }));
+ * ```
  *
- * @example <caption>Wraps WebSocket from nodejs-webSocket (using node.js)</caption>
- *
+ * ### Wraps nodejs-webSocket</caption>
+ * ```javascript
  * import { webSocket } from 'rxjs/webSocket';
  * import { w3cwebSocket } from 'webSocket';
  *
@@ -34,6 +36,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * );
  *
  * socket$.next(JSON.stringify({ op: 'hello' }));
+ * ```
  *
  * @param {string | WebSocketSubjectConfig} urlConfigOrSource the source of the webSocket as an url or a structure defining the webSocket object
  * @return {WebSocketSubject}

--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -20,11 +20,15 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * emits the complete notification. It can be used for composing with other
  * Observables, such as in a {@link mergeMap}.
  *
- * @example <caption>Emit the number 7, then complete.</caption>
+ * ## Examples
+ * ### Emit the number 7, then complete
+ * ```javascript
  * var result = Rx.Observable.empty().startWith(7);
  * result.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Map and flatten only odd numbers to the sequence 'a', 'b', 'c'</caption>
+ * ### Map and flatten only odd numbers to the sequence 'a', 'b', 'c'
+ * ```javascript
  * var interval = Rx.Observable.interval(1000);
  * var result = interval.mergeMap(x =>
  *   x % 2 === 1 ? Rx.Observable.of('a', 'b', 'c') : Rx.Observable.empty()
@@ -36,6 +40,7 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * // x will occur every 1000ms
  * // if x % 2 is equal to 1 print abc
  * // if x % 2 is not equal to 1 nothing will be output
+ * ```
  *
  * @see {@link create}
  * @see {@link never}

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -67,7 +67,9 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * all its arguments and puts them into an array. Note that project function will be called only
  * when output Observable is supposed to emit a result.
  *
- * @example <caption>Use forkJoin with operator emitting immediately</caption>
+ * ## Examples
+ * ### Use forkJoin with operator emitting immediately
+ * ```javascript
  * import { forkJoin, of } from 'rxjs';
  *
  * const observable = forkJoin(
@@ -83,9 +85,10 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * // Logs:
  * // [4, 8]
  * // "This is how it ends!"
+ * ```
  *
- *
- * @example <caption>Use forkJoin with operator emitting after some time</caption>
+ * ### Use forkJoin with operator emitting after some time
+ * ```javascript
  * import { forkJoin, interval } from 'rxjs';
  * import { take } from 'rxjs/operators';
  *
@@ -102,9 +105,10 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * // Logs:
  * // [2, 3] after 3 seconds
  * // "This is how it ends!" immediately after
+ * ```
  *
- *
- * @example <caption>Use forkJoin with project function</caption>
+ * ### Use forkJoin with project function
+ * ```javascript
  * import { jorkJoin, interval } from 'rxjs';
  * import { take } from 'rxjs/operators';
  *
@@ -122,6 +126,7 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * // Logs:
  * // 5 after 3 seconds
  * // "This is how it ends!" immediately after
+ * ```
  *
  * @see {@link combineLatest}
  * @see {@link zip}

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -122,16 +122,19 @@ export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, opti
  * installed and removed in each of elements.
  *
  *
- * @example <caption>Emits clicks happening on the DOM document</caption>
+ * ## Examples
+ * ### Emits clicks happening on the DOM document
+ * ```javascript
  * var clicks = fromEvent(document, 'click');
  * clicks.subscribe(x => console.log(x));
  *
  * // Results in:
  * // MouseEvent object logged to console every time a click
  * // occurs on the document.
+ * ```
  *
- *
- * @example <caption>Use addEventListener with capture option</caption>
+ * ### Use addEventListener with capture option
+ * ```javascript
  * var clicksInDocument = fromEvent(document, 'click', true); // note optional configuration parameter
  *                                                                          // which will be passed to addEventListener
  * var clicksInDiv = fromEvent(someDivInDocument, 'click');
@@ -145,6 +148,7 @@ export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, opti
  * // Since we specified optional `capture` option, document
  * // will catch event when it goes DOWN DOM tree, so console
  * // will log "document" and then "div".
+ * ```
  *
  * @see {@link bindCallback}
  * @see {@link bindNodeCallback}

--- a/src/internal/observable/fromEventPattern.ts
+++ b/src/internal/observable/fromEventPattern.ts
@@ -24,7 +24,9 @@ export function fromEventPattern<T>(addHandler: (handler: Function) => any, remo
  * called when the output Observable is subscribed, and `removeHandler` is
  * called when the Subscription is unsubscribed.
  *
- * @example <caption>Emits clicks happening on the DOM document</caption>
+ * ## Example
+ * ### Emits clicks happening on the DOM document
+ * ```javascript
  * function addClickHandler(handler) {
  *   document.addEventListener('click', handler);
  * }
@@ -38,6 +40,7 @@ export function fromEventPattern<T>(addHandler: (handler: Function) => any, remo
  *   removeClickHandler
  * );
  * clicks.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link from}
  * @see {@link fromEvent}

--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -25,7 +25,9 @@ import { SubscribableOrPromise } from '../types';
  * and exists only for convenience and readability reasons.
  *
  *
- * @example <caption>Change at runtime which Observable will be subscribed</caption>
+ * ## Examples
+ * ### Change at runtime which Observable will be subscribed
+ * ```javascript
  * let subscribeToFirst;
  * const firstOrSecond = Rx.Observable.if(
  *   () => subscribeToFirst,
@@ -45,8 +47,10 @@ import { SubscribableOrPromise } from '../types';
  * // Logs:
  * // "second"
  *
+ * ```
  *
- * @example <caption>Control an access to an Observable</caption>
+ * ### Control an access to an Observable
+ * ```javascript
  * let accessGranted;
  * const observableIfYouHaveAccess = Rx.Observable.if(
  *   () => accessGranted,
@@ -73,6 +77,7 @@ import { SubscribableOrPromise } from '../types';
  *
  * // Logs:
  * // "The end"
+ * ```
  *
  * @see {@link defer}
  *

--- a/src/internal/observable/interval.ts
+++ b/src/internal/observable/interval.ts
@@ -20,10 +20,12 @@ import { Subscriber } from '../Subscriber';
  * `async` IScheduler to provide a notion of time, but you may pass any
  * IScheduler to it.
  *
- * @example <caption>Emits ascending numbers, one every second (1000ms)</caption>
+ * ## Example
+ * Emits ascending numbers, one every second (1000ms)
+ * ```javascript
  * var numbers = Rx.Observable.interval(1000);
  * numbers.subscribe(x => console.log(x));
- *
+ * ```javascript
  * @see {@link timer}
  * @see {@link delay}
  *

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -35,7 +35,9 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * once all input Observables have completed. Any error delivered by an input
  * Observable will be immediately emitted on the output Observable.
  *
- * @example <caption>Merge together two Observables: 1s interval and clicks</caption>
+ * ## Examples
+ * ### Merge together two Observables: 1s interval and clicks
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var timer = Rx.Observable.interval(1000);
  * var clicksOrTimer = Rx.Observable.merge(clicks, timer);
@@ -46,8 +48,10 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * // clicks logs MouseEvents to console everytime the "document" is clicked
  * // Since the two streams are merged you see these happening
  * // as they occur.
+ * ```javascript
  *
- * @example <caption>Merge together 3 Observables, but only 2 run concurrently</caption>
+ * ### Merge together 3 Observables, but only 2 run concurrently
+ * ```javascript
  * var timer1 = Rx.Observable.interval(1000).take(10);
  * var timer2 = Rx.Observable.interval(2000).take(6);
  * var timer3 = Rx.Observable.interval(500).take(10);
@@ -63,6 +67,7 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * //   continue, and timer3 will start to run concurrently with timer2
  * // - when timer2 hits it's max iteration it terminates, and
  * //   timer3 will continue to emit a value every 500ms until it is complete
+ * ```
  *
  * @see {@link mergeAll}
  * @see {@link mergeMap}

--- a/src/internal/observable/never.ts
+++ b/src/internal/observable/never.ts
@@ -12,12 +12,16 @@ import { noop } from '../util/noop';
  * Observable keeps the subscription from being disposed automatically.
  * Subscriptions need to be manually disposed.
  *
- * @example <caption>Emit the number 7, then never emit anything else (not even complete).</caption>
+ * ##  Example
+ * ### Emit the number 7, then never emit anything else (not even complete)
+ * ```javascript
  * function info() {
  *   console.log('Will not be called');
  * }
  * var result = NEVER.startWith(7);
  * result.subscribe(x => console.log(x), info, info);
+ *
+ * ```
  *
  * @see {@link create}
  * @see {@link EMPTY}

--- a/src/internal/observable/onErrorResumeNext.ts
+++ b/src/internal/observable/onErrorResumeNext.ts
@@ -36,7 +36,9 @@ export function onErrorResumeNext<R>(array: ObservableInput<any>[]): Observable<
  * `onErrorResumeNext`. If you want to handle errors thrown in any given source, you can
  * always use the {@link catchError} operator on them before passing them into `onErrorResumeNext`.
  *
- * @example <caption>Subscribe to the next Observable after map fails</caption>
+ * ## Example
+ * Subscribe to the next Observable after map fails</caption>
+ * ```javascript
  * import { onErrorResumeNext, of } from 'rxjs/create';
  * import { map } from 'rxjs/operators';
  *
@@ -63,6 +65,7 @@ export function onErrorResumeNext<R>(array: ObservableInput<any>[]): Observable<
  * // 2
  * // 3
  * // "done"
+ * ```
  *
  * @see {@link concat}
  * @see {@link catch}

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -7,7 +7,9 @@ import { Subscription } from '../Subscription';
  * Convert an object into an observable sequence of [key, value] pairs
  * using an optional IScheduler to enumerate the object.
  *
- * @example <caption>Converts a javascript object to an Observable</caption>
+ * ## Example
+ * Converts a javascript object to an Observable
+ * ```javascript
  * var obj = {
  *   foo: 42,
  *   bar: 56,
@@ -26,6 +28,7 @@ import { Subscription } from '../Subscription';
  *   function () {
  *     console.log('Completed');
  *   });
+ * ```
  *
  * @param {Object} obj The object to inspect and turn into an
  * Observable sequence.

--- a/src/internal/observable/range.ts
+++ b/src/internal/observable/range.ts
@@ -14,10 +14,12 @@ import { Observable } from '../Observable';
  * IScheduler and just delivers the notifications synchronously, but may use
  * an optional IScheduler to regulate those deliveries.
  *
- * @example <caption>Emits the numbers 1 to 10</caption>
+ * ## Example
+ * Emits the numbers 1 to 10</caption>
+ * ```javascript
  * var numbers = Rx.Observable.range(1, 10);
  * numbers.subscribe(x => console.log(x));
- *
+ * ```
  * @see {@link timer}
  * @see {@link interval}
  *

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -15,13 +15,17 @@ import { Subscriber } from '../Subscriber';
  * emits the error notification. It can be used for composing with other
  * Observables, such as in a {@link mergeMap}.
  *
- * @example <caption>Emit the number 7, then emit an error.</caption>
+ * ## Examples
+ * ### Emit the number 7, then emit an error
+ * ```javascript
  * import { throwError, concat, of } from 'rxjs/create';
  *
  * const result = concat(of(7), throwError(new Error('oops!')));
  * result.subscribe(x => console.log(x), e => console.error(e));
+ * ```javascript
  *
- * @example <caption>Map and flatten numbers to the sequence 'a', 'b', 'c', but throw an error for 13</caption>
+ * ### Map and flatten numbers to the sequence 'a', 'b', 'c', but throw an error for 13
+ * ```javascript
  * import { throwError, interval, of } from 'rxjs/create';
  * import { mergeMap } from 'rxjs/operators';
  *
@@ -31,7 +35,7 @@ import { Subscriber } from '../Subscriber';
  *     of('a', 'b', 'c')
  *   )
  * ).subscribe(x => console.log(x), e => console.error(e));
- *
+ * ```
  * @see {@link create}
  * @see {@link empty}
  * @see {@link never}

--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -23,14 +23,18 @@ import { Subscriber } from '../Subscriber';
  * Observable emits only one value, `0`. Otherwise, it emits an infinite
  * sequence.
  *
- * @example <caption>Emits ascending numbers, one every second (1000ms), starting after 3 seconds</caption>
+ * ## Examples
+ * ### Emits ascending numbers, one every second (1000ms), starting after 3 seconds
+ * ```javascript
  * var numbers = Rx.Observable.timer(3000, 1000);
  * numbers.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Emits one number after five seconds</caption>
+ * ### Emits one number after five seconds
+ * ```javascript
  * var numbers = Rx.Observable.timer(5000);
  * numbers.subscribe(x => console.log(x));
- *
+ * ```
  * @see {@link interval}
  * @see {@link delay}
  *

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -48,8 +48,9 @@ export function zip<R>(...observables: Array<ObservableInput<any> | ((...values:
  * If the latest parameter is a function, this function is used to compute the created value from the input values.
  * Otherwise, an array of the input values is returned.
  *
- * @example <caption>Combine age and name from different sources</caption>
- *
+ * ## Example
+ * Combine age and name from different sources
+ * ```javascript
  * let age$ = Observable.of<number>(27, 25, 29);
  * let name$ = Observable.of<string>('Foo', 'Bar', 'Beer');
  * let isDev$ = Observable.of<boolean>(true, true, false);
@@ -65,7 +66,7 @@ export function zip<R>(...observables: Array<ObservableInput<any> | ((...values:
  * // { age: 27, name: 'Foo', isDev: true }
  * // { age: 25, name: 'Bar', isDev: true }
  * // { age: 29, name: 'Beer', isDev: false }
- *
+ * ```
  * @param observables
  * @return {Observable<R>}
  * @static true

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -30,11 +30,14 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * recent source value is emitted on the output Observable, and this process
  * repeats for the next source value.
  *
- * @example <caption>Emit clicks at a rate of at most one click per second</caption>
+ * ## Example
+ *
+ * Emit clicks at a rate of at most one click per second
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const result = clicks.pipe(audit(ev => Rx.Observable.interval(1000)));
  * result.subscribe(x => console.log(x));
- *
+ * ```
  * @see {@link auditTime}
  * @see {@link debounce}
  * @see {@link delayWhen}

--- a/src/internal/operators/auditTime.ts
+++ b/src/internal/operators/auditTime.ts
@@ -24,10 +24,14 @@ import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
  * output Observable, and this process repeats for the next source value.
  * Optionally takes a {@link IScheduler} for managing timers.
  *
- * @example <caption>Emit clicks at a rate of at most one click per second</caption>
+ * ## Example
+ *
+ * Emit clicks at a rate of at most one click per second
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const result = clicks.pipe(auditTime(1000));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link audit}
  * @see {@link debounceTime}

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -19,11 +19,16 @@ import { OperatorFunction } from '../types';
  * Observable and starts a new buffer internally, awaiting the next time
  * `closingNotifier` emits.
  *
- * @example <caption>On every click, emit array of most recent interval events</caption>
+ * ## Example
+ *
+ * On every click, emit array of most recent interval events
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const interval = interval(1000);
  * const buffered = interval.pipe(buffer(clicks));
  * buffered.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link bufferCount}
  * @see {@link bufferTime}

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -18,15 +18,23 @@ import { OperatorFunction, TeardownLogic } from '../types';
  * `null`, then new buffers are started immediately at the start of the source
  * and when each buffer closes and is emitted.
  *
- * @example <caption>Emit the last two click events as an array</caption>
+ * ## Examples
+ *
+ * Emit the last two click events as an array
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const buffered = clicks.pipe(bufferCount(2));
  * buffered.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>On every click, emit the last two click events as an array</caption>
+ * On every click, emit the last two click events as an array
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const buffered = clicks.pipe(bufferCount(2, 1));
  * buffered.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link buffer}
  * @see {@link bufferTime}

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -29,15 +29,23 @@ export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: nu
  * `maxBufferSize` is specified, the buffer will be closed either after
  * `bufferTimeSpan` milliseconds or when it contains `maxBufferSize` elements.
  *
- * @example <caption>Every second, emit an array of the recent click events</caption>
+ * ## Examples
+ *
+ * Every second, emit an array of the recent click events
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const buffered = clicks.pipe(bufferTime(1000));
  * buffered.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Every 5 seconds, emit the click events from the next 2 seconds</caption>
+ * Every 5 seconds, emit the click events from the next 2 seconds
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const buffered = clicks.pipe(bufferTime(2000, 5000));
  * buffered.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link buffer}
  * @see {@link bufferCount}

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -21,13 +21,18 @@ import { OperatorFunction, SubscribableOrPromise } from '../types';
  * Observable provided to `openings`, and closing and sending the buffers when
  * a Subscribable or Promise returned by the `closingSelector` function emits.
  *
- * @example <caption>Every other second, emit the click events from the next 500ms</caption>
+ * ## Example
+ *
+ * Every other second, emit the click events from the next 500ms
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const openings = interval(1000);
  * const buffered = clicks.pipe(bufferToggle(openings, i =>
  *   i % 2 ? interval(500) : empty()
  * ));
  * buffered.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link buffer}
  * @see {@link bufferCount}

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -23,12 +23,18 @@ import { OperatorFunction } from '../types';
  * returned by calling `closingSelector` function emits a value. When it closes
  * the buffer, it immediately opens a new buffer and repeats the process.
  *
- * @example <caption>Emit an array of the last clicks every [1-5] random seconds</caption>
+ * ## Example
+ *
+ * Emit an array of the last clicks every [1-5] random seconds
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const buffered = clicks.pipe(bufferWhen(() =>
  *   interval(1000 + Math.random() * 4000)
  * ));
  * buffered.subscribe(x => console.log(x));
+ * ```
+ *
  *
  * @see {@link buffer}
  * @see {@link bufferCount}

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -1,18 +1,20 @@
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
+import {Operator} from '../Operator';
+import {Subscriber} from '../Subscriber';
+import {Observable} from '../Observable';
 
-import { OuterSubscriber } from '../OuterSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
-import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction } from '../types';
+import {OuterSubscriber} from '../OuterSubscriber';
+import {subscribeToResult} from '../util/subscribeToResult';
+import {ObservableInput, OperatorFunction, MonoTypeOperatorFunction} from '../types';
 
 /**
  * Catches errors on the observable to be handled by returning a new observable or throwing an error.
  *
  * <img src="./img/catch.png" width="100%">
  *
- * @example <caption>Continues with a different Observable when there's an error</caption>
+ * ## Examples
+ * Continues with a different Observable when there's an error
  *
+ * ```javascript
  * of(1, 2, 3, 4, 5).pipe(
  *     map(n => {
  *   	   if (n == 4) {
@@ -24,9 +26,11 @@ import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction } from '../
  *   )
  *   .subscribe(x => console.log(x));
  *   // 1, 2, 3, I, II, III, IV, V
+ * ```
  *
- * @example <caption>Retries the caught source Observable again in case of error, similar to retry() operator</caption>
+ * Retries the caught source Observable again in case of error, similar to retry() operator
  *
+ * ```javascript
  * of(1, 2, 3, 4, 5).pipe(
  *     map(n => {
  *   	   if (n === 4) {
@@ -39,9 +43,11 @@ import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction } from '../
  *   )
  *   .subscribe(x => console.log(x));
  *   // 1, 2, 3, 1, 2, 3, ...
+ * ```
  *
- * @example <caption>Throws a new error when the source Observable throws an error</caption>
+ * Throws a new error when the source Observable throws an error
  *
+ * ```javascript
  * of(1, 2, 3, 4, 5).pipe(
  *     map(n => {
  *       if (n == 4) {
@@ -58,8 +64,9 @@ import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction } from '../
  *     err => console.log(err)
  *   );
  *   // 1, 2, 3, error in source. Details: four!
+ * ```
  *
- * @param {function} selector a function that takes as arguments `err`, which is the error, and `caught`, which
+ *  @param {function} selector a function that takes as arguments `err`, which is the error, and `caught`, which
  *  is the source observable, in case you'd like to "retry" that observable by returning it again. Whatever observable
  *  is returned by the `selector` will be used to continue the observable chain.
  * @return {Observable} An observable that originates from either the source or the observable returned by the

--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -27,7 +27,10 @@ export function concatAll<R>(): OperatorFunction<any, R>;
  * Note: `concatAll` is equivalent to `mergeAll` with concurrency parameter set
  * to `1`.
  *
- * @example <caption>For each click event, tick every second from 0 to 3, with no concurrency</caption>
+ * ## Example
+ *
+ * For each click event, tick every second from 0 to 3, with no concurrency
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const higherOrder = clicks.pipe(
  *   map(ev => interval(1000).pipe(take(4))),
@@ -40,6 +43,7 @@ export function concatAll<R>(): OperatorFunction<any, R>;
  * // For every click on the "document" it will emit values 0 to 3 spaced
  * // on a 1000ms interval
  * // one click = 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3
+ * ```
  *
  * @see {@link combineAll}
  * @see {@link concat}

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -32,7 +32,10 @@ export function concatMap<T, I, R>(project: (value: T, index: number) =>  Observ
  * Note: `concatMap` is equivalent to `mergeMap` with concurrency parameter set
  * to `1`.
  *
- * @example <caption>For each click event, tick every second from 0 to 3, with no concurrency</caption>
+ * ## Example
+ * For each click event, tick every second from 0 to 3, with no concurrency
+ *
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const result = clicks.pipe(
  *   concatMap(ev => interval(1000).pipe(take(4)),
@@ -44,6 +47,7 @@ export function concatMap<T, I, R>(project: (value: T, index: number) =>  Observ
  * // For every click on the "document" it will emit values 0 to 3 spaced
  * // on a 1000ms interval
  * // one click = 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3
+ * ```
  *
  * @see {@link concat}
  * @see {@link concatAll}

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -32,7 +32,9 @@ export function concatMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * Note: `concatMapTo` is equivalent to `mergeMapTo` with concurrency parameter
  * set to `1`.
  *
- * @example <caption>For each click event, tick every second from 0 to 3, with no concurrency</caption>
+ * ## Example
+ * For each click event, tick every second from 0 to 3, with no concurrency
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const result = clicks.pipe(
  *   concatMapTo(interval(1000).pipe(take(4))),
@@ -44,6 +46,7 @@ export function concatMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * // For every click on the "document" it will emit values 0 to 3 spaced
  * // on a 1000ms interval
  * // one click = 1000ms-> 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3
+ * ```
  *
  * @see {@link concat}
  * @see {@link concatAll}

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -2,7 +2,6 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Observer, OperatorFunction } from '../types';
 import { Subscriber } from '../Subscriber';
-
 /**
  * Counts the number of emissions on the source and emits that number when the
  * source completes.
@@ -21,20 +20,25 @@ import { Subscriber } from '../Subscriber';
  * as argument, in which case the output emission will represent the number of
  * source values that matched `true` with the `predicate`.
  *
- * @example <caption>Counts how many seconds have passed before the first click happened</caption>
+ * ## Examples
+ *
+ * Counts how many seconds have passed before the first click happened
+ * ```javascript
  * const seconds = interval(1000);
  * const clicks = fromEvent(document, 'click');
  * const secondsBeforeClick = seconds.pipe(takeUntil(clicks));
  * const result = secondsBeforeClick.pipe(count());
  * result.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Counts how many odd numbers are there between 1 and 7</caption>
+ * Counts how many odd numbers are there between 1 and 7
+ * ```javascript
  * const numbers = range(1, 7);
  * const result = numbers.pipe(count(i => i % 2 === 1));
  * result.subscribe(x => console.log(x));
- *
  * // Results in:
  * // 4
+ * ```javascript
  *
  * @see {@link max}
  * @see {@link min}
@@ -51,6 +55,7 @@ import { Subscriber } from '../Subscriber';
  * @method count
  * @owner Observable
  */
+
 export function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number> {
   return (source: Observable<T>) => source.lift(new CountOperator(predicate, source));
 }

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -31,10 +31,13 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * delay-like operator since output emissions do not necessarily occur at the
  * same time as they did on the source Observable.
  *
- * @example <caption>Emit the most recent click after a burst of clicks</caption>
+ * ## Example
+ * Emit the most recent click after a burst of clicks
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const result = clicks.pipe(debounce(() => interval(1000)));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link audit}
  * @see {@link debounceTime}

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -28,10 +28,13 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * they did on the source Observable. Optionally takes a {@link IScheduler} for
  * managing timers.
  *
- * @example <caption>Emit the most recent click after a burst of clicks</caption>
+ * ## Example
+ * Emit the most recent click after a burst of clicks
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const result = clicks.pipe(debounceTime(1000));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link auditTime}
  * @see {@link debounce}

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -21,11 +21,14 @@ export function defaultIfEmpty<T, R>(defaultValue?: R): OperatorFunction<T, T | 
  * specified default value if the source Observable is empty (completes without
  * having emitted any `next` value).
  *
- * @example <caption>If no clicks happen in 5 seconds, then emit "no clicks"</caption>
+ * ## Example
+ * If no clicks happen in 5 seconds, then emit "no clicks"
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const clicksBeforeFive = clicks.pipe(takeUntil(interval(5000)));
  * const result = clicksBeforeFive.pipe(defaultIfEmpty('no clicks'));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link empty}
  * @see {@link last}

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -22,16 +22,21 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  * If the delay argument is a Date, this operator time shifts the start of the
  * Observable execution until the given date occurs.
  *
- * @example <caption>Delay each click by one second</caption>
+ * ## Examples
+ * Delay each click by one second
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const delayedClicks = clicks.pipe(delay(1000)); // each click emitted after 1 second
  * delayedClicks.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Delay all clicks until a future date happens</caption>
+ * Delay all clicks until a future date happens
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const date = new Date('March 15, 2050 12:00:00'); // in the future
  * const delayedClicks = clicks.pipe(delay(date)); // click emitted only after that date
  * delayedClicks.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link debounceTime}
  * @see {@link delayWhen}

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -38,12 +38,15 @@ export function delayWhen<T>(delayDurationSelector: (value: T) => Observable<any
  * `delayWhen` will subscribe to the source Observable as soon as the output
  * Observable is subscribed.
  *
- * @example <caption>Delay each click by a random amount of time, between 0 and 5 seconds</caption>
+ * ## Example
+ * Delay each click by a random amount of time, between 0 and 5 seconds
+ * ```javascript
  * const clicks = fromEvent(document, 'click');
  * const delayedClicks = clicks.pipe(
  *   delayWhen(event => interval(Math.random() * 5000)),
  * );
  * delayedClicks.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link debounce}
  * @see {@link delay}

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -21,7 +21,9 @@ import { OperatorFunction } from '../types';
  *
  * Use this operator in conjunction with {@link materialize}.
  *
- * @example <caption>Convert an Observable of Notifications to an actual Observable</caption>
+ * ## Example
+ * Convert an Observable of Notifications to an actual Observable
+ * ```javascript
  * const notifA = new Rx.Notification('N', 'A');
  * const notifB = new Rx.Notification('N', 'B');
  * const notifE = new Rx.Notification('E', void 0,
@@ -35,6 +37,7 @@ import { OperatorFunction } from '../types';
  * // A
  * // B
  * // TypeError: x.toUpperCase is not a function
+ * ```
  *
  * @see {@link Notification}
  * @see {@link materialize}

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -20,13 +20,17 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * use might result in memory leaks. To help alleviate this in some scenarios, an optional `flushes` parameter is also provided so
  * that the internal `Set` can be "flushed", basically clearing it of values.
  *
- * @example <caption>A simple example with numbers</caption>
+ * ## Examples
+ * A simple example with numbers
+ * ```javascript
  * of(1, 1, 2, 2, 2, 1, 2, 3, 4, 3, 2, 1).pipe(
  *     distinct(),
  *   )
  *   .subscribe(x => console.log(x)); // 1, 2, 3, 4
+ * ```
  *
- * @example <caption>An example using a keySelector function</caption>
+ * An example using a keySelector function
+ * ```typescript
  * interface Person {
  *    age: number,
  *    name: string
@@ -44,7 +48,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * // displays:
  * // { age: 4, name: 'Foo' }
  * // { age: 7, name: 'Bar' }
- *
+ * ```
  * @see {@link distinctUntilChanged}
  * @see {@link distinctUntilKeyChanged}
  *

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -17,13 +17,17 @@ export function distinctUntilChanged<T, K>(compare: (x: K, y: K) => boolean, key
  *
  * If a comparator function is not provided, an equality check is used by default.
  *
- * @example <caption>A simple example with numbers</caption>
+ * ## Example
+ * A simple example with numbers
+ * ```javascript
  * of(1, 1, 2, 2, 2, 1, 1, 2, 3, 3, 4).pipe(
  *     distinctUntilChanged(),
  *   )
  *   .subscribe(x => console.log(x)); // 1, 2, 1, 2, 3, 4
+ * ```
  *
- * @example <caption>An example using a compare function</caption>
+ * An example using a compare function
+ * ```typescript
  * interface Person {
  *    age: number,
  *    name: string
@@ -43,6 +47,7 @@ export function distinctUntilChanged<T, K>(compare: (x: K, y: K) => boolean, key
  * // { age: 4, name: 'Foo' }
  * // { age: 7, name: 'Bar' }
  * // { age: 5, name: 'Foo' }
+ * ```
  *
  * @see {@link distinct}
  * @see {@link distinctUntilKeyChanged}

--- a/src/internal/operators/distinctUntilKeyChanged.ts
+++ b/src/internal/operators/distinctUntilKeyChanged.ts
@@ -14,8 +14,9 @@ export function distinctUntilKeyChanged<T, K>(key: string, compare: (x: K, y: K)
  *
  * If a comparator function is not provided, an equality check is used by default.
  *
- * @example <caption>An example comparing the name of persons</caption>
- *
+ * ## Examples
+ * An example comparing the name of persons
+ * ```typescript
  *  interface Person {
  *     age: number,
  *     name: string
@@ -35,9 +36,10 @@ export function distinctUntilKeyChanged<T, K>(key: string, compare: (x: K, y: K)
  * // { age: 4, name: 'Foo' }
  * // { age: 7, name: 'Bar' }
  * // { age: 5, name: 'Foo' }
+ * ```
  *
- * @example <caption>An example comparing the first letters of the name</caption>
- *
+ * An example comparing the first letters of the name
+ * ```typescript
  * interface Person {
  *     age: number,
  *     name: string
@@ -57,6 +59,7 @@ export function distinctUntilKeyChanged<T, K>(key: string, compare: (x: K, y: K)
  * // { age: 4, name: 'Foo1' }
  * // { age: 7, name: 'Bar' }
  * // { age: 5, name: 'Foo2' }
+ * ```
  *
  * @see {@link distinct}
  * @see {@link distinctUntilChanged}

--- a/src/internal/operators/elementAt.ts
+++ b/src/internal/operators/elementAt.ts
@@ -22,7 +22,9 @@ import { take } from './take';
  * not given and the `index` is out of range, the output Observable will emit an
  * `ArgumentOutOfRangeError` error.
  *
- * @example <caption>Emit only the third click event</caption>
+ * ## Example
+ * Emit only the third click event
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.elementAt(2);
  * result.subscribe(x => console.log(x));
@@ -31,6 +33,7 @@ import { take } from './take';
  * // click 1 = nothing
  * // click 2 = nothing
  * // click 3 = MouseEvent object logged to console
+ * ```
  *
  * @see {@link first}
  * @see {@link last}

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -6,10 +6,13 @@ import { Observer, OperatorFunction } from '../types';
 /**
  * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
  *
- * @example <caption>A simple example emitting true if all elements are less than 5, false otherwise</caption>
+ * ## Example
+ * A simple example emitting true if all elements are less than 5, false otherwise
+ * ```javascript
  *  Observable.of(1, 2, 3, 4, 5, 6)
  *     .every(x => x < 5)
  *     .subscribe(x => console.log(x)); // -> false
+ * ```
  *
  * @param {function} predicate A function for determining if an item meets a specified condition.
  * @param {any} [thisArg] Optional object to use for `this` in the callback.

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -26,11 +26,14 @@ export function exhaust<R>(): OperatorFunction<any, R>;
  * not yet completed. Once that one completes, it will accept and flatten the
  * next inner Observable and repeat this process.
  *
- * @example <caption>Run a finite timer for each click, only if there is no currently active timer</caption>
+ * ## Example
+ * Run a finite timer for each click, only if there is no currently active timer
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000).take(5));
  * var result = higherOrder.exhaust();
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link combineAll}
  * @see {@link concatAll}

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -35,10 +35,13 @@ export function exhaustMap<T, I, R>(project: (value: T, index: number) => Observ
  * that one completes, it will accept and flatten the next projected Observable
  * and repeat this process.
  *
- * @example <caption>Run a finite timer for each click, only if there is no currently active timer</caption>
+ * ## Example
+ * Run a finite timer for each click, only if there is no currently active timer
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.exhaustMap((ev) => Rx.Observable.interval(1000).take(5));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link concatMap}
  * @see {@link exhaust}

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -34,13 +34,16 @@ export function expand<T>(project: (value: T, index: number) => ObservableInput<
  * given to the `project` function to produce new output values. This is how
  * *expand* behaves recursively.
  *
- * @example <caption>Start emitting the powers of two on every click, at most 10 of them</caption>
+ * ## Example
+ * Start emitting the powers of two on every click, at most 10 of them
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var powersOfTwo = clicks
  *   .mapTo(1)
  *   .expand(x => Rx.Observable.of(2 * x).delay(1000))
  *   .take(10);
  * powersOfTwo.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link mergeMap}
  * @see {@link mergeScan}

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -24,10 +24,13 @@ export function filter<T>(predicate: (value: T, index: number) => boolean,
  * takes values from the source Observable, passes them through a `predicate`
  * function and only emits those values that yielded `true`.
  *
- * @example <caption>Emit only click events whose target was a DIV element</caption>
+ * ## Example
+ * Emit only click events whose target was a DIV element
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var clicksOnDivs = clicks.filter(ev => ev.target.tagName === 'DIV');
  * clicksOnDivs.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link distinct}
  * @see {@link distinctUntilChanged}

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -1,7 +1,7 @@
-import { Observable } from '../Observable';
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
-import { OperatorFunction, MonoTypeOperatorFunction } from '../types';
+import {Observable} from '../Observable';
+import {Operator} from '../Operator';
+import {Subscriber} from '../Subscriber';
+import {OperatorFunction, MonoTypeOperatorFunction} from '../types';
 
 export function find<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S,
                                      thisArg?: any): OperatorFunction<T, S>;
@@ -25,10 +25,13 @@ export function find<T>(predicate: (value: T, index: number) => boolean,
  * occurrence in the source. Unlike {@link first}, the `predicate` is required
  * in `find`, and does not emit an error if a valid value is not found.
  *
- * @example <caption>Find and emit the first click that happens on a DIV element</caption>
+ * ## Example
+ * Find and emit the first click that happens on a DIV element
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.find(ev => ev.target.tagName === 'DIV');
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link filter}
  * @see {@link first}
@@ -88,7 +91,7 @@ export class FindValueSubscriber<T> extends Subscriber<T> {
   }
 
   protected _next(value: T): void {
-    const { predicate, thisArg } = this;
+    const {predicate, thisArg} = this;
     const index = this.index++;
     try {
       const result = predicate.call(thisArg || this, value, index, this.source);

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -16,10 +16,13 @@ import { OperatorFunction } from '../types';
  * {@link first}, the `predicate` is required in `findIndex`, and does not emit
  * an error if a valid value is not found.
  *
- * @example <caption>Emit the index of first click that happens on a DIV element</caption>
+ * ## Example
+ * Emit the index of first click that happens on a DIV element
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.findIndex(ev => ev.target.tagName === 'DIV');
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link filter}
  * @see {@link find}

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -26,15 +26,20 @@ import { identity } from '../util/identity';
  * before it is able to emit a valid value. Throws an error if `defaultValue`
  * was not provided and a matching element is not found.
  *
- * @example <caption>Emit only the first click that happens on the DOM</caption>
+ * ## Examples
+ * Emit only the first click that happens on the DOM
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.first();
  * result.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Emits the first click that happens on a DIV</caption>
+ * Emits the first click that happens on a DIV
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.first(ev => ev.target.tagName === 'DIV');
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link filter}
  * @see {@link find}

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -19,7 +19,9 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  *
  * <img src="./img/groupBy.png" width="100%">
  *
- * @example <caption>Group objects by id and return as array</caption>
+ * ##Examples
+ * Group objects by id and return as array
+ * ```javascript
  * Observable.of<Obj>({id: 1, name: 'aze1'},
  *                    {id: 2, name: 'sf2'},
  *                    {id: 2, name: 'dg2'},
@@ -44,8 +46,10 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  * //   { id: 2, name: 'qsgqsfg2' } ]
  * //
  * // [ { id: 3, name: 'qfs3' } ]
+ * ```
  *
- * @example <caption>Pivot data on the id field</caption>
+ * Pivot data on the id field
+ * ```javascript
  * Observable.of<Obj>({id: 1, name: 'aze1'},
  *                    {id: 2, name: 'sf2'},
  *                    {id: 2, name: 'dg2'},
@@ -64,6 +68,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  * // { id: 1, values: [ 'aze1', 'erg1', 'df1' ] }
  * // { id: 2, values: [ 'sf2', 'dg2', 'sfqfb2', 'qsgqsfg2' ] }
  * // { id: 3, values: [ 'qfs1' ] }
+ * ```
  *
  * @param {function(value: T): K} keySelector A function that extracts the key
  * for each item.

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -17,10 +17,13 @@ import { OperatorFunction } from '../types';
  * applies a projection to each value and emits that projection in the output
  * Observable.
  *
- * @example <caption>Map every click to the clientX position of that click</caption>
+ * ## Example
+ * Map every click to the clientX position of that click
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var positions = clicks.map(ev => ev.clientX);
  * positions.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link mapTo}
  * @see {@link pluck}

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -16,10 +16,13 @@ import { OperatorFunction } from '../types';
  * Observable emits a value. In other words, ignores the actual source value,
  * and simply uses the emission moment to know when to emit the given `value`.
  *
- * @example <caption>Map every click to the string 'Hi'</caption>
+ * ## Example
+ * Map every click to the string 'Hi'
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var greetings = clicks.mapTo('Hi');
  * greetings.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link map}
  *

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -26,7 +26,9 @@ import { OperatorFunction } from '../types';
  * be consumed as `next` emissions. Use it in conjunction with
  * {@link dematerialize}.
  *
- * @example <caption>Convert a faulty Observable to an Observable of Notifications</caption>
+ * ## Example
+ * Convert a faulty Observable to an Observable of Notifications
+ * ```javascript
  * var letters = Rx.Observable.of('a', 'b', 13, 'd');
  * var upperCase = letters.map(x => x.toUpperCase());
  * var materialized = upperCase.materialize();
@@ -38,6 +40,7 @@ import { OperatorFunction } from '../types';
  * // - Notification {kind: "E", value: undefined, error: TypeError:
  * //   x.toUpperCase is not a function at MapSubscriber.letters.map.x
  * //   [as project] (http://1…, hasValue: false}
+ * ```
  *
  * @see {@link Notification}
  * @see {@link dematerialize}

--- a/src/internal/operators/max.ts
+++ b/src/internal/operators/max.ts
@@ -7,12 +7,16 @@ import { MonoTypeOperatorFunction } from '../types';
  *
  * <img src="./img/max.png" width="100%">
  *
- * @example <caption>Get the maximal value of a series of numbers</caption>
+ * ## Examples
+ * Get the maximal value of a series of numbers
+ * ```javascript
  * Rx.Observable.of(5, 4, 7, 2, 8)
  *   .max()
  *   .subscribe(x => console.log(x)); // -> 8
+ * ```
  *
- * @example <caption>Use a comparer function to get the maximal item</caption>
+ * Use a comparer function to get the maximal item
+ * ```typescript
  * interface Person {
  *   age: number,
  *   name: string
@@ -23,6 +27,7 @@ import { MonoTypeOperatorFunction } from '../types';
  *           .max<Person>((a: Person, b: Person) => a.age < b.age ? -1 : 1)
  *           .subscribe((x: Person) => console.log(x.name)); // -> 'Beer'
  * }
+ * ```
  *
  * @see {@link min}
  *

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -20,17 +20,22 @@ export function mergeAll<T>(concurrent?: number): OperatorFunction<ObservableInp
  * completes once all inner Observables have completed. Any error delivered by
  * a inner Observable will be immediately emitted on the output Observable.
  *
- * @example <caption>Spawn a new interval Observable for each click event, and blend their outputs as one Observable</caption>
+ * ## Examples
+ * Spawn a new interval Observable for each click event, and blend their outputs as one Observable
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000));
  * var firstOrder = higherOrder.mergeAll();
  * firstOrder.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Count from 0 to 9 every second for each click, but only allow 2 concurrent timers</caption>
+ * Count from 0 to 9 every second for each click, but only allow 2 concurrent timers
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var higherOrder = clicks.map((ev) => Rx.Observable.interval(1000).take(10));
  * var firstOrder = higherOrder.mergeAll(2);
  * firstOrder.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link combineAll}
  * @see {@link concatAll}

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -31,7 +31,9 @@ export function mergeMap<T, I, R>(project: (value: T, index: number) => Observab
  * returns an Observable, and then merging those resulting Observables and
  * emitting the results of this merger.
  *
- * @example <caption>Map and flatten each letter to an Observable ticking every 1 second</caption>
+ * ## Example
+ * Map and flatten each letter to an Observable ticking every 1 second
+ * ```javascript
  * var letters = Rx.Observable.of('a', 'b', 'c');
  * var result = letters.mergeMap(x =>
  *   Rx.Observable.interval(1000).map(i => x+i)
@@ -46,6 +48,7 @@ export function mergeMap<T, I, R>(project: (value: T, index: number) => Observab
  * // b1
  * // c1
  * // continues to list a,b,c with respective ascending integers
+ * ```
  *
  * @see {@link concatMap}
  * @see {@link exhaustMap}

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -22,10 +22,13 @@ export function mergeMapTo<T, I, R>(innerObservable: ObservableInput<I>, resultS
  * of the source value, and then merges those resulting Observables into one
  * single Observable, which is the output Observable.
  *
- * @example <caption>For each click event, start an interval Observable ticking every 1 second</caption>
+ * ## Example
+ * For each click event, start an interval Observable ticking every 1 second
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.mergeMapTo(Rx.Observable.interval(1000));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link concatMapTo}
  * @see {@link merge}

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -17,7 +17,9 @@ import { ObservableInput, OperatorFunction } from '../types';
  * <span class="informal">It's like {@link scan}, but the Observables returned
  * by the accumulator are merged into the outer Observable.</span>
  *
- * @example <caption>Count the number of click events</caption>
+ * ## Example
+ * Count the number of click events
+ * ```javascript
  * const click$ = Rx.Observable.fromEvent(document, 'click');
  * const one$ = click$.mapTo(1);
  * const seed = 0;
@@ -30,6 +32,7 @@ import { ObservableInput, OperatorFunction } from '../types';
  * 3
  * 4
  * // ...and so on for each click
+ * ```
  *
  * @param {function(acc: R, value: T): Observable<R>} accumulator
  * The accumulator function called on each source value.

--- a/src/internal/operators/min.ts
+++ b/src/internal/operators/min.ts
@@ -7,12 +7,16 @@ import { MonoTypeOperatorFunction } from '../types';
  *
  * <img src="./img/min.png" width="100%">
  *
- * @example <caption>Get the minimal value of a series of numbers</caption>
+ * ## Examples
+ * Get the minimal value of a series of numbers
+ * ```javascript
  * Rx.Observable.of(5, 4, 7, 2, 8)
  *   .min()
  *   .subscribe(x => console.log(x)); // -> 2
+ * ```
  *
- * @example <caption>Use a comparer function to get the minimal item</caption>
+ * Use a comparer function to get the minimal item
+ * ```typescript
  * interface Person {
  *   age: number,
  *   name: string
@@ -23,6 +27,7 @@ import { MonoTypeOperatorFunction } from '../types';
  *           .min<Person>( (a: Person, b: Person) => a.age < b.age ? -1 : 1)
  *           .subscribe((x: Person) => console.log(x.name)); // -> 'Bar'
  * }
+ * ```
  *
  * @see {@link max}
  *

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -30,7 +30,9 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  * for any kind of delaying of values in the stream, while using `observeOn` to specify which scheduler should be used
  * for notification emissions in general.
  *
- * @example <caption>Ensure values in subscribe are called just before browser repaint.</caption>
+ * ## Example
+ * Ensure values in subscribe are called just before browser repaint.
+ * ```javascript
  * const intervals = Rx.Observable.interval(10); // Intervals are scheduled
  *                                               // with async scheduler by default...
  *
@@ -39,6 +41,7 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  * .subscribe(val => {                           // scheduler to ensure smooth animation.
  *   someDiv.style.height = val + 'px';
  * });
+ * ```
  *
  * @see {@link delay}
  *

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -48,7 +48,9 @@ export function onErrorResumeNext<T, R>(array: ObservableInput<any>[]): Operator
  * specific actions based on what error was emitted by an Observable, you should try out {@link catch} instead.
  *
  *
- * @example <caption>Subscribe to the next Observable after map fails</caption>
+ * ## Example
+ * Subscribe to the next Observable after map fails
+ * ```javascript
  * Rx.Observable.of(1, 2, 3, 0)
  *   .map(x => {
  *       if (x === 0) { throw Error(); }
@@ -69,6 +71,7 @@ export function onErrorResumeNext<T, R>(array: ObservableInput<any>[]): Operator
  * // 2
  * // 3
  * // "that's it!"
+ * ```
  *
  * @see {@link concat}
  * @see {@link catch}

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -18,7 +18,9 @@ import { OperatorFunction } from '../types';
  * emissions from the source Observable, but not on the first emission, because
  * there is no previous value in that case.
  *
- * @example <caption>On every click (starting from the second), emit the relative distance to the previous click</caption>
+ * ## Example
+ * On every click (starting from the second), emit the relative distance to the previous click
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var pairs = clicks.pairwise();
  * var distance = pairs.map(pair => {
@@ -29,6 +31,7 @@ import { OperatorFunction } from '../types';
  *   return Math.sqrt(Math.pow(x0 - x1, 2) + Math.pow(y0 - y1, 2));
  * });
  * distance.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link buffer}
  * @see {@link bufferCount}

--- a/src/internal/operators/partition.ts
+++ b/src/internal/operators/partition.ts
@@ -20,13 +20,16 @@ import { UnaryFunction } from '../types';
  * predicate returns false. The first behaves like {@link filter} and the second
  * behaves like {@link filter} with the predicate negated.
  *
- * @example <caption>Partition click events into those on DIV elements and those elsewhere</caption>
+ * ## Example
+ * Partition click events into those on DIV elements and those elsewhere
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var parts = clicks.partition(ev => ev.target.tagName === 'DIV');
  * var clicksOnDivs = parts[0];
  * var clicksElsewhere = parts[1];
  * clicksOnDivs.subscribe(x => console.log('DIV clicked: ', x));
  * clicksElsewhere.subscribe(x => console.log('Other clicked: ', x));
+ * ```
  *
  * @see {@link filter}
  *

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -15,10 +15,13 @@ import { OperatorFunction } from '../types';
  * Observable. If a property can't be resolved, it will return `undefined` for
  * that value.
  *
- * @example <caption>Map every click to the tagName of the clicked target element</caption>
+ * ## Example
+ * Map every click to the tagName of the clicked target element
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var tagNames = clicks.pluck('target', 'tagName');
  * tagNames.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link map}
  *

--- a/src/internal/operators/reduce.ts
+++ b/src/internal/operators/reduce.ts
@@ -34,13 +34,16 @@ export function reduce<T, R>(accumulator: (acc: R, value: T, index: number) => R
  * that value will be used as the initial value for the accumulator. If no seed
  * value is specified, the first item of the source is used as the seed.
  *
- * @example <caption>Count the number of click events that happened in 5 seconds</caption>
+ * ## Example
+ * Count the number of click events that happened in 5 seconds
+ * ```javascript
  * var clicksInFiveSeconds = Rx.Observable.fromEvent(document, 'click')
  *   .takeUntil(Rx.Observable.interval(5000));
  * var ones = clicksInFiveSeconds.mapTo(1);
  * var seed = 0;
  * var count = ones.reduce((acc, one) => acc + one, seed);
  * count.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link count}
  * @see {@link expand}

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -22,11 +22,14 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * anything since the previous sampling. The `notifier` is subscribed to as soon
  * as the output Observable is subscribed.
  *
- * @example <caption>On every click, sample the most recent "seconds" timer</caption>
+ * ## Example
+ * On every click, sample the most recent "seconds" timer
+ * ```javascript
  * var seconds = Rx.Observable.interval(1000);
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = seconds.sample(clicks);
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link audit}
  * @see {@link debounce}

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -20,10 +20,13 @@ import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic
  * defined by the optional `scheduler` argument). The sampling starts as soon as
  * the output Observable is subscribed.
  *
- * @example <caption>Every second, emit the most recent click at most once</caption>
+ * ## Example
+ * Every second, emit the most recent click at most once
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.sampleTime(1000);
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link auditTime}
  * @see {@link debounceTime}

--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -28,12 +28,15 @@ export function scan<T, R>(accumulator: (acc: R, value: T, index: number) => R, 
  * that value will be used as the initial value for the accumulator. If no seed
  * value is specified, the first item of the source is used as the seed.
  *
- * @example <caption>Count the number of click events</caption>
+ * ## Example
+ * Count the number of click events
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var ones = clicks.mapTo(1);
  * var seed = 0;
  * var count = ones.scan((acc, one) => acc + one, seed);
  * count.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link expand}
  * @see {@link mergeScan}

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -22,7 +22,9 @@ import { Observer, OperatorFunction } from '../types';
  * observable emits before completing, the returned observable will emit `false` and complete. If one observable never
  * completes or emits after the other complets, the returned observable will never complete.
  *
- * @example <caption>figure out if the Konami code matches</caption>
+ * ## Example
+ * figure out if the Konami code matches
+ * ```javascript
  * var code = Rx.Observable.from([
  *  "ArrowUp",
  *  "ArrowUp",
@@ -46,6 +48,7 @@ import { Observer, OperatorFunction } from '../types';
  *        .sequenceEqual(code)
  *   );
  * matches.subscribe(matched => console.log('Successful cheat at Contra? ', matched));
+ * ```
  *
  * @see {@link combineLatest}
  * @see {@link zip}

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -14,13 +14,16 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * values are taken from the front of the queue and produced on the result
  * sequence. This causes values to be delayed.
  *
- * @example <caption>Skip the last 2 values of an Observable with many values</caption>
+ * ## Example
+ * Skip the last 2 values of an Observable with many values
+ * ```javascript
  * var many = Rx.Observable.range(1, 5);
  * var skipLastTwo = many.skipLast(2);
  * skipLastTwo.subscribe(x => console.log(x));
  *
  * // Results in:
  * // 1 2 3
+ * ```
  *
  * @see {@link skip}
  * @see {@link skipUntil}

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -35,10 +35,13 @@ export function switchMap<T, I, R>(project: (value: T, index: number) => Observa
  * emitting items from the new one. It continues to behave like this for
  * subsequent inner Observables.
  *
- * @example <caption>Rerun an interval Observable on every click event</caption>
+ * ## Example
+ * Rerun an interval Observable on every click event
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.switchMap((ev) => Rx.Observable.interval(1000));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link concatMap}
  * @see {@link exhaustMap}

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -31,10 +31,13 @@ export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * emits values only from the most recently emitted instance of
  * `innerObservable`.
  *
- * @example <caption>Rerun an interval Observable on every click event</caption>
+ * ## Example
+ * Rerun an interval Observable on every click event
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.switchMapTo(Rx.Observable.interval(1000));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link concatMapTo}
  * @see {@link switch}

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -18,10 +18,13 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * all of its values are emitted. After that, it completes, regardless if the
  * source completes.
  *
- * @example <caption>Take the first 5 seconds of an infinite 1-second interval Observable</caption>
+ * ## Example
+ * Take the first 5 seconds of an infinite 1-second interval Observable
+ * ```javascript
  * var interval = Rx.Observable.interval(1000);
  * var five = interval.take(5);
  * five.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link takeLast}
  * @see {@link takeUntil}

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -21,10 +21,13 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * whether or not more values will be emitted on the source. For this reason,
  * all values are emitted synchronously, followed by the complete notification.
  *
- * @example <caption>Take the last 3 values of an Observable with many values</caption>
+ * ## Example
+ * Take the last 3 values of an Observable with many values
+ * ```javascript
  * var many = Rx.Observable.range(1, 100);
  * var lastThree = many.pipe(takeLast(3));
  * lastThree.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link take}
  * @see {@link takeUntil}

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -23,11 +23,14 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * and completes. If the `notifier` doesn't emit any value and completes
  * then `takeUntil` will pass all values.
  *
- * @example <caption>Tick every second until the first click happens</caption>
+ * ## Example
+ * Tick every second until the first click happens
+ * ```javascript
  * var interval = Rx.Observable.interval(1000);
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = interval.takeUntil(clicks);
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link take}
  * @see {@link takeLast}

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -20,10 +20,13 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * returns false, at which point `takeWhile` stops mirroring the source
  * Observable and completes the output Observable.
  *
- * @example <caption>Emit click events only while the clientX property is greater than 200</caption>
+ * ## Example
+ * Emit click events only while the clientX property is greater than 200
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.takeWhile(ev => ev.clientX > 200);
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link take}
  * @see {@link takeLast}

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -33,12 +33,15 @@ export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T
  * Observer will never happen. `do` therefore simply spies on existing
  * execution, it does not trigger an execution to happen like `subscribe` does.
  *
- * @example <caption>Map every click to the clientX position of that click, while also logging the click event</caption>
+ * ## Example
+ * Map every click to the clientX position of that click, while also logging the click event
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var positions = clicks
  *   .do(ev => console.log(ev))
  *   .map(ev => ev.clientX);
  * positions.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link map}
  * @see {@link subscribe}

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -38,10 +38,13 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * value or completes, the timer is disabled, and this process repeats for the
  * next source value.
  *
- * @example <caption>Emit clicks at a rate of at most one click per second</caption>
+ * ## Example
+ * Emit clicks at a rate of at most one click per second
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.throttle(ev => Rx.Observable.interval(1000));
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link audit}
  * @see {@link debounce}

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -24,10 +24,13 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * and this process repeats for the next source value. Optionally takes a
  * {@link IScheduler} for managing timers.
  *
- * @example <caption>Emit clicks at a rate of at most one click per second</caption>
+ * ## Example
+ * Emit clicks at a rate of at most one click per second
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.throttleTime(1000);
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link auditTime}
  * @see {@link debounceTime}

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -7,8 +7,8 @@ import { MonoTypeOperatorFunction } from '../types';
  * an error. The error will be created at that time by the optional
  * `errorFactory` argument, otherwise, the error will be {@link ErrorEmpty}.
  *
- * @example
- *
+ * ## Example
+ * ```javascript
  * const click$ = fromEvent(button, 'click');
  *
  * clicks$.pipe(
@@ -21,6 +21,8 @@ import { MonoTypeOperatorFunction } from '../types';
  *   next() { console.log('The button was clicked'); },
  *   error(err) { console.error(err); },
  * });
+ * ```
+ *
  * @param {Function} [errorFactory] A factory function called to produce the
  * error to be thrown when the source observable completes without emitting a
  * value.

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -37,7 +37,9 @@ import { throwError } from '../observable/throwError';
  * `timeout` accepts also a Scheduler as a second parameter. It is used to schedule moment (or moments)
  * when returned Observable will check if source stream emitted value or completed.
  *
- * @example <caption>Check if ticks are emitted within certain timespan</caption>
+ * ## Examples
+ * Check if ticks are emitted within certain timespan
+ * ```javascript
  * const seconds = Rx.Observable.interval(1000);
  *
  * seconds.timeout(1100) // Let's use bigger timespan to be safe,
@@ -52,8 +54,10 @@ import { throwError } from '../observable/throwError';
  *     err => console.log(err) // Will emit error before even first value is emitted,
  *                             // since it did not arrive within 900ms period.
  * );
+ * ```
  *
- * @example <caption>Use Date to check if Observable completed</caption>
+ * Use Date to check if Observable completed
+ * ```javascript
  * const seconds = Rx.Observable.interval(1000);
  *
  * seconds.timeout(new Date("December 17, 2020 03:24:00"))
@@ -63,7 +67,7 @@ import { throwError } from '../observable/throwError';
  *     err => console.log(err) // On December 17, 2020 at 03:24:00 it will emit an error,
  *                             // since Observable did not complete by then.
  * );
- *
+ * ```
  * @see {@link timeoutWith}
  *
  * @param {number|Date} due Number specifying period within which Observable must emit values

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -37,7 +37,9 @@ export function timeoutWith<T, R>(due: number | Date, withObservable: Observable
  * as a consequence - when second Observable will be subscribed, since subscription happens
  * immediately after failing check.
  *
- * @example <caption>Add fallback observable</caption>
+ * ## Example
+ * Add fallback observable
+ * ```javascript
  * const seconds = Rx.Observable.interval(1000);
  * const minutes = Rx.Observable.interval(60 * 1000);
  *
@@ -48,6 +50,7 @@ export function timeoutWith<T, R>(due: number | Date, withObservable: Observable
  *         err => console.log(err) // Would be called after 900ms in case of `timeout`,
  *                                 // but here will never be called.
  *     );
+ * ```
  *
  * @param {number|Date} due Number specifying period within which Observable must emit values
  *                          or Date specifying before when Observable should complete

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -22,14 +22,16 @@ import { Operator } from '../Operator';
  * Observable `windowBoundaries` emits an item. Because each window is an
  * Observable, the output is a higher-order Observable.
  *
- * @example <caption>In every window of 1 second each, emit at most 2 click events</caption>
+ * ## Example
+ * In every window of 1 second each, emit at most 2 click events
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var interval = Rx.Observable.interval(1000);
  * var result = clicks.window(interval)
  *   .map(win => win.take(2)) // each window has at most 2 emissions
  *   .mergeAll(); // flatten the Observable-of-Observables
  * result.subscribe(x => console.log(x));
- *
+ * ```
  * @see {@link windowCount}
  * @see {@link windowTime}
  * @see {@link windowToggle}

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -22,18 +22,23 @@ import { OperatorFunction } from '../types';
  * started immediately at the start of the source and when each window completes
  * with size `windowSize`.
  *
- * @example <caption>Ignore every 3rd click event, starting from the first one</caption>
+ * ## Examples
+ * Ignore every 3rd click event, starting from the first one
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.windowCount(3)
  *   .map(win => win.skip(1)) // skip first of every 3 clicks
  *   .mergeAll(); // flatten the Observable-of-Observables
  * result.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Ignore every 3rd click event, starting from the third one</caption>
+ * Ignore every 3rd click event, starting from the third one
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.windowCount(2, 3)
  *   .mergeAll(); // flatten the Observable-of-Observables
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link window}
  * @see {@link windowTime}

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -30,26 +30,33 @@ import { OperatorFunction, SchedulerLike, SchedulerAction } from '../types';
  * after emitting last value and next one still will open as specified by
  * `windowTimeSpan` and `windowCreationInterval` arguments.
  *
- * @example <caption>In every window of 1 second each, emit at most 2 click events</caption>
+ * ## Examples
+ * In every window of 1 second each, emit at most 2 click events
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.windowTime(1000)
  *   .map(win => win.take(2)) // each window has at most 2 emissions
  *   .mergeAll(); // flatten the Observable-of-Observables
  * result.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Every 5 seconds start a window 1 second long, and emit at most 2 click events per window</caption>
+ * Every 5 seconds start a window 1 second long, and emit at most 2 click events per window
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.windowTime(1000, 5000)
  *   .map(win => win.take(2)) // each window has at most 2 emissions
  *   .mergeAll(); // flatten the Observable-of-Observables
  * result.subscribe(x => console.log(x));
+ * ```
  *
- * @example <caption>Same as example above but with maxWindowCount instead of take</caption>
+ * Same as example above but with maxWindowCount instead of take
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks.windowTime(1000, 5000, 2) // each window has still at most 2 emissions
  *   .mergeAll(); // flatten the Observable-of-Observables
  * result.subscribe(x => console.log(x));
-
+ * ```
+ *
  * @see {@link window}
  * @see {@link windowCount}
  * @see {@link windowToggle}

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -26,13 +26,16 @@ import { OperatorFunction } from '../types';
  * Observable emits an item and when the Observable returned by
  * `closingSelector` emits an item.
  *
- * @example <caption>Every other second, emit the click events from the next 500ms</caption>
+ * ## Example
+ * Every other second, emit the click events from the next 500ms
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var openings = Rx.Observable.interval(1000);
  * var result = clicks.windowToggle(openings, i =>
  *   i % 2 ? Rx.Observable.interval(500) : Rx.Observable.empty()
  * ).mergeAll();
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link window}
  * @see {@link windowCount}

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -26,13 +26,16 @@ import { OperatorFunction } from '../types';
  * produced by the specified `closingSelector` function emits an item. The first
  * window is opened immediately when subscribing to the output Observable.
  *
- * @example <caption>Emit only the first two clicks events in every window of [1-5] random seconds</caption>
+ * ## Example
+ * Emit only the first two clicks events in every window of [1-5] random seconds
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var result = clicks
  *   .windowWhen(() => Rx.Observable.interval(1000 + Math.random() * 4000))
  *   .map(win => win.take(2)) // each window has at most 2 emissions
  *   .mergeAll(); // flatten the Observable-of-Observables
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link window}
  * @see {@link windowCount}

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -40,11 +40,14 @@ export function withLatestFrom<T, R>(array: ObservableInput<any>[], project: (..
  * the value to be emitted on the output Observable. All input Observables must
  * emit at least one value before the output Observable will emit a value.
  *
- * @example <caption>On every click event, emit an array with the latest timer event plus the click event</caption>
+ * ## Example
+ * On every click event, emit an array with the latest timer event plus the click event
+ * ```javascript
  * var clicks = Rx.Observable.fromEvent(document, 'click');
  * var timer = Rx.Observable.interval(1000);
  * var result = clicks.withLatestFrom(timer);
  * result.subscribe(x => console.log(x));
+ * ```
  *
  * @see {@link combineLatest}
  *

--- a/src/internal/scheduler/animationFrame.ts
+++ b/src/internal/scheduler/animationFrame.ts
@@ -14,7 +14,9 @@ import { AnimationFrameScheduler } from './AnimationFrameScheduler';
  * It makes sure scheduled task will happen just before next browser content repaint,
  * thus performing animations as efficiently as possible.
  *
- * @example <caption>Schedule div height animation</caption>
+ * ## Example
+ * Schedule div height animation
+ * ```javascript
  * const div = document.querySelector('.some-div');
  *
  * Rx.Scheduler.animationFrame.schedule(function(height) {
@@ -25,7 +27,7 @@ import { AnimationFrameScheduler } from './AnimationFrameScheduler';
  * }, 0, 0);
  *
  * // You will see .some-div element growing in height
- *
+ * ```
  *
  * @static true
  * @name animationFrame

--- a/src/internal/scheduler/asap.ts
+++ b/src/internal/scheduler/asap.ts
@@ -21,8 +21,9 @@ import { AsapScheduler } from './AsapScheduler';
  * that task will execute first. That being said, if you need to schedule task asynchronously, but
  * as soon as possible, `asap` scheduler is your best bet.
  *
- * @example <caption>Compare async and asap scheduler</caption>
- *
+ * ## Example
+ * Compare async and asap scheduler<
+ * ```javascript
  * Rx.Scheduler.async.schedule(() => console.log('async')); // scheduling 'async' first...
  * Rx.Scheduler.asap.schedule(() => console.log('asap'));
  *
@@ -30,7 +31,7 @@ import { AsapScheduler } from './AsapScheduler';
  * // "asap"
  * // "async"
  * // ... but 'asap' goes first!
- *
+ * ```
  * @static true
  * @name asap
  * @owner Scheduler

--- a/src/internal/scheduler/async.ts
+++ b/src/internal/scheduler/async.ts
@@ -15,16 +15,19 @@ import { AsyncScheduler } from './AsyncScheduler';
  * executing synchronous code ends (commonly achieved by `setTimeout(deferredTask, 0)`),
  * better choice will be the {@link asap} scheduler.
  *
- * @example <caption>Use async scheduler to delay task</caption>
+ * ## Examples
+ * Use async scheduler to delay task
+ * ```javascript
  * const task = () => console.log('it works!');
  *
  * Rx.Scheduler.async.schedule(task, 2000);
  *
  * // After 2 seconds logs:
  * // "it works!"
+ * ```
  *
- *
- * @example <caption>Use async scheduler to repeat task in intervals</caption>
+ * Use async scheduler to repeat task in intervals
+ * ```javascript
  * function task(state) {
  *   console.log(state);
  *   this.schedule(state + 1, 1000); // `this` references currently executing Action,
@@ -38,6 +41,7 @@ import { AsyncScheduler } from './AsyncScheduler';
  * // 1 after 4s
  * // 2 after 5s
  * // 3 after 6s
+ * ```
  *
  * @static true
  * @name async

--- a/src/internal/scheduler/queue.ts
+++ b/src/internal/scheduler/queue.ts
@@ -17,8 +17,9 @@ import { QueueScheduler } from './QueueScheduler';
  * This means that when you execute task with `queue` scheduler, you are sure it will end
  * before any other task scheduled with that scheduler will start.
  *
- * @examples <caption>Schedule recursively first, then do something</caption>
- *
+ * ## Examples
+ * Schedule recursively first, then do something
+ * ```javascript
  * Rx.Scheduler.queue.schedule(() => {
  *   Rx.Scheduler.queue.schedule(() => console.log('second')); // will not happen now, but will be put on a queue
  *
@@ -28,10 +29,10 @@ import { QueueScheduler } from './QueueScheduler';
  * // Logs:
  * // "first"
  * // "second"
+ * ```
  *
- *
- * @example <caption>Reschedule itself recursively</caption>
- *
+ * Reschedule itself recursively
+ * ```javascript
  * Rx.Scheduler.queue.schedule(function(state) {
  *   if (state !== 0) {
  *     console.log('before', state);
@@ -56,7 +57,7 @@ import { QueueScheduler } from './QueueScheduler';
  * // "after", 2
  * // "before", 1
  * // "after", 1
- *
+ * ```
  *
  * @static true
  * @name queue


### PR DESCRIPTION
Dgeni is actually not capable to transform @example jsdoc notation. For this purpose I changed all examples to the md notation. For results see attached images. The only exception is generate.ts. the function overloading makes the example looks kinda weird. Will make a seperate pull request for generate.ts

![windowwhen_before](https://user-images.githubusercontent.com/6104311/40931668-29d4a646-682c-11e8-92d6-a15f4038d146.PNG)
![windowwhen_after](https://user-images.githubusercontent.com/6104311/40931672-2bd9c82c-682c-11e8-90eb-34604765f7a3.PNG)


