### PR TITLE
perf(internal): use strict equality for isObject()

### DIFF
--- a/src/internal/util/isObject.ts
+++ b/src/internal/util/isObject.ts
@@ -1,3 +1,3 @@
 export function isObject(x: any): x is Object {
-  return x != null && typeof x === 'object';
+  return x !== null && typeof x === 'object';
 }


### PR DESCRIPTION
In `isObject(x)` use triple equal instead of double equal comparison
with `null`, since `undefined` will be ruled out via the `typeof`, and
therefore it's sufficient to just check for `null` initially.