### PR TITLE
fix(umd): export fetch namespace

### DIFF
--- a/src/internal/umd.ts
+++ b/src/internal/umd.ts
@@ -20,3 +20,7 @@ export const ajax = _ajax;
 /* rxjs.webSocket */
 import * as _webSocket from '../webSocket/index';
 export const webSocket = _webSocket;
+
+/* rxjs.fetch */
+import * as _fetch from '../fetch/index';
+export const fetch = _fetch;


### PR DESCRIPTION
Oops. I forgot to make sure this was available in the umd bundle (which people use for playground apps)