### PR TITLE
docs(UI): Add Larger Callout to the Short Description

### DIFF
--- a/docs_app/src/styles/1-layouts/_api-page.scss
+++ b/docs_app/src/styles/1-layouts/_api-page.scss
@@ -76,4 +76,13 @@
             }
         }
     }
+
+    /* used to target the short description */
+    > p:nth-child(2) {
+        border-left: 5px solid $pink;
+        font-size: 1rem;
+        line-height: 1.25;
+        padding-left: .5rem;
+
+    }
 }


### PR DESCRIPTION
**Description:**

The short description now has more of a visual separation that allows it to be identified quicker when scanning the page and wanting to find out as quickly as possible the description for the given API.

---

**Screenshot**
![docs-short-description-callout](https://user-images.githubusercontent.com/442374/44435831-ebc84380-a57f-11e8-8025-70fdd817b93a.png)
