### PR TITLE
docs(UI): Add GitHub Logo to Docs

### DIFF
--- a/docs_app/src/app/app.component.html
+++ b/docs_app/src/app/app.component.html
@@ -28,13 +28,10 @@
       <img *ngSwitchDefault src="http://rxjsdocs.com/assets/img/Rx_Trnsprt_Logo-48-48.png" width="37" height="40" title="Home" alt="Home">
     </a>
     <aio-top-menu *ngIf="isSideBySide" [nodes]="topMenuNodes"></aio-top-menu>
-    <!-- <aio-search-box class="search-container" #searchBox (onSearch)="doSearch($event)" (onFocus)="doSearch($event)"></aio-search-box>
     <div class="toolbar-external-icons-container">
-      <a  href="https://twitter.com/reactivex" title="Twitter">
-        <img src="assets/images/logos/twitter-icon.svg"></a>
-      <a  href="https://github.com/ReactiveX/rxjs" title="GitHub">
-        <img src="assets/images/logos/github-icon.svg"></a>
-    </div> -->
+      <a href="https://github.com/ReactiveX/rxjs" title="GitHub" target="_blank">
+        <img src="assets/images/logos/github-icon.svg" alt="View on GitHub"></a>
+    </div>
   </mat-toolbar-row>
 </mat-toolbar>
 

--- a/docs_app/src/styles/1-layouts/_top-menu.scss
+++ b/docs_app/src/styles/1-layouts/_top-menu.scss
@@ -191,3 +191,30 @@ aio-search-box.search-container {
     }
   }
 }
+
+// EXTERNAL LINK ICONS
+.app-toolbar {
+  .toolbar-external-icons-container {
+    display: flex;
+    flex-direction: row;
+    height: 100%;
+
+    a {
+      display: flex;
+      align-items: center;
+      margin-left: 16px;
+
+      @media screen and (max-width: 480px) {
+        margin-left: 8px;
+      }
+
+      &:hover {
+        opacity: 0.8;
+      }
+
+      img {
+        height: 24px;
+      }
+    }
+  }
+}


### PR DESCRIPTION
**Description:**

Adding GitHub Logo that allows a person to jump to the project on GitHub.

![screen shot 2018-08-29 at 9 19 18 pm](https://user-images.githubusercontent.com/442374/44824120-f57e2680-abd1-11e8-92c0-ca72796f902c.png)



**Related issue (if exists):**
#3893 #3180 