### PR TITLE
chore(lint): ignore spec-dtslint in lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,14 +29,17 @@
     "all": true
   },
   "lint-staged": {
-    "*.@(js)": [
-      "eslint --fix",
-      "git add"
-    ],
-    "*.@(ts)": [
-      "tslint --fix",
-      "git add"
-    ]
+    "linters": {
+      "*.@(js)": [
+        "eslint --fix",
+        "git add"
+      ],
+      "*.@(ts)": [
+        "tslint --fix",
+        "git add"
+      ]
+    },
+    "ignore": ["spec-dtslint/**/*.{js,ts}"]
   },
   "scripts": {
     "precommit": "lint-staged",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

When `lint-staged` runs on `precommit` and lints the staged files, it should ignore any staged files that are in the `spec-dtslint` directory, as the `tslint.json` in that directory extends `dtslint/dtslint.json` and `dtslint` is not installed in `node_modules` - it's run using `npx` - so the `extends` will effect an error.

The configuration for `lint-staged` accepts an `ignore` option that takes an array of globs. It's documented [here](https://github.com/okonet/lint-staged#advanced-config-format).

**Related issue (if exists):** None