### PR TITLE
docs(external-references): Update Egghead link (#3616)

### DIFF
--- a/doc/external-references.md
+++ b/doc/external-references.md
@@ -4,7 +4,7 @@ Can't get enough RxJS? Check out these other great resources!
 
 ## Tutorials
 
-- [RxJS @ Egghead.io](https://egghead.io/technologies/rx)
+- [RxJS @ Egghead.io](https://egghead.io/courses/for/rxjs)
 - [The introduction to Reactive Programming you've been missing](https://gist.github.com/staltz/868e7e9bc2a7b8c1f754)
 - [2 minute introduction to Rx](https://medium.com/@andrestaltz/2-minute-introduction-to-rx-24c8ca793877)
 - [Learn RxJS - @jhusain](https://github.com/jhusain/learnrx)


### PR DESCRIPTION
**Description:** Updates the link of Egghead into [this new one](https://egghead.io/courses/for/rxjs)

**Related issue (if exists):** This PR fixes #3616