### PR TITLE
chore(typings): add missing multicast signatures

### DIFF
--- a/spec-dtslint/operators/multicast-spec.ts
+++ b/spec-dtslint/operators/multicast-spec.ts
@@ -11,25 +11,27 @@ it('should be possible to use a this with in a SubjectFactory', () => {
 });
 
 it('should be possible to use a selector', () => {
-  const p = of(1, 2, 3).pipe(multicast(() => new Subject<number>(), p => p)); // $ExpectType Observable<number>
-  const o = of(1, 2, 3).pipe(multicast(() => new Subject<number>(), p => of('foo'))); // $ExpectType Observable<string>
+  const o = of(1, 2, 3).pipe(multicast(new Subject<number>(), p => p)); // $ExpectType Observable<number>
+  const p = of(1, 2, 3).pipe(multicast(new Subject<number>(), p => of('foo'))); // $ExpectType Observable<string>
+  const q = of(1, 2, 3).pipe(multicast(() => new Subject<number>(), p => p)); // $ExpectType Observable<number>
+  const r = of(1, 2, 3).pipe(multicast(() => new Subject<number>(), p => of('foo'))); // $ExpectType Observable<string>
 });
 
 it('should enforce types', () => {
   const p = of(1, 2, 3).pipe(multicast()); // $ExpectError
 });
 
+it('should enforce Subject type', () => {
+  const o = of(1, 2, 3).pipe(multicast('foo')); // $ExpectError
+  const p = of(1, 2, 3).pipe(multicast(new Subject<string>())); // $ExpectError
+});
+
 it('should enforce SubjectFactory type', () => {
   const p = of(1, 2, 3).pipe(multicast('foo')); // $ExpectError
   const q = of(1, 2, 3).pipe(multicast(() => new Subject<string>())); // $ExpectError
-  const r = of(1, 2, 3).pipe(multicast(new Subject<number>(), p => p)); // $ExpectError
 });
 
-it('should enforce the type', () => {
+it('should enforce the selector type', () => {
   const o = of(1, 2, 3).pipe(multicast(() => new Subject<number>(), 5)); // $ExpectError
   const p = of(1, 2, 3).pipe(multicast(() => new Subject<number>(), (p: string) => 5)); // $ExpectError
-});
-
-it('should enfore the use of `this`', () => {
-  const o = of(1, 2, 3).pipe(multicast(function(foo: Observable<number>) { return new Subject<number>(); })); // $ExpectError
 });

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -199,7 +199,7 @@ describe('retry operator', () => {
 
     of(1, 2, 3).pipe(
       concat(throwError('bad!')),
-      multicast(() => new Subject()),
+      multicast(() => new Subject<number>()),
       refCount(),
       retry(4)
     ).subscribe(

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -3,10 +3,12 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { ConnectableObservable, connectableObservableDescriptor } from '../observable/ConnectableObservable';
-import { FactoryOrValue, MonoTypeOperatorFunction, OperatorFunction, UnaryFunction } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, UnaryFunction } from '../types';
 
 /* tslint:disable:max-line-length */
-export function multicast<T>(subjectOrSubjectFactory: FactoryOrValue<Subject<T>>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
+export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
+export function multicast<T>(subject: Subject<T>, selector?: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
+export function multicast<T, R>(subject: Subject<T>, selector?: OperatorFunction<T, R>): OperatorFunction<T, R>;
 export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
 export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: OperatorFunction<T, R>): OperatorFunction<T, R>;

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -9,7 +9,6 @@ import { FactoryOrValue, MonoTypeOperatorFunction, OperatorFunction, UnaryFuncti
 export function multicast<T>(subjectOrSubjectFactory: FactoryOrValue<Subject<T>>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export function multicast<T>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
-export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<R>>;
 export function multicast<T, R>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector?: OperatorFunction<T, R>): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds the missing `multicast` signatures mentioned in #4451. And removes an unnecessary signature that allowed the type of the returned observable to be specified explicitly in situations in which the returned observable's type would always be that of the source observable.

It's arguable that the added signatures are for situations that are not best-suited to using a subject rather than a factory, but that's not something that should be enforced by the type system, as the implementation allows it.

**Related issue (if exists):** #4451