### PR TITLE
chore(typings): fix iif observable typings for optional parameters (#…

### DIFF
--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -90,7 +90,10 @@ import { SubscribableOrPromise } from '../types';
  * @static true
  * @name iif
  * @owner Observable
- */
+*/
+/* tslint:disable:max-line-length */
+export function iif<T = never, F = never>(condition: () => boolean, trueResult?: SubscribableOrPromise<T>, falseResult?: SubscribableOrPromise<F>): Observable<T | F>;
+/* tslint:enable:max-line-length */
 export function iif<T, F>(
   condition: () => boolean,
   trueResult: SubscribableOrPromise<T> = EMPTY,


### PR DESCRIPTION
**Description:**
Fix typings for `iif` observable inference error when optional parameters are not supplied.

**Related issue (if exists):** #4494 
