### PR TITLE
chore: use strict TS option for dtslint

### DIFF
--- a/spec-dtslint/tsconfig.json
+++ b/spec-dtslint/tsconfig.json
@@ -11,8 +11,7 @@
       "rxjs/operators": ["../dist/types/operators"]
     },
     "skipLibCheck": true,
-    "strictFunctionTypes": true,
-    "strictNullChecks": true,
+    "strict": true,
     "target": "es2015"
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

As mentioned in #4968, the TypeScript compiler options could be more strict. Changing this is going to involve code changes. However, there's no reason we cannot enable `strict` for the dtslint tests right now. Doing so will allow us to use `$ExpectError` in more situations in our dtslint tests - the `'strictNullChecks': false` in the current configuration will prevent some types of errors from being reported. 

**Related issue (if exists):** #4968
