### PR TITLE
chore(lint): add no-const-enum rule

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -283,6 +283,26 @@
         "url-template": "^2.0.8"
       }
     },
+    "@phenomnomnominal/tsquery": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@phenomnomnominal/tsquery/-/tsquery-3.0.0.tgz",
+      "integrity": "sha512-SW8lKitBHWJ9fAYkJ9kJivuctwNYCh3BUxLdH0+XiR1GPBiu+7qiZzh8p8jqlj1LgVC1TbvfNFroaEsmYlL8Iw==",
+      "dev": true,
+      "requires": {
+        "esquery": "^1.0.1"
+      },
+      "dependencies": {
+        "esquery": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+          "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+          "dev": true,
+          "requires": {
+            "estraverse": "^4.0.0"
+          }
+        }
+      }
+    },
     "@samverschueren/stream-to-observable": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@samverschueren/stream-to-observable/-/stream-to-observable-0.3.0.tgz",
@@ -5064,12 +5084,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5084,17 +5106,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5211,7 +5236,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5223,6 +5249,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5237,6 +5264,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5244,12 +5272,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5268,6 +5298,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5348,7 +5379,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5360,6 +5392,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5481,6 +5514,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -10958,24 +10992,15 @@
       }
     },
     "tslint-etc": {
-      "version": "1.2.6",
-      "resolved": "https://registry.npmjs.org/tslint-etc/-/tslint-etc-1.2.6.tgz",
-      "integrity": "sha512-bD1KGDQ9RXOoETQeBGMN4PLZPhOz0syLu+lEVUBmovB2sq6qJqnFRnUCY4OBx9x+a+golOFNFfcxe5fyBltWow==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/tslint-etc/-/tslint-etc-1.5.0.tgz",
+      "integrity": "sha512-PmXf+9n3gl2cP1s7bhtHWs5Wbgk5ThJdngFtw8lKoi82NbUF95HLzAb2csU6aUdpLWwWI+IFQOwsRby+2MQg+w==",
       "dev": true,
       "requires": {
+        "@phenomnomnominal/tsquery": "^3.0.0",
         "tslib": "^1.8.0",
-        "tsutils": "^3.0.0"
-      },
-      "dependencies": {
-        "tsutils": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.0.0.tgz",
-          "integrity": "sha512-LjHBWR0vWAUHWdIAoTjoqi56Kz+FDKBgVEuL+gVPG/Pv7QW5IdaDDeK9Txlr6U0Cmckp5EgCIq1T25qe3J6hyw==",
-          "dev": true,
-          "requires": {
-            "tslib": "^1.8.1"
-          }
-        }
+        "tsutils": "^3.0.0",
+        "tsutils-etc": "^1.0.0"
       }
     },
     "tslint-no-toplevel-property-access": {
@@ -11009,6 +11034,21 @@
           }
         }
       }
+    },
+    "tsutils": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-3.10.0.tgz",
+      "integrity": "sha512-q20XSMq7jutbGB8luhKKsQldRKWvyBO2BGqni3p4yq8Ys9bEP/xQw3KepKmMRt9gJ4lvQSScrihJrcKdKoSU7Q==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.8.1"
+      }
+    },
+    "tsutils-etc": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/tsutils-etc/-/tsutils-etc-1.1.0.tgz",
+      "integrity": "sha512-pJlLtLmQPUyGHqY/Pq6EGnpGmQCnnTDZetQ7eWkeQ5xaw4GtfcR1Zt7HMKFHGDDp53HzQfbqQ+7ps6iJbfa9Hw==",
+      "dev": true
     },
     "tty-browserify": {
       "version": "0.0.0",

--- a/package.json
+++ b/package.json
@@ -212,7 +212,7 @@
     "ts-node": "6.1.0",
     "tsconfig-paths": "3.2.0",
     "tslint": "5.9.1",
-    "tslint-etc": "1.2.6",
+    "tslint-etc": "1.5.0",
     "tslint-no-toplevel-property-access": "0.0.2",
     "tslint-no-unused-expression-chai": "0.0.3",
     "typescript": "^3.0.1",

--- a/tslint.json
+++ b/tslint.json
@@ -58,6 +58,7 @@
       "check-separator",
       "check-type"
     ],
+    "no-const-enum": true,
     "no-toplevel-property-access": [
       true,
       "src/index.ts",
@@ -72,6 +73,7 @@
   },
   "rulesDirectory": [
     "tslint-no-unused-expression-chai",
+    "node_modules/tslint-etc/dist/rules",
     "node_modules/tslint-no-toplevel-property-access/rules"
   ]
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR enables the `no-const-enum` rule that's in `tslint-etc`.

ATM, `tslint-etc` is used in the dtslint tests to catch malformed type expectations. This PR bumps the `tslint-etc` version and enables the above-mentioned rule in the project's `tslint.json` file.

The reason const enums cannot be used is outlined in #4556. Basically, using a const enum prohibits isolated module transpilation, as it's necessary to refer to another file to determine the literal that should replace a reference to a const enum member. That means that versions of RxJS that export const enums cannot be used with `create-react-app`-generated projects or any other projects that build using isolated modules.

As configured, the rule forbids all use of const enums. The rule does have an `allowLocal` option, but I don't see the use of local (i.e. within a single module) const enums to be a likely use case.

The main reason for adding the rule is to prevent the sort of breaking change that happened in 6.4.0 from happening again. In #4556, I mentioned that I tried to include a test that compiled the project using isolated modules, but was unable to do so (the reason is given in the linked PR).

The linting in this PR will fail until #4556 is merged.

**Related issue (if exists):** #4556 
