### PR TITLE
docs(throwError): Fixed typo

### DIFF
--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -47,7 +47,7 @@ import { Subscriber } from '../Subscriber';
  * @return {Observable} An error Observable: emits only the error notification
  * using the given error argument.
  * @static true
- * @name throw
+ * @name throwError
  * @owner Observable
  */
 export function throwError(error: any, scheduler?: SchedulerLike): Observable<never> {


### PR DESCRIPTION
throwError documentation is referenced as throw

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
