### PR TITLE
Revert "Cancellable forEach"

### DIFF
--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -20,7 +20,6 @@ ObjectUnsubscribedErrorImpl.prototype = Object.create(Error.prototype);
  *
  * @see {@link Subject}
  * @see {@link BehaviorSubject}
- * @see {@link Observable.prototype.forEach}
  *
  * @class ObjectUnsubscribedError
  */

--- a/src/internal/util/isSubscription.ts
+++ b/src/internal/util/isSubscription.ts
@@ -1,9 +1,0 @@
-import { Subscription } from '../Subscription';
-
-/**
- * Tests to see if a value is an RxJS {@link Subscription}.
- * @param x the value to test
- */
-export function isSubscription(x: any): x is Subscription {
-  return x && typeof x.unsubscribe === 'function' && typeof x.add === 'function';
-}


### PR DESCRIPTION
Reverts ReactiveX/rxjs#3977

Currently, there's an issue with what is in there if you unsubscribe from a synchronous observable, synchronously, but after the observable completes:

```ts
const subs = new Subscription();

of('test').forEach(x => console.log(x), subs)
  .then(() => console.log('this should not be called'));

subs.unsubscribe();

// Logs
// "test"
// "this should not be called"
```

Solutions around this aren't too bad, but it adds a lot of bloat, mostly due to the fact we're accepting PromiseConstructorLike as an argument, and we're beholden to use it.

I want to revert this new feature until:

1. We deprecate and remove all Promise Constructor configuration (This is legacy, and users should use a proper polyfill)
2. We deprecate and update the behavior of `forEach` to call it's `next` handler on the next microtask, as per the proposals. (We can't do this until v7 because it's a breaking change)

I still want to use Subscriptions as a cancellation here, but it's going to have to wait.

Sorry folks.