### PR TITLE
docs(migration): mention util interfaces in migration import paths

### DIFF
--- a/docs_app/content/guide/v6/migration.md
+++ b/docs_app/content/guide/v6/migration.md
@@ -150,7 +150,7 @@ For JavaScript developers, the general rule is as follows:
 
 1. **rxjs:** Creation methods, types, schedulers and utilities
 ```ts
-import { Observable, Subject, asapScheduler, pipe, of, from, interval, merge, fromEvent } from 'rxjs';
+import { Observable, Subject, asapScheduler, pipe, of, from, interval, merge, fromEvent, SubscriptionLike, PartialObserver } from 'rxjs';
 ```
 
 2. **rxjs/operators**: All pipeable operators:


### PR DESCRIPTION
**Description:**

I added mentions of `SubscriptionLike` and `PartialObserver` into "Import paths" migration guide: https://github.com/ReactiveX/rxjs/blob/master/docs_app/content/guide/v6/migration.md#import-paths

The first bullet point already says:

> 1. rxjs: Creation methods, types, schedulers and utilities

so I only added `SubscriptionLike` and `PartialObserver` because these two are most common util interfaces I think.

**Related issue (if exists):**

#3681