### PR TITLE
fix(fromEventPattern): improve typings for fromEventPattern

### DIFF
--- a/src/internal/observable/fromEventPattern.ts
+++ b/src/internal/observable/fromEventPattern.ts
@@ -1,13 +1,13 @@
 import { Observable } from '../Observable';
 import { isArray } from '../util/isArray';
 import { isFunction } from '../util/isFunction';
-import { fromEvent } from './fromEvent';
+import { NodeEventHandler } from './fromEvent';
 import { map } from '../operators/map';
 
 /* tslint:disable:max-line-length */
-export function fromEventPattern<T>(addHandler: (handler: Function) => any, removeHandler?: (handler: Function, signal?: any) => void): Observable<T>;
+export function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any, removeHandler?: (handler: NodeEventHandler, signal?: any) => void): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function fromEventPattern<T>(addHandler: (handler: Function) => any, removeHandler?: (handler: Function, signal?: any) => void, resultSelector?: (...args: any[]) => T): Observable<T>;
+export function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any, removeHandler?: (handler: NodeEventHandler, signal?: any) => void, resultSelector?: (...args: any[]) => T): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -132,8 +132,8 @@ export function fromEventPattern<T>(addHandler: (handler: Function) => any, remo
  * @owner Observable
  */
 
-export function fromEventPattern<T>(addHandler: (handler: Function) => any,
-                                    removeHandler?: (handler: Function, signal?: any) => void,
+export function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any,
+                                    removeHandler?: (handler: NodeEventHandler, signal?: any) => void,
                                     resultSelector?: (...args: any[]) => T): Observable<T | T[]> {
 
   if (resultSelector) {


### PR DESCRIPTION
The handler in fromEventPattern is typed as a Function, meaning it takes no arguments. Overwriting this requires a pretty awkward cast. By applying the same change as in https://github.com/ReactiveX/rxjs/pull/3530 this becomes a lot easier.
