### PR TITLE
chore(build): Enable declarationMap in typings (#4176)

### DIFF
--- a/tsconfig/compat/tsconfig.cjs.json
+++ b/tsconfig/compat/tsconfig.cjs.json
@@ -6,6 +6,7 @@
     "removeComments": false,
     "declaration": true,
     "declarationDir": "../../dist-compat/typings",
+    "declarationMap": true,
     "outDir": "../../dist-compat/cjs"
   }
 }

--- a/tsconfig/tsconfig.types.json
+++ b/tsconfig/tsconfig.types.json
@@ -6,6 +6,7 @@
     "removeComments": false,
     "declaration": true,
     "declarationDir": "../dist/typings",
+    "declarationMap": true,
     "emitDeclarationOnly": true
   }
 }


### PR DESCRIPTION
**Description:**
Since our package includes source anyway, enabling declaration map will allow more easier navigation experiences.

**Related issue (if exists):**
#4176 