### PR TITLE
fix(pairwise): make it recursion-proof

### DIFF
--- a/spec/operators/pairwise-spec.ts
+++ b/spec/operators/pairwise-spec.ts
@@ -1,5 +1,7 @@
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { pairwise } from 'rxjs/operators';
+import { pairwise, take } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { expect } from 'chai';
 
 declare function asDiagram(arg: string): Function;
 
@@ -102,5 +104,26 @@ describe('pairwise operator', () => {
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should be recursively re-enterable', () => {
+    const results = new Array<[string, string]>();
+
+    const subject = new Subject<string>();
+
+    subject
+      .pipe(
+        pairwise(),
+        take(3)
+      )
+      .subscribe(pair => {
+        results.push(pair);
+        subject.next('c');
+      });
+
+    subject.next('a');
+    subject.next('b');
+
+    expect(results).to.deep.equal([['a', 'b'], ['b', 'c'], ['c', 'c']]);
   });
 });

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -70,12 +70,18 @@ class PairwiseSubscriber<T> extends Subscriber<T> {
   }
 
   _next(value: T): void {
+    let pair: [T, T] | undefined;
+
     if (this.hasPrev) {
-      this.destination.next([this.prev, value]);
+      pair = [this.prev, value];
     } else {
       this.hasPrev = true;
     }
 
     this.prev = value;
+
+    if (pair) {
+      this.destination.next(pair);
+    }
   }
 }


### PR DESCRIPTION
**Description:** `pairwise` calls `next` before saving the current value as the previous one, which makes it not recursively re-enterable. If its subscriber synchronously triggers the input observable, `pairwise` erroneously emits a pair with the wrong previous value.

**Related issue:** https://github.com/reduxjs/redux/issues/3404