### PR TITLE
refactor(mapTo): update function signature

### DIFF
--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -3,6 +3,10 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
 
+export function mapTo<R>(value: R): OperatorFunction<any, R>;
+/** @deprecated remove in v8. Use mapTo<R>(value: R): OperatorFunction<any, R> signature instead **/
+export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
+
 /**
  * Emits the given constant value on the output Observable every time the source
  * Observable emits a value.
@@ -35,8 +39,8 @@ import { OperatorFunction } from '../types';
  * @method mapTo
  * @owner Observable
  */
-export function mapTo<T, R>(value: R): OperatorFunction<T, R> {
-  return (source: Observable<T>) => source.lift(new MapToOperator(value));
+export function mapTo<R>(value: R): OperatorFunction<any, R> {
+  return (source: Observable<any>) => source.lift(new MapToOperator(value));
 }
 
 class MapToOperator<T, R> implements Operator<T, R> {


### PR DESCRIPTION
**Description:**
Reduce the number of generics used in the 'mapTo' function to 1 generic parameter. Mark the 2 generic variant as a deprecated variant

**Related issue (if exists):**
issue #5090 
