### PR TITLE
refactor(exhaustMap): Fix typo in ExhaustMapOperator

### DIFF
--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -72,10 +72,10 @@ export function exhaustMap<T, I, R>(
     );
   }
   return (source: Observable<T>) =>
-    source.lift(new ExhauseMapOperator(project));
+    source.lift(new ExhaustMapOperator(project));
 }
 
-class ExhauseMapOperator<T, R> implements Operator<T, R> {
+class ExhaustMapOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => ObservableInput<R>) {
   }
 


### PR DESCRIPTION
**Description:**
There seems to be a spelling error in `ExhaustMapOperator`. The class isn't exported and not used anywhere else except in this file.

**Related issue (if exists):**
None