### PR TITLE
fix(forkJoin): test for object literal

### DIFF
--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -504,5 +504,18 @@ describe('forkJoin', () => {
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
       expectSubscriptions(e2.subscriptions).toBe(e2subs);
     });
+
+    it('should accept promise as the first arg', done => {
+      const e1 = forkJoin(Promise.resolve(1));
+      const values: number[][] = [];
+
+      e1.subscribe({
+        next: x => values.push(x),
+        complete: () => {
+          expect(values).to.deep.equal([[1]]);
+          done();
+        }
+      });
+    });
   });
 });

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -147,7 +147,7 @@ export function forkJoin(
       return forkJoinInternal(first, null);
     }
     // TODO(benlesh): isObservable check will not be necessary when deprecated path is removed.
-    if (isObject(first) && !isObservable(first)) {
+    if (isObject(first) && Object.getPrototypeOf(first) === Object.prototype) {
       const keys = Object.keys(first);
       return forkJoinInternal(keys.map(key => first[key]), keys);
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes a problem with `forkJoin`'s inspection of its first argument to determine whether or not it should be joining the properties of an object literal.

The current code checks to see if the argument is not an `Observable` and if it isn't, it proceeds as if it has been called with an object literal. However. the argument could be another `ObservableInput` - like a `Promise`.

This PR adds a failing test and changes the check to compare the argument's prototype to `Object.prototype`.

**Related issue (if exists):** #4737