### PR TITLE
docs(concat): clarify array as input

### DIFF
--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -67,7 +67,7 @@ export function concat<R>(...observables: (ObservableInput<any> | SchedulerLike)
  * // 0 -1000ms-> 1 -1000ms-> 2 -1000ms-> 3 -immediate-> 1 ... 10
  * ```
  *
- * ### Concatenate an array of 3 Observables
+ * ### Concatenate 3 Observables
  * ```ts
  * import { concat, interval } from 'rxjs';
  * import { take } from 'rxjs/operators';
@@ -76,9 +76,7 @@ export function concat<R>(...observables: (ObservableInput<any> | SchedulerLike)
  * const timer2 = interval(2000).pipe(take(6));
  * const timer3 = interval(500).pipe(take(10));
  *
- * // an array itself being considered an observable source,
- * // use the spread operator to observe its values instead of itself
- * const result = concat(...[timer1, timer2, timer3]); // note that array is spread
+ * const result = concat(timer1, timer2, timer3);
  * result.subscribe(x => console.log(x));
  *
  * // results in the following:

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -75,7 +75,10 @@ export function concat<R>(...observables: (ObservableInput<any> | SchedulerLike)
  * const timer1 = interval(1000).pipe(take(10));
  * const timer2 = interval(2000).pipe(take(6));
  * const timer3 = interval(500).pipe(take(10));
- * const result = concat([timer1, timer2, timer3]); // note that array is passed
+ *
+ * // an array itself being considered an observable source,
+ * // use the spread operator to observe its values instead of itself
+ * const result = concat(...[timer1, timer2, timer3]); // note that array is spread
  * result.subscribe(x => console.log(x));
  *
  * // results in the following:


### PR DESCRIPTION
**Description:**
Since an array is itself an ObservableInput and so considered as an observable source, this specifies the use of spread operator to pass an array of observables.

**Related issue (if exists):**
#4697 