### PR TITLE
fix: convert @internal comment to JSDoc

### DIFF
--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -18,7 +18,7 @@ export function pipe<T, R>(...fns: Array<UnaryFunction<T, R>>): UnaryFunction<T,
   return pipeFromArray(fns);
 }
 
-/* @internal */
+/** @internal */
 export function pipeFromArray<T, R>(fns: Array<UnaryFunction<T, R>>): UnaryFunction<T, R> {
   if (!fns) {
     return noop as UnaryFunction<any, any>;


### PR DESCRIPTION
`@internal` and similar tags are only parsed in JSDoc.
