### PR TITLE
test(filter): fix test that seemed to be trying to infer unnecessaril…

### DIFF
--- a/spec-dtslint/operators/filter-spec.ts
+++ b/spec-dtslint/operators/filter-spec.ts
@@ -59,11 +59,9 @@ it('should support inference from a return type with Boolean as a predicate', ()
 });
 
 it('should support inference from a generic return type of the predicate', () => {
-  function isDefined<T>() {
-    return (value: T|undefined|null): value is T => {
-      return value !== undefined && value !== null;
-    };
+  function isDefined<T>(value: T|undefined|null): value is T {
+    return value !== undefined && value !== null;
   }
 
-  const o$ = of(1, null, {foo: 'bar'}, true, undefined, 'Nick Cage').pipe(filter(isDefined())); // $ExpectType Observable<string | number | boolean | { foo: string; }>
+  const o$ = of(1, null, {foo: 'bar'}, true, undefined, 'Nick Cage').pipe(filter(isDefined)); ; // $ExpectType Observable<string | number | boolean | { foo: string; }>
 });


### PR DESCRIPTION
…y via additional indirection

This started failing after a few merges, but looking at it, I'm not sure what it was testing or if the test was correct to begin with.

cc @kolodny... I think you added this test originally. @cartant I know you reviewed that PR as well.