### PR TITLE
 fix(fromFetch): don't abort if fetch resolves

### DIFF
--- a/spec/observables/dom/fetch-spec.ts
+++ b/spec/observables/dom/fetch-spec.ts
@@ -115,14 +115,19 @@ describe('fromFetch', () => {
         expect(response).to.equal(OK_RESPONSE);
       },
       error: done,
-      complete: done,
+      complete: () => {
+        // Wait until the complete and the subsequent unsubscribe are finished
+        // before testing these expectations:
+        setTimeout(() => {
+          expect(MockAbortController.created).to.equal(1);
+          expect(mockFetch.calls.length).to.equal(1);
+          expect(mockFetch.calls[0].input).to.equal('/foo');
+          expect(mockFetch.calls[0].init.signal).not.to.be.undefined;
+          expect(mockFetch.calls[0].init.signal.aborted).to.be.false;
+          done();
+        }, 0);
+      }
     });
-
-    expect(MockAbortController.created).to.equal(1);
-    expect(mockFetch.calls.length).to.equal(1);
-    expect(mockFetch.calls[0].input).to.equal('/foo');
-    expect(mockFetch.calls[0].init.signal).not.to.be.undefined;
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.false;
   });
 
   it('should handle Response that is not `ok`', done => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR rearranges an existing test so that the expectations are performed after the complete - and subsequent unsubscribe - are finished. The rearranged test fails.

It also adds a flag to the `fromFetch` implementation so that `abort` is not called in the teardown if the promise returned by `fetch` has resolved.

This fixes the problem, but it also highlights a problem with the implementation: streamed data obtained using `fromFetch` cannot be aborted, as the `AbortController` passed to fetch also aborts the promises returned from `text` and `json`, etc.

**Related issue (if exists):** #4739
