### PR TITLE
fix(windowTime): fix windowTime bug

### DIFF
--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -206,7 +206,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
   }
 
   protected _next(value: T): void {
-    const windows = this.windows;
+    const windows = this.windows.slice();
     const len = windows.length;
     for (let i = 0; i < len; i++) {
       const window = windows[i];


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

this line of code cause the bug
```js
const windows = this.windows
```


**Related issue (if exists):**
#4847 