### PR TITLE
docs (merge documentation): fix closing of code block

### DIFF
--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -48,7 +48,7 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * // clicks logs MouseEvents to console everytime the "document" is clicked
  * // Since the two streams are merged you see these happening
  * // as they occur.
- * ```javascript
+ * ```
  *
  * ### Merge together 3 Observables, but only 2 run concurrently
  * ```javascript


### PR DESCRIPTION
remove hanging 'javascript' after ``` which breaks formatting of documentation

Closes #3880

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Incorrect closing of multiline JS code block broke formatting within the merge document.

**Related issue (if exists):**
