### PR TITLE
fix(Observable): Fix Observable.subscribe to add operator TeardownLogic to returned Subscription

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -5,6 +5,9 @@ import { Observer, TeardownLogic } from '../src/internal/types';
 import { cold, expectObservable, expectSubscriptions } from './helpers/marble-testing';
 import { map } from '../src/internal/operators/map';
 import { noop } from '../src/internal/util/noop';
+import { NEVER } from '../src/internal/observable/never';
+import { Subscriber } from '../src/internal/Subscriber';
+import { Operator } from '../src/internal/Operator';
 
 declare const asDiagram: any, rxTestScheduler: any;
 const Observable = Rx.Observable;
@@ -696,6 +699,24 @@ describe('Observable.lift', () => {
       return observable;
     }
   }
+
+  it('should return Observable which calls TeardownLogic of operator on unsubscription', (done) => {
+
+    const myOperator: Operator<any, any> = {
+      call: (subscriber: Subscriber<any>, source: any) => {
+        const subscription = source.subscribe((x: any) => subscriber.next(x));
+        return () => {
+          subscription.unsubscribe();
+          done();
+        };
+      }
+    };
+
+    NEVER.lift(myOperator)
+      .subscribe()
+      .unsubscribe();
+
+  });
 
   it('should be overrideable in a custom Observable type that composes', (done) => {
     const result = new MyCustomObservable<number>((observer) => {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -204,7 +204,7 @@ export class Observable<T> implements Subscribable<T> {
     const sink = toSubscriber(observerOrNext, error, complete);
 
     if (operator) {
-      operator.call(sink, this.source);
+      sink.add(operator.call(sink, this.source));
     } else {
       sink.add(
         this.source || (config.useDeprecatedSynchronousErrorHandling && !sink.syncErrorThrowable) ?


### PR DESCRIPTION
The `Observable.subscribe` method does not add `TeardownLogic` of a lifted `Operator` to the returned Subscription. Therefore the `TeardownLogic` of such an `Operator` is never called on unsubscriptions. This PR fixes that issue.