### PR TITLE
fix(migrations): use latest version of package when adding compat

### DIFF
--- a/migrations/update-6_0_0/index.ts
+++ b/migrations/update-6_0_0/index.ts
@@ -1,31 +1,8 @@
-import { Rule, SchematicContext, Tree, SchematicsException, chain,  } from '@angular-devkit/schematics';
+import { Rule } from '@angular-devkit/schematics';
 import { NodePackageInstallTask } from '@angular-devkit/schematics/tasks';
 
-const rxjsCompatVersion = '^6.0.0-rc.0';
-
-export function rxjsV6MigrationSchematic(_options: any): Rule {
-  return (tree: Tree, context: SchematicContext) => {
-      const pkgPath = '/package.json';
-      const buffer = tree.read(pkgPath);
-      if (buffer == null) {
-        throw new SchematicsException('Could not read package.json');
-      }
-      const content = buffer.toString();
-      const pkg = JSON.parse(content);
-
-      if (pkg === null || typeof pkg !== 'object' || Array.isArray(pkg)) {
-        throw new SchematicsException('Error reading package.json');
-      }
-
-      if (!pkg.dependencies) {
-        pkg.dependencies = {};
-      }
-
-      pkg.dependencies['rxjs-compat'] = rxjsCompatVersion;
-
-      tree.overwrite(pkgPath, JSON.stringify(pkg, null, 2));
-      context.addTask(new NodePackageInstallTask());
-
-      return tree; // <3
+export function rxjsV6MigrationSchematic(): Rule {
+  return (_, context) => {
+      context.addTask(new NodePackageInstallTask({ packageName: 'rxjs-compat@6.5.2' }));
   };
 }

--- a/package.json
+++ b/package.json
@@ -175,7 +175,7 @@
   },
   "devDependencies": {
     "@angular-devkit/build-optimizer": "0.4.6",
-    "@angular-devkit/schematics": "^0.5.4",
+    "@angular-devkit/schematics": "^0.6.0",
     "@types/chai": "4.1.2",
     "@types/lodash": "4.14.102",
     "@types/mocha": "2.2.48",

--- a/spec/migration/update-6_0_0/index-spec.ts
+++ b/spec/migration/update-6_0_0/index-spec.ts
@@ -1,4 +1,6 @@
-import { Tree } from '@angular-devkit/schematics';
+import { getSystemPath, normalize, virtualFs } from '@angular-devkit/core';
+import { TempScopedNodeJsSyncHost } from '@angular-devkit/core/node/testing';
+import { HostTree } from '@angular-devkit/schematics';
 import { SchematicTestRunner, UnitTestTree } from '@angular-devkit/schematics/testing';
 import * as path from 'path';
 import { expect } from 'chai';
@@ -7,17 +9,27 @@ const collectionPath = path.join(__dirname, '../../../migrations/collection.json
 
 describe('Migration Schematic', () => {
   let tree: UnitTestTree;
+  let host: TempScopedNodeJsSyncHost;
 
-  beforeEach(() => {
-    tree = Tree.empty() as UnitTestTree;
-    tree.create('/package.json', `{}`);
+  beforeEach((done) => {
+    host = new TempScopedNodeJsSyncHost();
+    tree = new UnitTestTree(new HostTree(host));
+    process.chdir(getSystemPath(host.root));
+    host.write(normalize('/package.json'), virtualFs.stringToFileBuffer('{}'))
+      .toPromise()
+      .then(() => done(), err => done(err));
   });
 
-  it('adds missing dependencies', () => {
+  it('adds missing dependencies', (done) => {
     const runner = new SchematicTestRunner('schematics', collectionPath);
     tree = runner.runSchematic('rxjs-migration-01', {}, tree);
 
-    const pkg = JSON.parse(tree.readContent('/package.json'));
-    expect(pkg.dependencies['rxjs-compat']).to.equal('^6.0.0-rc.0');
+    runner.engine.executePostTasks().toPromise()
+      .then(() => host.read(normalize('/package.json')).toPromise())
+      .then(data => {
+        const pkg = JSON.parse(Buffer.from(data).toString());
+        expect(pkg.dependencies['rxjs-compat']).to.equal('^6.5.2');
+        done();
+      }).catch(err => done(err));
   });
 });


### PR DESCRIPTION
Update and cleanup the RxJS migration schematic.  

//cc @benlesh 