### PR TITLE
docs(UI): Add Separation Between API Header and Labels

### DIFF
--- a/docs_app/src/styles/2-modules/_api-pages.scss
+++ b/docs_app/src/styles/2-modules/_api-pages.scss
@@ -18,6 +18,10 @@
     flex-direction: column;
     align-items: flex-start;
   }
+
+  > h1 {
+    margin-right: 1rem;
+  }
 }
 
 .api-body {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This adds separation between the label and the first label as seen in the screenshot below.

**Related issue (if exists):**
closes #4200

![forkjoin-label-separate](https://user-images.githubusercontent.com/442374/46321069-50c77e00-c5af-11e8-8cf9-9b6254a8f667.png)
