### PR TITLE
docs: create example for share

### DIFF
--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -17,6 +17,43 @@ function shareSubjectFactory() {
  *
  * ![](share.png)
  *
+ * ## Example
+ * Generate new multicast Observable from the source Observable value
+ * ```typescript
+ * import { interval } from 'rxjs';
+ * import { share, map } from 'rxjs/operators';
+ *
+ * const source = interval(1000)
+ *   .pipe(
+ *         map((x: number) => {
+ *             console.log('Processing: ', x);
+ *             return x*x;
+ *         }),
+ *         share()
+ * );
+ *
+ * source.subscribe(x => console.log('subscription 1: ', x));
+ * source.subscribe(x => console.log('subscription 1: ', x));
+ *
+ * // Logs:
+ * // Processing:  0
+ * // subscription 1:  0
+ * // subscription 1:  0
+ * // Processing:  1
+ * // subscription 1:  1
+ * // subscription 1:  1
+ * // Processing:  2
+ * // subscription 1:  4
+ * // subscription 1:  4
+ * // Processing:  3
+ * // subscription 1:  9
+ * // subscription 1:  9
+ * // ... and so on
+ * ```
+ *
+ * @see {@link api/index/function/interval}
+ * @see {@link map}
+ *
  * @return {Observable<T>} An Observable that upon connection causes the source Observable to emit items to its Observers.
  * @method share
  * @owner Observable


### PR DESCRIPTION
create example usage of share operator

closes #4797

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** Add an example of `share()` usage, although there is no text under the `Description` area, I think the initial description describes the operator in-depth and I don't find any room for meaningful clarifications.
The description as seen in the docs  :
 `Returns a new Observable that multicasts (shares) the original Observable. As long as there is at least one Subscriber this Observable will be subscribed and emitting data. When all subscribers have unsubscribed it will unsubscribe from the source Observable. Because the Observable is multicasting it makes the stream hot. This is an alias for multicast(() => new Subject()), refCount().`  

**Related issue (if exists):** #4797