### PR TITLE
fix(toPromise): correct toPromise return type

### DIFF
--- a/spec-dtslint/Observable-spec.ts
+++ b/spec-dtslint/Observable-spec.ts
@@ -126,4 +126,8 @@ describe('pipe', () => {
     const customOperator = () => <T>(a: Observable<T>) => a;
     const o = of('foo').pipe(customOperator()); // $ExpectType Observable<string>
   });
+
+  it('should have proper return type for toPromise', () => {
+    const o = of('foo').toPromise(); // $ExpectType Promise<string | undefined>
+  });
 });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -347,9 +347,9 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /* tslint:disable:max-line-length */
-  toPromise<T>(this: Observable<T>): Promise<T>;
-  toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T>;
-  toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T>;
+  toPromise<T>(this: Observable<T>): Promise<T | undefined>;
+  toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T | undefined>;
+  toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;
   /* tslint:enable:max-line-length */
 
   /**
@@ -362,13 +362,13 @@ export class Observable<T> implements Subscribable<T> {
    * @return A Promise that resolves with the last value emit, or
    * rejects on an error.
    */
-  toPromise(promiseCtor?: PromiseConstructorLike): Promise<T> {
+  toPromise(promiseCtor?: PromiseConstructorLike): Promise<T | undefined> {
     promiseCtor = getPromiseCtor(promiseCtor);
 
     return new promiseCtor((resolve, reject) => {
-      let value: any;
+      let value: T | undefined;
       this.subscribe((x: T) => value = x, (err: any) => reject(err), () => resolve(value));
-    }) as Promise<T>;
+    }) as Promise<T | undefined>;
   }
 }
 


### PR DESCRIPTION
**Description:**
As described in #4196, the typing of `toPromise` does not match reality as it may return `undefined` in the case that no value is ever emitted. We have hit this bug in practice and believe it would be very useful to fix the actual typing.

(This does not implement the `default` argument as suggested in #4196 - while this seems like a reasonable addition, there are cases today where returning undefined is in fact desired, and it would be nice if the typing was correct for this case.)

**Related issue (if exists):**
*    #4196 - Typing of toPromise is wrong

(cc @sadarby)