### PR TITLE
 fix(first/last): fix type-guard signatures

### DIFF
--- a/compat/operator/first.ts
+++ b/compat/operator/first.ts
@@ -2,9 +2,9 @@ import { Observable } from 'rxjs';
 import { first as higherOrder } from 'rxjs/operators';
 
 /* tslint:disable:max-line-length */
-export function first<T>(this: Observable<T>, predicate?: null, defaultValue?: T): Observable<T>;
-export function first<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, defaultValue?: T): Observable<S>;
-export function first<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, defaultValue?: T): Observable<T>;
+export function first<T, D = T>(this: Observable<T>, predicate?: null, defaultValue?: D): Observable<T | D>;
+export function first<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, defaultValue?: S): Observable<S>;
+export function first<T, D = T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, defaultValue?: D): Observable<T | D>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/compat/operator/last.ts
+++ b/compat/operator/last.ts
@@ -2,9 +2,9 @@ import { Observable } from 'rxjs';
 import { last as higherOrder } from 'rxjs/operators';
 
 /* tslint:disable:max-line-length */
-export function last<T>(this: Observable<T>, predicate?: null, defaultValue?: T): Observable<T>;
-export function last<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, defaultValue?: T): Observable<S>;
-export function last<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, defaultValue?: T): Observable<T>;
+export function last<T, D = T>(this: Observable<T>, predicate?: null, defaultValue?: D): Observable<T | D>;
+export function last<T, S extends T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => value is S, defaultValue?: S): Observable<S>;
+export function last<T, D = T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean, defaultValue?: D): Observable<T | D>;
 /* tslint:enable:max-line-length */
 /**
  * Returns an Observable that emits only the last item emitted by the source Observable.

--- a/spec-dtslint/operators/first-spec.ts
+++ b/spec-dtslint/operators/first-spec.ts
@@ -7,35 +7,43 @@ it('should support an undefined predicate with no default', () => {
   const o = of('foo').pipe(first(undefined)); // $ExpectType Observable<string>
 });
 
-it('should support an undefined predicate with T default', () => {
+it('should support an undefined predicate with a T default', () => {
   const o = of('foo').pipe(first(undefined, 'bar')); // $ExpectType Observable<string>
 });
 
-it('should support an undefined predicate with non-T default', () => {
+it('should support an undefined predicate with a non-T default', () => {
   const o = of('foo').pipe(first(undefined, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should default D to T with an undfined predicate', () => {
+  const o = of('foo').pipe(first<string>(undefined)); // $Observable<string>
 });
 
 it('should support a null predicate with no default', () => {
   const o = of('foo').pipe(first(null)); // $ExpectType Observable<string>
 });
 
-it('should support a null predicate with T default', () => {
+it('should support a null predicate with a T default', () => {
   const o = of('foo').pipe(first(null, 'bar')); // $ExpectType Observable<string>
 });
 
-it('should support a null predicate with non-T default', () => {
+it('should support a null predicate with a non-T default', () => {
   const o = of('foo').pipe(first(null, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should default D to T with a null predicate', () => {
+  const o = of('foo').pipe(first<string>(null)); // $Observable<string>
 });
 
 it('should support a user-defined type guard with no default', () => {
   const o = of('foo').pipe(first(isFooBar)); // $ExpectType Observable<"foo" | "bar">
 });
 
-it('should support a user-defined type guard with a default', () => {
+it('should support a user-defined type guard with an S default', () => {
   const o = of('foo').pipe(first(isFooBar, 'bar')); // $ExpectType Observable<"foo" | "bar">
 });
 
-it('should widen a user-defined type guard with a non-T default', () => {
+it('should widen a user-defined type guard with a non-S default', () => {
   const o = of('foo').pipe(first(isFooBar, false)); // $ExpectType Observable<string | boolean>
 });
 
@@ -43,10 +51,14 @@ it('should support a predicate with no default', () => {
   const o = of('foo').pipe(first(x => !!x)); // $ExpectType Observable<string>
 });
 
-it('should support a predicate with T default', () => {
+it('should support a predicate with a T default', () => {
   const o = of('foo').pipe(first(x => !!x, 'bar')); // $ExpectType Observable<string>
 });
 
-it('should support a predicate with non-T default', () => {
+it('should support a predicate with a non-T default', () => {
   const o = of('foo').pipe(first(x => !!x, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should default D to T with a predicate', () => {
+  const o = of('foo').pipe(first<string>(x => !!x)); // $Observable<string>
 });

--- a/spec-dtslint/operators/first-spec.ts
+++ b/spec-dtslint/operators/first-spec.ts
@@ -1,0 +1,52 @@
+import { of } from 'rxjs';
+import { first } from 'rxjs/operators';
+
+const isFooBar = (value: string): value is 'foo' | 'bar' => /^(foo|bar)$/.test(value);
+
+it('should support an undefined predicate with no default', () => {
+  const o = of('foo').pipe(first(undefined)); // $ExpectType Observable<string>
+});
+
+it('should support an undefined predicate with T default', () => {
+  const o = of('foo').pipe(first(undefined, 'bar')); // $ExpectType Observable<string>
+});
+
+it('should support an undefined predicate with non-T default', () => {
+  const o = of('foo').pipe(first(undefined, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should support a null predicate with no default', () => {
+  const o = of('foo').pipe(first(null)); // $ExpectType Observable<string>
+});
+
+it('should support a null predicate with T default', () => {
+  const o = of('foo').pipe(first(null, 'bar')); // $ExpectType Observable<string>
+});
+
+it('should support a null predicate with non-T default', () => {
+  const o = of('foo').pipe(first(null, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should support a user-defined type guard with no default', () => {
+  const o = of('foo').pipe(first(isFooBar)); // $ExpectType Observable<"foo" | "bar">
+});
+
+it('should support a user-defined type guard with a default', () => {
+  const o = of('foo').pipe(first(isFooBar, 'bar')); // $ExpectType Observable<"foo" | "bar">
+});
+
+it('should widen a user-defined type guard with a non-T default', () => {
+  const o = of('foo').pipe(first(isFooBar, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should support a predicate with no default', () => {
+  const o = of('foo').pipe(first(x => !!x)); // $ExpectType Observable<string>
+});
+
+it('should support a predicate with T default', () => {
+  const o = of('foo').pipe(first(x => !!x, 'bar')); // $ExpectType Observable<string>
+});
+
+it('should support a predicate with non-T default', () => {
+  const o = of('foo').pipe(first(x => !!x, false)); // $ExpectType Observable<string | boolean>
+});

--- a/spec-dtslint/operators/last-spec.ts
+++ b/spec-dtslint/operators/last-spec.ts
@@ -1,0 +1,52 @@
+import { of } from 'rxjs';
+import { last } from 'rxjs/operators';
+
+const isFooBar = (value: string): value is 'foo' | 'bar' => /^(foo|bar)$/.test(value);
+
+it('should support an undefined predicate with no default', () => {
+  const o = of('foo').pipe(last(undefined)); // $ExpectType Observable<string>
+});
+
+it('should support an undefined predicate with T default', () => {
+  const o = of('foo').pipe(last(undefined, 'bar')); // $ExpectType Observable<string>
+});
+
+it('should support an undefined predicate with non-T default', () => {
+  const o = of('foo').pipe(last(undefined, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should support a null predicate with no default', () => {
+  const o = of('foo').pipe(last(null)); // $ExpectType Observable<string>
+});
+
+it('should support a null predicate with T default', () => {
+  const o = of('foo').pipe(last(null, 'bar')); // $ExpectType Observable<string>
+});
+
+it('should support a null predicate with non-T default', () => {
+  const o = of('foo').pipe(last(null, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should support a user-defined type guard with no default', () => {
+  const o = of('foo').pipe(last(isFooBar)); // $ExpectType Observable<"foo" | "bar">
+});
+
+it('should support a user-defined type guard with a default', () => {
+  const o = of('foo').pipe(last(isFooBar, 'bar')); // $ExpectType Observable<"foo" | "bar">
+});
+
+it('should widen a user-defined type guard with a non-T default', () => {
+  const o = of('foo').pipe(last(isFooBar, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should support a predicate with no default', () => {
+  const o = of('foo').pipe(last(x => !!x)); // $ExpectType Observable<string>
+});
+
+it('should support a predicate with T default', () => {
+  const o = of('foo').pipe(last(x => !!x, 'bar')); // $ExpectType Observable<string>
+});
+
+it('should support a predicate with non-T default', () => {
+  const o = of('foo').pipe(last(x => !!x, false)); // $ExpectType Observable<string | boolean>
+});

--- a/spec-dtslint/operators/last-spec.ts
+++ b/spec-dtslint/operators/last-spec.ts
@@ -7,35 +7,43 @@ it('should support an undefined predicate with no default', () => {
   const o = of('foo').pipe(last(undefined)); // $ExpectType Observable<string>
 });
 
-it('should support an undefined predicate with T default', () => {
+it('should support an undefined predicate with a T default', () => {
   const o = of('foo').pipe(last(undefined, 'bar')); // $ExpectType Observable<string>
 });
 
-it('should support an undefined predicate with non-T default', () => {
+it('should support an undefined predicate with a non-T default', () => {
   const o = of('foo').pipe(last(undefined, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should default D to T with an undfined predicate', () => {
+  const o = of('foo').pipe(last<string>(undefined)); // $Observable<string>
 });
 
 it('should support a null predicate with no default', () => {
   const o = of('foo').pipe(last(null)); // $ExpectType Observable<string>
 });
 
-it('should support a null predicate with T default', () => {
+it('should support a null predicate with a T default', () => {
   const o = of('foo').pipe(last(null, 'bar')); // $ExpectType Observable<string>
 });
 
-it('should support a null predicate with non-T default', () => {
+it('should support a null predicate with a non-T default', () => {
   const o = of('foo').pipe(last(null, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should default D to T with a null predicate', () => {
+  const o = of('foo').pipe(last<string>(null)); // $Observable<string>
 });
 
 it('should support a user-defined type guard with no default', () => {
   const o = of('foo').pipe(last(isFooBar)); // $ExpectType Observable<"foo" | "bar">
 });
 
-it('should support a user-defined type guard with a default', () => {
+it('should support a user-defined type guard with an S default', () => {
   const o = of('foo').pipe(last(isFooBar, 'bar')); // $ExpectType Observable<"foo" | "bar">
 });
 
-it('should widen a user-defined type guard with a non-T default', () => {
+it('should widen a user-defined type guard with a non-S default', () => {
   const o = of('foo').pipe(last(isFooBar, false)); // $ExpectType Observable<string | boolean>
 });
 
@@ -43,10 +51,14 @@ it('should support a predicate with no default', () => {
   const o = of('foo').pipe(last(x => !!x)); // $ExpectType Observable<string>
 });
 
-it('should support a predicate with T default', () => {
+it('should support a predicate with a T default', () => {
   const o = of('foo').pipe(last(x => !!x, 'bar')); // $ExpectType Observable<string>
 });
 
-it('should support a predicate with non-T default', () => {
+it('should support a predicate with a non-T default', () => {
   const o = of('foo').pipe(last(x => !!x, false)); // $ExpectType Observable<string | boolean>
+});
+
+it('should default D to T with a predicate', () => {
+  const o = of('foo').pipe(last<string>(x => !!x)); // $Observable<string>
 });

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -16,7 +16,7 @@ export function first<T>(
 ): MonoTypeOperatorFunction<T>;
 export function first<T, S extends T>(
   predicate: (value: T, index: number, source: Observable<T>) => value is S,
-  defaultValue?: T
+  defaultValue?: S
 ): OperatorFunction<T, S>;
 export function first<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,
@@ -72,10 +72,10 @@ export function first<T>(
  * @method first
  * @owner Observable
  */
