### PR TITLE
docs(test): Added docs and examples for shareReplay operator

### DIFF
--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -7,8 +7,10 @@ import { Subscriber } from '../Subscriber';
 /**
  * Share source and replay specified number of emissions on subscription.
  *
- * This operator is a specialization of `replay` that connects to the connectable observable sequence
- * when the number of observers goes from zero to one, and disconnects when there are no more observers.
+ * This operator is a specialization of `replay` that connects to a source observable
+ * and multicasts through a `ReplaySubject` constructed with the specified arguments.
+ * A successfully completed source will stay cached in the `shareReplayed observable` forever,
+ * but an errored source can be retried.
  *
  * ## Why use shareReplay?
  * You generally want to use `shareReplay` when you have side-effects or taxing computations
@@ -35,8 +37,8 @@ import { Subscriber } from '../Subscriber';
  * @see {@link share}
  * @see {@link publishReplay}
  *
- * @param {Number} [bufferSize] Maximum element count of the replay buffer.
- * @param {Number} [windowTime] Maximum time length of the replay buffer in milliseconds.
+ * @param {Number} [bufferSize=Number.POSITIVE_INFINITY] Maximum element count of the replay buffer.
+ * @param {Number} [windowTime=Number.MAX_VALUE] Maximum time length of the replay buffer in milliseconds.
  * @param {Scheduler} [scheduler] Scheduler where connected observers within the selector function
  * will be invoked on.
  * @return {Observable} An observable sequence that contains the elements of a sequence produced
@@ -44,7 +46,11 @@ import { Subscriber } from '../Subscriber';
  * @method shareReplay
  * @owner Observable
  */
-export function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike ): MonoTypeOperatorFunction<T> {
+export function shareReplay<T>(
+  bufferSize: number = Number.POSITIVE_INFINITY,
+  windowTime: number = Number.MAX_VALUE,
+  scheduler?: SchedulerLike
+): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(shareReplayOperator(bufferSize, windowTime, scheduler));
 }
 

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -5,6 +5,42 @@ import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { Subscriber } from '../Subscriber';
 
 /**
+ * Share source and replay specified number of emissions on subscription.
+ *
+ * This operator is a specialization of `replay` that connects to the connectable observable sequence
+ * when the number of observers goes from zero to one, and disconnects when there are no more observers.
+ *
+ * ## Why use shareReplay?
+ * You generally want to use `shareReplay` when you have side-effects or taxing computations
+ * that you do not wish to be executed amongst multiple subscribers.
+ * It may also be valuable in situations where you know you will have late subscribers to
+ * a stream that need access to previously emitted values.
+ * This ability to replay values on subscription is what differentiates {@link share} and `shareReplay`.
+ *
+ * ![](shareReplay.png)
+ *
+ * ## Example
+ * ```javascript
+ * const obs$ = interval(1000);
+ * const subscription = obs$.pipe(
+ *   take(4),
+ *   shareReplay(3)
+ * );
+ * subscription.subscribe(x => console.log('source A: ', x));
+ * subscription.subscribe(y => console.log('source B: ', y));
+ *
+ * ```
+ *
+ * @see {@link publish}
+ * @see {@link share}
+ * @see {@link publishReplay}
+ *
+ * @param {Number} [bufferSize] Maximum element count of the replay buffer.
+ * @param {Number} [windowTime] Maximum time length of the replay buffer in milliseconds.
+ * @param {Scheduler} [scheduler] Scheduler where connected observers within the selector function
+ * will be invoked on.
+ * @return {Observable} An observable sequence that contains the elements of a sequence produced
+ * by multicasting the source sequence within a selector function.
  * @method shareReplay
  * @owner Observable
  */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Added docs and code examples for shareReplay operator.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3819