### PR TITLE
Update example with async scheduler

### DIFF
--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -69,7 +69,7 @@ export function from<T>(input: ObservableInput<ObservableInput<T>>, scheduler?: 
  * ### with async scheduler
  * ```javascript
  * import { from } from 'rxjs/observable/from';
- * import { async } from 'rxjs/scheduler/async';
+ * import { async } from 'rxjs';
  *
  * console.log('start');
  *


### PR DESCRIPTION
when i use async import from 'rxjs/scheduler/async', show Error: Cannot find module 'rxjs-compat/Observable'.
So, I updated to import { async } from 'rxjs', it works ~

