### PR TITLE
docs(subject.md): clarify that refCount is an operator

### DIFF
--- a/doc/subject.md
+++ b/doc/subject.md
@@ -150,7 +150,7 @@ setTimeout(() => {
 }, 2000);
 ```
 
-If we wish to avoid explicit calls to `connect()`, we can use ConnectableObservable's `refCount()` method (reference counting), which returns an Observable that keeps track of how many subscribers it has. When the number of subscribers increases from `0` to `1`, it will call `connect()` for us, which starts the shared execution. Only when the number of subscribers decreases from `1` to `0` will it be fully unsubscribed, stopping further execution.
+If we wish to avoid explicit calls to `connect()`, we can use the `refCount()` operator (reference counting), which returns an Observable from a ConnectableObservable and keeps track of how many subscribers it has. When the number of subscribers increases from `0` to `1`, it will call `connect()` for us, which starts the shared execution. Only when the number of subscribers decreases from `1` to `0` will it be fully unsubscribed, stopping further execution.
 
 <span class="informal">`refCount` makes the multicasted Observable automatically start executing when the first subscriber arrives, and stop executing when the last subscriber leaves.</span>
 
@@ -202,7 +202,7 @@ setTimeout(() => {
 // observerB unsubscribed
 ```
 
-The `refCount()` method only exists on ConnectableObservable, and it returns an `Observable`, not another ConnectableObservable.
+The `refCount()` operator is only available to use on ConnectableObservable, and it returns an `Observable`, not another ConnectableObservable.
 
 ## BehaviorSubject
 


### PR DESCRIPTION
**Description:**

Clarify that refCount is an operator and not a method used directly on a ConnectableObservable.

**Related issue (if exists):**

Closes #4664