### PR TITLE
chore: remove useless import

### DIFF
--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -3,7 +3,6 @@ import { Observable } from './Observable';
 import { empty } from './observable/empty';
 import { of } from './observable/of';
 import { throwError } from './observable/throwError';
-import { deprecate } from 'util';
 
 // TODO: When this enum is removed, replace it with a type alias. See #4556.
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes a useless import - that appears to have been added by VS Code's autocomplete/autoimport feature.

**Related issue (if exists):** None