### PR TITLE
test(dtslint): add bufferTime

### DIFF
--- a/spec-dtslint/operators/bufferTime-spec.ts
+++ b/spec-dtslint/operators/bufferTime-spec.ts
@@ -1,0 +1,41 @@
+import { of, asyncScheduler } from 'rxjs';
+import { bufferTime } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(bufferTime(1)); // $ExpectType Observable<number[]>
+  const p = of(1, 2, 3).pipe(bufferTime(1, asyncScheduler)); // $ExpectType Observable<number[]>
+});
+
+it('should support a bufferCreationInterval', () => {
+  const o = of(1, 2, 3).pipe(bufferTime(1, 6)); // $ExpectType Observable<number[]>
+  const p = of(1, 2, 3).pipe(bufferTime(1, 6, asyncScheduler)); // $ExpectType Observable<number[]>
+  const q = of(1, 2, 3).pipe(bufferTime(1, undefined)); // $ExpectType Observable<number[]>
+  const r = of(1, 2, 3).pipe(bufferTime(1, null)); // $ExpectType Observable<number[]>
+});
+
+it('should support a maxBufferSize', () => {
+  const o = of(1, 2, 3).pipe(bufferTime(1, 6, 3)); // $ExpectType Observable<number[]>
+  const p = of(1, 2, 3).pipe(bufferTime(1, 6, 3, asyncScheduler)); // $ExpectType Observable<number[]>
+  const q = of(1, 2, 3).pipe(bufferTime(1, undefined, 3)); // $ExpectType Observable<number[]>
+  const r = of(1, 2, 3).pipe(bufferTime(1, null, 3)); // $ExpectType Observable<number[]>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(bufferTime()); // $ExpectError
+});
+
+it('should enforce type of bufferTimeSpan', () => {
+  const o = of(1, 2, 3).pipe(bufferTime('3')); // $ExpectError
+});
+
+it('should enforce type of scheduler', () => {
+  const o = of(1, 2, 3).pipe(bufferTime(3, '3')); // $ExpectError
+});
+
+it('should enforce type of bufferCreationInterval', () => {
+  const o = of(1, 2, 3).pipe(bufferTime(3, '3', asyncScheduler)); // $ExpectError
+});
+
+it('should enforce type of maxBufferSize', () => {
+  const o = of(1, 2, 3).pipe(bufferTime(3, 3, '3', asyncScheduler)); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `bufferTime`.

**Related issue (if exists):** #4093 
