### PR TITLE
chore(refCount): remove unnecessary reference of object

### DIFF
--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -12,8 +12,8 @@ import { refCount as higherOrderRefCount } from '../operators/refCount';
 export class ConnectableObservable<T> extends Observable<T> {
 
   protected _subject: Subject<T>;
-  private _refCount: number = 0;
-  private _connection: Subscription;
+  protected _refCount: number = 0;
+  protected _connection: Subscription;
   /** @internal */
   _isComplete = false;
 

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -12,8 +12,8 @@ import { refCount as higherOrderRefCount } from '../operators/refCount';
 export class ConnectableObservable<T> extends Observable<T> {
 
   protected _subject: Subject<T>;
-  protected _refCount: number = 0;
-  protected _connection: Subscription;
+  private _refCount: number = 0;
+  private _connection: Subscription;
   /** @internal */
   _isComplete = false;
 

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -60,20 +60,18 @@ import { Observable } from '../Observable';
  */
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return function refCountOperatorFunction(source: ConnectableObservable<T>): Observable<T> {
-    return source.lift(new RefCountOperator(source));
+    return source.lift(new RefCountOperator());
   } as MonoTypeOperatorFunction<T>;
 }
 
 class RefCountOperator<T> implements Operator<T, T> {
-  constructor(private connectable: ConnectableObservable<T>) {
-  }
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
 
-    const { connectable } = this;
+  call(subscriber: Subscriber<T>, connectable: ConnectableObservable<T>): TeardownLogic {
+
     (<any> connectable)._refCount++;
 
     const refCounter = new RefCountSubscriber(subscriber, connectable);
-    const subscription = source.subscribe(refCounter);
+    const subscription = connectable.subscribe(refCounter);
 
     if (!refCounter.closed) {
       (<any> refCounter).connection = connectable.connect();

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -61,8 +61,8 @@ import { Observable } from '../Observable';
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return function refCountOperatorFunction(source: ConnectableObservable<T>): Observable<T> {
     return source.lift(new RefCountOperator());
-  };
-} as MonoTypeOperatorFunction<T>
+  } as MonoTypeOperatorFunction<T>;
+}
 
 class RefCountOperator<T> implements Operator<T, T> {
 

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -60,9 +60,9 @@ import { Observable } from '../Observable';
  */
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return function refCountOperatorFunction(source: ConnectableObservable<T>): Observable<T> {
-    return source.lift(new RefCountOperator<T>());
+    return source.lift(new RefCountOperator());
   };
-}
+} as MonoTypeOperatorFunction<T>
 
 class RefCountOperator<T> implements Operator<T, T> {
 

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -60,8 +60,8 @@ import { Observable } from '../Observable';
  */
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return function refCountOperatorFunction(source: ConnectableObservable<T>): Observable<T> {
-    return source.lift(new RefCountOperator());
-  } as MonoTypeOperatorFunction<T>;
+    return source.lift(new RefCountOperator<T>());
+  };
 }
 
 class RefCountOperator<T> implements Operator<T, T> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Since the `source` and the `connectableObservable` is the same thing in RefCountOperator, there is no need to hold the variable `connectable` int the RefCountOperator
**Related issue (if exists):**
NONE