### PR TITLE
chore(bindCallback): implement bindCallback

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { ReplaySubject } from 'rxjs/internal/ReplaySubject';
 export { EMPTY } from 'rxjs/internal/EMPTY';
 export { NEVER } from 'rxjs/internal/NEVER';
 
+export { bindCallback } from 'rxjs/internal/create/bindCallback';
 export { combineLatest } from 'rxjs/internal/create/combineLatest';
 export { concat } from 'rxjs/internal/create/concat';
 export { defer } from 'rxjs/internal/create/defer';

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,6 +12,7 @@ export { EMPTY } from 'rxjs/internal/EMPTY';
 export { NEVER } from 'rxjs/internal/NEVER';
 
 export { bindCallback } from 'rxjs/internal/create/bindCallback';
+export { bindNodeCallback } from 'rxjs/internal/create/bindNodeCallback';
 export { combineLatest } from 'rxjs/internal/create/combineLatest';
 export { concat } from 'rxjs/internal/create/concat';
 export { defer } from 'rxjs/internal/create/defer';

--- a/src/internal/create/bindCallback-spec.ts
+++ b/src/internal/create/bindCallback-spec.ts
@@ -1,0 +1,261 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { bindCallback } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { assertDeepEquals } from 'rxjs/internal/test_helpers/assertDeepEquals';
+
+/** @test {bindCallback} */
+describe('bindCallback', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(assertDeepEquals);
+  });
+
+  describe('when not scheduled', () => {
+    it('should emit undefined from a callback without arguments', () => {
+      function callback(cb: Function) {
+        cb();
+      }
+      const boundCallback = bindCallback(callback);
+      const results: Array<string|number> = [];
+
+      boundCallback()
+        .subscribe((x: any) => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
+    it('should emit one value from a callback', () => {
+      function callback(datum: number, cb: (result: number) => void) {
+        cb(datum);
+      }
+      const boundCallback = bindCallback(callback);
+      const results: Array<string|number> = [];
+
+      boundCallback(42)
+        .subscribe(x => {
+          results.push(x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      expect(results).to.deep.equal([42, 'done']);
+    });
+
+    it('should set callback function context to context of returned function', () => {
+      function callback(this: any, cb: Function) {
+        cb(this.datum);
+      }
+
+      const boundCallback = bindCallback(callback);
+      const results: Array<string|number> = [];
+
+      boundCallback.apply({datum: 5})
+        .subscribe(
+          (x: number) => results.push(x),
+          null,
+          () => results.push('done')
+        );
+
+      expect(results).to.deep.equal([5, 'done']);
+    });
+
+    it('should not emit, throw or complete if immediately unsubscribed', (done: MochaDone) => {
+      const nextSpy = sinon.spy();
+      const throwSpy = sinon.spy();
+      const completeSpy = sinon.spy();
+      let timeout: number;
+      function callback(datum: number, cb: Function) {
+        // Need to cb async in order for the unsub to trigger
+        timeout = setTimeout(() => {
+          cb(datum);
+        });
+      }
+      const subscription = bindCallback(callback)(42)
+        .subscribe(nextSpy, throwSpy, completeSpy);
+      subscription.unsubscribe();
+
+      setTimeout(() => {
+        expect(nextSpy.called, 'next to not be called').to.be.false;
+        expect(throwSpy.called, 'error to not be called').to.be.false;
+        expect(completeSpy.called, 'complete to not be called').to.be.false;
+
+        clearTimeout(timeout);
+        done();
+      });
+    });
+  });
+
+  describe('when scheduled', () => {
+    it('should emit undefined from a callback without arguments', () => {
+      function callback(cb: Function) {
+        cb();
+      }
+      const boundCallback = bindCallback(callback, testScheduler);
+      const results: Array<string|number> = [];
+
+      boundCallback()
+        .subscribe(x => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      testScheduler.flush();
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
+    it('should emit one value from a callback', () => {
+      function callback(datum: number, cb: (result: number) => void) {
+        cb(datum);
+      }
+      const boundCallback = bindCallback(callback, testScheduler);
+      const results: Array<string|number> = [];
+
+      boundCallback(42)
+        .subscribe(x => {
+          results.push(x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      testScheduler.flush();
+
+      expect(results).to.deep.equal([42, 'done']);
+    });
+
+    it('should set callback function context to context of returned function', () => {
+      function callback(this: { datum: number }, cb: Function) {
+        cb(this.datum);
+      }
+
+      const boundCallback = bindCallback(callback, testScheduler);
+      const results: Array<string|number> = [];
+
+      boundCallback.apply({ datum: 5 })
+        .subscribe(
+          (x: number) => results.push(x),
+          null,
+          () => results.push('done')
+        );
+
+      testScheduler.flush();
+
+      expect(results).to.deep.equal([5, 'done']);
+    });
+
+    it('should error if callback throws', () => {
+      const expected = new Error('haha no callback for you');
+      function callback(datum: number, cb: Function): never {
+        throw expected;
+      }
+      const boundCallback = bindCallback(callback, testScheduler);
+
+      boundCallback(42)
+        .subscribe(x => {
+          throw new Error('should not next');
+        }, (err: any) => {
+          expect(err).to.equal(expected);
+        }, () => {
+          throw new Error('should not complete');
+        });
+
+      testScheduler.flush();
+    });
+
+  it('should pass multiple inner arguments as an array', () => {
+    function callback(datum: number, cb: (a: number, b: number, c: number, d: number) => void) {
+      cb(datum, 1, 2, 3);
+    }
+    const boundCallback = bindCallback(callback, testScheduler);
+    const results: Array<string|number[]> = [];
+
+    boundCallback(42)
+      .subscribe(x => {
+        results.push(x);
+      }, null, () => {
+        results.push('done');
+      });
+
+    testScheduler.flush();
+
+    expect(results).to.deep.equal([[42, 1, 2, 3], 'done']);
+  });
+
+  it('should cache value for next subscription and not call callbackFunc again', () => {
+    let calls = 0;
+    function callback(datum: number, cb: (x: number) => void) {
+      calls++;
+      cb(datum);
+    }
+    const boundCallback = bindCallback(callback, testScheduler);
+    const results1: Array<number|string> = [];
+    const results2: Array<number|string> = [];
+
+    const source = boundCallback(42);
+
+    source.subscribe(x => {
+      results1.push(x);
+    }, null, () => {
+      results1.push('done');
+    });
+
+    source.subscribe(x => {
+      results2.push(x);
+    }, null, () => {
+      results2.push('done');
+    });
+
+    testScheduler.flush();
+
+    expect(calls).to.equal(1);
+    expect(results1).to.deep.equal([42, 'done']);
+    expect(results2).to.deep.equal([42, 'done']);
+  });
+
+  it('should not even call the callbackFn if immediately unsubscribed', () => {
+      let calls = 0;
+      function callback(datum: number, cb: Function) {
+        calls++;
+        cb(datum);
+      }
+      const boundCallback = bindCallback(callback, testScheduler);
+      const results1: Array<number|string> = [];
+
+      const source = boundCallback(42);
+
+      const subscription = source.subscribe((x: any) => {
+        results1.push(x);
+      }, null, () => {
+        results1.push('done');
+      });
+
+      subscription.unsubscribe();
+
+      testScheduler.flush();
+
+      expect(calls).to.equal(0);
+    });
+  });
+
+  // TODO: canReportError
+  it.skip('should not swallow post-callback errors', () => {
+    function badFunction(callback: (answer: number) => void): void {
+      callback(42);
+      throw new Error('kaboom');
+    }
+    const consoleStub = sinon.stub(console, 'warn');
+    try {
+      bindCallback(badFunction)().subscribe();
+      expect(consoleStub).to.have.property('called', true);
+    } finally {
+      consoleStub.restore();
+    }
+  });
+});

--- a/src/internal/create/bindCallback.ts
+++ b/src/internal/create/bindCallback.ts
@@ -1,0 +1,259 @@
+import { FOType, SchedulerLike, Sink } from 'rxjs/internal/types';
+import { Observable } from 'rxjs/internal/Observable';
+import { sourceAsObservable } from 'rxjs/internal/util/sourceAsObservable';
+import { Subscription } from 'rxjs/internal/Subscription';
+import { AsyncSubject } from 'rxjs/internal/AsyncSubject';
+// TODO: canReportError
+// import { canReportError } from 'rxjs/internal/util/canReportError';
+
+// tslint:disable:max-line-length
+export function bindCallback<R1, R2, R3, R4>(callbackFunc: (callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): () => Observable<any[]>;
+export function bindCallback<R1, R2, R3>(callbackFunc: (callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2, R3]>;
+export function bindCallback<R1, R2>(callbackFunc: (callback: (res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2]>;
+export function bindCallback<R1>(callbackFunc: (callback: (res1: R1) => any) => any, scheduler?: SchedulerLike): () => Observable<R1>;
+export function bindCallback(callbackFunc: (callback: () => any) => any, scheduler?: SchedulerLike): () => Observable<void>;
+
+export function bindCallback<A1, R1, R2, R3, R4>(callbackFunc: (arg1: A1, callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<any[]>;
+export function bindCallback<A1, R1, R2, R3>(callbackFunc: (arg1: A1, callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<[R1, R2, R3]>;
+export function bindCallback<A1, R1, R2>(callbackFunc: (arg1: A1, callback: (res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<[R1, R2]>;
+export function bindCallback<A1, R1>(callbackFunc: (arg1: A1, callback: (res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<R1>;
+export function bindCallback<A1>(callbackFunc: (arg1: A1, callback: () => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<void>;
+
+export function bindCallback<A1, A2, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<any[]>;
+export function bindCallback<A1, A2, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<[R1, R2, R3]>;
+export function bindCallback<A1, A2, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, callback: (res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<[R1, R2]>;
+export function bindCallback<A1, A2, R1>(callbackFunc: (arg1: A1, arg2: A2, callback: (res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<R1>;
+export function bindCallback<A1, A2>(callbackFunc: (arg1: A1, arg2: A2, callback: () => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<void>;
+
+export function bindCallback<A1, A2, A3, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<any[]>;
+export function bindCallback<A1, A2, A3, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<[R1, R2, R3]>;
+export function bindCallback<A1, A2, A3, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<[R1, R2]>;
+export function bindCallback<A1, A2, A3, R1>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<R1>;
+export function bindCallback<A1, A2, A3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: () => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<void>;
+
+export function bindCallback<A1, A2, A3, A4, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<any[]>;
+export function bindCallback<A1, A2, A3, A4, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<[R1, R2, R3]>;
+export function bindCallback<A1, A2, A3, A4, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<[R1, R2]>;
+export function bindCallback<A1, A2, A3, A4, R1>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<R1>;
+export function bindCallback<A1, A2, A3, A4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: () => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<void>;
+
+export function bindCallback<A1, A2, A3, A4, A5, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<any[]>;
+export function bindCallback<A1, A2, A3, A4, A5, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<[R1, R2, R3]>;
+export function bindCallback<A1, A2, A3, A4, A5, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<[R1, R2]>;
+export function bindCallback<A1, A2, A3, A4, A5, R1>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<R1>;
+export function bindCallback<A1, A2, A3, A4, A5>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: () => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<void>;
+
+export function bindCallback<A, R>(callbackFunc: (...args: Array<A | ((result: R) => any)>) => any, scheduler?: SchedulerLike): (...args: A[]) => Observable<R>;
+export function bindCallback<A, R>(callbackFunc: (...args: Array<A | ((...results: R[]) => any)>) => any, scheduler?: SchedulerLike): (...args: A[]) => Observable<R[]>;
+
+export function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
+
+// tslint:enable:max-line-length
+
+/**
+ * Converts a callback API to a function that returns an Observable.
+ *
+ * <span class="informal">Give it a function `f` of type `f(x, callback)` and
+ * it will return a function `g` that when called as `g(x)` will output an
+ * Observable.</span>
+ *
+ * `bindCallback` is not an operator because its input and output are not
+ * Observables. The input is a function `func` with some parameters. The
+ * last parameter must be a callback function that `func` calls when it is
+ * done.
+ *
+ * The output of `bindCallback` is a function that takes the same parameters
+ * as `func`, except the last one (the callback). When the output function
+ * is called with arguments it will return an Observable. If function `func`
+ * calls its callback with one argument, the Observable will emit that value.
+ * If on the other hand the callback is called with multiple values the resulting
+ * Observable will emit an array with said values as arguments.
+ *
+ * It is **very important** to remember that input function `func` is not called
+ * when the output function is, but rather when the Observable returned by the output
+ * function is subscribed. This means if `func` makes an AJAX request, that request
+ * will be made every time someone subscribes to the resulting Observable, but not before.
+ *
+ * The last optional parameter - `scheduler` - can be used to control when the call
+ * to `func` happens after someone subscribes to Observable, as well as when results
+ * passed to callback will be emitted. By default, the subscription to an Observable calls `func`
+ * synchronously, but using {@link asyncScheduler} as the last parameter will defer the call to `func`,
+ * just like wrapping the call in `setTimeout` with a timeout of `0` would. If you were to use the async Scheduler
+ * and call `subscribe` on the output Observable, all function calls that are currently executing
+ * will end before `func` is invoked.
+ *
+ * By default, results passed to the callback are emitted immediately after `func` invokes the callback.
+ * In particular, if the callback is called synchronously, then the subscription of the resulting Observable
+ * will call the `next` function synchronously as well.  If you want to defer that call,
+ * you may use {@link asyncScheduler} just as before.  This means that by using `Scheduler.async` you can
+ * ensure that `func` always calls its callback asynchronously, thus avoiding terrifying Zalgo.
+ *
+ * Note that the Observable created by the output function will always emit a single value
+ * and then complete immediately. If `func` calls the callback multiple times, values from subsequent
+ * calls will not appear in the stream. If you need to listen for multiple calls,
+ *  you probably want to use {@link fromEvent} or {@link fromEventPattern} instead.
+ *
+ * If `func` depends on some context (`this` property) and is not already bound, the context of `func`
+ * will be the context that the output function has at call time. In particular, if `func`
+ * is called as a method of some objec and if `func` is not already bound, in order to preserve the context
+ * it is recommended that the context of the output function is set to that object as well.
+ *
+ * If the input function calls its callback in the "node style" (i.e. first argument to callback is
+ * optional error parameter signaling whether the call failed or not), {@link bindNodeCallback}
+ * provides convenient error handling and probably is a better choice.
+ * `bindCallback` will treat such functions the same as any other and error parameters
+ * (whether passed or not) will always be interpreted as regular callback argument.
+ *
+ * ## Examples
+ *
+ * ### Convert jQuery's getJSON to an Observable API
+ * ```javascript
+ * // Suppose we have jQuery.getJSON('/my/url', callback)
+ * const getJSONAsObservable = bindCallback(jQuery.getJSON);
+ * const result = getJSONAsObservable('/my/url');
+ * result.subscribe(x => console.log(x), e => console.error(e));
+ * ```
+ *
+ * ### Receive an array of arguments passed to a callback
+ * ```javascript
+ * someFunction((a, b, c) => {
+ *   console.log(a); // 5
+ *   console.log(b); // 'some string'
+ *   console.log(c); // {someProperty: 'someValue'}
+ * });
+ *
+ * const boundSomeFunction = bindCallback(someFunction);
+ * boundSomeFunction().subscribe(values => {
+ *   console.log(values) // [5, 'some string', {someProperty: 'someValue'}]
+ * });
+ * ```
+ *
+ * ### Compare behaviour with and without async Scheduler
+ * ```javascript
+ * function iCallMyCallbackSynchronously(cb) {
+ *   cb();
+ * }
+ *
+ * const boundSyncFn = bindCallback(iCallMyCallbackSynchronously);
+ * const boundAsyncFn = bindCallback(iCallMyCallbackSynchronously, null, Rx.Scheduler.async);
+ *
+ * boundSyncFn().subscribe(() => console.log('I was sync!'));
+ * boundAsyncFn().subscribe(() => console.log('I was async!'));
+ * console.log('This happened...');
+ *
+ * // Logs:
+ * // I was sync!
+ * // This happened...
+ * // I was async!
+ * ```
+ *
+ * ### Use bindCallback on an object method
+ * ```javascript
+ * const boundMethod = bindCallback(someObject.methodWithCallback);
+ * boundMethod.call(someObject) // make sure methodWithCallback has access to someObject
+ * .subscribe(subscriber);
+ * ```
+ *
+ * @see {@link bindNodeCallback}
+ * @see {@link from}
+ *
+ * @param {function} func A function with a callback as the last parameter.
+ * @param {SchedulerLike} [scheduler] The scheduler on which to schedule the
+ * callbacks.
+ * @return {function(...params: *): Observable} A function which returns the
+ * Observable that delivers the same values the callback would deliver.
+ * @name bindCallback
+ */
+
+export function bindCallback<T>(
+  callbackFunc: Function,
+  scheduler?: SchedulerLike
+): (...args: any[]) => Observable<T> {
+  return function (this: any, ...args: any[]): Observable<T> {
+    const context = this;
+    let subject: AsyncSubject<T>;
+    const params = {
+      context,
+      subject,
+      callbackFunc,
+      scheduler,
+    };
+    return sourceAsObservable((type: FOType.SUBSCRIBE, sink: Sink<T>, subs: Subscription) => {
+      if (type === FOType.SUBSCRIBE) {
+        if (!scheduler) {
+          if (!subject) {
+            subject = new AsyncSubject<T>();
+            const handler = (...innerArgs: any[]) => {
+              subject.next(innerArgs.length <= 1 ? innerArgs[0] : innerArgs);
+              subject.complete();
+            };
+
+            try {
+              callbackFunc.apply(context, [...args, handler]);
+            } catch (err) {
+              // TODO: canReportError
+              // if (canReportError(subject)) {
+                subject.error(err);
+              // } else {
+              //   console.warn(err);
+              // }
+            }
+          }
+          subject(FOType.SUBSCRIBE, sink, subs);
+        } else {
+          const state: WorkState<T> = {
+            args, subs, sink, params,
+          };
+          scheduler.schedule<WorkState<T>>(bindCallbackWork, 0, state, subs);
+        }
+      }
+    });
+  };
+}
+
+interface WorkState<T> {
+  args: any[];
+  subs: Subscription;
+  sink: Sink<T>;
+  params: ParamsContext<T>;
+}
+
+interface ParamsContext<T> {
+  callbackFunc: Function;
+  scheduler: SchedulerLike;
+  context: any;
+  subject: AsyncSubject<T>;
+}
+
+function bindCallbackWork<T>(state: WorkState<T>) {
+  const { args, subs, sink, params } = state;
+  if (subs.closed) {
+    return;
+  }
+  let { subject } = params;
+  if (!subject) {
+    const { callbackFunc, scheduler, context } = params;
+    subject = params.subject = new AsyncSubject<T>();
+    const handler = (...handlerArgs: any[]) => {
+      const value = handlerArgs.length <= 1 ? handlerArgs[0] : handlerArgs;
+      scheduler.schedule<NextState<T>>(nextWork, 0, { value, subject }, subs);
+    };
+    try {
+      callbackFunc.apply(context, [...args, handler]);
+    } catch (err) {
+      subject.error(err);
+    }
+  }
+  subject(FOType.SUBSCRIBE, sink, subs);
+}
+
+interface NextState<T> {
+  subject: AsyncSubject<T>;
+  value: T;
+}
+
+function nextWork<T>(state: NextState<T>) {
+  const { value, subject } = state;
+  subject.next(value);
+  subject.complete();
+}

--- a/src/internal/create/bindNodeCallback-spec.ts
+++ b/src/internal/create/bindNodeCallback-spec.ts
@@ -1,0 +1,283 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+import { bindNodeCallback } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { assertDeepEquals } from 'rxjs/internal/test_helpers/assertDeepEquals';
+
+/** @test {bindNodeCallback} */
+describe('bindNodeCallback', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(assertDeepEquals);
+  });
+
+  describe('when not scheduled', () => {
+    it('should emit undefined when callback is called without success arguments', () => {
+      function callback(cb: Function) {
+        cb(null);
+      }
+
+      const boundCallback = bindNodeCallback(callback);
+      const results: Array<number | string> = [];
+
+      boundCallback()
+        .subscribe((x: any) => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
+    it('should emit one value from a callback', () => {
+      function callback(datum: number, cb: (err: any, n: number) => void) {
+        cb(null, datum);
+      }
+      const boundCallback = bindNodeCallback(callback);
+      const results: Array<number | string> = [];
+
+      boundCallback(42)
+        .subscribe(x => {
+          results.push(x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      expect(results).to.deep.equal([42, 'done']);
+    });
+
+    it('should set context of callback to context of boundCallback', () => {
+      function callback(this: { datum: number }, cb: (err: any, n: number) => void) {
+        cb(null, this.datum);
+      }
+      const boundCallback = bindNodeCallback(callback);
+      const results: Array<number | string> = [];
+
+      boundCallback.call({datum: 42})
+        .subscribe(
+          (x: number) => results.push(x),
+          null,
+          () => results.push('done')
+        );
+
+      expect(results).to.deep.equal([42, 'done']);
+    });
+
+    it('should raise error from callback', () => {
+      const error = new Error();
+
+      function callback(cb: Function) {
+        cb(error);
+      }
+
+      const boundCallback = bindNodeCallback(callback);
+      const results: Array<number | string> = [];
+
+      boundCallback()
+        .subscribe(() => {
+          throw new Error('should not next');
+        }, (err: any) => {
+          results.push(err);
+        }, () => {
+          throw new Error('should not complete');
+        });
+
+      expect(results).to.deep.equal([error]);
+    });
+
+    it('should not emit, throw or complete if immediately unsubscribed', (done: MochaDone) => {
+      const nextSpy = sinon.spy();
+      const throwSpy = sinon.spy();
+      const completeSpy = sinon.spy();
+      let timeout: number;
+      function callback(datum: number, cb: (err: any, n: number) => void) {
+        // Need to cb async in order for the unsub to trigger
+        timeout = setTimeout(() => {
+          cb(null, datum);
+        });
+      }
+      const subscription = bindNodeCallback(callback)(42)
+        .subscribe(nextSpy, throwSpy, completeSpy);
+      subscription.unsubscribe();
+
+      setTimeout(() => {
+        expect(nextSpy.called, 'next to not be called').to.be.false;
+        expect(throwSpy.called, 'error to not be called').to.be.false;
+        expect(completeSpy.called, 'complete to not be called').to.be.false;
+
+        clearTimeout(timeout);
+        done();
+      });
+    });
+  });
+
+  describe('when scheduled', () => {
+    it('should emit undefined when callback is called without success arguments', () => {
+      function callback(cb: Function) {
+        cb(null);
+      }
+
+      const boundCallback = bindNodeCallback(callback, testScheduler);
+      const results: Array<number | string> = [];
+
+      boundCallback()
+        .subscribe((x: any) => {
+          results.push(typeof x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      testScheduler.flush();
+
+      expect(results).to.deep.equal(['undefined', 'done']);
+    });
+
+    it('should emit one value from a callback', () => {
+      function callback(datum: number, cb: (err: any, n: number) => void) {
+        cb(null, datum);
+      }
+      const boundCallback = bindNodeCallback(callback, testScheduler);
+      const results: Array<number | string> = [];
+
+      boundCallback(42)
+        .subscribe(x => {
+          results.push(x);
+        }, null, () => {
+          results.push('done');
+        });
+
+      testScheduler.flush();
+
+      expect(results).to.deep.equal([42, 'done']);
+    });
+
+    it('should set context of callback to context of boundCallback', () => {
+      function callback(this: { datum: number }, cb: (err: any, n: number) => void) {
+        cb(null, this.datum);
+      }
+      const boundCallback = bindNodeCallback(callback, testScheduler);
+      const results: Array<number | string> = [];
+
+      boundCallback.call({datum: 42})
+        .subscribe(
+          (x: number) => results.push(x),
+          null,
+          () => results.push('done')
+        );
+
+      testScheduler.flush();
+
+      expect(results).to.deep.equal([42, 'done']);
+    });
+
+    it('should error if callback throws', () => {
+      const expected = new Error('haha no callback for you');
+      function callback(datum: number, cb: (err: any, n: number) => void) {
+        throw expected;
+      }
+      const boundCallback = bindNodeCallback(callback, testScheduler);
+
+      boundCallback(42)
+        .subscribe(x => {
+          throw new Error('should not next');
+        }, (err: any) => {
+          expect(err).to.equal(expected);
+        }, () => {
+          throw new Error('should not complete');
+        });
+
+      testScheduler.flush();
+    });
+
+    it('should raise error from callback', () => {
+      const error = new Error();
+
+      function callback(cb: Function) {
+        cb(error);
+      }
+
+      const boundCallback = bindNodeCallback(callback, testScheduler);
+      const results: Array<number | string> = [];
+
+      boundCallback()
+        .subscribe(() => {
+          throw new Error('should not next');
+        }, (err: any) => {
+          results.push(err);
+        }, () => {
+          throw new Error('should not complete');
+        });
+
+      testScheduler.flush();
+
+      expect(results).to.deep.equal([error]);
+    });
+  });
+
+  it('should pass multiple inner arguments as an array', () => {
+    function callback(datum: number, cb: (err: any, a: number, b: number, c: number, d: number) => void) {
+      cb(null, datum, 1, 2, 3);
+    }
+    const boundCallback = bindNodeCallback(callback, testScheduler);
+    const results: Array<number[] | string> = [];
+
+    boundCallback(42)
+      .subscribe(x => {
+        results.push(x);
+      }, null, () => {
+        results.push('done');
+      });
+
+    testScheduler.flush();
+
+    expect(results).to.deep.equal([[42, 1, 2, 3], 'done']);
+  });
+
+  it('should cache value for next subscription and not call callbackFunc again', () => {
+    let calls = 0;
+    function callback(datum: number, cb: (err: any, n: number) => void) {
+      calls++;
+      cb(null, datum);
+    }
+    const boundCallback = bindNodeCallback(callback, testScheduler);
+    const results1: Array<number | string> = [];
+    const results2: Array<number | string> = [];
+
+    const source = boundCallback(42);
+
+    source.subscribe(x => {
+      results1.push(x);
+    }, null, () => {
+      results1.push('done');
+    });
+
+    source.subscribe(x => {
+      results2.push(x);
+    }, null, () => {
+      results2.push('done');
+    });
+
+    testScheduler.flush();
+
+    expect(calls).to.equal(1);
+    expect(results1).to.deep.equal([42, 'done']);
+    expect(results2).to.deep.equal([42, 'done']);
+  });
+
+  // TODO: canReportError
+  it.skip('should not swallow post-callback errors', () => {
+    function badFunction(callback: (error: Error, answer: number) => void): void {
+      callback(null, 42);
+      throw new Error('kaboom');
+    }
+    const consoleStub = sinon.stub(console, 'warn');
+    try {
+      bindNodeCallback(badFunction)().subscribe();
+      expect(consoleStub).to.have.property('called', true);
+    } finally {
+      consoleStub.restore();
+    }
+  });
+});

--- a/src/internal/create/bindNodeCallback.ts
+++ b/src/internal/create/bindNodeCallback.ts
@@ -1,0 +1,270 @@
+import { FOType, SchedulerLike, Sink } from 'rxjs/internal/types';
+import { Observable } from 'rxjs/internal/Observable';
+import { sourceAsObservable } from 'rxjs/internal/util/sourceAsObservable';
+import { Subscription } from 'rxjs/internal/Subscription';
+import { AsyncSubject } from 'rxjs/internal/AsyncSubject';
+// TODO: canReportError
+// import { canReportError } from 'rxjs/internal/util/canReportError';
+
+/* tslint:disable:max-line-length */
+export function bindNodeCallback<R1, R2, R3, R4>(callbackFunc: (callback: (err: any, res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export function bindNodeCallback<R1, R2, R3>(callbackFunc: (callback: (err: any, res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2, R3]>;
+export function bindNodeCallback<R1, R2>(callbackFunc: (callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2]>;
+export function bindNodeCallback<R1>(callbackFunc: (callback: (err: any, res1: R1) => any) => any, scheduler?: SchedulerLike): () => Observable<R1>;
+export function bindNodeCallback(callbackFunc: (callback: (err: any) => any) => any, scheduler?: SchedulerLike): () => Observable<void>;
+
+export function bindNodeCallback<A1, R1, R2, R3, R4>(callbackFunc: (arg1: A1, callback: (err: any, res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export function bindNodeCallback<A1, R1, R2, R3>(callbackFunc: (arg1: A1, callback: (err: any, res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<[R1, R2, R3]>;
+export function bindNodeCallback<A1, R1, R2>(callbackFunc: (arg1: A1, callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<[R1, R2]>;
+export function bindNodeCallback<A1, R1>(callbackFunc: (arg1: A1, callback: (err: any, res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<R1>;
+export function bindNodeCallback<A1>(callbackFunc: (arg1: A1, callback: (err: any) => any) => any, scheduler?: SchedulerLike): (arg1: A1) => Observable<void>;
+
+export function bindNodeCallback<A1, A2, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, callback: (err: any, res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export function bindNodeCallback<A1, A2, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, callback: (err: any, res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<[R1, R2, R3]>;
+export function bindNodeCallback<A1, A2, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<[R1, R2]>;
+export function bindNodeCallback<A1, A2, R1>(callbackFunc: (arg1: A1, arg2: A2, callback: (err: any, res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<R1>;
+export function bindNodeCallback<A1, A2>(callbackFunc: (arg1: A1, arg2: A2, callback: (err: any) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2) => Observable<void>;
+
+export function bindNodeCallback<A1, A2, A3, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export function bindNodeCallback<A1, A2, A3, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<[R1, R2, R3]>;
+export function bindNodeCallback<A1, A2, A3, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<[R1, R2]>;
+export function bindNodeCallback<A1, A2, A3, R1>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any, res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<R1>;
+export function bindNodeCallback<A1, A2, A3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, callback: (err: any) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3) => Observable<void>;
+
+export function bindNodeCallback<A1, A2, A3, A4, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export function bindNodeCallback<A1, A2, A3, A4, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<[R1, R2, R3]>;
+export function bindNodeCallback<A1, A2, A3, A4, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<[R1, R2]>;
+export function bindNodeCallback<A1, A2, A3, A4, R1>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any, res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<R1>;
+export function bindNodeCallback<A1, A2, A3, A4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, callback: (err: any) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4) => Observable<void>;
+
+export function bindNodeCallback<A1, A2, A3, A4, A5, R1, R2, R3, R4>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export function bindNodeCallback<A1, A2, A3, A4, A5, R1, R2, R3>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<[R1, R2, R3]>;
+export function bindNodeCallback<A1, A2, A3, A4, A5, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<[R1, R2]>;
+export function bindNodeCallback<A1, A2, A3, A4, A5, R1>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<R1>;
+export function bindNodeCallback<A1, A2, A3, A4, A5>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<void>;
+
+export function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+/* tslint:enable:max-line-length */
+
+/**
+ * Converts a Node.js-style callback API to a function that returns an
+ * Observable.
+ *
+ * <span class="informal">It's just like {@link bindCallback}, but the
+ * callback is expected to be of type `callback(error, result)`.</span>
+ *
+ * `bindNodeCallback` is not an operator because its input and output are not
+ * Observables. The input is a function `func` with some parameters, but the
+ * last parameter must be a callback function that `func` calls when it is
+ * done. The callback function is expected to follow Node.js conventions,
+ * where the first argument to the callback is an error object, signaling
+ * whether call was successful. If that object is passed to callback, it means
+ * something went wrong.
+ *
+ * The output of `bindNodeCallback` is a function that takes the same
+ * parameters as `func`, except the last one (the callback). When the output
+ * function is called with arguments, it will return an Observable.
+ * If `func` calls its callback with error parameter present, Observable will
+ * error with that value as well. If error parameter is not passed, Observable will emit
+ * second parameter. If there are more parameters (third and so on),
+ * Observable will emit an array with all arguments, except first error argument.
+ *
+ * Note that `func` will not be called at the same time output function is,
+ * but rather whenever resulting Observable is subscribed. By default call to
+ * `func` will happen synchronously after subscription, but that can be changed
+ * with proper `scheduler` provided as optional third parameter. {@link SchedulerLike}
+ * can also control when values from callback will be emitted by Observable.
+ * To find out more, check out documentation for {@link bindCallback}, where
+ * {@link SchedulerLike} works exactly the same.
+ *
+ * As in {@link bindCallback}, context (`this` property) of input function will be set to context
+ * of returned function, when it is called.
+ *
+ * After Observable emits value, it will complete immediately. This means
+ * even if `func` calls callback again, values from second and consecutive
+ * calls will never appear on the stream. If you need to handle functions
+ * that call callbacks multiple times, check out {@link fromEvent} or
+ * {@link fromEventPattern} instead.
+ *
+ * Note that `bindNodeCallback` can be used in non-Node.js environments as well.
+ * "Node.js-style" callbacks are just a convention, so if you write for
+ * browsers or any other environment and API you use implements that callback style,
+ * `bindNodeCallback` can be safely used on that API functions as well.
+ *
+ * Remember that Error object passed to callback does not have to be an instance
+ * of JavaScript built-in `Error` object. In fact, it does not even have to an object.
+ * Error parameter of callback function is interpreted as "present", when value
+ * of that parameter is truthy. It could be, for example, non-zero number, non-empty
+ * string or boolean `true`. In all of these cases resulting Observable would error
+ * with that value. This means usually regular style callbacks will fail very often when
+ * `bindNodeCallback` is used. If your Observable errors much more often then you
+ * would expect, check if callback really is called in Node.js-style and, if not,
+ * switch to {@link bindCallback} instead.
+ *
+ * Note that even if error parameter is technically present in callback, but its value
+ * is falsy, it still won't appear in array emitted by Observable.
+ *
+ * ## Examples
+ * ###  Read a file from the filesystem and get the data as an Observable
+ * ```javascript
+ * import * as fs from 'fs';
+ * const readFileAsObservable = bindNodeCallback(fs.readFile);
+ * const result = readFileAsObservable('./roadNames.txt', 'utf8');
+ * result.subscribe(x => console.log(x), e => console.error(e));
+ * ```
+ *
+ * ### Use on function calling callback with multiple arguments
+ * ```javascript
+ * someFunction((err, a, b) => {
+ *   console.log(err); // null
+ *   console.log(a); // 5
+ *   console.log(b); // "some string"
+ * });
+ * const boundSomeFunction = bindNodeCallback(someFunction);
+ * boundSomeFunction()
+ * .subscribe(value => {
+ *   console.log(value); // [5, "some string"]
+ * });
+ * ```
+ *
+ * ### Use on function calling callback in regular style
+ * ```javascript
+ * someFunction(a => {
+ *   console.log(a); // 5
+ * });
+ * const boundSomeFunction = bindNodeCallback(someFunction);
+ * boundSomeFunction()
+ * .subscribe(
+ *   value => {}             // never gets called
+ *   err => console.log(err) // 5
+ * );
+ * ```
+ *
+ * @see {@link bindCallback}
+ * @see {@link from}
+ *
+ * @param {function} func Function with a Node.js-style callback as the last parameter.
+ * @param {SchedulerLike} [scheduler] The scheduler on which to schedule the
+ * callbacks.
+ * @return {function(...params: *): Observable} A function which returns the
+ * Observable that delivers the same values the Node.js callback would
+ * deliver.
+ * @name bindNodeCallback
+ */
+export function bindNodeCallback<T>(
+  callbackFunc: Function,
+  scheduler?: SchedulerLike
+): (...args: any[]) => Observable<T> {
+
+  return function(this: any, ...args: any[]): Observable<T> {
+    const context = this;
+    let subject: AsyncSubject<T>;
+    const params: ParamsState<T> = {
+      args,
+      callbackFunc,
+      scheduler,
+      context,
+      subject,
+    };
+    return sourceAsObservable((type: FOType.SUBSCRIBE, sink: Sink<T>, subs: Subscription) => {
+      if (type === FOType.SUBSCRIBE) {
+        if (!scheduler) {
+          if (!subject) {
+            subject = params.subject = new AsyncSubject<T>();
+
+            const handler = (...handlerArgs: any[]) => {
+              const err = handlerArgs.shift();
+              if (err) {
+                subject.error(err);
+                return;
+              }
+              subject.next(handlerArgs.length <= 1 ? handlerArgs[0] : handlerArgs);
+              subject.complete();
+            };
+
+            try {
+              callbackFunc.apply(context, [...args, handler]);
+            } catch (err) {
+              // TODO: canReportError
+              // if (canReportError(subject)) {
+                subject.error(err);
+              // } else {
+              //   console.warn(err);
+              // }
+            }
+          }
+          subject(FOType.SUBSCRIBE, sink, subs);
+        } else {
+          const state: WorkState<T> = {
+            subs, sink, params,
+          };
+          scheduler.schedule<WorkState<T>>(callbackWork, 0, state, subs);
+        }
+      }
+    });
+  };
+}
+
+interface WorkState<T> {
+  subs: Subscription;
+  sink: Sink<T>;
+  params: ParamsState<T>;
+}
+
+interface ParamsState<T> {
+  callbackFunc: Function;
+  args: any[];
+  scheduler: SchedulerLike;
+  subject: AsyncSubject<T>;
+  context: any;
+}
+
+function callbackWork<T>(state: WorkState<T>) {
+  const { subs, sink, params } = state;
+  if (subs.closed) {
+    return;
+  }
+  let { subject } = params;
+  if (!subject) {
+    const { args, callbackFunc, scheduler, context } = params;
+    subject = params.subject = new AsyncSubject<T>();
+
+    const handler = (...handlerArgs: any[]) => {
+      const err = handlerArgs.shift();
+      if (err) {
+        scheduler.schedule<ErrorState<T>>(errorWork, 0, { err, subject }, subs);
+      } else {
+        const value = handlerArgs.length <= 1 ? handlerArgs[0] : handlerArgs;
+        scheduler.schedule<NextState<T>>(nextWork, 0, { value, subject }, subs);
+      }
+    };
+
+    try {
+      callbackFunc.apply(context, [...args, handler]);
+    } catch (err) {
+      scheduler.schedule<ErrorState<T>>(errorWork, 0, { err, subject }, subs);
+    }
+  }
+  subject(FOType.SUBSCRIBE, sink, subs);
+}
+
+interface NextState<T> {
+  subject: AsyncSubject<T>;
+  value: T;
+}
+
+function nextWork<T>(state: NextState<T>) {
+  const { value, subject } = state;
+  subject.next(value);
+  subject.complete();
+}
+
+interface ErrorState<T> {
+  subject: AsyncSubject<T>;
+  err: any;
+}
+
+function errorWork<T>(state: ErrorState<T>) {
+  const { err, subject } = state;
+  subject.error(err);
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Add `bindCallback` and `bindNodeCallback` to the `experimental` branch.

**Related issue (if exists):** None
