### PR TITLE
docs(throttleTime): add double click example making use of throttle-config

### DIFF
--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -24,7 +24,10 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * and this process repeats for the next source value. Optionally takes a
  * {@link SchedulerLike} for managing timers.
  *
- * ## Example
+ * ## Examples
+ *
+ * #### Limit click rate
+ *
  * Emit clicks at a rate of at most one click per second
  * ```ts
  * import { fromEvent } from 'rxjs';
@@ -34,6 +37,35 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * const result = clicks.pipe(throttleTime(1000));
  * result.subscribe(x => console.log(x));
  * ```
+ *
+ * #### Double Click
+ *
+ * The following example only emits clicks which happen within a subsequent
+ * delay of 400ms of the previous click. This for example can emulate a double
+ * click. It makes use of the `trailing` parameter of the throttle configuration.
+ *
+ * ```ts
+ * import { fromEvent, asyncScheduler } from 'rxjs';
+ * import { throttleTime, withLatestFrom } from 'rxjs/operators';
+ *
+ * // defaultThottleConfig = { leading: true, trailing: false }
+ * const throttleConfig = {
+ *   leading: false,
+ *   trailing: true
+ * }
+ *
+ * const click = fromEvent(document, 'click');
+ * const doubleClick = click.pipe(
+ *   throttleTime(400, asyncScheduler, throttleConfig)
+ * );
+ *
+ * doubleClick.subscribe((throttleValue: Event) => {
+ *   console.log(`Double-clicked! Timestamp: ${throttleValue.timeStamp}`);
+ * });
+ * ```
+ *
+ * If you enable the `leading` parameter in this example, the output would be the primary click and
+ * the double click, but restricts additional clicks within 400ms.
  *
  * @see {@link auditTime}
  * @see {@link debounceTime}


### PR DESCRIPTION
**Description:**

The example contains the simulation of double-clicks that happen within a time-range of 400ms.

**Related issue (if exists):**
#4647