### PR TITLE
test(dtslint): add distinctUntilChanged

### DIFF
--- a/spec-dtslint/operators/distinctUntilChanged-spec.ts
+++ b/spec-dtslint/operators/distinctUntilChanged-spec.ts
@@ -1,0 +1,35 @@
+import { of } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
+
+interface Person { name: string; }
+const sample: Person = { name: 'Tim' };
+
+it('should infer correctly', () => {
+  const o = of(sample).pipe(distinctUntilChanged()); // $ExpectType Observable<Person>
+});
+
+it('should accept a compare', () => {
+  const o = of(sample).pipe(distinctUntilChanged((p1, p2) => p1.name === p2.name)); // $ExpectType Observable<Person>
+});
+
+it('should accept a keySelector', () => {
+  const o = of(sample).pipe(distinctUntilChanged((name1, name2) => name1 === name2, p => p.name)); // $ExpectType Observable<Person>
+});
+
+it('should enforce types', () => {
+  const o = of(sample).pipe(distinctUntilChanged('F00D')); // $ExpectError
+});
+
+it('should enforce types of compare', () => {
+  const o = of(sample).pipe(distinctUntilChanged((p1, p2) => p1.foo === p2.name)); // $ExpectError
+  const p = of(sample).pipe(distinctUntilChanged((p1, p2) => p1.name === p2.foo)); // $ExpectError
+});
+
+it('should enforce types of keySelector', () => {
+  const o = of(sample).pipe(distinctUntilChanged((name1 , name2) => name1 === name2, p => p.foo)); // $ExpectError
+});
+
+it('should enforce types of compare in combination with keySelector', () => {
+  const o = of(sample).pipe(distinctUntilChanged((name1: number, name2) => name1 === name2, p => p.name)); // $ExpectError
+  const p = of(sample).pipe(distinctUntilChanged((name1, name2: number) => name1 === name2, p => p.name)); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `distinctUntilChanged`.

**Related issue (if exists):** #4093 
