### PR TITLE
test(pluck): fix problem with dtslint pluck test

### DIFF
--- a/spec-dtslint/operators/pluck-spec.ts
+++ b/spec-dtslint/operators/pluck-spec.ts
@@ -2,101 +2,41 @@ import { of } from 'rxjs';
 import { pluck } from 'rxjs/operators';
 
 it('should infer correctly', () => {
-  const a = of({ name: 'abc', id: 123 }).pipe(pluck('name')); // $ExpectType Observable<string>
+  const a = of({ name: 'abc' }).pipe(pluck('name')); // $ExpectType Observable<string>
 });
 
 it('should support nested object of 2 layer depth', () => {
-  const a = of({ name: 'def', id: 256, address: { postcode: 2 } }).pipe(pluck('address', 'postcode')); // $ExpectType Observable<number>
+  const a = of({ a: { name: 'abc' } }).pipe(pluck('a', 'name')); // $ExpectType Observable<string>
 });
 
 it('should support nested object of 3 layer depth', () => {
-  const a = of({
-    name: 'def',
-    id: 256,
-    address: {
-      postcode: {
-        x: 1
-      }
-    }
-  }).pipe(pluck('address', 'postcode', 'x')); // $ExpectType Observable<number>
+  const a = of({ a: { b: { name: 'abc' } } }).pipe(pluck('a', 'b', 'name')); // $ExpectType Observable<string>
 });
 
 it('should support nested object of 4 layer depth', () => {
-  const a = of({
-    name: 'def',
-    id: 256,
-    address: {
-      postcode: {
-        x: {
-          y: 1
-        }
-      }
-    }
-  }).pipe(pluck('address', 'postcode', 'x', 'y')); // $ExpectType Observable<number>
+  const a = of({ a: { b: { c: { name: 'abc' } } } }).pipe(pluck('a', 'b', 'c', 'name')); // $ExpectType Observable<string>
 });
 
 it('should support nested object of 5 layer depth', () => {
-  const a = of({
-    name: 'def',
-    id: 256,
-    address: {
-      postcode: {
-        x: {
-          y: {
-            z: 1
-          }
-        }
-      }
-    }
-  }).pipe(pluck('address', 'postcode', 'x', 'y', 'z')); // $ExpectType Observable<number>
+  const a = of({ a: { b: { c: { d: { name: 'abc' } } } } }).pipe(pluck('a', 'b', 'c', 'd', 'name')); // $ExpectType Observable<string>
 });
 
 it('should support nested object of 6 layer depth', () => {
-  const a = of({
-    name: 'def',
-    id: 256,
-    address: {
-      postcode: {
-        x: {
-          y: {
-            z: {
-              aa: 1
-            }
-          }
-        }
-      }
-    }
-  }).pipe(pluck('address', 'postcode', 'x', 'y', 'z', 'aa')); // $ExpectType Observable<number>
+  const a = of({ a: { b: { c: { d: { e: { name: 'abc' } } } } } }).pipe(pluck('a', 'b', 'c', 'd', 'e', 'name')); // $ExpectType Observable<string>
 });
 
-it('should infer empty interface for more than 6 layer depth', () => {
-  const a = of({
-    name: 'def',
-    id: 256,
-    address: {
-      postcode: {
-        x: {
-          y: {
-            z: {
-              aa: {
-                ab: 1
-              }
-            }
-          }
-        }
-      }
-    }
-  }).pipe(pluck('address', 'postcode', 'x', 'y', 'z', 'aa', 'ab')); // $ExpectType Observable<{}>
+it('should support nested object of more than 6 layer depth', () => {
+  const a = of({ a: { b: { c: { d: { e: { f: { name: 'abc' } } } } } } }).pipe(pluck('a', 'b', 'c', 'd', 'e', 'f', 'name')); // $ExpectType Observable<{}>
 });
 
 it('should infer empty interface for non-existance key', () => {
-  const a = of({ name: 'abc', id: 123 }).pipe(pluck('xyz')); // $ExpectType Observable<{}>
+  const a = of({ name: 'abc' }).pipe(pluck('xyz')); // $ExpectType Observable<{}>
 });
 
 it('should infer empty interface for empty parameter', () => {
-  const a = of({ name: 'abc', id: 123 }).pipe(pluck()); // $ExpectType Observable<{}>
+  const a = of({ name: 'abc' }).pipe(pluck()); // $ExpectType Observable<{}>
 });
 
 it('should accept string only', () => {
-  const a = of({ name: 'abc', id: 123}).pipe(pluck(1)); // $ExpectError
+  const a = of({ name: 'abc' }).pipe(pluck(1)); // $ExpectError
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes a problem with the `dtslint` test for `pluck` in PR 4215 - which is currently breaking the build in Travis.

The problem seems to have been some sort of non-visible character hidden amongst the whitespace.

**Related issue (if exists):** #4215