### PR TITLE
docs(buffer): fix example

### DIFF
--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -28,8 +28,8 @@ import { OperatorFunction } from '../types';
  * import { buffer } from 'rxjs/operators';
  *
  * const clicks = fromEvent(document, 'click');
- * const interval = interval(1000);
- * const buffered = interval.pipe(buffer(clicks));
+ * const intervalEvents = interval(1000);
+ * const buffered = intervalEvents.pipe(buffer(clicks));
  * buffered.subscribe(x => console.log(x));
  * ```
  *


### PR DESCRIPTION
Fixes a duplicate declaration error in the `buffer` example.