### PR TITLE
docs(examples): update examples

### DIFF
--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -63,28 +63,29 @@ export function of<A extends Array<any>>(...args: A): Observable<ValueFromArray<
  *   err => console.log('error:', err),
  *   () => console.log('the end'),
  * );
- * // result:
- * // 'next: 10'
- * // 'next: 20'
- * // 'next: 30'
- * // 'the end'
  *
+ * // Outputs
+ * // next: 10
+ * // next: 20
+ * // next: 30
+ * // the end
  * ```
  *
- * Emit the array `[1,2,3]`
+ * Emit the array `[1, 2, 3]`
  *
  * ```ts
  * import { of } from 'rxjs';
  *
- * of([1,2,3])
+ * of([1, 2, 3])
  * .subscribe(
  *   next => console.log('next:', next),
  *   err => console.log('error:', err),
  *   () => console.log('the end'),
  * );
- * // result:
- * // 'next: [1,2,3]'
- * // 'the end'
+ *
+ * // Outputs
+ * // next: [1, 2, 3]
+ * // the end
  * ```
  *
  * @see {@link from}

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -50,21 +50,23 @@ export function zip<R>(...observables: Array<ObservableInput<any> | ((...values:
  * Otherwise, an array of the input values is returned.
  *
  * ## Example
+ *
  * Combine age and name from different sources
+ *
  * ```ts
  * import { zip, of } from 'rxjs';
  * import { map } from 'rxjs/operators';
  *
- * let age$ =of(27, 25, 29);
- * let name$ =of('Foo', 'Bar', 'Beer');
- * let isDev$ =of(true, true, false);
+ * let age$ = of(27, 25, 29);
+ * let name$ = of('Foo', 'Bar', 'Beer');
+ * let isDev$ = of(true, true, false);
  *
  * zip(age$, name$, isDev$).pipe(
- *   map(([age, name, isDev]) => ({ age, name, isDev })),
+ *   map(([age, name, isDev]) => ({ age, name, isDev }))
  * )
  * .subscribe(x => console.log(x));
  *
- * // outputs
+ * // Outputs
  * // { age: 27, name: 'Foo', isDev: true }
  * // { age: 25, name: 'Bar', isDev: true }
  * // { age: 29, name: 'Beer', isDev: false }

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -21,19 +21,29 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * that the internal `Set` can be "flushed", basically clearing it of values.
  *
  * ## Examples
+ * 
  * A simple example with numbers
+ * 
  * ```ts
  * import { of } from 'rxjs';
  * import { distinct } from 'rxjs/operators';
  *
- * of(1, 1, 2, 2, 2, 1, 2, 3, 4, 3, 2, 1).pipe(
- *     distinct(),
+ * of(1, 1, 2, 2, 2, 1, 2, 3, 4, 3, 2, 1)
+ *   .pipe(
+ *     distinct()
  *   )
- *   .subscribe(x => console.log(x)); // 1, 2, 3, 4
+ *   .subscribe(x => console.log(x));
+ *
+ * // Outputs
+ * // 1
+ * // 2
+ * // 3
+ * // 4
  * ```
  *
  * An example using a keySelector function
- * ```typescript
+ * 
+ * ```ts
  * import { of } from 'rxjs';
  * import { distinct } from 'rxjs/operators';
  *
@@ -42,16 +52,16 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  *    name: string
  * }
  *
- *of(
+ * of(
  *     { age: 4, name: 'Foo'},
  *     { age: 7, name: 'Bar'},
- *     { age: 5, name: 'Foo'},
+ *     { age: 5, name: 'Foo'}
  *   ).pipe(
- *     distinct((p: Person) => p.name),
+ *     distinct((p: Person) => p.name)
  *   )
  *   .subscribe(x => console.log(x));
  *
- * // displays:
+ * // Outputs
  * // { age: 4, name: 'Foo' }
  * // { age: 7, name: 'Bar' }
  * ```

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -21,9 +21,9 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * that the internal `Set` can be "flushed", basically clearing it of values.
  *
  * ## Examples
- * 
+ *
  * A simple example with numbers
- * 
+ *
  * ```ts
  * import { of } from 'rxjs';
  * import { distinct } from 'rxjs/operators';
@@ -42,7 +42,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * ```
  *
  * An example using a keySelector function
- * 
+ *
  * ```ts
  * import { of } from 'rxjs';
  * import { distinct } from 'rxjs/operators';


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Update `of`, `zip` and `distinct` examples

**Related issue (if exists):**
