### PR TITLE
docs(combineLatest) Typo in combineLatest description

### DIFF
--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -69,8 +69,8 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * To ensure output array has always the same length, `combineLatest` will
  * actually wait for all input Observables to emit at least once,
  * before it starts emitting results. This means if some Observable emits
- * values before other Observables started emitting, all these values but last
- * will be lost. On the other hand, if some Observable does not emit value but
+ * values before other Observables started emitting, all these values but the last
+ * will be lost. On the other hand, if some Observable does not emit a value but
  * completes, resulting Observable will complete at the same moment without
  * emitting anything, since it will be now impossible to include value from
  * completed Observable in resulting array. Also, if some input Observable does

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -69,7 +69,7 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * To ensure output array has always the same length, `combineLatest` will
  * actually wait for all input Observables to emit at least once,
  * before it starts emitting results. This means if some Observable emits
- * values before other Observables started emitting, all that values but last
+ * values before other Observables started emitting, all these values but last
  * will be lost. On the other hand, if some Observable does not emit value but
  * completes, resulting Observable will complete at the same moment without
  * emitting anything, since it will be now impossible to include value from


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Minor typo fixes for docs of combineLatest

**Related issue (if exists):**
