### PR TITLE
chore(typings): add type guard overloads for first/last

### DIFF
--- a/compat/operator/first.ts
+++ b/compat/operator/first.ts
@@ -1,8 +1,12 @@
 import { Observable } from 'rxjs';
 import { first as higherOrder } from 'rxjs/operators';
 
-export function first<T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-                         defaultValue?: T): Observable<T>;
+/* tslint:disable:max-line-length */
+export function first<T>(this: Observable<T>, predicate?: null, defaultValue?: T): Observable<T>;
+export function first<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, defaultValue?: T): Observable<S>;
+export function first<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, defaultValue?: T): Observable<T>;
+/* tslint:enable:max-line-length */
+
 /**
  * Emits only the first value (or the first value that meets some condition)
  * emitted by the source Observable.
@@ -47,5 +51,5 @@ export function first<T>(this: Observable<T>, predicate?: (value: T, index: numb
  * @owner Observable
  */
 export function first<T>(this: Observable<T>, ...args: any[]): Observable<T> {
-    return higherOrder<T>(...args)(this);
-  }
+  return higherOrder<T>(...args)(this);
+}

--- a/compat/operator/last.ts
+++ b/compat/operator/last.ts
@@ -1,8 +1,11 @@
 import { Observable } from 'rxjs';
 import { last as higherOrder } from 'rxjs/operators';
 
