### PR TITLE
fix(endWith): ability to endWith different types (#4183)

### DIFF
--- a/spec-dtslint/operators/endWith-spec.ts
+++ b/spec-dtslint/operators/endWith-spec.ts
@@ -33,10 +33,10 @@ it('should infer type for rest parameters', () => {
   const a = of(1, 2, 3).pipe(endWith(4, 5, 6, 7, 8, 9, 10)); // $ExpectType Observable<number>
 });
 
-it('should accept empty parameter', () => {
-  const a = of(1, 2, 3).pipe(endWith()); // $ExpectType Observable<number>
+it('should infer with different types', () => {
+  const a = of(1, 2, 3).pipe(endWith('4', true)); // $ExpectType Observable<string | number | boolean>
 });
 
-it('should enforce type', () => {
-  const a = of(1, 2, 3).pipe(endWith('4')); // $ExpectError
+it('should accept empty parameter', () => {
+  const a = of(1, 2, 3).pipe(endWith()); // $ExpectType Observable<number>
 });

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -4,17 +4,17 @@ import { scalar } from '../observable/scalar';
 import { empty } from '../observable/empty';
 import { concat as concatStatic } from '../observable/concat';
 import { isScheduler } from '../util/isScheduler';
-import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
 export function endWith<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, v4: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(v1: T, v2: T, v3: T, v4: T, v5: T, v6: T, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T>;
+export function endWith<T, A = T>(v1: A, scheduler?: SchedulerLike): OperatorFunction<T, T | A>;
+export function endWith<T, A = T, B = T>(v1: A, v2: B, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B>;
+export function endWith<T, A = T, B = T, C = T>(v1: A, v2: B, v3: C, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C>;
+export function endWith<T, A = T, B = T, C = T, D = T>(v1: A, v2: B, v3: C, v4: D, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C | D>;
+export function endWith<T, A = T, B = T, C = T, D = T, E = T>(v1: A, v2: B, v3: C, v4: D, v5: E, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C | D | E>;
+export function endWith<T, A = T, B = T, C = T, D = T, E = T, F = T>(v1: A, v2: B, v3: C, v4: D, v5: E, v6: F, scheduler?: SchedulerLike): OperatorFunction<T, T | A | B | C | D | E | F>;
+export function endWith<T, Z = T>(...array: Array<Z | SchedulerLike>): OperatorFunction<T, T | Z>;
 /* tslint:enable:max-line-length */
 
 /**


### PR DESCRIPTION
**Description:** add ability for endWith operator to end the Observable with different types.

**Related issue (if exists):** #4183 
