### PR TITLE
docs(of): add of operator docs

### DIFF
--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -47,9 +47,9 @@ import { Observable } from '../Observable';
  * ```
  *
  * @see {@link from}
+ * @see {@link range}
  *
- * @param {T} args A comma separated list of arguments to be converted
- * into next notifications
+ * @param {...T} values A comma separated list of arguments you want to be emitted
  * @return {Observable} An Observable that emits the arguments
  * described above and then completes.
  * @method of

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -5,6 +5,57 @@ import { empty } from './empty';
 import { scalar } from './scalar';
 import { Observable } from '../Observable';
 
+/**
+ * Converts the arguments to an observable sequence.
+ *
+ * <span class="informal">Each argument becomes a `next` notification.</span>
+ *
+ * ![](of.png)
+ *
+ * Unlike {@link from}, it does not do any flattening and emits each argument in whole
+ * as a separate `next` notification.
+ *
+ * ## Examples
+ *
+ * Emit the values `10, 20, 30`
+ *
+ * ```javascript
+ * of(10, 20, 30)
+ * .subscribe(
+ *   next => console.log('next:', next),
+ *   err => console.log('error:', err),
+ *   () => console.log('the end'),
+ * );
+ * // result:
+ * // 'next: 10'
+ * // 'next: 20'
+ * // 'next: 30'
+ *
+ * ```
+ *
+ * Emit the array `[1,2,3]`
+ *
+ * ```javascript
+ * of([1,2,3])
+ * .subscribe(
+ *   next => console.log('next:', next),
+ *   err => console.log('error:', err),
+ *   () => console.log('the end'),
+ * );
+ * // result:
+ * // 'next: [1,2,3]'
+ * ```
+ *
+ * @see {@link from}
+ *
+ * @param {T} args A comma separated list of arguments to be converted
+ * into next notifications
+ * @return {Observable} An Observable that emits the arguments
+ * described above and then completes.
+ * @method of
+ * @owner Observable
+ */
+
 export function of<T>(a: T, scheduler?: SchedulerLike): Observable<T>;
 export function of<T, T2>(a: T, b: T2, scheduler?: SchedulerLike): Observable<T | T2>;
 export function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler?: SchedulerLike): Observable<T | T2 | T3>;

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -5,6 +5,22 @@ import { empty } from './empty';
 import { scalar } from './scalar';
 import { Observable } from '../Observable';
 
+/* tslint:disable:max-line-length */
+export function of<T>(a: T, scheduler?: SchedulerLike): Observable<T>;
+export function of<T, T2>(a: T, b: T2, scheduler?: SchedulerLike): Observable<T | T2>;
+export function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
+export function of<T, T2, T3, T4>(a: T, b: T2, c: T3, d: T4, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
+export function of<T, T2, T3, T4, T5>(a: T, b: T2, c: T3, d: T4, e: T5, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
+export function of<T, T2, T3, T4, T5, T6>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
+export function of<T, T2, T3, T4, T5, T6, T7>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, scheduler?: SchedulerLike):
+  Observable<T | T2 | T3 | T4 | T5 | T6 | T7>;
+export function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, scheduler?: SchedulerLike):
+  Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
+export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler?: SchedulerLike):
+  Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+export function of<T>(...args: Array<T | SchedulerLike>): Observable<T>;
+/* tslint:enable:max-line-length */
+
 /**
  * Converts the arguments to an observable sequence.
  *
@@ -56,19 +72,6 @@ import { Observable } from '../Observable';
  * @owner Observable
  */
 
-export function of<T>(a: T, scheduler?: SchedulerLike): Observable<T>;
-export function of<T, T2>(a: T, b: T2, scheduler?: SchedulerLike): Observable<T | T2>;
-export function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler?: SchedulerLike): Observable<T | T2 | T3>;
-export function of<T, T2, T3, T4>(a: T, b: T2, c: T3, d: T4, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4>;
-export function of<T, T2, T3, T4, T5>(a: T, b: T2, c: T3, d: T4, e: T5, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
-export function of<T, T2, T3, T4, T5, T6>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, scheduler?: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function of<T, T2, T3, T4, T5, T6, T7>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, scheduler?: SchedulerLike):
-  Observable<T | T2 | T3 | T4 | T5 | T6 | T7>;
-export function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, scheduler?: SchedulerLike):
-  Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
-export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler?: SchedulerLike):
-  Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
-export function of<T>(...args: Array<T | SchedulerLike>): Observable<T>;
 export function of<T>(...args: Array<T | SchedulerLike>): Observable<T> {
   let scheduler = args[args.length - 1] as SchedulerLike;
   if (isScheduler(scheduler)) {


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

add description and examples for the rxjs/of observable creator
