### PR TITLE
test(delay operator): execute tests with TestScheduler#run

### DIFF
--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -3,7 +3,7 @@ import { delay, repeatWhen, skip, take, tap, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 declare const asDiagram: Function;
 
@@ -16,144 +16,167 @@ describe('delay operator', () => {
   });
 
   asDiagram('delay(20)')('should delay by specified timeframe', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a--b--|  ');
       const t = time('     --|      ');
       const expected = '-----a--b--|';
-    const subs =     '^        !  ';
+      const subs = '    ^--------!  ';
 
-    const result = e1.pipe(delay(t, rxTestScheduler));
+      const result = e1.pipe(delay(t, testScheduler));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(subs);
     });
+  });
 
   it('should delay by absolute time period', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--b--|   ');
       const t = time('    ---|      ');
       const expected = '-----a--b--|';
-    const subs =     '^       !   ';
+      const subs = '    ^-------!   ';
 
-    const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
+      const absoluteDelay = new Date(testScheduler.now() + t);
+      const result = e1.pipe(delay(absoluteDelay, testScheduler));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(subs);
     });
+  });
 
   it('should delay by absolute time period after subscription', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---^--a--b--|   ');
       const t = time('        ---|      ');
       const expected = '   ------a--b--|';
-    const subs =        '^        !   ';
+      const subs = '       ^--------!   ';
 
-    const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
+      const absoluteDelay = new Date(testScheduler.now() + t);
+      const result = e1.pipe(delay(absoluteDelay, testScheduler));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(subs);
     });
+  });
 
   it('should raise error when source raises error', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a---b---#');
       const t = time('     ---|     ');
       const expected = '------a---b#';
-    const subs =     '^          !';
+      const subs = '    ^----------!';
 
-    const result = e1.pipe(delay(t, rxTestScheduler));
+      const result = e1.pipe(delay(t, testScheduler));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(subs);
     });
+  });
 
   it('should raise error when source raises error', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--b--#');
       const t = time('    ---|   ');
       const expected = '-----a--#';
-    const subs =     '^       !';
+      const subs = '    ^-------!';
 
-    const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
+      const absoluteDelay = new Date(testScheduler.now() + t);
+      const result = e1.pipe(delay(absoluteDelay, testScheduler));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(subs);
     });
+  });
 
   it('should raise error when source raises error after subscription', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---^---a---b---#');
       const t = time('         ---|     ');
       const expected = '   -------a---b#';
-    const e1Sub =       '^           !';
+      const e1Sub = '      ^-----------!';
 
-    const absoluteDelay = new Date(rxTestScheduler.now() + t);
-    const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
+      const absoluteDelay = new Date(testScheduler.now() + t);
+      const result = e1.pipe(delay(absoluteDelay, testScheduler));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1Sub);
     });
+  });
 
   it('should delay when source does not emits', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ----|   ');
       const t = time('      ---|');
       const expected = '-------|';
-    const subs =     '^   !   ';
+      const subs = '    ^---!   ';
 
-    const result = e1.pipe(delay(t, rxTestScheduler));
+      const result = e1.pipe(delay(t, testScheduler));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(subs);
     });
+  });
 
   it('should delay when source is empty', () => {
+    testScheduler.run(({ cold, time, expectObservable }) => {
       const e1 = cold(' |');
       const t = time('  ---|');
       const expected = '---|';
 
-    const result = e1.pipe(delay(t, rxTestScheduler));
+      const result = e1.pipe(delay(t, testScheduler));
 
       expectObservable(result).toBe(expected);
     });
+  });
 
   it('should not complete when source does not completes', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a---b---------');
       const t = time('     ---|          ');
       const expected = '------a---b------';
       const unsub = '   ----------------!';
-    const subs =     '^               !';
+      const subs = '    ^---------------!';
 
-    const result = e1.pipe(delay(t, rxTestScheduler));
+      const result = e1.pipe(delay(t, testScheduler));
 
       expectObservable(result, unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(subs);
     });
+  });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a---b----');
       const t = time('     ---|     ');
-    const e1subs =   '^       !   ';
+      const e1subs = '  ^-------!   ';
       const expected = '------a--   ';
