### PR TITLE
fix(scan-operator): Improve typings using newer TS features

### DIFF
--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -1,13 +1,7 @@
 import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { OperatorFunction, MonoTypeOperatorFunction } from '../types';
-
-/* tslint:disable:max-line-length */
-export function scan<T>(accumulator: (acc: T, value: T, index: number) => T, seed?: T): MonoTypeOperatorFunction<T>;
-export function scan<T>(accumulator: (acc: T[], value: T, index: number) => T[], seed?: T[]): OperatorFunction<T, T[]>;
-export function scan<T, R>(accumulator: (acc: R, value: T, index: number) => R, seed?: R): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
+import { OperatorFunction } from '../types';
 
 /**
  * Applies an accumulator function over the source Observable, and returns each
@@ -52,7 +46,7 @@ export function scan<T, R>(accumulator: (acc: R, value: T, index: number) => R, 
  * @method scan
  * @owner Observable
  */
-export function scan<T, R>(accumulator: (acc: R, value: T, index: number) => R, seed?: T | R): OperatorFunction<T, R> {
+export function scan<T, R = T>(accumulator: (acc: R, value: T, index: number) => R, seed?: R): OperatorFunction<T, R> {
   let hasSeed = false;
   // providing a seed of `undefined` *should* be valid and trigger
   // hasSeed! so don't use `seed !== undefined` checks!

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -54,12 +54,11 @@ import { map } from './map';
 export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunction<T, TimeInterval<T>> {
   return (source: Observable<T>) => defer(() => {
     return source.pipe(
-      // TODO(benlesh): correct these typings.
       scan(
         ({ current }, value) => ({ value, current: scheduler.now(), last: current }),
-        { current: scheduler.now(), value: undefined,  last: undefined }
-      ) as any,
-      map<any, TimeInterval<T>>(({ current, last, value }) => new TimeInterval(value, current - last)),
+        { current: scheduler.now(), value: undefined, last: undefined } as { current: number, value?: T, last?: number }
+      ),
+      map(({ current, last, value }) => new TimeInterval(value, current - last)),
     );
   });
 }


### PR DESCRIPTION
**Description:**
The `scan` operator does not properly infer types when the output Observable type differs from the input Observable type (i.e. `T != R`). This issue was discussed at length a few years back in https://github.com/ReactiveX/rxjs/pull/2897. That PR was ultimately closed because there were unavoidable limitations due to the minimum supported TypeScript at that time. The current minimum TS version should allow these types to be improved.

Using issue https://github.com/ReactiveX/rxjs/issues/3150 as an example:

```
of('0').pipe(
  scan((acc, str) => acc + parseInt(str), 0)
);
```

The current types cause both `acc` and `str` to be inferred as a `string` type, but `acc` should be inferred to be a `number` from the seed value `0`, which is what my change fixes.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/3150