### PR TITLE
chore(typings): fix of observable static function inference for 9+ pa…

### DIFF
--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -19,6 +19,7 @@ export function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: 
 export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler?: SchedulerLike):
   Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
 export function of<T>(...args: Array<T | SchedulerLike>): Observable<T>;
+export function of<T>(...args: Array<unknown | SchedulerLike>): Observable<T>;
 /* tslint:enable:max-line-length */
 
 /**


### PR DESCRIPTION
**Description:** Fix typings for of observable static function so that it infer empty interface instead of error

**Related issue (if exists):** #4502 
