### PR TITLE
fix(delay): emit complete notification as soon as possible

### DIFF
--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -11,10 +11,10 @@ declare const rxTestScheduler: TestScheduler;
 /** @test {delay} */
 describe('delay operator', () => {
   asDiagram('delay(20)')('should delay by specified timeframe', () => {
-    const e1 =   hot('---a--b--|  ');
-    const t =   time(   '--|      ');
-    const expected = '-----a--b--|';
-    const subs =     '^        !  ';
+    const e1 =   hot('---a--b--|');
+    const t =   time(   '--|    ');
+    const expected = '-----a--b|';
+    const subs =     '^        !';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 
@@ -25,7 +25,7 @@ describe('delay operator', () => {
   it('should delay by absolute time period', () => {
     const e1 =   hot('--a--b--|   ');
     const t =   time(  '---|      ');
-    const expected = '-----a--b--|';
+    const expected = '-----a--(b|)';
     const subs =     '^       !   ';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
@@ -38,7 +38,7 @@ describe('delay operator', () => {
   it('should delay by absolute time period after subscription', () => {
     const e1 =   hot('---^--a--b--|   ');
     const t =   time(      '---|      ');
-    const expected =    '------a--b--|';
+    const expected =    '------a--(b|)';
     const subs =        '^        !   ';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
@@ -86,10 +86,10 @@ describe('delay operator', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1Sub);
   });
 
-  it('should delay when source does not emits', () => {
+  it('should not delay when source does not emits', () => {
     const e1 =   hot('----|   ');
     const t =   time(    '---|');
-    const expected = '-------|';
+    const expected = '----|';
     const subs =     '^   !   ';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
@@ -98,10 +98,20 @@ describe('delay operator', () => {
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
-  it('should delay when source is empty', () => {
+  it('should not delay when source is empty', () => {
     const e1 =  cold('|');
     const t =   time('---|');
-    const expected = '---|';
+    const expected = '|';
+
+    const result = e1.pipe(delay(t, rxTestScheduler));
+
+    expectObservable(result).toBe(expected);
+  });
+
+  it('should delay complete when a value is scheduled', () => {
+    const e1 =  cold('-a-|');
+    const t =   time('---|');
+    const expected = '----(a|)';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 

--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -1,5 +1,5 @@
-import { of } from 'rxjs';
-import { delay, repeatWhen, skip, take, tap, mergeMap } from 'rxjs/operators';
+import { of, concat } from 'rxjs';
+import { delay, repeatWhen, skip, take, tap, mergeMap, ignoreElements } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
@@ -185,5 +185,20 @@ describe('delay operator', () => {
     );
 
     expectObservable(result).toBe(expected);
+  });
+
+  it('should be possible to delay complete by composition', () => {
+    const e1 =   hot('---a--b--|  ');
+    const t =   time(   '--|      ');
+    const expected = '-----a--b--|';
+    const subs =     '^        !  ';
+
+    const result = concat(
+      e1.pipe(delay(t, rxTestScheduler)),
+      of(undefined).pipe(delay(t, rxTestScheduler), ignoreElements()),
+    );
+
+    expectObservable(result).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 });

--- a/spec/operators/mergeScan-spec.ts
+++ b/spec/operators/mergeScan-spec.ts
@@ -320,7 +320,7 @@ describe('mergeScan', () => {
   it('should emit accumulator if inner completes without value after source completes', () => {
     const e1 = hot('--a--^--b--c--d--e--f--g--|');
     const e1subs =      '^                    !';
-    const expected =    '-----------------------(x|)';
+    const expected =    '---------------------(x|)';
 
     const source = e1.pipe(
       mergeScan((acc, x) => EMPTY.delay(50, rxTestScheduler), ['1'])

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -376,7 +376,7 @@ describe('TestScheduler', () => {
         const output = cold('-a|').pipe(
           delay(1000 * 10)
         );
-        const expected = '   - 10s a|';
+        const expected = '   - 10s (a|)';
         expectObservable(output).toBe(expected);
       });
     });

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -97,6 +97,9 @@ class DelaySubscriber<T> extends Subscriber<T> {
     if (queue.length > 0) {
       const delay = Math.max(0, queue[0].time - scheduler.now());
       this.schedule(state, delay);
+    } else if (source.isStopped) {
+      source.destination.complete();
+      source.active = false;
     } else {
       this.unsubscribe();
       source.active = false;
@@ -143,7 +146,9 @@ class DelaySubscriber<T> extends Subscriber<T> {
   }
 
   protected _complete() {
-    this.scheduleNotification(Notification.createComplete());
+    if (this.queue.length === 0) {
+      this.destination.complete();
+    }
     this.unsubscribe();
   }
 }


### PR DESCRIPTION
**Description:**
This is an attempt to fix #4249. `delay` will now emit complete notification as soon as possible. This means that if there are no values queued it'll emit immediately. If there are queued values then it'll emit complete right after the last scheduled value.

Since complete shouldn't be delayed I'm not even adding it into the queue which means complete might be sent in the same frame as the last value. For this reason I had to change this test https://github.com/ReactiveX/rxjs/compare/master...martinsik:fix-4249?expand=1#diff-dd8d0ea30be1698896e447581ec91fffR379

**Related issue (if exists):**
This is a breaking change although probably not many people rely on this behavior.
Closes #4249