### PR TITLE
fix: use `unknown` type for errors

### DIFF
--- a/spec-dtslint/Observable-spec.ts
+++ b/spec-dtslint/Observable-spec.ts
@@ -126,4 +126,12 @@ describe('pipe', () => {
     const customOperator = () => <T>(a: Observable<T>) => a;
     const o = of('foo').pipe(customOperator()); // $ExpectType Observable<string>
   });
+
+  it('should not make assumptions about the error type', () => {
+    of('foo').subscribe({
+      error: error => {
+        error.name; // $ExpectError
+      }
+    });
+  });
 });

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -974,8 +974,12 @@ describe('ajax', () => {
     ajax(ajaxRequest)
       .subscribe({
         error(err) {
-          expect(err.name).to.equal('AjaxTimeoutError');
-          done();
+          if (err instanceof AjaxTimeoutError) {
+            expect(err.name).to.equal('AjaxTimeoutError');
+            done();
+          } else {
+            throw new Error('expected an AjaxTimeoutError');
+          }
         }
       });
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -61,21 +61,21 @@ export type InteropObservable<T> = { [Symbol.observable]: () => Subscribable<T>;
 export interface NextObserver<T> {
   closed?: boolean;
   next: (value: T) => void;
-  error?: (err: any) => void;
+  error?: (err: unknown) => void;
   complete?: () => void;
 }
 
 export interface ErrorObserver<T> {
   closed?: boolean;
   next?: (value: T) => void;
-  error: (err: any) => void;
+  error: (err: unknown) => void;
   complete?: () => void;
 }
 
 export interface CompletionObserver<T> {
   closed?: boolean;
   next?: (value: T) => void;
-  error?: (err: any) => void;
+  error?: (err: unknown) => void;
   complete: () => void;
 }
 
@@ -84,7 +84,7 @@ export type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | Completion
 export interface Observer<T> {
   closed?: boolean;
   next: (value: T) => void;
-  error: (err: any) => void;
+  error: (err: unknown) => void;
   complete: () => void;
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Errors can be of any type. `unknown` is preferable to `any`, as `any` completely disables type checking:

```ts
declare const myError: any;
myError.some.property.that.does.not.exist // runtime error!
```