### PR TITLE
docs(EMPTY): fix broken link, updated description

### DIFF
--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -4,6 +4,36 @@ import { SchedulerLike } from '../types';
 /**
  * The same Observable instance returned by any call to {@link empty} without a
  * `scheduler`. It is preferrable to use this over `empty()`.
+ *
+ * ## Examples
+ * ### Emit the number 7, then complete
+ * ```ts
+ * import { EMPTY } from 'rxjs';
+ * import { startWith } from 'rxjs/operators';
+ *
+ * const result = EMPTY.pipe(startWith(7));
+ * result.subscribe(x => console.log(x));
+ * ```
+ *
+ * ### Map and flatten only odd numbers to the sequence 'a', 'b', 'c'
+ * ```ts
+ * import { EMPTY, interval, of } from 'rxjs';
+ * import { mergeMap } from 'rxjs/operators';
+ *
+ * const interval$ = interval(1000);
+ *
+ * const result = interval$.pipe(
+ *   mergeMap(x => x % 2 === 1 ? of('a', 'b', 'c') : EMPTY),
+ * );
+ * result.subscribe(x => console.log(x));
+ *
+ * // Results in the following to the console:
+ * // x is equal to the count on the interval eg(0,1,2,3,...)
+ * // x will occur every 1000ms
+ * // if x % 2 is equal to 1 print abc
+ * // if x % 2 is not equal to 1 nothing will be output
+ * ```
+ *
  */
 export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
 
@@ -57,7 +87,7 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * the emission of the complete notification.
  * @return An "empty" Observable: emits only the complete
  * notification.
- * @deprecated Deprecated in favor of using {@link EMPTY} constant, or {@link scheduled} (e.g. `scheduled([], scheduler)`)
+ * @deprecated Deprecated in favor of using {@link index/EMPTY} constant, or {@link scheduled} (e.g. `scheduled([], scheduler)`)
  */
 export function empty(scheduler?: SchedulerLike) {
   return scheduler ? emptyScheduled(scheduler) : EMPTY;

--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -4,36 +4,6 @@ import { SchedulerLike } from '../types';
 /**
  * The same Observable instance returned by any call to {@link empty} without a
  * `scheduler`. It is preferrable to use this over `empty()`.
- *
- * ## Examples
- * ### Emit the number 7, then complete
- * ```ts
- * import { EMPTY } from 'rxjs';
- * import { startWith } from 'rxjs/operators';
- *
- * const result = EMPTY.pipe(startWith(7));
- * result.subscribe(x => console.log(x));
- * ```
- *
- * ### Map and flatten only odd numbers to the sequence 'a', 'b', 'c'
- * ```ts
- * import { EMPTY, interval, of } from 'rxjs';
- * import { mergeMap } from 'rxjs/operators';
- *
- * const interval$ = interval(1000);
- *
- * const result = interval$.pipe(
- *   mergeMap(x => x % 2 === 1 ? of('a', 'b', 'c') : EMPTY),
- * );
- * result.subscribe(x => console.log(x));
- *
- * // Results in the following to the console:
- * // x is equal to the count on the interval eg(0,1,2,3,...)
- * // x will occur every 1000ms
- * // if x % 2 is equal to 1 print abc
- * // if x % 2 is not equal to 1 nothing will be output
- * ```
- *
  */
 export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

At some point we’d need to move `empty()` examples to `EMPTY` so I just moved it now,
since I already moved my codebase to `EMPTY` and there’s still no description in official docs

**Related issue (if exists):**
