### PR TITLE
docs(install): Enfoced correct node version for docs_app

### DIFF
--- a/package.json
+++ b/package.json
@@ -239,7 +239,8 @@
     "xmlhttprequest": "1.8.0"
   },
   "engines": {
-    "npm": ">=2.0.0"
+    "node": ">=10.0.0",
+    "npm": ">=6.0.0"
   },
   "typings": "./dist/package/Rx.d.ts",
   "ng-update": {


### PR DESCRIPTION
**Description:**
To prevent confusion I fixed the required node version in package.json to the required version 10 and enforced it in npmrc to prevent an errornous install
