### PR TITLE
Remove --save option as it isn't required anymore

### DIFF
--- a/docs_app/content/guide/v6/migration.md
+++ b/docs_app/content/guide/v6/migration.md
@@ -31,7 +31,7 @@ rxjs-5-to-6-migrate -p [path/to/tsconfig.json]
 In order to minimize the impact of the upgrade, RxJS v6 releases with a sibling package,  `rxjs-compat`, which provides a compatibility layer between the v6 and v5 APIs.
 Most developers with existing applications should upgrade by installing both `rxjs` and `rxjs-compat` at ^6.0.0:
 
-`npm install rxjs@6 rxjs-compat@6 --save`
+`npm install rxjs@6 rxjs-compat@6`
 
 For details about this package, see https://www.npmjs.com/package/rxjs-compat.
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

"As of npm 5.0.0, installed modules are added as a dependency by default, so the --save option is no longer needed. The other save options still exist and are listed in the documentation for npm install."

https://stackoverflow.com/a/19578808/142358

**Related issue (if exists):**