### PR TITLE
docs(publishLast): add publishLast operator docs

### DIFF
--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -4,6 +4,62 @@ import { multicast } from './multicast';
 import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { UnaryFunction } from '../types';
 
+/**
+ * Returns an observable sequence that is the result of invoking the selector on a
+ * connectable observable sequence that shares a single subscription to the underlying
+ * sequence containing only the last notification.
+ *
+ * ![](publishLast.png)
+ *
+ * Similar to {@link publish}, but it waits until the source observable completes and stores
+ * the last emitted value.
+ * Similar to {@link publishReplay} and {@link publishBehavior}, this keeps storing the last
+ * value even if it has no more subscribers. If subsequent subscriptions happen, they will
+ * immediately emit that last stored value and complete.
+ *
+ * ## Example
+ *
+ * ```js
+ * const connectable =
+ *   interval(1000)
+ *     .pipe(
+ *       tap(x => console.log("side effect", x)),
+ *       take(3),
+ *       publishLast());
+ *
+ * connectable.subscribe(
+ *   x => console.log(  "Sub. A", x),
+ *   err => console.log("Sub. A Error", err),
+ *   () => console.log( "Sub. A Complete"));
+ *
+ * connectable.subscribe(
+ *   x => console.log(  "Sub. B", x),
+ *   err => console.log("Sub. B Error", err),
+ *   () => console.log( "Sub. B Complete"));
+ *
+ * connectable.connect();
+ *
+ * // Results:
+ * //    "side effect 0"
+ * //    "side effect 1"
+ * //    "side effect 2"
+ * //    "Sub. A 2"
+ * //    "Sub. B 2"
+ * //    "Sub. A Complete"
+ * //    "Sub. B Complete"
+ * ```
+ *
+ * @see {@link ConnectableObservable}
+ * @see {@link publish}
+ * @see {@link publishReplay}
+ * @see {@link publishBehavior}
+ *
+ * @return {ConnectableObservable} An observable sequence that contains the elements of a
+ * sequence produced by multicasting the source sequence.
+ * @method publishLast
+ * @owner Observable
+ */
+
 export function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>> {
   return (source: Observable<T>) => multicast(new AsyncSubject<T>())(source);
 }

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -12,7 +12,7 @@ import { UnaryFunction } from '../types';
  *
  * Similar to {@link publish}, but it waits until the source observable completes and stores
  * the last emitted value.
- * Similar to {@link publishReplay} and {@link publishBehavior}, this keeps storing the last
+ * Similarly to {@link publishReplay} and {@link publishBehavior}, this keeps storing the last
  * value even if it has no more subscribers. If subsequent subscriptions happen, they will
  * immediately emit that last stored value and complete.
  *

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -5,9 +5,8 @@ import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { UnaryFunction } from '../types';
 
 /**
- * Returns an observable sequence that is the result of invoking the selector on a
- * connectable observable sequence that shares a single subscription to the underlying
- * sequence containing only the last notification.
+ * Returns a connectable observable sequence that shares a single subscription to the
+ * underlying sequence containing only the last notification.
  *
  * ![](publishLast.png)
  *

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -14,7 +14,7 @@ import { UnaryFunction } from '../types';
  * the last emitted value.
  * Similarly to {@link publishReplay} and {@link publishBehavior}, this keeps storing the last
  * value even if it has no more subscribers. If subsequent subscriptions happen, they will
- * immediately emit that last stored value and complete.
+ * immediately get that last stored value and complete.
  *
  * ## Example
  *


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Included formal summary, description, example and return values.