### PR TITLE
Backport #4487 from master to v5

### DIFF
--- a/tools/make-closure-core.js
+++ b/tools/make-closure-core.js
@@ -7,6 +7,7 @@ var compilerFlags = {
   jsCode: [{src: source}],
   languageIn: 'ES2015',
   createSourceMap: true,
+  rewritePolyfills: false,
 };
 
 var output = compiler(compilerFlags);


### PR DESCRIPTION
The latest v5 (https://unpkg.com/rxjs@5/bundles/Rx.min.js) has the same problem.