### PR TITLE
fix: make TS type def of VirtualAction compatible with TS >= 2.6

### DIFF
--- a/src/scheduler/AsyncAction.ts
+++ b/src/scheduler/AsyncAction.ts
@@ -14,10 +14,12 @@ export class AsyncAction<T> extends Action<T> {
   public state: T;
   public delay: number;
   protected pending: boolean = false;
+  protected work: (this: this, state?: T) => void;
 
   constructor(protected scheduler: AsyncScheduler,
-              protected work: (this: AsyncAction<T>, state?: T) => void) {
+              work: (this: AsyncAction<T>, state?: T) => void) {
     super(scheduler, work);
+    this.work = work;
   }
 
   public schedule(state?: T, delay: number = 0): Subscription {


### PR DESCRIPTION
**Description:**
I ran into a problem when using RxJS 5.5.11 with typescript newer than 2.6.
The type def for `VirtualAction` from `rxjs/scheduler/VirtualTimeScheduler` is not compatible with newer typescript, so I cannot compile my project.

```
ERROR in /home/---/workspace/project/node_modules/rxjs/scheduler/VirtualTimeScheduler.d.ts                               
ERROR in /home/---/workspace/project/node_modules/rxjs/scheduler/VirtualTimeScheduler.d.ts(24,15):                       
TS2416: Property 'work' in type 'VirtualAction<T>' is not assignable to the same property in base type 'AsyncAction<T>'.                           
  Type '(this: VirtualAction<T>, state?: T | undefined) => void' is not assignable to type '(this: AsyncAction<T>, state?: T | undefined) => void'.
    The 'this' types of each signature are incompatible.                                                                                           
      Type 'AsyncAction<T>' is not assignable to type 'VirtualAction<T>'.                                                                          
        Property 'index' is missing in type 'AsyncAction<T>'.                                                                                      
```

**Related issue (if exists):**
Fixes: #3031