### PR TITLE
perf(shareReplay): use correct default paramter

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -1,8 +1,9 @@
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { shareReplay, mergeMapTo, retry, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { Observable, interval, Operator, Observer } from 'rxjs';
+import { Observable, interval, Operator, Observer, of } from 'rxjs';
 
 declare function asDiagram(arg: string): Function;
 declare const rxTestScheduler: TestScheduler;
@@ -174,6 +175,16 @@ describe('shareReplay operator', () => {
 
     rxTestScheduler.flush();
     expect(results).to.deep.equal([0, 1, 2, 4, 5, 6, 7, 8, 9]);
+  });
+
+  it('when no windowTime is given ReplaySubject should be in _infiniteTimeWindow mode', () => {
+    const spy = sinon.spy(rxTestScheduler, 'now');
+
+    of(1)
+      .pipe(shareReplay(1, undefined, rxTestScheduler))
+      .subscribe();
+    spy.restore();
+    expect(spy, 'ReplaySubject should not call scheduler.now() when no windowTime is given').to.be.not.called;
   });
 
   it('should not break lift() composability', (done: MochaDone) => {

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -234,6 +234,22 @@ describe('ReplaySubject', () => {
       )).toBe(sourceTemplate);
       expectObservable(subscriber1).toBe(expected1);
     });
+
+    it('should only replay bufferSize items when 40 time units ago more were emited', () => {
+      const replaySubject = new ReplaySubject<string>(2, 40, rxTestScheduler);
+      function feedNextIntoSubject(x: string) { replaySubject.next(x); }
+      function feedErrorIntoSubject(err: any) { replaySubject.error(err); }
+      function feedCompleteIntoSubject() { replaySubject.complete(); }
+
+      const sourceTemplate =  '1234     |';
+      const subscriber1 = hot('    (a|)').mergeMapTo(replaySubject);
+      const expected1   =     '    (34) |';
+
+      expectObservable(hot(sourceTemplate).do(
+        feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject
+      )).toBe(sourceTemplate);
+      expectObservable(subscriber1).toBe(expected1);
+    });
   });
 
   it('should be an Observer which can be given to Observable.subscribe', () => {

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -38,7 +38,7 @@ import { Subscriber } from '../Subscriber';
  * @see {@link publishReplay}
  *
  * @param {Number} [bufferSize=Number.POSITIVE_INFINITY] Maximum element count of the replay buffer.
- * @param {Number} [windowTime=Number.MAX_VALUE] Maximum time length of the replay buffer in milliseconds.
+ * @param {Number} [windowTime=Number.POSITIVE_INFINITY] Maximum time length of the replay buffer in milliseconds.
  * @param {Scheduler} [scheduler] Scheduler where connected observers within the selector function
  * will be invoked on.
  * @return {Observable} An observable sequence that contains the elements of a sequence produced
@@ -48,7 +48,7 @@ import { Subscriber } from '../Subscriber';
  */
 export function shareReplay<T>(
   bufferSize: number = Number.POSITIVE_INFINITY,
-  windowTime: number = Number.MAX_VALUE,
+  windowTime: number = Number.POSITIVE_INFINITY,
   scheduler?: SchedulerLike
 ): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(shareReplayOperator(bufferSize, windowTime, scheduler));


### PR DESCRIPTION
**Description:**
shareReplay() uses a wrong default value for `windowTime` parameter since #3872. To disable the time function of the internal ReplaySubject the `windowTime` must be `Number.POSITIVE_INFINITY` and not `Number.MAX_VALUE`.
This makes shareReplay() faster because the ReplaySubject will not call `scheduler.now()`, when it is not needed.

This PR also adds a test, whichs checks if the ReplaySubject is in `_infiniteTimeWindow` mode, when no `windowTime` is given to shareReplay().

This will need merging with #4059 whatever comes first.