### PR TITLE
docs(link): update link to documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -129,7 +129,7 @@ from the main (upstream) repository:
 - The folder `docs-app` contains everything you need for building and developing the docs
 - the folder `doc` used to be the documentation, but should remain until all content is transferred.
 - The [Documentation README](docs_app/README.md) will support you
-- After a PR is merged to master the docs will be published to https://rxjs-dev.firebaseapp.com/
+- After a PR is merged to master the docs will be published to https://rxjs.dev/
 
 ## Unit Tests
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Reactive Extensions Library for JavaScript. This is a rewrite of [Reactive-Exten
 - [Contribution Guidelines](CONTRIBUTING.md)
 - [Maintainer Guidelines](doc/maintainer-guidelines.md)
 - [Creating Operators](doc/operator-creation.md)
-- [API Documentation (WIP)](https://rxjs-dev.firebaseapp.com/)
+- [API Documentation (WIP)](https://rxjs.dev/)
 
 ## Versions In This Repository
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Update link to documentation

**Related issue (if exists):**
Closes #4517 

There are a couple of more places where `rxjs-dev.firebaseapp.com` is used:

* [sitemap.template.xml](https://github.com/ReactiveX/rxjs/blob/master/docs_app/tools/transforms/templates/sitemap.template.xml)
* [publish-docs.sh](https://github.com/ReactiveX/rxjs/blob/master/docs_app/scripts/publish-docs.sh)

but I'm not sure if I'm the right person to make changes there :)
