### PR TITLE
[WIP] chore(build): use importHelpers from TS instead of rollupInject

### DIFF
--- a/integration/systemjs/systemjs-compatibility-spec.js
+++ b/integration/systemjs/systemjs-compatibility-spec.js
@@ -2,7 +2,10 @@ var System = require('systemjs');
 var path = require('path');
 
 System.config({
-  map: { 'rxjs': path.join(__dirname, '..', '..', 'dist', 'package', '/') },
+  map: {
+    'rxjs': path.join(__dirname, '..', '..', 'dist', 'package', '/'),
+    'tslib': 'node_modules/tslib/tslib.js',
+  },
   packages: {
     'rxjs': {main: 'index.js', defaultExtension: 'js' },
     'rxjs/ajax': {main: 'index.js', defaultExtension: 'js' },

--- a/package.json
+++ b/package.json
@@ -219,7 +219,6 @@
     "protractor": "3.1.1",
     "rollup": "0.36.3",
     "rollup-plugin-alias": "1.4.0",
-    "rollup-plugin-inject": "2.0.0",
     "rollup-plugin-node-resolve": "2.0.0",
     "rx": "latest",
     "rxjs": "^5.5.7",

--- a/tools/make-umd-bundle.js
+++ b/tools/make-umd-bundle.js
@@ -1,25 +1,13 @@
-var _ = require('lodash');
-
 var rollup = require('rollup');
-var rollupInject = require('rollup-plugin-inject');
 var rollupNodeResolve = require('rollup-plugin-node-resolve');
 
 var fs = require('fs');
-var path = require('path');
-
-var tslib = require('tslib');
 
 rollup.rollup({
   entry: 'dist/esm5_for_rollup/internal/umd.js',
   plugins: [
     rollupNodeResolve({
       jsnext: true,
-    }),
-    rollupInject({
-      exclude: 'node_modules/**',
-      modules: _.mapValues(tslib, function (value, key) {
-        return ['tslib', key];
-      }),
     }),
   ],
 }).then(function (bundle) {

--- a/tools/make-umd-compat-bundle.js
+++ b/tools/make-umd-compat-bundle.js
@@ -1,12 +1,8 @@
-var _ = require('lodash');
-
 var rollup = require('rollup');
 var rollupAlias = require('rollup-plugin-alias');
-var rollupInject = require('rollup-plugin-inject');
 var rollupNodeResolve = require('rollup-plugin-node-resolve');
 
 var fs = require('fs');
-var tslib = require('tslib');
 
 rollup.rollup({
   entry: 'dist-compat/esm5_for_rollup/compat/umd.js',
@@ -21,12 +17,6 @@ rollup.rollup({
     }),
     rollupNodeResolve({
       jsnext: true,
-    }),
-    rollupInject({
-      exclude: 'node_modules/**',
-      modules: _.mapValues(tslib, function (value, key) {
-        return ['tslib', key];
-      }),
     }),
   ],
 }).then(function (bundle) {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -9,6 +9,7 @@
     "noImplicitThis": true,
     "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",
+    "importHelpers": true,
     "stripInternal": false,
     "target": "es5",
     "outDir": "./.out",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This follows up my [previous PR](https://github.com/ReactiveX/rxjs/pull/2121#issuecomment-260616205) on this aspect, now it's time to finish the second half.


**Related issue (if exists):**

- #2121
