### PR TITLE
fix(endWith): wrap args - they are not observables - in of before concatenating

### DIFF
--- a/spec/operators/endWith-spec.ts
+++ b/spec/operators/endWith-spec.ts
@@ -20,6 +20,16 @@ describe('endWith operator', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
+  it('should append numbers to a cold Observable', () => {
+    const values = { a: 1, b: 2, c: 3, s: 4 };
+    const e1 =  cold('---a--b--c--|', values);
+    const e1subs =   '^           !';
+    const expected = '---a--b--c--(s|)';
+
+    expectObservable(e1.pipe(endWith(values.s))).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
   it('should end an observable with given value', () => {
     const e1 =   hot('--a--|');
     const e1subs =   '^    !';

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -1,5 +1,6 @@
 import { Observable } from '../Observable';
 import { concat } from '../observable/concat';
+import { of } from '../observable/of';
 import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
@@ -62,5 +63,5 @@ export function endWith<T, Z = T>(...array: Array<Z | SchedulerLike>): OperatorF
  * @owner Observable
  */
 export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => concat(source, ...(array as any[])) as Observable<T>;
+  return (source: Observable<T>) => concat(source, of(...(array as any[]))) as Observable<T>;
 }

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -63,5 +63,5 @@ export function endWith<T, Z = T>(...array: Array<Z | SchedulerLike>): OperatorF
  * @owner Observable
  */
 export function endWith<T>(...array: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => concat(source, of(...(array as any[]))) as Observable<T>;
+  return (source: Observable<T>) => concat(source, of(...array)) as Observable<T>;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR spreads the arguments passed to `endWith` into a call to `of` which is then passed to `concat.

The current implementation spreads the args directly into `concat` which is incorrect. The tests pass because strings are iterable and are therefore valid observable inputs. And the strings in the tests each contain only a single character. The test added in this PR uses numbers for values, and their use effects an error from the current, incorrect `endWith` implementation.

**Related issue (if exists):** #4731