### PR TITLE
fix(throttleTime): fix trailing

### DIFF
--- a/spec/operators/throttleTime-spec.ts
+++ b/spec/operators/throttleTime-spec.ts
@@ -152,6 +152,15 @@ describe('throttleTime operator', () => {
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
+    asDiagram('throttleTime(fn, { leading: true, trailing: true })')('should handle a busy producer emitting a regular repeating sequence', () =>  {
+      const e1 =   hot('abcdabcdabcdabcdabcd|');
+      const subs =     '^                   !';
+      const t =   time('----|               ');
+      const expected = 'a---a---a---a---a---(d|';
+
+      expectObservable(e1.pipe(throttleTime(t, rxTestScheduler, { leading: true, trailing: true }))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   describe('throttleTime(fn, { leading: false, trailing: true })', () => {

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -114,14 +114,15 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
   clearThrottle() {
     const throttled = this.throttled;
     if (throttled) {
+      throttled.unsubscribe();
+      this.remove(throttled);
+      this.throttled = null;
       if (this.trailing && this._hasTrailingValue) {
+        this.add(this.throttled = this.scheduler.schedule<DispatchArg<T>>(dispatchNext, this.duration, { subscriber: this }));
         this.destination.next(this._trailingValue);
         this._trailingValue = null;
         this._hasTrailingValue = false;
       }
-      throttled.unsubscribe();
-      this.remove(throttled);
-      this.throttled = null;
     }
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Emitting a trailing value should be counted as emitting a value.

[Commit that introduced bug](https://github.com/ReactiveX/rxjs/commit/bb0738f3e6df643158c4a7d1e38f035978b42882)

**Related issue (if exists):**
[#2859](https://github.com/ReactiveX/rxjs/issues/2859)