### PR TITLE
Explicitly cast thenable to boolean in conditional expression

### DIFF
--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -154,7 +154,7 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private subscribeToNextSource(): void {
     const next = this.nextSources.shift();
-    if (next) {
+    if (!!next) {
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
       const destination = this.destination as Subscription;
       destination.add(innerSubscriber);

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -122,7 +122,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private throttle(value: T): void {
     const duration = this.tryDurationSelector(value);
-    if (duration) {
+    if (!!duration) {
       this.add(this._throttled = subscribeToResult(this, duration));
     }
   }

--- a/src/internal/util/subscribeTo.ts
+++ b/src/internal/util/subscribeTo.ts
@@ -22,13 +22,13 @@ export const subscribeTo = <T>(result: ObservableInput<T>) => {
         return result.subscribe(subscriber);
       }
     };
-  } else if (result && typeof result[Symbol_observable] === 'function') {
+  } else if (!!result && typeof result[Symbol_observable] === 'function') {
     return subscribeToObservable(result as any);
   } else if (isArrayLike(result)) {
     return subscribeToArray(result);
   } else if (isPromise(result)) {
     return subscribeToPromise(result as Promise<any>);
-  } else if (result && typeof result[Symbol_iterator] === 'function') {
+  } else if (!!result && typeof result[Symbol_iterator] === 'function') {
     return subscribeToIterable(result as any);
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;


### PR DESCRIPTION
This allows rxjs to be compiled under a new tsetse check:
http://tsetse.info/ban-promise-as-condition

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
