### PR TITLE
feat(test): Add npm script to test with ts-node not caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ range(1, 200)
 
 - `npm run build_all` - builds everything
 - `npm test` - runs tests
+- `npm run test_no_cache` - run test with `ts-node` set to false
 
 `npm run info` will list available scripts (there are a lot LOL)
 

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
     "postpublish": "npm run tests2png && ./docs_app/scripts/publish-docs.sh",
     "publish_docs": "./publish_docs.sh",
     "test": "cross-env TS_NODE_PROJECT=spec/tsconfig.json mocha --opts spec/support/default.opts \"spec/**/*-spec.ts\"",
+    "test_no_cache": "cross-env TS_NODE_PROJECT=spec/tsconfig.json TS_NODE_CACHE=false mocha --opts spec/support/default.opts \"spec/**/*-spec.ts\"",
     "test_transpile_only": "cross-env TS_NODE_PROJECT=spec/tsconfig.json TS_NODE_TRANSPILE_ONLY=true mocha --opts spec/support/default.opts \"spec/**/*-spec.ts\"",
     "test:browser": "echo \"Browser test is not working currently\" && exit -1 && npm-run-all build:spec:browser && opn spec/support/mocha-browser-runner.html",
     "test:cover": "nyc npm test",

--- a/spec/migration/update-6_0_0/index-spec.ts
+++ b/spec/migration/update-6_0_0/index-spec.ts
@@ -13,11 +13,12 @@ describe('Migration Schematic', () => {
     tree.create('/package.json', `{}`);
   });
 
-  it('adds missing dependencies', () => {
+  it('adds missing dependencies', (done) => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
     tree = runner.runSchematic('rxjs-migration-01', {}, tree);
 
     const pkg = JSON.parse(tree.readContent('/package.json'));
     expect(pkg.dependencies['rxjs-compat']).to.equal('^6.0.0-rc.0');
+    done();
   });
 });


### PR DESCRIPTION
**Description:**

There is a npm script that can run - `npm run test_no_cache`, that will
run the test with `TS_NODE_CACHE` set to false.

**Related issue (if exists):**
#3948