### PR TITLE
fix(testscheduler): type arguments to Observable creation functions

### DIFF
--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -145,7 +145,7 @@ describe('TestScheduler', () => {
     it('should create a cold observable', () => {
       const expected = ['A', 'B'];
       const scheduler = new TestScheduler(null);
-      const source = scheduler.createColdObservable<string>('--a---b--|', { a: 'A', b: 'B' });
+      const source = scheduler.createColdObservable('--a---b--|', { a: 'A', b: 'B' });
       expect(source).to.be.an.instanceOf(Observable);
       source.subscribe(x => {
         expect(x).to.equal(expected.shift());
@@ -159,7 +159,7 @@ describe('TestScheduler', () => {
     it('should create a cold observable', () => {
       const expected = ['A', 'B'];
       const scheduler = new TestScheduler(null);
-      const source = scheduler.createHotObservable<string>('--a---b--|', { a: 'A', b: 'B' });
+      const source = scheduler.createHotObservable('--a---b--|', { a: 'A', b: 'B' });
       expect(source).to.be.an.instanceof(Subject);
       source.subscribe(x => {
         expect(x).to.equal(expected.shift());

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -45,7 +45,12 @@ export class TestScheduler extends VirtualTimeScheduler {
     return indexOf * TestScheduler.frameTimeFactor;
   }
 
-  createColdObservable<T>(marbles: string, values?: any, error?: any): ColdObservable<T> {
+  /**
+   * @param marbles A diagram in the marble DSL. Letters map to keys in `values` if provided.
+   * @param values Values to use for the letters in `marbles`. If ommitted, the letters themselves are used.
+   * @param error The error to use for the `#` marble (if present).
+   */
+  createColdObservable<T = string>(marbles: string, values?: { [marble: string]: T }, error?: any): ColdObservable<T> {
     if (marbles.indexOf('^') !== -1) {
       throw new Error('cold observable cannot have subscription offset "^"');
     }
@@ -58,7 +63,12 @@ export class TestScheduler extends VirtualTimeScheduler {
     return cold;
   }
 
-  createHotObservable<T>(marbles: string, values?: any, error?: any): HotObservable<T> {
+  /**
+   * @param marbles A diagram in the marble DSL. Letters map to keys in `values` if provided.
+   * @param values Values to use for the letters in `marbles`. If ommitted, the letters themselves are used.
+   * @param error The error to use for the `#` marble (if present).
+   */
+  createHotObservable<T = string>(marbles: string, values?: { [marble: string]: T }, error?: any): HotObservable<T> {
     if (marbles.indexOf('!') !== -1) {
       throw new Error('hot observable cannot have unsubscription marker "!"');
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Adds types to the arguments of `TestScheduler` `createHot/ColdObservable` to allow type inference.

**Related issue (if exists):**
Fixes #3921 
