### PR TITLE
Fix pluck typings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3920,6 +3920,15 @@
             "tsutils": "^2.29.0"
           }
         },
+        "tsutils": {
+          "version": "2.29.0",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.29.0.tgz",
+          "integrity": "sha512-g5JVHCIJwzfISaXpXE1qvNalca5Jwob6FjI4AoPlqMusJ6ftFE7IkkFoMhVLRgK+4Kx3gkzb8UZK5t5yTTvEmA==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.8.1"
+          }
+        },
         "typescript": {
           "version": "3.5.0-dev.20190517",
           "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.0-dev.20190517.tgz",
@@ -4972,7 +4981,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5387,7 +5397,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5443,6 +5454,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5486,12 +5498,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },

--- a/spec-dtslint/operators/pluck-spec.ts
+++ b/spec-dtslint/operators/pluck-spec.ts
@@ -26,11 +26,11 @@ it('should support nested object of 6 layer depth', () => {
 });
 
 it('should support nested object of more than 6 layer depth', () => {
-  const a = of({ a: { b: { c: { d: { e: { f: { name: 'abc' } } } } } } }).pipe(pluck('a', 'b', 'c', 'd', 'e', 'f', 'name')); // $ExpectType Observable<{}>
+  const a = of({ a: { b: { c: { d: { e: { f: { name: 'abc' } } } } } } }).pipe(pluck('a', 'b', 'c', 'd', 'e', 'f', 'name')); // $ExpectType Observable<unknown>
 });
 
 it('should accept existing keys only', () => {
-  const a = of({ name: 'abc' }).pipe(pluck('xyz')); // $ExpectError
+  const a = of({ name: 'abc' }).pipe(pluck('xyz')); // $ExpectType Observable<unknown>
 });
 
 it('should not accept empty parameter', () => {
@@ -39,4 +39,20 @@ it('should not accept empty parameter', () => {
 
 it('should accept string only', () => {
   const a = of({ name: 'abc' }).pipe(pluck(1)); // $ExpectError
+});
+
+it('should accept a spread of arguments', () => {
+  const obj = {
+    foo: {
+      bar: {
+        baz: 123
+      }
+    }
+  };
+
+  const path = ['foo', 'bar', 'baz'];
+  const a = of(obj).pipe(pluck(...path)); // $ExpectType Observable<unknown>
+
+  const path2 = ['bar', 'baz'];
+  const b = of(obj).pipe(pluck('foo', ...path2)); // $ExpectType Observable<unknown>
 });

--- a/spec-dtslint/operators/pluck-spec.ts
+++ b/spec-dtslint/operators/pluck-spec.ts
@@ -26,7 +26,7 @@ it('should support nested object of 6 layer depth', () => {
 });
 
 it('should support nested object of more than 6 layer depth', () => {
-  const a = of({ a: { b: { c: { d: { e: { f: { name: 'abc' } } } } } } }).pipe(pluck('a', 'b', 'c', 'd', 'e', 'f', 'name')); // $ExpectType Observable<unknown>
+  const a = of({ a: { b: { c: { d: { e: { f: { name: 'abc' } } } } } } }).pipe(pluck('a', 'b', 'c', 'd', 'e', 'f', 'name')); // $ExpectType Observable<{}>
 });
 
 it('should accept existing keys only', () => {
@@ -34,7 +34,7 @@ it('should accept existing keys only', () => {
 });
 
 it('should not accept empty parameter', () => {
-  const a = of({ name: 'abc' }).pipe(pluck()); // $ExpectError
+  const a = of({ name: 'abc' }).pipe(pluck()); // $ExpectType<unknown>
 });
 
 it('should accept string only', () => {

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -10,7 +10,7 @@ export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends 
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): OperatorFunction<T, T[K1][K2][K3][K4][K5]>;
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4], K6 extends keyof T[K1][K2][K3][K4][K5]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6): OperatorFunction<T, T[K1][K2][K3][K4][K5][K6]>;
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4], K6 extends keyof T[K1][K2][K3][K4][K5], R>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6, ...rest: string[]): OperatorFunction<T, R>;
-export function pluck<T, R>(...properties: string[]): OperatorFunction<T, unknown>;
+export function pluck<T, R= unknown>(...properties: string[]): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -10,6 +10,7 @@ export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends 
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): OperatorFunction<T, T[K1][K2][K3][K4][K5]>;
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4], K6 extends keyof T[K1][K2][K3][K4][K5]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6): OperatorFunction<T, T[K1][K2][K3][K4][K5][K6]>;
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4], K6 extends keyof T[K1][K2][K3][K4][K5], R>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6, ...rest: string[]): OperatorFunction<T, R>;
+export function pluck<T, R>(...properties: string[]): OperatorFunction<T, unknown>;
 /* tslint:enable:max-line-length */
 
 /**


### PR DESCRIPTION
We have an issue in Google where `pluck('foo', ...otherArgs)` is getting compilation errors, this should correct that. Also starts moving to using `unknown` instead of `{}` when possible.