### PR TITLE
docs(jsdoc): add examples for endWith operator

### DIFF
--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -21,6 +21,44 @@ export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperator
  * Returns an Observable that emits the items you specify as arguments after it finishes emitting
  * items emitted by the source Observable.
  *
+ * ## Examples
+ * ### Emits a value before completing (appends an emission to a series of emissions).
+ *
+ * ```javascript
+ * from(['hi', 'how are you?', 'sorry, I have to go now']).pipe(
+ *   endWith('goodbye!'),
+ * )
+ * .subscribe(word => console.log(word));
+ * // result:
+ * // 'hi'
+ * // 'how are you?'
+ * // 'sorry, I have to go now'
+ * // 'goodbye!'
+ * ```
+ *
+ * ### Emits a value before completing (with no prior emissions)
+ * ```javascript
+ * empty().pipe(
+ *   endWith('goodbye!'),
+ * )
+ * .subscribe(word => console.log(word));
+ * // result:
+ * // 'goodbye!'
+ * ```
+ *
+ * ### Does not work with abnormal termination
+ * ```javascript
+ * throwError('any error').pipe(
+ *   endWith('goodbye!'),
+ * )
+ * .subscribe(
+ *   word => console.log(word),
+ *   err => console.log('sorry, I choked'),
+ * );
+ * // result:
+ * // 'sorry, I choked' - endWith won't emit values when an error is thrown
+ * ```
+ *
  * @param {...T} values - Items you want the modified Observable to emit last.
  * @param {Scheduler} [scheduler] - A {@link IScheduler} to use for scheduling
  * the emissions of the `next` notifications.

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -22,10 +22,10 @@ export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperator
  * items emitted by the source Observable.
  *
  * ## Examples
- * ### Emits a value before completing (appends an emission to a series of emissions).
+ * ### After the source observable completes, appends an emission and then completes too.
  *
  * ```javascript
- * from(['hi', 'how are you?', 'sorry, I have to go now']).pipe(
+ * of('hi', 'how are you?', 'sorry, I have to go now').pipe(
  *   endWith('goodbye!'),
  * )
  * .subscribe(word => console.log(word));
@@ -34,29 +34,6 @@ export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperator
  * // 'how are you?'
  * // 'sorry, I have to go now'
  * // 'goodbye!'
- * ```
- *
- * ### Emits a value before completing (with no prior emissions)
- * ```javascript
- * empty().pipe(
- *   endWith('goodbye!'),
- * )
- * .subscribe(word => console.log(word));
- * // result:
- * // 'goodbye!'
- * ```
- *
- * ### Does not work with abnormal termination
- * ```javascript
- * throwError('any error').pipe(
- *   endWith('goodbye!'),
- * )
- * .subscribe(
- *   word => console.log(word),
- *   err => console.log('sorry, I choked'),
- * );
- * // result:
- * // 'sorry, I choked' - endWith won't emit values when an error is thrown
  * ```
  *
  * @param {...T} values - Items you want the modified Observable to emit last.

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -21,7 +21,7 @@ export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperator
  * Returns an Observable that emits the items you specify as arguments after it finishes emitting
  * items emitted by the source Observable.
  *
- * ## Examples
+ * ## Example
  * ### After the source observable completes, appends an emission and then completes too.
  *
  * ```javascript


### PR DESCRIPTION
**Description:**
Add jsdoc examples for `endWith` operator.
