### PR TITLE
docs(throttle): Add explanation of trailing behavior

### DIFF
--- a/compat/operator/throttleTime.ts
+++ b/compat/operator/throttleTime.ts
@@ -17,8 +17,13 @@ import { throttleTime as higherOrder } from 'rxjs/operators';
  * value arrives, it is forwarded to the output Observable, and then the timer
  * is enabled. After `duration` milliseconds (or the time unit determined
  * internally by the optional `scheduler`) has passed, the timer is disabled,
- * and this process repeats for the next source value. Optionally takes a
- * {@link IScheduler} for managing timers.
+ * and this process repeats for the next source value.
+ *
+ * When `trailing` is enabled in the `config` the last value emitted from the
+ * source observable during the timer is forwarded at the end of the timer if one
+ * was emitted.
+ *
+ * Optionally takes a {@link IScheduler} for managing timers.
  *
  * @example <caption>Emit clicks at a rate of at most one click per second</caption>
  * var clicks = Rx.Observable.fromEvent(document, 'click');
@@ -36,6 +41,8 @@ import { throttleTime as higherOrder } from 'rxjs/operators';
  * internally by the optional `scheduler`.
  * @param {Scheduler} [scheduler=asyncScheduler] The {@link SchedulerLike} to use for
  * managing the timers that handle the throttling.
+ * @param {ThrottleConfig} config a configuration object to define `leading` and `trailing` behavior. Defaults
+ * to `{ leading: true, trailing: false }`.
  * @return {Observable<T>} An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.
  * @method throttleTime

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -38,6 +38,10 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * value or completes, the timer is disabled, and this process repeats for the
  * next source value.
  *
+ * When `trailing` is enabled in the `config` the last value emitted from the
+ * source observable during the timer is forwarded at the end of the timer if one
+ * was emitted.
+ *
  * ## Example
  * Emit clicks at a rate of at most one click per second
  * ```ts
@@ -58,7 +62,7 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * @param {function(value: T): SubscribableOrPromise} durationSelector A function
  * that receives a value from the source Observable, for computing the silencing
  * duration for each source value, returned as an Observable or a Promise.
- * @param {Object} config a configuration object to define `leading` and `trailing` behavior. Defaults
+ * @param {ThrottleConfig} config a configuration object to define `leading` and `trailing` behavior. Defaults
  * to `{ leading: true, trailing: false }`.
  * @return {Observable<T>} An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -21,8 +21,13 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * value arrives, it is forwarded to the output Observable, and then the timer
  * is enabled. After `duration` milliseconds (or the time unit determined
  * internally by the optional `scheduler`) has passed, the timer is disabled,
- * and this process repeats for the next source value. Optionally takes a
- * {@link SchedulerLike} for managing timers.
+ * and this process repeats for the next source value.
+ *
+ * When `trailing` is enabled in the `config` the last value emitted from the
+ * source observable during the timer is forwarded at the end of the timer if one
+ * was emitted.
+ *
+ * Optionally takes a {@link SchedulerLike} for managing timers.
  *
  * ## Example
  * Emit clicks at a rate of at most one click per second
@@ -46,7 +51,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * internally by the optional `scheduler`.
  * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for
  * managing the timers that handle the throttling.
- * @param {Object} config a configuration object to define `leading` and
+ * @param {ThrottleConfig} config a configuration object to define `leading` and
  * `trailing` behavior. Defaults to `{ leading: true, trailing: false }`.
  * @return {Observable<T>} An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adding documentation of `trailing` on `throttleTime` and `throttle` operators.

**Related issue (if exists):**
