### PR TITLE
docs(index): fix markup typo

### DIFF
--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -43,7 +43,7 @@ import { Subscriber } from '../Subscriber';
  * @see {@link delay}
  *
  * @param {number|Date} [dueTime] The initial delay time specified as a Date object or as an integer denoting
- * milliseconds to wait before emitting the first value of 0`.
+ * milliseconds to wait before emitting the first value of `0`.
  * @param {number|SchedulerLike} [periodOrScheduler] The period of time between emissions of the
  * subsequent numbers.
  * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for scheduling


### PR DESCRIPTION
change
```
0`
```
to
```
`0`
```

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
