### PR TITLE
chore(dtslint): disable no-unnecessary-generics

### DIFF
--- a/spec-dtslint/tslint.json
+++ b/spec-dtslint/tslint.json
@@ -1,6 +1,7 @@
 {
   "extends": "dtslint/dtslint.json",
   "rules": {
+    "no-unnecessary-generics": false,
     "no-useless-files": false
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Disables the [`no-unnecessary-generics`](https://github.com/Microsoft/dtslint/blob/master/docs/no-unnecessary-generics.md) TSLint rule that's applied to the dtslint tests. There are tests that deliberately involve generics that the rule thinks are unnecessary (in a `.d.ts` file context), but that's not the case.

**Related issue (if exists):** None