### PR TITLE
fix: chain subscriptions from interop observables

### DIFF
--- a/spec/helpers/interop-helper-spec.ts
+++ b/spec/helpers/interop-helper-spec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { Observable, of, Subscriber } from 'rxjs';
+import { observable as symbolObservable } from 'rxjs/internal/symbol/observable';
+import { rxSubscriber as symbolSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
+import { asInteropObservable, asInteropSubscriber } from './interop-helper';
+
+describe('interop helper', () => {
+  it('should simulate interop observables', () => {
+    const observable = asInteropObservable(of(42));
+    expect(observable).to.not.be.instanceOf(Observable);
+    expect(observable[symbolObservable]).to.be.a('function');
+  });
+
+  it('should simulate interop subscribers', () => {
+    const subscriber = asInteropSubscriber(new Subscriber());
+    expect(subscriber).to.not.be.instanceOf(Subscriber);
+    expect(subscriber[symbolSubscriber]).to.be.undefined;
+  });
+});

--- a/spec/helpers/interop-helper.ts
+++ b/spec/helpers/interop-helper.ts
@@ -1,0 +1,57 @@
+import { Observable, Subscriber, Subscription } from 'rxjs';
+import { rxSubscriber as symbolSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
+
+/**
+ * Returns an observable that will be deemed by this package's implementation
+ * to be an observable that requires interop. The returned observable will fail
+ * the `instanceof Observable` test and will deem any `Subscriber` passed to
+ * its `subscribe` method to be untrusted.
+ */
+export function asInteropObservable<T>(observable: Observable<T>): Observable<T> {
+  return new Proxy(observable, {
+    get(target: Observable<T>, key: string | number | symbol) {
+      if (key === 'subscribe') {
+        const { subscribe } = target;
+        return interopSubscribe(subscribe);
+      }
+      return Reflect.get(target, key);
+    },
+    getPrototypeOf(target: Observable<T>) {
+      const { subscribe, ...rest } = Object.getPrototypeOf(target);
+      return {
+        ...rest,
+        subscribe: interopSubscribe(subscribe)
+      };
+    }
+  });
+}
+
+/**
+ * Returns a subscriber that will be deemed by this package's implementation to
+ * be untrusted. The returned subscriber will fail the `instanceof Subscriber`
+ * test and will not include the symbol that identifies trusted subscribers.
+ */
+export function asInteropSubscriber<T>(subscriber: Subscriber<T>): Subscriber<T> {
+  return new Proxy(subscriber, {
+    get(target: Subscriber<T>, key: string | number | symbol) {
+      if (key === symbolSubscriber) {
+        return undefined;
+      }
+      return Reflect.get(target, key);
+    },
+    getPrototypeOf(target: Subscriber<T>) {
+      const { [symbolSubscriber]: symbol, ...rest } = Object.getPrototypeOf(target);
+      return rest;
+    }
+  });
+}
+
+function interopSubscribe<T>(subscribe: (...args: any[]) => Subscription) {
+  return function (this: Observable<T>, ...args: any[]): Subscription {
+    const [arg] = args;
+    if (arg instanceof Subscriber) {
+      return subscribe.call(this, asInteropSubscriber(arg));
+    }
+    return subscribe.apply(this, args);
+  };
+}

--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -149,6 +149,12 @@ describe('catchError operator', () => {
       const expected = '-1-2-3-5-6-7-     ';
       const unsub = '   ------------!     ';
 
+      // This test is the same as the previous test, but the observable is
+      // manipulated to make it look like an interop observable - an observable
+      // from a foreign library. Interop subscribers are treated differently:
+      // they are wrapped in a safe subscriber. This test ensures that
+      // unsubscriptions are chained all the way to the interop subscriber.
+
       const result = e1.pipe(catchError(() => asInteropObservable(e2)));
 
       expectObservable(result, unsub).toBe(expected);

--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -5,6 +5,7 @@ import * as sinon from 'sinon';
 import { createObservableInputs } from '../helpers/test-helper';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare function asDiagram(arg: string): Function;
 
@@ -132,6 +133,23 @@ describe('catchError operator', () => {
       const unsub = '   ------------!     ';
 
       const result = e1.pipe(catchError(() => e2));
+
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should unsubscribe from a caught cold caught interop observable when unsubscribed explicitly', () => {
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -1-2-3-#          ');
+      const e1subs = '  ^------!          ';
+      const e2 =  cold('       5-6-7-8-9-|');
+      const e2subs = '  -------^----!     ';
+      const expected = '-1-2-3-5-6-7-     ';
+      const unsub = '   ------------!     ';
+
+      const result = e1.pipe(catchError(() => asInteropObservable(e2)));
 
       expectObservable(result, unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -217,6 +217,12 @@ describe('exhaustMap', () => {
 
     const observableLookup = { x: x, y: y, z: z };
 
+    // This test is the same as the previous test, but the observable is
+    // manipulated to make it look like an interop observable - an observable
+    // from a foreign library. Interop subscribers are treated differently:
+    // they are wrapped in a safe subscriber. This test ensures that
+    // unsubscriptions are chained all the way to the interop subscriber.
+
     const result = e1.pipe(
       mergeMap(x => of(x)),
       exhaustMap(value => asInteropObservable(observableLookup[value])),

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { mergeMap, map } from 'rxjs/operators';
 import { asapScheduler, defer, Observable, from, of, timer } from 'rxjs';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare const type: Function;
 declare const asDiagram: Function;
@@ -257,6 +258,30 @@ describe('mergeMap', () => {
     );
 
     expectObservable(source, unsub).toBe(expected, values);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chains with interop inners when result is unsubscribed explicitly', () => {
+    const x =   cold(         '--a--b--c--d--e--|           ');
+    const xsubs =    '         ^           !                ';
+    const y =   cold(                   '---f---g---h---i--|');
+    const ysubs =    '                   ^ !                ';
+    const e1 =   hot('---------x---------y---------|        ');
+    const e1subs =   '^                    !                ';
+    const expected = '-----------a--b--c--d-                ';
+    const unsub =    '                     !                ';
+
+    const observableLookup = { x: x, y: y };
+
+    const result = e1.pipe(
+      mergeMap(x => of(x)),
+      mergeMap(value => asInteropObservable(observableLookup[value])),
+      mergeMap(x => of(x)),
+    );
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -273,6 +273,12 @@ describe('mergeMap', () => {
 
     const observableLookup = { x: x, y: y };
 
+    // This test manipulates the observable to make it look like an interop
+    // observable - an observable from a foreign library. Interop subscribers
+    // are treated differently: they are wrapped in a safe subscriber. This
+    // test ensures that unsubscriptions are chained all the way to the
+    // interop subscriber.
+
     const result = e1.pipe(
       mergeMap(x => of(x)),
       mergeMap(value => asInteropObservable(observableLookup[value])),

--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { onErrorResumeNext, takeWhile } from 'rxjs/operators';
 import { concat, defer, throwError, of } from 'rxjs';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare function asDiagram(arg: string): Function;
 
@@ -127,6 +128,17 @@ describe('onErrorResumeNext operator', () => {
     ).subscribe(() => { /* noop */ });
 
     expect(sideEffects).to.deep.equal([1, 2]);
+  });
+
+  it('should unsubscribe from an interop observble upon explicit unsubscription', () => {
+    const source =  hot('--a--b--#');
+    const next   = cold(        '--c--d--');
+    const nextSubs =    '        ^   !';
+    const subs =        '^           !';
+    const expected =    '--a--b----c--';
+
+    expectObservable(source.pipe(onErrorResumeNext(asInteropObservable(next))), subs).toBe(expected);
+    expectSubscriptions(next.subscriptions).toBe(nextSubs);
   });
 
   it('should work with promise', (done: MochaDone) => {

--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -137,6 +137,12 @@ describe('onErrorResumeNext operator', () => {
     const subs =        '^           !';
     const expected =    '--a--b----c--';
 
+    // This test manipulates the observable to make it look like an interop
+    // observable - an observable from a foreign library. Interop subscribers
+    // are treated differently: they are wrapped in a safe subscriber. This
+    // test ensures that unsubscriptions are chained all the way to the
+    // interop subscriber.
+
     expectObservable(source.pipe(onErrorResumeNext(asInteropObservable(next))), subs).toBe(expected);
     expectSubscriptions(next.subscriptions).toBe(nextSubs);
   });

--- a/spec/operators/skipUntil-spec.ts
+++ b/spec/operators/skipUntil-spec.ts
@@ -106,6 +106,12 @@ describe('skipUntil', () => {
     const expected =  ('----------          ');
     const unsub =      '         !          ';
 
+    // This test is the same as the previous test, but the observable is
+    // manipulated to make it look like an interop observable - an observable
+    // from a foreign library. Interop subscribers are treated differently:
+    // they are wrapped in a safe subscriber. This test ensures that
+    // unsubscriptions are chained all the way to the interop subscriber.
+
     const result = e1.pipe(
       mergeMap(x => of(x)),
       skipUntil(asInteropObservable(skip)),

--- a/spec/operators/skipUntil-spec.ts
+++ b/spec/operators/skipUntil-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { concat, defer, Observable, of, Subject } from 'rxjs';
 import { skipUntil, mergeMap } from 'rxjs/operators';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare function asDiagram(arg: string): Function;
 
@@ -89,6 +90,25 @@ describe('skipUntil', () => {
     const result = e1.pipe(
       mergeMap(x => of(x)),
       skipUntil(skip),
+      mergeMap(x => of(x)),
+    );
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    expectSubscriptions(skip.subscriptions).toBe(skipSubs);
+  });
+
+  it('should not break unsubscription chains with interop inners when result is unsubscribed explicitly', () => {
+    const e1 =     hot('--a--b--c--d--e----|');
+    const e1subs =     '^        !          ';
+    const skip =   hot('-------------x--|   ');
+    const skipSubs =   '^        !          ';
+    const expected =  ('----------          ');
+    const unsub =      '         !          ';
+
+    const result = e1.pipe(
+      mergeMap(x => of(x)),
+      skipUntil(asInteropObservable(skip)),
       mergeMap(x => of(x)),
     );
 
@@ -248,7 +268,6 @@ describe('skipUntil', () => {
   });
 
   it('should stop listening to a synchronous notifier after its first nexted value', () => {
-    // const source =   hot('-^-o---o---o---o---o---o---|');
     const sideEffects: number[] = [];
     const synchronousNotifer = concat(
       defer(() => {

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -182,6 +182,12 @@ describe('switchMap', () => {
 
     const observableLookup = { x: x, y: y };
 
+    // This test is the same as the previous test, but the observable is
+    // manipulated to make it look like an interop observable - an observable
+    // from a foreign library. Interop subscribers are treated differently:
+    // they are wrapped in a safe subscriber. This test ensures that
+    // unsubscriptions are chained all the way to the interop subscriber.
+
     const result = e1.pipe(
       mergeMap(x => of(x)),
       switchMap(value => asInteropObservable(observableLookup[value])),

--- a/spec/util/toSubscriber-spec.ts
+++ b/spec/util/toSubscriber-spec.ts
@@ -12,7 +12,7 @@ describe('toSubscriber', () => {
     expect(sub2.closed).to.be.true;
   });
 
-it('should not be closed when other subscriber created with same observer instance completes', () => {
+  it('should not be closed when other subscriber created with same observer instance completes', () => {
     let observer = {
       next: function () { /*noop*/ }
     };

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -154,6 +154,9 @@ class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
       this.add(innerSubscriber);
       const innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+      // The returned subscription will usually be the subscriber that was
+      // passed. However, interop subscribers will be wrapped and for
+      // unsubscriptions to chain correctly, the wrapper needs to be added, too.
       if (innerSubscription !== innerSubscriber) {
         this.add(innerSubscription);
       }

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -153,7 +153,10 @@ class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
       this._unsubscribeAndRecycle();
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
       this.add(innerSubscriber);
-      subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+      const innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+      if (innerSubscription !== innerSubscriber) {
+        this.add(innerSubscription);
+      }
     }
   }
 }

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -122,10 +122,13 @@ class ExhaustMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(result: ObservableInput<R>, value: T, index: number): void {
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    subscribeToResult<T, R>(this, result, value, index, innerSubscriber);
+    const innerSubscription = subscribeToResult<T, R>(this, result, undefined, undefined, innerSubscriber);
+    if (innerSubscription !== innerSubscriber) {
+      destination.add(innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -126,6 +126,9 @@ class ExhaustMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
     const innerSubscription = subscribeToResult<T, R>(this, result, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
     if (innerSubscription !== innerSubscriber) {
       destination.add(innerSubscription);
     }

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -146,6 +146,9 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
     const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
     if (innerSubscription !== innerSubscriber) {
       destination.add(innerSubscription);
     }

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -142,10 +142,13 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(ish: ObservableInput<R>, value: T, index: number): void {
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
+    const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
+    if (innerSubscription !== innerSubscriber) {
+      destination.add(innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -103,10 +103,13 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(ish: any, value: T, index: number): void {
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
+    const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
+    if (innerSubscription !== innerSubscriber) {
+      destination.add(innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -107,6 +107,9 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
     const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
     if (innerSubscription !== innerSubscriber) {
       destination.add(innerSubscription);
     }

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -162,7 +162,10 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
       const destination = this.destination as Subscription;
       destination.add(innerSubscriber);
-      subscribeToResult(this, next, undefined, undefined, innerSubscriber);
+      const innerSubscription = subscribeToResult(this, next, undefined, undefined, innerSubscriber);
+      if (innerSubscription !== innerSubscriber) {
+        destination.add(innerSubscription);
+      }
     } else {
       this.destination.complete();
     }

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -163,6 +163,9 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
       const destination = this.destination as Subscription;
       destination.add(innerSubscriber);
       const innerSubscription = subscribeToResult(this, next, undefined, undefined, innerSubscriber);
+      // The returned subscription will usually be the subscriber that was
+      // passed. However, interop subscribers will be wrapped and for
+      // unsubscriptions to chain correctly, the wrapper needs to be added, too.
       if (innerSubscription !== innerSubscriber) {
         destination.add(innerSubscription);
       }

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -74,7 +74,11 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
     this.add(innerSubscriber);
     this.innerSubscription = innerSubscriber;
-    subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
+    const innerSubscription = subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
+    if (innerSubscription !== innerSubscriber) {
+      this.add(innerSubscription);
+      this.innerSubscription = innerSubscription;
+    }
   }
 
   protected _next(value: T) {

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -75,6 +75,9 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.add(innerSubscriber);
     this.innerSubscription = innerSubscriber;
     const innerSubscription = subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
     if (innerSubscription !== innerSubscriber) {
       this.add(innerSubscription);
       this.innerSubscription = innerSubscription;

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -133,10 +133,13 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (innerSubscription) {
       innerSubscription.unsubscribe();
     }
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    this.innerSubscription = subscribeToResult(this, result, value, index, innerSubscriber);
+    this.innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+    if (this.innerSubscription !== innerSubscriber) {
+      destination.add(this.innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -137,6 +137,9 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
     this.innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
     if (this.innerSubscription !== innerSubscriber) {
       destination.add(this.innerSubscription);
     }

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -8,15 +8,30 @@ import { Observable } from '../Observable';
 export function subscribeToResult<T, R>(
   outerSubscriber: OuterSubscriber<T, R>,
   result: any,
+  outerValue: undefined,
+  outerIndex: undefined,
+  innerSubscriber: InnerSubscriber<T, R>
+): Subscription | undefined;
+
+export function subscribeToResult<T, R>(
+  outerSubscriber: OuterSubscriber<T, R>,
+  result: any,
+  outerValue?: T,
+  outerIndex?: number
+): Subscription | undefined;
+
+export function subscribeToResult<T, R>(
+  outerSubscriber: OuterSubscriber<T, R>,
+  result: any,
   outerValue?: T,
   outerIndex?: number,
-  destination: Subscriber<R> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
+  innerSubscriber: Subscriber<R> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
 ): Subscription | undefined {
-  if (destination.closed) {
+  if (innerSubscriber.closed) {
     return undefined;
   }
   if (result instanceof Observable) {
-    return result.subscribe(destination);
+    return result.subscribe(innerSubscriber);
   }
-  return subscribeTo(result)(destination) as Subscription;
+  return subscribeTo(result)(innerSubscriber) as Subscription;
 }

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -10,20 +10,13 @@ export function subscribeToResult<T, R>(
   result: any,
   outerValue?: T,
   outerIndex?: number,
-  destination?: Subscriber<any>
-): Subscription;
-export function subscribeToResult<T, R>(
-  outerSubscriber: OuterSubscriber<T, R>,
-  result: any,
-  outerValue?: T,
-  outerIndex?: number,
-  destination: Subscriber<any> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
-): Subscription | void {
+  destination: Subscriber<R> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
+): Subscription | undefined {
   if (destination.closed) {
     return undefined;
   }
   if (result instanceof Observable) {
     return result.subscribe(destination);
   }
-  return subscribeTo(result)(destination);
+  return subscribeTo(result)(destination) as Subscription;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes a bug in which subscriptions returned from interop observables are ignored - instead of being composed into the subscription chain. Prior to this fix, when an interop observable was returned to a flattening operator - like `mergeMap` or `switchMap` - the interop observable would not be unsubscribed upon explicit unsubscription from the flattening operator.

The bug was introduced in the changes made in https://github.com/ReactiveX/rxjs/pull/2479 and https://github.com/ReactiveX/rxjs/pull/4037.

This PR:

* adds a test helper for simulating an interop observable;
* copies existing, chaining-related tests and uses an interop observable within them;
* ensures subscriptions returned from interop observables are added to the subscription chain;
* fixes another bug in which `subscribeToResult` was passed outer values and indices when they should have been passed to the `InnerSubscriber` (the bug would have manifested itself in the now-deprecated result selectors for the flattening operators); and
* tweaks the `subscribeToResult` signature to make it safer (if an `InnerSubscriber` is passed, `value` and `index` must be `undefined` and must be passed via the `InnerSubscriber` instead).

**Related issue (if exists):** #5051