### PR TITLE
test(from): comment out test that dtslint is confused about

### DIFF
--- a/spec-dtslint/observables/from-spec.ts
+++ b/spec-dtslint/observables/from-spec.ts
@@ -49,7 +49,7 @@ it('should accept an array of Observables', () => {
 //     yield 42;
 //   }());
 
-//   const o = from([of(1), ['test'], iterable]); // $ExpectType Observable<IterableIterator<number> | Observable<number> | string[]>
+//   const o = from([of(1), ['test'], iterable]); // $__TODO__ExpectType Observable<IterableIterator<number> | Observable<number> | string[]>
 // });
 
 it('should support scheduler', () => {

--- a/spec-dtslint/observables/from-spec.ts
+++ b/spec-dtslint/observables/from-spec.ts
@@ -36,13 +36,21 @@ it('should accept an array of Observables', () => {
   const o = from([of(1), of(2), of(3)]); // $ExpectType Observable<Observable<number>>
 });
 
-it('should accept an array of Inputs', () => {
-  const iterable = (function*() {
-    yield 42;
-  }());
+// TODO(benlesh): enable this test, once the issue is resolved upstream
 
-  const o = from([of(1), ['test'], iterable]); // $ExpectType Observable<IterableIterator<number> | Observable<number> | string[]>
-});
+// NOTE: It appears to be working, it's just that dtslint sometimes says it wants
+// Observable<IterableIterator<number> | Observable<number> | string[]>
+// and if you switch it to that, it wants
+// Observable<Observable<number> | IterableIterator<number> | string[]>
+// and vica versa.
+
+// it('should accept an array of Inputs', () => {
+//   const iterable = (function*() {
+//     yield 42;
+//   }());
+
+//   const o = from([of(1), ['test'], iterable]); // $ExpectType Observable<IterableIterator<number> | Observable<number> | string[]>
+// });
 
 it('should support scheduler', () => {
   const a = from([1, 2, 3], animationFrameScheduler); // $ExpectType Observable<number>

--- a/spec-dtslint/observables/from-spec.ts
+++ b/spec-dtslint/observables/from-spec.ts
@@ -36,7 +36,7 @@ it('should accept an array of Observables', () => {
   const o = from([of(1), of(2), of(3)]); // $ExpectType Observable<Observable<number>>
 });
 
-// TODO(benlesh): enable this test, once the issue is resolved upstream
+// TODO(benlesh): enable this test, once the issue is resolved upstream (https://github.com/Microsoft/dtslint/issues/191)
 
 // NOTE: It appears to be working, it's just that dtslint sometimes says it wants
 // Observable<IterableIterator<number> | Observable<number> | string[]>


### PR DESCRIPTION
There's one dtslint test that is failing no matter what you do, and it really shouldn't be failing. This just comments it out until it's resolved upstream (hopefully).