### PR TITLE
fix(fromEvent): Support React Native and node-compatible event sources.

### DIFF
--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -13,6 +13,14 @@ export interface NodeStyleEventEmitter {
 
 export type NodeEventHandler = (...args: any[]) => void;
 
+// For APIs that implement `addListener` and `removeListener` methods that may
+// not use the same arguments or return EventEmitter values
+// such as React Native
+export interface NodeCompatibleEventEmitter {
+  addListener: (eventName: string, handler: NodeEventHandler) => void | {};
+  removeListener: (eventName: string, handler: NodeEventHandler) => void | {};
+}
+
 export interface JQueryStyleEventEmitter {
   on: (eventName: string, handler: Function) => void;
   off: (eventName: string, handler: Function) => void;
@@ -23,7 +31,7 @@ export interface HasEventTargetAddRemove<E> {
   removeEventListener(type: string, listener?: ((evt: E) => void) | null, options?: EventListenerOptions | boolean): void;
 }
 
-export type EventTargetLike<T> = HasEventTargetAddRemove<T> | NodeStyleEventEmitter | JQueryStyleEventEmitter;
+export type EventTargetLike<T> = HasEventTargetAddRemove<T> | NodeStyleEventEmitter | NodeCompatibleEventEmitter | JQueryStyleEventEmitter;
 
 export type FromEventTarget<T> = EventTargetLike<T> | ArrayLike<EventTargetLike<T>>;
 


### PR DESCRIPTION
React Native implements a similar interface to Node.js event listeners -- specifically, its Event Emitters have addListener and removeListener methods. These are compatible with the Node interface, but they are not identical to the Node.js *style* since the addListener method returns a subscription rather than the event emitter itself, and the removeListener method returns nothing.

These return values are not actually used by fromEvent, so creating an Observable from an Event Emitter where addListener returns something different and removeListener returns nothing should still work to create a compatible Observable that emits with the corresponding events.

Closes #3809 