### PR TITLE
fix: evenly distribute values on throttleTime(fn, {leading: true, trailing: true})

### DIFF
--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -153,13 +153,16 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
     const throttled = this.throttled;
     if (throttled) {
       if (this.trailing && this._hasTrailingValue) {
+        this.add(this.throttled = this.scheduler.schedule<DispatchArg<T>>(dispatchNext, this.duration, { subscriber: this }));
         this.destination.next(this._trailingValue);
         this._trailingValue = null;
         this._hasTrailingValue = false;
       }
       throttled.unsubscribe();
       this.remove(throttled);
-      this.throttled = null;
+      if (throttled === this.throttled) {
+        this.throttled = null;
+      }
     }
   }
 }


### PR DESCRIPTION
fixes https://github.com/ReactiveX/rxjs/issues/2727
fixes https://github.com/ReactiveX/rxjs/issues/3712

reproduction (rxjs 6.5.1) https://stackblitz.com/edit/rxjs-tthiju

Look at the new test `it('should handle a busy producer emitting a regular repeating sequence'`

```typescript
      const e1 =   hot('abcdeabcdeabcdeabcdea|');
      const expected = 'a----a----a----a----a|';
```

That should be the expected behavior for `{leading: true, trailing: true}`. Thats the same behavior of https://lodash.com/docs/4.17.11#throttle and https://underscorejs.org/#throttle as well.

Right now throttleTime does it more like:
```typescript
      const e1 =   hot('abcdefabcdefabcdefabcdefa|');
      const expected = 'a----fa----fa----fa----fa|';
```