### PR TITLE
Fix docs buffer marble diagram missing

### DIFF
--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -12,7 +12,7 @@ import { OperatorFunction } from '../types';
  * <span class="informal">Collects values from the past as an array, and emits
  * that array only when another Observable emits.</span>
  *
- * ![](content/img/buffer.png)
+ * ![](buffer.png)
  *
  * Buffers the incoming Observable values until the given `closingNotifier`
  * Observable emits a value, at which point it emits the buffer on the output


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Fix broken image of marble diagram for buffer operator in docs


**Related issue (if exists):**

#5095 
