### PR TITLE
fix(types): add Boolean signature to filter

### DIFF
--- a/spec-dtslint/operators/filter-spec.ts
+++ b/spec-dtslint/operators/filter-spec.ts
@@ -38,3 +38,9 @@ it('should enforce user-defined type guard types', () => {
   const o = of(1, 2, 3).pipe(filter((value: string): value is '1' => value < '3')); // $ExpectError
   const p = of(1, 2, 3).pipe(filter((value: number, index): value is 1 => index < '3')); // $ExpectError
 });
+
+it('should support Boolean as a predicate', () => {
+  const o = of(1, 2, 3).pipe(filter(Boolean)); // $ExpectType Observable<number>
+  const p = of(1, null, undefined).pipe(filter(Boolean)); // $ExpectType Observable<number>
+  const q = of(null, undefined).pipe(filter(Boolean)); // $ExpectType Observable<never>
+});

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -330,4 +330,13 @@ describe('filter operator', () => {
 
     // tslint:disable enable
   });
+
+  it('should support Boolean as a predicate', () => {
+    const source = hot('-t--f--^-t-f-t-f--t-f--f--|', { t: 1, f: 0 });
+    const subs =              '^                  !';
+    const expected =          '--t---t----t-------|';
+
+    expectObservable(source.pipe(filter(Boolean))).toBe(expected, { t: 1, f: 0 });
+    expectSubscriptions(source.subscriptions).toBe(subs);
+  });
 });

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -4,6 +4,7 @@ import { Observable } from '../Observable';
 import { OperatorFunction, MonoTypeOperatorFunction, TeardownLogic } from '../types';
 
 /* tslint:disable:max-line-length */
+export function filter<T>(predicate: BooleanConstructor): OperatorFunction<T, NonNullable<T>>;
 export function filter<T, S extends T>(predicate: (value: T, index: number) => value is S,
                                        thisArg?: any): OperatorFunction<T, S>;
 export function filter<T>(predicate: (value: T, index: number) => boolean,


### PR DESCRIPTION
Closes #4959

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds another signature overload to `filter` to match `Boolean` predicates. This solves the problem identified in #4959 and is sufficiently specific that I cannot foresee it effecting any problems.

I've added a conventional test and a dtslint test.

Other operators that have a similar issue are: `find`, `first`, `last` and `takeWhile`. If this fix is approved, I'll have a look at what can be done for those (`first` and `last` are a little more complicated, as they support a default value).

@benlesh @rkirov

**Related issue (if exists):** #4959 
