### PR TITLE
docs(startWith-operator): add examples

### DIFF
--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -20,7 +20,25 @@ export function startWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperat
  * Returns an Observable that emits the items you specify as arguments before it begins to emit
  * items emitted by the source Observable.
  *
+ * <span class="informal">First emits its arguments in order, and then any
+ * emissions from the source.</span>
+ *
  * ![](startWith.png)
+ *
+ * ## Examples
+ *
+ * Start the chain of emissions with `"first"`, `"second"`
+ *
+ * ```javascript
+ *   of("from source")
+ *    .pipe(startWith("first", "second"))
+ *    .subscribe(x => console.log(x));
+ *
+ * // results:
+ * //   "first"
+ * //   "second"
+ * //   "from source"
+ * ```
  *
  * @param {...T} values - Items you want the modified Observable to emit first.
  * @param {SchedulerLike} [scheduler] - A {@link SchedulerLike} to use for scheduling


### PR DESCRIPTION



<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Improve documentation of startWith operator by adding usage examples and an alternative description
of the behavior
