### PR TITLE
docs(operators): skipWhile() docs to improve

### DIFF
--- a/src/internal/operators/skipWhile.ts
+++ b/src/internal/operators/skipWhile.ts
@@ -7,7 +7,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * Returns an Observable that skips all items emitted by the source Observable as long as a specified condition holds
  * true, but emits all further source items as soon as the condition becomes false.
  *
- * ![](skipWhile.png)
+ * ![](skipWhile.png) ====> Update the marble diagram 
  *
  * @param {Function} predicate - A function to test each item emitted from the source Observable.
  * @return {Observable<T>} An Observable that begins emitting items emitted by the source Observable when the


### PR DESCRIPTION
I took a look at the marble diagram, usually they guide me well, but this one is a bit tricky. Because I misunderstood with filter(), thinking that the condition will be always checked for skipWhile(), which is true, UNTIL we reach one time the condition equals false.
 I didn't see that UNTIL :/

Is it possible in the marble to add these values ==> 2 / 3 / 4 (condition becomes false) / 5 / 6 / 1 / 2 / 3 (so adding  the last 1 / 2 / 3) to show people that the value will be emitted.

Thanks,
Martin

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
