### PR TITLE
docs(observable): fix example

### DIFF
--- a/docs_app/content/guide/observable.md
+++ b/docs_app/content/guide/observable.md
@@ -405,7 +405,7 @@ Each Observable must define how to dispose resources of that execution when we c
 For instance, this is how we clear an interval execution set with `setInterval`:
 
 ```js
-var observable = Rx.Observable.create(function subscribe(observer) {
+var observable = Observable.create(function subscribe(observer) {
   // Keep track of the interval resource
   var intervalID = setInterval(() => {
     observer.next('hi');


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fix a small typo in one of the examples.

**Related issue (if exists):**
