### PR TITLE
Add subscription via Observable overload to Observable.subscribe

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -71,6 +71,7 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   subscribe(observer?: PartialObserver<T>): Subscription;
+  subscribe(observable?: Observable<T>): Subscription;
   /** @deprecated Use an observer instead of a complete callback */
   subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
   /** @deprecated Use an observer instead of an error callback */


### PR DESCRIPTION
This works implementation wise but is not allowed based from the types.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I noticed that a valid way to subscribe to an Observable is to run `Observable.subscribe(otherObservable)`. While this works in the JS world, the Typescript compiler errors due to a missing type overload. I added it, I hope I did not overlook any deprecation notice.

**Related issue (if exists):**
