### PR TITLE
doc: explicitly note that resultSelector is deprecated

### DIFF
--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -65,7 +65,7 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  * @param {S} initialState Initial state.
  * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).
  * @param {function (state: S): S} iterate Iteration step function.
- * @param {function (state: S): T} resultSelector Selector function for results produced in the sequence.
+ * @param {function (state: S): T} resultSelector Selector function for results produced in the sequence. (deprecated)
  * @param {SchedulerLike} [scheduler] A {@link SchedulerLike} on which to run the generator loop. If not provided, defaults to emit immediately.
  * @returns {Observable<T>} The generated sequence.
  */

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -60,7 +60,7 @@ export function concatMap<T, I, R>(project: (value: T, index: number) =>  Observ
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
  * @return {Observable} An Observable that emits the result of applying the
- * projection function (and the optional `resultSelector`) to each item emitted
+ * projection function (and the optional deprecated `resultSelector`) to each item emitted
  * by the source Observable and taking values from each projected inner
  * Observable sequentially.
  * @method concatMap

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -21,10 +21,10 @@ import { identity } from '../util/identity';
  * If called with no arguments, `first` emits the first value of the source
  * Observable, then completes. If called with a `predicate` function, `first`
  * emits the first value of the source that matches the specified condition. It
- * may also take a `resultSelector` function to produce the output value from
- * the input value, and a `defaultValue` to emit in case the source completes
- * before it is able to emit a valid value. Throws an error if `defaultValue`
- * was not provided and a matching element is not found.
+ * may also take a deprecated `resultSelector` function to produce the output
+ * value from the input value, and a `defaultValue` to emit in case the source
+ * completes before it is able to emit a valid value. Throws an error if
+ * `defaultValue` was not provided and a matching element is not found.
  *
  * ## Examples
  * Emit only the first click that happens on the DOM

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -64,9 +64,9 @@ export function mergeMap<T, I, R>(project: (value: T, index: number) => Observab
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits the result of applying the
- * projection function (and the optional `resultSelector`) to each item emitted
- * by the source Observable and merging the results of the Observables obtained
- * from this transformation.
+ * projection function (and the optional deprecated `resultSelector`) to each item
+ * emitted by the source Observable and merging the results of the Observables
+ * obtained from this transformation.
  * @method mergeMap
  * @owner Observable
  */

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -53,8 +53,8 @@ export function switchMap<T, I, R>(project: (value: T, index: number) => Observa
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
  * @return {Observable} An Observable that emits the result of applying the
- * projection function (and the optional `resultSelector`) to each item emitted
- * by the source Observable and taking only the values from the most recently
+ * projection function (and the optional deprecated `resultSelector`) to each item
+ * emitted by the source Observable and taking only the values from the most recently
  * projected inner Observable.
  * @method switchMap
  * @owner Observable

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -47,7 +47,7 @@ export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
  * @return {Observable} An Observable that emits items from the given
- * `innerObservable` (and optionally transformed through the deprecated `resultSelector`) 
+ * `innerObservable` (and optionally transformed through the deprecated `resultSelector`)
  * every time a value is emitted on the source Observable, and taking only the values
  * from the most recently projected inner Observable.
  * @method switchMapTo

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -47,8 +47,8 @@ export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
  * @return {Observable} An Observable that emits items from the given
- * `innerObservable` (and optionally transformed through `resultSelector`) every
- * time a value is emitted on the source Observable, and taking only the values
+ * `innerObservable` (and optionally transformed through the deprecated `resultSelector`) 
+ * every time a value is emitted on the source Observable, and taking only the values
  * from the most recently projected inner Observable.
  * @method switchMapTo
  * @owner Observable


### PR DESCRIPTION
**Description:** makes it clearer for readers of the generated docs that resultSelector is deprecated

**Related issue (if exists):** n/a
