### PR TITLE
fix(Subscription): Return Empty when teardown === null

### DIFF
--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -130,11 +130,11 @@ export class Subscription implements SubscriptionLike {
    */
   add(teardown: TeardownLogic): Subscription {
     let subscription = (<Subscription>teardown);
-    
+
     if (!(<any>teardown)) {
       return Subscription.EMPTY;
     }
-    
+
     switch (typeof teardown) {
       case 'function':
         subscription = new Subscription(<(() => void)>teardown);

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -130,6 +130,11 @@ export class Subscription implements SubscriptionLike {
    */
   add(teardown: TeardownLogic): Subscription {
     let subscription = (<Subscription>teardown);
+    
+    if (!(<any>teardown)) {
+      return Subscription.EMPTY;
+    }
+    
     switch (typeof teardown) {
       case 'function':
         subscription = new Subscription(<(() => void)>teardown);
@@ -147,9 +152,6 @@ export class Subscription implements SubscriptionLike {
         }
         break;
       default: {
-        if (!(<any>teardown)) {
-          return Subscription.EMPTY;
-        }
         throw new Error('unrecognized teardown ' + teardown + ' added to Subscription.');
       }
     }


### PR DESCRIPTION
**Description:**
Subscription.add breaks if teardown function is null. (works with undefined)

`typeof teardown` returns object when null. It breaks later when rxjs tries to access the closed property.

The commit fixes that by first checking for null/undefined.

**Related issue (if exists):**
Haven't found an issue