### PR TITLE
fix(startWith): add empty signature

### DIFF
--- a/compat/operator/startWith.ts
+++ b/compat/operator/startWith.ts
@@ -2,13 +2,14 @@ import { Observable, SchedulerLike } from 'rxjs';
 import { startWith as higherOrder } from 'rxjs/operators';
 
 /* tslint:disable:max-line-length */
-export function startWith<T>(this: Observable<T>, v1: T, scheduler?: SchedulerLike): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, scheduler?: SchedulerLike): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, scheduler?: SchedulerLike): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, scheduler?: SchedulerLike): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: SchedulerLike): Observable<T>;
-export function startWith<T>(this: Observable<T>, v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: SchedulerLike): Observable<T>;
-export function startWith<T>(this: Observable<T>, ...array: Array<T | SchedulerLike>): Observable<T>;
+export function startWith<T>(this: Observable<T>, scheduler?: SchedulerLike): Observable<T>;
+export function startWith<T, D = T>(this: Observable<T>, v1: D, scheduler?: SchedulerLike): Observable<T | D>;
+export function startWith<T, D = T, E = T>(this: Observable<T>, v1: D, v2: E, scheduler?: SchedulerLike): Observable<T | D | E>;
+export function startWith<T, D = T, E = T, F = T>(this: Observable<T>, v1: D, v2: E, v3: F, scheduler?: SchedulerLike): Observable<T | D | E | F>;
+export function startWith<T, D = T, E = T, F = T, G = T>(this: Observable<T>, v1: D, v2:  E, v3: F, v4: G, scheduler?: SchedulerLike): Observable<T | D | E | F | G>;
+export function startWith<T, D = T, E = T, F = T, G = T, H = T>(this: Observable<T>, v1: D, v2: E, v3: F, v4: G, v5: H, scheduler?: SchedulerLike): Observable<T | D | E | F | G | H>;
+export function startWith<T, D = T, E = T, F = T, G = T, H = T, I = T>(this: Observable<T>, v1: D, v2: E, v3: F, v4: G, v5: H, v6: I, scheduler?: SchedulerLike): Observable<T | D | E | F | G | H | I>;
+export function startWith<T, D = T>(this: Observable<T>, ...array: Array<D | SchedulerLike>): Observable<T | D>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -25,6 +26,6 @@ export function startWith<T>(this: Observable<T>, ...array: Array<T | SchedulerL
  * @method startWith
  * @owner Observable
  */
-export function startWith<T>(this: Observable<T>, ...array: Array<T | SchedulerLike>): Observable<T> {
-  return higherOrder(...array)(this);
+export function startWith<T, D>(this: Observable<T>, ...array: Array<D | SchedulerLike>): Observable<T |D> {
+  return higherOrder<T, D>(...array)(this);
 }

--- a/spec-dtslint/operators/startWith-spec.ts
+++ b/spec-dtslint/operators/startWith-spec.ts
@@ -1,0 +1,30 @@
+import { of, asyncScheduler  } from 'rxjs';
+import { startWith } from 'rxjs/operators';
+
+it('should infer correctly with one value', () => {
+  const o = of(1, 2, 3).pipe(startWith(4)); // $ExpectType Observable<number>
+});
+
+it('should infer correctly with multiple values', () => {
+  const o = of(1, 2, 3).pipe(startWith(4, 5, 6)); // $ExpectType Observable<number>
+});
+
+it('should infer correctly with no value', () => {
+  const o = of(1, 2, 3).pipe(startWith()); // $ExpectType Observable<number>
+});
+
+it('should infer correctly with a value and a scheduler', () => {
+  const o = of(1, 2, 3).pipe(startWith(5, asyncScheduler)); // $ExpectType Observable<number>
+});
+
+it('should infer correctly with only a scheduler', () => {
+  const o = of(1, 2, 3).pipe(startWith(asyncScheduler)); // $ExpectType Observable<number>
+});
+
+it('should enforce types with one value', () => {
+  const o = of(1, 2, 3).pipe(startWith('foo')); // $ExpectError
+});
+
+it('should enforce types with multiple value', () => {
+  const o = of(1, 2, 3).pipe(startWith(4, 'foo')); // $ExpectError
+});

--- a/spec-dtslint/operators/startWith-spec.ts
+++ b/spec-dtslint/operators/startWith-spec.ts
@@ -17,14 +17,14 @@ it('should infer correctly with a value and a scheduler', () => {
   const o = of(1, 2, 3).pipe(startWith(5, asyncScheduler)); // $ExpectType Observable<number>
 });
 
+it('should infer correctly with a different type', () => {
+  const o = of(1, 2, 3).pipe(startWith('foo')); // $ExpectType Observable<string | number>
+});
+
+it('should infer correctly with multiple different types', () => {
+  const o = of(1, 2, 3).pipe(startWith('foo', 4, true)); // $ExpectType Observable<string | number | boolean>
+});
+
 it('should infer correctly with only a scheduler', () => {
   const o = of(1, 2, 3).pipe(startWith(asyncScheduler)); // $ExpectType Observable<number>
-});
-
-it('should enforce types with one value', () => {
-  const o = of(1, 2, 3).pipe(startWith('foo')); // $ExpectError
-});
-
-it('should enforce types with multiple value', () => {
-  const o = of(1, 2, 3).pipe(startWith(4, 'foo')); // $ExpectError
 });

--- a/spec/operators/startWith-spec.ts
+++ b/spec/operators/startWith-spec.ts
@@ -136,7 +136,7 @@ describe('startWith operator', () => {
     const e1subs =   '^  !';
     const expected = '-a-|';
 
-    expectObservable(e1.pipe(startWith<any>(rxTestScheduler))).toBe(expected);
+    expectObservable(e1.pipe(startWith(rxTestScheduler))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -7,6 +7,7 @@ import { isScheduler } from '../util/isScheduler';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
+export function startWith<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 export function startWith<T>(v1: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 export function startWith<T>(v1: T, v2: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 export function startWith<T>(v1: T, v2: T, v3: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -12,8 +12,8 @@ export function startWith<T, D = T>(v1: D, scheduler?: SchedulerLike): OperatorF
 export function startWith<T, D = T, E = T>(v1: D, v2: E, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E>;
 export function startWith<T, D = T, E = T, F = T>(v1: D, v2: E, v3: F, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E | F>;
 export function startWith<T, D = T, E = T, F = T, G = T>(v1: D, v2:  E, v3: F, v4: G, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E | F | G>;
-export function startWith<T, D = T, E = T, F = T, G = T, H = T>(v1: D, v2: E, v3: F, v4: G, v5: H, scheduler?: SchedulerLike): OperatorFunction<T,  T | D | E | F | G | H>;
-export function startWith<T, D = T, E = T, F = T, G = T, H = T, I = T>(v1: D, v2: E, v3: F, v4: G, v5: H, v6: I, scheduler?: SchedulerLike): OperatorFunction<T,  T | D | E | F | G | H | I>;
+export function startWith<T, D = T, E = T, F = T, G = T, H = T>(v1: D, v2: E, v3: F, v4: G, v5: H, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E | F | G | H>;
+export function startWith<T, D = T, E = T, F = T, G = T, H = T, I = T>(v1: D, v2: E, v3: F, v4: G, v5: H, v6: I, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E | F | G | H | I>;
 export function startWith<T, D = T>(...array: Array<D | SchedulerLike>): OperatorFunction<T, T | D>;
 /* tslint:enable:max-line-length */
 

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -4,17 +4,17 @@ import { scalar } from '../observable/scalar';
 import { empty } from '../observable/empty';
 import { concat as concatStatic } from '../observable/concat';
 import { isScheduler } from '../util/isScheduler';
-import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, SchedulerLike } from '../types';
 
 /* tslint:disable:max-line-length */
 export function startWith<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, v4: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function startWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function startWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T>;
+export function startWith<T, D = T>(v1: D, scheduler?: SchedulerLike): OperatorFunction<T, T | D>;
+export function startWith<T, D = T, E = T>(v1: D, v2: E, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E>;
+export function startWith<T, D = T, E = T, F = T>(v1: D, v2: E, v3: F, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E | F>;
+export function startWith<T, D = T, E = T, F = T, G = T>(v1: D, v2:  E, v3: F, v4: G, scheduler?: SchedulerLike): OperatorFunction<T, T | D | E | F | G>;
+export function startWith<T, D = T, E = T, F = T, G = T, H = T>(v1: D, v2: E, v3: F, v4: G, v5: H, scheduler?: SchedulerLike): OperatorFunction<T,  T | D | E | F | G | H>;
+export function startWith<T, D = T, E = T, F = T, G = T, H = T, I = T>(v1: D, v2: E, v3: F, v4: G, v5: H, v6: I, scheduler?: SchedulerLike): OperatorFunction<T,  T | D | E | F | G | H | I>;
+export function startWith<T, D = T>(...array: Array<D | SchedulerLike>): OperatorFunction<T, T | D>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -49,7 +49,7 @@ export function startWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperat
  * @method startWith
  * @owner Observable
  */
-export function startWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T> {
+export function startWith<T, D>(...array: Array<T | SchedulerLike>): OperatorFunction<T, T | D> {
   return (source: Observable<T>) => {
     let scheduler = <SchedulerLike>array[array.length - 1];
     if (isScheduler(scheduler)) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds an overload to `startWith` that only takes a scheduler.

**Related issue (if exists):**
Closes #3947