### PR TITLE
docs(Observable): change the example with error handling

### DIFF
--- a/doc/observable.md
+++ b/doc/observable.md
@@ -360,20 +360,23 @@ const observable = new Observable(function subscribe(subscriber) {
 });
 ```
 
-It is a good idea to wrap any code in `subscribe` with `try`/`catch` block that will deliver an Error notification if it catches an exception:
+It is a good point to mention that  `try`/`catch` is unnecessary because even without it exceptions are delivered to the error notification:
 
 ```ts
 import { Observable } from 'rxjs';
 
 const observable = new Observable(function subscribe(subscriber) {
-  try {
-    subscriber.next(1);
-    subscriber.next(2);
-    subscriber.next(3);
-    subscriber.complete();
-  } catch (err) {
-    subscriber.error(err); // delivers an error if it caught one
-  }
+  subscriber.next(1);
+  subscriber.next(2);
+  subscriber.next(3);
+  foo(); // Calls subscriber.error!
+  subscriber.complete();
+});
+
+observable.subscribe({
+  next(x) { console.log('got value ' + x); },
+  error(err) { console.error('something wrong occurred: ' + err); },
+  complete() { console.log('done'); }
 });
 ```
 


### PR DESCRIPTION
remove unnecessary try/catch

fix #4982

**Description:** according to the following issue change the example of error handling in Observable docs section 

**Related issue (if exists):**  #4982
