### PR TITLE
fix(observableMatcher): add chai import to observableMatcher

### DIFF
--- a/spec/helpers/observableMatcher.ts
+++ b/spec/helpers/observableMatcher.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import * as chai from 'chai';
 
 function stringify(x: any): string {
   return JSON.stringify(x, function (key: string, value: any) {


### PR DESCRIPTION
**Description:**

I was working on updating the operator specs to execute in the context of `TestScheduler#run` and I noticed failing specs reporting "ReferenceError: chai is not defined"

eg. (contrived example)
```
  1) delay operator
       should delay by absolute time period:
     ReferenceError: chai is not defined
      at TestScheduler.observableMatcher [as assertDeepEqual] (spec/helpers/observableMatcher.ts:45:5)
      at src/internal/testing/TestScheduler.ts:186:14
      at Array.filter (<anonymous>)
      at TestScheduler.flush (src/internal/testing/TestScheduler.ts:184:39)
      at TestScheduler.run (src/internal/testing/TestScheduler.ts:419:12)
      at spec/operators/delay-spec.ts:33:19
      at Context.modified (spec/helpers/testScheduler-ui.ts:199:13)
```


It looks like this import statement is all that's needed to fix