### PR TITLE
fix(subscribe): Deprecate null starting parameter signatures for subscribe

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -70,12 +70,12 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   subscribe(observer?: PartialObserver<T>): Subscription;
-  /** @deprecated */
-  subscribe(next: null, error: null, complete: () => void): Subscription;
-  /** @deprecated */
-  subscribe(next: null, error: (error: any) => void, complete?: () => void): Subscription;
-  /** @deprecated */
-  subscribe(next: (value: T) => void, error: null, complete: () => void): Subscription;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
+  /** @deprecated Use an observer instead of an error callback */
+  subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
   /**
    * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -70,6 +70,12 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   subscribe(observer?: PartialObserver<T>): Subscription;
+  /** @deprecated */
+  subscribe(next: null, error: null, complete: () => void): Subscription;
+  /** @deprecated */
+  subscribe(next: null, error: (error: any) => void, complete?: () => void): Subscription;
+  /** @deprecated */
+  subscribe(next: (value: T) => void, error: null, complete: () => void): Subscription;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
   /**
    * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -6,12 +6,12 @@ import { noop } from '../util/noop';
 import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
-/** @deprecated */
-export function tap<T>(next: null, error: null, complete: () => void): MonoTypeOperatorFunction<T>;
-/** @deprecated */
-export function tap<T>(next: null, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-/** @deprecated */
-export function tap<T>(next: (value: T) => void, error: null, complete: () => void): MonoTypeOperatorFunction<T>;
+/** @deprecated Use an observer instead of a complete callback */
+export function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
+/** @deprecated Use an observer instead of an error callback */
+export function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+/** @deprecated Use an observer instead of a complete callback */
+export function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -6,6 +6,12 @@ import { noop } from '../util/noop';
 import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
+/** @deprecated */
+export function tap<T>(next: null, error: null, complete: () => void): MonoTypeOperatorFunction<T>;
+/** @deprecated */
+export function tap<T>(next: null, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+/** @deprecated */
+export function tap<T>(next: (value: T) => void, error: null, complete: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -40,6 +40,12 @@ export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | P
 
 export interface Subscribable<T> {
   subscribe(observer?: PartialObserver<T>): Unsubscribable;
+  /** @deprecated */
+  subscribe(next: null, error: null, complete: () => void): Unsubscribable;
+  /** @deprecated */
+  subscribe(next: null, error: (error: any) => void, complete?: () => void): Unsubscribable;
+  /** @deprecated */
+  subscribe(next: (value: T) => void, error: null, complete: () => void): Unsubscribable;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
 }
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -40,12 +40,12 @@ export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | P
 
 export interface Subscribable<T> {
   subscribe(observer?: PartialObserver<T>): Unsubscribable;
-  /** @deprecated */
-  subscribe(next: null, error: null, complete: () => void): Unsubscribable;
-  /** @deprecated */
-  subscribe(next: null, error: (error: any) => void, complete?: () => void): Unsubscribable;
-  /** @deprecated */
-  subscribe(next: (value: T) => void, error: null, complete: () => void): Unsubscribable;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable;
+  /** @deprecated Use an observer instead of an error callback */
+  subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Unsubscribable;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Unsubscribable;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
 }
 


### PR DESCRIPTION
**Description:**
Per discussion on #4159, this deprecates the signatures for `.subscribe` and `.tap` that are `(null, null, complete)`, `(null, error, complete)`, and `(next, null, complete)`.

**Related issue (if exists):**
#4159 