### PR TITLE
feat(filterByLatestFrom): add filterByLatestFrom operator

### DIFF
--- a/doc/decision-tree-widget/tree.yml
+++ b/doc/decision-tree-widget/tree.yml
@@ -21,6 +21,9 @@ children:
       - label: based on custom logic
         children:
         - label: filter
+      - label: based on another obvervable
+        children:
+        - label: filterByLatestFrom
       - label: if they are at the start of the Observable
         children:
         - label: and only the first value

--- a/doc/operators.md
+++ b/doc/operators.md
@@ -179,6 +179,7 @@ There are operators for different purposes, and they may be categorized as: crea
 - [`distinctUntilKeyChanged`](../class/es6/Observable.js~Observable.html#instance-method-distinctUntilKeyChanged)
 - [`elementAt`](../class/es6/Observable.js~Observable.html#instance-method-elementAt)
 - [`filter`](../class/es6/Observable.js~Observable.html#instance-method-filter)
+- [`filterByLatestFrom`](../class/es6/Observable.js~Observable.html#instance-method-filterByLatestFrom)
 - [`first`](../class/es6/Observable.js~Observable.html#instance-method-first)
 - [`ignoreElements`](../class/es6/Observable.js~Observable.html#instance-method-ignoreElements)
 - [`last`](../class/es6/Observable.js~Observable.html#instance-method-last)

--- a/spec/operators/filterByLatestFrom-spec.ts
+++ b/spec/operators/filterByLatestFrom-spec.ts
@@ -1,0 +1,135 @@
+import { map, filterByLatestFrom } from 'rxjs/operators';
+import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { of } from 'rxjs';
+
+declare function asDiagram(arg: string): Function;
+
+/** @test {filterByLatestFrom} */
+describe('filterByLatestFrom operator', () => {
+  function mapToIsOdd() {
+    return map((x: number | string) => (+x) % 2 === 1);
+  }
+
+  function mapToIsPrime() {
+    return map((i: number | string) => {
+      if (+i <= 1) { return false; }
+      const max = Math.floor(Math.sqrt(+i));
+      for (let j = 2; j <= max; ++j) {
+        if (+i % j === 0) { return false; }
+      }
+      return true;
+    });
+  }
+
+  asDiagram('filterByLatestFrom')('should filter in if the latest value emitted by other observable is odd', () => {
+    const source = cold('-a--b---c---d-e-|');
+    const filter = cold('--1--2-3-4------|');
+    const expected =    '----b---c-------|';
+
+    const result = source.pipe(filterByLatestFrom(filter.pipe(mapToIsOdd())));
+
+    expectObservable(result).toBe(expected);
+  });
+
+  it('should filter in if latest is prime', () => {
+    const source = hot('-a--b--^--c-d-e-f--g-h--j--|');
+    const filter = hot('-1--2--^-3-4-5-6--7-8--9---|');
+    const subs =              '^                   !';
+    const expected =          '---c---e----g-------|';
+
+    expectObservable(source.pipe(filterByLatestFrom(filter.pipe(mapToIsPrime())))).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(filter.subscriptions).toBe(subs);
+  });
+
+  it('should filter with an always-true latest value', () => {
+    const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
+    const subs =              '^                  !';
+    const expected =          '--3-4-5-6--7-8--9--|';
+
+    expectObservable(source.pipe(filterByLatestFrom(of(true)))).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should filter with an always-false latest value', () => {
+    const source = hot('-1--2--^-3-4-5-6--7-8--9--|');
+    const subs =              '^                  !';
+    const expected =          '-------------------|';
+
+    expectObservable(source.pipe(filterByLatestFrom(of(false)))).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  it('should filter in if the latest is prime, source unsubscribes early', () => {
+    const source = hot('-a--b--^--c-d-e-f--g-h--j--|');
+    const filter = hot('-1--2--^-3-4-5-6--7-8--9---|');
+    const subs =              '^            !       ';
+    const unsub =             '             !       ';
+    const expected =          '---c---e----g-       ';
+
+    expectObservable(source.pipe(filterByLatestFrom(filter.pipe(mapToIsPrime()))), unsub).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(filter.subscriptions).toBe(subs);
+  });
+
+  it('should filter in if latest is prime, source throws', () => {
+    const source = hot('-a--b--^--c-d-e-f--g-h--j--#');
+    const filter = hot('-1--2--^-3-4-5-6--7-8--9---|');
+    const subs =              '^                   !';
+    const expected =          '---c---e----g-------#';
+
+    expectObservable(source.pipe(filterByLatestFrom(filter.pipe(mapToIsPrime())))).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(filter.subscriptions).toBe(subs);
+  });
+
+  it('should filter in if latest is prime, but filter throws', () => {
+    const source = hot('-a--b--^--c-d-e-f--g-h--j--|');
+    const filter = hot('-1--2--^-3-4-5-#            ');
+    const subs =              '^       !            ';
+    const expected =          '---c---e#            ';
+
+    expectObservable(source.pipe(filterByLatestFrom(filter.pipe(mapToIsPrime())))).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(filter.subscriptions).toBe(subs);
+  });
+
+  it('should filter in if latest is prime, source errors', () => {
+    const source = hot('-a--b--^--c-d-e-f--g-h--j--#', undefined, new Error('boo-hoo'));
+    const filter = hot('-1--2--^-3-4-5-6--7-8--9---|');
+    const subs =              '^                   !';
+    const expected =          '---c---e----g-------#';
+
+    expectObservable(source.pipe(filterByLatestFrom(
+      filter.pipe(mapToIsPrime())
+    ))).toBe(expected, undefined, new Error('boo-hoo'));
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(filter.subscriptions).toBe(subs);
+  });
+
+  it('should filter in if latest is prime, but filter errors', () => {
+    const source = hot('-a--b--^--c-d-e-f--g-h--j--|');
+    const filter = hot('-1--2--^-3-4-5-#            ', undefined, new Error('boo-hoo'));
+    const subs =              '^       !            ';
+    const expected =          '---c---e#            ';
+
+    expectObservable(source.pipe(filterByLatestFrom(
+      filter.pipe(mapToIsPrime())
+    ))).toBe(expected, undefined, new Error('boo-hoo'));
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(filter.subscriptions).toBe(subs);
+  });
+
+  it('should filter with empty', () => {
+    const source = hot('-a--b--^--c-d-e-f--g-h--j--|');
+    const filter = hot('-------^-------------------|');
+    const subs =              '^                   !';
+    const expected =          '--------------------|';
+
+    expectObservable(source.pipe(filterByLatestFrom(
+      filter.pipe(mapToIsPrime())
+    ))).toBe(expected);
+    expectSubscriptions(source.subscriptions).toBe(subs);
+    expectSubscriptions(filter.subscriptions).toBe(subs);
+  });
+});

--- a/src/internal/operators/filterByLatestFrom.ts
+++ b/src/internal/operators/filterByLatestFrom.ts
@@ -1,0 +1,77 @@
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Observable } from '../Observable';
+import { OuterSubscriber } from '../OuterSubscriber';
+import { subscribeToResult } from '../util/subscribeToResult';
+import { ObservableInput, MonoTypeOperatorFunction, OperatorFunction } from '../types';
+
+/* tslint:disable:max-line-length */
+export function filterByLatestFrom<T>(filter: ObservableInput<boolean>): MonoTypeOperatorFunction<T>;
+export function filterByLatestFrom<T, S extends T>(filter: ObservableInput<boolean>): OperatorFunction<T, S>;
+/* tslint:enable:max-line-length */
+/**
+ * Filters the source Observable by the latest value emitted by the filter Observable
+ *
+ * ![](filterByLatestFrom.png)
+ *
+ * ## Example
+ * On every click event, emit if the timer has emitted an odd number of times
+ * ```ts
+ * import { fromEvent, interval } from 'rxjs';
+ * import { filterByLatestFrom } from 'rxjs/operators';
+ *
+ * const clicks = fromEvent(document, 'click');
+ * const timer = interval(1000);
+ * const result = clicks.pipe(filterByLatestFrom(timer, map(interval => interval % 2 === 1)));
+ * result.subscribe(x => console.log(x));
+ * ```
+ *
+ * @param {ObservableInput} filter An input Observable to filter the source by.
+ * @return {Observable} An Observable which only emits if the latest value of
+ * the inputObservable is true.
+ * @method filterByLatestFrom
+ * @owner Observable
+ */
+export function filterByLatestFrom<T>(filter: ObservableInput<boolean>): MonoTypeOperatorFunction<T> {
+  return (source: Observable<T>) => {
+    return source.lift(new FilterByLatestFromOperator(filter));
+  };
+}
+
+class FilterByLatestFromOperator<T> implements Operator<T, T> {
+  constructor(private observable: ObservableInput<boolean>) {}
+
+  call(subscriber: Subscriber<T>, source: any): any {
+    return source.subscribe(new FilterByLatestFromSubscriber(subscriber, this.observable));
+  }
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
+class FilterByLatestFromSubscriber<T> extends OuterSubscriber<T, boolean> {
+  private value = false;
+
+  constructor(destination: Subscriber<T>,
+              private observable: ObservableInput<boolean>) {
+    super(destination);
+
+    this.add(subscribeToResult<T, boolean>(this, observable));
+  }
+
+  notifyNext(outerValue: T, innerValue: boolean): void {
+    this.value = innerValue;
+  }
+
+  notifyComplete() {
+    // noop
+  }
+
+  protected _next(value: T) {
+    if (this.value === true) {
+      this.destination.next(value);
+    }
+  }
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -31,6 +31,7 @@ export { exhaust } from '../internal/operators/exhaust';
 export { exhaustMap } from '../internal/operators/exhaustMap';
 export { expand } from '../internal/operators/expand';
 export { filter } from '../internal/operators/filter';
+export { filterByLatestFrom } from '../internal/operators/filterByLatestFrom';
 export { finalize } from '../internal/operators/finalize';
 export { find } from '../internal/operators/find';
 export { findIndex } from '../internal/operators/findIndex';


### PR DESCRIPTION
This operator allows to use other observables as filters.

This is doable with other operators, but is prone to error and complicated to write.

## Feature Request

**Describe the solution you'd like**
This should either be a core operator or addition of good documentation about the implementation and pitfalls.

**Describe alternatives you've considered**
This can be implemented as a user land operator.

**(If this is new operator request) describe reason it should be core operator**
There should be a clear answer to filtering using input from an additional observable.

**Additional context**
The most common issue is that it is very simple to think that moving the filter into the inner observable is safe. Example in a comment. There is an issue that RxJS does not have a canonical extensions library like lodash. Many operators in RxJS do not need to be in the core, but they still are. I would gladly add this to the canonical extensions library, if it were available.

