### PR TITLE
docs(test): fix typo in the resource and navigation test

### DIFF
--- a/docs_app/src/app/custom-elements/resource/resource.service.spec.ts
+++ b/docs_app/src/app/custom-elements/resource/resource.service.spec.ts
@@ -44,7 +44,7 @@ describe('ResourceService', () => {
     it('categories observable should complete', () => {
       let completed = false;
       resourceService.categories.subscribe(undefined, undefined, () => completed = true);
-      expect(true).toBe(true, 'observable completed');
+      expect(completed).toBe(true, 'observable completed');
     });
 
     it('should reshape contributors.json to sorted category array', () => {

--- a/docs_app/src/app/navigation/navigation.service.spec.ts
+++ b/docs_app/src/app/navigation/navigation.service.spec.ts
@@ -46,10 +46,11 @@ describe('NavigationService', () => {
     it('navigationViews observable should complete', () => {
       let completed = false;
       navService.navigationViews.subscribe(undefined, undefined, () => completed = true);
-      expect(true).toBe(true, 'observable completed');
 
       // Stop `$httpMock.verify()` from complaining.
-      httpMock.expectOne({});
+      httpMock.expectOne({}).flush({});
+
+      expect(completed).toBe(true, 'observable completed');
     });
 
     it('should return the same object to all subscribers', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Just typo in the tests

**Related issue (if exists):**
