### PR TITLE
Gracefully handle null schedulers in `delay` operator

### DIFF
--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -176,4 +176,10 @@ describe('delay operator', () => {
 
     expectObservable(result).toBe(expected);
   });
+  it('should not throw when provided scheduler is null', () => {
+    const input = cold('a|');
+    const sched: TestScheduler = null;
+    const observable = input.pipe(delay(10, sched));
+    expect(() => observable.subscribe()).to.not.throw();
+  });
 });

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -58,7 +58,10 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  * @owner Observable
  */
 export function delay<T>(delay: number|Date,
-                         scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
+                         scheduler?: SchedulerLike): MonoTypeOperatorFunction<T> {
+  if (!scheduler) {
+    scheduler = async;
+  }
   const absoluteDelay = isDate(delay);
   const delayFor = absoluteDelay ? (+delay - scheduler.now()) : Math.abs(<number>delay);
   return (source: Observable<T>) => source.lift(new DelayOperator(delayFor, scheduler));


### PR DESCRIPTION
### Issue
Passing a `null` `TestScheduler` to `delay` causes unhandled errors.

### Background

As I see it, there are two rational outcomes when a null value is passed
to the delay function for the scheduler argument.

1) Throw a clear exception stating that null values are not allowed
2) Accept null, but treat it as `undefined`, using the default `async`
   in its stead.

The current behaviour is neither.  It throws the unhandled error:
```
TypeError: Cannot read property 'now' of undefined
```

### Solution
I'm proposing that we opt for option 2.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->
