### PR TITLE
docs(UI): Spacing Between Heading and Badges

### DIFF
--- a/docs_app/src/styles/2-modules/_label.scss
+++ b/docs_app/src/styles/2-modules/_label.scss
@@ -36,32 +36,37 @@ label.raised, .api-header label {
     }
 }
 
-.api-header label {
+.api-header {
 
-    // The API badges should be a little smaller
-    padding: 2px 10px;
-    font-size: 12px;
+    margin-right: 10px;
 
-    @media screen and (max-width: 600px) {
-        margin: 4px 0;
-    }
+    label {
 
-    &.api-status-label {
-        background-color: $mediumgray;
+        // The API badges should be a little smaller
+        padding: 2px 10px;
+        font-size: 12px;
 
-        &.impure-pipe {
-            background-color: $brightred;
+        @media screen and (max-width: 600px) {
+            margin: 4px 0;
         }
-    }
 
-    &.api-type-label {
-        background-color: $accentgrey;
+        &.api-status-label {
+            background-color: $mediumgray;
 
-        @each $name, $symbol in $api-symbols {
-            &.#{$name} {
-                background: map-get($symbol, background);
+            &.impure-pipe {
+                background-color: $brightred;
             }
         }
 
+        &.api-type-label {
+            background-color: $accentgrey;
+
+            @each $name, $symbol in $api-symbols {
+                &.#{$name} {
+                    background: map-get($symbol, background);
+                }
+            }
+
+        }
     }
 }


### PR DESCRIPTION
**Description:**

This is a small UI fix for the docs that give some separation between the heading and the badges.

![header-label-seperation](https://user-images.githubusercontent.com/442374/44129976-3d562526-a019-11e8-89ec-3aa909c046f9.png)
