### PR TITLE
docs(repeatWhen): add doc for repeatWhen

### DIFF
--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -18,6 +18,56 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  *
  * ![](repeatWhen.png)
  *
+ * ## Example
+ *
+ * repeat a message
+ * ```ts
+ * import { of,interval } from 'rxjs';
+ * import { map, repeatWhen,take } from 'rxjs/operators';
+ *
+ * const notifier = interval(2000).pipe(
+ *   take(3)
+ * )
+ * const source = of('Hello World').pipe(
+ *   repeatWhen(() => notifier)
+ * );
+ * source.subscribe(x => console.log(x));
+ *
+ * // Results
+ * // Hello World
+ * // Hello World
+ * // Hello World
+ * // Hello World
+ * ```
+ * repeat values multiple times
+ *
+ * ```ts
+ * import { of,interval } from 'rxjs';
+ * import { map, repeatWhen,take } from 'rxjs/operators';
+ *
+ * const notifier = interval(2000).pipe(
+ *   take(3)
+ * )
+ * const source = interval(1000).pipe(
+ *   take(2),
+ *   repeatWhen(() => notifier)
+ * );
+ * source.subscribe(x => console.log(x));
+ * // repeat values
+ * // 0
+ * // 1
+ * // 2s later
+ * // 0
+ * // 1
+ * // 2s later
+ * // 0
+ * // 1
+ * // 2s later
+ * // 0
+ * // 1
+ * ```
+ *
+ *
  * @param {function(notifications: Observable): Observable} notifier - Receives an Observable of notifications with
  * which a user can `complete` or `error`, aborting the repetition.
  * @return {Observable} The source Observable modified with repeat logic.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

add example code for repeatWhen

**Related issue (if exists):**
[issue 4676](https://github.com/ReactiveX/rxjs/issues/4676)