### PR TITLE
docs(marbles): Fix for Marble Diagrams

### DIFF
--- a/docs_app/src/styles/2-modules/_api-pages.scss
+++ b/docs_app/src/styles/2-modules/_api-pages.scss
@@ -30,6 +30,12 @@
     }
   }
 
+  .description img {
+    border: 1px solid #dfdfdf;
+    max-width: 100%;
+    width: 100%;
+  }
+
   .method-table {
     h3 {
       margin: 6px 0;

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "test:cover": "nyc npm test",
     "test:circular": "dependency-cruise --validate .dependency-cruiser.json -x \"^node_modules\" dist/esm5",
     "test:systemjs": "node integration/systemjs/systemjs-compatibility-spec.js",
-    "tests2png": "mkdirp tmp/docs/img && mocha --opts spec/support/tests2png.opts \"spec/**/*-spec.ts\"",
+    "tests2png": "mkdirp docs_app/content/img && mocha --opts spec/support/tests2png.opts \"spec/**/*-spec.ts\"",
     "compat_build_all": "npm-run-all compat_clean_dist compat_build_cjs compat_build_esm5 compat_build_esm2015 compat_build_esm5_for_rollup compat_build_umd compat_generate_packages",
     "compat_build_closure": "node ./tools/make-closure-compat.js",
     "compat_build_cjs": "npm-run-all compat_clean_dist_cjs compat_compile_dist_cjs",

--- a/spec/helpers/tests2png/diagram-test-runner.ts
+++ b/spec/helpers/tests2png/diagram-test-runner.ts
@@ -96,7 +96,7 @@ global.asDiagram = function asDiagram(operatorLabel: string, glit: glitFn) {
         let inputStreams = getInputStreams(global.rxTestScheduler);
         global.rxTestScheduler.flush();
         inputStreams = updateInputStreamsPostFlush(inputStreams);
-        let filename = './tmp/docs/img/' + makeFilename(operatorLabel);
+        let filename = './docs_app/content/img/' + makeFilename(operatorLabel);
         painter(inputStreams, operatorLabel, outputStreams, filename);
         console.log('Painted ' + filename);
       });

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -12,7 +12,7 @@ import { OperatorFunction } from '../types';
  * <span class="informal">Collects values from the past as an array, and emits
  * that array only when another Observable emits.</span>
  *
- * ![](buffer.png)
+ * ![](content/img/buffer.png)
  *
  * Buffers the incoming Observable values until the given `closingNotifier`
  * Observable emits a value, at which point it emits the buffer on the output


### PR DESCRIPTION
@JWO719 @benlesh - Not sure if this is completely correct, but it does output the diagrams as you will see with the buffer.ts test if you were to run `npm run tests2png`

![buffer-diagram](https://user-images.githubusercontent.com/442374/46096710-e4531600-c18d-11e8-9e51-26893d59509a.png)


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
