### PR TITLE
fix(subscriber): don't unsubscribe self

### DIFF
--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -23,8 +23,8 @@ describe('Subscriber', () => {
   it('should accept subscribers as a destination if they meet the proper criteria', () => {
     const fakeSubscriber = {
       [rxSubscriber](this: any) { return this; },
-      _addParentTeardownLogic() { /* noop */ },
-      add() { /* noop */ }
+      add() { /* noop */ },
+      syncErrorThrowable: false
     };
 
     const subscriber = new Subscriber(fakeSubscriber as any);

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -23,7 +23,8 @@ describe('Subscriber', () => {
   it('should accept subscribers as a destination if they meet the proper criteria', () => {
     const fakeSubscriber = {
       [rxSubscriber](this: any) { return this; },
-      _addParentTeardownLogic() { /* noop */ }
+      _addParentTeardownLogic() { /* noop */ },
+      add() { /* noop */ }
     };
 
     const subscriber = new Subscriber(fakeSubscriber as any);

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -7,7 +7,7 @@ declare const type: Function;
 declare const asDiagram: Function;
 
 /** @test {mergeMap} */
-describe('mergeMap', () => {
+describe.only('mergeMap', () => {
   asDiagram('mergeMap(i => 10*i\u2014\u201410*i\u2014\u201410*i\u2014| )')
   ('should map-and-flatten each item to an Observable', () => {
     const e1 =    hot('--1-----3--5-------|');

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -7,7 +7,7 @@ declare const type: Function;
 declare const asDiagram: Function;
 
 /** @test {mergeMap} */
-describe.only('mergeMap', () => {
+describe('mergeMap', () => {
   asDiagram('mergeMap(i => 10*i\u2014\u201410*i\u2014\u201410*i\u2014| )')
   ('should map-and-flatten each item to an Observable', () => {
     const e1 =    hot('--1-----3--5-------|');

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { mergeMap, map, mapTo } from 'rxjs/operators';
-import { asapScheduler, concat, defer, Observable, from, of, timer } from 'rxjs';
+import { mergeMap, map } from 'rxjs/operators';
+import { asapScheduler, defer, Observable, from, of, timer } from 'rxjs';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare const type: Function;
@@ -772,18 +772,18 @@ describe('mergeMap', () => {
     const results: (number | string)[] = [];
 
     const wrapped = new Observable<number>(subscriber => {
-        const subscription = timer(0, asapScheduler).pipe(mapTo(42)).subscribe(subscriber);
+        const subscription = timer(0, asapScheduler).subscribe(subscriber);
         return () => subscription.unsubscribe();
     });
     wrapped.pipe(
-      mergeMap(value => concat(of(value), timer(0, asapScheduler).pipe(mapTo(value))))
+      mergeMap(() => timer(0, asapScheduler))
     ).subscribe({
       next(value) { results.push(value); },
       complete() { results.push('done'); }
     });
 
     setTimeout(() => {
-      expect(results).to.deep.equal([42, 42, 'done']);
+      expect(results).to.deep.equal([0, 'done']);
       done();
     }, 0);
   });

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
-import { mergeMap, map } from 'rxjs/operators';
-import { asapScheduler, defer, Observable, from, of } from 'rxjs';
+import { mergeMap, map, mapTo } from 'rxjs/operators';
+import { asapScheduler, concat, defer, Observable, from, of, timer } from 'rxjs';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 
 declare const type: Function;
@@ -717,7 +717,7 @@ describe('mergeMap', () => {
     // Added as a failing test when investigating:
     // https://github.com/ReactiveX/rxjs/issues/4071
 
-    const results: any[] = [];
+    const results: (number | string)[] = [];
 
     of(1).pipe(
       mergeMap(() => defer(() =>
@@ -744,7 +744,7 @@ describe('mergeMap', () => {
     // Added as a failing test when investigating:
     // https://github.com/ReactiveX/rxjs/issues/4071
 
-    const results: any[] = [];
+    const results: (number | string)[] = [];
 
     of(1).pipe(
       mergeMap(() =>
@@ -760,6 +760,30 @@ describe('mergeMap', () => {
 
     setTimeout(() => {
       expect(results).to.deep.equal([3, 'done']);
+      done();
+    }, 0);
+  });
+
+  it('should support wrapped sources', (done: MochaDone) => {
+
+    // Added as a failing test when investigating:
+    // https://github.com/ReactiveX/rxjs/issues/4095
+
+    const results: (number | string)[] = [];
+
+    const wrapped = new Observable<number>(subscriber => {
+        const subscription = timer(0, asapScheduler).pipe(mapTo(42)).subscribe(subscriber);
+        return () => subscription.unsubscribe();
+    });
+    wrapped.pipe(
+      mergeMap(value => concat(of(value), timer(0, asapScheduler).pipe(mapTo(value))))
+    ).subscribe({
+      next(value) { results.push(value); },
+      complete() { results.push('done'); }
+    });
+
+    setTimeout(() => {
+      expect(results).to.deep.equal([42, 42, 'done']);
       done();
     }, 0);
   });

--- a/spec/operators/observeOn-spec.ts
+++ b/spec/operators/observeOn-spec.ts
@@ -103,23 +103,21 @@ describe('observeOn operator', () => {
       .pipe(observeOn(asapScheduler))
       .subscribe(
         x => {
-          const observeOnSubscriber = subscription._subscriptions[0];
-          expect(observeOnSubscriber._subscriptions.length).to.equal(2); // one for the consumer, and one for the notification
-          expect(observeOnSubscriber._subscriptions[1].state.notification.kind)
-            .to.equal('N');
-          expect(observeOnSubscriber._subscriptions[1].state.notification.value)
-            .to.equal(x);
+          // see #4106 - inner subscriptions are now added to destinations
+          // so the subscription will contain an ObserveOnSubscriber and a subscription for the scheduled action
+          expect(subscription._subscriptions.length).to.equal(2);
+          const actionSubscription = subscription._subscriptions[1];
+          expect(actionSubscription.state.notification.kind).to.equal('N');
+          expect(actionSubscription.state.notification.value).to.equal(x);
           results.push(x);
         },
         err => done(err),
         () => {
           // now that the last nexted value is done, there should only be a complete notification scheduled
           // the consumer will have been unsubscribed via Subscriber#_parentSubscription
-          const observeOnSubscriber = subscription._subscriptions[0];
-          expect(observeOnSubscriber._subscriptions.length).to.equal(1); // one for the complete notification
-          // only this completion notification should remain.
-          expect(observeOnSubscriber._subscriptions[0].state.notification.kind)
-            .to.equal('C');
+          expect(subscription._subscriptions.length).to.equal(1);
+          const actionSubscription = subscription._subscriptions[0];
+          expect(actionSubscription.state.notification.kind).to.equal('C');
           // After completion, the entire _subscriptions list is nulled out anyhow, so we can't test much further than this.
           expect(results).to.deep.equal([1, 2, 3]);
           done();

--- a/spec/operators/switch-spec.ts
+++ b/spec/operators/switch-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { Observable, of, NEVER, queueScheduler, Subject } from 'rxjs';
-import { switchAll } from 'rxjs/operators';
+import { map, switchAll } from 'rxjs/operators';
 
 declare function asDiagram(arg: string): Function;
 declare const type: Function;
@@ -222,9 +222,9 @@ describe('switchAll', () => {
   it('should not leak when child completes before each switch (prevent memory leaks #2355)', () => {
     let iStream: Subject<number>;
     const oStreamControl = new Subject<number>();
-    const oStream = oStreamControl.map(() => {
-      return (iStream = new Subject<number>());
-    });
+    const oStream = oStreamControl.pipe(
+      map(() => (iStream = new Subject<number>()))
+    );
     const switcher = oStream.pipe(switchAll());
     const result: number[] = [];
     let sub = switcher.subscribe((x) => result.push(x));
@@ -242,9 +242,9 @@ describe('switchAll', () => {
 
   it('should not leak if we switch before child completes (prevent memory leaks #2355)', () => {
     const oStreamControl = new Subject<number>();
-    const oStream = oStreamControl.map(() => {
-      return (new Subject<number>());
-    });
+    const oStream = oStreamControl.pipe(
+      map(() => new Subject<number>())
+    );
     const switcher = oStream.pipe(switchAll());
     const result: number[] = [];
     let sub = switcher.subscribe((x) => result.push(x));

--- a/spec/operators/switch-spec.ts
+++ b/spec/operators/switch-spec.ts
@@ -252,9 +252,14 @@ describe('switchAll', () => {
     [0, 1, 2, 3, 4].forEach((n) => {
       oStreamControl.next(n); // creates inner
     });
-    // Expect two children of switch(): The oStream and the first inner
+    // Expect one child of switch(): The oStream
     expect(
       (sub as any)._subscriptions[0]._subscriptions.length
+    ).to.equal(1);
+    // Expect two children of subscribe(): The destination and the first inner
+    // See #4106 - inner subscriptions are now added to destinations
+    expect(
+      (sub as any)._subscriptions.length
     ).to.equal(2);
     sub.unsubscribe();
   });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -199,7 +199,7 @@ export class Observable<T> implements Subscribable<T> {
     if (operator) {
       operator.call(sink, this.source);
     } else {
-      sink._addParentTeardownLogic(
+      sink.add(
         this.source || (config.useDeprecatedSynchronousErrorHandling && !sink.syncErrorThrowable) ?
         this._subscribe(sink) :
         this._trySubscribe(sink)

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -155,11 +155,6 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   }
 
   /** @deprecated This is an internal implementation detail, do not use. */
-  _addParentTeardownLogic(parentTeardownLogic: TeardownLogic) {
-    /*noop*/
-  }
-
-  /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribeAndRecycle(): Subscriber<T> {
     const { _parent, _parents } = this;
     this._parent = null;
@@ -315,5 +310,5 @@ export class SafeSubscriber<T> extends Subscriber<T> {
 }
 
 export function isTrustedSubscriber(obj: any) {
-  return obj instanceof Subscriber || ('_addParentTeardownLogic' in obj && obj[rxSubscriberSymbol]);
+  return obj instanceof Subscriber || ('syncErrorThrowable' in obj && obj[rxSubscriberSymbol]);
 }

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -78,7 +78,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
             const trustedSubscriber = destinationOrNext[rxSubscriberSymbol]() as Subscriber<any>;
             this.syncErrorThrowable = trustedSubscriber.syncErrorThrowable;
             this.destination = trustedSubscriber;
-            trustedSubscriber._addParentTeardownLogic(this);
+            trustedSubscriber.add(this);
           } else {
             this.syncErrorThrowable = true;
             this.destination = new SafeSubscriber<T>(this, <PartialObserver<any>> destinationOrNext);
@@ -116,7 +116,6 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     if (!this.isStopped) {
       this.isStopped = true;
       this._error(err);
-      this._unsubscribeParentSubscription();
     }
   }
 
@@ -130,7 +129,6 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     if (!this.isStopped) {
       this.isStopped = true;
       this._complete();
-      this._unsubscribeParentSubscription();
     }
   }
 
@@ -158,18 +156,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
 
   /** @deprecated This is an internal implementation detail, do not use. */
   _addParentTeardownLogic(parentTeardownLogic: TeardownLogic) {
-    if (parentTeardownLogic !== this) {
-      this._parentSubscription = this.add(parentTeardownLogic);
-    }
-  }
-
-  /** @deprecated This is an internal implementation detail, do not use. */
-  _unsubscribeParentSubscription() {
-    if (this._parentSubscription !== null) {
-      ++this._keepAliveCount;
-      this._parentSubscription.unsubscribe();
-      --this._keepAliveCount;
-    }
+    /*noop*/
   }
 
   /** @deprecated This is an internal implementation detail, do not use. */

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -45,7 +45,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   /** @internal */ syncErrorThrowable: boolean = false;
 
   protected isStopped: boolean = false;
-  protected destination: PartialObserver<any>; // this `any` is the escape hatch to erase extra type param (e.g. R)
+  protected destination: PartialObserver<any> | Subscriber<any>; // this `any` is the escape hatch to erase extra type param (e.g. R)
 
   private _parentSubscription: Subscription | null = null;
 

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -166,7 +166,9 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribeParentSubscription() {
     if (this._parentSubscription !== null) {
+      ++this._keepAliveCount;
       this._parentSubscription.unsubscribe();
+      --this._keepAliveCount;
     }
   }
 

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -36,8 +36,6 @@ export class Subscription implements SubscriptionLike {
   /** @internal */
   protected _parents: Subscription[] = null;
   /** @internal */
-  protected _keepAliveCount: number = 0;
-  /** @internal */
   private _subscriptions: SubscriptionLike[] = null;
 
   /**
@@ -60,7 +58,7 @@ export class Subscription implements SubscriptionLike {
     let hasErrors = false;
     let errors: any[];
 
-    if (this.closed || this._keepAliveCount > 0) {
+    if (this.closed) {
       return;
     }
 

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -36,6 +36,8 @@ export class Subscription implements SubscriptionLike {
   /** @internal */
   protected _parents: Subscription[] = null;
   /** @internal */
+  protected _keepAliveCount: number = 0;
+  /** @internal */
   private _subscriptions: SubscriptionLike[] = null;
 
   /**
@@ -45,7 +47,6 @@ export class Subscription implements SubscriptionLike {
   constructor(unsubscribe?: () => void) {
     if (unsubscribe) {
       (<any> this)._unsubscribe = unsubscribe;
-
     }
   }
 
@@ -59,7 +60,7 @@ export class Subscription implements SubscriptionLike {
     let hasErrors = false;
     let errors: any[];
 
-    if (this.closed) {
+    if (this.closed || this._keepAliveCount > 0) {
       return;
     }
 

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -4,6 +4,7 @@ import { isArray } from '../util/isArray';
 import { Operator } from '../Operator';
 import { ObservableInput, PartialObserver } from '../types';
 import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
@@ -126,6 +127,8 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     const iterators = this.iterators;
     const len = iterators.length;
 
+    this.unsubscribe();
+
     if (len === 0) {
       this.destination.complete();
       return;
@@ -135,7 +138,8 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
     for (let i = 0; i < len; i++) {
       let iterator: ZipBufferIterator<any, any> = <any>iterators[i];
       if (iterator.stillUnsubscribed) {
-        this.add(iterator.subscribe(iterator, i));
+        const destination = this.destination as Subscription;
+        destination.add(iterator.subscribe(iterator, i));
       } else {
         this.active--; // not an observable
       }

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -2,6 +2,7 @@ import { async } from '../scheduler/async';
 import { isDate } from '../util/isDate';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
 import { Notification } from '../Notification';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
@@ -110,7 +111,8 @@ class DelaySubscriber<T> extends Subscriber<T> {
 
   private _schedule(scheduler: SchedulerLike): void {
     this.active = true;
-    this.add(scheduler.schedule<DelayState<T>>(DelaySubscriber.dispatch, this.delay, {
+    const destination = this.destination as Subscription;
+    destination.add(scheduler.schedule<DelayState<T>>(DelaySubscriber.dispatch, this.delay, {
       source: this, destination: this.destination, scheduler: scheduler
     }));
   }
@@ -137,10 +139,12 @@ class DelaySubscriber<T> extends Subscriber<T> {
     this.errored = true;
     this.queue = [];
     this.destination.error(err);
+    this.unsubscribe();
   }
 
   protected _complete() {
     this.scheduleNotification(Notification.createComplete());
+    this.unsubscribe();
   }
 }
 

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -132,6 +132,7 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
   protected _complete(): void {
     this.completed = true;
     this.tryComplete();
+    this.unsubscribe();
   }
 
   private removeSubscription(subscription: InnerSubscriber<T, R>): T {
@@ -149,7 +150,8 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     const notifierSubscription = subscribeToResult(this, delayNotifier, value);
 
     if (notifierSubscription && !notifierSubscription.closed) {
-      this.add(notifierSubscription);
+      const destination = this.destination as Subscription;
+      destination.add(notifierSubscription);
       this.delayNotifierSubscriptions.push(notifierSubscription);
     }
   }
@@ -199,6 +201,7 @@ class SubscriptionDelaySubscriber<T> extends Subscriber<T> {
   }
 
   protected _complete() {
+    this.unsubscribe();
     this.subscribeToSource();
   }
 

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -120,7 +120,8 @@ class ExhaustMapSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private _innerSub(result: ObservableInput<R>, value: T, index: number): void {
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
-    this.add(innerSubscriber);
+    const destination = this.destination as Subscription;
+    destination.add(innerSubscriber);
     subscribeToResult<T, R>(this, result, value, index, innerSubscriber);
   }
 
@@ -129,6 +130,7 @@ class ExhaustMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (!this.hasSubscription) {
       this.destination.complete();
     }
+    this.unsubscribe();
   }
 
   notifyNext(outerValue: T, innerValue: R,
@@ -142,7 +144,8 @@ class ExhaustMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   notifyComplete(innerSub: Subscription): void {
-    this.remove(innerSub);
+    const destination = this.destination as Subscription;
+    destination.remove(innerSub);
 
     this.hasSubscription = false;
     if (this.hasCompleted) {

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -140,7 +140,8 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private _innerSub(ish: ObservableInput<R>, value: T, index: number): void {
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
-    this.add(innerSubscriber);
+    const destination = this.destination as any as Subscription;
+    destination.add(innerSubscriber);
     subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
   }
 
@@ -149,6 +150,7 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (this.active === 0 && this.buffer.length === 0) {
       this.destination.complete();
     }
+    this.unsubscribe();
   }
 
   notifyNext(outerValue: T, innerValue: R,

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -140,7 +140,7 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private _innerSub(ish: ObservableInput<R>, value: T, index: number): void {
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
-    const destination = this.destination as any as Subscription;
+    const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
     subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
   }

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -101,7 +101,8 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private _innerSub(ish: any, value: T, index: number): void {
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
-    this.add(innerSubscriber);
+    const destination = this.destination as Subscription;
+    destination.add(innerSubscriber);
     subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
   }
 
@@ -113,6 +114,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
       }
       this.destination.complete();
     }
+    this.unsubscribe();
   }
 
   notifyNext(outerValue: T, innerValue: R,
@@ -126,7 +128,8 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   notifyComplete(innerSub: Subscription): void {
     const buffer = this.buffer;
-    this.remove(innerSub);
+    const destination = this.destination as Subscription;
+    destination.remove(innerSub);
     this.active--;
     if (buffer.length > 0) {
       this._next(buffer.shift());

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -1,6 +1,7 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
 import { Notification } from '../Notification';
 import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
 
@@ -88,7 +89,8 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
   }
 
   private scheduleMessage(notification: Notification<any>): void {
-    this.add(this.scheduler.schedule(
+    const destination = this.destination as Subscription;
+    destination.add(this.scheduler.schedule(
       ObserveOnSubscriber.dispatch,
       this.delay,
       new ObserveOnMessage(notification, this.destination)
@@ -101,10 +103,12 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
 
   protected _error(err: any): void {
     this.scheduleMessage(Notification.createError(err));
+    this.unsubscribe();
   }
 
   protected _complete(): void {
     this.scheduleMessage(Notification.createComplete());
+    this.unsubscribe();
   }
 }
 

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -2,6 +2,7 @@ import { Observable } from '../Observable';
 import { from } from '../observable/from';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
 import { isArray } from '../util/isArray';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
@@ -143,17 +144,20 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   protected _error(err: any): void {
     this.subscribeToNextSource();
+    this.unsubscribe();
   }
 
   protected _complete(): void {
     this.subscribeToNextSource();
+    this.unsubscribe();
   }
 
   private subscribeToNextSource(): void {
     const next = this.nextSources.shift();
     if (next) {
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
-      this.add(innerSubscriber);
+      const destination = this.destination as Subscription;
+      destination.add(innerSubscriber);
       subscribeToResult(this, next, undefined, undefined, innerSubscriber);
     } else {
       this.destination.complete();

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -114,7 +114,8 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
       innerSubscription.unsubscribe();
     }
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
-    this.add(innerSubscriber);
+    const destination = this.destination as Subscription;
+    destination.add(innerSubscriber);
     this.innerSubscription = subscribeToResult(this, result, value, index, innerSubscriber);
   }
 
@@ -123,6 +124,7 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (!innerSubscription || innerSubscription.closed) {
       super._complete();
     }
+    this.unsubscribe();
   }
 
   protected _unsubscribe() {
@@ -130,7 +132,8 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   notifyComplete(innerSub: Subscription): void {
-    this.remove(innerSub);
+    const destination = this.destination as Subscription;
+    destination.remove(innerSub);
     this.innerSubscription = null;
     if (this.isStopped) {
       super._complete();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes a problem that was introduced in #3963 and was partially fixed in #4072.

The problem was introduced with this change - to `Subscriber` - in #3963 where a parent subscription is unsubscribed upon a `complete` notification:

```diff
complete(): void {
  if (!this.isStopped) {
    this.isStopped = true;
    this._complete();
+   this._unsubscribeParentSubscription();
  }
}
```

The parent subscription is added to the subscriber in `Observable.subscribe`:

```ts
const sink = toSubscriber(observerOrNext, error, complete);

if (operator) {
  operator.call(sink, this.source);
} else {
  sink._addParentTeardownLogic(
    this.source || (config.useDeprecatedSynchronousErrorHandling && !sink.syncErrorThrowable) ?
    this._subscribe(sink) :
    this._trySubscribe(sink)
  );
}
```

In numerous situations, the subscription passed to `_addParentTeardownLogic` will be the same subscriber. That is, it will be `sink`.

Adding `sink` to itself, as a parent, introduces a bug, as `sink` will be unsubscribed from within the `complete` method - which differs from the pre-#3963 mechanism.

#4072 introduced a check to ensure that a specific subscriber isn't added to itself as a parent. However, it's still possible for a subscriber that is a *child* of the specific subscriber to be added as a *parent*. And doing so will see the specific subscriber's `unsubscribe` called within its `complete` method - which can effect unwanted behaviour. See the failing test that's included in this PR.

This PR solves the problem by adding a `_keepAliveCount` that's incremented before unsubscribing the parent subscription and is decremented afterwards. In `Subscription.unsubscribe`, if `_keepAliveCount` is greater than zero, the subscription is not unsubscribed.

**Related issue (if exists):** #4095