### PR TITLE
fix(Observable): use more granular Observable exports in compat mode

### DIFF
--- a/compat/Observable.ts
+++ b/compat/Observable.ts
@@ -1,1 +1,2 @@
-export {Observable, Subscribable, SubscribableOrPromise, ObservableInput} from 'rxjs';
+export {Observable} from 'rxjs/internal/Observable';
+export {Subscribable, SubscribableOrPromise, ObservableInput} from 'rxjs/internal/types';


### PR DESCRIPTION
**Description:** Use more granular exports in compat/Observable.ts to enable tree shaking optimization even if the consumer is compiling to CommonJS (instead of ES2015) modules.

**Related issue (if exists):** https://github.com/ReactiveX/rxjs/issues/3971

Importing `Observable` and calling `Observable.create`, with `"module": "commonjs"` vs `"module": "es2015"` in tsconfig.json:

### Before patch

| | `"module": "commonjs"` | `"module": "es2015"` |
|-|-|-|
| rxjs | 79.6 KiB | 14.7 KiB |
| rxjs-compat | 80 KiB | 80.1 KiB

### After patch

| | `"module": "commonjs"` | `"module": "es2015"` |
|-|-|-|
| rxjs | 79.6 KiB | 14.7 KiB |
| rxjs-compat | 18.6 KiB | 18.7 KiB