### PR TITLE
 fix(defer): restrict allowed factory types

### DIFF
--- a/spec-dtslint/observables/defer-spec.ts
+++ b/spec-dtslint/observables/defer-spec.ts
@@ -19,3 +19,7 @@ it('should support union type returns', () => {
 it('should infer correctly with void functions', () => {
   const a = defer(() => {}); // $ExpectType Observable<never>
 });
+
+it('should error if an ObservableInput is not returned', () => {
+  const a = defer(() => 42); // $ExpectError
+});

--- a/spec-dtslint/observables/defer-spec.ts
+++ b/spec-dtslint/observables/defer-spec.ts
@@ -23,3 +23,7 @@ it('should infer correctly with void functions', () => {
 it('should error if an ObservableInput is not returned', () => {
   const a = defer(() => 42); // $ExpectError
 });
+
+it('should infer correctly with functions that sometimes do not return an ObservableInput', () => {
+  const a = defer(() => { if (Math.random() < 0.5) { return of(42); } }); // $ExpectType Observable<number>
+});

--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -52,18 +52,16 @@ import { empty } from './empty';
  * @name defer
  * @owner Observable
  */
-export function defer<O extends ObservableInput<any>>(observableFactory: () => O): Observable<ObservedValueOf<O>>;
-export function defer(observableFactory: () => void): Observable<never>;
-export function defer<O extends ObservableInput<any>>(observableFactory: () => O | void): Observable<ObservedValueOf<O>> {
-  return new Observable<ObservedValueOf<O>>(subscriber => {
-    let input: O | void;
+export function defer<R extends ObservableInput<any> | void>(observableFactory: () => R): Observable<ObservedValueOf<R>> {
+  return new Observable<ObservedValueOf<R>>(subscriber => {
+    let input: R | void;
     try {
       input = observableFactory();
     } catch (err) {
       subscriber.error(err);
       return undefined;
     }
-    const source = input ? from(input) : empty();
+    const source = input ? from(input as ObservableInput<ObservedValueOf<R>>) : empty();
     return source.subscribe(subscriber);
   });
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes a problem with the `defer` type signatures that was introduced in #4810 - the PR that ensured that `Observable<never>` was inferred for factory functions that return `void`.

The problem was that `() => void` will match functions returning any value - as the return value is ignored - which meant that factories could return anything - e.g. a `number`.

See the discussion on [this commit](https://github.com/ReactiveX/rxjs/commit/362d1d4fc1d7f15e7168453ea640079d0ca19dba#commitcomment-33814932).

The PR includes a failing dtslint test that is fixed by the change.

**Related issue (if exists):** #4804 #4810 
