### PR TITLE
Fix teardown issues with synchronous inner-observables

### DIFF
--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { switchMap, mergeMap, map } from 'rxjs/operators';
-import { of, Observable } from 'rxjs';
+import { switchMap, mergeMap, map, takeWhile } from 'rxjs/operators';
+import { concat, defer, of, Observable } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 
@@ -167,6 +167,31 @@ describe('switchMap', () => {
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should stop listening to a synchronous observable when unsubscribed', () => {
+    const sideEffects: number[] = [];
+    const synchronousObservable = concat(
+      defer(() => {
+        sideEffects.push(1);
+        return of(1);
+      }),
+      defer(() => {
+        sideEffects.push(2);
+        return of(2);
+      }),
+      defer(() => {
+        sideEffects.push(3);
+        return of(3);
+      })
+    );
+
+    of(null).pipe(
+      switchMap(() => synchronousObservable),
+      takeWhile((x) => x != 2) // unsubscribe at the second side-effect
+    ).subscribe(() => { /* noop */ });
+
+    expect(sideEffects).to.deep.equal([1, 2]);
   });
 
   it('should switch inner cold observables, inner never completes', () => {

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -3,6 +3,7 @@ import {Subscriber} from '../Subscriber';
 import {Observable} from '../Observable';
 
 import {OuterSubscriber} from '../OuterSubscriber';
+import { InnerSubscriber } from '../InnerSubscriber';
 import {subscribeToResult} from '../util/subscribeToResult';
 import {ObservableInput, OperatorFunction, MonoTypeOperatorFunction} from '../types';
 
@@ -121,7 +122,9 @@ class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
         return;
       }
       this._unsubscribeAndRecycle();
-      this.add(subscribeToResult(this, result));
+      const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+      this.add(innerSubscriber);
+      subscribeToResult(this, result, undefined, undefined, innerSubscriber);
     }
   }
 }

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -100,7 +100,9 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(ish: any, value: T, index: number): void {
-    this.add(subscribeToResult<T, R>(this, ish, value, index));
+    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    this.add(innerSubscriber);
+    subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
   }
 
   protected _complete(): void {

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -152,7 +152,9 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
   private subscribeToNextSource(): void {
     const next = this.nextSources.shift();
     if (next) {
-      this.add(subscribeToResult(this, next));
+      const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+      this.add(innerSubscriber);
+      subscribeToResult(this, next, undefined, undefined, innerSubscriber);
     } else {
       this.destination.complete();
     }

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -44,7 +44,10 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   constructor(destination: Subscriber<R>, notifier: ObservableInput<any>) {
     super(destination);
-    this.add(this.innerSubscription = subscribeToResult(this, notifier));
+    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    this.add(innerSubscriber);
+    this.innerSubscription = innerSubscriber;
+    subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
   }
 
   protected _next(value: T) {

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -113,7 +113,9 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (innerSubscription) {
       innerSubscription.unsubscribe();
     }
-    this.add(this.innerSubscription = subscribeToResult(this, result, value, index));
+    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    this.add(innerSubscriber);
+    this.innerSubscription = subscribeToResult(this, result, value, index, innerSubscriber);
   }
 
   protected _complete(): void {


### PR DESCRIPTION
 This PR fixes teardown issues that arised when unsubscribing from an observable emitting values from inner-observable(s) synchronously after subscription, like reported in #4025. An even simpler example is available [here](https://stackblitz.com/edit/typescript-ecmb6g?file=index.ts&devtoolsheight=50).
 Basically, the problem is that even after the unsubscription, the inner-observable(s) will continue to run until an asynchronous step is reached.

 This was simply because most ``OuterSubscriber``s first call ``subscribeToResult`` on an inner-Observable and THEN call ``this.add`` on the returned Subscription. This sounds fair, but when we're dealing with an unsubscription happening synchronously after the subscription, ``this.add`` will not have been called yet, and so the teardown will happen without unsubscribing from those inner-observables.

 A fix has already been brought in https://github.com/ReactiveX/rxjs/commit/40852ff71, but only for the ``MergeMapSubscriber``. In this fix, an ``InnerSubscriber`` is created, registered through ``this.add`` and then given as a last argument to ``subscribeToResult``, which will use it instead of creating one.
 It looks like it worked well for ``mergeMap`` and other related operators for some time now, so I brought the same fix for the following ``OuterSubscriber``s (I linked an example showing problematic real use-cases for each of them):
   - [CatchSubscriber](https://stackblitz.com/edit/typescript-p9ygrd?file=index.ts&devtoolsheight=50)
   - [ExhaustMapSubscriber](https://stackblitz.com/edit/typescript-oesxqp?file=index.ts&devtoolsheight=50)
   - [MergeScanSubscriber](https://stackblitz.com/edit/typescript-mbp98x?file=index.ts&devtoolsheight=50)
   - [OnErrorResumeNextSubscriber](https://stackblitz.com/edit/typescript-hpfqqz?file=index.ts&devtoolsheight=50)
   - [SkipUntilSubscriber](https://stackblitz.com/edit/typescript-etcev1?file=index.ts&devtoolsheight=50)
   - [SwitchMapSubscriber](https://stackblitz.com/edit/typescript-ecmb6g?file=index.ts&devtoolsheight=50)

 I was hesitant to also bring the same fix to other OuterSubscribers with the same problems.

 For example, with combineLatest the following code:
 ```js
 combineLatest(
   of(1), // should be subscribed to
   throwError(new Error()), // error! -> Teardown
   defer(() => { // should not run
     console.log("side-effect 1");
     return of(2).pipe(
       tap(() => console.log("side-effect 2")) // just to insist a little
     );
   })
 ).subscribe(
   (i) => { console.log("next", i); },
   (e) => { console.log("error!"); },
   () => { console.log("complete"); },
 );
 ```
 outputs:
 ```sh
 error
 side-effect 1
 side-effect 2
 ```
 instead of just:
 ```sh
 error
 ```

 But here, it's not that problematic, considering that we can just think that every Observable given to a CombineLatest run at the same time (or at least, that's a mental model I have when I'm using it).
 Still, code run for nothing there and the code logic looks wrong. What do you think we should do?

 The same problematic logic ("adding" the return of a ``subscribeToResult``) is also written for many other ``OuterSubscriber``s.
 Namely for the ``BufferSubscriber``, ``BufferToggleSubscriber``, ``DistinctSubscriber`` (for its ``flushes`` argument, but unsubscribing/erroring from that observable just completes/errors the observable its applied on), ``ExpandSubscriber``, ``SwitchFirstSubscriber``, ``ThrottleSubscriber``, ``WithLatestFromSubscriber``, ``WindowSubscriber`` and ``WindowToggleSubscriber`` but I did not yet succeed to reproduce a real use-case with any of them where that would be problematic. For this reason, I did not update the logic there.