### PR TITLE
fix(bundle): don't export `operators` twice

### DIFF
--- a/compat/umd.ts
+++ b/compat/umd.ts
@@ -2,12 +2,8 @@
   NOTE: This is the global export file for rxjs v6 and higher.
  */
 
-/* rxjs */
+/* rxjs and rxjs.operators */
 export * from './Rx';
-
-/* rxjs.operators */
-import * as _operators from 'rxjs/operators';
-export const operators = _operators;
 
 /* rxjs.testing */
 import * as _testing from 'rxjs/testing';


### PR DESCRIPTION
At the moment operators are exported twice for UMDs.

https://github.com/ReactiveX/rxjs/blob/master/src/internal/Rx.ts#L181-L183

and

https://github.com/ReactiveX/rxjs/blob/master/src/internal/umd.ts#L9-L10

Follow up of https://github.com/ReactiveX/rxjs/pull/4309