### PR TITLE
use more exact return type in Notification#do

### DIFF
--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -53,13 +53,13 @@ export class Notification<T> {
 
   /**
    * Given some {@link Observer} callbacks, deliver the value represented by the
-   * current Notification to the correctly corresponding callback.
-   * @param {function(value: T): void} next An Observer `next` callback.
-   * @param {function(err: any): void} [error] An Observer `error` callback.
-   * @param {function(): void} [complete] An Observer `complete` callback.
-   * @return {any}
+   * current Notification to the correctly corresponding callback and return its return value.
+   * @param {function(value: T): A} next An Observer `next` callback.
+   * @param {function(err: any): B} [error] An Observer `error` callback.
+   * @param {function(): C} [complete] An Observer `complete` callback.
+   * @return {A | B | C} return value of the executed callback, or `undefined` if no callback matched.
    */
-  do(next: (value: T) => void, error?: (err: any) => void, complete?: () => void): any {
+  do<A = undefined, B = undefined, C = undefined>(next: (value: T) => A, error?: (err: any) => B, complete?: () => C): A | B | C {
     const kind = this.kind;
     switch (kind) {
       case 'N':


### PR DESCRIPTION
**Description:**

This prevents a return type of `any` when the type can be inferred from callback types.

```

// Before: return type is always `any`

// ============

// After:

// when all 3 callbacks are specified: return type becomes (union of their return types)
const a = notification.do(
  _ => 'str',
  _ => 123,
  _ => ({a: 1})
);  // => a: string | number | {a: number}

// when not all of callbacks are specified:
// return type becomes (undefined | union of specified return types)
const b = notification.do(
  _ => 'str'
); // => b: string | undefined

```

**Related issue (if exists):**
