### PR TITLE
docs(UI): Move See Also Section Down

### DIFF
--- a/docs_app/tools/transforms/templates/api/export-base.template.html
+++ b/docs_app/tools/transforms/templates/api/export-base.template.html
@@ -5,7 +5,7 @@
   {% include "includes/security-notes.html" %}
   {% include "includes/deprecation.html" %}
   {% block overview %}{% endblock %}
-  {% include "includes/see-also.html" %}
   {% block details %}{% endblock %}
   {% include "includes/usageNotes.html" %}
+  {% include "includes/see-also.html" %}
 {% endblock %}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The See Also section is too high in the docs and is seen as having more
importance than anything below. See Also is more of an extension to the
current doc in being able to find more information or related
information.