### PR TITLE
fix first operator

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -33,7 +33,7 @@ will emit `1`, `4`, `9`.  Another useful operator is [`first`](/api/operators/fi
 import { of } from 'rxjs';
 import { first } from 'rxjs/operators';
 
-first()(of(1, 2, 3).subscribe((v) => console.log(`value: ${v}`));
+first()(of(1, 2, 3)).subscribe((v) => console.log(`value: ${v}`));
 
 // Logs:
 // value: 1 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** there is a missing ")" in this first() operator example in Rxjs guide. in the operators section [https://rxjs-dev.firebaseapp.com/guide/operators](url)

![Bug](https://user-images.githubusercontent.com/31720219/58488930-90f4f580-816a-11e9-92c1-a102a1752d0b.png)


**Related issue (if exists):** i submitted an issue here [https://github.com/ReactiveX/rxjs/issues/4812](url)
