### PR TITLE
feat(flow): add functional version pipe(name flow)

### DIFF
--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -38,6 +38,7 @@ describe('index', () => {
     expect(index.pipe).to.exist;
     expect(index.noop).to.exist;
     expect(index.identity).to.exist;
+    expect(index.flow).to.exist;
   });
 
   it('should export error types', () => {

--- a/spec/util/flow-spec.ts
+++ b/spec/util/flow-spec.ts
@@ -1,0 +1,31 @@
+import { map, toArray} from 'rxjs/operators';
+import { flow, of } from 'rxjs';
+import { expect } from 'chai';
+
+declare const asDiagram: any;
+
+/** @test {flow */
+describe('flow', () => {
+  it('should be equal obs.pipe(...observable)', (done) => {
+    const e1 = of(1);
+    const obs_pipe = e1.pipe(
+      map(v => v + 1),
+      map(v => v.toString())
+    ).pipe(
+      toArray()
+    );
+
+    const obs_flow = flow(
+      e1,
+      map(v => v + 1),
+      map(v => v.toString())
+    ).pipe(
+      toArray(),
+    );
+
+    Promise.all([obs_pipe.toPromise(), obs_flow.toPromise()]).then(([v_pipe, v_flow]) => {
+      expect(v_pipe).deep.eq(v_flow);
+      done();
+    });
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ export { pipe } from './internal/util/pipe';
 export { noop } from './internal/util/noop';
 export { identity } from './internal/util/identity';
 export { isObservable } from './internal/util/isObservable';
+export { flow } from './internal/util/flow';
 
 /* Error types */
 export { ArgumentOutOfRangeError } from './internal/util/ArgumentOutOfRangeError';

--- a/src/internal/util/flow.ts
+++ b/src/internal/util/flow.ts
@@ -1,0 +1,38 @@
+import { Observable, OperatorFunction } from 'rxjs';
+
+/* tslint:disable:max-line-length */
+export function flow<T>(obs: Observable<T>): Observable<T>;
+export function flow<T, A>(obs: Observable<T>, op1: OperatorFunction<T, A>): Observable<A>;
+export function flow<T, A, B>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction<A, B>): Observable<B>;
+export function flow<T, A, B, C>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction<B, C>): Observable<C>;
+export function flow<T, A, B, C, D>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction < B, C >, op4: OperatorFunction<C, D>): Observable<D>;
+export function flow<T, A, B, C, D, E>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction < B, C >, op4: OperatorFunction < C, D >, op5: OperatorFunction<D, E>): Observable<E>;
+export function flow<T, A, B, C, D, E, F>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction < B, C >, op4: OperatorFunction < C, D >, op5: OperatorFunction < D, E >, op6: OperatorFunction<E, F>): Observable<F>;
+export function flow<T, A, B, C, D, E, F, G>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction < B, C >, op4: OperatorFunction < C, D >, op5: OperatorFunction < D, E >, op6: OperatorFunction < E, F >, op7: OperatorFunction<F, G>): Observable<G>;
+export function flow<T, A, B, C, D, E, F, G, H>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction < B, C >, op4: OperatorFunction < C, D >, op5: OperatorFunction < D, E >, op6: OperatorFunction < E, F >, op7: OperatorFunction < F, G >, op8: OperatorFunction<G, H>): Observable<H>;
+export function flow<T, A, B, C, D, E, F, G, H, I>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction < B, C >, op4: OperatorFunction < C, D >, op5: OperatorFunction < D, E >, op6: OperatorFunction < E, F >, op7: OperatorFunction < F, G >, op8: OperatorFunction < G, H >, op9: OperatorFunction<H, I>): Observable<I>;
+export function flow<T, A, B, C, D, E, F, G, H, I>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction < A, B >, op3: OperatorFunction < B, C >, op4: OperatorFunction < C, D >, op5: OperatorFunction < D, E >, op6: OperatorFunction < E, F >, op7: OperatorFunction < F, G >, op8: OperatorFunction < G, H >, op9: OperatorFunction < H, I >, ...operations: OperatorFunction < any, any > []): Observable<{}>;
+
+  /**
+   * Functional version pipe, it more readable than pipe
+   * @method flow
+   * @return {Observable} the Observable result of all of the operators having
+   * been called in the order they were passed in.
+   *
+   * ### Example
+   * ```ts
+   * import { interval, flow } from 'rxjs';
+   * import { map, filter, scan } from 'rxjs/operators';
+   *
+   * flow(
+   *    interval(1000),
+   *    filter(x => x % 2 === 0),
+   *    map(x => x + x),
+   *    scan((acc, x) => acc + x)
+   * ).subscribe(x => console.log(x))
+   * ```
+   */
+export function flow<T>(obs: Observable<T>, ...operators: OperatorFunction<any, any>[]) {
+  // @ts-ignore
+  return obs.pipe(...operators);
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [x ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Add functional version pipe for increase readability

**define:**
```ts
function flow(obs, ...operators)
function flow<T>(obs: Observable<T>): Observable<T>;
function flow<T, A>(obs: Observable<T>, op1: OperatorFunction<T, A>): Observable<A>;
function flow<T, A, B>(obs: Observable<T>, op1: OperatorFunction < T, A >, op2: OperatorFunction<A, B>): Observable<B>;
...
```

**usage:**
```ts

CreateEventObs<MouseEvent>(elm, "click").pipe(
  flatMap(evt => request(url, {
   ...
  }).pipe(
    catchError(() => ({error:"response error"}))
  ))
)

// replace with
flow(
  CreateEventObs<MouseEvent>(elm, "click"),
  flatMap(evt => flow(
    request(url, {
      ... 
    }),
    catchError(() => ({error:"response error"}))
  ))
)
```

Obviously, the function version is more readable.

**Related issue (if exists):**
