### PR TITLE
docs(empty): Fixed broken syntax and import in example

### DIFF
--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -32,11 +32,11 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  *
  * ### Map and flatten only odd numbers to the sequence 'a', 'b', 'c'
  * ```ts
- * import { empty, interval } from 'rxjs';
+ * import { empty, interval, of } from 'rxjs';
  * import { mergeMap } from 'rxjs/operators';
  *
  * const interval$ = interval(1000);
- * result = interval$.pipe(
+ * const result = interval$.pipe(
  *   mergeMap(x => x % 2 === 1 ? of('a', 'b', 'c') : empty()),
  * );
  * result.subscribe(x => console.log(x));


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
