### PR TITLE
docs(operators): fixed references to marble diagrams

### DIFF
--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -81,7 +81,7 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  *
  * <span class="informal">Use it instead of nexting values in a for loop.</span>
  *
- * <img src="./img/generate.png" width="100%">
+ * ![](generate.png)
  *
  * `generate` allows you to create stream of values generated with a loop very similar to
  * traditional for loop. First argument of `generate` is a beginning value. Second argument

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -8,7 +8,7 @@ import { Subscription } from '../Subscription';
  *
  * <span class="informal">Turn entries of an object into a stream.</span>
  *
- * <img src="./img/pairs.png" width="100%">
+ * <img src="/assets/images/marble-diagrams/pairs.png" width="100%">
  *
  * `pairs` takes an arbitrary object and returns an Observable that emits arrays. Each
  * emitted array has exactly two elements - the first is a key from the object

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -8,7 +8,7 @@ import { Subscription } from '../Subscription';
  *
  * <span class="informal">Turn entries of an object into a stream.</span>
  *
- * <img src="/assets/images/marble-diagrams/pairs.png" width="100%">
+ * <img src="pairs.png" width="100%">
  *
  * `pairs` takes an arbitrary object and returns an Observable that emits arrays. Each
  * emitted array has exactly two elements - the first is a key from the object

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -8,7 +8,7 @@ import { Subscription } from '../Subscription';
  *
  * <span class="informal">Turn entries of an object into a stream.</span>
  *
- * <img src="pairs.png" width="100%">
+ * ![](pairs.png)
  *
  * `pairs` takes an arbitrary object and returns an Observable that emits arrays. Each
  * emitted array has exactly two elements - the first is a key from the object

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -23,7 +23,7 @@ export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T
  * <span class="informal">Intercepts each emission on the source and runs a
  * function, but returns an output which is identical to the source as long as errors don't occur.</span>
  *
- * ![](do.png)
+ * ![](tap.png)
  *
  * Returns a mirrored Observable of the source Observable, but modified so that
  * the provided Observer is called to perform a side effect for every value,


### PR DESCRIPTION
**Description:**
Noticed that the documentation for [`tap`](https://rxjs.dev/api/operators/tap) references a missing marble diagram.

**Related issue (if exists):**
n/a