### PR TITLE
feat(shareReplay): added 'disconnect' feature

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -1,0 +1,141 @@
+# Operators
+
+An operator is just a function that takes an Observable as its input and returns another Observable.  For example, there is an operator called `map()`, that is equivalent to the Array method of the same name. Just as `[1, 2, 3].map(x => x * x)` will yield `[1, 4, 9]`, the Observable created like this:
+
+```ts
+import { of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+map(x => x * x)(of(1, 2, 3).subscribe((v) => console.log(`value: ${v}`));
+
+// Logs:
+// value: 1 
+// value: 4
+// value: 9 
+
+```
+
+will emit `1`, `4`, `9`.  Another useful operator is `first()`:
+
+```ts
+import { of } from 'rxjs';
+import { first } from 'rxjs/operators';
+
+first()(of(1, 2, 3).subscribe((v) => console.log(`value: ${v}`));
+
+// Logs:
+// value: 1 
+```
+
+Note that `map` logically must be constructed on the fly, since it must be built using the mapping function.  Although `first` could be a constant, by convention, it is likewise constructed on the fly.  As a general practice, all operators are constructed, whether they need arguments or not.
+
+In addition to `map()` and `first()`, there are [over one hundred useful operators](/api) included in the library, but some particularly useful ones are
+
+* `filter(f)` — remove any values that fail to pass the test `f()`
+* `take(n)` — emit only the first `n` values and then complete
+* `delay(n)` — delay the emission of each value by `n` milliseconds
+
+## Piping
+
+Operators are functions, so they *can* be used like ordinary functions: `op()(obs)` — but in practice, there tend to be many of them convolved together, and quickly become unreadable: `op4()(op3()(op2()(op1()(obs))))`. For that reason, Observable have a method called `.pipe()` that accomplishes the same thing while being much easier to read:
+
+```ts
+obs.pipe(
+  op1(),
+  op2(),
+  op3(),
+  op3(),
+)
+```
+
+As a stylistic matter, `op()(obs)` is never used, even if there is only one operator; `obs.pipe(op())` is universally preferred.
+
+
+## Higher-order Observables
+
+Observables most commonly emit ordinary values like strings and numbers, but surprisingly often, it is necessary to handle Observables *of* Observables, so-called higher-order Observables.  For example, imagine you had an Observable emitting strings that were the URLs of files you wanted to see.  The code might look like this:
+
+```ts
+const fileObservable = urlObservable.pipe(
+   map(url => http.get(url)),
+);
+```
+
+`http.get()` returns an Observable (of string or string arrays probably) for each individual URL.  Now you have a higher-order Observable.
+
+But how do you work with a higher-order Observable? Typically, by _flattening_: by (somehow) converting a higher-order Observable into an ordinary Observable.  For example:
+
+```ts
+const fileObservable = urlObservable.pipe(
+   map(url => http.get(url)),
+   concatAll(),
+);
+```
+
+The [`concatAll()`](/api/operators/concatAll) operator subscribes to each "inner" Observable that comes out of the "outer" Observable, and copies all the emitted values until that Observable completes, and goes on to the next one.  All of the values are in that way concatenated.  Other useful higher-order operators are
+
+* [`mergeAll()`](/api/operators/mergeAll) — subscribes to each inner Observable as it arrives, then emits each value as it arrives
+* [`switchAll()`](/api/operators/switchAll) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, but when the next inner Observable arrives, unsubscribes to the previous one, and subscribes to the new one.
+* [`exhaust()`](/api/operators/exhaust) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, discarding all newly arriving inner Observables until that first one completes, then waits for the next inner Observable.
+
+Just as many array library combine [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`flat()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) (or `flatten()`) into a single [`flatMap()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap), there are mapping equivalents of all the RxJS flattening operators [`concatMap()`](/api/operators/concatMap), [`mergeMap()`](/api/operators/mergeMap), [`switchMap()`](/api/operators/switchMap), and [`exhaustMap()`](/api/operators/exhaustMap).
+
+
+## Creating custom observables
+
+### Use the `pipe()` function to make new operators
+
+If there is a commonly used sequence of operators in your code, use the `pipe()` function to extract the sequence into a new operator. Even if a sequence is not that common, breaking it out into a single operator can improve readability.
+
+For example, you could make a function that discarded odd values and doubled even values like this:
+
+```ts
+function discardOddDisableEven() {
+  return pipe(
+    filter(v => ! (v % 2)),
+    map(v => v + v),
+  );
+}
+```
+
+(The `pipe()` function is analogous to, but not the same thing as, the `.pipe()` method on an Observable.)
+
+It is more complicated, but if you have to write an operator that cannot be made from a combination of existing operators (a rare occurrance), you can write an operator from scratch, like this:
+
+
+```ts
+function delay(delayInMillis) {
+  return (observable) => new Observable(observer => {
+    const allTimerIDs = new Set();
+    const subscription = observable.subscribe({
+      next(value) {
+        const timerID = setTimeout(() => {
+          observer.next(value);
+          allTimerIDs.delete(timerID);
+        }, delayInMillis);
+        allTimerIDs.add(timerID);
+      },
+      error(err) {
+        observer.error(err);
+      },
+      complete() {
+        observer.complete();
+      }
+    });
+    return () => {
+      subscription.unsubscribe();
+      allTimerIDs.forEach(timerID => {
+        clearTimeout(timerID);
+      });
+    }
+  });
+}
+```
+
+Note that you must
+
+1. implement all three Observer functions, `next()`, `error()`, and `complete()` when subscribing to the input Observable.
+2. implement a "teardown" function that cleans up when the Observable completes (in this case by unsubscribing and clearing any pending timeouts).
+3. return that teardown function from the function passed to the Observable constructor.
+
+Of course, this is only an example; the `delay()` operator [already exists](/api/operators/delay).

