### PR TITLE
Remove manual serialization of payload.

### DIFF
--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -66,7 +66,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * subscribes and unsubscribes. Server can use them to verify that some kind of messages should start or stop
  * being forwarded to the client. In case of the above example application, after getting subscription message with proper identifier,
  * gateway server can decide that it should connect to real sport news service and start forwarding messages from it.
- * Note that both messages will be sent as returned by the functions, meaning they will have to be serialized manually, just
+ * Note that both messages will be sent as returned by the functions, they are by default serialized using JSON.stringify, just
  * as messages pushed via `next`. Also bear in mind that these messages will be sent on *every* subscription and
  * unsubscription. This is potentially dangerous, because one consumer of an Observable may unsubscribe and the server
  * might stop sending messages, since it got unsubscription message. This needs to be handled
@@ -103,8 +103,8 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * // Note that at least one consumer has to subscribe to the created subject - otherwise "nexted" values will be just buffered and not sent,
  * // since no connection was established!
  *
- * subject.next(JSON.stringify({message: 'some message'}));
- * // This will send a message to the server once a connection is made. Remember to serialize sent value first!
+ * subject.next({message: 'some message'});
+ * // This will send a message to the server once a connection is made. Remember value is by default serialized with JSON.stringify!
  *
  * subject.complete(); // Closes the connection.
  *
@@ -118,14 +118,14 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * const subject = webSocket('ws://localhost:8081');
  *
  * const observableA = subject.multiplex(
- *   () => JSON.stringify({subscribe: 'A'}), // When server gets this message, it will start sending messages for 'A'...
- *   () => JSON.stringify({unsubscribe: 'A'}), // ...and when gets this one, it will stop.
- *   message => message.type === 'A' // Server will tag all messages for 'A' with type property.
+ *   () => {subscribe: 'A'}, // When server gets this message, it will start sending messages for 'A'...
+ *   () => {unsubscribe: 'A'}, // ...and when gets this one, it will stop.
+ *   message => message.type === 'A' // Server should tag all messages for 'A' with type property.
  * );
  *
  * const observableB = subject.multiplex( // And the same goes for 'B'.
- *   () => JSON.stringify({subscribe: 'B'}),
- *   () => JSON.stringify({unsubscribe: 'B'}),
+ *   () => {subscribe: 'B'},
+ *   () => {unsubscribe: 'B'},
  *   message => message.type === 'B'
  * );
  *

--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -125,7 +125,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  *
  * const observableB = subject.multiplex( // And the same goes for 'B'.
  *   () => {subscribe: 'B'},
- *   () => {unsubscribe: 'B'},
+ *   () => ({unsubscribe: 'B'}),
  *   message => message.type === 'B'
  * );
  *

--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -124,7 +124,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * );
  *
  * const observableB = subject.multiplex( // And the same goes for 'B'.
- *   () => {subscribe: 'B'},
+ *   () => ({subscribe: 'B'}),
  *   () => ({unsubscribe: 'B'}),
  *   message => message.type === 'B'
  * );

--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -104,7 +104,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * // since no connection was established!
  *
  * subject.next({message: 'some message'});
- * // This will send a message to the server once a connection is made. Remember value is by default serialized with JSON.stringify!
+ * // This will send a message to the server once a connection is made. Remember value is serialized with JSON.stringify by default!
  *
  * subject.complete(); // Closes the connection.
  *


### PR DESCRIPTION
Remove manual serialization of payload using JSON.stringify since it is default serializer. In the sample code of the WebSocket operator. 

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