-    const unsub =    '        !   ';
+      const unsub = '   --------!   ';
 
       const result = e1.pipe(
         mergeMap((x: any) => of(x)),
-      delay(t, rxTestScheduler),
+        delay(t, testScheduler),
         mergeMap((x: any) => of(x))
       );
 
       expectObservable(result, unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
+  });
 
   it('should not complete when source never completes', () => {
+    testScheduler.run(({ cold, time, expectObservable }) => {
       const e1 = cold(' -');
       const t = time('  ---|');
       const expected = '-';
 
-    const result = e1.pipe(delay(t, rxTestScheduler));
+      const result = e1.pipe(delay(t, testScheduler));
 
       expectObservable(result).toBe(expected);
     });
+  });
 
   it('should unsubscribe scheduled actions after execution', () => {
+    testScheduler.run(({ cold, time, expectObservable }) => {
       let subscribeSpy: any = null;
       const counts: number[] = [];
 
@@ -162,7 +185,7 @@ describe('delay operator', () => {
       const duration = time('-|');
       const result = e1.pipe(
         repeatWhen(notifications => {
-        const delayed = notifications.pipe(delay(duration, rxTestScheduler));
+          const delayed = notifications.pipe(delay(duration, testScheduler));
           subscribeSpy = sinon.spy(delayed['source'], 'subscribe');
           return delayed;
         }),
@@ -182,3 +205,4 @@ describe('delay operator', () => {
       expectObservable(result).toBe(expected);
     });
   });
+});

--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -6,174 +6,179 @@ import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
 
 declare const asDiagram: Function;
-declare const rxTestScheduler: TestScheduler;
 
 /** @test {delay} */
 describe('delay operator', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   asDiagram('delay(20)')('should delay by specified timeframe', () => {
-    const e1 =   hot('---a--b--|  ');
-    const t =   time(   '--|      ');
-    const expected = '-----a--b--|';
+      const e1 = hot('  ---a--b--|  ');
+      const t = time('     --|      ');
+      const expected = '-----a--b--|';
     const subs =     '^        !  ';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-  });
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
 
   it('should delay by absolute time period', () => {
-    const e1 =   hot('--a--b--|   ');
-    const t =   time(  '---|      ');
-    const expected = '-----a--b--|';
+      const e1 = hot('  --a--b--|   ');
+      const t = time('    ---|      ');
+      const expected = '-----a--b--|';
     const subs =     '^       !   ';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
     const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-  });
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
 
   it('should delay by absolute time period after subscription', () => {
-    const e1 =   hot('---^--a--b--|   ');
-    const t =   time(      '---|      ');
-    const expected =    '------a--b--|';
+      const e1 = hot('  ---^--a--b--|   ');
+      const t = time('        ---|      ');
+      const expected = '   ------a--b--|';
     const subs =        '^        !   ';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
     const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-  });
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
 
   it('should raise error when source raises error', () => {
-    const e1 =   hot('---a---b---#');
-    const t =   time(   '---|     ');
-    const expected = '------a---b#';
+      const e1 = hot('  ---a---b---#');
+      const t = time('     ---|     ');
+      const expected = '------a---b#';
     const subs =     '^          !';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-  });
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
 
   it('should raise error when source raises error', () => {
-    const e1 =   hot('--a--b--#');
-    const t =   time(  '---|   ');
-    const expected = '-----a--#';
+      const e1 = hot('  --a--b--#');
+      const t = time('    ---|   ');
+      const expected = '-----a--#';
     const subs =     '^       !';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
     const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-  });
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
 
   it('should raise error when source raises error after subscription', () => {
-    const e1 =   hot('---^---a---b---#');
-    const t =   time(       '---|     ');
-    const expected =    '-------a---b#';
+      const e1 = hot('  ---^---a---b---#');
+      const t = time('         ---|     ');
+      const expected = '   -------a---b#';
     const e1Sub =       '^           !';
 
     const absoluteDelay = new Date(rxTestScheduler.now() + t);
     const result = e1.pipe(delay(absoluteDelay, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1Sub);
-  });
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1Sub);
+    });
 
   it('should delay when source does not emits', () => {
-    const e1 =   hot('----|   ');
-    const t =   time(    '---|');
-    const expected = '-------|';
+      const e1 = hot('  ----|   ');
+      const t = time('      ---|');
+      const expected = '-------|';
     const subs =     '^   !   ';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-  });
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
 
   it('should delay when source is empty', () => {
-    const e1 =  cold('|');
-    const t =   time('---|');
-    const expected = '---|';
+      const e1 = cold(' |');
+      const t = time('  ---|');
+      const expected = '---|';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-  });
+      expectObservable(result).toBe(expected);
+    });
 
   it('should not complete when source does not completes', () => {
-    const e1 =   hot('---a---b---------');
-    const t =   time(   '---|          ');
-    const expected = '------a---b------';
-    const unsub =    '----------------!';
+      const e1 = hot('  ---a---b---------');
+      const t = time('     ---|          ');
+      const expected = '------a---b------';
+      const unsub = '   ----------------!';
     const subs =     '^               !';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-  });
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   hot('---a---b----');
-    const t =   time(   '---|     ');
+      const e1 = hot('  ---a---b----');
+      const t = time('     ---|     ');
     const e1subs =   '^       !   ';
