### PR TITLE
chore(subject): test error after complete, etc.

### DIFF
--- a/src/internal/Subject-spec.ts
+++ b/src/internal/Subject-spec.ts
@@ -426,14 +426,57 @@ describe('Subject', () => {
     expect(results).to.deep.equal(['a', 'C']);
   });
 
+  it('should not error after completed', () => {
+    const error = new Error('wut?');
+    const subject = new Subject<string>();
+    const results: (string|Error)[] = [];
+    subject.subscribe(x => results.push(x), (err) => results.push(err), () => results.push('C'));
+    subject.next('a');
+    subject.complete();
+    subject.error(error);
+    expect(results).to.deep.equal(['a', 'C']);
+  });
+
+  it('should not complete after completed', () => {
+    const subject = new Subject<string>();
+    const results: string[] = [];
+    subject.subscribe(x => results.push(x), null, () => results.push('C'));
+    subject.next('a');
+    subject.complete();
+    subject.complete();
+    expect(results).to.deep.equal(['a', 'C']);
+  });
+
   it('should not next after error', () => {
     const error = new Error('wut?');
     const subject = new Subject<string>();
-    const results: string[] = [];
+    const results: (string|Error)[] = [];
     subject.subscribe(x => results.push(x), (err) => results.push(err));
     subject.next('a');
     subject.error(error);
     subject.next('b');
+    expect(results).to.deep.equal(['a', error]);
+  });
+
+  it('should not error after error', () => {
+    const error = new Error('wut?');
+    const subject = new Subject<string>();
+    const results: (string|Error)[] = [];
+    subject.subscribe(x => results.push(x), (err) => results.push(err));
+    subject.next('a');
+    subject.error(error);
+    subject.error(error);
+    expect(results).to.deep.equal(['a', error]);
+  });
+
+  it('should not complete after error', () => {
+    const error = new Error('wut?');
+    const subject = new Subject<string>();
+    const results: (string|Error)[] = [];
+    subject.subscribe(x => results.push(x), (err) => results.push(err), () => results.push('C'));
+    subject.next('a');
+    subject.error(error);
+    subject.complete();
     expect(results).to.deep.equal(['a', error]);
   });
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Add remaining variations: should not error after complete, etc.

**Related issue (if exists):** None