### PR TITLE
docs(observable): Update Observable docs

### DIFF
--- a/doc/observable.md
+++ b/doc/observable.md
@@ -42,7 +42,7 @@ console.log('just before subscribe');
 observable.subscribe({
   next(x) { console.log('got value ' + x); },
   error(err) { console.error('something wrong occurred: ' + err); },
-  complete() { console.log('done'); },
+  complete() { console.log('done'); }
 });
 console.log('just after subscribe');
 ```
@@ -128,7 +128,7 @@ const foo = new Observable(subscriber => {
 foo.subscribe(x => {
   console.log(x);
 });
-foo.subscribe(function (y) {
+foo.subscribe(y => {
   console.log(y);
 });
 ```
@@ -323,7 +323,7 @@ There are three types of values an Observable Execution can deliver:
 - "Error" notification: sends a JavaScript Error or exception.
 - "Complete" notification: does not send a value.
 
-"Next" notifications are the most important and most common type: they represent actual data being delivered to an subscriber. Error and Complete notifications may happen only once during the Observable Execution, and there can only be either one of them.
+"Next" notifications are the most important and most common type: they represent actual data being delivered to an subscriber. "Error" and "Complete" notifications may happen only once during the Observable Execution, and there can only be either one of them.
 
 These constraints are expressed best in the so-called *Observable Grammar* or *Contract*, written as a regular expression:
 
@@ -390,7 +390,7 @@ const subscription = observable.subscribe(x => console.log(x));
 The Subscription represents the ongoing execution, and has a minimal API which allows you to cancel that execution. Read more about the [`Subscription` type here](./subscription). With `subscription.unsubscribe()` you can cancel the ongoing execution:
 
 ```ts
-import { Observable, from } from 'rxjs';
+import { from } from 'rxjs';
 
 const observable = from([10, 20, 30]);
 const subscription = observable.subscribe(x => console.log(x));


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Update Observable in `docs_app` to match the style of Observable in `docs`.

* @benlesh [updated](https://github.com/ReactiveX/rxjs/commit/b256ee170625a0c323852bbb97b25cee7cce613a) old docs related to Observable more than a month ago. This update is just his changes transferred to the Observable in `docs_app`.

* There are also a few small fixes for Observable in `docs`.

**Related issue (if exists):**
