### PR TITLE
fix(node): will no longer error mixing RxJS 6.3 and 6.2

### DIFF
--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
-import * as Rx from 'rxjs/Rx';
-
-const Subscriber = Rx.Subscriber;
+import { SafeSubscriber } from 'rxjs/internal/Subscriber';
+import { Subscriber } from 'rxjs';
+import { rxSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
 
 /** @test {Subscriber} */
 describe('Subscriber', () => {
@@ -18,6 +18,28 @@ describe('Subscriber', () => {
     sub.next();
 
     expect(times).to.equal(2);
+  });
+
+  it('should accept subscribers as a destination if they meet the proper criteria', () => {
+    const fakeSubscriber = {
+      [rxSubscriber](this: any) { return this; },
+      _addParentTeardownLogic() { /* noop */ }
+    };
+
+    const subscriber = new Subscriber(fakeSubscriber as any);
+    expect((subscriber as any).destination).to.equal(fakeSubscriber);
+  });
+
+  it('should wrap unsafe observers in a safe subscriber', () => {
+    const observer = {
+      next(x: any) { /* noop */ },
+      error(err: any) { /* noop */ },
+      complete() { /* noop */ }
+    };
+
+    const subscriber = new Subscriber(observer);
+    expect((subscriber as any).destination).not.to.equal(observer);
+    expect((subscriber as any).destination).to.be.an.instanceof(SafeSubscriber);
   });
 
   it('should ignore error messages after unsubscription', () => {

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -190,7 +190,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
  * @ignore
  * @extends {Ignored}
  */
-class SafeSubscriber<T> extends Subscriber<T> {
+export class SafeSubscriber<T> extends Subscriber<T> {
 
   private _context: any;
 
@@ -326,5 +326,5 @@ class SafeSubscriber<T> extends Subscriber<T> {
 }
 
 function isTrustedSubscriber(obj: any) {
-  return obj instanceof Subscriber || ('syncErrorThrowable' in obj && obj[rxSubscriberSymbol]);
+  return obj instanceof Subscriber || ('_addParentTeardownLogic' in obj && obj[rxSubscriberSymbol]);
 }


### PR DESCRIPTION
- updates `isTrustedSubscriber` to check for `_addParentTeardownLogic`

resolves #4077
