### PR TITLE
docs(serviceWorker): change marble diagrams to load lazily

### DIFF
--- a/docs_app/ngsw-config.json
+++ b/docs_app/ngsw-config.json
@@ -30,7 +30,8 @@
           "/assets/images/**",
           "/generated/images/marketing/**",
           "!/assets/images/favicons/**",
-          "!/**/_unused/**"
+          "!/**/_unused/**",
+          "!/assets/images/marble-diagrams/**"
         ]
       }
     }, {
@@ -65,6 +66,15 @@
           "/generated/docs/**/*.json",
           "/generated/images/**",
           "!/**/_unused/**"
+        ]
+      }
+    }, {
+      "name": "marble-diagrams",
+      "installMode": "lazy",
+      "updateMode": "lazy",
+      "resources": {
+        "files": [
+          "/assets/images/marble-diagrams/**"
         ]
       }
     }


### PR DESCRIPTION
Till now the service worker configuration was slightly misconfigured so that all marble diagrams were loaded eagerly. This is totally unnessacary, therefore I changed it to load completly lazily.

I'm not very familar with service worker so I'd appreciate any feedback here!