### PR TITLE
docs(README): remove mention of info script

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,8 +112,6 @@ range(1, 200).pipe(
 - `npm test` - runs tests
 - `npm run test_no_cache` - run test with `ts-node` set to false
 
-`npm run info` will list available scripts (there are a lot LOL)
-
 ## Performance Tests
 
 Run `npm run build_perf` or `npm run perf` to run the performance tests with `protractor`.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Remove the mention of `npm run info`, as that script was removed in #3587.

**Related issue (if exists):** #4503
