### PR TITLE
feat(range): accept one argument

### DIFF
--- a/spec/observables/range-spec.ts
+++ b/spec/observables/range-spec.ts
@@ -73,6 +73,21 @@ describe('range', () => {
     });
 
   });
+
+  it('should accept only one argument where count is argument and start is zero', () => {
+    const e1 = range(5)
+      .pipe(concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : 20, rxTestScheduler))));
+    const expected = 'a-b-c-d-(e|)';
+    const values = {
+      a: 0,
+      b: 1,
+      c: 2,
+      d: 3,
+      e: 4
+    };
+    expectObservable(e1).toBe(expected, values);
+    expectObservable(e1).toBe(expected, values);
+  });
 });
 
 describe('RangeObservable', () => {

--- a/src/internal/observable/range.ts
+++ b/src/internal/observable/range.ts
@@ -24,7 +24,7 @@ import { Observable } from '../Observable';
  * @see {@link index/interval}
  *
  * @param {number} [start=0] The value of the first integer in the sequence.
- * @param {number} [count=0] The number of sequential integers to generate.
+ * @param {number} count The number of sequential integers to generate.
  * @param {SchedulerLike} [scheduler] A {@link SchedulerLike} to use for scheduling
  * the emissions of the notifications.
  * @return {Observable} An Observable of numbers that emits a finite range of
@@ -34,9 +34,14 @@ import { Observable } from '../Observable';
  * @owner Observable
  */
 export function range(start: number = 0,
-                      count: number = 0,
+                      count?: number,
                       scheduler?: SchedulerLike): Observable<number> {
   return new Observable<number>(subscriber => {
+    if (count === undefined) {
+      count = start;
+      start = 0;
+    }
+
     let index = 0;
     let current = start;
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
