### PR TITLE
docs(concatAll): fix map import

### DIFF
--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -32,7 +32,7 @@ export function concatAll<R>(): OperatorFunction<any, R>;
  * For each click event, tick every second from 0 to 3, with no concurrency
  * ```javascript
  * import { fromEvent, interval } from 'rxjs';
- * import { ma, take, concatAll } from 'rxjs/operators';
+ * import { map, take, concatAll } from 'rxjs/operators';
  *
  * const clicks = fromEvent(document, 'click');
  * const higherOrder = clicks.pipe(


### PR DESCRIPTION
**Description:**

Fixes import of `map` operator for `concatAll` example.
