### PR TITLE
test(dtslint): add exhaustMap

### DIFF
--- a/spec-dtslint/operators/exhaustMap-spec.ts
+++ b/spec-dtslint/operators/exhaustMap-spec.ts
@@ -1,0 +1,38 @@
+import { of } from 'rxjs';
+import { exhaustMap } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap(p => of(Boolean(p)))); // $ExpectType Observable<boolean>
+});
+
+it('should support a projector that takes an index', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap((p, index) => of(Boolean(p)))); // $ExpectType Observable<boolean>
+});
+
+it('should infer correctly by using the resultSelector first parameter', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap(p => of(Boolean(p)), a => a)); // $ExpectType Observable<number>
+});
+
+it('should infer correctly by using the resultSelector second parameter', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap(p => of(Boolean(p)), (a, b) => b)); // $ExpectType Observable<boolean>
+});
+
+it('should support a resultSelector that takes an inner index', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap(p => of(Boolean(p)), (a, b, innnerIndex) => a)); // $ExpectType Observable<number>
+});
+
+it('should support a resultSelector that takes an inner and outer index', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap(p => of(Boolean(p)), (a, b, innnerIndex, outerIndex) => a)); // $ExpectType Observable<number>
+});
+
+it('should support an undefined resultSelector', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap(p => of(Boolean(p)), undefined)); // $ExpectType Observable<boolean>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap()); // $ExpectError
+});
+
+it('should enforce the return type', () => {
+  const o = of(1, 2, 3).pipe(exhaustMap(p => p)); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `exhaustMap`.

**Related issue (if exists):** #4093 
