### PR TITLE
docs(fromEventPattern): add missing backticks

### DIFF
--- a/src/internal/observable/fromEventPattern.ts
+++ b/src/internal/observable/fromEventPattern.ts
@@ -89,7 +89,7 @@ export function fromEventPattern<T>(addHandler: (handler: Function) => any, remo
  *   function(handler) { return someAPI.registerEventHandler(handler); }, // Note that we return the token here...
  *   function(handler, token) { someAPI.unregisterEventHandler(token); }  // ...to then use it here.
  * );
- *
+ * ```
  *
  * ## Example
  * ### Use with project function


### PR DESCRIPTION
There were some backticks missing for correct markdown and therefore the log printed out a huge amount of warnings building the docs. But this merge request fix one of these warnings:D