### PR TITLE
chore(distinctUntilKeyChanged): nail down key's typing with keyof T

### DIFF
--- a/compat/operator/distinctUntilKeyChanged.ts
+++ b/compat/operator/distinctUntilKeyChanged.ts
@@ -4,7 +4,7 @@ import { distinctUntilKeyChanged as higherOrder } from 'rxjs/operators';
 
 /* tslint:disable:max-line-length */
 export function distinctUntilKeyChanged<T>(this: Observable<T>, key: string): Observable<T>;
-export function distinctUntilKeyChanged<T, K>(this: Observable<T>, key: string, compare: (x: K, y: K) => boolean): Observable<T>;
+export function distinctUntilKeyChanged<T, K extends keyof T>(this: Observable<T>, key: string, compare: (x: T[K], y: T[K]) => boolean): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -64,6 +64,7 @@ export function distinctUntilKeyChanged<T, K>(this: Observable<T>, key: string, 
  * @method distinctUntilKeyChanged
  * @owner Observable
  */
-export function distinctUntilKeyChanged<T>(this: Observable<T>, key: string, compare?: (x: T, y: T) => boolean): Observable<T> {
-  return higherOrder<T, T>(key, compare)(this);
+// tslint:disable-next-line:max-line-length
+export function distinctUntilKeyChanged<T, K extends keyof T>(this: Observable<T>, key: string, compare?: (x: T[K], y: T[K]) => boolean): Observable<T> {
+  return higherOrder<T, K>(key, compare)(this);
 }

--- a/compat/operator/distinctUntilKeyChanged.ts
+++ b/compat/operator/distinctUntilKeyChanged.ts
@@ -3,8 +3,8 @@ import { Observable } from 'rxjs';
 import { distinctUntilKeyChanged as higherOrder } from 'rxjs/operators';
 
 /* tslint:disable:max-line-length */
-export function distinctUntilKeyChanged<T>(this: Observable<T>, key: string): Observable<T>;
-export function distinctUntilKeyChanged<T, K extends keyof T>(this: Observable<T>, key: string, compare: (x: T[K], y: T[K]) => boolean): Observable<T>;
+export function distinctUntilKeyChanged<T>(this: Observable<T>, key: keyof T): Observable<T>;
+export function distinctUntilKeyChanged<T, K extends keyof T>(this: Observable<T>, key: K, compare: (x: T[K], y: T[K]) => boolean): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -65,6 +65,6 @@ export function distinctUntilKeyChanged<T, K extends keyof T>(this: Observable<T
  * @owner Observable
  */
 // tslint:disable-next-line:max-line-length
-export function distinctUntilKeyChanged<T, K extends keyof T>(this: Observable<T>, key: string, compare?: (x: T[K], y: T[K]) => boolean): Observable<T> {
+export function distinctUntilKeyChanged<T, K extends keyof T>(this: Observable<T>, key: K, compare?: (x: T[K], y: T[K]) => boolean): Observable<T> {
   return higherOrder<T, K>(key, compare)(this);
 }

--- a/spec-dtslint/operators/distinctUntilKeyChanged-spec.ts
+++ b/spec-dtslint/operators/distinctUntilKeyChanged-spec.ts
@@ -1,0 +1,20 @@
+import { of } from 'rxjs';
+import { distinctUntilKeyChanged } from 'rxjs/operators';
+
+const sample = {name: 'foobar', num: 42};
+
+it('should enforce key set', () => {
+  const o = of(sample).pipe(distinctUntilKeyChanged('something')); // $ExpectError
+});
+
+it('should enforce key set with compare', () => {
+  const o = of(sample).pipe(distinctUntilKeyChanged('something', () => true)); // $ExpectError
+});
+
+it("should enforce compare's type", () => {
+  const o = of(sample).pipe(distinctUntilKeyChanged('name', (a: number, b: number) => true)); // $ExpectError
+});
+
+it("should enforce key set and compare's type", () => {
+  const o = of(sample).pipe(distinctUntilKeyChanged('something', (a: number, b: number) => true)); // $ExpectError
+});

--- a/spec/operators/distinctUntilKeyChanged-spec.ts
+++ b/spec/operators/distinctUntilKeyChanged-spec.ts
@@ -185,7 +185,7 @@ describe('distinctUntilKeyChanged operator', () => {
     const e1subs =   '^                !';
     const expected = '--a--------------|';
 
-    expectObservable((<any>e1).pipe(distinctUntilKeyChanged('val', () => true))).toBe(expected, values);
+    expectObservable(e1.pipe(distinctUntilKeyChanged('val', () => true))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -195,7 +195,7 @@ describe('distinctUntilKeyChanged operator', () => {
     const e1subs =   '^                   !';
     const expected = '--a--a--a--a--a--a--|';
 
-    expectObservable((<any>e1).pipe(distinctUntilKeyChanged('val', () => false))).toBe(expected, values);
+    expectObservable(e1.pipe(distinctUntilKeyChanged('val', () => false))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -206,7 +206,7 @@ describe('distinctUntilKeyChanged operator', () => {
     const expected = '--a-----c-----e--|';
     const selector = (x: number, y: number) => y % 2 === 0;
 
-    expectObservable((<any>e1).pipe(distinctUntilKeyChanged('val', selector))).toBe(expected, values);
+    expectObservable(e1.pipe(distinctUntilKeyChanged('val', selector))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
@@ -222,7 +222,7 @@ describe('distinctUntilKeyChanged operator', () => {
       return x === y;
     };
 
-    expectObservable((<any>e1).pipe(distinctUntilKeyChanged('val', selector))).toBe(expected, values);
+    expectObservable(e1.pipe(distinctUntilKeyChanged('val', selector))).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/src/internal/operators/distinctUntilKeyChanged.ts
+++ b/src/internal/operators/distinctUntilKeyChanged.ts
@@ -3,7 +3,7 @@ import { MonoTypeOperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
 export function distinctUntilKeyChanged<T>(key: string): MonoTypeOperatorFunction<T>;
-export function distinctUntilKeyChanged<T, K>(key: string, compare: (x: K, y: K) => boolean): MonoTypeOperatorFunction<T>;
+export function distinctUntilKeyChanged<T, K extends keyof T>(key: string, compare: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -70,6 +70,6 @@ export function distinctUntilKeyChanged<T, K>(key: string, compare: (x: K, y: K)
  * @method distinctUntilKeyChanged
  * @owner Observable
  */
-export function distinctUntilKeyChanged<T>(key: string, compare?: (x: T, y: T) => boolean): MonoTypeOperatorFunction<T> {
+export function distinctUntilKeyChanged<T, K extends keyof T>(key: string, compare?: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T> {
   return distinctUntilChanged((x: T, y: T) => compare ? compare(x[key], y[key]) : x[key] === y[key]);
 }

--- a/src/internal/operators/distinctUntilKeyChanged.ts
+++ b/src/internal/operators/distinctUntilKeyChanged.ts
@@ -2,8 +2,8 @@ import { distinctUntilChanged } from './distinctUntilChanged';
 import { MonoTypeOperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
-export function distinctUntilKeyChanged<T>(key: string): MonoTypeOperatorFunction<T>;
-export function distinctUntilKeyChanged<T, K extends keyof T>(key: string, compare: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T>;
+export function distinctUntilKeyChanged<T>(key: keyof T): MonoTypeOperatorFunction<T>;
+export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -70,6 +70,6 @@ export function distinctUntilKeyChanged<T, K extends keyof T>(key: string, compa
  * @method distinctUntilKeyChanged
  * @owner Observable
  */
-export function distinctUntilKeyChanged<T, K extends keyof T>(key: string, compare?: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T> {
+export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare?: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T> {
   return distinctUntilChanged((x: T, y: T) => compare ? compare(x[key], y[key]) : x[key] === y[key]);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

With better typing constraint on `T[key]` looks up from **TypeScript**.