### PR TITLE
test(dtslint): add findIndex

### DIFF
--- a/spec-dtslint/operators/findIndex-spec.ts
+++ b/spec-dtslint/operators/findIndex-spec.ts
@@ -2,31 +2,31 @@ import { of, Observable } from 'rxjs';
 import { findIndex } from 'rxjs/operators';
 
 it('should infer correctly', () => {
-  const o = of(1, 2, 3).pipe(findIndex(n => n === 3)); // $ExpectType Observable<number>
+  const o = of('foo', 'bar', 'baz').pipe(findIndex(p => p === 'foo')); // $ExpectType Observable<number>
 });
 
 it('should support a predicate that takes an index ', () => {
-  const o = of(1, 2, 3).pipe(findIndex((n, index) => index === 3)); // $ExpectType Observable<number>
+  const o = of('foo', 'bar', 'baz').pipe(findIndex((p, index) => index === 3)); // $ExpectType Observable<number>
 });
 
 it('should support a predicate that takes a source ', () => {
-  const o = of(1, 2, 3).pipe(findIndex((n, index, source) => n === 3)); // $ExpectType Observable<number>
+  const o = of('foo', 'bar', 'baz').pipe(findIndex((p, index, source) => p === 'foo')); // $ExpectType Observable<number>
 });
 
 it('should support an argument ', () => {
-  const o = of(1, 2, 3).pipe(findIndex((n) => n === 3, 'foo')); // $ExpectType Observable<number>
+  const o = of('foo', 'bar', 'baz').pipe(findIndex(p => p === 'foo', 123)); // $ExpectType Observable<number>
 });
 
 it('should enforce types', () => {
-  const o = of(1, 2, 3).pipe(findIndex()); // $ExpectError
+  const o = of('foo', 'bar', 'baz').pipe(findIndex()); // $ExpectError
 });
 
 it('should enforce predicate types', () => {
-  const o = of(1, 2, 3).pipe(findIndex((n: string) => n === 3)); // $ExpectError
-  const p = of(1, 2, 3).pipe(findIndex((n, index: string) => n === 3)); // $ExpectError
-  const q = of(1, 2, 3).pipe(findIndex((n, index, source: Observable<string>) => n === 3)); // $ExpectError
+  const o = of('foo', 'bar', 'baz').pipe(findIndex((p: number) => p === 3)); // $ExpectError
+  const p = of('foo', 'bar', 'baz').pipe(findIndex((p, index: string) => p === 3)); // $ExpectError
+  const q = of('foo', 'bar', 'baz').pipe(findIndex((p, index, source: Observable<number>) => p === 3)); // $ExpectError
 });
 
 it('should enforce predicate return type', () => {
-  const o = of(1, 2, 3).pipe(findIndex(n => n)); // $ExpectError
+  const o = of('foo', 'bar', 'baz').pipe(findIndex(p => p)); // $ExpectError
 });

--- a/spec-dtslint/operators/findIndex-spec.ts
+++ b/spec-dtslint/operators/findIndex-spec.ts
@@ -1,0 +1,32 @@
+import { of, Observable } from 'rxjs';
+import { findIndex } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(findIndex(n => n === 3)); // $ExpectType Observable<number>
+});
+
+it('should support a predicate that takes an index ', () => {
+  const o = of(1, 2, 3).pipe(findIndex((n, index) => index === 3)); // $ExpectType Observable<number>
+});
+
+it('should support a predicate that takes a source ', () => {
+  const o = of(1, 2, 3).pipe(findIndex((n, index, source) => n === 3)); // $ExpectType Observable<number>
+});
+
+it('should support an argument ', () => {
+  const o = of(1, 2, 3).pipe(findIndex((n) => n === 3, 'foo')); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(findIndex()); // $ExpectError
+});
+
+it('should enforce predicate types', () => {
+  const o = of(1, 2, 3).pipe(findIndex((n: string) => n === 3)); // $ExpectError
+  const p = of(1, 2, 3).pipe(findIndex((n, index: string) => n === 3)); // $ExpectError
+  const q = of(1, 2, 3).pipe(findIndex((n, index, source: Observable<string>) => n === 3)); // $ExpectError
+});
+
+it('should enforce predicate return type', () => {
+  const o = of(1, 2, 3).pipe(findIndex(n => n)); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `findIndex`.

**Related issue (if exists):** #4093 
