### PR TITLE
doc: remove legacy uses of flatMap

### DIFF
--- a/doc/introduction.md
+++ b/doc/introduction.md
@@ -11,7 +11,7 @@ The essential concepts in RxJS which solve async event management are:
 - **Observable:** represents the idea of an invokable collection of future values or events.
 - **Observer:** is a collection of callbacks that knows how to listen to values delivered by the Observable.
 - **Subscription:** represents the execution of an Observable, is primarily useful for cancelling the execution.
-- **Operators:** are pure functions that enable a functional programming style of dealing with collections with operations like `map`, `filter`, `concat`, `flatMap`, etc.
+- **Operators:** are pure functions that enable a functional programming style of dealing with collections with operations like `map`, `filter`, `concat`, `reduce`, etc.
 - **Subject:** is the equivalent to an EventEmitter, and the only way of multicasting a value or event to multiple Observers.
 - **Schedulers:** are centralized dispatchers to control concurrency, allowing us to coordinate when computation happens on e.g. `setTimeout` or `requestAnimationFrame` or others.
 

--- a/docs_app/content/guide/overview.md
+++ b/docs_app/content/guide/overview.md
@@ -11,7 +11,7 @@ The essential concepts in RxJS which solve async event management are:
 - **Observable:** represents the idea of an invokable collection of future values or events.
 - **Observer:** is a collection of callbacks that knows how to listen to values delivered by the Observable.
 - **Subscription:** represents the execution of an Observable, is primarily useful for cancelling the execution.
-- **Operators:** are pure functions that enable a functional programming style of dealing with collections with operations like `map`, `filter`, `concat`, `flatMap`, etc.
+- **Operators:** are pure functions that enable a functional programming style of dealing with collections with operations like `map`, `filter`, `concat`, `reduce`, etc.
 - **Subject:** is the equivalent to an EventEmitter, and the only way of multicasting a value or event to multiple Observers.
 - **Schedulers:** are centralized dispatchers to control concurrency, allowing us to coordinate when computation happens on e.g. `setTimeout` or `requestAnimationFrame` or others.
 

--- a/docs_app/content/guide/rx-library.md
+++ b/docs_app/content/guide/rx-library.md
@@ -25,7 +25,7 @@ RxJS offers a number of functions that can be used to create new observables. Th
 
 ## Operators
 
-Operators are functions that build on the observables foundation to enable sophisticated manipulation of collections. For example, RxJS defines operators such as `map()`, `filter()`, `concat()`, and `flatMap()`.
+Operators are functions that build on the observables foundation to enable sophisticated manipulation of collections. For example, RxJS defines operators such as `map()`, `filter()`, `concat()`, and `reduce()`.
 
 Operators take configuration options, and they return a function that takes a source observable. When executing this returned function, the operator observes the source observable’s emitted values, transforms them, and returns a new observable of those transformed values. Here is a simple example:
 

--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { repeatWhen, map, mergeMap, takeUntil, flatMap } from 'rxjs/operators';
+import { repeatWhen, map, mergeMap, takeUntil } from 'rxjs/operators';
 import { of, EMPTY, Observable, Subscriber } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
@@ -374,7 +374,7 @@ describe('repeatWhen operator', () => {
       repeatWhen((notifications: any) => notifications.pipe(
         map(() => 'x'),
         takeUntil(
-          notifications.pipe(flatMap(() => {
+          notifications.pipe(mergeMap(() => {
             if (++invoked < 3) {
               return EMPTY;
             } else {

--- a/spec/operators/retryWhen-spec.ts
+++ b/spec/operators/retryWhen-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { retryWhen, map, mergeMap, takeUntil, flatMap } from 'rxjs/operators';
+import { retryWhen, map, mergeMap, takeUntil } from 'rxjs/operators';
 import { of, EMPTY } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
@@ -319,7 +319,7 @@ describe('retryWhen operator', () => {
     const result = source.pipe(retryWhen((errors: any) => errors.pipe(
         map(() => 'x'),
         takeUntil(
-          errors.pipe(flatMap(() => {
+          errors.pipe(mergeMap(() => {
             if (++invoked < 3) {
               return EMPTY;
             } else {

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -33,7 +33,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  *   {id: 2, name: 'qsgqsfg2'},
  * ).pipe(
  *   groupBy(p => p.id),
- *   flatMap((group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], []))),
+ *   mergeMap((group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], []))),
  * )
  * .subscribe(p => console.log(p));
  *
@@ -63,7 +63,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  *   {id: 2, name: 'qsgqsfg2'},
  * ).pipe(
  *   groupBy(p => p.id, p => p.name),
- *   flatMap( (group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], ["" + group$.key]))),
+ *   mergeMap( (group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], ["" + group$.key]))),
  *   map(arr => ({'id': parseInt(arr[0]), 'values': arr.slice(1)})),
  * )
  * .subscribe(p => console.log(p));


### PR DESCRIPTION
**Description:** replaces legacy uses of the flatMap operator with mergeMap or something else in docs

**Related issue (if exists):** n/a
