### PR TITLE
style(Notification): Use enum to safely type the notification kinds

### DIFF
--- a/spec/Notification-spec.ts
+++ b/spec/Notification-spec.ts
@@ -12,7 +12,7 @@ describe('Notification', () => {
   });
 
   it('should not allow convert to observable if given kind is unknown', () => {
-    const n = new Notification('x');
+    const n = new Notification('x' as any);
     expect(() => n.toObservable()).to.throw();
   });
 

--- a/src/internal/Rx.ts
+++ b/src/internal/Rx.ts
@@ -153,7 +153,7 @@ export {AsyncSubject} from './AsyncSubject';
 export {ReplaySubject} from './ReplaySubject';
 export {BehaviorSubject} from './BehaviorSubject';
 export {ConnectableObservable} from './observable/ConnectableObservable';
-export {Notification} from './Notification';
+export {Notification, NotificationKind} from './Notification';
 export {EmptyError} from './util/EmptyError';
 export {ArgumentOutOfRangeError} from './util/ArgumentOutOfRangeError';
 export {ObjectUnsubscribedError} from './util/ObjectUnsubscribedError';


### PR DESCRIPTION
**Description:**
Rather than using magic strings which are easily use incorrectly, this PR introduces a `enum NotificationKind`. 

This is not a breaking change as all clients that happen to already test the kind against a string will still have the same behaviour, both at compiletime and runtime, with the exception that if they use a notification kind letter that does not exist, they will get a compile time error.