### PR TITLE
fix(takeLast): no arguments lead to undefined emission - changed to A…

### DIFF
--- a/spec/operators/takeLast-spec.ts
+++ b/spec/operators/takeLast-spec.ts
@@ -146,6 +146,11 @@ describe('takeLast operator', () => {
       .to.throw(ArgumentOutOfRangeError);
   });
 
+  it('should throw if total is not provided (takeLast()) or undefined', () => {
+    expect(() => { range(0, 10).pipe(takeLast(undefined)); })
+        .to.throw(ArgumentOutOfRangeError);
+  });
+
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
     const e1 = hot('---^--a--b-----c--d--e--|');
     const unsub =     '         !            ';

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -59,7 +59,7 @@ export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
 
 class TakeLastOperator<T> implements Operator<T, T> {
   constructor(private total: number) {
-    if (this.total < 0) {
+    if (this.total < 0 || this.total === undefined) {
       throw new ArgumentOutOfRangeError;
     }
   }


### PR DESCRIPTION
…rgumentOutOfRangeError #4851

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
takeLast should throw argumentRangeError if applied with no argument 

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/4851
