### PR TITLE
docs(bufferToggle): use non-deprecated syntax in example

### DIFF
--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -26,13 +26,13 @@ import { OperatorFunction, SubscribableOrPromise } from '../types';
  * Every other second, emit the click events from the next 500ms
  *
  * ```javascript
- * import { fromEvent, interval, empty } from 'rxjs';
+ * import { fromEvent, interval, EMPTY } from 'rxjs';
  * import { bufferToggle } from 'rxjs/operators';
  *
  * const clicks = fromEvent(document, 'click');
  * const openings = interval(1000);
  * const buffered = clicks.pipe(bufferToggle(openings, i =>
- *   i % 2 ? interval(500) : empty()
+ *   i % 2 ? interval(500) : EMPTY
  * ));
  * buffered.subscribe(x => console.log(x));
  * ```


### PR DESCRIPTION
Swapping `empty()` for non-deprecated `EMPTY` in the example.