-export function first<T>(
+export function first<T, S extends T>(
   predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,
-  defaultValue?: T
-): MonoTypeOperatorFunction<T> {
+  defaultValue?: S
+): OperatorFunction<T, S> {
   const hasDefaultValue = arguments.length >= 2;
   return (source: Observable<T>) => source.pipe(
     predicate ? filter((v, i) => predicate(v, i, source)) : identity,

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { EmptyError } from '../util/EmptyError';
-import { MonoTypeOperatorFunction, OperatorFunction } from '../../internal/types';
+import { OperatorFunction } from '../../internal/types';
 import { filter } from './filter';
 import { take } from './take';
 import { defaultIfEmpty } from './defaultIfEmpty';
@@ -10,18 +10,18 @@ import { throwIfEmpty } from './throwIfEmpty';
 import { identity } from '../util/identity';
 
 /* tslint:disable:max-line-length */
-export function first<T>(
+export function first<T, D = T>(
   predicate?: null,
-  defaultValue?: T
-): MonoTypeOperatorFunction<T>;
+  defaultValue?: D
+): OperatorFunction<T, T | D>;
 export function first<T, S extends T>(
   predicate: (value: T, index: number, source: Observable<T>) => value is S,
   defaultValue?: S
 ): OperatorFunction<T, S>;
-export function first<T>(
+export function first<T, D = T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  defaultValue?: T
-): MonoTypeOperatorFunction<T>;
+  defaultValue?: D
+): OperatorFunction<T, T | D>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -72,14 +72,14 @@ export function first<T>(
  * @method first
  * @owner Observable
  */
-export function first<T, S extends T>(
+export function first<T, D>(
   predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,
-  defaultValue?: S
-): OperatorFunction<T, S> {
+  defaultValue?: D
+): OperatorFunction<T, T | D> {
   const hasDefaultValue = arguments.length >= 2;
   return (source: Observable<T>) => source.pipe(
     predicate ? filter((v, i) => predicate(v, i, source)) : identity,
     take(1),
-    hasDefaultValue ? defaultIfEmpty(defaultValue) : throwIfEmpty(() => new EmptyError()),
+    hasDefaultValue ? defaultIfEmpty<T | D>(defaultValue) : throwIfEmpty(() => new EmptyError()),
   );
 }

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -73,7 +73,7 @@ export function first<T>(
  * @owner Observable
  */
 export function first<T>(
-  predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+  predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,
   defaultValue?: T
 ): MonoTypeOperatorFunction<T> {
   const hasDefaultValue = arguments.length >= 2;

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { EmptyError } from '../util/EmptyError';
-import { MonoTypeOperatorFunction, OperatorFunction } from '../../internal/types';
+import { OperatorFunction } from '../../internal/types';
 import { filter } from './filter';
 import { takeLast } from './takeLast';
 import { throwIfEmpty } from './throwIfEmpty';
@@ -10,18 +10,18 @@ import { defaultIfEmpty } from './defaultIfEmpty';
 import { identity } from '../util/identity';
 
 /* tslint:disable:max-line-length */
-export function last<T>(
+export function last<T, D = T>(
   predicate?: null,
-  defaultValue?: T
-): MonoTypeOperatorFunction<T>;
+  defaultValue?: D
+): OperatorFunction<T, T | D>;
 export function last<T, S extends T>(
   predicate: (value: T, index: number, source: Observable<T>) => value is S,
   defaultValue?: S
 ): OperatorFunction<T, S>;
-export function last<T>(
+export function last<T, D = T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  defaultValue?: T
-): MonoTypeOperatorFunction<T>;
+  defaultValue?: D
+): OperatorFunction<T, T | D>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -41,14 +41,14 @@ export function last<T>(
  * from the source, or an NoSuchElementException if no such items are emitted.
  * @throws - Throws if no items that match the predicate are emitted by the source Observable.
  */
-export function last<T, S extends T>(
+export function last<T, D>(
   predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,
-  defaultValue?: S
-): OperatorFunction<T, S> {
+  defaultValue?: D
+): OperatorFunction<T, T | D> {
   const hasDefaultValue = arguments.length >= 2;
   return (source: Observable<T>) => source.pipe(
     predicate ? filter((v, i) => predicate(v, i, source)) : identity,
     takeLast(1),
-    hasDefaultValue ? defaultIfEmpty(defaultValue) : throwIfEmpty(() => new EmptyError()),
+    hasDefaultValue ? defaultIfEmpty<T | D>(defaultValue) : throwIfEmpty(() => new EmptyError()),
   );
 }

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -42,7 +42,7 @@ export function last<T>(
  * @throws - Throws if no items that match the predicate are emitted by the source Observable.
  */
 export function last<T>(
-  predicate?: (value: T, index: number, source: Observable<T>) => boolean,
+  predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,
   defaultValue?: T
 ): MonoTypeOperatorFunction<T> {
   const hasDefaultValue = arguments.length >= 2;

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -16,7 +16,7 @@ export function last<T>(
 ): MonoTypeOperatorFunction<T>;
 export function last<T, S extends T>(
   predicate: (value: T, index: number, source: Observable<T>) => value is S,
-  defaultValue?: T
+  defaultValue?: S
 ): OperatorFunction<T, S>;
 export function last<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,
@@ -41,10 +41,10 @@ export function last<T>(
  * from the source, or an NoSuchElementException if no such items are emitted.
  * @throws - Throws if no items that match the predicate are emitted by the source Observable.
  */
-export function last<T>(
+export function last<T, S extends T>(
   predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,
-  defaultValue?: T
-): MonoTypeOperatorFunction<T> {
+  defaultValue?: S
+): OperatorFunction<T, S> {
   const hasDefaultValue = arguments.length >= 2;
   return (source: Observable<T>) => source.pipe(
     predicate ? filter((v, i) => predicate(v, i, source)) : identity,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes problems with the implementation and type-guard signatures for the `first` and `last` operators.

**Related issue (if exists):** #3951