### PR TITLE
fix(IE10): Remove dependency on Object.setPrototypeOf

### DIFF
--- a/src/internal/util/ArgumentOutOfRangeError.ts
+++ b/src/internal/util/ArgumentOutOfRangeError.ts
@@ -1,3 +1,19 @@
+export interface ArgumentOutOfRangeError extends Error {
+}
+
+export interface ArgumentOutOfRangeErrorCtor {
+  new(): ArgumentOutOfRangeError;
+}
+
+function ArgumentOutOfRangeErrorImpl(this: any) {
+  Error.call(this);
+  this.message = 'argument out of range';
+  this.name = 'ArgumentOutOfRangeError';
+  return this;
+}
+
+ArgumentOutOfRangeErrorImpl.prototype = Object.create(Error.prototype);
+
 /**
  * An error thrown when an element was queried at a certain index of an
  * Observable, but no such index or position exists in that sequence.
@@ -8,12 +24,4 @@
  *
  * @class ArgumentOutOfRangeError
  */
-export class ArgumentOutOfRangeError extends Error {
-
-  public readonly name = 'ArgumentOutOfRangeError';
-
-  constructor() {
-    super('argument out of range');
-    (Object as any).setPrototypeOf(this, ArgumentOutOfRangeError.prototype);
-  }
-}
+export const ArgumentOutOfRangeError: ArgumentOutOfRangeErrorCtor = ArgumentOutOfRangeErrorImpl as any;

--- a/src/internal/util/EmptyError.ts
+++ b/src/internal/util/EmptyError.ts
@@ -1,3 +1,19 @@
+export interface EmptyError extends Error {
+}
+
+export interface EmptyErrorCtor {
+  new(): EmptyError;
+}
+
+function EmptyErrorImpl(this: any) {
+  Error.call(this);
+  this.message = 'no elements in sequence';
+  this.name = 'EmptyError';
+  return this;
+}
+
+EmptyErrorImpl.prototype = Object.create(Error.prototype);
+
 /**
  * An error thrown when an Observable or a sequence was queried but has no
  * elements.
@@ -8,12 +24,4 @@
  *
  * @class EmptyError
  */
-export class EmptyError extends Error {
-
-  public readonly name = 'EmptyError';
-
-  constructor() {
-    super('no elements in sequence');
-    (Object as any).setPrototypeOf(this, EmptyError.prototype);
-  }
-}
+export const EmptyError: EmptyErrorCtor = EmptyErrorImpl as any;

--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -1,3 +1,19 @@
+export interface ObjectUnsubscribedError extends Error {
+}
+
+export interface ObjectUnsubscribedErrorCtor {
+  new(): ObjectUnsubscribedError;
+}
+
+function ObjectUnsubscribedErrorImpl(this: any) {
+  Error.call(this);
+  this.message = 'object unsubscribed';
+  this.name = 'ObjectUnsubscribedError';
+  return this;
+}
+
+ObjectUnsubscribedErrorImpl.prototype = Object.create(Error.prototype);
+
 /**
  * An error thrown when an action is invalid because the object has been
  * unsubscribed.
@@ -7,12 +23,4 @@
  *
  * @class ObjectUnsubscribedError
  */
-export class ObjectUnsubscribedError extends Error {
-
-  public readonly name = 'ObjectUnsubscribedError';
-
-  constructor() {
-    super('object unsubscribed');
-    (Object as any).setPrototypeOf(this, ObjectUnsubscribedError.prototype);
-  }
-}
+export const ObjectUnsubscribedError: ObjectUnsubscribedErrorCtor = ObjectUnsubscribedErrorImpl as any;

--- a/src/internal/util/TimeoutError.ts
+++ b/src/internal/util/TimeoutError.ts
@@ -1,3 +1,19 @@
+export interface TimeoutError extends Error {
+}
+
+export interface TimeoutErrorCtor {
+  new(): TimeoutError;
+}
+
+function TimeoutErrorImpl(this: any) {
+  Error.call(this);
+  this.message = 'Timeout has occurred';
+  this.name = 'TimeoutError';
+  return this;
+}
+
+TimeoutErrorImpl.prototype = Object.create(Error.prototype);
+
 /**
  * An error thrown when duetime elapses.
  *
@@ -5,12 +21,4 @@
  *
  * @class TimeoutError
  */
-export class TimeoutError extends Error {
-
-  public readonly name = 'TimeoutError';
-
-  constructor() {
-    super('Timeout has occurred');
-    (Object as any).setPrototypeOf(this, TimeoutError.prototype);
-  }
-}
+export const TimeoutError: TimeoutErrorCtor = TimeoutErrorImpl as any;

--- a/src/internal/util/UnsubscriptionError.ts
+++ b/src/internal/util/UnsubscriptionError.ts
@@ -1,15 +1,25 @@
+export interface UnsubscriptionError extends Error {
+  readonly errors: any[];
+}
+
+export interface UnsubscriptionErrorCtor {
+  new(errors: any[]): UnsubscriptionError;
+}
+
+function UnsubscriptionErrorImpl(this: any, errors: any[]) {
+  Error.call(this);
+  this.message = errors ?
+  `${errors.length} errors occurred during unsubscription:
+${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '';
+  this.name = 'UnsubscriptionError';
+  this.errors = errors;
+  return this;
+}
+
+UnsubscriptionErrorImpl.prototype = Object.create(Error.prototype);
+
 /**
  * An error thrown when one or more errors have occurred during the
  * `unsubscribe` of a {@link Subscription}.
  */
-export class UnsubscriptionError extends Error {
-
-  public readonly name = 'UnsubscriptionError';
-
-  constructor(public errors: any[]) {
-    super(errors ?
-      `${errors.length} errors occurred during unsubscription:
-  ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '');
-    (Object as any).setPrototypeOf(this, UnsubscriptionError.prototype);
-  }
-}
+export const UnsubscriptionError: UnsubscriptionErrorCtor = UnsubscriptionErrorImpl as any;


### PR DESCRIPTION
This reimplements all Error types as ES5 classes, and types them with TypeScript such that
we no longer need to rely on Object.setPrototypeOf, which was causing issues for users who had not
polyfilled it properly in IE10.

fixes #3966