--- a/docs_app/content/navigation.json
+++ b/docs_app/content/navigation.json
@@ -39,6 +39,10 @@
 					"title": "Subjects"
 				},
         {
+					"url": "guide/operators",
+					"title": "Operators"
+				},
+        {
 					"url": "guide/scheduler",
 					"title": "Scheduler"
         },

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -1,8 +1,16 @@
 import { Observable } from '../Observable';
+import { Operator } from '../Operator';
 import { ReplaySubject } from '../ReplaySubject';
+import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
-import { Subscriber } from '../Subscriber';
+
+export interface ShareReplayConfig {
+  bufferSize?: number;
+  windowTime?: number;
+  scheduler?: SchedulerLike;
+  disconnect?: boolean;
+}
 
 /**
  * Share source and replay specified number of emissions on subscription.
@@ -19,6 +27,13 @@ import { Subscriber } from '../Subscriber';
  * a stream that need access to previously emitted values.
  * This ability to replay values on subscription is what differentiates {@link share} and `shareReplay`.
  *
+ * ## What is configurable?
+ * The following behaviors are configurable the ShareReplayConfig object
+ * * bufferSize -  Maximum element count of the replay buffer. (default: Number.POSITIVE_INFINITY)
+ * * windowTime -  Maximum time length of the replay buffer in milliseconds. (default: Number.POSITIVE_INFINITY)
+ * * scheduler -   Scheduler where connected observers within the selector function. (default: none)
+ * * disconnect -  If set, when the reference count drops to zero, the replay buffer will clear. (default: false)
+ *
  * ![](shareReplay.png)
  *
  * ## Example
@@ -26,7 +41,7 @@ import { Subscriber } from '../Subscriber';
  * const obs$ = interval(1000);
  * const subscription = obs$.pipe(
  *   take(4),
- *   shareReplay(3)
+ *   shareReplay({bufferSize: 3})
  * );
  * subscription.subscribe(x => console.log('source A: ', x));
  * subscription.subscribe(y => console.log('source B: ', y));
@@ -37,56 +52,78 @@ import { Subscriber } from '../Subscriber';
  * @see {@link share}
  * @see {@link publishReplay}
  *
- * @param {Number} [bufferSize=Number.POSITIVE_INFINITY] Maximum element count of the replay buffer.
- * @param {Number} [windowTime=Number.POSITIVE_INFINITY] Maximum time length of the replay buffer in milliseconds.
- * @param {Scheduler} [scheduler] Scheduler where connected observers within the selector function
- * will be invoked on.
+ * @param {Object} config a configuration object to define `bufferSize`, `windowTime`, `scheduler`,
+ * and `disconnect` behavior. Defaults to `{ }`.
  * @return {Observable} An observable sequence that contains the elements of a sequence produced
  * by multicasting the source sequence within a selector function.
  * @method shareReplay
  * @owner Observable
  */
 export function shareReplay<T>(
-  bufferSize: number = Number.POSITIVE_INFINITY,
+  configOrBuffersize?: ShareReplayConfig | number,
   windowTime: number = Number.POSITIVE_INFINITY,
   scheduler?: SchedulerLike
 ): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(shareReplayOperator(bufferSize, windowTime, scheduler));
