### PR TITLE
docs(accessibility): minor tweaks to improve accessibility

### DIFF
--- a/docs_app/content/marketing/index.html
+++ b/docs_app/content/marketing/index.html
@@ -9,7 +9,7 @@
 
     <!-- LOGO -->
     <div class="hero-logo">
-      <img src="generated/images/marketing/home/Rx_Logo-512-512.png"/>
+      <img src="generated/images/marketing/home/Rx_Logo-512-512.png" alt="RxJS logo"/>
     </div>
 
     <!-- CONTAINER -->

--- a/docs_app/src/app/app.component.html
+++ b/docs_app/src/app/app.component.html
@@ -37,7 +37,7 @@
 
 <aio-search-results #searchResultsView *ngIf="showSearchResults" [searchResults]="searchResults | async" (resultSelected)="hideSearchResults()"></aio-search-results>
 
-<mat-sidenav-container class="sidenav-container" [class.starting]="isStarting" [class.has-floating-toc]="hasFloatingToc" role="main">
+<mat-sidenav-container class="sidenav-container" [class.starting]="isStarting" [class.has-floating-toc]="hasFloatingToc">
 
   <mat-sidenav [ngClass]="{'collapsed': !isSideBySide}" #sidenav class="sidenav" [mode]="mode" [opened]="isOpened" (openedChange)="updateHostClasses()">
     <aio-nav-menu *ngIf="!isSideBySide" [nodes]="topMenuNarrowNodes" [currentNode]="currentNodes?.TopBarNarrow" [isWide]="false"></aio-nav-menu>
@@ -48,7 +48,7 @@
     </div> -->
   </mat-sidenav>
 
-  <section class="sidenav-content" [id]="pageId" role="content">
+  <section class="sidenav-content" [id]="pageId" role="main">
     <aio-mode-banner [mode]="deployment.mode" [version]="versionInfo"></aio-mode-banner>
     <aio-doc-viewer [class.no-animations]="isStarting"
         [doc]="currentDocument"

--- a/docs_app/src/app/custom-elements/api/api-list.component.html
+++ b/docs_app/src/app/custom-elements/api/api-list.component.html
@@ -14,7 +14,7 @@
   </aio-select> -->
 
   <div class="form-search">
-    <input #filter placeholder="Filter" (input)="setQuery($event.target.value)">
+    <input #filter placeholder="Filter" aria-label="Filter" (input)="setQuery($event.target.value)">
     <i class="material-icons">search</i>
   </div>
 </div>

--- a/docs_app/src/app/custom-elements/contributor/contributor.component.ts
+++ b/docs_app/src/app/custom-elements/contributor/contributor.component.ts
@@ -18,15 +18,18 @@ import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
                     </a>
                     <a *ngIf="person.twitter" mat-button class="icon"
                         href="{{person.twitter}}" target="_blank" (click)="$event.stopPropagation()">
-                        <span class="fa fa-twitter fa-2x"></span>
+                        <span class="fa fa-twitter fa-2x" aria-hidden="true"></span>
+                        <span class="sr-only">Twitter {{person.name}}</span>
                     </a>
                     <a *ngIf="person.github" mat-button class="icon"
                         href="{{person.github}}" target="_blank" (click)="$event.stopPropagation()">
-                        <span class="fa fa-github fa-2x"></span>
+                        <span class="fa fa-github fa-2x" aria-hidden="true"></span>
+                        <span class="sr-only">Github {{person.name}}</span>
                     </a>
                     <a *ngIf="person.website" mat-button class="icon"
                         href="{{person.website}}" target="_blank" (click)="$event.stopPropagation()">
-                        <span class="fa fa-link fa-2x"></span>
+                        <span class="fa fa-link fa-2x" aria-hidden="true"></span>
+                        <span class="sr-only">Personal website {{person.name}}</span>
                     </a>
                 </div>
             </div>

--- a/docs_app/src/index.html
+++ b/docs_app/src/index.html
@@ -141,7 +141,7 @@
     <div class="background-sky hero"></div>
     <section id="intro">
       <div class="hero-logo">
-        <img src="assets/images/logos/angular/angular.svg" width="250" height="250" alt="RxJS logo">
+        <img src="assets/images/logos/angular/angular.svg" width="250" height="250" alt="Angular logo">
       </div>
       <div class="homepage-container">
         <div class="hero-headline">One framework.<br>Mobile &amp; desktop.</div>

--- a/docs_app/src/index.html
+++ b/docs_app/src/index.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html>
+<html lang="en">
 <head>
   <meta charset="utf-8">
   <title>RxJS</title>

--- a/docs_app/src/index.html
+++ b/docs_app/src/index.html
@@ -141,7 +141,7 @@
     <div class="background-sky hero"></div>
     <section id="intro">
       <div class="hero-logo">
-        <img src="assets/images/logos/angular/angular.svg" width="250" height="250">
+        <img src="assets/images/logos/angular/angular.svg" width="250" height="250" alt="RxJS logo">
       </div>
       <div class="homepage-container">
         <div class="hero-headline">One framework.<br>Mobile &amp; desktop.</div>

--- a/docs_app/src/styles/2-modules/_code.scss
+++ b/docs_app/src/styles/2-modules/_code.scss
@@ -152,15 +152,15 @@ ol.linenums {
   .str { color: #800 }  /* string content */
   .kwd { color: #00f }  /* a keyword */
   .com { color: #060 }  /* a comment */
-  .typ { color: red }  /* a type name */
-  .lit { color: #08c }  /* a literal value */
+  .typ { color: #de0000 }  /* a type name */
+  .lit { color: #0074af }  /* a literal value */
   /* punctuation, lisp open bracket, lisp close bracket */
   .pun, .opn, .clo { color: #660 }
   .tag { color: #008 }  /* a markup tag name */
   .atn { color: #606 }  /* a markup attribute name */
   .atv { color: #800 }  /* a markup attribute value */
   .dec, .var { color: #606 }  /* a declaration; a variable name */
-  .fun { color: red }  /* a function name */
+  .fun { color: #de0000 }  /* a function name */
 }
 
 /* Use higher contrast and text-weight for printable form. */

--- a/docs_app/src/styles/2-modules/_notification.scss
+++ b/docs_app/src/styles/2-modules/_notification.scss
@@ -50,10 +50,10 @@ aio-notification {
 
     .action-button {
       margin-left: 10px;
-      background: $brightred;
+      background: $pink;
       border-radius: 15px;
       text-transform: uppercase;
-      padding: 0 10px;
+      padding: 6px 10px;
       font-size: 12px;
       @media (max-width: 780px) {
         display: none;

--- a/docs_app/src/styles/_constants.scss
+++ b/docs_app/src/styles/_constants.scss
@@ -83,7 +83,7 @@ $api-symbols: (
   ),
   function: (
     content: 'F',
-    background: $green-500
+    background: $green-800
   ),
   enum: (
     content: 'E',


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
I reviewed the accessibility of the new website with aXe and pa11y.
These changes addresses some of the flaws.

I also change the notification style because it had the Angular styles applied (and also triggered the accessibility color contrast warning).

**Related issue (if exists):** /
