### PR TITLE
docs(navigation): remove duplicated nav link

### DIFF
--- a/docs_app/content/navigation.json
+++ b/docs_app/content/navigation.json
@@ -42,10 +42,6 @@
 					"title": "Subjects"
 				},
         {
-					"url": "guide/operators",
-					"title": "Operators"
-				},
-        {
 					"url": "guide/scheduler",
 					"title": "Scheduler"
         },


### PR DESCRIPTION
**Description:**

Remove the duplicated 'Operator' side nav link in the docs site.

Before:
<img width="262" alt="Screen Shot 2019-05-05 at 12 50 53 PM" src="https://user-images.githubusercontent.com/19582796/57199543-24088a00-6f35-11e9-92b9-c8215f4bbf59.png">

After:
<img width="264" alt="Screen Shot 2019-05-05 at 12 50 43 PM" src="https://user-images.githubusercontent.com/19582796/57199545-2bc82e80-6f35-11e9-827c-19ab16a3dff9.png">

**Related issue (if exists):**
N/A