### PR TITLE
(docs cdn): Fix link to cdn for version 5.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,9 @@ npm install @reactivex/rxjs@5.0.0
 
 For CDN, you can use [unpkg](https://unpkg.com/):
   
-https://unpkg.com/rxjs/bundles/Rx.min.js
+https://unpkg.com/rxjs@version/bundles/Rx.min.js
+
+*replace **version** with the current version. See [docs](http://reactivex.io/rxjs/manual/installation.html#cdn).*
 
 #### Node.js Usage:
 


### PR DESCRIPTION
**Description:**
Link to cdn was not working for version 5. The fix was taken from the reactivex docs http://reactivex.io/rxjs/manual/installation.html#cdn
