### PR TITLE
Overload take while to accept a type guard

### DIFF
--- a/spec-dtslint/operators/takeWhile-spec.ts
+++ b/spec-dtslint/operators/takeWhile-spec.ts
@@ -1,0 +1,10 @@
+import { of } from 'rxjs';
+import { takeWhile } from 'rxjs/operators';
+
+it('should support a user-defined type guard', () => {
+  const o = of('foo').pipe(takeWhile((s): s is 'foo' => true)); // $ExpectType Observable<"foo">
+});
+
+it('should support a predicate', () => {
+  const o = of('foo').pipe(takeWhile(s => true)); // $ExpectType Observable<string>
+});

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -1,7 +1,10 @@
 import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { OperatorFunction, MonoTypeOperatorFunction, TeardownLogic } from '../types';
+
+export function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S): OperatorFunction<T, S>;
+export function takeWhile<T>(predicate: (value: T, index: number) => boolean): MonoTypeOperatorFunction<T>;
 
 /**
  * Emits values emitted by the source Observable so long as each value satisfies


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This pull request overloads the takeWhile operator with an additional signature to accept a type guard.

I tried to keep the code as similar as possible to the corresponding overload signature of the filter operator. Please let me know, if I should change something.

I wasn't sure if the JSDoc should be changed as well. The return type of the filter operator is just `Observable` (without a generic) whereas the one of the takeWhile operator is `Observable<T>`.

**Related issue (if exists):**

This PR fixes #4081.
