### PR TITLE
test(dtslint): add partition

### DIFF
--- a/spec-dtslint/operators/partition-spec.ts
+++ b/spec-dtslint/operators/partition-spec.ts
@@ -1,0 +1,22 @@
+import * as Rx from 'rxjs/Rx';
+
+const Observable = Rx.Observable;
+
+it('should infer correctly', () => {
+  const o = Observable.of('a', 'b', 'c').partition((value, index) => true); // $ExpectType [Observable<string>, Observable<string>]
+  const p = Observable.of('a', 'b', 'c').partition(() => true); // $ExpectType [Observable<string>, Observable<string>]
+});
+
+it('should accept a thisArg parameter', () => {
+  const o = Observable.of('a', 'b', 'c').partition(() => true, 5); // $ExpectType [Observable<string>, Observable<string>]
+});
+
+it('should enforce types', () => {
+  const o = Observable.of('a', 'b', 'c').partition(); // $ExpectError
+});
+
+it('should enforce predicate types', () => {
+  const o = Observable.of('a', 'b', 'c').partition('nope'); // $ExpectError
+  const p = Observable.of('a', 'b', 'c').partition((value: number) => true); // $ExpectError
+  const q = Observable.of('a', 'b', 'c').partition((value, index: string) => true); // $ExpectError
+});


### PR DESCRIPTION
Description:
This PR adds dtslint tests for `partition`.

The typings when using a pipeable operator were giving errors.
I resorted back to how the other specs are written for the `partition` operator at https://github.com/ReactiveX/rxjs/blob/master/spec/operators/partition-spec.ts.

I think if we want to support a pipeable `partition` operator, we would have to create "a lot" of extra `pipe` typings.

Related issue (if exists): #4093
