### PR TITLE
fix(pipe): Special handling for 0-arg case.

### DIFF
--- a/spec/util/pipe-spec.ts
+++ b/spec/util/pipe-spec.ts
@@ -23,7 +23,7 @@ describe('pipe', () => {
     expect(c).to.equal(a);
   });
 
-  it('should return a noop if not passed a function', () => {
+  it('should return the identity if not passed any functions', () => {
     const c = pipe();
 
     expect(c('whatever')).to.equal('whatever');

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -1,4 +1,5 @@
 import { noop } from './noop';
+import { identity } from './identity';
 import { UnaryFunction } from '../types';
 
 /* tslint:disable:max-line-length */
@@ -23,6 +24,10 @@ export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any,
 export function pipeFromArray<T, R>(fns: Array<UnaryFunction<T, R>>): UnaryFunction<T, R> {
   if (!fns) {
     return noop as UnaryFunction<any, any>;
+  }
+
+  if (fns.length === 0) {
+    return identity as UnaryFunction<any, any>;
   }
 
   if (fns.length === 1) {

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -22,10 +22,6 @@ export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any,
 
 /** @internal */
 export function pipeFromArray<T, R>(fns: Array<UnaryFunction<T, R>>): UnaryFunction<T, R> {
-  if (!fns) {
-    return noop as UnaryFunction<any, any>;
-  }
-
   if (fns.length === 0) {
     return identity as UnaryFunction<any, any>;
   }

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -22,7 +22,7 @@ export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any,
 
 /** @internal */
 export function pipeFromArray<T, R>(fns: Array<UnaryFunction<T, R>>): UnaryFunction<T, R> {
-  if (!fns || fns.length === 0) {
+  if (fns.length === 0) {
     return identity as UnaryFunction<any, any>;
   }
 

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -22,7 +22,7 @@ export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any,
 
 /** @internal */
 export function pipeFromArray<T, R>(fns: Array<UnaryFunction<T, R>>): UnaryFunction<T, R> {
-  if (fns.length === 0) {
+  if (!fns || fns.length === 0) {
     return identity as UnaryFunction<any, any>;
   }
 


### PR DESCRIPTION
Optimize calling `pipe` with 0 args.

Closes #4933

There is an `if (!fns)` check in the `pipeFromArray` helper, and it results in `noop`. The test for `pipe` says the 0-arg case returns a no-op, but it checks for `identity`. The test is probably meant to test for that check, but the check is for the lack of an args array, so I added a check for that test to test and fixed the test's label.

The `if (!fns)` check might not be necessary at all. It is unreachable from client code, since `pipeFromArray` is internal, and is only used from `pipe`, which will never pass null/undefined.