### PR TITLE
docs(guide): fix broken anchor link

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -139,7 +139,7 @@ For a complete overview, see the [references page](/api).
 - [`timer`](/api/index/function/timer)
 - [`iif`](/api/index/function/iif)
 
-### Join Creation Operators
+### <a id="join-creation-operators"></a>Join Creation Operators ###
 These are Observable creation operators that also have join functionality -- emitting values of multiple source Observables.
 
 - [`combineLatest`](/api/index/function/combineLatest)
@@ -208,7 +208,7 @@ These are Observable creation operators that also have join functionality -- emi
 - [`throttle`](/api/operators/throttle)
 - [`throttleTime`](/api/operators/throttleTime)
 
-### Join Operators
+### <a id="join-operators"></a>Join Operators ###
 Also see the [Join Creation Operators](#join-creation-operators) section above.
 
 - [`combineAll`](/api/operators/combineAll)

--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -121,7 +121,7 @@ There are operators for different purposes, and they may be categorized as: crea
 
 For a complete overview, see the [references page](/api).
 
-### <a id="creation-operators-list"></a>Creation Operators ###
+### <a id="creation-operators-list"></a>Creation Operators
 
 - [`ajax`](/api/ajax/ajax)
 - [`bindCallback`](/api/index/function/bindCallback)
@@ -139,7 +139,7 @@ For a complete overview, see the [references page](/api).
 - [`timer`](/api/index/function/timer)
 - [`iif`](/api/index/function/iif)
 
-### <a id="join-creation-operators"></a>Join Creation Operators ###
+### <a id="join-creation-operators"></a>Join Creation Operators
 These are Observable creation operators that also have join functionality -- emitting values of multiple source Observables.
 
 - [`combineLatest`](/api/index/function/combineLatest)
@@ -208,7 +208,7 @@ These are Observable creation operators that also have join functionality -- emi
 - [`throttle`](/api/operators/throttle)
 - [`throttleTime`](/api/operators/throttleTime)
 
-### <a id="join-operators"></a>Join Operators ###
+### <a id="join-operators"></a>Join Operators
 Also see the [Join Creation Operators](#join-creation-operators) section above.
 
 - [`combineAll`](/api/operators/combineAll)

--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -69,7 +69,7 @@ import { interval } from 'rxjs';
 const observable = interval(1000 /* number of milliseconds */);
 ```
 
-See the list of [all static creation operators here](#creation-operators).
+See the list of [all static creation operators here](#creation-operators-list).
 
 
 ## Higher-order Observables
@@ -121,7 +121,7 @@ There are operators for different purposes, and they may be categorized as: crea
 
 For a complete overview, see the [references page](/api).
 
-### Creation Operators
+### <a id="creation-operators-list"></a>Creation Operators ###
 
 - [`ajax`](/api/ajax/ajax)
 - [`bindCallback`](/api/index/function/bindCallback)


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
fix broken anchor link at guide (https://rxjs.dev/guide/operators#creation-operators)
at this section
```
See the list of all static creation operators here.
```
The `all the static creation operators here` anchor link not working due to have same id reference
**Related issue (if exists):**
