### PR TITLE
Reduce scheduler footprint for default usage of shareReplay, timeInterval, and timestamp

### DIFF
--- a/integration/side-effects/snapshots/esm/websocket.js
+++ b/integration/side-effects/snapshots/esm/websocket.js
@@ -1,9 +1,1 @@
 import "tslib";
-
-var NotificationKind;
-
-(function(NotificationKind) {
-    NotificationKind["NEXT"] = "N";
-    NotificationKind["ERROR"] = "E";
-    NotificationKind["COMPLETE"] = "C";
-})(NotificationKind || (NotificationKind = {}));

--- a/integration/side-effects/snapshots/esm2015/websocket.js
+++ b/integration/side-effects/snapshots/esm2015/websocket.js
@@ -1,7 +1,1 @@
-var NotificationKind;
 
-(function(NotificationKind) {
-    NotificationKind["NEXT"] = "N";
-    NotificationKind["ERROR"] = "E";
-    NotificationKind["COMPLETE"] = "C";
-})(NotificationKind || (NotificationKind = {}));

--- a/integration/side-effects/snapshots/esm5/websocket.js
+++ b/integration/side-effects/snapshots/esm5/websocket.js
@@ -1,9 +1,1 @@
 import "tslib";
-
-var NotificationKind;
-
-(function(NotificationKind) {
-    NotificationKind["NEXT"] = "N";
-    NotificationKind["ERROR"] = "E";
-    NotificationKind["COMPLETE"] = "C";
-})(NotificationKind || (NotificationKind = {}));

--- a/spec/operators/timestamp-spec.ts
+++ b/spec/operators/timestamp-spec.ts
@@ -2,7 +2,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { timestamp, map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of } from 'rxjs';
-import { Timestamp } from 'rxjs/internal/operators/timestamp';
 
 declare function asDiagram(arg: string): Function;
 
