### PR TITLE
fix(WebSocketSubject): close websocket connection attempt on unsubscribe

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -171,6 +171,32 @@ describe('webSocket', () => {
       (<any>socket.close).restore();
     });
 
+    it('should close the socket when unsubscribed while connecting', () => {
+      const subject = webSocket<string>('ws://mysocket');
+      subject.subscribe();
+      const socket = MockWebSocket.lastSocket;
+      sinon.spy(socket, 'close');
+      subject.unsubscribe();
+
+      expect(socket.close).have.been.called;
+      expect(socket.readyState).to.equal(3); // closed
+
+      (<any>socket.close).restore();
+    });
+
+    it('should close the socket when subscription is cancelled while connecting', () => {
+      const subject = webSocket<string>('ws://mysocket');
+      const subscription = subject.subscribe();
+      const socket = MockWebSocket.lastSocket;
+      sinon.spy(socket, 'close');
+      subscription.unsubscribe();
+
+      expect(socket.close).have.been.called;
+      expect(socket.readyState).to.equal(3); // closed
+
+      (<any>socket.close).restore();
+    });
+
     it('should close the socket with a code and a reason when errored', () => {
       const subject = webSocket<string>('ws://mysocket');
       subject.subscribe();

--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -5,7 +5,7 @@ import { map, retry, take, repeat, takeWhile } from 'rxjs/operators';
 
 declare const __root__: any;
 
-/** @test {webSocket} */
+/** @test {webSocket}  */
 describe('webSocket', () => {
   let __ws: any;
 

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -367,7 +367,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     subscriber.add(() => {
       const { _socket } = this;
       if (this._output.observers.length === 0) {
-        if (_socket && _socket.readyState === 1) {
+        if (_socket && (_socket.readyState === 1 || _socket.readyState === 0)) {
           _socket.close();
         }
         this._resetState();
@@ -378,7 +378,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
 
   unsubscribe() {
     const { _socket } = this;
-    if (_socket && _socket.readyState === 1) {
+    if (_socket && (_socket.readyState === 1 || _socket.readyState === 0)) {
       _socket.close();
     }
     this._resetState();


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fix closing the underlying WebSocket when a WebSocketSubject is unsubscribed while the WebSocket is in the `CONNECTING` state.

Initial support for closing a WebSocket before it was opened was added in #4446.
However, that pull-request still waits for the connection to eventually become open before attempting to close it.

This pull-request takes it a step further by closing the WebSocket as soon as the subject is unsubscribed.

**Related issue (if exists):** #4446 #4447