### PR TITLE
AjaxObservable: complete subscribers on abort

### DIFF
--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -411,6 +411,13 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       }
     }
     xhr.onload = xhrLoad;
+    xhr.onabort = () => {
+      const { subscriber, progressSubscriber } = (<any>xhrLoad);
+      if (progressSubscriber) {
+        progressSubscriber.complete();
+      }
+      subscriber.complete();
+    }
     (<any>xhrLoad).subscriber = this;
     (<any>xhrLoad).progressSubscriber = progressSubscriber;
     (<any>xhrLoad).request = request;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
It is possible for an XHR to be aborted externally, for example when the machine loses connectivity.

Currently, when the XHR is aborted in this way, the subscription remains.

In this case, I think we would want to complete the observable? Although it might also be useful to emit something to indicate it was aborted.