### PR TITLE
Adding static publish/multicast variants, and deprecating operators that return ConnectableObservable

### DIFF
--- a/src/internal/observable/multicast.ts
+++ b/src/internal/observable/multicast.ts
@@ -1,0 +1,8 @@
+import { Observable } from '../Observable';
+import { Subject } from '../Subject';
+import { ConnectableObservable } from '../observable/ConnectableObservable';
+
+export function multicast<T>(source: Observable<T>, subjectOrSubjectFactory?: (() => Subject<T>) | Subject<T>) {
+  const subjectFactory = (typeof subjectOrSubjectFactory === 'function') ? subjectOrSubjectFactory : () => subjectOrSubjectFactory;
+  return new ConnectableObservable(source, subjectFactory);
+}

--- a/src/internal/observable/publish.ts
+++ b/src/internal/observable/publish.ts
@@ -1,0 +1,52 @@
+import { Observable } from '../Observable';
+import { Subject } from '../Subject';
+import { multicast } from './multicast';
+import { ConnectableObservable } from '../observable/ConnectableObservable';
+
+/**
+ * Shares a single observable to many subscribers via a single, underlying {@link Subject}
+ *
+ * Publishing a source will return a {@link ConnectableObservable}, which is an observable
+ * that pairs the `source` to an single, underlying {@link Subject}. When a consumer
+ * subscribes to the returned observable, they are actually subscribing to the subject, and the
+ * {@link Subscription} returned is the subscription from that action.
+ * When `connect` is called on the returned observable, the `source` is subscribed to
+ * with that subject, connecting the source to all subscribed observers through the subject,
+ * and thus "multicasting".
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { of, publish } from 'rxjs';
+ * const source = of(1, 2, 3);
+ *
+ * const shared = publish(source);
+ *
+ * shared.subscribe({
+ *  next: v => console.log('sub1: ', v),
+ *  complete: () => console.log('sub1: done'),
+ * });
+ *
+ * shared.subscribe({
+ *  next: v => console.log('sub2: ', v),
+ *  complete: () => console.log('sub2: done'),
+ * });
+ *
+ * shared.connect();
+ *
+ * // Output
+ * // sub1: 1
+ * // sub2: 1
+ * // sub1: 2
+ * // sub2: 2
+ * // sub1: 3
+ * // sub2: 4
+ * // sub1: done
+ * // sub2: done
+ * ```
+ *
+ * @param source The observable to multicast
+ */
+export function publish<T>(source: Observable<T>): ConnectableObservable<T> {
+  return multicast(source, new Subject<T>());
+}

--- a/src/internal/observable/publishCurrentValue.ts
+++ b/src/internal/observable/publishCurrentValue.ts
@@ -1,0 +1,8 @@
+import { Observable } from '../Observable';
+import { BehaviorSubject as CurrentValueSubject } from '../BehaviorSubject';
+import { multicast } from './multicast';
+import { ConnectableObservable } from '../observable/ConnectableObservable';
+
+export function publishCurrentValue<T>(source: Observable<T>, initialValue: T): ConnectableObservable<T> {
+  return multicast(source, new CurrentValueSubject<T>(initialValue));
+}

--- a/src/internal/observable/publishLast.ts
+++ b/src/internal/observable/publishLast.ts
@@ -1,0 +1,8 @@
+import { Observable } from '../Observable';
+import { AsyncSubject } from '../AsyncSubject';
+import { multicast } from './multicast';
+import { ConnectableObservable } from '../observable/ConnectableObservable';
+
+export function publishLast<T>(source: Observable<T>): ConnectableObservable<T> {
+  return multicast(source, new AsyncSubject<T>());
+}

--- a/src/internal/observable/publishReplay.ts
+++ b/src/internal/observable/publishReplay.ts
@@ -1,0 +1,12 @@
+import { Observable } from '../Observable';
+import { ReplaySubject } from '../ReplaySubject';
+import { multicast } from './multicast';
+import { ConnectableObservable } from '../observable/ConnectableObservable';
+
+export function publishReplay<T>(
+  source: Observable<T>,
+  bufferSize = Number.POSITIVE_INFINITY,
+  windowTime = Number.POSITIVE_INFINITY
+): ConnectableObservable<T> {
+  return multicast(source, new ReplaySubject<T>(bufferSize, windowTime));
+}

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -4,10 +4,13 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { ConnectableObservable, connectableObservableDescriptor } from '../observable/ConnectableObservable';
 import { OperatorFunction, UnaryFunction, ObservedValueOf, ObservableInput } from '../types';
