### PR TITLE
test(take operator): use TestScheduler for tests

### DIFF
--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -16,8 +16,8 @@ describe('take operator', () => {
 
   asDiagram('take(2)')('should take two values of an observable with many values', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =  cold('--a-----b----c---d--|');
-      const e1subs =   '^-------!------------';
+      const e1 = cold(' --a-----b----c---d--|');
+      const e1subs = '  ^-------!------------';
       const expected = '--a-----(b|)         ';
 
       expectObservable(e1.pipe(take(2))).toBe(expected);
@@ -27,8 +27,8 @@ describe('take operator', () => {
 
   it('should work with empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =  cold('|');
-      const e1subs =   '(^!)';
+      const e1 = cold(' |');
+      const e1subs = '  (^!)';
       const expected = '|';
 
       expectObservable(e1.pipe(take(42))).toBe(expected);
@@ -39,7 +39,7 @@ describe('take operator', () => {
   it('should go on forever on never', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
       const e1 =  cold('-');
-      const e1subs =   '^';
+      const e1subs = '  ^';
       const expected = '-';
 
       expectObservable(e1.pipe(take(42))).toBe(expected);
@@ -51,7 +51,7 @@ describe('take operator', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('--a--^--b----c---d--|');
       const e1subs: string[] = []; // Don't subscribe at all
-      const expected =    '|';
+      const expected = '   |';
 
       expectObservable(e1.pipe(take(0))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -60,8 +60,8 @@ describe('take operator', () => {
 
   it('should take one value of an observable with one value', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('---(a|)');
-      const e1subs =   '^--!---';
+      const e1 = hot('  ---(a|)');
+      const e1subs = '  ^--!---';
       const expected = '---(a|)';
 
       expectObservable(e1.pipe(take(1))).toBe(expected);
@@ -72,8 +72,8 @@ describe('take operator', () => {
   it('should take one values of an observable with many values', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('--a--^--b----c---d--|');
-      const e1subs =      '^--!------------';
-      const expected =    '---(b|)         ';
+      const e1subs = '     ^--!------------';
+      const expected = '   ---(b|)         ';
 
       expectObservable(e1.pipe(take(1))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -83,8 +83,8 @@ describe('take operator', () => {
   it('should error on empty', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('--a--^----|');
-      const e1subs =      '^----!';
-      const expected =    '-----|';
+      const e1subs = '     ^----!';
+      const expected = '   -----|';
 
       expectObservable(e1.pipe(take(42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -94,8 +94,8 @@ describe('take operator', () => {
   it('should propagate error from the source observable', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('---^---#', null, 'too bad');
-      const e1subs =    '^---!';
-      const expected =  '----#';
+      const e1subs = '   ^---!';
+      const expected = ' ----#';
 
       expectObservable(e1.pipe(take(42))).toBe(expected, null, 'too bad');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -105,8 +105,8 @@ describe('take operator', () => {
   it('should propagate error from an observable with values', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('---^--a--b--#');
-      const e1subs =    '^--------!';
-      const expected =  '---a--b--#';
+      const e1subs = '   ^--------!';
+      const expected = ' ---a--b--#';
 
       expectObservable(e1.pipe(take(42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -116,9 +116,9 @@ describe('take operator', () => {
   it('should allow unsubscribing explicitly and early', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('---^--a--b-----c--d--e--|');
-      const unsub =     '---------!------------';
-      const e1subs =    '^--------!------------';
-      const expected =  '---a--b---            ';
+      const unsub = '    ---------!------------';
+      const e1subs = '   ^--------!------------';
+      const expected = ' ---a--b---            ';
 
       expectObservable(e1.pipe(take(42)), unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -127,8 +127,8 @@ describe('take operator', () => {
 
   it('should work with throw', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =  cold('#');
-      const e1subs =   '(^!)';
+      const e1 = cold(' #');
+      const e1subs = '  (^!)';
       const expected = '#';
 
       expectObservable(e1.pipe(take(42))).toBe(expected);
@@ -144,9 +144,9 @@ describe('take operator', () => {
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('---^--a--b-----c--d--e--|');
-      const unsub =     '---------!            ';
-      const e1subs =    '^--------!            ';
-      const expected =  '---a--b---            ';
+      const unsub = '    ---------!            ';
+      const e1subs = '   ^--------!            ';
+      const expected = ' ---a--b---            ';
 
       const result = e1.pipe(
         mergeMap((x: string) => of(x)),

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -15,7 +15,6 @@ describe('take operator', () => {
   });
 
   asDiagram('take(2)')('should take two values of an observable with many values', () => {
-    
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
       const e1 =  cold('--a-----b----c---d--|');
       const e1subs =   '^-------!------------';
@@ -23,7 +22,7 @@ describe('take operator', () => {
 
       expectObservable(e1.pipe(take(2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    })
+    });
   });
 
   it('should work with empty', () => {
@@ -31,7 +30,7 @@ describe('take operator', () => {
       const e1 =  cold('|');
       const e1subs =   '(^!)';
       const expected = '|';
-  
+
       expectObservable(e1.pipe(take(42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -42,7 +41,7 @@ describe('take operator', () => {
       const e1 =  cold('-');
       const e1subs =   '^';
       const expected = '-';
-  
+
       expectObservable(e1.pipe(take(42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -53,7 +52,7 @@ describe('take operator', () => {
       const e1 = hot('--a--^--b----c---d--|');
       const e1subs: string[] = []; // Don't subscribe at all
       const expected =    '|';
-  
+
       expectObservable(e1.pipe(take(0))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -64,7 +63,7 @@ describe('take operator', () => {
       const e1 =   hot('---(a|)');
       const e1subs =   '^--!---';
       const expected = '---(a|)';
-  
+
       expectObservable(e1.pipe(take(1))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -75,7 +74,7 @@ describe('take operator', () => {
       const e1 = hot('--a--^--b----c---d--|');
       const e1subs =      '^--!------------';
       const expected =    '---(b|)         ';
-  
+
       expectObservable(e1.pipe(take(1))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -86,7 +85,7 @@ describe('take operator', () => {
       const e1 = hot('--a--^----|');
       const e1subs =      '^----!';
       const expected =    '-----|';
-  
+
       expectObservable(e1.pipe(take(42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -97,7 +96,7 @@ describe('take operator', () => {
       const e1 = hot('---^---#', null, 'too bad');
       const e1subs =    '^---!';
       const expected =  '----#';
-  
+
       expectObservable(e1.pipe(take(42))).toBe(expected, null, 'too bad');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -108,7 +107,7 @@ describe('take operator', () => {
       const e1 = hot('---^--a--b--#');
       const e1subs =    '^--------!';
       const expected =  '---a--b--#';
-  
+
       expectObservable(e1.pipe(take(42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -120,7 +119,7 @@ describe('take operator', () => {
       const unsub =     '---------!------------';
       const e1subs =    '^--------!------------';
       const expected =  '---a--b---            ';
-  
+
       expectObservable(e1.pipe(take(42)), unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -131,7 +130,7 @@ describe('take operator', () => {
       const e1 =  cold('#');
       const e1subs =   '(^!)';
       const expected = '#';
-  
+
       expectObservable(e1.pipe(take(42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
@@ -148,13 +147,13 @@ describe('take operator', () => {
       const unsub =     '---------!            ';
       const e1subs =    '^--------!            ';
       const expected =  '---a--b---            ';
-  
+
       const result = e1.pipe(
         mergeMap((x: string) => of(x)),
         take(42),
         mergeMap((x: string) => of(x))
       );
-  
+
       expectObservable(result, unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -1,110 +1,140 @@
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { take, mergeMap } from 'rxjs/operators';
 import { range, ArgumentOutOfRangeError, of, Observable, Subject } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 declare function asDiagram(arg: string): Function;
 
 /** @test {take} */
 describe('take operator', () => {
-  asDiagram('take(2)')('should take two values of an observable with many values', () => {
-    const e1 =  cold('--a-----b----c---d--|');
-    const e1subs =   '^       !            ';
-    const expected = '--a-----(b|)         ';
+  let testScheduler: TestScheduler;
 
-    expectObservable(e1.pipe(take(2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  asDiagram('take(2)')('should take two values of an observable with many values', () => {
+    
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =  cold('--a-----b----c---d--|');
+      const e1subs =   '^-------!------------';
+      const expected = '--a-----(b|)         ';
+
+      expectObservable(e1.pipe(take(2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    })
   });
 
   it('should work with empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
-
-    expectObservable(e1.pipe(take(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =  cold('|');
+      const e1subs =   '(^!)';
+      const expected = '|';
+  
+      expectObservable(e1.pipe(take(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should go on forever on never', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
-
-    expectObservable(e1.pipe(take(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =  cold('-');
+      const e1subs =   '^';
+      const expected = '-';
+  
+      expectObservable(e1.pipe(take(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should be empty on take(0)', () => {
-    const e1 = hot('--a--^--b----c---d--|');
-    const e1subs: string[] = []; // Don't subscribe at all
-    const expected =    '|';
-
-    expectObservable(e1.pipe(take(0))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b----c---d--|');
+      const e1subs: string[] = []; // Don't subscribe at all
+      const expected =    '|';
+  
+      expectObservable(e1.pipe(take(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should take one value of an observable with one value', () => {
-    const e1 =   hot('---(a|)');
-    const e1subs =   '^  !   ';
-    const expected = '---(a|)';
-
-    expectObservable(e1.pipe(take(1))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('---(a|)');
+      const e1subs =   '^--!---';
+      const expected = '---(a|)';
+  
+      expectObservable(e1.pipe(take(1))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should take one values of an observable with many values', () => {
-    const e1 = hot('--a--^--b----c---d--|');
-    const e1subs =      '^  !            ';
-    const expected =    '---(b|)         ';
-
-    expectObservable(e1.pipe(take(1))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b----c---d--|');
+      const e1subs =      '^--!------------';
+      const expected =    '---(b|)         ';
+  
+      expectObservable(e1.pipe(take(1))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should error on empty', () => {
-    const e1 = hot('--a--^----|');
-    const e1subs =      '^    !';
-    const expected =    '-----|';
-
-    expectObservable(e1.pipe(take(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^----|');
+      const e1subs =      '^----!';
+      const expected =    '-----|';
+  
+      expectObservable(e1.pipe(take(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should propagate error from the source observable', () => {
-    const e1 = hot('---^---#', null, 'too bad');
-    const e1subs =    '^   !';
-    const expected =  '----#';
-
-    expectObservable(e1.pipe(take(42))).toBe(expected, null, 'too bad');
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^---#', null, 'too bad');
+      const e1subs =    '^---!';
+      const expected =  '----#';
+  
+      expectObservable(e1.pipe(take(42))).toBe(expected, null, 'too bad');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should propagate error from an observable with values', () => {
-    const e1 = hot('---^--a--b--#');
-    const e1subs =    '^        !';
-    const expected =  '---a--b--#';
-
-    expectObservable(e1.pipe(take(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^--a--b--#');
+      const e1subs =    '^--------!';
+      const expected =  '---a--b--#';
+  
+      expectObservable(e1.pipe(take(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 = hot('---^--a--b-----c--d--e--|');
-    const unsub =     '         !            ';
-    const e1subs =    '^        !            ';
-    const expected =  '---a--b---            ';
-
-    expectObservable(e1.pipe(take(42)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^--a--b-----c--d--e--|');
+      const unsub =     '---------!------------';
+      const e1subs =    '^--------!------------';
+      const expected =  '---a--b---            ';
+  
+      expectObservable(e1.pipe(take(42)), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with throw', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
-
-    expectObservable(e1.pipe(take(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =  cold('#');
+      const e1subs =   '(^!)';
+      const expected = '#';
+  
+      expectObservable(e1.pipe(take(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should throw if total is less than zero', () => {
@@ -113,19 +143,21 @@ describe('take operator', () => {
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
-    const e1 = hot('---^--a--b-----c--d--e--|');
-    const unsub =     '         !            ';
-    const e1subs =    '^        !            ';
-    const expected =  '---a--b---            ';
-
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      take(42),
-      mergeMap((x: string) => of(x))
-    );
-
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^--a--b-----c--d--e--|');
+      const unsub =     '---------!            ';
+      const e1subs =    '^--------!            ';
+      const expected =  '---a--b---            ';
+  
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        take(42),
+        mergeMap((x: string) => of(x))
+      );
+  
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should unsubscribe from the source when it reaches the limit', () => {


### PR DESCRIPTION
This switches the `take` operator tests over to use the `TestScheduler#run` method.

It looks like the subscription marbles syntax is changed for `TestScheduler` - ticks are denoted by a `-` and not a space - so those expectations needed to be updated too. Other than that the content of the tests should be the same as before.

