### PR TITLE
test(dtslint): add bufferToggle

### DIFF
--- a/spec-dtslint/operators/bufferToggle-spec.ts
+++ b/spec-dtslint/operators/bufferToggle-spec.ts
@@ -6,7 +6,7 @@ it('should infer correctly', () => {
 });
 
 it('should support Promises', () => {
-  const promise = new Promise<string>(() => 'a');
+  const promise = Promise.resolve('a');
   const o = of(1, 2, 3).pipe(bufferToggle(promise, value => of(new Date()))); // $ExpectType Observable<number[]>
   const p = of(1, 2, 3).pipe(bufferToggle(of('a', 'b', 'c'), value => promise)); // $ExpectType Observable<number[]>
   const q = of(1, 2, 3).pipe(bufferToggle(promise, value => promise)); // $ExpectType Observable<number[]>

--- a/spec-dtslint/operators/bufferToggle-spec.ts
+++ b/spec-dtslint/operators/bufferToggle-spec.ts
@@ -1,0 +1,32 @@
+import { of, NEVER } from 'rxjs';
+import { bufferToggle } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(bufferToggle(of('a', 'b', 'c'), value => of(new Date()))); // $ExpectType Observable<number[]>
+});
+
+it('should support Promises', () => {
+  const promise = new Promise<string>(() => 'a');
+  const o = of(1, 2, 3).pipe(bufferToggle(promise, value => of(new Date()))); // $ExpectType Observable<number[]>
+  const p = of(1, 2, 3).pipe(bufferToggle(of('a', 'b', 'c'), value => promise)); // $ExpectType Observable<number[]>
+  const q = of(1, 2, 3).pipe(bufferToggle(promise, value => promise)); // $ExpectType Observable<number[]>
+});
+
+it('should support NEVER', () => {
+  const o = of(1, 2, 3).pipe(bufferToggle(NEVER, value => of(new Date()))); // $ExpectType Observable<number[]>
+  const p = of(1, 2, 3).pipe(bufferToggle(of('a', 'b', 'c'), value => NEVER)); // $ExpectType Observable<number[]>
+  const q = of(1, 2, 3).pipe(bufferToggle(NEVER, value => NEVER)); // $ExpectType Observable<number[]>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(bufferToggle()); // $ExpectError
+});
+
+it('should enforce type of openings', () => {
+  const o = of(1, 2, 3).pipe(bufferToggle('a', () => of('a', 'b', 'c'))); // $ExpectError
+});
+
+it('should enforce type of closingSelector', () => {
+  const o = of(1, 2, 3).pipe(bufferToggle(of('a', 'b', 'c'), 'a')); // $ExpectError
+  const p = of(1, 2, 3).pipe(bufferToggle(of('a', 'b', 'c'), (value: number) => of('a', 'b', 'c'))); // $ExpectError
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds dtslint tests for `bufferToggle`.

**Related issue (if exists):** #4093 
