### PR TITLE
fix(TS): Error impls now properly type `this`

### DIFF
--- a/src/internal/util/ArgumentOutOfRangeError.ts
+++ b/src/internal/util/ArgumentOutOfRangeError.ts
@@ -6,7 +6,7 @@ export interface ArgumentOutOfRangeErrorCtor {
 }
 
 const ArgumentOutOfRangeErrorImpl = (() => {
-  function ArgumentOutOfRangeErrorImpl(this: any) {
+  function ArgumentOutOfRangeErrorImpl(this: Error) {
     Error.call(this);
     this.message = 'argument out of range';
     this.name = 'ArgumentOutOfRangeError';

--- a/src/internal/util/EmptyError.ts
+++ b/src/internal/util/EmptyError.ts
@@ -6,7 +6,7 @@ export interface EmptyErrorCtor {
 }
 
 const EmptyErrorImpl = (() => {
-  function EmptyErrorImpl(this: any) {
+  function EmptyErrorImpl(this: Error) {
     Error.call(this);
     this.message = 'no elements in sequence';
     this.name = 'EmptyError';

--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -6,7 +6,7 @@ export interface ObjectUnsubscribedErrorCtor {
 }
 
 const ObjectUnsubscribedErrorImpl = (() => {
-  function ObjectUnsubscribedErrorImpl(this: any) {
+  function ObjectUnsubscribedErrorImpl(this: Error) {
     Error.call(this);
     this.message = 'object unsubscribed';
     this.name = 'ObjectUnsubscribedError';

--- a/src/internal/util/TimeoutError.ts
+++ b/src/internal/util/TimeoutError.ts
@@ -6,7 +6,7 @@ export interface TimeoutErrorCtor {
 }
 
 const TimeoutErrorImpl = (() => {
-  function TimeoutErrorImpl(this: any) {
+  function TimeoutErrorImpl(this: Error) {
     Error.call(this);
     this.message = 'Timeout has occurred';
     this.name = 'TimeoutError';

--- a/src/internal/util/UnsubscriptionError.ts
+++ b/src/internal/util/UnsubscriptionError.ts
@@ -7,13 +7,13 @@ export interface UnsubscriptionErrorCtor {
 }
 
 const UnsubscriptionErrorImpl = (() => {
-  function UnsubscriptionErrorImpl(this: any, errors: any[]) {
+  function UnsubscriptionErrorImpl(this: Error, errors: (Error|string)[]) {
     Error.call(this);
     this.message = errors ?
       `${errors.length} errors occurred during unsubscription:
 ${errors.map((err, i) => `${i + 1}) ${err.toString()}`).join('\n  ')}` : '';
     this.name = 'UnsubscriptionError';
-    this.errors = errors;
+    (this as any).errors = errors;
     return this;
   }
 


### PR DESCRIPTION
Fixes an issue with TypeScript compilation in more strict environments.

