### PR TITLE
docs(operators): variable interval rename to i

### DIFF
--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -26,9 +26,9 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Tick every second until the first click happens
  * ```javascript
- * const interval = interval(1000);
+ * const i = interval(1000);
  * const clicks = fromEvent(document, 'click');
- * const result = interval.pipe(takeUntil(clicks));
+ * const result = i.pipe(takeUntil(clicks));
  * result.subscribe(x => console.log(x));
  * ```
  *

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -26,9 +26,9 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ## Example
  * Tick every second until the first click happens
  * ```javascript
- * const i = interval(1000);
+ * const source = interval(1000);
  * const clicks = fromEvent(document, 'click');
- * const result = i.pipe(takeUntil(clicks));
+ * const result = source.pipe(takeUntil(clicks));
  * result.subscribe(x => console.log(x));
  * ```
  *


### PR DESCRIPTION
in example the const interval(1000); will result in error. so rename interval to i

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
