### PR TITLE
fix(WebSocketSubject): fix subject failing to close socket

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -143,6 +143,34 @@ describe('webSocket', () => {
       (<any>socket.close).restore();
     });
 
+    it('should close the socket when unsubscribed before socket open', () => {
+      const subject = webSocket<string>('ws://mysocket');
+      subject.subscribe();
+      subject.unsubscribe();
+      const socket = MockWebSocket.lastSocket;
+      sinon.spy(socket, 'close');
+      socket.open();
+
+      expect(socket.close).have.been.called;
+      expect(socket.readyState).to.equal(3); // closed
+
+      (<any>socket.close).restore();
+    });
+
+    it('should close the socket when subscription is cancelled before socket open', () => {
+      const subject = webSocket<string>('ws://mysocket');
+      const subscription = subject.subscribe();
+      subscription.unsubscribe();
+      const socket = MockWebSocket.lastSocket;
+      sinon.spy(socket, 'close');
+      socket.open();
+
+      expect(socket.close).have.been.called;
+      expect(socket.readyState).to.equal(3); // closed
+
+      (<any>socket.close).restore();
+    });
+
     it('should close the socket with a code and a reason when errored', () => {
       const subject = webSocket<string>('ws://mysocket');
       subject.subscribe();

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -187,6 +187,12 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     });
 
     socket.onopen = (e: Event) => {
+      const { _socket } = this;
+      if (!_socket) {
+        socket.close();
+        this._resetState();
+        return;
+      }
       const { openObserver } = this._config;
       if (openObserver) {
         openObserver.next(e);
@@ -285,14 +291,11 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   }
 
   unsubscribe() {
-    const { source, _socket } = this;
+    const { _socket } = this;
     if (_socket && _socket.readyState === 1) {
       _socket.close();
-      this._resetState();
     }
+    this._resetState();
     super.unsubscribe();
-    if (!source) {
-      this.destination = new ReplaySubject();
-    }
   }
 }


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Fix WebSocketSubject failing to close the underlying socket connection when it is unsubscribed
before the socket is in the open state. Currently, when unsubscribe is called on the subject or
when a subscription is unsubscribed there are checks on whether the socket is open (readyState = 1)
before it closes the connection. If unsubscribe is called before the connection is open, it will not
close the socket but will reset the state of the subject (_socket set to null), and it becomes
impossible to close the socket.

**Related issue (if exists):** #4447 