### PR TITLE
docs(webSocket): Fix typo unubscribe to unsubscribe

### DIFF
--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -141,7 +141,7 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * subB.unsubscribe();
  * // Message '{"unsubscribe": "B"}' is sent to the server, which stops sending 'B' messages.
  *
- * subA.unubscribe();
+ * subA.unsubscribe();
  * // Message '{"unsubscribe": "A"}' makes the server stop sending messages for 'A'. Since there is no more subscribers to root Subject,
  * // socket connection closes.
  * ```


### PR DESCRIPTION
Fix typo unubscribe to unsubscribe

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
