### PR TITLE
chore(dtslint): refine test descriptions

### DIFF
--- a/spec-dtslint/util/pipe-spec.ts
+++ b/spec-dtslint/util/pipe-spec.ts
@@ -84,21 +84,21 @@ it('should enforce types for the 9th argument', () => {
   const o = pipe(a('0', '1'), a('1', '2'), a('2', '3'), a('3', '4'), a('4', '5'), a('5', '6'), a('6', '7'), a('7', '8'), a('#', '9')); // $ExpectError
 });
 
-it('should return generic OperatorFunction 1', () => {
+it('should return a non-narrowed Observable type', () => {
   const customOperator = <T>(p: T) => (a: Observable<T>) => a;
 
   const staticPipe = pipe(customOperator('infer'));
   const o = of('foo').pipe(staticPipe); // $ExpectType Observable<string>
 });
 
-it('should return generic OperatorFunction 2', () => {
+it('should return an explicit Observable type', () => {
   const customOperator = <T>() => (a: Observable<T>) => a;
 
   const staticPipe = pipe(customOperator<string>());
   const o = of('foo').pipe(staticPipe); // $ExpectType Observable<string>
 });
 
-it('should return generic OperatorFunction 3', () => {
+it('should return Observable<{}> when T cannot be inferred', () => {
   const customOperator = <T>() => (a: Observable<T>) => a;
 
   // type can't be possibly be inferred here, so it's {} instead of T.
@@ -106,7 +106,7 @@ it('should return generic OperatorFunction 3', () => {
   const o = of('foo').pipe(staticPipe); // $ExpectType Observable<{}>
 });
 
-it('should return generic function', () => {
+it('should return a non-narrowed type', () => {
   const func = pipe((value: string) => value, (value: string) => value + value);
-  const value = func("foo"); // $ExpectType string
+  const value = func('foo'); // $ExpectType string
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Generic functions are never returned, as doing so is unsafe. In this PR, the test descriptions have been changed to better reflect what's tested.

**Related issue (if exists):** #4182, #4187