### PR TITLE
refactor(internal): remove unused import of root in symbol/observable

### DIFF
--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,5 +1,3 @@
-import { root } from '../util/root';
-
 /** Symbol.observable addition */
 /* Note: This will add Symbol.observable globally for all TypeScript users,
   however, we are no longer polyfilling Symbol.observable */


### PR DESCRIPTION
Just what is says. There's an unused import in the symbol/observable.ts file.