### PR TITLE
missing output from the example

### DIFF
--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -46,6 +46,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(project: (value:
  * // outputs
  * // 1
  * // 1
+ * // 1
  * // 2
  * // 4
  * // 8


### PR DESCRIPTION
Missing the third 1 from the output

**Description:**

The doc for switchMap() states that the output for the first example is: 

> const switched = of(1, 2, 3).pipe(switchMap((x: number) => of(x, x ** 2, x ** 3)));
> switched.subscribe(x => console.log(x));
> // outputs
> // 1
> // 1
> // 2
> // 4
> // 8
> // ... and so on

The example when ran is giving:

1
1
**1**
2
4
8
...

