### PR TITLE
docs(take): clean up example code

### DIFF
--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -21,9 +21,19 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Take the first 5 seconds of an infinite 1-second interval Observable
  * ```javascript
- * const interval = interval(1000);
- * const five = interval.pipe(take(5));
- * five.subscribe(x => console.log(x));
+ * import { interval } from 'rxjs';
+ * import { take } from 'rxjs/operators';
+ *
+ * const intervalCount = interval(1000);
+ * const takeFive = intervalCount.pipe(take(5));
+ * takeFive.subscribe(x => console.log(x));
+ *
+ * // Logs:
+ * // 0
+ * // 1
+ * // 2
+ * // 3
+ * // 4
  * ```
  *
  * @see {@link takeLast}


### PR DESCRIPTION
**Description:**

The example has been cleaned up a bit along with having the look of the code example that is starting to be used around the docs. 
