### PR TITLE
docs(content): updated 'Getting Started' CTA link (#4148)

### DIFF
--- a/docs_app/content/marketing/index.html
+++ b/docs_app/content/marketing/index.html
@@ -18,7 +18,7 @@
         <h2 class="hero-headline no-toc">RxJS</h2>
         <span class="hero-subheadline">Reactive Extensions Library for JavaScript</span>
       </div>
-      <a class="button hero-cta" href="/api">Get Started</a>
+      <a class="button hero-cta" href="/guide/overview">Get Started</a>
     </div>
 
   </section>


### PR DESCRIPTION
Description: 
* Updated the link `Getting Started` to point to the "Introduction" content.
* The link to API documentation aka "/api" already exists in the header under `Reference`

**Related issue (if exists):** #4148 
