### PR TITLE
`async` decorator for observable-yielding generators

### DIFF
--- a/spec/observables/async-spec.ts
+++ b/spec/observables/async-spec.ts
@@ -1,0 +1,22 @@
+import { expect } from 'chai';
+import { of, async } from 'rxjs';
+
+// REVIEWER: Before I invest in writing more tests, I want to make sure I'm on
+// the right path to an accepted contribution.
+
+/** @test {async} */
+describe('async', () => {
+  it('should step through yielded observables', (done) => {
+    const f = async(function* (d) {
+      const a = yield ['a'];
+      const b = yield of('b');
+      const c = yield Promise.resolve('c');
+      return a + b + c + d;
+    });
+    const observable = f('d');
+    observable.subscribe((x) => {
+      expect(x).to.equal('abcd');
+      done();
+    });
+  });
+});

--- a/spec/observables/spawn-spec.ts
+++ b/spec/observables/spawn-spec.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { of, spawn } from 'rxjs';
+
+/** @test {spawn} */
+describe('spawn', () => {
+  it('should step through yielded observables', (done) => {
+    const spawned = spawn(function* () {
+      const a = yield ['a'];
+      const b = yield of('b');
+      const c = yield Promise.resolve('c');
+      return a + b + c;
+    });
+    spawned.subscribe((x) => {
+      expect(x).to.equal('abc');
+      done();
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,6 +40,7 @@ export { UnsubscriptionError } from './internal/util/UnsubscriptionError';
 export { TimeoutError } from './internal/util/TimeoutError';
 
 /* Static observable creation exports */
+export { async } from './internal/observable/async';
 export { bindCallback } from './internal/observable/bindCallback';
 export { bindNodeCallback } from './internal/observable/bindNodeCallback';
 export { combineLatest } from './internal/observable/combineLatest';
@@ -60,6 +61,7 @@ export { onErrorResumeNext } from './internal/observable/onErrorResumeNext';
 export { pairs } from './internal/observable/pairs';
 export { race } from './internal/observable/race';
 export { range } from './internal/observable/range';
+export { spawn } from './internal/observable/spawn';
 export { throwError } from './internal/observable/throwError';
 export { timer } from './internal/observable/timer';
 export { using } from './internal/observable/using';

--- a/src/internal/observable/async.ts
+++ b/src/internal/observable/async.ts
@@ -1,0 +1,184 @@
+import { Observable } from '../Observable';
+import { Observer } from '../types';
+import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
+import { from } from './from';
+import { take } from '../operators/take';
+
+// REVIEWER: These comments are addressed to the reviewer asking for guidance.
+// They must be removed before the code is approved.
+
+// REVIEWER: I am happy to change the name of this function to something less
+// "special". I've taken `async` from the popular decorator for
+// promise-yielding generator functions that predated async functions. If you
+// want a different name, please just prescribe one.
+
+// REVIEWER: I've left types off a few variables, not just for convenience, but
+// sometimes because I do not know how to declare the type in TypeScript.
+// Please show me how to type variables that need them.
+
+/**
+ * Turns a generator function into an observable constructor.
+ *
+ * `async` is a decorator for generator functions that yield observables (or
+ * anything that can be converted to an observable with `from`) on the way to
+ * returning a final value. `async` returns a new function that creates an
+ * observable instead of a generator object. That observable will yield
+ * at most one value, the final return value of the generator. It will
+ * subscribe to every yielded observable on the way, so that when it is
+ * unsubscribed, the intermediate observable will be unsubscribed, which is
+ * useful for canceling work like AJAX requests.
+ *
+ * ## Example
+ *
+ * ```javascript
+ * import { ajax } from 'rxjs/ajax'
+ * import { async } from 'rxjs/observable/async'
+ *
+ * const logIn = async(function* ({username, password}) {
+ *   try {
+ *     return { token: yield ajax.getJSON(...) };
+ *   } catch (error) {
+ *     return { error };
+ *   }
+ * })
+ *
+ * const observable = logIn() // Request not yet sent.
+ * const subscription = observable.subscribe( // Request sent now.
+ *   ({ value }) => console.log('token', value),
+ *   ({ error }) => console.error('error', error),
+ * )
+ * subscription.unsubscribe() // Request canceled.
+ * ```
+ *
+ * @param {(...args: Args) => Iterator<Observable<any> | T>} A generator
+ * function that yields intermediate observables on its way to returning
+ * a final value.
+ * @return {(...args: Args) => Observable<T>}
+ * @name async
+ */
+
+// REVIEWER: Is it ok to use non-single-letter type variables?
+// If not, please prescribe a replacement.
+export function async<T, Args extends any[]>(
+  f: (...args: Args) => Iterator<Observable<any> | T>,
+): (...args: Args) => Observable<T> {
+  // Return a function that constructs an Observable.
+  return function<This>(this: This, ...args: Args) {
+    return Observable.create((observer: Observer<T>) => {
+      const iterator = f.apply(this, args);
+      return new IteratorSubscriber(observer, iterator);
+    });
+  };
+}
+
+// This may seem like an implementation detail, but exporting it makes it much
+// easier to build a `flow` alternative for observables in MobX.
+// https://medium.com/@thejohnfreeman/escaping-pipeline-hell-38d962f66d31
+export class IteratorSubscriber<T> extends Subscriber<T> {
+  private subscription: Subscription | null;
+
+  public constructor(
+    observer: Observer<T>,
+    private iterator: Iterator<any>,
+  ) {
+    super(observer);
+    this.step('next');
+  }
+
+  private step(key: 'next' | 'throw' | 'return', arg?: T | Error): void {
+    // Unsubscribe now.
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+
+    let result;
+    try {
+      result = this.iterator[key](arg);
+    } catch (error) {
+      this.error(error);
+      return;
+    }
+
+    // `value` is either the generator's final return value of type `T`, or it
+    // is a yielded value that can be converted to an observable of type
+    // `Observable<any>` using `from`. Only the generator knows what type to
+    // expect from the observables it yields, and it may be a different type
+    // every time. The type is bound to the yield expression, not to the
+    // generator itself.
+    // REVIEWER: Is there a way to declare a type for `value`? How?
+    const { value, done } = result;
+
+    if (done) {
+      this.next(value);
+      this.complete();
+      return;
+    }
+
+    // We're going to create an observable from the value and `subscribe` to
+    // it. It is possible that our subscription's `next` method is called
+    // before `subscribe` returns the subscription. This happens for
+    // "synchronous" observables, e.g. arrays. In such cases, the `next`
+    // method will have already saved a subscription for an observable later
+    // in the generator's execution, and we don't want to override it with
+    // our subscription. Thus, we save our subscription to a temporary
+    // variable and copy it to `this.subscription` only after checking that
+    // it does not already hold another subscription.
+    //
+    // The observables proposal adds a `start` method to the `Observer` type
+    // that accepts the `Subscription` before `next`, `complete`, or `error`
+    // are ever called. That will solve our problem, but the implementation is
+    // not yet available in RxJS.
+    //
+    // Being able to cancel the subscription before it completes will let us
+    // stop counting values and lose the `take` operator. It will let us
+    // assume in our completion callback that no values have been sent.
+    //
+    // REVIEWER: I'm counting values as a defensive measure. This will affect
+    // performance slightly. Please let me know if you want these defensive
+    // measures removed.
+    let count = 0;
+    // REVIEWER: I'm using from here to build an `Observable` from an
+    // `ObservableInput`. Should I use something else?
+    const subscription = from(value)
+      .pipe(take(1))
+      .subscribe(
+        (value: any) => {
+          count += 1;
+          if (count > 1) {
+            // This means `take` failed to cancel our subscription before
+            // a second value was delivered.
+            // REVIEWER: Shouldn't this be unreachable? How should it be
+            // handled?
+            console.error('awaited observable returned too many values');
+          }
+          // Recurse.
+          this.step('next', value);
+        },
+        error => this.step('throw', error),
+        () => {
+          if (count < 1) {
+            // The observable completed without ever yielding a value to pass
+            // to the generator. This stops progress.
+            // REVIEWER: How should we handle this?
+            console.error('awaited observable completed with no value');
+          }
+          // If `count > 1`, that case was already handled in the `next`
+          // callback.
+        },
+      );
+    if (!this.subscription) {
+      this.subscription = subscription;
+    }
+  }
+
+  public unsubscribe() {
+    this.iterator = null;
+    if (this.subscription) {
+      this.subscription.unsubscribe();
+      this.subscription = null;
+    }
+    super.unsubscribe();
+  }
+}

--- a/src/internal/observable/async.ts
+++ b/src/internal/observable/async.ts
@@ -51,20 +51,20 @@ import { take } from '../operators/take';
  * subscription.unsubscribe() // Request canceled.
  * ```
  *
- * @param {(...args: Args) => Iterator<Observable<any> | T>} A generator
+ * @param {(...args: any[]) => Iterator<Observable<any> | T>} A generator
  * function that yields intermediate observables on its way to returning
  * a final value.
- * @return {(...args: Args) => Observable<T>}
+ * @return {(...args: any[]) => Observable<T>}
  * @name async
  */
 
 // REVIEWER: Is it ok to use non-single-letter type variables?
 // If not, please prescribe a replacement.
-export function async<T, Args extends any[]>(
-  f: (...args: Args) => Iterator<ObservableInput<any> | T>,
-): (...args: Args) => Observable<T> {
+export function async<T>(
+  f: (...args: any[]) => Iterator<ObservableInput<any> | T>,
+): (...args: any[]) => Observable<T> {
   // Return a function that constructs an Observable.
-  return function<This>(this: This, ...args: Args) {
+  return function<This>(this: This, ...args: any[]) {
     return Observable.create((observer: Observer<T>) => {
       const iterator = f.apply(this, args);
       return new IteratorSubscriber(observer, iterator);

--- a/src/internal/observable/async.ts
+++ b/src/internal/observable/async.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { Observer } from '../types';
+import { ObservableInput, Observer } from '../types';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { from } from './from';
@@ -61,7 +61,7 @@ import { take } from '../operators/take';
 // REVIEWER: Is it ok to use non-single-letter type variables?
 // If not, please prescribe a replacement.
 export function async<T, Args extends any[]>(
-  f: (...args: Args) => Iterator<Observable<any> | T>,
+  f: (...args: Args) => Iterator<ObservableInput<any> | T>,
 ): (...args: Args) => Observable<T> {
   // Return a function that constructs an Observable.
   return function<This>(this: This, ...args: Args) {

--- a/src/internal/observable/spawn.ts
+++ b/src/internal/observable/spawn.ts
@@ -1,3 +1,5 @@
+import { Observable } from '../Observable';
+import { ObservableInput } from '../types';
 import { async } from './async';
 
 // REVIEWER: Do I need to spell out every category of `ObservableInput`, or
@@ -36,6 +38,8 @@ import { async } from './async';
  * @returns {Observable<T>} An observable with the final value.
  * @name spawn
  */
-export function spawn(f: () => Iterator<any>) {
+export function spawn<T>(
+  f: () => Iterator<ObservableInput<any> | T>,
+): Observable<T> {
   return async(f)();
 }

--- a/src/internal/observable/spawn.ts
+++ b/src/internal/observable/spawn.ts
@@ -1,0 +1,41 @@
+import { async } from './async';
+
+// REVIEWER: Do I need to spell out every category of `ObservableInput`, or
+// can I just call them observables?
+
+/**
+ * Spawns a generator function which allows for Promises, Observable
+ * sequences, Arrays, Objects, Generators and functions.
+ *
+ * ## Example
+ *
+ * ```javascript
+ * import { of } from 'rxjs/observable/of'
+ * import { spawn } from 'rxjs/observable/spawn'
+ *
+ * const spawned = spawn(function* () {
+ *   const a = yield ['a'];
+ *   const b = yield of('b');
+ *   const c = yield Promise.resolve('c');
+ *   return a + b + c;
+ * });
+ *
+ * spawned.subscribe(
+ *   (x) => console.log('next %s', x),
+ *   (e) => console.log('error %s', e),
+ *   () => console.log('completed')
+ * );
+ *
+ * // Logs:
+ * // next 'abc'
+ * // completed
+ * ```
+ *
+ * @param {() => Iterator<ObservableInput<any> | T>} A generator function that
+ * yields intermediate observables on its way to returning a final value.
+ * @returns {Observable<T>} An observable with the final value.
+ * @name spawn
+ */
+export function spawn(f: () => Iterator<any>) {
+  return async(f)();
+}


### PR DESCRIPTION
A [longer version][] of the justification for this change is available online. In brief, we're missing the observable equivalent of async functions. Chaining operators like `map`, `filter`, and `catchError` with observables that yield a single value is as painful as chaining callbacks on promises. Async functions let us write asynchronous code in a synchronous style, which is easier to read, write, and comprehend. Short of native syntax like async/await, we can offer a decorator for generator functions.

[longer version]: https://medium.com/@thejohnfreeman/escaping-pipeline-hell-38d962f66d31

Note: A [limitation in TypeScript](https://github.com/Microsoft/TypeScript/issues/2983) prevents us from more accurately constraining the types of iterators/generators.

I started on the path of this contribution before reading the [suggestion](https://github.com/ReactiveX/rxjs/blob/master/doc/operator-creation.md) to create a separate library. My mistake. I figured it's worth a shot anyhow, and I'll make the effort to move it to a separate library if it is rejected here. If it is rejected, I would still appreciate any feedback you can offer. I've left comments in the code asking for specific feedback. I'd love to hear what kind of tests you'd like to see.

Fixes #1497