### PR TITLE
docs(content): add 'API DOCS' CTA link to main page (#4148)

### DIFF
--- a/docs_app/content/marketing/index.html
+++ b/docs_app/content/marketing/index.html
@@ -19,6 +19,7 @@
         <span class="hero-subheadline">Reactive Extensions Library for JavaScript</span>
       </div>
       <a class="button hero-cta" href="/guide/overview">Get Started</a>
+      <a class="button hero-cta" href="/api">API Docs</a>
     </div>
 
   </section>

--- a/docs_app/src/styles/1-layouts/_marketing-layout.scss
+++ b/docs_app/src/styles/1-layouts/_marketing-layout.scss
@@ -58,6 +58,10 @@ section#intro {
     justify-content: center;
     align-items: center;
 
+    .hero-cta + .hero-cta {
+      margin-top: 15px;
+    }
+
     @media  (max-width: 780px) {
       display: flex;
       flex-direction: column;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description: This adds a "API Docs" CTA link to the main page of the marketing site. This addresses the most recent comment made by @JWO719 in #4148**

**Related issue (if exists): #4148**

![image](https://user-images.githubusercontent.com/17665837/47691259-d0089b80-dbc7-11e8-937b-451f3f1e402a.png)