@@ -31,10 +30,10 @@ describe('timestamp operator', () => {
     const expected =    '-w--x----y---z--|';
 
     const expectedValue = {
-      w: new Timestamp('b', 10),
-      x: new Timestamp('c', 40),
-      y: new Timestamp('d', 90),
-      z: new Timestamp('e', 130)
+      w: { value: 'b', timestamp: 10 },
+      x: { value: 'c', timestamp: 40 },
+      y: { value: 'd', timestamp: 90 },
+      z: { value: 'e', timestamp: 130 }
     };
 
     expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
@@ -65,8 +64,8 @@ describe('timestamp operator', () => {
     const expected = '-y--z--';
 
     const expectedValue = {
-      y: new Timestamp('a', 10),
-      z: new Timestamp('b', 40)
+      y: { value: 'a', timestamp: 10 },
+      z: { value: 'b', timestamp: 40 }
     };
 
     expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
@@ -80,8 +79,8 @@ describe('timestamp operator', () => {
     const expected = '-y--z---           ';
 
     const expectedValue = {
-      y: new Timestamp('a', 10),
-      z: new Timestamp('b', 40)
+      y: { value: 'a', timestamp: 10 },
+      z: { value: 'b', timestamp: 40 }
     };
 
     const result = e1.pipe(timestamp(rxTestScheduler));
@@ -97,8 +96,8 @@ describe('timestamp operator', () => {
     const unsub =    '       !           ';
 
     const expectedValue = {
-      y: new Timestamp('a', 10),
-      z: new Timestamp('b', 40)
+      y: { value: 'a', timestamp: 10 },
+      z: { value: 'b', timestamp: 40 }
     };
 
     const result = e1.pipe(
@@ -135,8 +134,8 @@ describe('timestamp operator', () => {
     const expected = '-y--z--#';
 
     const expectedValue = {
-      y: new Timestamp('a', 10),
-      z: new Timestamp('b', 40)
+      y: { value: 'a', timestamp: 10 },
+      z: { value: 'b', timestamp: 40 }
     };
 
     expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -1,17 +1,39 @@
 import { Subject } from './Subject';
-import { SchedulerLike } from './types';
-import { queue } from './scheduler/queue';
+import { TimestampProvider } from './types';
 import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
-import { ObserveOnSubscriber } from './operators/observeOn';
 import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 import { SubjectSubscription } from './SubjectSubscription';
+
 /**
- * A variant of Subject that "replays" or emits old values to new subscribers.
- * It buffers a set number of values and will emit those values immediately to
- * any new subscribers in addition to emitting new values to existing subscribers.
+ * A variant of {@link Subject} that "replays" old values to new subscribers by emitting them when they first subscribe.
  *
- * @class ReplaySubject<T>
+ * `ReplaySubject` has an internal buffer that will store a specified number of values that it has observed. Like `Subject`,
+ * `ReplaySubject` "observes" values by having them passed to its `next` method. When it observes a value, it will store that
+ * value for a time determined by the configuration of the `ReplaySubject`, as passed to its constructor.
+ *
+ * When a new subscriber subscribes to the `ReplaySubject` instance, it will synchronously emit all values in its buffer in
+ * a First-In-First-Out (FIFO) manner. The `ReplaySubject` will also complete, if it has observed completion; and it will
+ * error if it has observed an error.
+ *
+ * There are two main configuration items to be concerned with:
+ *
+ * 1. `bufferSize` - This will determine how many items are stored in the buffer, defaults to infinite.
+ * 2. `windowTime` - The amount of time to hold a value in the buffer before removing it from the buffer.
+ *
+ * Both configurations may exist simultaneously. So if you would like to buffer a maximum of 3 values, as long as the values
+ * are less than 2 seconds old, you could do so with a `new ReplaySubject(3, 2000)`.
+ *
+ * ### Differences with BehaviorSubject
+ *
+ * `BehaviorSubject` is similar to `new ReplaySubject(1)`, with a couple fo exceptions:
+ *
+ * 1. `BehaviorSubject` comes "primed" with a single value upon construction.
+ * 2. `ReplaySubject` will replay values, even after observing an error, where `BehaviorSubject` will not.
+ *
+ * {@see Subject}
+ * {@see BehaviorSubject}
+ * {@see shareReplay}
  */
 export class ReplaySubject<T> extends Subject<T> {
   private _events: (ReplayEvent<T> | T)[] = [];
@@ -19,9 +41,15 @@ export class ReplaySubject<T> extends Subject<T> {
   private _windowTime: number;
   private _infiniteTimeWindow: boolean = false;
 
+  /**
+   * @param bufferSize The size of the buffer to replay on subscription
+   * @param windowTime The amount of time the buffered items will say buffered
+   * @param timestampProvider An object with a `now()` method that provides the current timestamp. This is used to
+   * calculate the amount of time something has been buffered.
+   */
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
               windowTime: number = Number.POSITIVE_INFINITY,
-              private scheduler?: SchedulerLike) {
+              private timestampProvider: TimestampProvider = Date) {
     super();
     this._bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;
@@ -48,18 +76,17 @@ export class ReplaySubject<T> extends Subject<T> {
   }
 
   private nextTimeWindow(value: T): void {
-    this._events.push(new ReplayEvent(this._getNow(), value));
+    this._events.push({ time: this._getNow(), value });
     this._trimBufferThenGetEvents();
 
     super.next(value);
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @deprecated Remove in v8. This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): Subscription {
     // When `_infiniteTimeWindow === true` then the buffer is already trimmed
     const _infiniteTimeWindow = this._infiniteTimeWindow;
     const _events = _infiniteTimeWindow ? this._events : this._trimBufferThenGetEvents();
-    const scheduler = this.scheduler;
     const len = _events.length;
     let subscription: Subscription;
 
@@ -70,10 +97,6 @@ export class ReplaySubject<T> extends Subject<T> {
     } else {
       this.observers.push(subscriber);
       subscription = new SubjectSubscription(this, subscriber);
-    }
-
-    if (scheduler) {
-      subscriber.add(subscriber = new ObserveOnSubscriber<T>(subscriber, scheduler));
     }
 
     if (_infiniteTimeWindow) {
@@ -95,8 +118,9 @@ export class ReplaySubject<T> extends Subject<T> {
     return subscription;
   }
 
-  _getNow(): number {
-    return (this.scheduler || queue).now();
+  private _getNow(): number {
+    const { timestampProvider: scheduler } = this;
+    return scheduler ? scheduler.now() : Date.now();
   }
 
   private _trimBufferThenGetEvents(): ReplayEvent<T>[] {
@@ -131,7 +155,7 @@ export class ReplaySubject<T> extends Subject<T> {
 
 }
 
-class ReplayEvent<T> {
-  constructor(public time: number, public value: T) {
-  }
+interface ReplayEvent<T> {
+  time: number;
+  value: T;
 }

--- a/src/internal/operators/timestamp.ts
+++ b/src/internal/operators/timestamp.ts
@@ -1,5 +1,4 @@
-import { async } from '../scheduler/async';
-import { OperatorFunction, SchedulerLike, Timestamp as TimestampInterface } from '../types';
+import { OperatorFunction, Timestamp as TimestampInterface, TimestampProvider, Timestamp } from '../types';
 import { map } from './map';
 
 /**
@@ -31,16 +30,8 @@ import { map } from './map';
  * });
  * ```
  *
- * @param scheduler
- * @return {Observable<Timestamp<any>>|WebSocketSubject<T>|Observable<T>}
- * @name timestamp
+ * @param timestampProvider An object with a `now()` method used to get the current timestamp.
  */
-export function timestamp<T>(scheduler: SchedulerLike = async): OperatorFunction<T, Timestamp<T>> {
-  return map((value: T) => new Timestamp(value, scheduler.now()));
-  // return (source: Observable<T>) => source.lift(new TimestampOperator(scheduler));
-}
-
-export class Timestamp<T> implements TimestampInterface<T> {
-  constructor(public value: T, public timestamp: number) {
-  }
+export function timestamp<T>(timestampProvider: TimestampProvider = Date): OperatorFunction<T, Timestamp<T>> {
+  return map((value: T) => ({ value, timestamp: timestampProvider.now()}));
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -90,13 +90,25 @@ export interface Observer<T> {
 
 /** SCHEDULER INTERFACES */
 
-export interface SchedulerLike {
-  now(): number;
+export interface SchedulerLike extends TimestampProvider {
   schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay?: number, state?: T): Subscription;
 }
 
 export interface SchedulerAction<T> extends Subscription {
   schedule(state?: T, delay?: number): Subscription;
+}
+
+/**
+ * This is a type that provides a method to allow RxJS to create a numeric timestamp
+ */
+export interface TimestampProvider {
+  /**
+   * Returns a timestamp as a number.
+   *
+   * This is used by types like `ReplaySubject` or operators like `timestamp` to calculate
+   * the amount of time passed between events.
+   */
+  now(): number;
 }
 
 /**

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -11,13 +11,37 @@ export type FactoryOrValue<T> = T | (() => T);
 
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}
 
+/**
+ * A value and the time at which it was emitted.
+ *
+ * Emitted by the `timestamp` operator
+ *
+ * {@see timestamp}
+ */
 export interface Timestamp<T> {
   value: T;
+  /**
+   * The timestamp. By default, this is in epoch milliseconds.
+   * Could vary based on the timestamp provider passed to the operator.
+   */
   timestamp: number;
 }
 
+/**
+ * A value emitted and the amount of time since the last value was emitted.
+ *
+ * Emitted by the `timeInterval` operator.
+ *
+ * {@see timeInterval}
+ */
 export interface TimeInterval<T> {
   value: T;
+
+  /**
+   * The amount of time between this value's emission and the previous value's emission.
+   * If this is the first emitted value, then it will be the amount of time since subscription
+   * started.
+   */
   interval: number;
 }
 


### PR DESCRIPTION
Refactors `ReplaySubject`, `timeInterval`, and `timestamp` to remove reliance on Schedulers that were not necessary. This should help drastically reduce the amount of code pulled in for default `shareReplay` usage or `timestamp` usage.

See commit messages for more details.

NOTE: Breaking change in that `ReplaySubject` will no longer have inherent `observeOn` behavior if provided a scheduler.