### PR TITLE
docs(rxjs): Order JSDocs for Scheduler and Improve Readability

### DIFF
--- a/src/internal/Rx.ts
+++ b/src/internal/Rx.ts
@@ -186,16 +186,16 @@ export const operators = _operators;
 
 /**
  * @typedef {Object} Rx.Scheduler
+ * @property {SchedulerLike} asap Schedules on the micro task queue, which uses the
+ * fastest transport mechanism available, either Node.js' `process.nextTick()`,
+ * Web Worker MessageChannel, setTimeout, or others. Use this for
+ * asynchronous conversions.
  * @property {SchedulerLike} queue Schedules on a queue in the current event frame
  * (trampoline scheduler). Use this for iteration operations.
- * @property {SchedulerLike} asap Schedules on the micro task queue, which uses the
- * fastest transport mechanism available, either Node.js' `process.nextTick()`
- * or Web Worker MessageChannel or setTimeout or others. Use this for
- * asynchronous conversions.
+ * @property {SchedulerLike} animationFrame Schedules work with `requestAnimationFrame`.
+ * Use this for synchronizing with the platform's painting.
  * @property {SchedulerLike} async Schedules work with `setInterval`. Use this for
  * time-based operations.
- * @property {SchedulerLike} animationFrame Schedules work with `requestAnimationFrame`.
- * Use this for synchronizing with the platform's painting
  */
 let Scheduler = {
   asap,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Found that the Symbol properties were out of order and some minor sentence structure for readability.