### PR TITLE
docs(Subscription): add description for child subscription

### DIFF
--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -124,7 +124,7 @@ export class Subscription implements SubscriptionLike {
 
   /**
    * Adds a tear down to be called during the unsubscribe() of this
-   * Subscription.
+   * Subscription. Can also be used to add a child subscription.
    *
    * If the tear down being added is a subscription that is already
    * unsubscribed, is the same reference `add` is being called on, or is
@@ -132,6 +132,8 @@ export class Subscription implements SubscriptionLike {
    *
    * If this subscription is already in an `closed` state, the passed
    * tear down logic will be executed immediately.
+   *
+   * When a parent subscription is unsubscribed, any child subscriptions that were added to it are also unsubscribed.
    *
    * @param {TeardownLogic} teardown The additional logic to execute on
    * teardown.


### PR DESCRIPTION
**Description:**
Make clear that add() can be used to add child subscriptions.

While learning how to use subscriptions, I found out that you can add child subscriptions to a parent subscription. 

Description in [this](https://blog.angularindepth.com/rxjs-composing-subscriptions-b53ab22f1fd5) great post: 

> The add method can be used to add a child subscription — or a tear-down function — to a parent subscription. When a parent subscription is unsubscribed, any child subscriptions that were added to it are also unsubscribed.

The official doc for `add()` does not mention this powerful feature.