+  // absorb old-style arguments, if given
+  const config: ShareReplayConfig =
+    (typeof (configOrBuffersize) === 'number') ? {
+      bufferSize: configOrBuffersize,
+      windowTime,
+      scheduler,
+    } : (configOrBuffersize || {});
+
+  return (source: Observable<T>) => source.lift(new ShareReplayOperator(config));
 }
 
-function shareReplayOperator<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike) {
-  let subject: ReplaySubject<T>;
-  let refCount = 0;
-  let subscription: Subscription;
-  let hasError = false;
-  let isComplete = false;
+class ShareReplayOperator<T> implements Operator<T, T> {
+  refCount = 0;
+  subject: ReplaySubject<T>;
+  subscription: Subscription;
+  hasError = false;
 
-  return function shareReplayOperation(this: Subscriber<T>, source: Observable<T>) {
-    refCount++;
-    if (!subject || hasError) {
-      hasError = false;
-      subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
-      subscription = source.subscribe({
-        next(value) { subject.next(value); },
-        error(err) {
-          hasError = true;
-          subject.error(err);
+  constructor(private readonly config: ShareReplayConfig) { }
+
+  call(subscriber: Subscriber<T>, source: any) {
+    const op = this;
+    this.refCount++;
+    if (!this.subject || this.hasError) {
+      this.hasError = false;
+      this.subject = new ReplaySubject<T>(this.config.bufferSize, this.config.windowTime, this.config.scheduler);
+
+      this.subscription = source.subscribe({
+        next(value: T) {
+          op.subject.next(value);
+        },
+        error(err: any) {
+          op.hasError = true;
+          op.subject.error(err);
         },
         complete() {
-          isComplete = true;
-          subject.complete();
+          op.subject.complete();
         },
       });
     }
 
-    const innerSub = subject.subscribe(this);
+    return this.subject.subscribe(new ShareReplaySubscriber<T>(subscriber, op));
+  }
 
-    return () => {
-      refCount--;
-      innerSub.unsubscribe();
-      if (subscription && refCount === 0 && isComplete) {
-        subscription.unsubscribe();
-      }
-    };
-  };
+  teardown() {
+    this.refCount--;
+    if (this.subject && (this.refCount === 0) && this.config.disconnect) {
+      this.subscription.unsubscribe();
+      this.subject = undefined;
+    }
+  }
+}
+
+class ShareReplaySubscriber<T> extends Subscriber<T> {
+  constructor(destination: Subscriber<T>, private op: ShareReplayOperator<T>) {
+    super(destination);
+  }
+  unsubscribe() {
+    if (!this.isStopped) {
+      super.unsubscribe();
+      this.op.teardown();
+    }
+  }
 }


### PR DESCRIPTION
**Description:**
Updated shareReplay to support 'disconnect'.  That is, when the refCount drops to 0, the buffer can (optionally) be dropped, and then, upon the next subscription, re-subscribes to the source.

Rather than adding *another* parameter,  a config-object interface has been added. For compatibility, the old parameters still work,  but the disconnect option can only be reached with the config option, so `shareReplay(3)` is equivalent to `shareReplay({ bufferSize: 3})`, but you might instead want `shareReplay({ bufferSize: 3, disconnect: true})`.

**Related issue (if exists):**

This is in response to [issue 3722](https://github.com/ReactiveX/rxjs/issues/3722).