### PR TITLE
docs(throwError): mistake on description for demo

### DIFF
--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -30,7 +30,7 @@ import { Subscriber } from '../Subscriber';
  *
  * ---
  *
- * ### Map and flatten numbers to the sequence 'a', 'b', 'c', but throw an error for 13
+ * ### Map and flatten numbers to the sequence 'a', 'b', 'c', but throw an error for 2
  * ```javascript
  * import { throwError, interval, of } from 'rxjs';
  * import { mergeMap } from 'rxjs/operators';


### PR DESCRIPTION
the demo shows that when 2 is emitted, an error throws, but description says 13. Maybe it's an previous version -.-

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
