### PR TITLE
refactor(map): set generic type instead of any

### DIFF
--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -79,7 +79,7 @@ class MapSubscriber<T, R> extends Subscriber<T> {
   // NOTE: This looks unoptimized, but it's actually purposefully NOT
   // using try/catch optimizations.
   protected _next(value: T) {
-    let result: any;
+    let result: R;
     try {
       result = this.project.call(this.thisArg, value, this.count++);
     } catch (err) {


### PR DESCRIPTION
**Description:**
Since the return type of the `MapSubscriber`'s `project` method is defined as generic `R`, the result returned when calling this method could also be of type `R` (instead of `any`).