### PR TITLE
fix(pluck): param type

### DIFF
--- a/spec-dtslint/operators/pluck-spec.ts
+++ b/spec-dtslint/operators/pluck-spec.ts
@@ -37,6 +37,10 @@ it('should not accept empty parameter', () => {
   const a = of({ name: 'abc' }).pipe(pluck()); // $ExpectError
 });
 
-it('should accept string only', () => {
+it('should not accept a number when plucking an object', () => {
   const a = of({ name: 'abc' }).pipe(pluck(1)); // $ExpectError
 });
+
+it('should support arrays', () => {
+  const a = of(['abc']).pipe(pluck(0)) // ExpectType Observable<string>
+})

--- a/spec-dtslint/operators/pluck-spec.ts
+++ b/spec-dtslint/operators/pluck-spec.ts
@@ -44,3 +44,8 @@ it('should not accept a number when plucking an object', () => {
 it('should support arrays', () => {
   const a = of(['abc']).pipe(pluck(0)) // ExpectType Observable<string>
 })
+
+it('should support picking by symbols', () => {
+  const sym = Symbol('sym')
+  const a = of({ [sym]: 'abc' }).pipe(pluck(sym)) // $ExpectType Observable<string>
+})

--- a/spec-dtslint/operators/pluck-spec.ts
+++ b/spec-dtslint/operators/pluck-spec.ts
@@ -42,7 +42,7 @@ it('should not accept a number when plucking an object', () => {
 });
 
 it('should support arrays', () => {
-  const a = of(['abc']).pipe(pluck(0)) // ExpectType Observable<string>
+  const a = of(['abc']).pipe(pluck(0)) // $ExpectType Observable<string>
 })
 
 it('should support picking by symbols', () => {

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -25,6 +25,16 @@ describe('pluck operator', () => {
     expectObservable(result).toBe(expected, {x: '1', y: '2', z: '3'});
   });
 
+  it('should work for one array', () => {
+    const a =   cold('--x--|', {x: ['abc']});
+    const asubs =    '^    !';
+    const expected = '--y--|';
+
+    const r = a.pipe(pluck(0));
+    expectObservable(r).toBe(expected, {y: 'abc'});
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
+
   it('should work for one object', () => {
     const a =   cold('--x--|', {x: {prop: 42}});
     const asubs =    '^    !';

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -190,4 +190,16 @@ describe('pluck operator', () => {
     expectObservable(r, unsub).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
   });
+
+  it('should support symbols', () => {
+    const sym = Symbol('sym');
+
+    const a =   cold('--x--|', {x: {[sym]: 'abc'}});
+    const asubs =    '^    !';
+    const expected = '--y--|';
+
+    const r = a.pipe(pluck(sym));
+    expectObservable(r).toBe(expected, {y: 'abc'});
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
 });

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -13,14 +13,14 @@ export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends 
 /* tslint:enable:max-line-length */
 
 /**
- * Maps each source value (an object) to its specified nested property.
+ * Maps each source value to its specified nested property.
  *
  * <span class="informal">Like {@link map}, but meant only for picking one of
- * the nested properties of every emitted object.</span>
+ * the nested properties of every emitted value.</span>
  *
  * ![](pluck.png)
  *
- * Given a list of strings describing a path to an object property, retrieves
+ * Given a list of strings or numbers describing a path to a property, retrieves
  * the value of a specified nested property from all values in the source
  * Observable. If a property can't be resolved, it will return `undefined` for
  * that value.
@@ -39,12 +39,12 @@ export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends 
  * @see {@link map}
  *
  * @param {...string} properties The nested properties to pluck from each source
- * value (an object).
+ * value.
  * @return {Observable} A new Observable of property values from the source values.
  * @method pluck
  * @owner Observable
  */
-export function pluck<T, R>(...properties: string[]): OperatorFunction<T, R> {
+export function pluck<T, R>(...properties: Array<string | number>): OperatorFunction<T, R> {
   const length = properties.length;
   if (length === 0) {
     throw new Error('list of properties cannot be empty.');
@@ -52,7 +52,7 @@ export function pluck<T, R>(...properties: string[]): OperatorFunction<T, R> {
   return (source: Observable<T>) => map(plucker(properties, length))(source as any);
 }
 
-function plucker(props: string[], length: number): (x: string) => any {
+function plucker(props: Array<string | number>, length: number): (x: string) => any {
   const mapper = (x: string) => {
     let currentProp = x;
     for (let i = 0; i < length; i++) {

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -44,7 +44,7 @@ export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends 
  * @method pluck
  * @owner Observable
  */
-export function pluck<T, R>(...properties: Array<string | number>): OperatorFunction<T, R> {
+export function pluck<T, R>(...properties: Array<string | number | symbol>): OperatorFunction<T, R> {
   const length = properties.length;
   if (length === 0) {
     throw new Error('list of properties cannot be empty.');
@@ -52,7 +52,7 @@ export function pluck<T, R>(...properties: Array<string | number>): OperatorFunc
   return (source: Observable<T>) => map(plucker(properties, length))(source as any);
 }
 
-function plucker(props: Array<string | number>, length: number): (x: string) => any {
+function plucker(props: Array<string | number | symbol>, length: number): (x: any) => any {
   const mapper = (x: string) => {
     let currentProp = x;
     for (let i = 0; i < length; i++) {


### PR DESCRIPTION
Fix: The parameter type of pluck does not accept numbers as array indices while the operator itself already supports arrays.