### PR TITLE
fix(filter): Fix overload order for filter to support inferring the generic type

### DIFF
--- a/spec-dtslint/operators/filter-spec.ts
+++ b/spec-dtslint/operators/filter-spec.ts
@@ -65,8 +65,5 @@ it('should support inference from a generic return type of the predicate', () =>
     };
   }
 
-  // $ExpectType Observable<string>
-  const source = of('World', 'test', null, 'ok').pipe(
-    filter(isDefined()),
-  );
+  const o$ = of(1, null, {foo: 'bar'}, true, undefined, 'Nick Cage').pipe(filter(isDefined())); // $ExpectType Observable<string | number | boolean | { foo: string; }>
 });

--- a/spec-dtslint/operators/filter-spec.ts
+++ b/spec-dtslint/operators/filter-spec.ts
@@ -57,3 +57,16 @@ it('should support inference from a return type with Boolean as a predicate', ()
   const i$: Observable<I> = of();
   const s$: Observable<string> = i$.pipe(map(i => i.a), filter(Boolean)); // $ExpectType Observable<string>
 });
+
+it('should support inference from a generic return type of the predicate', () => {
+  function isDefined<T>() {
+    return (value: T|undefined|null): value is T => {
+      return value !== undefined && value !== null;
+    };
+  }
+
+  // $ExpectType Observable<string>
+  const source = of('World', 'test', null, 'ok').pipe(
+    filter(isDefined()),
+  );
+});

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -4,10 +4,10 @@ import { Observable } from '../Observable';
 import { OperatorFunction, MonoTypeOperatorFunction, TeardownLogic } from '../types';
 
 /* tslint:disable:max-line-length */
-// NOTE(benlesh): T|null|undefined solves the issue discussed here: https://github.com/ReactiveX/rxjs/issues/4959#issuecomment-520629091
-export function filter<T>(predicate: BooleanConstructor): OperatorFunction<T|null|undefined, NonNullable<T>>;
 export function filter<T, S extends T>(predicate: (value: T, index: number) => value is S,
                                        thisArg?: any): OperatorFunction<T, S>;
+// NOTE(benlesh): T|null|undefined solves the issue discussed here: https://github.com/ReactiveX/rxjs/issues/4959#issuecomment-520629091
+export function filter<T>(predicate: BooleanConstructor): OperatorFunction<T|null|undefined, NonNullable<T>>;
 export function filter<T>(predicate: (value: T, index: number) => boolean,
                           thisArg?: any): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */


### PR DESCRIPTION
The provided test will create an `Observable<never>` with the order unchanged.
