### PR TITLE
fix(throttleTime): double emission with leading and trailing enabled

### DIFF
--- a/spec/operators/throttleTime-spec.ts
+++ b/spec/operators/throttleTime-spec.ts
@@ -141,16 +141,44 @@ describe('throttleTime operator', () => {
   });
 
   describe('throttleTime(fn, { leading: true, trailing: true })', () => {
-    asDiagram('throttleTime(fn, { leading: true, trailing: true })')('should immediately emit the first and last values in each time window', () =>  {
-      const e1 =   hot('-a-xy-----b--x--cxxx--|');
-      const e1subs =   '^                     !';
-      const t =  time( '----|                  ');
-      const expected = '-a---y----b---x-c---x-|';
+    asDiagram('throttleTime(fn, { leading: true, trailing: true })')('should immediately emit the first and last values in each time window', () => {
+      const e1 =   hot('a123b12-c-23d-2-ef---|');
+      const t =   time('----|                 ');
+      const expected = 'a---b---c---d---e---f|';
 
       const result = e1.pipe(throttleTime(t, rxTestScheduler, { leading: true, trailing: true }));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+
+    it('should immediately emit the first value in each time window', () =>  {
+      const e1 =   hot('-a---x------b|');
+      const t =   time('----|         ');
+      const expected = '-a---x------b|';
+
+      const result = e1.pipe(throttleTime(t, rxTestScheduler, { leading: true, trailing: true }));
+
+      expectObservable(result).toBe(expected);
+    });
+
+    it('should emit the last throttled value when complete', () => {
+      const e1 =   hot('-x--|');
+      const t =   time('----|');
+      const expected = '----(x|)';
+
+      const result = e1.pipe(throttleTime(t, rxTestScheduler, { leading: false, trailing: true }));
+
+      expectObservable(result).toBe(expected);
+    });
+
+    it('should emit both simple leading and trailing', () => {
+      const e1 =   hot('-a-b------------------|');
+      const t =   time('----|                  ');
+      const expected = '-a---b----------------|';
+
+      const result = e1.pipe(throttleTime(t, rxTestScheduler, { leading: true, trailing: true }));
+
+      expectObservable(result).toBe(expected);
     });
 
     it('should emit the value if only a single one is given', () => {

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -158,13 +158,13 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
       this.throttled = null;
 
       if (this.trailing && this._hasTrailingValue) {
-        this.destination.next(this._trailingValue);
-        this._trailingValue = null;
-        this._hasTrailingValue = false;
-
         if (this.leading && this.trailing) {
           this.throttle();
         }
+
+        this.destination.next(this._trailingValue);
+        this._trailingValue = null;
+        this._hasTrailingValue = false;
       }
     }
   }


### PR DESCRIPTION
This PR fixes an issue with throttleTime emitting both leading and trailing values in the same time window.
    
Double emission problem:
```
source:   a123b12-c-23d-2-ef---
expected: a---b---c---d---e---f
actual:   a---b1---c2---2-e---f
```
    
Closes #2466 and closes #2727.
Follows #2749 and #2864.