### PR TITLE
test(dtslint): add bufferCount

### DIFF
--- a/spec-dtslint/operators/bufferCount-spec.ts
+++ b/spec-dtslint/operators/bufferCount-spec.ts
@@ -1,0 +1,19 @@
+import { of } from 'rxjs';
+import { bufferCount } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(bufferCount(1)); // $ExpectType Observable<number[]>
+  const p = of(1, 2, 3).pipe(bufferCount(1, 7)); // $ExpectType Observable<number[]>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(bufferCount()); // $ExpectError
+});
+
+it('should enforce type of bufferSize', () => {
+  const o = of(1, 2, 3).pipe(bufferCount('7')); // $ExpectError
+});
+
+it('should enforce type of startBufferEvery', () => {
+  const o = of(1, 2, 3).pipe(bufferCount(1, '7')); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `bufferCount`.

**Related issue (if exists):** #4093 
