### PR TITLE
fix(docs-app): remove stopWordFilter from lunr pipeline

### DIFF
--- a/docs_app/src/app/search/search-worker.js
+++ b/docs_app/src/app/search/search-worker.js
@@ -28,6 +28,7 @@ self.onmessage = handleMessage;
 // the path and search terms for a page
 function createIndex(addFn) {
   return lunr(/** @this */function() {
+    this.pipeline.remove(lunr.stopWordFilter);
     this.ref('path');
     this.field('titleWords', {boost: 100});
     this.field('headingWords', {boost: 50});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR removes the stopWordFilter from the lunr pipeline. It filters words like "of" and "from" when indexing, missing some operators or functions when searching.

https://github.com/olivernn/lunr.js/blob/master/lib/stop_word_filter.js


**Related issue (if exists):**
Fixes #4524