### PR TITLE
docs(sitemap): fixed the sitemap for docs

### DIFF
--- a/docs_app/tools/transforms/templates/sitemap.template.xml
+++ b/docs_app/tools/transforms/templates/sitemap.template.xml
@@ -2,6 +2,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {%- for url in doc.urls %}
   <url>
-    <loc>https://angular.io/{$ url $}</loc>
+    <loc>https://rxjs-dev.firebaseapp.com/{$ url $}</loc>
   </url>{% endfor %}
 </urlset>


### PR DESCRIPTION
**Description:**
Fixed sitemap for docs which pointed to angular.io website.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3888