### PR TITLE
docs(operators): add missing import to the example

### DIFF
--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -30,10 +30,10 @@ import { ObservableInput, OperatorFunction } from '../types';
  * count$.subscribe(x => console.log(x));
  *
  * // Results:
- * 1
- * 2
- * 3
- * 4
+ * // 1
+ * // 2
+ * // 3
+ * // 4
  * // ...and so on for each click
  * ```
  *

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -19,7 +19,7 @@ import { ObservableInput, OperatorFunction } from '../types';
  * Count the number of click events
  * ```javascript
  * import { fromEvent, of } from 'rxjs';
- * import { mapTo } from 'rxjs/operators';
+ * import { mapTo, mergeScan } from 'rxjs/operators';
  *
  * const click$ = fromEvent(document, 'click');
  * const one$ = click$.pipe(mapTo(1));


### PR DESCRIPTION
mergeScan import was missing in the example so it did not work

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [x] Add the operator to Rx
- [x] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [x] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [x] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [x] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [x] The operator should be listed in `doc/operators.md` in a category of operators
- [x] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [x] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [x] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
mergeScan import was missing in the example so it did not work

**Related issue (if exists):**
