### PR TITLE
 fix(defer): use overload sig for void factory

### DIFF
--- a/spec-dtslint/observables/defer-spec.ts
+++ b/spec-dtslint/observables/defer-spec.ts
@@ -15,3 +15,7 @@ it('should infer correctly with function return promise', () => {
 it('should support union type returns', () => {
   const a = defer(() => Math.random() > 0.5 ? of(123) : of('abc')); // $ExpectType Observable<string | number>
 });
+
+it('should infer correctly with void functions', () => {
+  const a = defer(() => {}); // $ExpectType Observable<never>
+});

--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -52,6 +52,8 @@ import { empty } from './empty';
  * @name defer
  * @owner Observable
  */
+export function defer<O extends ObservableInput<any>>(observableFactory: () => O): Observable<ObservedValueOf<O>>;
+export function defer(observableFactory: () => void): Observable<never>;
 export function defer<O extends ObservableInput<any>>(observableFactory: () => O | void): Observable<ObservedValueOf<O>> {
   return new Observable<ObservedValueOf<O>>(subscriber => {
     let input: O | void;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing dtslint test and then fixes the problem it exposes by separating the `defer` signatures, so that the signature that accepts a factory that returns `void` returns `Observable<never>`.

**Related issue (if exists):** #4804