### PR TITLE
feat(Subject): SnapShotReplaySubject

### DIFF
--- a/spec/subjects/SnapShotReplaySubject-spec.ts
+++ b/spec/subjects/SnapShotReplaySubject-spec.ts
@@ -89,7 +89,6 @@ describe('SnapShotReplaySubject', () => {
 
         done();
 
-
     });
 
 });

--- a/spec/subjects/SnapShotReplaySubject-spec.ts
+++ b/spec/subjects/SnapShotReplaySubject-spec.ts
@@ -1,0 +1,95 @@
+import {SnapShotReplaySubject, Subject} from 'rxjs';
+import {expect} from 'chai';
+
+/** @test {SnapShotReplaySubject} */
+describe('SnapShotReplaySubject', () => {
+    it('should extend Subject', () => {
+        const subject = new SnapShotReplaySubject(null);
+        expect(subject).to.be.instanceof(Subject);
+    });
+
+    it('should be able construct with provided keyProvder', () => {
+        const subject = new SnapShotReplaySubject<any>(value => {
+            return value.key;
+        });
+        expect(subject).to.be.instanceof(SnapShotReplaySubject);
+    });
+
+    it('should contain 2 values ', () => {
+        const subject = new SnapShotReplaySubject<any>(value => {
+            return value.key;
+        });
+        const values = [];
+
+        subject.next({key: 'IBM', price: 100});
+        subject.next({key: 'IBM', price: 101});
+        subject.next({key: 'IBM', price: 102});
+        subject.next({key: 'AAPL', price: 200});
+
+        subject.subscribe(value => {
+            values.push(value);
+        });
+
+        expect(values.length).to.be.equal(2);
+    });
+
+    it('should have last published value for an item', () => {
+        const subject = new SnapShotReplaySubject<any>(value => {
+            return value.key;
+        });
+
+        let expected = 102;
+
+        subject.next({key: 'IBM', price: 100});
+        subject.next({key: 'IBM', price: 101});
+        subject.next({key: 'IBM', price: 102});
+        subject.next({key: 'AAPL', price: 200});
+
+        subject.subscribe(value => {
+          if ( value.key === 'IBM') {
+              expected = value.price;
+          }
+        });
+
+        expect(expected).to.be.equal(102);
+    });
+
+    it('should pump old and new values to multiple subscribers', (done: MochaDone) => {
+        const subject = new SnapShotReplaySubject<any>(value => {
+            return value.key;
+        });
+        let i = 0;
+        let j = 0;
+        const sub1Expected = [
+            {key: 'IBM', price: 100},
+            {key: 'IBM', price: 101},
+            {key: 'AAPL', price: 103},
+        ];
+        const sub2Expected = [
+            {key: 'IBM', price: 101},
+            {key: 'AAPL', price: 103},
+            ];
+
+        subject.subscribe((x: any) => {
+            expect(x.key).to.equal(sub1Expected[i].key);
+            expect(x.price).to.equal(sub1Expected[i].price);
+            i++;
+        });
+
+        subject.next( {key: 'IBM', price: 100});
+        subject.next( {key: 'IBM', price: 101});
+
+        subject.subscribe((x: any) => {
+            expect(x.key).to.equal(sub2Expected[j].key);
+            expect(x.price).to.equal(sub2Expected[j].price);
+            j++;
+        });
+
+        subject.next( {key: 'AAPL', price: 103});
+
+        done();
+
+
+    });
+
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Subject } from './internal/Subject';
 export { BehaviorSubject } from './internal/BehaviorSubject';
 export { ReplaySubject } from './internal/ReplaySubject';
 export { AsyncSubject } from './internal/AsyncSubject';
+export { SnapShotReplaySubject } from './internal/SnapShotReplaySubject';
 
 /* Schedulers */
 export { asap as asapScheduler } from './internal/scheduler/asap';

--- a/src/internal/SnapShotReplaySubject.ts
+++ b/src/internal/SnapShotReplaySubject.ts
@@ -1,0 +1,62 @@
+import { Subject } from './Subject';
+import { Subscriber } from './Subscriber';
+import { Subscription } from './Subscription';
+import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
+import { SubjectSubscription } from './SubjectSubscription';
+/**
+ * A variant of Subject that "replays" or emits old values to new subscribers.
+ * It buffers a set number of values and will emit those values immediately to
+ * any new subscribers in addition to emitting new values to existing subscribers.
+ * Values are keyed by the provided functor
+ * Keeps maps of latest Values by key
+ *
+ * @class SnapShotReplaySubject<T>
+ */
+export class SnapShotReplaySubject<T> extends Subject<T> {
+  private _eventsMap: Map<any, T> = new Map<any, T>();
+
+  private _keyProvider: (value: T) => any;
+
+  constructor(keyProvider: (value: T) => any) {
+    super();
+    this._keyProvider = keyProvider;
+    this.next = this.keyedNext;
+  }
+
+  private keyedNext(value: T): void {
+    const key = this._keyProvider(value);
+    this._eventsMap.set(key, value);
+    super.next(value);
+  }
+
+
+  /** @deprecated This is an internal implementation detail, do not use. */
+  _subscribe(subscriber: Subscriber<T>): Subscription {
+
+    let subscription: Subscription;
+
+    if (this.closed) {
+      throw new ObjectUnsubscribedError();
+    } else if (this.isStopped || this.hasError) {
+      subscription = Subscription.EMPTY;
+    } else {
+      this.observers.push(subscriber);
+      subscription = new SubjectSubscription(this, subscriber);
+    }
+
+    const values = Array.from(this._eventsMap.values());
+
+    values.forEach(value => {
+      subscriber.next(value);
+    });
+
+    if (this.hasError) {
+      subscriber.error(this.thrownError);
+    } else if (this.isStopped) {
+      subscriber.complete();
+    }
+
+    return subscription;
+  }
+
+}

--- a/src/internal/SnapShotReplaySubject.ts
+++ b/src/internal/SnapShotReplaySubject.ts
@@ -15,7 +15,7 @@ import { SubjectSubscription } from './SubjectSubscription';
 export class SnapShotReplaySubject<T> extends Subject<T> {
   private _eventsMap: Map<any, T> = new Map<any, T>();
 
-  private _keyProvider: (value: T) => any;
+  private readonly _keyProvider: (value: T) => any;
 
   constructor(keyProvider: (value: T) => any) {
     super();
@@ -28,7 +28,6 @@ export class SnapShotReplaySubject<T> extends Subject<T> {
     this._eventsMap.set(key, value);
     super.next(value);
   }
-
 
   /** @deprecated This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): Subscription {


### PR DESCRIPTION
SnapShotReplay Subject will collect items based on some key
if new value with same key is published it will replace the old value

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
