### PR TITLE
fix(AjaxObservable): switch to encodeURIComponent to properly encode body form data

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -643,6 +643,40 @@ describe('Observable.ajax', () => {
       expect(complete).to.be.true;
     });
 
+    it('properly encode full URLs passed', () => {
+      const expected = { test: 'https://google.com/search?q=encodeURI+vs+encodeURIComponent' };
+      let result: Rx.AjaxResponse;
+      let complete = false;
+
+      Rx.Observable
+        .ajax.post('/flibbertyJibbet', expected)
+        .subscribe(x => {
+          result = x;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.method).to.equal('POST');
+      expect(request.url).to.equal('/flibbertyJibbet');
+      expect(request.requestHeaders).to.deep.equal({
+        'X-Requested-With': 'XMLHttpRequest',
+        'Content-Type': 'application/x-www-form-urlencoded; charset=UTF-8'
+      });
+
+      request.respondWith({
+        'status': 200,
+        'contentType': 'application/json',
+        'responseText': JSON.stringify(expected)
+      });
+
+      expect(request.data)
+        .to.equal('test=https%3A%2F%2Fgoogle.com%2Fsearch%3Fq%3DencodeURI%2Bvs%2BencodeURIComponent');
+      expect(result.response).to.deep.equal(expected);
+      expect(complete).to.be.true;
+    });
+
     it('should succeed on 204 No Content', () => {
       const expected = null;
       let result: Rx.AjaxResponse;

--- a/src/observable/dom/AjaxObservable.ts
+++ b/src/observable/dom/AjaxObservable.ts
@@ -292,7 +292,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
     switch (contentType) {
       case 'application/x-www-form-urlencoded':
-        return Object.keys(body).map(key => `${encodeURI(key)}=${encodeURI(body[key])}`).join('&');
+        return Object.keys(body).map(key => `${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`).join('&');
       case 'application/json':
         return JSON.stringify(body);
       default:


### PR DESCRIPTION
**Description:**
Switch to encodeURIComponent so characters like & and + are properly encoded. This fix is in RxJS 6
but is not in RxJS 5.

**Related issue:**
Fixes #3824
