### PR TITLE
test(dtslint): add auditTime

### DIFF
--- a/spec-dtslint/operators/auditTime-spec.ts
+++ b/spec-dtslint/operators/auditTime-spec.ts
@@ -1,0 +1,16 @@
+import { of, asyncScheduler } from 'rxjs';
+import { auditTime } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('a', 'b', 'c').pipe(auditTime(47)); // $ExpectType Observable<string>
+});
+
+it('should support a scheduler', () => {
+  const o = of('a', 'b', 'c').pipe(auditTime(47, asyncScheduler)); // $ExpectType Observable<string>
+});
+
+it('should enforce types', () => {
+  const o = of('a', 'b', 'c').pipe(auditTime()); // $ExpectError
+  const p = of('a', 'b', 'c').pipe(auditTime('47')); // $ExpectError
+  const q = of('a', 'b', 'c').pipe(auditTime(47, 'foo')); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `auditTime`.

**Related issue (if exists):** #4093 
