### PR TITLE
docs(operators): Add a simple example in doc string

### DIFF
--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -36,6 +36,16 @@ export function switchMap<T, R, O extends ObservableInput<any>>(project: (value:
  * subsequent inner Observables.
  *
  * ## Example
+ * Generate new Observable according to source Observable values
+ * ```javascript
+ * import { of } from 'rxjs';
+ * import { switchMap } from 'rxjs/operators';
+ *
+ * const switched = of(1,2,3).pipe(switchMap((x) => of( x, x ** 2, x ** 3)));
+ * switched.subscribe(x => console.log(x));
+ * ```
+ * 
+ *
  * Rerun an interval Observable on every click event
  * ```javascript
  * import { fromEvent, interval } from 'rxjs';

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -37,14 +37,20 @@ export function switchMap<T, R, O extends ObservableInput<any>>(project: (value:
  *
  * ## Example
  * Generate new Observable according to source Observable values
- * ```javascript
+ * ```typescript
  * import { of } from 'rxjs';
  * import { switchMap } from 'rxjs/operators';
  *
- * const switched = of(1,2,3).pipe(switchMap((x: number) => of( x, x ** 2, x ** 3)));
+ * const switched = of(1, 2, 3).pipe(switchMap((x: number) => of( x, x ** 2, x ** 3)));
  * switched.subscribe(x => console.log(x));
+ * // outputs
+ * // 1
+ * // 1
+ * // 2
+ * // 4
+ * // 8
+ * // ... and so on
  * ```
- *
  *
  * Rerun an interval Observable on every click event
  * ```javascript

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -41,7 +41,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(project: (value:
  * import { of } from 'rxjs';
  * import { switchMap } from 'rxjs/operators';
  *
- * const switched = of(1, 2, 3).pipe(switchMap((x: number) => of( x, x ** 2, x ** 3)));
+ * const switched = of(1, 2, 3).pipe(switchMap((x: number) => of(x, x ** 2, x ** 3)));
  * switched.subscribe(x => console.log(x));
  * // outputs
  * // 1

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -41,10 +41,10 @@ export function switchMap<T, R, O extends ObservableInput<any>>(project: (value:
  * import { of } from 'rxjs';
  * import { switchMap } from 'rxjs/operators';
  *
- * const switched = of(1,2,3).pipe(switchMap((x) => of( x, x ** 2, x ** 3)));
+ * const switched = of(1,2,3).pipe(switchMap((x: number) => of( x, x ** 2, x ** 3)));
  * switched.subscribe(x => console.log(x));
  * ```
- * 
+ *
  *
  * Rerun an interval Observable on every click event
  * ```javascript


### PR DESCRIPTION
Add much simpler example to help understand what `switchMap` can do. It is easy to understand for document reader.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
