### PR TITLE
Add concatMap overload to include changes from Google

### DIFF
--- a/spec-dtslint/operators/concatMap-spec.ts
+++ b/spec-dtslint/operators/concatMap-spec.ts
@@ -40,3 +40,7 @@ it('should enforce types', () => {
 it('should enforce the return type', () => {
   const o = of(1, 2, 3).pipe(concatMap(p => p)); // $ExpectError
 });
+
+it('should produce `Observable<never>` when concating an empty stream', () => {
+  const o = of(1, 2, 3).pipe(concatMap(n => of())); // $ExpectType Observable<never>
+});

--- a/spec-dtslint/operators/concatMap-spec.ts
+++ b/spec-dtslint/operators/concatMap-spec.ts
@@ -33,14 +33,14 @@ it('should support union-type projections', () => {
   const o = of(Math.random()).pipe(concatMap(n => n > 0.5 ? of('life') : of(42))); // $ExpectType Observable<string | number>
 });
 
+it('should support union-type projections with empty streams', () => {
+  const o: Observable<number> = of(1, 2, 3).pipe(concatMap(n => Math.random() < 0.5 ? of(123) : of()));
+});
+
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(concatMap()); // $ExpectError
 });
 
 it('should enforce the return type', () => {
   const o = of(1, 2, 3).pipe(concatMap(p => p)); // $ExpectError
-});
-
-it('should produce `Observable<never>` when concating an empty stream', () => {
-  const o = of(1, 2, 3).pipe(concatMap(n => of())); // $ExpectType Observable<never>
 });

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -2,6 +2,7 @@ import { mergeMap } from './mergeMap';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 
 /* tslint:disable:max-line-length */
+export function concatMap<T>(project: (value: T, index: number) => ObservableInput<never>): OperatorFunction<T, never>;
 export function concatMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) =>  O): OperatorFunction<T, ObservedValueOf<O>>;
 /** @deprecated resultSelector no longer supported, use inner map instead */
 export function concatMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;


### PR DESCRIPTION
This PR includes downstream changes in Google that were needed to keep the build green for a vast amount of projects when updating to v7-alpha