### PR TITLE
doc: remove some legacy Rx.* usages in jsdoc

### DIFF
--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -158,11 +158,11 @@ class RefCountSubscriber<T> extends Subscriber<T> {
     // supply the RefCountSubscriber with the shared connection Subscription.
     // For example:
     // ```
-    // Observable.range(0, 10)
-    //   .publish()
-    //   .refCount()
-    //   .take(5)
-    //   .subscribe();
+    // range(0, 10).pipe(
+    //   publish(),
+    //   refCount(),
+    //   take(5),
+    // ).subscribe();
     // ```
     // In order to account for this case, RefCountSubscriber should only dispose
     // the ConnectableObservable's shared connection Subscription if the

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -96,9 +96,9 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * ## Examples
  * ### Combine two timer Observables
  * ```javascript
- * const firstTimer = Rx.Observable.timer(0, 1000); // emit 0, 1, 2... after every second, starting from now
- * const secondTimer = Rx.Observable.timer(500, 1000); // emit 0, 1, 2... after every second, starting 0,5s from now
- * const combinedTimers = Rx.Observable.combineLatest(firstTimer, secondTimer);
+ * const firstTimer = timer(0, 1000); // emit 0, 1, 2... after every second, starting from now
+ * const secondTimer = timer(500, 1000); // emit 0, 1, 2... after every second, starting 0,5s from now
+ * const combinedTimers = combineLatest(firstTimer, secondTimer);
  * combinedTimers.subscribe(value => console.log(value));
  * // Logs
  * // [0, 0] after 0.5s

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -57,7 +57,7 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  * const res = generate(0, x => x < 10, x => x + 1, x => x);
  *
  * @example <caption>Using asap scheduler, produces sequence of 2, 3, 5, then completes.</caption>
- * const res = generate(1, x => x < 5, x =>  * 2, x => x + 1, Rx.Scheduler.asap);
+ * const res = generate(1, x => x < 5, x =>  * 2, x => x + 1, asap);
  *
  * @see {@link from}
  * @see {@link Observable}

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -35,7 +35,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * Emit clicks at a rate of at most one click per second
  * ```javascript
  * const clicks = fromEvent(document, 'click');
- * const result = clicks.pipe(audit(ev => Rx.Observable.interval(1000)));
+ * const result = clicks.pipe(audit(ev => interval(1000)));
  * result.subscribe(x => console.log(x));
  * ```
  * @see {@link auditTime}

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -24,9 +24,9 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Convert an Observable of Notifications to an actual Observable
  * ```javascript
- * const notifA = new Rx.Notification('N', 'A');
- * const notifB = new Rx.Notification('N', 'B');
- * const notifE = new Rx.Notification('E', void 0,
+ * const notifA = new Notification('N', 'A');
+ * const notifB = new Notification('N', 'B');
+ * const notifE = new Notification('E', undefined,
  *   new TypeError('x.toUpperCase is not a function')
  * );
  * const materialized = of(notifA, notifB, notifE);

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -21,7 +21,12 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  *
  * ##Examples
  * Group objects by id and return as array
- * ```javascript
+ * ```typescript
+ * interface Obj {
+ *    id: number,
+ *    name: string,
+ * }
+ * 
  * of<Obj>(
  *   {id: 1, name: 'aze1'},
  *   {id: 2, name: 'sf2'},
@@ -51,7 +56,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  * ```
  *
  * Pivot data on the id field
- * ```javascript
+ * ```typescript
  * of<Obj>(
  *   {id: 1, name: 'aze1'},
  *   {id: 2, name: 'sf2'},


### PR DESCRIPTION
**Description:** standardizes style of examples to use rxjs6-style .pipe() etc.

**Related issue (if exists):** n/a
