### PR TITLE
refactor: remove uses of `tryCatch` helper

### DIFF
--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -1,7 +1,5 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 
@@ -94,29 +92,25 @@ class DistinctUntilChangedSubscriber<T, K> extends Subscriber<T> {
   }
 
   protected _next(value: T): void {
-
-    const keySelector = this.keySelector;
-    let key: any = value;
-
-    if (keySelector) {
-      key = tryCatch(this.keySelector)(value);
-      if (key === errorObject) {
-        return this.destination.error(errorObject.e);
-      }
+    let key: any;
+    try {
+      const { keySelector } = this;
+      key = keySelector ? keySelector(value) : value;
+    } catch (err) {
+      return this.destination.error(err);
     }
-
-    let result: any = false;
-
+    let result = false;
     if (this.hasKey) {
-      result = tryCatch(this.compare)(this.key, key);
-      if (result === errorObject) {
-        return this.destination.error(errorObject.e);
+      try {
+        const { compare } = this;
+        result = compare(this.key, key);
+      } catch (err) {
+        return this.destination.error(err);
       }
     } else {
       this.hasKey = true;
     }
-
-    if (Boolean(result) === false) {
+    if (!result) {
       this.key = key;
       this.destination.next(value);
     }

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,8 +1,6 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 import { Subscription } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
@@ -126,15 +124,18 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
     const index = this.index++;
     if (this.active < this.concurrent) {
       destination.next(value);
-      let result = tryCatch(this.project)(value, index);
-      if (result === errorObject) {
-        destination.error(errorObject.e);
-      } else if (!this.scheduler) {
-        this.subscribeToProjection(result, value, index);
-      } else {
-        const state: DispatchArg<T, R> = { subscriber: this, result, value, index };
-        const destination = this.destination as Subscription;
-        destination.add(this.scheduler.schedule<DispatchArg<T, R>>(ExpandSubscriber.dispatch, 0, state));
+      try {
+        const { project } = this;
+        const result = project(value, index);
+        if (!this.scheduler) {
+          this.subscribeToProjection(result, value, index);
+        } else {
+          const state: DispatchArg<T, R> = { subscriber: this, result, value, index };
+          const destination = this.destination as Subscription;
+          destination.add(this.scheduler.schedule<DispatchArg<T, R>>(ExpandSubscriber.dispatch, 0, state));
+        }
+      } catch (e) {
+        destination.error(e);
       }
     } else {
       this.buffer.push(value);

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -2,8 +2,6 @@ import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
@@ -86,14 +84,16 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
   protected _next(value: any): void {
     if (this.active < this.concurrent) {
       const index = this.index++;
-      const ish = tryCatch(this.accumulator)(this.acc, value);
       const destination = this.destination;
-      if (ish === errorObject) {
-        destination.error(errorObject.e);
-      } else {
-        this.active++;
-        this._innerSub(ish, value, index);
+      let ish;
+      try {
+        const { accumulator } = this;
+        ish = accumulator(this.acc, value);
+      } catch (e) {
+        return destination.error(e);
       }
+      this.active++;
+      this._innerSub(ish, value, index);
     } else {
       this.buffer.push(value);
     }

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -3,8 +3,6 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
@@ -113,8 +111,11 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private subscribeToRetries() {
     this.notifications = new Subject();
-    const retries = tryCatch(this.notifier)(this.notifications);
-    if (retries === errorObject) {
+    let retries;
+    try {
+      const { notifier } = this;
+      retries = notifier(this.notifications);
+    } catch (e) {
       return super.complete();
     }
     this.retries = retries;

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -3,8 +3,6 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
@@ -66,9 +64,11 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
       if (!retries) {
         errors = new Subject();
-        retries = tryCatch(this.notifier)(errors);
-        if (retries === errorObject) {
-          return super.error(errorObject.e);
+        try {
+          const { notifier } = this;
+          retries = notifier(errors);
+        } catch (e) {
+          return super.error(e);
         }
         retriesSubscription = subscribeToResult(this, retries);
       } else {

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -2,8 +2,6 @@ import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 
 import { Observer, OperatorFunction } from '../types';
 
@@ -117,13 +115,10 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
       let a = _a.shift();
       let b = _b.shift();
       let areEqual = false;
-      if (comparator) {
-        areEqual = tryCatch(comparator)(a, b);
-        if (areEqual === errorObject) {
-          this.destination.error(errorObject.e);
-        }
-      } else {
-        areEqual = a === b;
+      try {
+        areEqual = comparator ? comparator(a, b) : a === b;
+      } catch (e) {
+        this.destination.error(e);
       }
       if (!areEqual) {
         this.emit(false);

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -3,8 +3,6 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
@@ -158,29 +156,28 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
              innerSub: InnerSubscriber<T, any>): void {
 
     if (outerValue === this.openings) {
-
-      const { closingSelector } = this;
-      const closingNotifier = tryCatch(closingSelector)(innerValue);
-
-      if (closingNotifier === errorObject) {
-        return this.error(errorObject.e);
-      } else {
-        const window = new Subject<T>();
-        const subscription = new Subscription();
-        const context = { window, subscription };
-        this.contexts.push(context);
-        const innerSubscription = subscribeToResult(this, closingNotifier, context as any);
-
-        if (innerSubscription.closed) {
-          this.closeWindow(this.contexts.length - 1);
-        } else {
-          (<any> innerSubscription).context = context;
-          subscription.add(innerSubscription);
-        }
-
-        this.destination.next(window);
-
+      let closingNotifier;
+      try {
+        const { closingSelector } = this;
+        closingNotifier = closingSelector(innerValue);
+      } catch (e) {
+        return this.error(e);
       }
+
+      const window = new Subject<T>();
+      const subscription = new Subscription();
+      const context = { window, subscription };
+      this.contexts.push(context);
+      const innerSubscription = subscribeToResult(this, closingNotifier, context as any);
+
+      if (innerSubscription.closed) {
+        this.closeWindow(this.contexts.length - 1);
+      } else {
+        (<any>innerSubscription).context = context;
+        subscription.add(innerSubscription);
+      }
+
+      this.destination.next(window);
     } else {
       this.closeWindow(this.contexts.indexOf(outerValue));
     }

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -3,8 +3,6 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
-import { tryCatch } from '../util/tryCatch';
-import { errorObject } from '../util/errorObject';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
@@ -132,13 +130,15 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     const window = this.window = new Subject<T>();
     this.destination.next(window);
 
-    const closingNotifier = tryCatch(this.closingSelector)();
-    if (closingNotifier === errorObject) {
-      const err = errorObject.e;
-      this.destination.error(err);
-      this.window.error(err);
-    } else {
-      this.add(this.closingNotification = subscribeToResult(this, closingNotifier));
+    let closingNotifier;
+    try {
+      const { closingSelector } = this;
+      closingNotifier = closingSelector();
+    } catch (e) {
+      this.destination.error(e);
+      this.window.error(e);
+      return;
     }
+    this.add(this.closingNotification = subscribeToResult(this, closingNotifier));
   }
 }


### PR DESCRIPTION
The `tryCatch` helper is a leftover from the CrankshaftScript days and
is considered bad practice for modern JavaScript engines. Same for the
`errorObject` trick.