### PR TITLE
refactor: remove observers for loop in subject class

### DIFF
--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -63,12 +63,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
       throw new ObjectUnsubscribedError();
     }
     if (!this.isStopped) {
-      const { observers } = this;
-      const len = observers.length;
-      const copy = observers.slice();
-      for (let i = 0; i < len; i++) {
-        copy[i].next(value);
-      }
+      this.observers.slice().map(observer => observer.next(value));
     }
   }
 
@@ -79,12 +74,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     this.hasError = true;
     this.thrownError = err;
     this.isStopped = true;
-    const { observers } = this;
-    const len = observers.length;
-    const copy = observers.slice();
-    for (let i = 0; i < len; i++) {
-      copy[i].error(err);
-    }
+    this.observers.slice().map(observer => observer.error(err));
     this.observers.length = 0;
   }
 
@@ -93,12 +83,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
       throw new ObjectUnsubscribedError();
     }
     this.isStopped = true;
-    const { observers } = this;
-    const len = observers.length;
-    const copy = observers.slice();
-    for (let i = 0; i < len; i++) {
-      copy[i].complete();
-    }
+    this.observers.slice().map(observer => observer.complete());
     this.observers.length = 0;
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
