### PR TITLE
fix(race): ignore latter sources after first complete or error

### DIFF
--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -137,4 +137,14 @@ export class RaceSubscriber<T> extends OuterSubscriber<T, T> {
 
     this.destination.next(innerValue);
   }
+
+  notifyComplete(innerSub: InnerSubscriber<T, T>): void {
+    this.hasFirst = true;
+    super.notifyComplete(innerSub);
+  }
+
+  notifyError(error: any, innerSub: InnerSubscriber<T, T>): void {
+    this.hasFirst = true;
+    super.notifyError(error, innerSub);
+  }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The implementation of `race` ignores latter sources if an earlier source emits a `next` notification. This PR fixes the implementation so that latter sources are also ignored if an earlier source wins the race by emitting either a `complete` or an `error` notification.

This PR adds failing tests that are fixed by the change.

For more information, see the related issue - it contains code snippets that highlight the inconsistent behaviour.

**Related issue (if exists):** #4808