### PR TITLE
docs(fromFetch): typo in docs

### DIFF
--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -23,7 +23,7 @@ import { Observable } from '../../Observable';
  *
  * const data$ = fromFetch('https://api.github.com/users?per_page=5').pipe(
  *  switchMap(response => {
- *    if(response.ok) {
+ *    if (response.ok) {
  *      // OK return data
  *      return response.json();
  *    } else {
@@ -34,7 +34,7 @@ import { Observable } from '../../Observable';
  *  catchError(err => {
  *    // Network or other error, handle appropriately
  *    console.error(err);
- *    return of({ error: true, message: error.message })
+ *    return of({ error: true, message: err.message })
  *  })
  * );
  *

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -23,7 +23,7 @@ import { Observable } from '../../Observable';
  *
  * const data$ = fromFetch('https://api.github.com/users?per_page=5').pipe(
  *  switchMap(response => {
- *    if(responose.ok) {
+ *    if(response.ok) {
  *      // OK return data
  *      return response.json();
  *    } else {
@@ -58,7 +58,7 @@ export function fromFetch(input: string | Request, init?: RequestInit): Observab
     let unsubscribed = false;
 
     if (init) {
-      // If we a signal is provided, just have it teardown. It's a cancellation token, basically.
+      // If a signal is provided, just have it teardown. It's a cancellation token, basically.
       if (init.signal) {
         outerSignalHandler = () => {
           if (!signal.aborted) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Fixed two typos in doc blocs

**Related issue (if exists):**
