### PR TITLE
feat(tap): reset throwIfEmpty hasValue on retry

### DIFF
--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -78,6 +78,12 @@ class DoOperator<T> implements Operator<T, T> {
               private complete?: () => void) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+    /* make sure throwIfEmpty hasValue is set to false on re-subscribe */
+    if (this.nextOrObserver) {
+      if (this.nextOrObserver['hasValue']) {
+        this.nextOrObserver['hasValue'] = false;
+      }
+    }
     return source.subscribe(new TapSubscriber(subscriber, this.nextOrObserver, this.error, this.complete));
   }
 }

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -78,12 +78,6 @@ class DoOperator<T> implements Operator<T, T> {
               private complete?: () => void) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    /* make sure throwIfEmpty hasValue is set to false on re-subscribe */
-    if (this.nextOrObserver) {
-      if (this.nextOrObserver['hasValue']) {
-        this.nextOrObserver['hasValue'] = false;
-      }
-    }
     return source.subscribe(new TapSubscriber(subscriber, this.nextOrObserver, this.error, this.complete));
   }
 }

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -2,7 +2,7 @@ import { EmptyError } from '../util/EmptyError';
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { TeardownLogic } from '../types';
+import { TeardownLogic, MonoTypeOperatorFunction } from '../types';
 
 /**
  * If the source observable completes without emitting a value, it will emit
@@ -34,7 +34,7 @@ import { TeardownLogic } from '../types';
  * error to be thrown when the source observable completes without emitting a
  * value.
  */
-export function throwIfEmpty <T>(errorFactory: (() => any) = defaultErrorFactory) {
+export function throwIfEmpty <T>(errorFactory: (() => any) = defaultErrorFactory): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => {
     return source.lift(new ThrowIfEmptyOperator(errorFactory));
   };

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -18,7 +18,7 @@ import { TeardownLogic } from '../types';
  *
  * const click$ = fromEvent(button, 'click');
  *
- * clicks$.pipe(
+ * click$.pipe(
  *   takeUntil(timer(1000)),
  *   throwIfEmpty(
  *     () => new Error('the button was not clicked within 1 second')
@@ -26,7 +26,7 @@ import { TeardownLogic } from '../types';
  * )
  * .subscribe({
  *   next() { console.log('The button was clicked'); },
- *   error(err) { console.error(err); },
+ *   error(err) { console.error(err); }
  * });
  * ```
  *

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -30,7 +30,7 @@ import { TeardownLogic, MonoTypeOperatorFunction } from '../types';
  * });
  * ```
  *
- * @param {Function} [errorFactory] A factory function called to produce the
+ * @param errorFactory A factory function called to produce the
  * error to be thrown when the source observable completes without emitting a
  * value.
  */
@@ -63,7 +63,13 @@ class ThrowIfEmptySubscriber<T> extends Subscriber<T> {
 
   protected _complete() {
     if (!this.hasValue) {
-        this.destination.error(this.errorFactory());
+      let err: any;
+      try {
+        err = this.errorFactory();
+      } catch (e) {
+        err = e;
+      }
+      this.destination.error(err);
     } else {
         return this.destination.complete();
     }

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -1,6 +1,8 @@
-import { tap } from './tap';
 import { EmptyError } from '../util/EmptyError';
-import { MonoTypeOperatorFunction } from '../types';
+import { Observable } from '../Observable';
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { TeardownLogic } from '../types';
 
 /**
  * If the source observable completes without emitting a value, it will emit
@@ -32,16 +34,41 @@ import { MonoTypeOperatorFunction } from '../types';
  * error to be thrown when the source observable completes without emitting a
  * value.
  */
-export const throwIfEmpty =
-  <T>(errorFactory: (() => any) = defaultErrorFactory) => tap<T>({
-    hasValue: false,
-    next() { this.hasValue = true; },
-    complete() {
-      if (!this.hasValue) {
-        throw errorFactory();
-      }
+export function throwIfEmpty <T>(errorFactory: (() => any) = defaultErrorFactory) {
+  return (source: Observable<T>) => {
+    return source.lift(new ThrowIfEmptyOperator(errorFactory));
+  };
+}
+
+class ThrowIfEmptyOperator<T> implements Operator<T, T> {
+  constructor(private errorFactory: () => any) {
+  }
+
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+    return source.subscribe(new ThrowIfEmptySubscriber(subscriber, this.errorFactory));
+  }
+}
+
+class ThrowIfEmptySubscriber<T> extends Subscriber<T> {
+  private hasValue: boolean = false;
+
+  constructor(destination: Subscriber<T>, private errorFactory: () => any) {
+    super(destination);
+  }
+
+  protected _next(value: T): void {
+    this.hasValue = true;
+    this.destination.next(value);
+  }
+
+  protected _complete() {
+    if (!this.hasValue) {
+        this.destination.error(this.errorFactory());
+    } else {
+        return this.destination.complete();
     }
-  } as any);
+  }
+}
 
 function defaultErrorFactory() {
   return new EmptyError();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):** 
https://github.com/ReactiveX/rxjs/issues/4565
