### PR TITLE
Don't comment on locked issues

### DIFF
--- a/.github/lock.yml
+++ b/.github/lock.yml
@@ -10,10 +10,7 @@ exemptLabels: []
 lockLabel: false
 
 # Comment to post before locking. Set to `false` to disable
-lockComment: >
-  This thread has been automatically locked since there has not been
-  any recent activity after it was closed. Please open a new issue for
-  related bugs.
+lockComment: false
 
 # Limit to only `issues` or `pulls`
 # only: issues


### PR DESCRIPTION
If you set up lock bot to _only_ lock, it won't make notifications on old threads. It does mean that users won't get told why the issue is locked though, so it's a bit of a tradeoff. For ye old issue reporters and PR makers (like myself), I want to get notifications on relevant threads I'm in rather than knowing about every locked one.