### PR TITLE
fix(of): Fix compilation failure in TS 3.5+ for `of()`

### DIFF
--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -29,6 +29,7 @@ export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4,
 export function of<T>(...args: (T | SchedulerLike)[]): Observable<T>;
 
 // TODO(benlesh): Update the typings for this when we can switch to TS 3.x
+export function of(): Observable<never>;
 export function of<T>(a: T): Observable<T>;
 export function of<T, T2>(a: T, b: T2): Observable<T | T2>;
 export function of<T, T2, T3>(a: T, b: T2, c: T3): Observable<T | T2 | T3>;


### PR DESCRIPTION
I've also heard, that great commit summaries contain fewer than 50 characters. Thanks, Github! <3