+import { Subscription } from '../Subscription';
 
 /* tslint:disable:max-line-length */
+/** @deprecated remove in v8. Use static version of {@link multicast} */
 export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export function multicast<T, O extends ObservableInput<any>>(subject: Subject<T>, selector: (shared: Observable<T>) => O): UnaryFunction<Observable<T>, ConnectableObservable<ObservedValueOf<O>>>;
+/** @deprecated remove in v8. Use static version of {@link multicast} */
 export function multicast<T>(subjectFactory: (this: Observable<T>) => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export function multicast<T, O extends ObservableInput<any>>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
 /* tslint:enable:max-line-length */
@@ -28,18 +31,16 @@ export function multicast<T, O extends ObservableInput<any>>(SubjectFactory: (th
  * @return {Observable} An Observable that emits the results of invoking the selector
  * on the items emitted by a `ConnectableObservable` that shares a single subscription to
  * the underlying stream.
- * @method multicast
- * @owner Observable
  */
 export function multicast<T, R>(subjectOrSubjectFactory: Subject<T> | (() => Subject<T>),
                                 selector?: (source: Observable<T>) => Observable<R>): OperatorFunction<T, R> {
   return function multicastOperatorFunction(source: Observable<T>): Observable<R> {
     let subjectFactory: () => Subject<T>;
     if (typeof subjectOrSubjectFactory === 'function') {
-      subjectFactory = <() => Subject<T>>subjectOrSubjectFactory;
+      subjectFactory = subjectOrSubjectFactory;
     } else {
       subjectFactory = function subjectFactory() {
-        return <Subject<T>>subjectOrSubjectFactory;
+        return subjectOrSubjectFactory;
       };
     }
 
@@ -51,7 +52,7 @@ export function multicast<T, R>(subjectOrSubjectFactory: Subject<T> | (() => Sub
     connectable.source = source;
     connectable.subjectFactory = subjectFactory;
 
-    return <ConnectableObservable<R>> connectable;
+    return connectable;
   };
 }
 
@@ -62,7 +63,8 @@ export class MulticastOperator<T, R> implements Operator<T, R> {
   call(subscriber: Subscriber<R>, source: any): any {
     const { selector } = this;
     const subject = this.subjectFactory();
-    const subscription = selector(subject).subscribe(subscriber);
+    const subscription = new Subscription();
+    subscription.add(selector(subject).subscribe(subscriber));
     subscription.add(source.subscribe(subject));
     return subscription;
   }

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -5,9 +5,9 @@ import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { MonoTypeOperatorFunction, OperatorFunction, UnaryFunction, ObservableInput, ObservedValueOf } from '../types';
 
 /* tslint:disable:max-line-length */
+/** @deprecated removed in v8. Use the static version of {@link publish}, (e.g. `import { publish } from 'rxjs'; publish(obs$)`) */
 export function publish<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export function publish<T, O extends ObservableInput<any>>(selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
-export function publish<T>(selector: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/operators/publishBehavior.ts
+++ b/src/internal/operators/publishBehavior.ts
@@ -5,11 +5,9 @@ import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { UnaryFunction } from '../types';
 
 /**
- * @param value
- * @return {ConnectableObservable<T>}
- * @method publishBehavior
- * @owner Observable
+ * @param initialValue
+ * @deprecated remove in v8. Use static {@link publishCurrentValue}.
  */
-export function publishBehavior<T>(value: T):  UnaryFunction<Observable<T>, ConnectableObservable<T>> {
-  return (source: Observable<T>) => multicast(new BehaviorSubject<T>(value))(source) as ConnectableObservable<T>;
+export function publishBehavior<T>(initialValue: T):  UnaryFunction<Observable<T>, ConnectableObservable<T>> {
+  return (source: Observable<T>) => multicast(new BehaviorSubject<T>(initialValue))(source) as ConnectableObservable<T>;
 }

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -58,10 +58,9 @@ import { UnaryFunction } from '../types';
  *
  * @return {ConnectableObservable} An observable sequence that contains the elements of a
  * sequence produced by multicasting the source sequence.
- * @method publishLast
- * @owner Observable
+ *
+ * @deprecated Use the static version of {@link publishLast}
  */
-
 export function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>> {
   return (source: Observable<T>) => multicast(new AsyncSubject<T>())(source);
 }


### PR DESCRIPTION
Work in progress....