### PR TITLE
docs(playground): Ability to use console for playground

### DIFF
--- a/docs_app/src/assets/js/devtools-welcome.js
+++ b/docs_app/src/assets/js/devtools-welcome.js
@@ -4,11 +4,9 @@ var welcomeText = (
   '| |_) |\\ \\/ /  | \\___ \\  \n' +
   '|  _ <  >  < |_| |___) |    \n' +
   '|_| \\_\\/_/\\_\\___/|____/ \n' +
-  '\nOpen http://stackblitz.com and try this code to get\n' +
   '\nstarted experimenting with RxJS:\n' +
-  '\nimport { interval } from "rxjs"\n' +
-  '\nimport { take } from "rxjs/operators"\n' +
-  '\nconst subscription = interval(500).pipe(take(4)).subscribe(console.log)\n'
+  '\ntype this into the console:\n' +
+  '\nrxjs.interval(500).pipe(rxjs.operators.take(4)).subscribe(console.log)\n'
 );
 if (console.info) {
   console.info(welcomeText);

--- a/docs_app/src/index.html
+++ b/docs_app/src/index.html
@@ -151,6 +151,7 @@
       <b><i>This website requires JavaScript.</i></b>
     </h2>
   </noscript>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/rxjs/6.3.3/rxjs.umd.min.js" async></script>
   <script src="assets/js/devtools-welcome.js"></script>
 </body>
 </html>


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This adds rxjs to the global namespace in the docs app so that anyone can use the console as a playground in learning and testing while looking at the docs. An example would be:

```
rxjs.interval(4000).pipe(rxjs.operators.take(4)).subscribe(console.log);
```
