### PR TITLE
docs(MIGRATION): fix `#drop-compat` anchor

### DIFF
--- a/docs_app/content/guide/v6/migration.md
+++ b/docs_app/content/guide/v6/migration.md
@@ -38,7 +38,7 @@ For details about this package, see https://www.npmjs.com/package/rxjs-compat.
 The compatibility package increases the bundle size of your application, which is why we recommend removing it as soon as your application and dependencies have been updated. 
 This size increase is exacerbated if you are using a version of Webpack before 4.0.0. 
 
-For a full explanation of what you will have to update in order to remove `rxjs-compat`, see [Dropping the compatibility layer]<a id="drop-compat"></a>. Note also that fully updating your application to v6 may expose existing type errors that were not previously shown. 
+For a full explanation of what you will have to update in order to remove `rxjs-compat`, see [Dropping the compatibility layer](#drop-compat). Note also that fully updating your application to v6 may expose existing type errors that were not previously shown. 
 
 <a id="breaking-changes"></a>
 


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fix for `#drop-compat` anchor in MIGRATION.md docs