### PR TITLE
test(dtslint): add skipWhile

### DIFF
--- a/spec-dtslint/operators/skipWhile-spec.ts
+++ b/spec-dtslint/operators/skipWhile-spec.ts
@@ -1,0 +1,23 @@
+import { of } from 'rxjs';
+import { skipWhile } from 'rxjs/operators';
+
+it('should support a predicate', () => {
+  const o = of('foo', 'bar', 'baz').pipe(skipWhile(value => value === 'bar')); // $ExpectType Observable<string>
+});
+
+it('should support a predicate with an index', () => {
+  const o = of('foo', 'bar', 'baz').pipe(skipWhile((value, index) => index < 3)); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const o = of('foo', 'bar', 'baz').pipe(skipWhile()); // $ExpectError
+});
+
+it('should enforce predicate types', () => {
+  const o = of('foo', 'bar', 'baz').pipe(skipWhile(value => value < 3)); // $ExpectError
+  const p = of('foo', 'bar', 'baz').pipe(skipWhile((value, index) => index < '3')); // $ExpectError
+});
+
+it('should enforce predicate return type', () => {
+  const o = of('foo', 'bar', 'baz').pipe(skipWhile(value => value)); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `skipWhile`.

While doing this I noticed some inconsistency with the `predicate` parameter in comparison to other operators. For example some of them also have a `source` as 3rd parameter, and have `thisArg` parameter. Or the `filter` operator also has a type guard. I don't know if this is intended, just wanted to point this out 😄 

**Related issue (if exists):** #4093 
