### PR TITLE
docs(installation): update imports to use rxjs 6+ convention (#3827)

### DIFF
--- a/docs_app/content/guide/installation.md
+++ b/docs_app/content/guide/installation.md
@@ -16,7 +16,7 @@ import * as rxjs from 'rxjs';
 rxjs.of(1, 2, 3);
 ```
 
-To import only what you need by patching (this is useful for size-sensitive bundling):
+To import only what you need using pipeable operators:
 
 ```js
 import { of } from 'rxjs';
@@ -24,6 +24,7 @@ import { map } from 'rxjs/operators';
 
 of(1,2,3).pipe(map(x => x + '!!!')); // etc
 ```
+* See [Pipeable Operator Documentation](https://github.com/ReactiveX/rxjs/blob/91088dae1df097be2370c73300ffa11b27fd0100/doc/pipeable-operators.md) for more information about pipeable operator.
 
 To use with globally imported bundle
 ```js

--- a/docs_app/content/guide/installation.md
+++ b/docs_app/content/guide/installation.md
@@ -11,30 +11,18 @@ npm install rxjs
 To import the entire core set of functionality:
 
 ```js
-import Rx from 'rxjs/Rx';
+import * as rxjs from 'rxjs';
 
-Rx.Observable.of(1, 2, 3);
+rxjs.of(1, 2, 3);
 ```
 
 To import only what you need by patching (this is useful for size-sensitive bundling):
 
 ```js
-import ❴ Observable ❵ from 'rxjs/Observable';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/operator/map';
+import { of } from 'rxjs';
+import { map } from 'rxjs/operators';
 
-Observable.of(1,2,3).map(x => x + '!!!'); // etc
-```
-
-To import what you need and use it with proposed bind operator:
-Note: This additional syntax requires transpiler support and this syntax may be completely withdrawn from TC39 without notice! Use at your own risk.
-
-```js
-import ❴ Observable ❵ from 'rxjs/Observable';
-import ❴ of ❵ from 'rxjs/observable/of';
-import ❴ map ❵ from 'rxjs/operator/map';
-
-Observable::of(1,2,3)::map(x => x + '!!!'); // etc
+of(1,2,3).pipe(map(x => x + '!!!')); // etc
 ```
 
 ## CommonJS via npm

--- a/docs_app/content/guide/installation.md
+++ b/docs_app/content/guide/installation.md
@@ -25,6 +25,14 @@ import { map } from 'rxjs/operators';
 of(1,2,3).pipe(map(x => x + '!!!')); // etc
 ```
 
+To use with globally imported bundle
+```js
+const { of } = rxjs;
+const { map } = rxjs.operators;
+
+of(1,2,3).pipe(map(x => x + '!!!')); // etc
+```
+
 ## CommonJS via npm
 
 If you receive an error like error TS2304: Cannot find name 'Promise' or error TS2304: Cannot find name 'Iterable' when using RxJS you may need to install a supplemental set of typings.
@@ -60,3 +68,5 @@ For CDN, you can use. [unpkg](https://unpkg.com/). Just replace version with the
 For RxJS 5.0.0-beta.1 through beta.11: [https://unpkg.com/@reactivex/rxjs@version/dist/global/Rx.umd.js](https://unpkg.com/@reactivex/rxjs@version/dist/global/Rx.umd.js)
 
 For RxJS 5.0.0-beta.12 and higher: [https://unpkg.com/@reactivex/rxjs@version/dist/global/Rx.js](https://unpkg.com/@reactivex/rxjs@version/dist/global/Rx.js)
+
+For RxJS 6.0.0 and higher: [https://unpkg.com/@reactivex/rxjs@version/dist/global/rxjs.umd.js](https://unpkg.com/@reactivex/rxjs@version/dist/global/rxjs.umd.js)

--- a/docs_app/content/guide/v6/migration.md
+++ b/docs_app/content/guide/v6/migration.md
@@ -751,3 +751,19 @@ fromEvent(button, 'click').pipe(
  map(resultSelector)
 )
 ```
+
+### UMD module name change
+In RxJS v6.x, UMD module name has been changed from Rx to rxjs so that it's align with other imports module name.
+
+```js
+const rx= Rx;
+
+rx.Observable.of(1,2,3).map(x => x + '!!!');
+
+// becomes
+
+const { of } = rxjs;
+const { map } = rxjs.operators;
+
+of(1,2,3).pipe(map(x => x + '!!!')); // etc
+```


### PR DESCRIPTION
**Description:** Update sample in Installation section to use Rxjs 6+ convention.

**Related issue (if exists):** #3827 
