### PR TITLE
build(bundles): inline sourcesmap and stop shipping sourcecode

### DIFF
--- a/.make-packages.js
+++ b/.make-packages.js
@@ -112,11 +112,6 @@ createImportTargets(importTargets, "_esm2015/", ESM2015_PKG);
 // Make the distribution folder
 mkdirp.sync(PKG_ROOT);
 
-// Copy over the sources
-copySources('src/', SRC_ROOT_PKG);
-// Copy legacy-reexport sources
-copySources('legacy-reexport/', SRC_ROOT_PKG);
-
 copySources(CJS_ROOT, CJS_PKG);
 fs.copySync(LEGACY_REEXPORT_ROOT, CJS_PKG, {overwrite: false, errorOnExist: true});
 

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,7 @@
     "removeComments": true,
     "preserveConstEnums": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strictFunctionTypes": true,
     "noImplicitAny": true,
     "noImplicitReturns": true,


### PR DESCRIPTION
- Source codes are not needed for sourcemaps when having `inlineSource`
- Yesterday it was discussed that we should probably make `rxjs` stop publishing `src/` while still having sourceMaps to work.

With the other PR https://github.com/ReactiveX/rxjs/pull/4309 downstream users shall no longer require to compile RxJs code in order to get it working in Bazel thus there is no need to ship it and as a matter of fact we're remove Bazel.



//cc @alexeagle & @gregmagolan 