### PR TITLE
test(dtslint): add timestamp

### DIFF
--- a/spec-dtslint/operators/timestamp-spec.ts
+++ b/spec-dtslint/operators/timestamp-spec.ts
@@ -1,0 +1,14 @@
+import { of, asyncScheduler } from 'rxjs';
+import { timestamp } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of('a', 'b', 'c').pipe(timestamp()); // $ExpectType Observable<Timestamp<string>>
+});
+
+it('should support a scheduler', () => {
+  const o = of('a', 'b', 'c').pipe(timestamp(asyncScheduler)); // $ExpectType Observable<Timestamp<string>>
+});
+
+it('should enforce scheduler type', () => {
+  const o = of('a', 'b', 'c').pipe(timestamp('nope')); // $ExpectError
+});


### PR DESCRIPTION
Description:
This PR adds dtslint tests for `timestamp`.

Related issue (if exists): #4093