-    const expected = '------a--   ';
+      const expected = '------a--   ';
     const unsub =    '        !   ';
 
-    const result = e1.pipe(
-      mergeMap((x: any) => of(x)),
+      const result = e1.pipe(
+        mergeMap((x: any) => of(x)),
       delay(t, rxTestScheduler),
-      mergeMap((x: any) => of(x))
-    );
+        mergeMap((x: any) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
 
   it('should not complete when source never completes', () => {
-    const e1 =  cold('-');
-    const t =   time('---|');
-    const expected = '-';
+      const e1 = cold(' -');
+      const t = time('  ---|');
+      const expected = '-';
 
     const result = e1.pipe(delay(t, rxTestScheduler));
 
-    expectObservable(result).toBe(expected);
-  });
+      expectObservable(result).toBe(expected);
+    });
 
   it('should unsubscribe scheduled actions after execution', () => {
-    let subscribeSpy: any = null;
-    const counts: number[] = [];
+      let subscribeSpy: any = null;
+      const counts: number[] = [];
 
-    const e1 =       cold('a|');
-    const expected =      '--a-(a|)';
-    const duration = time('-|');
-    const result = e1.pipe(
-      repeatWhen(notifications => {
+      const e1 = cold('      a|');
+      const expected = '     --a-(a|)';
+      const duration = time('-|');
+      const result = e1.pipe(
+        repeatWhen(notifications => {
         const delayed = notifications.pipe(delay(duration, rxTestScheduler));
-        subscribeSpy = sinon.spy(delayed['source'], 'subscribe');
-        return delayed;
-      }),
-      skip(1),
-      take(2),
-      tap({
-        next() {
-          const [[subscriber]] = subscribeSpy.args;
-          counts.push(subscriber._subscriptions.length);
-        },
-        complete() {
-          expect(counts).to.deep.equal([1, 1]);
-        }
-      })
-    );
+          subscribeSpy = sinon.spy(delayed['source'], 'subscribe');
+          return delayed;
+        }),
+        skip(1),
+        take(2),
+        tap({
+          next() {
+            const [[subscriber]] = subscribeSpy.args;
+            counts.push(subscriber._subscriptions.length);
+          },
+          complete() {
+            expect(counts).to.deep.equal([1, 1]);
+          }
+        })
+      );
 
-    expectObservable(result).toBe(expected);
+      expectObservable(result).toBe(expected);
+    });
   });
-});

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -67,7 +67,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   createTime(marbles: string): number {
-    const indexOf: number = marbles.indexOf('|');
+    const indexOf = marbles.trim().indexOf('|');
     if (indexOf === -1) {
       throw new Error('marble diagram for time should have a completion marker "|"');
     }

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -14,6 +14,7 @@ export interface RunHelpers {
   cold: typeof TestScheduler.prototype.createColdObservable;
   hot: typeof TestScheduler.prototype.createHotObservable;
   flush: typeof TestScheduler.prototype.flush;
+  time: typeof TestScheduler.prototype.createTime;
   expectObservable: typeof TestScheduler.prototype.expectObservable;
   expectSubscriptions: typeof TestScheduler.prototype.expectSubscriptions;
 }
@@ -412,6 +413,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       cold: this.createColdObservable.bind(this),
       hot: this.createHotObservable.bind(this),
       flush: this.flush.bind(this),
+      time: this.createTime.bind(this),
       expectObservable: this.expectObservable.bind(this),
       expectSubscriptions: this.expectSubscriptions.bind(this),
     };


### PR DESCRIPTION
This switches the `delay` operator tests over to use the `TestScheduler#run` method.

A made a couple of assumptions:

 - I removed the  `declare const rxTestScheduler: TestScheduler;` line to instantiate the `TestScheduler` instance in a consistent way (see #5038) I assumed the declaration was for the typescript interpreter and it's not needed with this change.
 - I added time to the run helpers - I think it was omitted deliberately but maybe we need it now so that we can have spaces in the time marbles for Prettier-safe alignment. I added a `trim()` to the  `createTime()` method to do this. 

