### PR TITLE
chore(find): fix compat signatures

### DIFF
--- a/compat/operator/find.ts
+++ b/compat/operator/find.ts
@@ -4,10 +4,10 @@ import { find as higherOrder } from 'rxjs/operators';
 /* tslint:disable:max-line-length */
 export function find<T, S extends T>(this: Observable<T>,
                                      predicate: (value: T, index: number) => value is S,
-                                     thisArg?: any): Observable<S>;
+                                     thisArg?: any): Observable<S | undefined>;
 export function find<T>(this: Observable<T>,
                         predicate: (value: T, index: number) => boolean,
-                        thisArg?: any): Observable<T>;
+                        thisArg?: any): Observable<T | undefined>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -44,6 +44,6 @@ export function find<T>(this: Observable<T>,
  * @owner Observable
  */
 export function find<T>(this: Observable<T>, predicate: (value: T, index: number, source: Observable<T>) => boolean,
-                        thisArg?: any): Observable<T> {
+                        thisArg?: any): Observable<T | undefined> {
   return higherOrder(predicate, thisArg)(this);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I forgot to update the compat signatures in #3970.

**Related issue (if exists):** #3969