### PR TITLE
unused variables

### DIFF
--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -93,7 +93,7 @@ export class AsyncAction<T> extends Action<T> {
     }
 
     this.pending = false;
-    const error = this._execute(state, delay);
+    const error = this._execute(state);
     if (error) {
       return error;
     } else if (this.pending === false && this.id != null) {
@@ -114,7 +114,7 @@ export class AsyncAction<T> extends Action<T> {
     }
   }
 
-  protected _execute(state: T, delay: number): any {
+  protected _execute(state: T): any {
     let errored: boolean = false;
     let errorValue: any = undefined;
     try {


### PR DESCRIPTION
An unused variable seems to exist for the _ execute function.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Couldn't unused variables affect readability?
