### PR TITLE
docs (shareReplay): fix missing and add additional documentation

### DIFF
--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -11,6 +11,9 @@ export interface ShareReplayConfig {
   scheduler?: SchedulerLike;
 }
 
+export function shareReplay<T>(config: ShareReplayConfig): MonoTypeOperatorFunction<T>;
+export function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+
 /**
  * Share source and replay specified number of emissions on subscription.
  *
@@ -28,6 +31,15 @@ export interface ShareReplayConfig {
  *
  * ![](shareReplay.png)
  *
+ * ## Reference counting
+ * As of RXJS version 6.4.0 a new overload signature was added to allow for manual control over what
+ * happens when the operators internal reference counter drops to zero.
+ * If `refCount` is true, the source will be unsubscribed from once the reference count drops to zero, i.e.
+ * the inner `ReplaySubject` will be unsubscribed. All new subscribers will receive value emissions from a
+ * new `ReplaySubject` which in turn will cause a new subscription to the source observable.
+ * If `refCount` is false on the other hand, the source will not be unsubscribed meaning that the inner
+ * `ReplaySubject` will still be subscribed to the source (and potentially run for ever).
+ *
  * ## Example
  * ```ts
  * import { interval } from 'rxjs';
@@ -38,9 +50,65 @@ export interface ShareReplayConfig {
  *   take(4),
  *   shareReplay(3)
  * );
- * shared$.subscribe(x => console.log('source A: ', x));
- * shared$.subscribe(y => console.log('source B: ', y));
+ * shared$.subscribe(x => console.log('sub A: ', x));
+ * shared$.subscribe(y => console.log('sub B: ', y));
  *
+ * ```
+ *
+ * ## Example for refCount usage
+ * ```ts
+ * // Code take from https://blog.angularindepth.com/rxjs-whats-changed-with-sharereplay-65c098843e95
+ * // and adapted to showcase the refCount property.
+ * import { interval, Observable, defer } from 'rxjs';
+ * import { shareReplay, take, tap, finalize } from 'rxjs/operators';
+ *
+ * const log = <T>(source: Observable<T>, name: string) => defer(() => {
+ *   console.log(`${name}: subscribed`);
+ *   return source.pipe(
+ *     tap({
+ *       next: value => console.log(`${name}: ${value}`),
+ *       complete: () => console.log(`${name}: complete`)
+ *     }),
+ *     finalize(() => console.log(`${name}: unsubscribed`))
+ *   );
+ * });
+ *
+ * const obs$ = log(interval(1000), 'source');
+ *
+ * const shared$ = log(obs$.pipe(
+ *   shareReplay({bufferSize: 1, refCount: true }),
+ *   take(2),
+ * ), 'shared');
+ *
+ * shared$.subscribe(x => console.log('sub A: ', x));
+ * shared$.subscribe(y => console.log('sub B: ', y));
+ *
+ * // PRINTS:
+ * // shared: subscribed <-- reference count = 1
+ * // source: subscribed
+ * // shared: subscribed <-- reference count = 2
+ * // source: 0
+ * // shared: 0
+ * // sub A: 0
+ * // shared: 0
+ * // sub B: 0
+ * // source: 1
+ * // shared: 1
+ * // sub A: 1
+ * // shared: complete <-- take(2) completes the subscription for sub A
+ * // shared: unsubscribed <-- reference count = 1
+ * // shared: 1
+ * // sub B: 1
+ * // shared: complete <-- take(2) completes the subscription for sub B
+ * // shared: unsubscribed <-- reference count = 0
+ * // source: unsubscribed <-- replaySubject unsubscribes from source observable because the reference count dropped to 0 and refCount is true
+ *
+ * // In case of refCount being false, the unsubscribe is never called on the source and the source would keep on emitting, even if no subscribers
+ * // are listening.
+ * // source: 2
+ * // source: 3
+ * // source: 4
+ * // ...
  * ```
  *
  * @see {@link publish}
@@ -56,8 +124,6 @@ export interface ShareReplayConfig {
  * @method shareReplay
  * @owner Observable
  */
-export function shareReplay<T>(config: ShareReplayConfig): MonoTypeOperatorFunction<T>;
-export function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 export function shareReplay<T>(
   configOrBufferSize?: ShareReplayConfig | number,
   windowTime?: number,


### PR DESCRIPTION
- Fix missing documentation due to incorrect line ordering
- Add additional documentation for the refCount parameter

Fixes #4796

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Documentation for the shareReplay operator was not shown due to the function overloads being positioned between the documentation and the actual implementation. Moving the overloads above the JSDocs fixes the issue.
Furthermore, documentation was added to explain the refCount parameter. Understanding how the shareReplay operator behaves with regards to the refCount setting is critical.

**Related issue (if exists):**
#4796 