### PR TITLE
docs(migration): use function for this context

### DIFF
--- a/docs_app/content/guide/v6/migration.md
+++ b/docs_app/content/guide/v6/migration.md
@@ -100,7 +100,7 @@ The following example shows the kind of changes you will need to make in user-de
 Here is an example of a user-defined prototype operator:
 
 ```ts
-Observable.prototype.userDefined = () => {
+Observable.prototype.userDefined = function () {
   return new Observable((subscriber) => {
     this.subscribe({
       next(value) { subscriber.next(value); },
@@ -108,7 +108,7 @@ Observable.prototype.userDefined = () => {
       complete() { subscriber.complete(); },
    });
   });
-});
+};
 
 source$.userDefined().subscribe();
 ```


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

With the v5 user-defined operator example, a non-arrow function needs to be used if the `this` context is to refer to the `Observable` instance.

**Related issue (if exists):** None