### PR TITLE
fix(Observable): Update typings of pipe

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -296,7 +296,7 @@ export class Observable<T> implements Subscribable<T> {
   pipe<A, B, C, D, E, F, G>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>): Observable<G>;
   pipe<A, B, C, D, E, F, G, H>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>): Observable<H>;
   pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): Observable<I>;
-  pipe<R>(...operations: OperatorFunction<T, R>[]): Observable<R>;
+  pipe<R>(...operations: OperatorFunction<any, any>[]): Observable<R>;
   /* tslint:enable:max-line-length */
 
   /**


### PR DESCRIPTION
**Description:**
Added <any, any>[] as tyings for the generic type of operators provided to the pipe, as
OperatorFunctions can transform the type.

The fix is as suggested by @cartant  here: https://github.com/ReactiveX/rxjs/issues/3766#issuecomment-393447462

Travis CI passes for typescript current, but not for next (not related to my change): https://travis-ci.org/akehir/rxjs/builds/388179712

**Related issue (if exists):**
#3766 