### PR TITLE
docs(observable.md): Fixed broken link in Observable guide

### DIFF
--- a/docs_app/content/guide/observable.md
+++ b/docs_app/content/guide/observable.md
@@ -5,7 +5,7 @@ Observables are lazy Push collections of multiple values. They fill the missing 
 | | Single | Multiple |
 | --- | --- | --- |
 | **Pull** | [`Function`](https://developer.mozilla.org/en-US/docs/Glossary/Function) | [`Iterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) |
-| **Push** | [`Promise`](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise) | [`Observable`](../class/es6/Observable.js~Observable.html) |
+| **Push** | [`Promise`](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise) | [`Observable`](/api/index/class/Observable) |
 
 **Example.** The following is an Observable that pushes the values `1`, `2`, `3` immediately (synchronously) when subscribed, and the value `4` after one second has passed since the subscribe call, then completes:
 


### PR DESCRIPTION
**Description:**
The link to Observable in the first table in this page was broken
https://rxjs.dev/guide/observable

It looks like the link was still using the format used in the old version of the docs.

This PR fixes the link and I've built and run the docs locally to confirm it now works.
