### PR TITLE
fix(compat): remove internal from import locations

### DIFF
--- a/compat/Observable.ts
+++ b/compat/Observable.ts
@@ -1,2 +1,2 @@
-export {Observable} from 'rxjs/internal/Observable';
-export {Subscribable, SubscribableOrPromise, ObservableInput} from 'rxjs/internal/types';
+export {Observable} from 'rxjs';
+export {Subscribable, SubscribableOrPromise, ObservableInput} from 'rxjs';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes the problem reported in #4070 by removing `internal` from the import locations within `compat/Observable.ts`. Note that *no other import locations* within `compat` include `internal`.

For more information:

* [this comment](https://github.com/ReactiveX/rxjs/issues/4070#issuecomment-428075235) shows the commit that introduced the problem; and
* [this comment](https://github.com/ReactiveX/rxjs/issues/4070#issuecomment-428901656) explains how the problem is effected in Angular-CLI projects.

**Related issue (if exists):** #4070