### PR TITLE
docs(window): fix import syntax

### DIFF
--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -26,7 +26,7 @@ import { Operator } from '../Operator';
  * In every window of 1 second each, emit at most 2 click events
  * ```javascript
  * import { fromEvent, interval } from 'rxjs';
- * import { window, mergeAll, map take } from 'rxjs/operators';
+ * import { window, mergeAll, map, take } from 'rxjs/operators';
  *
  *  const clicks = fromEvent(document, 'click');
  *  const sec = interval(1000);


### PR DESCRIPTION
Fixes small glitch in import syntax for `window` example.