### PR TITLE
docs(compile): fix ambigiouse links in doc compile

### DIFF
--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -59,11 +59,6 @@ const WEBSOCKETSUBJECT_INVALID_ERROR_OBJECT =
 
 export type WebSocketMessage = string | ArrayBuffer | Blob | ArrayBufferView;
 
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @extends {Ignored}
- * @hide true
- */
 export class WebSocketSubject<T> extends AnonymousSubject<T> {
 
   private _config: WebSocketSubjectConfig<T>;

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -193,7 +193,7 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  *
  *
  * @see {@link from}
- * @see {@link create}
+ * @see {@link index/Observable.create}
  *
  * @param {S} initialState Initial state.
  * @param {function (state: S): boolean} condition Condition to terminate generation (upon returning false).

--- a/src/internal/util/TimeoutError.ts
+++ b/src/internal/util/TimeoutError.ts
@@ -17,7 +17,7 @@ TimeoutErrorImpl.prototype = Object.create(Error.prototype);
 /**
  * An error thrown when duetime elapses.
  *
- * @see {@link timeout}
+ * @see {@link operators/timeout}
  *
  * @class TimeoutError
  */


### PR DESCRIPTION
There were some minor compilation errors in the doc.
2 ambigiouse links and one invalid (old docs related) annotation