### PR TITLE
chore: remove unused imports

### DIFF
--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -1,8 +1,6 @@
 import { Observable } from '../Observable';
 import { ObservableInput, SchedulerLike, ObservedValueOf } from '../types';
-import { isScheduler } from '../util/isScheduler';
 import { of } from './of';
-import { from } from './from';
 import { concatAll } from '../operators/concatAll';
 
 /* tslint:disable:max-line-length */

--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { SubscribableOrPromise, ObservedValueOf, ObservableInput } from '../types';
+import { ObservedValueOf, ObservableInput } from '../types';
 import { from } from './from'; // lol
 import { empty } from './empty';
 

--- a/src/internal/operators/elementAt.ts
+++ b/src/internal/operators/elementAt.ts
@@ -1,5 +1,3 @@
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
 import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -1,6 +1,4 @@
 import { Observable } from '../Observable';
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
 import { EmptyError } from '../util/EmptyError';
 import { OperatorFunction } from '../../internal/types';
 import { filter } from './filter';

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -1,6 +1,4 @@
 import { Observable } from '../Observable';
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
 import { EmptyError } from '../util/EmptyError';
 import { OperatorFunction } from '../../internal/types';
 import { filter } from './filter';

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -1,4 +1,3 @@
-
 import { mergeMap } from './mergeMap';
 import { identity } from '../util/identity';
 import { OperatorFunction, ObservableInput } from '../types';

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -1,4 +1,3 @@
-import { Observable } from '../Observable';
 import { OperatorFunction, ObservedValueOf } from '../../internal/types';
 import { mergeMap } from './mergeMap';
 import { ObservableInput } from '../types';

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -3,7 +3,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { ConnectableObservable, connectableObservableDescriptor } from '../observable/ConnectableObservable';
-import { MonoTypeOperatorFunction, OperatorFunction, UnaryFunction, ObservedValueOf, ObservableInput } from '../types';
+import { OperatorFunction, UnaryFunction, ObservedValueOf, ObservableInput } from '../types';
 
 /* tslint:disable:max-line-length */
 export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -1,10 +1,3 @@
-import { Operator } from '../Operator';
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
-import { Subscription } from '../Subscription';
-import { OuterSubscriber } from '../OuterSubscriber';
-import { InnerSubscriber } from '../InnerSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction } from '../types';
 import { switchMap } from './switchMap';
 

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -1,4 +1,3 @@
-
 import { Observable } from '../Observable';
 import { async } from '../scheduler/async';
 import { SchedulerLike, OperatorFunction } from '../types';

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -1,8 +1,4 @@
 import { async } from '../scheduler/async';
-import { isDate } from '../util/isDate';
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { TimeoutError } from '../util/TimeoutError';
 import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
 import { timeoutWith } from './timeoutWith';

--- a/src/internal/operators/timestamp.ts
+++ b/src/internal/operators/timestamp.ts
@@ -1,4 +1,3 @@
-
 import { async } from '../scheduler/async';
 import { OperatorFunction, SchedulerLike, Timestamp as TimestampInterface } from '../types';
 import { map } from './map';

--- a/src/internal/util/isObservable.ts
+++ b/src/internal/util/isObservable.ts
@@ -1,5 +1,4 @@
 import { Observable } from '../Observable';
-import { ObservableInput } from '../types';
 
 /**
  * Tests to see if the object is an RxJS {@link Observable}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I find some unused imports while viewing the operators code.

**Related issue (if exists):**
