### PR TITLE
Import is missing in the documentation

### DIFF
--- a/src/internal/observable/dom/ajax.ts
+++ b/src/internal/observable/dom/ajax.ts
@@ -41,6 +41,7 @@ import {  AjaxObservable, AjaxCreationMethod  } from './AjaxObservable';
  * ## Using ajax() with object as argument and method POST with a two seconds delay.
  * ```ts
  * import { ajax } from 'rxjs/ajax';
+ * import { map, catchError } from 'rxjs/operators';
  * import { of } from 'rxjs';
  *
  * const users = ajax({


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Import is missing in one of the examples related to AJAX

**Related issue (if exists):**
