### PR TITLE
 fix(TestScheduler): flush expectations correctly

### DIFF
--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -462,5 +462,18 @@ describe('TestScheduler', () => {
       expect(testScheduler['runMode']).to.equal(runMode);
       expect(AsyncScheduler.delegate).to.equal(delegate);
     });
+
+    it('should flush expectations correctly', () => {
+      expect(() => {
+        const testScheduler = new TestScheduler(assertDeepEquals);
+        testScheduler.run(({ cold, expectObservable, flush }) => {
+          expectObservable(cold('-x')).toBe('-x');
+          expectObservable(cold('-y')).toBe('-y');
+          const expectation = expectObservable(cold('-z'));
+          flush();
+          expectation.toBe('-q');
+        });
+      }).to.throw();
+    });
   });
 });

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -141,17 +141,14 @@ export class TestScheduler extends VirtualTimeScheduler {
     }
 
     super.flush();
-    const { flushTests } = this;
-    const flushTestsCopy = flushTests.slice();
 
-    for (let i = 0, l = flushTests.length; i < l; i++) {
-      const test = flushTestsCopy[i];
+    this.flushTests = this.flushTests.filter(test => {
       if (test.ready) {
-        // remove it from the original array, not our copy
-        flushTests.splice(i, 1);
         this.assertDeepEqual(test.actual, test.expected);
+        return false;
       }
-    }
+      return true;
+    });
   }
 
   /** @nocollapse */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adds a failing test for the `TestScheduler` and applies the fix from #3898.

**Related issue (if exists):** #3898
