### PR TITLE
docs(build): deploy docs to firebase on publish

### DIFF
--- a/docs_app/package.json
+++ b/docs_app/package.json
@@ -11,6 +11,7 @@
     "aio-use-npm": "node tools/ng-packages-installer restore .",
     "aio-check-local": "node tools/ng-packages-installer check .",
     "ng": "ng",
+    "firebase": "firebase",
     "start": "ng serve --aot",
     "prebuild": "npm run setup",
     "build": "npm run ~~build",

--- a/docs_app/scripts/publish-docs.sh
+++ b/docs_app/scripts/publish-docs.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+readonly projectId=rxjs-dev
+readonly deployedUrl=https://rxjs-dev.firebaseapp.com
+readonly firebaseToken=$FIREBASE_TOKEN
+
+# Deploy
+(
+  cd "`dirname $0`/.."
+
+  # Build the app
+  npm run build --env=stable
+
+  # Include any mode-specific files
+  cp -rf src/extra-files/$deployEnv/. dist/
+
+  # Deploy to Firebase
+  npm run firebase -- login
+  npm run firebase -- use "$projectId"
+  npm run firebase -- deploy --message "Deploy docs automatically" --non-interactive
+  npm run firebase -- logout
+)

--- a/package.json
+++ b/package.json
@@ -87,6 +87,7 @@
     "perf:protractor": "echo \"Protractor is not working currently\" && exit -1 && protractor protractor.conf.js",
     "perf:micro": "node ./perf/micro/index.js",
     "prepublish": "shx rm -rf ./typings && npm run build_all",
+    "postpublish": "./docs_app/scripts/publish-docs.sh",
     "publish_docs": "./publish_docs.sh",
     "test": "cross-env TS_NODE_PROJECT=spec/tsconfig.json mocha --opts spec/support/default.opts \"spec/**/*-spec.ts\"",
     "test_transpile_only": "cross-env TS_NODE_PROJECT=spec/tsconfig.json TS_NODE_TRANSPILE_ONLY=true mocha --opts spec/support/default.opts \"spec/**/*-spec.ts\"",


### PR DESCRIPTION
This script should deploy the docs if the rxjs node module is published.
I am not completly sure if it is working completly because I couldn't test it :D
Mind that you have to enter the credentials for the firebase account each time. 