### PR TITLE
comparor ->comparer

### DIFF
--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -8,7 +8,7 @@ import { errorObject } from '../util/errorObject';
 import { Observer, OperatorFunction } from '../types';
 
 /**
- * Compares all values of two observables in sequence using an optional comparer function
+ * Compares all values of two observables in sequence using an optional comparator function
  * and returns an observable of a single boolean value representing whether or not the two sequences
  * are equal.
  *
@@ -55,24 +55,24 @@ import { Observer, OperatorFunction } from '../types';
  * @see {@link withLatestFrom}
  *
  * @param {Observable} compareTo The observable sequence to compare the source sequence to.
- * @param {function} [comparer] An optional function to compare each value pair
+ * @param {function} [comparator] An optional function to compare each value pair
  * @return {Observable} An Observable of a single boolean value representing whether or not
  * the values emitted by both observables were equal in sequence.
  * @method sequenceEqual
  * @owner Observable
  */
 export function sequenceEqual<T>(compareTo: Observable<T>,
-                                 comparer?: (a: T, b: T) => boolean): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) => source.lift(new SequenceEqualOperator(compareTo, comparer));
+                                 comparator?: (a: T, b: T) => boolean): OperatorFunction<T, boolean> {
+  return (source: Observable<T>) => source.lift(new SequenceEqualOperator(compareTo, comparator));
 }
 
 export class SequenceEqualOperator<T> implements Operator<T, boolean> {
   constructor(private compareTo: Observable<T>,
-              private comparer: (a: T, b: T) => boolean) {
+              private comparator: (a: T, b: T) => boolean) {
   }
 
   call(subscriber: Subscriber<boolean>, source: any): any {
-    return source.subscribe(new SequenceEqualSubscriber(subscriber, this.compareTo, this.comparer));
+    return source.subscribe(new SequenceEqualSubscriber(subscriber, this.compareTo, this.comparator));
   }
 }
 
@@ -88,7 +88,7 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
 
   constructor(destination: Observer<R>,
               private compareTo: Observable<T>,
-              private comparer: (a: T, b: T) => boolean) {
+              private comparator: (a: T, b: T) => boolean) {
     super(destination);
     (this.destination as Subscription).add(compareTo.subscribe(new SequenceEqualCompareToSubscriber(destination, this)));
   }
@@ -112,13 +112,13 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
   }
 
   checkValues() {
-    const { _a, _b, comparer } = this;
+    const { _a, _b, comparator } = this;
     while (_a.length > 0 && _b.length > 0) {
       let a = _a.shift();
       let b = _b.shift();
       let areEqual = false;
-      if (comparer) {
-        areEqual = tryCatch(comparer)(a, b);
+      if (comparator) {
+        areEqual = tryCatch(comparator)(a, b);
         if (areEqual === errorObject) {
           this.destination.error(errorObject.e);
         }

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -8,7 +8,7 @@ import { errorObject } from '../util/errorObject';
 import { Observer, OperatorFunction } from '../types';
 
 /**
- * Compares all values of two observables in sequence using an optional comparor function
+ * Compares all values of two observables in sequence using an optional comparer function
  * and returns an observable of a single boolean value representing whether or not the two sequences
  * are equal.
  *
@@ -55,24 +55,24 @@ import { Observer, OperatorFunction } from '../types';
  * @see {@link withLatestFrom}
  *
  * @param {Observable} compareTo The observable sequence to compare the source sequence to.
- * @param {function} [comparor] An optional function to compare each value pair
+ * @param {function} [comparer] An optional function to compare each value pair
  * @return {Observable} An Observable of a single boolean value representing whether or not
  * the values emitted by both observables were equal in sequence.
  * @method sequenceEqual
  * @owner Observable
  */
 export function sequenceEqual<T>(compareTo: Observable<T>,
-                                 comparor?: (a: T, b: T) => boolean): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) => source.lift(new SequenceEqualOperator(compareTo, comparor));
+                                 comparer?: (a: T, b: T) => boolean): OperatorFunction<T, boolean> {
+  return (source: Observable<T>) => source.lift(new SequenceEqualOperator(compareTo, comparer));
 }
 
 export class SequenceEqualOperator<T> implements Operator<T, boolean> {
   constructor(private compareTo: Observable<T>,
-              private comparor: (a: T, b: T) => boolean) {
+              private comparer: (a: T, b: T) => boolean) {
   }
 
   call(subscriber: Subscriber<boolean>, source: any): any {
-    return source.subscribe(new SequenceEqualSubscriber(subscriber, this.compareTo, this.comparor));
+    return source.subscribe(new SequenceEqualSubscriber(subscriber, this.compareTo, this.comparer));
   }
 }
 
@@ -88,7 +88,7 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
 
   constructor(destination: Observer<R>,
               private compareTo: Observable<T>,
-              private comparor: (a: T, b: T) => boolean) {
+              private comparer: (a: T, b: T) => boolean) {
     super(destination);
     (this.destination as Subscription).add(compareTo.subscribe(new SequenceEqualCompareToSubscriber(destination, this)));
   }
@@ -112,13 +112,13 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
   }
 
   checkValues() {
-    const { _a, _b, comparor } = this;
+    const { _a, _b, comparer } = this;
     while (_a.length > 0 && _b.length > 0) {
       let a = _a.shift();
       let b = _b.shift();
       let areEqual = false;
-      if (comparor) {
-        areEqual = tryCatch(comparor)(a, b);
+      if (comparer) {
+        areEqual = tryCatch(comparer)(a, b);
         if (areEqual === errorObject) {
           this.destination.error(errorObject.e);
         }


### PR DESCRIPTION
replace comparor with comparer

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
mistake spell comparer to comparor