### PR TITLE
fix(of): deprecation warning when using of as intended

### DIFF
--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -26,7 +26,6 @@ export function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: 
 /** @deprecated use {@link scheduled} instead `scheduled([a, b, c], scheduler)` */
 export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler: SchedulerLike):
   Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
-/** @deprecated use {@link scheduled} instead `scheduled([a, b, c], scheduler)` */
 export function of<T>(...args: (T | SchedulerLike)[]): Observable<T>;
 
 // TODO(benlesh): Update the typings for this when we can switch to TS 3.x


### PR DESCRIPTION
**Description:**

Typescript picks the deprecated signature when using `of`. ~~By moving the signature to the bottom it will pick the correct one.~~ Removed the deprecation comment instead

**Related issue (if exists):**

closes https://github.com/ReactiveX/rxjs/issues/4723
