### PR TITLE
docs(forkJoin): Fix typo of jorkJoin

### DIFF
--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -109,7 +109,7 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  *
  * ### Use forkJoin with project function
  * ```javascript
- * import { jorkJoin, interval } from 'rxjs';
+ * import { forkJoin, interval } from 'rxjs';
  * import { take } from 'rxjs/operators';
  *
  * const observable = forkJoin(


### PR DESCRIPTION
**Description:**

This is a follow up on 4005 that only fixes the typo and not touching the imports

**Related issue (if exists):**
Relates to the PR https://github.com/ReactiveX/rxjs/pull/4005
