### PR TITLE
chore: Bump es-abstract dependency in package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2332,9 +2332,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.0.tgz",
-      "integrity": "sha512-lri42nNq1tIohUuwFBYEM3wKwcrcJa78jukGDdWsuaNxTtxBFGFkKUQ15nc9J+ipje4mhbQR6JwABb4VvawR3A==",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.14.2.tgz",
+      "integrity": "sha512-DgoQmbpFNOofkjJtKwr87Ma5EW4Dc8fWhD0R+ndq7Oc456ivUfGOOP6oAZTTKl5/CcNMP+EN+e3/iUzgE0veZg==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.0",


### PR DESCRIPTION
This fixes #5099 by bumping the version of `es-abstract` from the unpublished 1.14.0 to 1.14.2.

Version 1.14.2 is the latest patch version within the currently used minor range. There's also 1.15.0 and 1.16.0 but I decided to upgrade conservatively.

I usually use Yarn so I'm not sure on the canonical way to upgrade a transitive dependency using npm. I just ran `npm i es-abstract@1.14.2` and then did a diff on `package-lock.json`.

Since none of `es-abstract`'s dependencies apparently changed between 1.14.0 and 1.14.2, it looks safe to only bump the resolved package version itself (and its fingerprint), so that's what this PR achieves.