### PR TITLE
test(operator-concat): using run mode tests

### DIFF
--- a/spec/helpers/observableMatcher.ts
+++ b/spec/helpers/observableMatcher.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import * as chai from 'chai';
 
 function stringify(x: any): string {
   return JSON.stringify(x, function (key: string, value: any) {

--- a/spec/operators/concat-spec.ts
+++ b/spec/operators/concat-spec.ts
@@ -18,30 +18,32 @@ describe('concat operator', () => {
 
   asDiagram('concat')('should concatenate two cold observables', () => {
     testScheduler.run(({ cold, expectObservable }) => {
-      const e1 =   cold('--a--b-|');
-      const e2 =   cold(       '--x---y--|');
-      const expected =  '--a--b---x---y--|';
+      const e1 = cold('  --a--b-|');
+      const e2 = cold('         --x---y--|');
+      const expected = ' --a--b---x---y--|';
 
       expectObservable(e1.pipe(concat(e2, rxTestScheduler))).toBe(expected);
     });
   });
 
-  it('should work properly with scalar observables', (done) => {
+  it('should work properly with scalar observables', done => {
     const results: string[] = [];
 
-    const s1 = new Observable<number>((observer) => {
+    const s1 = new Observable<number>(observer => {
       setTimeout(() => {
         observer.next(1);
         observer.complete();
       });
-    })
-    .pipe(concat(of(2)));
+    }).pipe(concat(of(2)));
 
-    s1.subscribe((x) => {
+    s1.subscribe(
+      x => {
         results.push('Next: ' + x);
-      }, (x) => {
+      },
+      x => {
         done(new Error('should not be called'));
-      }, () => {
+      },
+      () => {
         results.push('Completed');
         expect(results).to.deep.equal(['Next: 1', 'Next: 2', 'Completed']);
         done();
@@ -51,25 +53,25 @@ describe('concat operator', () => {
 
   it('should complete without emit if both sources are empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold(  '----|');
-      const e2subs =    '--^---!';
-      const expected =  '------|';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('    ----|');
+      const e2subs = '   --^---!';
+      const expected = ' ------|';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
     });
   });
 
   it('should not complete if first source does not complete', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('-');
-      const e1subs =    '^';
-      const e2 =   cold('--|');
+      const e1 = cold('  -');
+      const e1subs = '   ^';
+      const e2 = cold('  --|');
       const e2subs: string[] = [];
-      const expected =  '-';
+      const expected = ' -';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -79,11 +81,11 @@ describe('concat operator', () => {
 
   it('should not complete if second source does not complete', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold('---');
-      const e2subs =    '--^';
-      const expected =  '---';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('  ---');
+      const e2subs = '   --^';
+      const expected = ' ---';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -93,11 +95,11 @@ describe('concat operator', () => {
 
   it('should not complete if both sources do not complete', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('-');
-      const e1subs =    '^';
-      const e2 =   cold('-');
+      const e1 = cold('  -');
+      const e1subs = '   ^';
+      const e2 = cold('  -');
       const e2subs: string[] = [];
-      const expected =  '-';
+      const expected = ' -';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -107,11 +109,11 @@ describe('concat operator', () => {
 
   it('should raise error when first source is empty, second source raises error', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold(  '----#');
-      const e2subs =    '--^---!';
-      const expected =  '------#';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('    ----#');
+      const e2subs = '   --^---!';
+      const expected = ' ------#';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -121,11 +123,11 @@ describe('concat operator', () => {
 
   it('should raise error when first source raises error, second source is empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---#');
-      const e1subs =    '^--!';
-      const e2 =   cold('----|');
+      const e1 = cold('  ---#');
+      const e1subs = '   ^--!';
+      const e2 = cold('  ----|');
       const e2subs: string[] = [];
-      const expected =  '---#';
+      const expected = ' ---#';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -135,11 +137,11 @@ describe('concat operator', () => {
 
   it('should raise first error when both source raise error', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---#');
-      const e1subs =    '^--!';
-      const e2 =   cold('------#');
+      const e1 = cold('  ---#');
+      const e1subs = '   ^--!';
+      const e2 = cold('  ------#');
       const e2subs: string[] = [];
-      const expected =  '---#';
+      const expected = ' ---#';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -149,11 +151,11 @@ describe('concat operator', () => {
 
   it('should concat if first source emits once, second source is empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--a--|');
-      const e1subs =    '^----!';
-      const e2 =   cold(     '--------|');
-      const e2subs =    '-----^-------!';
-      const expected =  '--a----------|';
+      const e1 = cold('  --a--|');
+      const e1subs = '   ^----!';
+      const e2 = cold('       --------|');
+      const e2subs = '   -----^-------!';
+      const expected = ' --a----------|';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -163,11 +165,11 @@ describe('concat operator', () => {
 
   it('should concat if first source is empty, second source emits once', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold(  '--a--|');
-      const e2subs =    '--^----!';
-      const expected =  '----a--|';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('    --a--|');
+      const e2subs = '   --^----!';
+      const expected = ' ----a--|';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -175,28 +177,31 @@ describe('concat operator', () => {
     });
   });
 
-  it('should emit element from first source, and should not complete if second ' +
-  'source does not complete', () => {
-    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--a--|');
-      const e1subs =    '^----!';
-      const e2 =   cold(     '-');
-      const e2subs =    '-----^';
-      const expected =  '--a---';
+  it(
+    'should emit element from first source, and should not complete if second ' +
+      'source does not complete',
+    () => {
+      testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const e1 = cold('  --a--|');
+        const e1subs = '   ^----!';
+        const e2 = cold('       -');
+        const e2subs = '   -----^';
+        const expected = ' --a---';
 
-      expectObservable(e1.pipe(concat(e2))).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-      expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    });
-  });
+        expectObservable(e1.pipe(concat(e2))).toBe(expected);
+        expectSubscriptions(e1.subscriptions).toBe(e1subs);
+        expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      });
+    }
+  );
 
   it('should not complete if first source does not complete', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('-');
-      const e1subs =    '^';
-      const e2 =   cold('--a--|');
+      const e1 = cold('  -');
+      const e1subs = '   ^';
+      const e2 = cold('  --a--|');
       const e2subs: string[] = [];
-      const expected =  '-';
+      const expected = ' -';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -206,61 +211,61 @@ describe('concat operator', () => {
 
   it('should emit elements from each source when source emit once', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-    const e1 =   cold('---a|');
-    const e1subs =    '^---!';
-    const e2 =   cold(    '-----b--|');
-    const e2subs =    '----^-------!';
-    const expected =  '---a-----b--|';
+      const e1 = cold('  ---a|');
+      const e1subs = '   ^---!';
+      const e2 = cold('      -----b--|');
+      const e2subs = '   ----^-------!';
+      const expected = ' ---a-----b--|';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
     });
   });
 
   it('should unsubscribe to inner source if outer is unsubscribed early', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a-a--a|            ');
-      const e1subs =    '^--------!            ';
-      const e2 =   cold(         '-----b-b--b-|');
-      const e2subs =    '---------^-------!    ';
-      const unsub =     '-----------------!    ';
-      const expected =  '---a-a--a-----b-b     ';
+      const e1 = cold('  ---a-a--a|            ');
+      const e1subs = '   ^--------!            ';
+      const e2 = cold('           -----b-b--b-|');
+      const e2subs = '   ---------^-------!    ';
+      const unsub = '    -----------------!    ';
+      const expected = ' ---a-a--a-----b-b     ';
 
-    expectObservable(e1.pipe(concat(e2)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2)), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
     });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-    const e1 =   cold('---a-a--a|            ');
-    const e1subs =    '^--------!            ';
-    const e2 =   cold(         '-----b-b--b-|');
-    const e2subs =    '---------^-------!    ';
-    const expected =  '---a-a--a-----b-b-    ';
-    const unsub =     '-----------------!    ';
+      const e1 = cold('  ---a-a--a|            ');
+      const e1subs = '   ^--------!            ';
+      const e2 = cold('           -----b-b--b-|');
+      const e2subs = '   ---------^-------!    ';
+      const expected = ' ---a-a--a-----b-b-    ';
+      const unsub = '    -----------------!    ';
 
-    const result = e1.pipe(
-      mergeMap((x) => of(x)),
-      concat(e2),
-      mergeMap((x) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap(x => of(x)),
+        concat(e2),
+        mergeMap(x => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
     });
   });
 
   it('should raise error from first source and does not emit from second source', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--#');
-      const e1subs =    '^-!';
-      const e2 =   cold('----a--|');
+      const e1 = cold('  --#');
+      const e1subs = '   ^-!';
+      const e2 = cold('  ----a--|');
       const e2subs: string[] = [];
-      const expected =  '--#';
+      const expected = ' --#';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -270,11 +275,11 @@ describe('concat operator', () => {
 
   it('should emit element from first source then raise error from second source', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--a--|');
-      const e1subs =    '^----!';
-      const e2 =   cold(     '-------#');
-      const e2subs =    '-----^------!';
-      const expected =  '--a---------#';
+      const e1 = cold('  --a--|');
+      const e1subs = '   ^----!';
+      const e2 = cold('       -------#');
+      const e2subs = '   -----^------!';
+      const expected = ' --a---------#';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -282,42 +287,50 @@ describe('concat operator', () => {
     });
   });
 
-  it('should emit all elements from both hot observable sources if first source ' +
-  'completes before second source starts emit', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('--a--b-|');
-      const e1subs =   '^------!';
-      const e2 =   hot('--------x--y--|');
-      const e2subs =   '-------^------!';
-      const expected = '--a--b--x--y--|';
+  it(
+    'should emit all elements from both hot observable sources if first source ' +
+      'completes before second source starts emit',
+    () => {
+      testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+        const e1 = hot('  --a--b-|');
+        const e1subs = '  ^------!';
+        const e2 = hot('  --------x--y--|');
+        const e2subs = '  -------^------!';
+        const expected = '--a--b--x--y--|';
 
-      expectObservable(e1.pipe(concat(e2))).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-      expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    });
-  });
+        expectObservable(e1.pipe(concat(e2))).toBe(expected);
+        expectSubscriptions(e1.subscriptions).toBe(e1subs);
+        expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      });
+    }
+  );
 
-  it('should emit elements from second source regardless of completion time ' +
-  'when second source is cold observable', () => {
-      testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('--a--b--c---|');
-      const e1subs =   '^-----------!';
-      const e2 =  cold('-x-y-z-|');
-      const e2subs =   '------------^------!';
-      const expected = '--a--b--c----x-y-z-|';
+  it(
+    'should emit elements from second source regardless of completion time ' +
+      'when second source is cold observable',
+    () => {
+      testScheduler.run(
+        ({ hot, cold, expectObservable, expectSubscriptions }) => {
+          const e1 = hot('  --a--b--c---|');
+          const e1subs = '  ^-----------!';
+          const e2 = cold(' -x-y-z-|');
+          const e2subs = '  ------------^------!';
+          const expected = '--a--b--c----x-y-z-|';
 
-      expectObservable(e1.pipe(concat(e2))).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-      expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    });
-  });
+          expectObservable(e1.pipe(concat(e2))).toBe(expected);
+          expectSubscriptions(e1.subscriptions).toBe(e1subs);
+          expectSubscriptions(e2.subscriptions).toBe(e2subs);
+        }
+      );
+    }
+  );
 
   it('should not emit collapsing element from second source', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('--a--b--c--|');
-      const e1subs =   '^----------!';
-      const e2 =   hot('--------x--y--z--|');
-      const e2subs =   '-----------^-----!';
+      const e1 = hot('  --a--b--c--|');
+      const e1subs = '  ^----------!';
+      const e2 = hot('  --------x--y--z--|');
+      const e2subs = '  -----------^-----!';
       const expected = '--a--b--c--y--z--|';
 
       expectObservable(e1.pipe(concat(e2))).toBe(expected);
@@ -328,13 +341,13 @@ describe('concat operator', () => {
 
   it('should accept scheduler with multiple observables', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a|');
-      const e1subs =    '^---!';
-      const e2 =   cold(    '---b--|');
-      const e2subs =    '----^-----!';
-      const e3 =   cold(          '---c--|');
-      const e3subs =    '----------^-----!';
-      const expected =  '---a---b-----c--|';
+      const e1 = cold('  ---a|');
+      const e1subs = '   ^---!';
+      const e2 = cold('      ---b--|');
+      const e2subs = '   ----^-----!';
+      const e3 = cold('            ---c--|');
+      const e3subs = '   ----------^-----!';
+      const expected = ' ---a---b-----c--|';
 
       expectObservable(e1.pipe(concat(e2, e3, rxTestScheduler))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -345,9 +358,9 @@ describe('concat operator', () => {
 
   it('should accept scheduler without observable parameters', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a-|');
-      const e1subs =    '^----!';
-      const expected =  '---a-|';
+      const e1 = cold('  ---a-|');
+      const e1subs = '   ^----!';
+      const expected = ' ---a-|';
 
       expectObservable(e1.pipe(concat(rxTestScheduler))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -356,9 +369,9 @@ describe('concat operator', () => {
 
   it('should emit self without parameters', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a-|');
-      const e1subs =    '^----!';
-      const expected =  '---a-|';
+      const e1 = cold('  ---a-|');
+      const e1subs = '   ^----!';
+      const expected = ' ---a-|';
 
       expectObservable(e1.pipe(concat())).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/concat-spec.ts
+++ b/spec/operators/concat-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of, Observable } from 'rxjs';
 import { concat, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 declare function asDiagram(arg: string): Function;
 
@@ -10,202 +10,237 @@ declare const rxTestScheduler: TestScheduler;
 
 /** @test {concat} */
 describe('concat operator', () => {
-  asDiagram('concat')('should concatenate two cold observables', () => {
-    const e1 =   cold('--a--b-|');
-    const e2 =   cold(       '--x---y--|');
-    const expected =  '--a--b---x---y--|';
+  let testScheduler: TestScheduler;
 
-    expectObservable(e1.pipe(concat(e2, rxTestScheduler))).toBe(expected);
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  asDiagram('concat')('should concatenate two cold observables', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const e1 =   cold('--a--b-|');
+      const e2 =   cold(       '--x---y--|');
+      const expected =  '--a--b---x---y--|';
+
+      expectObservable(e1.pipe(concat(e2, rxTestScheduler))).toBe(expected);
+    });
   });
 
   it('should work properly with scalar observables', (done) => {
     const results: string[] = [];
 
     const s1 = new Observable<number>((observer) => {
-        setTimeout(() => {
-          observer.next(1);
-          observer.complete();
-        });
-      })
-      .pipe(concat(of(2)));
+      setTimeout(() => {
+        observer.next(1);
+        observer.complete();
+      });
+    })
+    .pipe(concat(of(2)));
 
     s1.subscribe((x) => {
-          results.push('Next: ' + x);
-        }, (x) => {
-          done(new Error('should not be called'));
-        }, () => {
-          results.push('Completed');
-          expect(results).to.deep.equal(['Next: 1', 'Next: 2', 'Completed']);
-          done();
-        }
-      );
+        results.push('Next: ' + x);
+      }, (x) => {
+        done(new Error('should not be called'));
+      }, () => {
+        results.push('Completed');
+        expect(results).to.deep.equal(['Next: 1', 'Next: 2', 'Completed']);
+        done();
+      }
+    );
   });
 
   it('should complete without emit if both sources are empty', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold(  '----|');
-    const e2subs =    '  ^   !';
-    const expected =  '------|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold(  '----|');
+      const e2subs =    '--^---!';
+      const expected =  '------|';
 
     expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should not complete if first source does not completes', () => {
-    const e1 =   cold('-');
-    const e1subs =    '^';
-    const e2 =   cold('--|');
-    const e2subs: string[] = [];
-    const expected =  '-';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should not complete if second source does not completes', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold('---');
-    const e2subs =    '  ^';
-    const expected =  '---';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should not complete if both sources do not complete', () => {
-    const e1 =   cold('-');
-    const e1subs =    '^';
-    const e2 =   cold('-');
-    const e2subs: string[] = [];
-    const expected =  '-';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should raise error when first source is empty, second source raises error', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold(  '----#');
-    const e2subs =    '  ^   !';
-    const expected =  '------#';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should raise error when first source raises error, second source is empty', () => {
-    const e1 =   cold('---#');
-    const e1subs =    '^  !';
-    const e2 =   cold('----|');
-    const e2subs: string[] = [];
-    const expected =  '---#';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should raise first error when both source raise error', () => {
-    const e1 =   cold('---#');
-    const e1subs =    '^  !';
-    const e2 =   cold('------#');
-    const e2subs: string[] = [];
-    const expected =  '---#';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should concat if first source emits once, second source is empty', () => {
-    const e1 =   cold('--a--|');
-    const e1subs =    '^    !';
-    const e2 =   cold(     '--------|');
-    const e2subs =    '     ^       !';
-    const expected =  '--a----------|';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should concat if first source is empty, second source emits once', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold(  '--a--|');
-    const e2subs =    '  ^    !';
-    const expected =  '----a--|';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should emit element from first source, and should not complete if second ' +
-  'source does not completes', () => {
-    const e1 =   cold('--a--|');
-    const e1subs =    '^    !';
-    const e2 =   cold(     '-');
-    const e2subs =    '     ^';
-    const expected =  '--a---';
-
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not complete if first source does not complete', () => {
-    const e1 =   cold('-');
-    const e1subs =    '^';
-    const e2 =   cold('--a--|');
-    const e2subs: string[] = [];
-    const expected =  '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('-');
+      const e1subs =    '^';
+      const e2 =   cold('--|');
+      const e2subs: string[] = [];
+      const expected =  '-';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should not complete if second source does not complete', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold('---');
+      const e2subs =    '--^';
+      const expected =  '---';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should not complete if both sources do not complete', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('-');
+      const e1subs =    '^';
+      const e2 =   cold('-');
+      const e2subs: string[] = [];
+      const expected =  '-';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should raise error when first source is empty, second source raises error', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold(  '----#');
+      const e2subs =    '--^---!';
+      const expected =  '------#';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should raise error when first source raises error, second source is empty', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---#');
+      const e1subs =    '^--!';
+      const e2 =   cold('----|');
+      const e2subs: string[] = [];
+      const expected =  '---#';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should raise first error when both source raise error', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---#');
+      const e1subs =    '^--!';
+      const e2 =   cold('------#');
+      const e2subs: string[] = [];
+      const expected =  '---#';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should concat if first source emits once, second source is empty', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--a--|');
+      const e1subs =    '^----!';
+      const e2 =   cold(     '--------|');
+      const e2subs =    '-----^-------!';
+      const expected =  '--a----------|';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should concat if first source is empty, second source emits once', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold(  '--a--|');
+      const e2subs =    '--^----!';
+      const expected =  '----a--|';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should emit element from first source, and should not complete if second ' +
+  'source does not complete', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--a--|');
+      const e1subs =    '^----!';
+      const e2 =   cold(     '-');
+      const e2subs =    '-----^';
+      const expected =  '--a---';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should not complete if first source does not complete', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('-');
+      const e1subs =    '^';
+      const e2 =   cold('--a--|');
+      const e2subs: string[] = [];
+      const expected =  '-';
+
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit elements from each source when source emit once', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
     const e1 =   cold('---a|');
-    const e1subs =    '^   !';
+    const e1subs =    '^---!';
     const e2 =   cold(    '-----b--|');
-    const e2subs =    '    ^       !';
+    const e2subs =    '----^-------!';
     const expected =  '---a-----b--|';
 
     expectObservable(e1.pipe(concat(e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should unsubscribe to inner source if outer is unsubscribed early', () => {
-    const e1 =   cold('---a-a--a|            ');
-    const e1subs =    '^        !            ';
-    const e2 =   cold(         '-----b-b--b-|');
-    const e2subs =    '         ^       !    ';
-    const unsub =     '                 !    ';
-    const expected =  '---a-a--a-----b-b     ';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a-a--a|            ');
+      const e1subs =    '^--------!            ';
+      const e2 =   cold(         '-----b-b--b-|');
+      const e2subs =    '---------^-------!    ';
+      const unsub =     '-----------------!    ';
+      const expected =  '---a-a--a-----b-b     ';
 
     expectObservable(e1.pipe(concat(e2)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
     const e1 =   cold('---a-a--a|            ');
-    const e1subs =    '^        !            ';
+    const e1subs =    '^--------!            ';
     const e2 =   cold(         '-----b-b--b-|');
-    const e2subs =    '         ^       !    ';
+    const e2subs =    '---------^-------!    ';
     const expected =  '---a-a--a-----b-b-    ';
-    const unsub =     '                 !    ';
+    const unsub =     '-----------------!    ';
 
     const result = e1.pipe(
       mergeMap((x) => of(x)),
@@ -216,100 +251,117 @@ describe('concat operator', () => {
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should raise error from first source and does not emit from second source', () => {
-    const e1 =   cold('--#');
-    const e1subs =    '^ !';
-    const e2 =   cold('----a--|');
-    const e2subs: string[] = [];
-    const expected =  '--#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--#');
+      const e1subs =    '^-!';
+      const e2 =   cold('----a--|');
+      const e2subs: string[] = [];
+      const expected =  '--#';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit element from first source then raise error from second source', () => {
-    const e1 =   cold('--a--|');
-    const e1subs =    '^    !';
-    const e2 =   cold(     '-------#');
-    const e2subs =    '     ^      !';
-    const expected =  '--a---------#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--a--|');
+      const e1subs =    '^----!';
+      const e2 =   cold(     '-------#');
+      const e2subs =    '-----^------!';
+      const expected =  '--a---------#';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit all elements from both hot observable sources if first source ' +
   'completes before second source starts emit', () => {
-    const e1 =   hot('--a--b-|');
-    const e1subs =   '^      !';
-    const e2 =   hot('--------x--y--|');
-    const e2subs =   '       ^      !';
-    const expected = '--a--b--x--y--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('--a--b-|');
+      const e1subs =   '^------!';
+      const e2 =   hot('--------x--y--|');
+      const e2subs =   '-------^------!';
+      const expected = '--a--b--x--y--|';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit elements from second source regardless of completion time ' +
   'when second source is cold observable', () => {
-    const e1 =   hot('--a--b--c---|');
-    const e1subs =   '^           !';
-    const e2 =  cold('-x-y-z-|');
-    const e2subs =   '            ^      !';
-    const expected = '--a--b--c----x-y-z-|';
+      testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('--a--b--c---|');
+      const e1subs =   '^-----------!';
+      const e2 =  cold('-x-y-z-|');
+      const e2subs =   '------------^------!';
+      const expected = '--a--b--c----x-y-z-|';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not emit collapsing element from second source', () => {
-    const e1 =   hot('--a--b--c--|');
-    const e1subs =   '^          !';
-    const e2 =   hot('--------x--y--z--|');
-    const e2subs =   '           ^     !';
-    const expected = '--a--b--c--y--z--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('--a--b--c--|');
+      const e1subs =   '^----------!';
+      const e2 =   hot('--------x--y--z--|');
+      const e2subs =   '-----------^-----!';
+      const expected = '--a--b--c--y--z--|';
 
-    expectObservable(e1.pipe(concat(e2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(e1.pipe(concat(e2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should accept scheduler with multiple observables', () => {
-    const e1 =   cold('---a|');
-    const e1subs =    '^   !';
-    const e2 =   cold(    '---b--|');
-    const e2subs =    '    ^     !';
-    const e3 =   cold(          '---c--|');
-    const e3subs =    '          ^     !';
-    const expected =  '---a---b-----c--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a|');
+      const e1subs =    '^---!';
+      const e2 =   cold(    '---b--|');
+      const e2subs =    '----^-----!';
+      const e3 =   cold(          '---c--|');
+      const e3subs =    '----------^-----!';
+      const expected =  '---a---b-----c--|';
 
-    expectObservable(e1.pipe(concat(e2, e3, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(e3.subscriptions).toBe(e3subs);
+      expectObservable(e1.pipe(concat(e2, e3, rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(e3.subscriptions).toBe(e3subs);
+    });
   });
 
   it('should accept scheduler without observable parameters', () => {
-    const e1 =   cold('---a-|');
-    const e1subs =    '^    !';
-    const expected =  '---a-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a-|');
+      const e1subs =    '^----!';
+      const expected =  '---a-|';
 
-    expectObservable(e1.pipe(concat(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(concat(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should emit self without parameters', () => {
-    const e1 =   cold('---a-|');
-    const e1subs =    '^    !';
-    const expected =  '---a-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a-|');
+      const e1subs =    '^----!';
+      const expected =  '---a-|';
 
-    expectObservable(e1.pipe(concat())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(concat())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** 

Adjusts to run mode tests for concat operator.

**Related issue (if exists):**
