### PR TITLE
fix(find): add undefined to return type

### DIFF
--- a/spec-dtslint/operators/find-spec.ts
+++ b/spec-dtslint/operators/find-spec.ts
@@ -1,0 +1,26 @@
+import { of } from 'rxjs';
+import { find } from 'rxjs/operators';
+
+it('should support a user-defined type guard', () => {
+  const o = of('foo').pipe(find((s): s is 'foo' => true)); // $ExpectType Observable<"foo" | undefined>
+});
+
+it('should support a user-defined type guard that takes an index', () => {
+  const o = of('foo').pipe(find((s, index): s is 'foo' => true)); // $ExpectType Observable<"foo" | undefined>
+});
+
+it('should support a user-defined type guard that takes an index and the source', () => {
+  const o = of('foo').pipe(find((s, index, source): s is 'foo' => true)); // $ExpectType Observable<"foo" | undefined>
+});
+
+it('should support a predicate', () => {
+  const o = of('foo').pipe(find(s => true)); // $ExpectType Observable<string | undefined>
+});
+
+it('should support a predicate that takes an index', () => {
+  const o = of('foo').pipe(find((s, index) => true)); // $ExpectType Observable<string | undefined>
+});
+
+it('should support a predicate that takes an index and the source', () => {
+  const o = of('foo').pipe(find((s, index, source) => true)); // $ExpectType Observable<string | undefined>
+});

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -1,12 +1,12 @@
 import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
-import {OperatorFunction, MonoTypeOperatorFunction} from '../types';
+import {OperatorFunction} from '../types';
 
 export function find<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S,
                                      thisArg?: any): OperatorFunction<T, S | undefined>;
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                        thisArg?: any): MonoTypeOperatorFunction<T | undefined>;
+                        thisArg?: any): OperatorFunction<T, T | undefined>;
 /**
  * Emits only the first value emitted by the source Observable that meets some
  * condition.

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -4,13 +4,9 @@ import {Subscriber} from '../Subscriber';
 import {OperatorFunction, MonoTypeOperatorFunction} from '../types';
 
 export function find<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S,
-                                     thisArg?: any): OperatorFunction<T, S>;
-export function find<T, S extends T>(predicate: (value: T, index: number) => value is S,
-                                     thisArg?: any): OperatorFunction<T, S>;
+                                     thisArg?: any): OperatorFunction<T, S | undefined>;
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                        thisArg?: any): MonoTypeOperatorFunction<T>;
-export function find<T>(predicate: (value: T, index: number) => boolean,
-                        thisArg?: any): MonoTypeOperatorFunction<T>;
+                        thisArg?: any): MonoTypeOperatorFunction<T | undefined>;
 /**
  * Emits only the first value emitted by the source Observable that meets some
  * condition.
@@ -48,14 +44,14 @@ export function find<T>(predicate: (value: T, index: number) => boolean,
  * @owner Observable
  */
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                        thisArg?: any): MonoTypeOperatorFunction<T> {
+                        thisArg?: any): OperatorFunction<T, T | undefined> {
   if (typeof predicate !== 'function') {
     throw new TypeError('predicate is not a function');
   }
-  return (source: Observable<T>) => source.lift(new FindValueOperator(predicate, source, false, thisArg));
+  return (source: Observable<T>) => source.lift(new FindValueOperator(predicate, source, false, thisArg)) as Observable<T | undefined>;
 }
 
-export class FindValueOperator<T> implements Operator<T, T> {
+export class FindValueOperator<T> implements Operator<T, T | number | undefined> {
   constructor(private predicate: (value: T, index: number, source: Observable<T>) => boolean,
               private source: Observable<T>,
               private yieldIndex: boolean,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes the return types for the `find` operator to indicate that `undefined` is a value that could be emitted.

Removes unnecessary overload signatures and adds dtslint tests.

**Related issue (if exists):** #3969