### PR TITLE
fix: clear subscription on shareReplay completion

### DIFF
--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -168,6 +168,7 @@ function shareReplayOperator<T>({
         },
         complete() {
           isComplete = true;
+          subscription = undefined;
           subject.complete();
         },
       });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

In `shareReplay`, the subscription needs to be cleared to prevent the implementation holding a reference to the completed source. In Angular, not clearing the reference can lead to components not being garbage collected.

Using the DevTools, I've verified that the fix in this PR is required, but I have no idea how a test could be written for this sort of thing.

**Related issue (if exists):** #5034