### PR TITLE
fix(from): Changed the priority of observable detection

### DIFF
--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -59,6 +59,21 @@ describe('from', () => {
     })
   });
 
+  const fakeArrayObservable = <T>(...values: T[]) => {
+    let arr = ['bad array!'];
+    arr[Symbol.observable] = () =>  {
+      return {
+        subscribe: (observer: Observer<T>) => {
+          for (const value of values) {
+            observer.next(value);
+          }
+          observer.complete();
+        }
+      };
+    };
+    return arr;
+  };
+
   const fakerator = <T>(...values: T[]) => ({
     [Symbol.iterator as symbol]: () => {
       const clone = [...values];
@@ -75,6 +90,7 @@ describe('from', () => {
   const sources: Array<{ name: string, value: any }> = [
     { name: 'observable', value: of('x') },
     { name: 'observable-like', value: fakervable('x') },
+    { name: 'observable-like-array', value: fakeArrayObservable('x') },
     { name: 'array', value: ['x'] },
     { name: 'promise', value: Promise.resolve('x') },
     { name: 'iterator', value: fakerator('x') },

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -17,7 +17,7 @@ export function from<T>(input: ObservableInput<T>, scheduler?: SchedulerLike): O
     if (input instanceof Observable) {
       return input;
     }
-    return new Observable(subscribeTo(input));
+    return new Observable<T>(subscribeTo(input));
   }
 
   if (input != null) {

--- a/src/internal/util/subscribeTo.ts
+++ b/src/internal/util/subscribeTo.ts
@@ -22,14 +22,14 @@ export const subscribeTo = <T>(result: ObservableInput<T>) => {
         return result.subscribe(subscriber);
       }
     };
+  } else if (result && typeof result[Symbol_observable] === 'function') {
+    return subscribeToObservable(result as any);
   } else if (isArrayLike(result)) {
     return subscribeToArray(result);
   } else if (isPromise(result)) {
     return subscribeToPromise(result as Promise<any>);
   } else if (result && typeof result[Symbol_iterator] === 'function') {
     return subscribeToIterable(result as any);
-  } else if (result && typeof result[Symbol_observable] === 'function') {
-    return subscribeToObservable(result as any);
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;
     const msg = `You provided ${value} where a stream was expected.`


### PR DESCRIPTION
**Description:**

This PR ensures that `Observable.from` uses Observable Symbol interop mechanism before attempting any others. 

**Related issue (if exists):**

Closes #3779 