### PR TITLE
test(dtslint): add mergeMapTo

### DIFF
--- a/spec-dtslint/operators/mergeMapTo-spec.ts
+++ b/spec-dtslint/operators/mergeMapTo-spec.ts
@@ -9,6 +9,14 @@ it('should infer correctly multiple types', () => {
   const o = of(1, 2, 3).pipe(mergeMapTo(of('foo', 4))); // $ExpectType Observable<string | number>
 });
 
+it('should infer correctly with an array', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo([4, 5, 6])); // $ExpectType Observable<number>
+});
+
+it('should infer correctly with a Promise', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(new Promise<string>(() => {}))); // $ExpectType Observable<string>
+});
+
 it('should support a concurrent parameter', () => {
   const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), 4)); // $ExpectType Observable<string>
 });
@@ -39,6 +47,7 @@ it('should enforce types', () => {
 
 it('should enforce the return type', () => {
   const o = of(1, 2, 3).pipe(mergeMapTo(p => p)); // $ExpectError
+  const p = of(1, 2, 3).pipe(mergeMapTo(4)); // $ExpectError
 });
 
 it('should enforce types of the concurrent parameter', () => {

--- a/spec-dtslint/operators/mergeMapTo-spec.ts
+++ b/spec-dtslint/operators/mergeMapTo-spec.ts
@@ -1,0 +1,50 @@
+import { of } from 'rxjs';
+import { mergeMapTo } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'))); // $ExpectType Observable<string>
+});
+
+it('should infer correctly multiple types', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo', 4))); // $ExpectType Observable<string | number>
+});
+
+it('should support a concurrent parameter', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), 4)); // $ExpectType Observable<string>
+});
+
+it('should infer correctly by using the resultSelector first parameter', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), a => a)); // $ExpectType Observable<number>
+});
+
+it('should infer correctly by using the resultSelector second parameter', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), (a, b) => b)); // $ExpectType Observable<string>
+});
+
+it('should support a resultSelector that takes an inner index', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), (a, b, innnerIndex) => a)); // $ExpectType Observable<number>
+});
+
+it('should support a resultSelector that takes an inner and outer index', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), (a, b, innnerIndex, outerIndex) => a)); // $ExpectType Observable<number>
+});
+
+it('should support a resultSelector and concurrent parameter', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), (a, b) => b, 4)); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo()); // $ExpectError
+});
+
+it('should enforce the return type', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(p => p)); // $ExpectError
+});
+
+it('should enforce types of the concurrent parameter', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), '4')); // $ExpectError
+});
+
+it('should enforce types of the concurrent parameter with a resultSelector', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of('foo'), (a => a), '4')); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `mergeMapTo`.

**Related issue (if exists):** #4093 