-export function last<T>(this: Observable<T>, predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-                        defaultValue?: T): Observable<T>;
+/* tslint:disable:max-line-length */
+export function last<T>(this: Observable<T>, predicate?: null, defaultValue?: T): Observable<T>;
+export function last<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, defaultValue?: T): Observable<S>;
+export function last<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, defaultValue?: T): Observable<T>;
+/* tslint:enable:max-line-length */
 /**
  * Returns an Observable that emits only the last item emitted by the source Observable.
  * It optionally takes a predicate function as a parameter, in which case, rather than emitting

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -170,10 +170,6 @@ describe('Observable.prototype.first', () => {
     expectSubscriptions(e1.subscriptions).toBe(sub);
   });
 
-  // The current signature for first suggests that this test is not rquired. In
-  // fact, with type checking enabled, it will fail. See:
-  // https://github.com/ReactiveX/rxjs/issues/3717
-  /*
   it('should support type guards without breaking previous behavior', () => {
     // tslint:disable no-unused-variable
 
@@ -183,8 +179,8 @@ describe('Observable.prototype.first', () => {
       interface Baz { baz?: number; }
       class Foo implements Bar, Baz { constructor(public bar: string = 'name', public baz: number = 42) {} }
 
-      const isBar = (x: any): x is Bar => x && (<Bar>x).bar !== undefined;
-      const isBaz = (x: any): x is Baz => x && (<Baz>x).baz !== undefined;
+      const isBar = (x: any): x is Bar => x && (x as Bar).bar !== undefined;
+      const isBaz = (x: any): x is Baz => x && (x as Baz).baz !== undefined;
 
       const foo: Foo = new Foo();
       Observable.of(foo).pipe(first())
@@ -232,5 +228,4 @@ describe('Observable.prototype.first', () => {
 
     // tslint:disable enable
   });
-  */
 });

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -217,6 +217,12 @@ describe('Observable.prototype.first', () => {
       // missing predicate preserves the type
       xs.pipe(first()).subscribe(x => x); // x is still string | number
 
+      // null predicate preserves the type
+      xs.pipe(first(null)).subscribe(x => x); // x is still string | number
+
+      // undefined predicate preserves the type
+      xs.pipe(first(undefined)).subscribe(x => x); // x is still string | number
+
       // After the type guard `first` predicates, the type is narrowed to string
       xs.pipe(first(isString))
         .subscribe(s => s.length); // s is string

--- a/spec/operators/last-spec.ts
+++ b/spec/operators/last-spec.ts
@@ -163,8 +163,6 @@ describe('Observable.prototype.last', () => {
       // After the type guard `last` predicates, the type is narrowed to string
       xs.pipe(last(isString))
         .subscribe(s => s.length); // s is string
-      xs.pipe(last(isString, s => s.substr(0))) // s is string in predicate)
-        .subscribe(s => s.length); // s is string
 
       // boolean predicates preserve the type
       xs.pipe(last(x => typeof x === 'string'))

--- a/spec/operators/last-spec.ts
+++ b/spec/operators/last-spec.ts
@@ -160,6 +160,12 @@ describe('Observable.prototype.last', () => {
       // missing predicate preserves the type
       xs.pipe(last()).subscribe(x => x); // x is still string | number
 
+      // null predicate preserves the type
+      xs.pipe(last(null)).subscribe(x => x); // x is still string | number
+
+      // undefined predicate preserves the type
+      xs.pipe(last(undefined)).subscribe(x => x); // x is still string | number
+
       // After the type guard `last` predicates, the type is narrowed to string
       xs.pipe(last(isString))
         .subscribe(s => s.length); // s is string

--- a/spec/operators/last-spec.ts
+++ b/spec/operators/last-spec.ts
@@ -113,10 +113,6 @@ describe('Observable.prototype.last', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  // The current signature for last suggests that this test is not required. In
-  // fact, with type checking enabled, it will fail. See:
-  // https://github.com/ReactiveX/rxjs/issues/3717
-  /*
   it('should support type guards without breaking previous behavior', () => {
     // tslint:disable no-unused-variable
 
@@ -126,8 +122,8 @@ describe('Observable.prototype.last', () => {
       interface Baz { baz?: number; }
       class Foo implements Bar, Baz { constructor(public bar: string = 'name', public baz: number = 42) {} }
 
-      const isBar = (x: any): x is Bar => x && (<Bar>x).bar !== undefined;
-      const isBaz = (x: any): x is Baz => x && (<Baz>x).baz !== undefined;
+      const isBar = (x: any): x is Bar => x && (x as Bar).bar !== undefined;
+      const isBaz = (x: any): x is Baz => x && (x as Baz).baz !== undefined;
 
       const foo: Foo = new Foo();
       of(foo).pipe(last())
@@ -177,5 +173,4 @@ describe('Observable.prototype.last', () => {
 
     // tslint:disable enable
   });
-  */
 });

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -10,17 +10,16 @@ import { throwIfEmpty } from './throwIfEmpty';
 import { identity } from '../util/identity';
 
 /* tslint:disable:max-line-length */
-export function first<T>(): MonoTypeOperatorFunction<T>;
 export function first<T>(
-  predicate: null | undefined,
-  defaultValue: T
+  predicate?: null,
+  defaultValue?: T
 ): MonoTypeOperatorFunction<T>;
 export function first<T, S extends T>(
-  predicate?: (value: T, index: number, source: Observable<T>) => value is S,
+  predicate: (value: T, index: number, source: Observable<T>) => value is S,
   defaultValue?: T
 ): OperatorFunction<T, S>;
 export function first<T>(
-  predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+  predicate: (value: T, index: number, source: Observable<T>) => boolean,
   defaultValue?: T
 ): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -2,12 +2,28 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { EmptyError } from '../util/EmptyError';
-import { MonoTypeOperatorFunction } from '../../internal/types';
+import { MonoTypeOperatorFunction, OperatorFunction } from '../../internal/types';
 import { filter } from './filter';
 import { take } from './take';
 import { defaultIfEmpty } from './defaultIfEmpty';
 import { throwIfEmpty } from './throwIfEmpty';
 import { identity } from '../util/identity';
+
+/* tslint:disable:max-line-length */
+export function first<T>(): MonoTypeOperatorFunction<T>;
+export function first<T>(
+  predicate: null | undefined,
+  defaultValue: T
+): MonoTypeOperatorFunction<T>;
+export function first<T, S extends T>(
+  predicate?: (value: T, index: number, source: Observable<T>) => value is S,
+  defaultValue?: T
+): OperatorFunction<T, S>;
+export function first<T>(
+  predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+  defaultValue?: T
+): MonoTypeOperatorFunction<T>;
+/* tslint:enable:max-line-length */
 
 /**
  * Emits only the first value (or the first value that meets some condition)

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -10,17 +10,16 @@ import { defaultIfEmpty } from './defaultIfEmpty';
 import { identity } from '../util/identity';
 
 /* tslint:disable:max-line-length */
-export function last<T>(): MonoTypeOperatorFunction<T>;
 export function last<T>(
-  predicate: null | undefined,
-  defaultValue: T
+  predicate?: null,
+  defaultValue?: T
 ): MonoTypeOperatorFunction<T>;
 export function last<T, S extends T>(
-  predicate?: (value: T, index: number, source: Observable<T>) => value is S,
+  predicate: (value: T, index: number, source: Observable<T>) => value is S,
   defaultValue?: T
 ): OperatorFunction<T, S>;
 export function last<T>(
-  predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+  predicate: (value: T, index: number, source: Observable<T>) => boolean,
   defaultValue?: T
 ): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -2,12 +2,28 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { EmptyError } from '../util/EmptyError';
-import { MonoTypeOperatorFunction } from '../../internal/types';
+import { MonoTypeOperatorFunction, OperatorFunction } from '../../internal/types';
 import { filter } from './filter';
 import { takeLast } from './takeLast';
 import { throwIfEmpty } from './throwIfEmpty';
 import { defaultIfEmpty } from './defaultIfEmpty';
 import { identity } from '../util/identity';
+
+/* tslint:disable:max-line-length */
+export function last<T>(): MonoTypeOperatorFunction<T>;
+export function last<T>(
+  predicate: null | undefined,
+  defaultValue: T
+): MonoTypeOperatorFunction<T>;
+export function last<T, S extends T>(
+  predicate?: (value: T, index: number, source: Observable<T>) => value is S,
+  defaultValue?: T
+): OperatorFunction<T, S>;
+export function last<T>(
+  predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+  defaultValue?: T
+): MonoTypeOperatorFunction<T>;
+/* tslint:enable:max-line-length */
 
 /**
  * Returns an Observable that emits only the last item emitted by the source Observable.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Uncomments the tests that were skipped when enabling type checking for the test suite. And adds overload signatures with type guards to `first` and `last`.

Note that because the predicates are optional, additional overload signatures that match calls made with no arguments or with a `null` or `undefined` predicate are required. Otherwise, the `S` type parameter is inferred as `{}` and the type of the output observable becomes `Observable<{}>`.

**Related issue (if exists):** #3717
