### PR TITLE
docs(Subject): Clarity for Subject Implementations

### DIFF
--- a/src/internal/AsyncSubject.ts
+++ b/src/internal/AsyncSubject.ts
@@ -3,6 +3,9 @@ import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
 
 /**
+ * A variant of Subject that only emits a value when it completes. It will emit
+ * its latest value to all its observers on completion.
+ *
  * @class AsyncSubject<T>
  */
 export class AsyncSubject<T> extends Subject<T> {

--- a/src/internal/BehaviorSubject.ts
+++ b/src/internal/BehaviorSubject.ts
@@ -5,6 +5,9 @@ import { SubscriptionLike } from './types';
 import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 
 /**
+ * A variant of Subject that requires an initial value and emits its current
+ * value whenever it is subscribed to.
+ *
  * @class BehaviorSubject<T>
  */
 export class BehaviorSubject<T> extends Subject<T> {

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -7,6 +7,10 @@ import { ObserveOnSubscriber } from './operators/observeOn';
 import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 import { SubjectSubscription } from './SubjectSubscription';
 /**
+ * A variant of Subject that "replays" or emits old values to new subscribers.
+ * It buffers a set number of values and will emit those values immediately to
+ * any new subscribers in addition to emitting new values to existing subscribers.
+ *
  * @class ReplaySubject<T>
  */
 export class ReplaySubject<T> extends Subject<T> {

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -8,6 +8,12 @@ import { SubjectSubscription } from './SubjectSubscription';
 import { rxSubscriber as rxSubscriberSymbol } from '../internal/symbol/rxSubscriber';
 
 /**
+ * A Subject is a special type of Observable that allows values to be
+ * multicasted to many Observables. Subjects are like EventEmitters
+ *
+ * Every Subject is an Observable and an Observer. You can subscribe to a
+ * Subject, and you can call next to feed values as well as error and complete
+ *
  * @class SubjectSubscriber<T>
  */
 export class SubjectSubscriber<T> extends Subscriber<T> {
@@ -125,6 +131,12 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     }
   }
 
+  /**
+   * Creates a new Observable with this Subject as the source. You can do this
+   * to create customize Observer-side logic of the Subject and conceal it from
+   * code that uses the Observable.
+   * @return {Observable} Observable that the Subject casts to
+   */
   asObservable(): Observable<T> {
     const observable = new Observable<T>();
     (<any>observable).source = this;

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -8,12 +8,6 @@ import { SubjectSubscription } from './SubjectSubscription';
 import { rxSubscriber as rxSubscriberSymbol } from '../internal/symbol/rxSubscriber';
 
 /**
- * A Subject is a special type of Observable that allows values to be
- * multicasted to many Observables. Subjects are like EventEmitters
- *
- * Every Subject is an Observable and an Observer. You can subscribe to a
- * Subject, and you can call next to feed values as well as error and complete
- *
  * @class SubjectSubscriber<T>
  */
 export class SubjectSubscriber<T> extends Subscriber<T> {
@@ -23,6 +17,12 @@ export class SubjectSubscriber<T> extends Subscriber<T> {
 }
 
 /**
+ * A Subject is a special type of Observable that allows values to be
+ * multicasted to many Observables. Subjects are like EventEmitters.
+ *
+ * Every Subject is an Observable and an Observer. You can subscribe to a
+ * Subject, and you can call next to feed values as well as error and complete.
+ *
  * @class Subject<T>
  */
 export class Subject<T> extends Observable<T> implements SubscriptionLike {


### PR DESCRIPTION
This is at least partially #3553.

**Description:** This includes some basic descriptions about the various `Subject` classes. The documentation was acquired from doc/subject.md and contextually rewritten.

**Related issue (if exists):** #3553