### PR TITLE
fix(find): unsubscribe from source when found

### DIFF
--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
-import { find, mergeMap } from 'rxjs/operators';
+import { find, mergeMap, delay } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { of, Observable, from } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
+
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {find} */
 describe('find operator', () => {
@@ -129,6 +132,20 @@ describe('find operator', () => {
     );
 
     expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should unsubscribe when the predicate is matched', () => {
+    const source = hot('--a--b---c-|');
+    const subs =       '^    !';
+    const expected =   '-------(b|)';
+
+    const duration = rxTestScheduler.createTime('--|');
+
+    expectObservable((<any>source).pipe(
+      find((value: string) => value === 'b'),
+      delay(duration, rxTestScheduler)
+    )).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -22,13 +22,13 @@ describe('find operator', () => {
 
     const predicate = function (x: number) { return x % 5 === 0; };
 
-    expectObservable((<any>source).pipe(find(predicate))).toBe(expected, values);
+    expectObservable(source.pipe(find(predicate))).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should throw if not provided a function', () => {
     expect(() => {
-      (<any>of('yut', 'yee', 'sam')).pipe(find('yee' as any));
+      of('yut', 'yee', 'sam').pipe(find('yee' as any));
     }).to.throw(TypeError, 'predicate is not a function');
   });
 
@@ -37,7 +37,7 @@ describe('find operator', () => {
     const subs =       '^';
     const expected =   '-';
 
-    expectObservable((<any>source).pipe(find(truePredicate))).toBe(expected);
+    expectObservable(source.pipe(find(truePredicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -46,7 +46,7 @@ describe('find operator', () => {
     const subs =        '(^!)';
     const expected =    '(x|)';
 
-    const result = (<any>source).pipe(find(truePredicate));
+    const result = source.pipe(find(truePredicate));
 
     expectObservable(result).toBe(expected, {x: undefined});
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -61,7 +61,7 @@ describe('find operator', () => {
       return value === 'a';
     };
 
-    expectObservable((<any>source).pipe(find(predicate))).toBe(expected);
+    expectObservable(source.pipe(find(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -74,7 +74,7 @@ describe('find operator', () => {
       return value === 'b';
     };
 
-    expectObservable((<any>source).pipe(find(predicate))).toBe(expected);
+    expectObservable(source.pipe(find(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -90,7 +90,7 @@ describe('find operator', () => {
       return value === this.target;
     };
 
-    expectObservable((<any>source).pipe(find(predicate, finder))).toBe(expected);
+    expectObservable(source.pipe(find(predicate, finder))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -103,7 +103,7 @@ describe('find operator', () => {
       return value === 'z';
     };
 
-    expectObservable((<any>source).pipe(find(predicate))).toBe(expected, { x: undefined });
+    expectObservable(source.pipe(find(predicate))).toBe(expected, { x: undefined });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -113,7 +113,7 @@ describe('find operator', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source).pipe(find((value: string) => value === 'z'));
+    const result = source.pipe(find((value: string) => value === 'z'));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -125,7 +125,7 @@ describe('find operator', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source).pipe(
+    const result = source.pipe(
       mergeMap((x: string) => of(x)),
       find((value: string) => value === 'z'),
       mergeMap((x: string) => of(x))
@@ -142,7 +142,7 @@ describe('find operator', () => {
 
     const duration = rxTestScheduler.createTime('--|');
 
-    expectObservable((<any>source).pipe(
+    expectObservable(source.pipe(
       find((value: string) => value === 'b'),
       delay(duration, rxTestScheduler)
     )).toBe(expected);
@@ -158,7 +158,7 @@ describe('find operator', () => {
       return value === 'z';
     };
 
-    expectObservable((<any>source).pipe(find(predicate))).toBe(expected);
+    expectObservable(source.pipe(find(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -171,7 +171,7 @@ describe('find operator', () => {
       throw 'error';
     };
 
-    expectObservable((<any>source).pipe(find(predicate))).toBe(expected);
+    expectObservable(source.pipe(find(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -21,7 +21,7 @@ describe('findIndex operator', () => {
 
     const predicate = function (x: number) { return x % 5 === 0; };
 
-    expectObservable((<any>source).pipe(findIndex(predicate))).toBe(expected, { x: 2 });
+    expectObservable(source.pipe(findIndex(predicate))).toBe(expected, { x: 2 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -30,7 +30,7 @@ describe('findIndex operator', () => {
     const subs =       '^';
     const expected =   '-';
 
-    expectObservable((<any>source).pipe(findIndex(truePredicate))).toBe(expected);
+    expectObservable(source.pipe(findIndex(truePredicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -39,7 +39,7 @@ describe('findIndex operator', () => {
     const subs =        '(^!)';
     const expected =    '(x|)';
 
-    const result = (<any>source).pipe(findIndex(truePredicate));
+    const result = source.pipe(findIndex(truePredicate));
 
     expectObservable(result).toBe(expected, {x: -1});
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -55,7 +55,7 @@ describe('findIndex operator', () => {
       return value === sourceValue;
     };
 
-    expectObservable((<any>source).pipe(findIndex(predicate))).toBe(expected, { x: 0 });
+    expectObservable(source.pipe(findIndex(predicate))).toBe(expected, { x: 0 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -68,7 +68,7 @@ describe('findIndex operator', () => {
       return value === 7;
     };
 
-    expectObservable((<any>source).pipe(findIndex(predicate))).toBe(expected, { x: 1 });
+    expectObservable(source.pipe(findIndex(predicate))).toBe(expected, { x: 1 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -81,7 +81,7 @@ describe('findIndex operator', () => {
     const predicate = function (this: typeof sourceValues, value: number) {
       return value === this.b;
     };
-    const result = (<any>source).pipe(findIndex(predicate, sourceValues));
+    const result = source.pipe(findIndex(predicate, sourceValues));
 
     expectObservable(result).toBe(expected, { x: 1 });
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -96,7 +96,7 @@ describe('findIndex operator', () => {
       return value === 'z';
     };
 
-    expectObservable((<any>source).pipe(findIndex(predicate))).toBe(expected, { x: -1 });
+    expectObservable(source.pipe(findIndex(predicate))).toBe(expected, { x: -1 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -106,7 +106,7 @@ describe('findIndex operator', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source).pipe(findIndex((value: string) => value === 'z'));
+    const result = source.pipe(findIndex((value: string) => value === 'z'));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
@@ -118,10 +118,10 @@ describe('findIndex operator', () => {
     const expected =   '-------     ';
     const unsub =      '      !     ';
 
-    const result = (<any>source).pipe(
+    const result = source.pipe(
       mergeMap((x: string) => of(x)),
       findIndex((value: string) => value === 'z'),
-      mergeMap((x: string) => of(x))
+      mergeMap((x: number) => of(x))
     );
 
     expectObservable(result, unsub).toBe(expected);
@@ -135,7 +135,7 @@ describe('findIndex operator', () => {
 
     const duration = rxTestScheduler.createTime('--|');
 
-    expectObservable((<any>source).pipe(
+    expectObservable(source.pipe(
       findIndex((value: string) => value === 'b'),
       delay(duration, rxTestScheduler)
     )).toBe(expected, { x: 1 });
@@ -151,7 +151,7 @@ describe('findIndex operator', () => {
       return value === 'z';
     };
 
-    expectObservable((<any>source).pipe(findIndex(predicate))).toBe(expected);
+    expectObservable(source.pipe(findIndex(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
@@ -164,7 +164,7 @@ describe('findIndex operator', () => {
       throw 'error';
     };
 
-    expectObservable((<any>source).pipe(findIndex(predicate))).toBe(expected);
+    expectObservable(source.pipe(findIndex(predicate))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 });

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -1,8 +1,11 @@
-import { findIndex, mergeMap } from 'rxjs/operators';
+import { findIndex, mergeMap, delay } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
+
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {findIndex} */
 describe('findIndex operator', () => {
@@ -122,6 +125,20 @@ describe('findIndex operator', () => {
     );
 
     expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should unsubscribe when the predicate is matched', () => {
+    const source = hot('--a--b---c-|');
+    const subs =       '^    !';
+    const expected =   '-------(x|)';
+
+    const duration = rxTestScheduler.createTime('--|');
+
+    expectObservable((<any>source).pipe(
+      findIndex((value: string) => value === 'b'),
+      delay(duration, rxTestScheduler)
+    )).toBe(expected, { x: 1 });
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -1,9 +1,12 @@
 import { expect } from 'chai';
 import { hot, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { first, mergeMap } from 'rxjs/operators';
+import { first, mergeMap, delay } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
 import { of, from, Observable, Subject, EmptyError } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
+
+declare const rxTestScheduler: TestScheduler;
 
 /** @test {first} */
 describe('Observable.prototype.first', () => {
@@ -99,6 +102,20 @@ describe('Observable.prototype.first', () => {
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should unsubscribe when the first value is receiv', () => {
+    const source = hot('--a--b---c-|');
+    const subs =       '^ !';
+    const expected =   '----(a|)';
+
+    const duration = rxTestScheduler.createTime('--|');
+
+    expectObservable((<any>source).pipe(
+      first(),
+      delay(duration, rxTestScheduler)
+    )).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
   it('should return first value that matches a predicate', () => {

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -111,7 +111,7 @@ describe('Observable.prototype.first', () => {
 
     const duration = rxTestScheduler.createTime('--|');
 
-    expectObservable((<any>source).pipe(
+    expectObservable(source.pipe(
       first(),
       delay(duration, rxTestScheduler)
     )).toBe(expected);

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -88,6 +88,7 @@ export class FindValueSubscriber<T> extends Subscriber<T> {
 
     destination.next(value);
     destination.complete();
+    this.unsubscribe();
   }
 
   protected _next(value: T): void {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes #3934 and adds unsubscribe-when-matched tests for `find`, `findIndex` and `first`.

**Related issue (if exists):** #3934