### PR TITLE
feat(isPromise): change isPromise to return bool, add tests

### DIFF
--- a/spec/util/isPromise-spec.ts
+++ b/spec/util/isPromise-spec.ts
@@ -1,0 +1,38 @@
+import { of } from 'rxjs';
+import { expect } from 'chai';
+import { isPromise } from 'rxjs/util/isPromise';
+
+describe('isPromise', () => {
+  it('should return true for new Promise', () => {
+    const o = new Promise<any>(() => null);
+    expect(isPromise(o)).to.be.true;
+  });
+
+  it('should return true for a Promise that comes from an Observable', () => {
+    const o: any = of(null).toPromise();
+    expect(isPromise(o)).to.be.true;
+  });
+
+  it('should NOT return true for any Observable', () => {
+    const o: any = of(null);
+
+    expect(isPromise(o)).to.be.false;
+  });
+
+  it('should return false for null', () => {
+    expect(isPromise(null)).to.be.false;
+  });
+
+  it('should return false for undefined', () => {
+    expect(isPromise(undefined)).to.be.false;
+  });
+
+  it('should return false for a number', () => {
+    expect(isPromise(1)).to.be.false;
+  });
+
+  it('should return false for a string', () => {
+    expect(isPromise('1')).to.be.false;
+  });
+
+});

--- a/src/internal/util/isPromise.ts
+++ b/src/internal/util/isPromise.ts
@@ -1,3 +1,8 @@
+/**
+ * Tests to see if the object is an ES2015 (ES6) Promise
+ * @see {@link https://www.ecma-international.org/ecma-262/6.0/#sec-promise-objects}
+ * @param value the object to test
+ */
 export function isPromise(value: any): value is PromiseLike<any> {
-  return value && typeof (<any>value).subscribe !== 'function' && typeof (value as any).then === 'function';
+  return !!value && typeof (<any>value).subscribe !== 'function' && typeof (value as any).then === 'function';
 }


### PR DESCRIPTION
isPromise returns a boolean like isObservable instead of a "falsy" value. isPromise is available for more than internal use since Observable has toPromise. Add tests to validate isPromise.

**Description:**
isObservable was exposed from the internal util methods in [6.1.0](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#610-2018-05-03) and had the null/undefined errors fixed in [6.2.0](https://github.com/ReactiveX/rxjs/blob/master/CHANGELOG.md#610-2018-05-03). Exposing isPromise from the internal util methods and updating it to also return a boolean instead of a "truthy" / "falsy" seems consistent.

**Related issue (if exists):**
Related to #4424 