### PR TITLE
docs(CoC): add code of conduct to documentation

### DIFF
--- a/docs_app/content/code-of-conduct.md
+++ b/docs_app/content/code-of-conduct.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+In the interest of fostering an open and welcoming environment, we as
+contributors and maintainers pledge to making participation in our project and
+our community a harassment-free experience for everyone, regardless of age, body
+size, disability, ethnicity, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance, race,
+religion, or sexual identity and orientation.
+
+## Our Standards
+
+Examples of behavior that contributes to creating a positive environment
+include:
+
+* Using welcoming and inclusive language
+* Being respectful of differing viewpoints and experiences
+* Gracefully accepting constructive criticism
+* Focusing on what is best for the community
+* Showing empathy towards other community members
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery and unwelcome sexual attention or
+  advances
+* Trolling, insulting/derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or electronic
+  address, without explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Our Responsibilities
+
+Project maintainers are responsible for clarifying the standards of acceptable
+behavior and are expected to take appropriate and fair corrective action in
+response to any instances of unacceptable behavior.
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community. Examples of
+representing a project or community include using an official project e-mail
+address, posting via an official social media account, or acting as an appointed
+representative at an online or offline event. Representation of a project may be
+further defined and clarified by project maintainers.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting Ben Lesh (ben@benlesh.com), Tracy Lee (tracy@thisdot.co) or OJ Kwon (kwon.ohjoong@gmail.com). All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage], version 1.4,
+available at https://www.contributor-covenant.org/version/1/4/code-of-conduct.html
+
+[homepage]: https://www.contributor-covenant.org

--- a/docs_app/content/marketing/index.html
+++ b/docs_app/content/marketing/index.html
@@ -44,6 +44,18 @@
         </div>
       </div>
     </div>
+    <hr>
+    <div layout="row" layout-xs="column" class="home-row homepage-container">
+      <div layout="row" layout-xs="column" class="home-row">
+        <a href="code-of-conduct">
+          <div class="card">
+            <div class="card-text-container">
+              <p>Please pay attention to our</p>
+              <div class="text-headline">Code of Conduct</div>
+            </div>
+          </div>
+        </a>
+      </div>
   </div><!-- end of home rows -->
 
 </article>

--- a/docs_app/content/navigation.json
+++ b/docs_app/content/navigation.json
@@ -43,9 +43,14 @@
           "url": "guide/v6/migration",
           "title": "Migration"
         }
-      ],
-      "docVersions": []
+      ]
+    },
+    {
+      "url": "code-of-conduct",
+      "title": "Code of Conduct",
+      "tooltip": "Code of Conduct"
     }
-  ]
+  ],
+  "docVersions": []
 }
 

--- a/docs_app/src/styles/1-layouts/_marketing-layout.scss
+++ b/docs_app/src/styles/1-layouts/_marketing-layout.scss
@@ -214,7 +214,8 @@ section#intro {
   align-items: center;
   position: relative;
   width: 70%;
-  min-width: 350px;
+  min-width: 270px;
+  text-align: center;
   height: auto;
   margin: auto;
   padding: 24px;


### PR DESCRIPTION
closes #3791 

adds a page for the code of conduct and a link to get there directly from the start page.
Totally open for any kind of UI suggestions :D
The content of the code of conduct is just copied from the rxjs repo.

![homecoc](https://user-images.githubusercontent.com/6104311/40992682-c594b5b4-68f7-11e8-998f-066bb861eab3.PNG)
![cocpage](https://user-images.githubusercontent.com/6104311/40992684-c6e3a3f8-68f7-11e8-8a66-5b55332a98a2.PNG)
