### PR TITLE
feat(docs) add doc for `timeinterval` operator

### DIFF
--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -6,6 +6,42 @@ import { scan } from './scan';
 import { defer } from '../observable/defer';
 import { map } from './map';
 
+/**
+ *
+ * emit time interval between current value with last value
+ *
+ *
+ * ![](timeinterval.png)
+ *
+ * `timeinterval` operator accepts as an argument as the Scheduler, default value is Scheduler.async
+ *
+ * ## Examples
+ * emit inteval between current value with the last value
+ *
+ * ```javascript
+ * const seconds = interval(1000);
+ *
+ * seconds.pipe(timeinterval())
+ * .subscribe(
+ *     value => console.log(value),
+ *     err => console.log(err),
+ * );
+ *
+ * seconds.pipe(timeout(900))
+ * .subscribe(
+ *     value => console.log(value),
+ *     err => console.log(err),
+ * );
+ * // {value: 0, interval: 1001}
+ * // {value: 1, interval: 1003}
+ * // {value: 2, interval: 997}
+ * ```
+ *
+ * @param {SchedulerLike} [scheduler] Scheduler controlling when timeout checks occur.
+ * @return {Observable<T>} Observable that emit infomation about value and interval
+ * @method timeInterval
+ * @owner Observable
+ */
 export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunction<T, TimeInterval<T>> {
   return (source: Observable<T>) => defer(() => {
     return source.pipe(

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -9,7 +9,7 @@ import { map } from './map';
 /**
  *
  * Emits an object containing the current value, and the time that has
- * passed between emitting the current value and the previous value, which is 
+ * passed between emitting the current value and the previous value, which is
  * calculated by using the provided `scheduler`'s `now()` method to retrieve
  * the current time at each emission, then calculating the difference. The `scheduler`
  * defaults to {@link asyncScheduler}, so by default, the `interval` will be in


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
add documentation for operator `timeInterval`
**Related issue (if exists):**
