### PR TITLE
Fixes error "Property 'observable' does not exist on type 'SymbolCons…

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,3 +1,4 @@
+import 'rxjs/internal/symbol/observable';
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
 


### PR DESCRIPTION
Fixes error "Property 'observable' does not exist on type 'SymbolConstructor'".

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes error "Property 'observable' does not exist on type 'SymbolConstructor'" by importing Symbol.observable from file

Not sure if it's possible to simplify it somehow, as I am not fully aware of how the Symbol get's imported in the first place.

This error was happening on a new Angular v7 project, where I have libraries - that live in an external location to the root folder - importing 'rxjs' with an alias: 
in `tsconfig.js`:
```
"paths": {
     ...
      "rxjs": [
        "node_modules/rxjs/index.js"
      ],
      "rxjs/*": [
        "node_modules/rxjs/*"
      ],
      ...
}
```

**Related issue (if exists):**

There's no topic with issue, but in a nutshell, this was the output of `ng serve`:
```
ERROR in node_modules/rxjs/internal/types.d.ts(48,13): error TS2339: Property 'observable' does not exist on type 'SymbolConstructor'.

ℹ ｢wdm｣: Failed to compile.
```

While with the inclusion of the file, it compiles without error.