### PR TITLE
docs(scheduler): Fix inconsistency with the naming

### DIFF
--- a/doc/scheduler.md
+++ b/doc/scheduler.md
@@ -82,7 +82,7 @@ observable.subscribe(finalObserver);
 console.log('just after subscribe');
 ```
 
-The `proxyObserver` is created in `observeOn(Rx.Scheduler.async)`, and its `next(val)` function is approximately the following:
+The `proxyObserver` is created in `observeOn(asyncScheduler)`, and its `next(val)` function is approximately the following:
 
 ```ts
 const proxyObserver = {


### PR DESCRIPTION
**Description:**
The doc is mentioning `Rx.Scheduler.async` while everywhere else we always use `asyncScheduler`.
