### PR TITLE
fix(closure): static prop frameTimeFactor being collapsed when compil…

### DIFF
--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -32,6 +32,7 @@ export class TestScheduler extends VirtualTimeScheduler {
    * The number of virtual time units each character in a marble diagram represents. If
    * the test scheduler is being used in "run mode", via the `run` method, this is temporarly
    * set to `1` for the duration of the `run` block, then set back to whatever value it was.
+   * @nocollapse
    */
   static frameTimeFactor = 10;
 


### PR DESCRIPTION
This was breaking an internal test in Google, upstreaming the fix here