### PR TITLE
fix(subscribable): make subscribe() signature match Observable

### DIFF
--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -39,7 +39,7 @@ describe('zipAll operator', () => {
       of('a', 'b', 'c'),
       of(1, 2, 3)
     )
-    .pipe(zipAll((a, b) => a + b))
+    .pipe(zipAll((a, b) => String(a) + String(b)))
     .subscribe((x) => {
       expect(x).to.equal(expected[i++]);
     }, null, done);
@@ -378,7 +378,7 @@ describe('zipAll operator', () => {
       of('a', 'b', 'c'),
       of(1, 2)
     )
-    .pipe(zipAll((a, b) => a + b))
+    .pipe(zipAll((a, b) => String(a) + String(b)))
     .subscribe((x) => {
       expect(x).to.equal(expected[i++]);
     }, null, done);

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -231,7 +231,7 @@ describe('zipAll operator', () => {
       const b = [4, 5, 6];
       const expected = '---x--#';
 
-      const selector = function (x: number, y: number) {
+      const selector = function (x: string, y: number) {
         if (y === 5) {
           throw new Error('too bad');
         } else {

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -39,9 +39,8 @@ export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | P
 /** OBSERVABLE INTERFACES */
 
 export interface Subscribable<T> {
-  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
-            error?: (error: any) => void,
-            complete?: () => void): Unsubscribable;
+  subscribe(observer?: PartialObserver<T>): Unsubscribable;
+  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
 }
 
 export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Iterable<T>;


### PR DESCRIPTION
**Description:**
The signature of `Subscribable.subscribe()` did not match that of `Observable.subscribe()`, which made the two types not compatible if `T=never` (see linked issue).

It also was wrong, because it allowed passing both an Observer and functions at the same time. 

This makes it match the signature of `Observable.subscribe()` exactly, which solves the type error in the issue.

It is not breaking (unless you passed both observer and functions, which is extremely unlikely and did not work at runtime anyway as `SafeSubscriber` checks if the first argument is a function and if yes, discards the other arguments, so this would only highlight a bug).

The alternative discussed in the issue was removing the 3-arg overload, but the discussion in the spec does not seem resolved yet, it is not clear that the interface is supposed to represent the spec, it would be a breaking change and require way more changes in rxjs (it did not compile when I tried).

**Related issue (if exists):**
Fixes #3891

cc @cartant 