### PR TITLE
fix(fromFetch): abort signal ignored if already aborted

### DIFF
--- a/spec/observables/dom/fetch-spec.ts
+++ b/spec/observables/dom/fetch-spec.ts
@@ -173,13 +173,23 @@ describe('fromFetch', () => {
   });
 
   it('should allow passing of init object', done => {
-    const myInit = {};
-    const fetch$ = fromFetch('/foo', myInit);
+    const fetch$ = fromFetch('/foo', {method: 'HEAD'});
     fetch$.subscribe({
       error: done,
       complete: done,
     });
-    expect(mockFetch.calls[0].init).to.equal(myInit);
+    expect(mockFetch.calls[0].init.method).to.equal('HEAD');
+  });
+
+  it('should pass in a signal with the init object without mutating the init', done => {
+    const myInit = {method: 'DELETE'};
+    const fetch$ = fromFetch('/bar', myInit);
+    fetch$.subscribe({
+      error: done,
+      complete: done,
+    });
+    expect(mockFetch.calls[0].init.method).to.equal(myInit.method);
+    expect(mockFetch.calls[0].init).not.to.equal(myInit);
     expect(mockFetch.calls[0].init.signal).not.to.be.undefined;
   });
 

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -61,12 +61,16 @@ export function fromFetch(input: string | Request, init?: RequestInit): Observab
     if (init) {
       // If a signal is provided, just have it teardown. It's a cancellation token, basically.
       if (init.signal) {
-        outerSignalHandler = () => {
-          if (!signal.aborted) {
-            controller.abort();
-          }
-        };
-        init.signal.addEventListener('abort', outerSignalHandler);
+        if (init.signal.aborted) {
+          controller.abort();
+        } else {
+          outerSignalHandler = () => {
+            if (!signal.aborted) {
+              controller.abort();
+            }
+          };
+          init.signal.addEventListener('abort', outerSignalHandler);
+        }
       }
       init = { ...init, signal };
     } else {

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -68,7 +68,7 @@ export function fromFetch(input: string | Request, init?: RequestInit): Observab
         };
         init.signal.addEventListener('abort', outerSignalHandler);
       }
-      init.signal = signal;
+      init = { ...init, signal };
     } else {
       init = { signal };
     }


### PR DESCRIPTION
**Description:**

Fix two issues with abort signal handling in `fromFetch`:

- The `signal` property on the init object was modified, which could lead to issues if the init object is reused for multiple requests.
- The `fromFetch` function basically ignored the incoming signal if it is already aborted.

**Related issue (if exists):**
