### PR TITLE
docs: update theme_color to match site colors

### DIFF
--- a/docs_app/src/index.html
+++ b/docs_app/src/index.html
@@ -26,7 +26,7 @@
   <!-- -->
 
   <link rel="manifest" href="pwa-manifest.json">
-  <meta name="theme-color" content="#1976d2">
+  <meta name="theme-color" content="#d81b60">
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="translucent">
 

--- a/docs_app/src/pwa-manifest.json
+++ b/docs_app/src/pwa-manifest.json
@@ -49,7 +49,7 @@
     }
   ],
   "start_url": "/?utm_source=homescreen",
-  "background_color": "#1976d2",
-  "theme_color": "#1976d2",
+  "background_color": "#ffffff",
+  "theme_color": "#d81b60",
   "display": "standalone"
 }


### PR DESCRIPTION
**Description:**

The documentation site was still using Angular blue for `theme_color`. This updates the colors to match the rest of the site.

| Before | After |
| ------------- | ------------- |
| ![Screenshot_20190531-010607](https://user-images.githubusercontent.com/3341/58685583-df102180-8341-11e9-8d8c-6a7ea1138c4d.png) | ![Screenshot_20190531-010955](https://user-images.githubusercontent.com/3341/58685590-e46d6c00-8341-11e9-9e81-7c83fbfa8f4e.png) |
| ![Screenshot_20190531-011918](https://user-images.githubusercontent.com/3341/58685708-3a421400-8342-11e9-8f95-f7f4408f7376.png) | ![Screenshot_20190531-011149](https://user-images.githubusercontent.com/3341/58685613-f9e29600-8341-11e9-846d-ec8eb2bde038.png) |
