### PR TITLE
fix(Scheduler): Wrap Date.now in arrow fn and drop existance check

### DIFF
--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -23,8 +23,12 @@ import { SchedulerLike, SchedulerAction } from './types';
  */
 export class Scheduler implements SchedulerLike {
 
-  /** @nocollapse */
-  public static now: () => number = Date.now ? Date.now : () => +new Date();
+  /**
+   * Note: the extra arrow function wrapper is to make testing by overriding
+   * Date.now easier.
+   * @nocollapse
+   */
+  public static now: () => number = () => Date.now();
 
   constructor(private SchedulerAction: typeof Action,
               now: () => number = Scheduler.now) {


### PR DESCRIPTION
**Description:** Uses Date.now indirectly in the Scheduler, rather than getting the reference statically. Makes common testing infrastructure work, by making it possible to monkeypatch Date.now.

Just assigning Date.now as the default argument for the `now` constructor param would have the same problem as before. But it would be possible to use `() => Date.now()` there instead, if you don't need to keep backwards compatibility with the Scheduler API.

**Related issue (if exists):** #3847
