### PR TITLE
docs(windowToggle): fix example

### DIFF
--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -27,14 +27,14 @@ import { OperatorFunction } from '../types';
  * ## Example
  * Every other second, emit the click events from the next 500ms
  * ```javascript
- * import { fromEvent, interval } from 'rxjs';
+ * import { fromEvent, interval, EMPTY } from 'rxjs';
  * import { windowToggle, mergeAll } from 'rxjs/operators';
  *
  * const clicks = fromEvent(document, 'click');
  * const openings = interval(1000);
  * const result = clicks.pipe(
- *   windowToggle(openings, i => i % 2 ? interval(500) : empty()),
- *   mergeAll(),
+ *   windowToggle(openings, i => i % 2 ? interval(500) : EMPTY),
+ *   mergeAll()
  * );
  * result.subscribe(x => console.log(x));
  * ```


### PR DESCRIPTION
The example was missing an import for `empty()`, but since that function is deprecated I figured it should be using `EMPTY` anyway? 🤔 