### PR TITLE
test(dtslint): add catchError

### DIFF
--- a/spec-dtslint/operators/catchError-spec.ts
+++ b/spec-dtslint/operators/catchError-spec.ts
@@ -1,0 +1,18 @@
+import { of, Observable } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(catchError((() => of(4, 5, 6)))); // $ExpectType Observable<number>
+});
+
+it('should infer correctly when returning another type', () => {
+  const o = of(1, 2, 3).pipe(catchError((() => of('a', 'b', 'c')))); // $ExpectType Observable<string | number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(catchError()); // $ExpectError
+});
+
+it('should enforce type of caught', () => {
+  const o = of(1, 2, 3).pipe(catchError((err, caught: Observable<string>) => of('a', 'b', 'c'))); // $ExpectError
+});

--- a/spec-dtslint/operators/catchError-spec.ts
+++ b/spec-dtslint/operators/catchError-spec.ts
@@ -5,12 +5,20 @@ it('should infer correctly', () => {
   const o = of(1, 2, 3).pipe(catchError((() => of(4, 5, 6)))); // $ExpectType Observable<number>
 });
 
+it('should infer correctly when not returning', () => {
+  const o = of(1, 2, 3).pipe(catchError((() => { throw new Error('your hands in the air'); }))); // $ExpectType Observable<number>
+});
+
 it('should infer correctly when returning another type', () => {
   const o = of(1, 2, 3).pipe(catchError((() => of('a', 'b', 'c')))); // $ExpectType Observable<string | number>
 });
 
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(catchError()); // $ExpectError
+});
+
+it('should enforce that selector returns an Observable', () => {
+  const o = of(1, 2, 3).pipe(catchError((err) => {})); // $ExpectError
 });
 
 it('should enforce type of caught', () => {


### PR DESCRIPTION
Description:
This PR adds dtslint tests for `catchError`.

Related issue (if exists): #4093