### PR TITLE
fix(ajax): Fix case-insensitive headers in HTTP request

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -600,6 +600,26 @@ describe('ajax', () => {
       expect(MockXMLHttpRequest.mostRecent.data).to.equal('{"🌟":"🚀"}');
     });
 
+    it('should send json body not mattered on case-sensitivity of HTTP headers', () => {
+      const body = {
+        hello: 'world'
+      };
+
+      const requestObj = {
+        url: '/flibbertyJibbet',
+        method: '',
+        body: body,
+        headers: {
+          'cOnTeNt-TyPe': 'application/json; charset=UTF-8'
+        }
+      };
+
+      ajax(requestObj).subscribe();
+
+      expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
+      expect(MockXMLHttpRequest.mostRecent.data).to.equal('{"hello":"world"}');
+    });
+
     it('should error if send request throws', (done: MochaDone) => {
       const expected = new Error('xhr send failure');
 

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -202,17 +202,18 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
     const headers = request.headers = request.headers || {};
 
     // force CORS if requested
-    if (!request.crossDomain && !headers['X-Requested-With']) {
+    if (!request.crossDomain && !this.getHeader(headers, 'X-Requested-With')) {
       headers['X-Requested-With'] = 'XMLHttpRequest';
     }
 
     // ensure content type is set
-    if (!('Content-Type' in headers) && !(root.FormData && request.body instanceof root.FormData) && typeof request.body !== 'undefined') {
+    let contentTypeHeader = this.getHeader(headers, 'Content-Type');
+    if (!contentTypeHeader && !(root.FormData && request.body instanceof root.FormData) && typeof request.body !== 'undefined') {
       headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
     }
 
     // properly serialize body
-    request.body = this.serializeBody(request.body, request.headers['Content-Type']);
+    request.body = this.serializeBody(request.body, this.getHeader(request.headers, 'Content-Type'));
 
     this.send();
   }
@@ -313,6 +314,16 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
         xhr.setRequestHeader(key, headers[key]);
       }
     }
+  }
+
+  private getHeader(headers: {}, headerName: string): any {
+    for (let key in headers) {
+      if (key.toLowerCase() === headerName.toLowerCase()) {
+        return headers[key];
+      }
+    }
+
+    return undefined;
   }
 
   private setupEvents(xhr: XMLHttpRequest, request: AjaxRequest) {


### PR DESCRIPTION
**Description:**
In RFC 7230 and RFC 7540 is written, that HTTP headers is case-insensitive, so this is fix for correct serializing request body based on HTTP headers.