### PR TITLE
fix(closure): Annotate next() for ReplaySubject

### DIFF
--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -28,6 +28,7 @@ export class ReplaySubject<T> extends Subject<T> {
 
     if (windowTime === Number.POSITIVE_INFINITY) {
       this._infiniteTimeWindow = true;
+      /** @override */
       this.next = this.nextInfiniteTimeWindow;
     } else {
       this.next = this.nextTimeWindow;


### PR DESCRIPTION
Closure thinks `next()` is `UnusableType` instead of `(value: T) => void`, adding an `@override` annotation when overriding the method fixes this issue
