### PR TITLE
docs(throwIfEmpty): add missing marble diagram

### DIFF
--- a/spec/operators/throwIfEmpty-spec.ts
+++ b/spec/operators/throwIfEmpty-spec.ts
@@ -3,9 +3,19 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { EMPTY, of, EmptyError } from 'rxjs';
 import { throwIfEmpty } from 'rxjs/operators';
 
+declare function asDiagram(arg: string): Function;
+
 /** @test {timeout} */
 describe('throwIfEmpty', () => {
   describe('with errorFactory', () => {
+    asDiagram('throwIfEmpty')('should error when empty', () => {
+      const source = cold('----|');
+      const expected =    '----#';
+      expectObservable(
+        source.pipe(throwIfEmpty(() => new Error('test')))
+      ).toBe(expected, undefined, new Error('test'));
+    });
+
     it('should throw if empty', () => {
       const error = new Error('So empty inside');
       let thrown: any;

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -7,6 +7,8 @@ import { MonoTypeOperatorFunction } from '../types';
  * an error. The error will be created at that time by the optional
  * `errorFactory` argument, otherwise, the error will be {@link EmptyError}.
  *
+ * ![](throwIfEmpty.png)
+ *
  * ## Example
  * ```javascript
  * const click$ = fromEvent(button, 'click');


### PR DESCRIPTION
**Description:**

I've noticed that the new `throwIfEmpty` operator doesn't have a marble diagram so this PR adds `asDiagram` test and also adds the image into its docblock.

This is what it looks like:
![throwifempty](https://user-images.githubusercontent.com/238765/42092939-f41b6a98-7baa-11e8-918d-8116c583a623.png)
