### PR TITLE
chore(dtslint): add higher-order observable tests

### DIFF
--- a/spec-dtslint/operators/concatAll-spec.ts
+++ b/spec-dtslint/operators/concatAll-spec.ts
@@ -1,0 +1,10 @@
+import { of } from 'rxjs';
+import { concatAll } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(of(1, 2, 3)).pipe(concatAll()); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(concatAll()); // $ExpectError
+});

--- a/spec-dtslint/operators/exhaust-spec.ts
+++ b/spec-dtslint/operators/exhaust-spec.ts
@@ -1,0 +1,10 @@
+import { of } from 'rxjs';
+import { exhaust } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(of(1, 2, 3)).pipe(exhaust()); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(exhaust()); // $ExpectError
+});

--- a/spec-dtslint/operators/mergeAll-spec.ts
+++ b/spec-dtslint/operators/mergeAll-spec.ts
@@ -1,0 +1,10 @@
+import { of } from 'rxjs';
+import { mergeAll } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(of(1, 2, 3)).pipe(mergeAll()); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(mergeAll()); // $ExpectError
+});

--- a/spec-dtslint/operators/switchAll-spec.ts
+++ b/spec-dtslint/operators/switchAll-spec.ts
@@ -1,0 +1,10 @@
+import { of } from 'rxjs';
+import { switchAll } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(of(1, 2, 3)).pipe(switchAll()); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(switchAll()); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I should have included these dtslint tests in #3945 to show that the change does fix the reported issue. It does.

**Related issue (if exists):** #3841