### PR TITLE
docs(ajax): added ajax and webSocket docs back to the list

### DIFF
--- a/docs_app/tools/transforms/angular-api-package/index.js
+++ b/docs_app/tools/transforms/angular-api-package/index.js
@@ -67,7 +67,10 @@ module.exports = new Package('angular-api', [basePackage, typeScriptPackage])
     // NOTE: This list should be in sync with tools/public_api_guard/BUILD.bazel
     readTypeScriptModules.sourceFiles = [
       'index.ts',
-      'operators/index.ts'
+      'operators/index.ts',
+      'ajax/index.ts',
+      'webSocket/index.ts',
+      'testing/index.ts'
     ];
 
     // API Examples

--- a/src/internal/observable/dom/ajax.ts
+++ b/src/internal/observable/dom/ajax.ts
@@ -1,3 +1,19 @@
 import {  AjaxObservable, AjaxCreationMethod  } from './AjaxObservable';
-
+/**
+ * There is an ajax operator on the Rx object.
+ *
+ * It creates an observable for an Ajax request with either a request object with
+ * url, headers, etc or a string for a URL.
+ *
+ * ## Using ajax.getJSON() to fetch data from API.
+ * ```javascript
+ * import { ajax } from 'rxjs/ajax';
+ * import { map, catchError } from 'rxjs/operators';
+ *
+ * const obs$ = ajax.getJSON(`https://api.github.com/users?per_page=5`).pipe(
+ *   map(userResponse => console.log('users: ', userResponse)),
+ *   catchError(error => console.log('error: ', error))
+ * ));
+ * ```
+ */
 export const ajax: AjaxCreationMethod = AjaxObservable.create;


### PR DESCRIPTION
**Description:**
- Added ajax docs back to the list
- Added webSocket docs back to the list

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3961
https://github.com/ReactiveX/rxjs/issues/3962