### PR TITLE
docs(scheduler): remove link to Stackblitz example

### DIFF
--- a/docs_app/content/guide/scheduler.md
+++ b/docs_app/content/guide/scheduler.md
@@ -10,7 +10,6 @@
 
 In the example below, we take the usual simple Observable that emits values `1`, `2`, `3` synchronously, and use the operator `observeOn` to specify the `async` scheduler to use for delivering those values.
 
-[View on Stackblitz](https://stackblitz.com/edit/typescript-jexdny)
 ```ts
 import { Observable, asyncScheduler } from 'rxjs';
 import { observeOn } from 'rxjs/operators';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Remove link to Stackblitz example because each code snippet provides such link anyway.

**Related issue (if exists):**
