### PR TITLE
docs(contributing): fix minor grammar issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,7 +114,7 @@ from the main (upstream) repository:
 - 2 space indentation only
 - favor readability over terseness
 
-(TBD): For now try to follow the style that exists elsewhere in the source, and use your best judgment.
+(TBD): For now, try to follow the style that exists elsewhere in the source, and use your best judgment.
 
 ## Documentation
 
@@ -172,7 +172,7 @@ testing techniques.
 ### Macro
 
 [Macro performance tests](perf/macro) are best written for scenarios where many object instance allocations (or deallocations) are occurring. Operators
-that create a lot of child subscriptions, or operators that emit new objects like Observables and Subjects are definitely worth creating
+that create a lot of child subscriptions or operators that emit new objects like Observables and Subjects are definitely worth creating
 macro performance tests for.
 
 Other scenarios for macro performance testing may include common end-to-end scenarios from real-world apps. If you have a situation in your
@@ -248,7 +248,7 @@ Must be one of the following:
   generation
 
 ### Scope
-The scope could be anything specifying place of the commit change. For example
+The scope could be anything specifying the place of the commit change. For example
 `Observable`, `Subject`, `switchMap`, etc.
 
 ### Subject


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Fixes minor grammar issues on CONTRIBUTING.md

**Related issue (if exists):**
N/A