### PR TITLE
docs(combineLatest): fix startWith typo

### DIFF
--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -171,7 +171,7 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * ### Combine an array of Observables
  * ```ts
  * import { combineLatest, of } from 'rxjs';
- * import { delay, starWith } from 'rxjs/operators';
+ * import { delay, startWith } from 'rxjs/operators';
  *
  * const observables = [1, 5, 10].map(
  *   n => of(n).pipe(


### PR DESCRIPTION
Description:
Fix typo in combineLatest docs

Related issue (if exists):
None
