### PR TITLE
feat(distinctUntilKeyChanged): Added support for multiple keys (#4486)

### DIFF
--- a/spec/operators/distinctUntilKeyChanged-spec.ts
+++ b/spec/operators/distinctUntilKeyChanged-spec.ts
@@ -26,6 +26,16 @@ describe('distinctUntilKeyChanged operator', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should distinguish between values by multiple keys', () => {
+    const values = {a: {o: 1, k: 2}, b: {o: 1, k: 2, i: 3}, c: {o: 4, k: 2}, d: {o: 1, k: 5}};
+    const e1 =   hot('--a--b--a--c--c--d--|', values);
+    const e1subs =   '^                   !';
+    const expected = '--a--------c-----d--|';
+
+    expectObservable((<any>e1).pipe(distinctUntilKeyChanged(['o', 'k']))).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should distinguish between values and does not completes', () => {
     const values = {a: {val: 1}, b: {val: 2}};
     const e1 =   hot('--a--a--a--b--b--a-', values);

--- a/src/internal/operators/distinctUntilKeyChanged.ts
+++ b/src/internal/operators/distinctUntilKeyChanged.ts
@@ -2,8 +2,8 @@ import { distinctUntilChanged } from './distinctUntilChanged';
 import { MonoTypeOperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
-export function distinctUntilKeyChanged<T>(key: keyof T): MonoTypeOperatorFunction<T>;
-export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T>;
+export function distinctUntilKeyChanged<T>(key: keyof T | (keyof T)[]): MonoTypeOperatorFunction<T>;
+export function distinctUntilKeyChanged<T, K extends keyof T>(key: K | K[], compare: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -70,6 +70,7 @@ export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare: (
  * @method distinctUntilKeyChanged
  * @owner Observable
  */
-export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare?: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T> {
-  return distinctUntilChanged((x: T, y: T) => compare ? compare(x[key], y[key]) : x[key] === y[key]);
+export function distinctUntilKeyChanged<T, K extends keyof T>(key: K | K[], compare?: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T> {
+  const keys = [].concat(key);
+  return distinctUntilChanged((x: T, y: T) => keys.every(k => compare ? compare(x[k], y[k]) : x[k] === y[k]));
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Added support for multiple keys for `distinctUntilKeyChanged`. It's more often that you need to listen to multiple key changes than a single key change.

My knowledge is very limited with typescript but I managed to get it to work. I would probably need help to finish this PR.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/4486