### PR TITLE
fix(google): Subclassing TestScheduler needs RunHelpers

### DIFF
--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,1 +1,1 @@
-export { TestScheduler } from '../internal/testing/TestScheduler';
+export { TestScheduler, RunHelpers } from '../internal/testing/TestScheduler';


### PR DESCRIPTION
Until now, folks subclassing `TestScheduler` needed to `run(callback: (helpers: RunHelpers...` method. This was super brittle so we need to properly export this so it can be used more sanely