### PR TITLE
fix(Notification): replace const enum

### DIFF
--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -3,8 +3,17 @@ import { Observable } from './Observable';
 import { empty } from './observable/empty';
 import { of } from './observable/of';
 import { throwError } from './observable/throwError';
+import { deprecate } from 'util';
 
-export type NotificationKind = 'N' | 'E' | 'C';
+// TODO: When this enum is removed, replace it with a type alias. See #4556.
+/**
+ * @deprecated NotificationKind is deprecated as const enums are not compatible with isolated modules. Use a string literal instead.
+ */
+export enum NotificationKind {
+  NEXT = 'N',
+  ERROR = 'E',
+  COMPLETE = 'C',
+}
 
 /**
  * Represents a push-based event or value that an {@link Observable} can emit.
@@ -23,7 +32,7 @@ export type NotificationKind = 'N' | 'E' | 'C';
 export class Notification<T> {
   hasValue: boolean;
 
-  constructor(public kind: NotificationKind, public value?: T, public error?: any) {
+  constructor(public kind: 'N' | 'E' | 'C', public value?: T, public error?: any) {
     this.hasValue = kind === 'N';
   }
 

--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -4,11 +4,7 @@ import { empty } from './observable/empty';
 import { of } from './observable/of';
 import { throwError } from './observable/throwError';
 
-export const enum NotificationKind {
-  NEXT = 'N',
-  ERROR = 'E',
-  COMPLETE = 'C',
-}
+export type NotificationKind = 'N' | 'E' | 'C';
 
 /**
  * Represents a push-based event or value that an {@link Observable} can emit.
@@ -28,7 +24,7 @@ export class Notification<T> {
   hasValue: boolean;
 
   constructor(public kind: NotificationKind, public value?: T, public error?: any) {
-    this.hasValue = kind === NotificationKind.NEXT;
+    this.hasValue = kind === 'N';
   }
 
   /**
@@ -38,11 +34,11 @@ export class Notification<T> {
    */
   observe(observer: PartialObserver<T>): any {
     switch (this.kind) {
-      case NotificationKind.NEXT:
+      case 'N':
         return observer.next && observer.next(this.value);
-      case NotificationKind.ERROR:
+      case 'E':
         return observer.error && observer.error(this.error);
-      case NotificationKind.COMPLETE:
+      case 'C':
         return observer.complete && observer.complete();
     }
   }
@@ -58,11 +54,11 @@ export class Notification<T> {
   do(next: (value: T) => void, error?: (err: any) => void, complete?: () => void): any {
     const kind = this.kind;
     switch (kind) {
-      case NotificationKind.NEXT:
+      case 'N':
         return next && next(this.value);
-      case NotificationKind.ERROR:
+      case 'E':
         return error && error(this.error);
-      case NotificationKind.COMPLETE:
+      case 'C':
         return complete && complete();
     }
   }
@@ -92,18 +88,18 @@ export class Notification<T> {
   toObservable(): Observable<T> {
     const kind = this.kind;
     switch (kind) {
-      case NotificationKind.NEXT:
+      case 'N':
         return of(this.value);
-      case NotificationKind.ERROR:
+      case 'E':
         return throwError(this.error);
-      case NotificationKind.COMPLETE:
+      case 'C':
         return empty();
     }
     throw new Error('unexpected notification kind value');
   }
 
-  private static completeNotification: Notification<any> = new Notification(NotificationKind.COMPLETE);
-  private static undefinedValueNotification: Notification<any> = new Notification(NotificationKind.NEXT, undefined);
+  private static completeNotification: Notification<any> = new Notification('C');
+  private static undefinedValueNotification: Notification<any> = new Notification('N', undefined);
 
   /**
    * A shortcut to create a Notification instance of the type `next` from a
@@ -115,7 +111,7 @@ export class Notification<T> {
    */
   static createNext<T>(value: T): Notification<T> {
     if (typeof value !== 'undefined') {
-      return new Notification(NotificationKind.NEXT, value);
+      return new Notification('N', value);
     }
     return Notification.undefinedValueNotification;
   }
@@ -129,7 +125,7 @@ export class Notification<T> {
    * @nocollapse
    */
   static createError<T>(err?: any): Notification<T> {
-    return new Notification(NotificationKind.ERROR, undefined, err);
+    return new Notification('E', undefined, err);
   }
 
   /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR replaces the `NotiticationKind` const enum that was introduced in 6.4.0 with a string-literal union type. The latter is type-safe and compatible with single-module transpilation. Const enums are not, as the transpiler cannot know what should be used as a replacement for a reference to a const enum without using type information.

The `NotiticationKind` const enum is a problem for any projects using the `--isolatedModules` flag or for projects using the Babel TypeScript transform - which means any TypeScript projects generated with `create-react-app`.

**Related issue (if exists):** #4538