### PR TITLE
docs(operators):correct example

### DIFF
--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -25,14 +25,14 @@ import { Operator } from '../Operator';
  * ## Example
  * In every window of 1 second each, emit at most 2 click events
  * ```javascript
- * const clicks = fromEvent(document, 'click');
- * const interval = interval(1000);
- * const result = clicks.pipe(
- *   window(interval),
- *   map(win => win.take(2)), // each window has at most 2 emissions
- *   mergeAll(),              // flatten the Observable-of-Observables
- * );
- * result.subscribe(x => console.log(x));
+ *  const clicks = fromEvent(document, 'click');
+ *  const sec = interval(1000);
+ *  const result = clicks.pipe(
+ *      window(sec),
+ *      map(win => win.pipe(take(2))), // each window has at most 2 emissions
+ *      mergeAll(),              // flatten the Observable-of-Observables
+ *  );
+ *  result.subscribe(x => console.log(x));
  * ```
  * @see {@link windowCount}
  * @see {@link windowTime}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
