### PR TITLE
fix(bundle): closure to not rewrite polyfills for minification

### DIFF
--- a/tools/make-closure.js
+++ b/tools/make-closure.js
@@ -9,6 +9,7 @@ module.exports = function makeClosure(sourcePath) {
     jsCode: [{src: source}],
     languageIn: 'ES2015',
     createSourceMap: true,
+    rewritePolyfills: false,
   };
 
   var output = compiler(compilerFlags);


### PR DESCRIPTION
**Description:**
Sorry I've never been using umd bundle in a ES5 environment w/o external polyfill (i.e. `core-js`) already existed, am I right?
 
**Related issue (if exists):**
fixes: #4427