### PR TITLE
docs(forkJoin): Add missing import in forkJoin array example

### DIFF
--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -110,7 +110,7 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  *
  * ### Use forkJoin with an array of observable inputs
  * ```ts
- * import { forkJoin, of } from 'rxjs';
+ * import { forkJoin, of, timer } from 'rxjs';
  *
  * const observable = forkJoin([
  *   of(1, 2, 3, 4),


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The observable array example in the forkJoin documentation wasn't importing the `timer` operator, so it broke when I opened the example in StackBlitz. This PR just adds the missing import to the example.

**Related issue (if exists):**
None I could find.