### PR TITLE
test(operator-concatAll): use run mode

### DIFF
--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import { from, throwError, of, Observable } from 'rxjs';
 import { concatAll, take, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { observableMatcher } from 'spec/helpers/observableMatcher';
+import { expectObservable } from '../helpers/marble-testing';
 
 declare function asDiagram(arg: string): Function;
 declare const type: Function;
@@ -10,16 +11,24 @@ declare const rxTestScheduler: TestScheduler;
 
 /** @test {concatAll} */
 describe('concatAll operator', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   asDiagram('concatAll')('should concat an observable of observables', () => {
-    const x = cold(    '----a------b------|                 ');
-    const y = cold(                      '---c-d---|        ');
-    const z = cold(                               '---e--f-|');
-    const outer = hot('-x---y----z------|              ', { x: x, y: y, z: z });
-    const expected =  '-----a------b---------c-d------e--f-|';
+    testScheduler.run(({ cold, hot, expectObservable }) => {
+      const x = cold(    '----a------b------|                 ');
+      const y = cold(                      '---c-d---|        ');
+      const z = cold(                               '---e--f-|');
+      const outer = hot('-x---y----z------|              ', { x: x, y: y, z: z });
+      const expected =  '-----a------b---------c-d------e--f-|';
 
-    const result = outer.pipe(concatAll());
+      const result = outer.pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
+      expectObservable(result).toBe(expected);
+    });
   });
 
   it('should concat sources from promise', function (done) {
@@ -85,353 +94,403 @@ describe('concatAll operator', () => {
   });
 
   it('should concat merging a hot observable of non-overlapped observables', () => {
-    const values = {
-      x: cold(       'a-b---------|'),
-      y: cold(                 'c-d-e-f-|'),
-      z: cold(                          'g-h-i-j-k-|')
-    };
+    testScheduler.run(({ cold, hot, expectObservable }) => {
+      const values = {
+        x: cold(       'a-b---------|'),
+        y: cold(                 'c-d-e-f-|'),
+        z: cold(                          'g-h-i-j-k-|')
+      };
 
-    const e1 =   hot('--x---------y--------z--------|', values);
-    const expected = '--a-b---------c-d-e-f-g-h-i-j-k-|';
+      const e1 =   hot('--x---------y--------z--------|', values);
+      const expected = '--a-b---------c-d-e-f-g-h-i-j-k-|';
 
-    expectObservable(e1.pipe(concatAll())).toBe(expected);
+      expectObservable(e1.pipe(concatAll())).toBe(expected);
+    });
   });
 
   it('should raise error if inner observable raises error', () => {
-    const values = {
-      x: cold(       'a-b---------|'),
-      y: cold(                 'c-d-e-f-#'),
-      z: cold(                          'g-h-i-j-k-|')
-    };
-    const e1 =   hot('--x---------y--------z--------|', values);
-    const expected = '--a-b---------c-d-e-f-#';
+    testScheduler.run(({ cold, hot, expectObservable }) => {
+      const values = {
+        x: cold(       'a-b---------|'),
+        y: cold(                 'c-d-e-f-#'),
+        z: cold(                          'g-h-i-j-k-|')
+      };
+      const e1 =   hot('--x---------y--------z--------|', values);
+      const expected = '--a-b---------c-d-e-f-#';
 
-    expectObservable(e1.pipe(concatAll())).toBe(expected);
+      expectObservable(e1.pipe(concatAll())).toBe(expected);
+    });
   });
 
   it('should raise error if outer observable raises error', () => {
-    const values = {
-      y: cold(       'a-b---------|'),
-      z: cold(                 'c-d-e-f-|'),
-    };
-    const e1 =   hot('--y---------z---#    ', values);
-    const expected = '--a-b---------c-#';
+    testScheduler.run(({ cold, hot, expectObservable }) => {
+      const values = {
+        y: cold(       'a-b---------|'),
+        z: cold(                 'c-d-e-f-|'),
+      };
+      const e1 =   hot('--y---------z---#    ', values);
+      const expected = '--a-b---------c-#';
 
-    expectObservable(e1.pipe(concatAll())).toBe(expected);
+      expectObservable(e1.pipe(concatAll())).toBe(expected);
+    });
   });
 
   it('should complete without emit if both sources are empty', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold(  '----|');
-    const e2subs =    '  ^   !';
-    const expected =  '------|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold(  '----|');
+      const e2subs =    '--^---!';
+      const expected =  '------|';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not complete if first source does not completes', () => {
-    const e1 =   cold('-');
-    const e1subs =    '^';
-    const e2 =   cold('--|');
-    const e2subs: string[] = [];
-    const expected =  '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('-');
+      const e1subs =    '^';
+      const e2 =   cold('--|');
+      const e2subs: string[] = [];
+      const expected =  '-';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not complete if second source does not completes', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold('---');
-    const e2subs =    '  ^';
-    const expected =  '---';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold('---');
+      const e2subs =    '--^';
+      const expected =  '---';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not complete if both sources do not complete', () => {
-    const e1 =   cold('-');
-    const e1subs =    '^';
-    const e2 =   cold('-');
-    const e2subs: string[] = [];
-    const expected =  '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('-');
+      const e1subs =    '^';
+      const e2 =   cold('-');
+      const e2subs: string[] = [];
+      const expected =  '-';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should raise error when first source is empty, second source raises error', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold(  '----#');
-    const e2subs =    '  ^   !';
-    const expected =  '------#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold(  '----#');
+      const e2subs =    '--^---!';
+      const expected =  '------#';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should raise error when first source raises error, second source is empty', () => {
-    const e1 =   cold('---#');
-    const e1subs =    '^  !';
-    const e2 =   cold('----|');
-    const e2subs: string[] = [];
-    const expected =  '---#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---#');
+      const e1subs =    '^--!';
+      const e2 =   cold('----|');
+      const e2subs: string[] = [];
+      const expected =  '---#';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should raise first error when both source raise error', () => {
-    const e1 =   cold('---#');
-    const e1subs =    '^  !';
-    const e2 =   cold('------#');
-    const e2subs: string[] = [];
-    const expected =  '---#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---#');
+      const e1subs =    '^--!';
+      const e2 =   cold('------#');
+      const e2subs: string[] = [];
+      const expected =  '---#';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should concat if first source emits once, second source is empty', () => {
-    const e1 =   cold('--a--|');
-    const e1subs =    '^    !';
-    const e2 =   cold(     '--------|');
-    const e2subs =    '     ^       !';
-    const expected =  '--a----------|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--a--|');
+      const e1subs =    '^----!';
+      const e2 =   cold(     '--------|');
+      const e2subs =    '-----^-------!';
+      const expected =  '--a----------|';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should concat if first source is empty, second source emits once', () => {
-    const e1 =   cold('--|');
-    const e1subs =    '^ !';
-    const e2 =   cold(  '--a--|');
-    const e2subs =    '  ^    !';
-    const expected =  '----a--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--|');
+      const e1subs =    '^-!';
+      const e2 =   cold(  '--a--|');
+      const e2subs =    '--^----!';
+      const expected =  '----a--|';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit element from first source, and should not complete if second ' +
   'source does not completes', () => {
-    const e1 =   cold('--a--|');
-    const e1subs =    '^    !';
-    const e2 =   cold(     '-');
-    const e2subs =    '     ^';
-    const expected =  '--a---';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--a--|');
+      const e1subs =    '^----!';
+      const e2 =   cold(     '-');
+      const e2subs =    '-----^';
+      const expected =  '--a---';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not complete if first source does not complete', () => {
-    const e1 =   cold('-');
-    const e1subs =    '^';
-    const e2 =   cold('--a--|');
-    const e2subs: string[] = [];
-    const expected =  '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('-');
+      const e1subs =    '^';
+      const e2 =   cold('--a--|');
+      const e2subs: string[] = [];
+      const expected =  '-';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit elements from each source when source emit once', () => {
-    const e1 =   cold('---a|');
-    const e1subs =    '^   !';
-    const e2 =   cold(    '-----b--|');
-    const e2subs =    '    ^       !';
-    const expected =  '---a-----b--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a|');
+      const e1subs =    '^---!';
+      const e2 =   cold(    '-----b--|');
+      const e2subs =    '----^-------!';
+      const expected =  '---a-----b--|';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should unsubscribe to inner source if outer is unsubscribed early', () => {
-    const e1 =   cold('---a-a--a|            ');
-    const e1subs =    '^        !            ';
-    const e2 =   cold(         '-----b-b--b-|');
-    const e2subs =    '         ^       !    ';
-    const unsub =     '                 !    ';
-    const expected =  '---a-a--a-----b-b     ';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a-a--a|            ');
+      const e1subs =    '^--------!            ';
+      const e2 =   cold(         '-----b-b--b-|');
+      const e2subs =    '---------^-------!    ';
+      const unsub =     '-----------------!    ';
+      const expected =  '---a-a--a-----b-b     ';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   cold('---a-a--a|            ');
-    const e1subs =    '^        !            ';
-    const e2 =   cold(         '-----b-b--b-|');
-    const e2subs =    '         ^       !    ';
-    const expected =  '---a-a--a-----b-b-    ';
-    const unsub =     '                 !    ';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a-a--a|            ');
+      const e1subs =    '^--------!            ';
+      const e2 =   cold(         '-----b-b--b-|');
+      const e2subs =    '---------^-------!    ';
+      const expected =  '---a-a--a-----b-b-    ';
+      const unsub =     '-----------------!    ';
 
-    const result = of(e1, e2).pipe(
-      mergeMap((x) => of(x)),
-      concatAll(),
-      mergeMap((x) => of(x))
-    );
+      const result = of(e1, e2).pipe(
+        mergeMap((x) => of(x)),
+        concatAll(),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should raise error from first source and does not emit from second source', () => {
-    const e1 =   cold('--#');
-    const e1subs =    '^ !';
-    const e2 =   cold('----a--|');
-    const e2subs: string[] = [];
-    const expected =  '--#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--#');
+      const e1subs =    '^-!';
+      const e2 =   cold('----a--|');
+      const e2subs: string[] = [];
+      const expected =  '--#';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit element from first source then raise error from second source', () => {
-    const e1 =   cold('--a--|');
-    const e1subs =    '^    !';
-    const e2 =   cold(     '-------#');
-    const e2subs =    '     ^      !';
-    const expected =  '--a---------#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('--a--|');
+      const e1subs =    '^----!';
+      const e2 =   cold(     '-------#');
+      const e2subs =    '-----^------!';
+      const expected =  '--a---------#';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit all elements from both hot observable sources if first source ' +
   'completes before second source starts emit', () => {
-    const e1 =   hot('--a--b-|');
-    const e1subs =   '^      !';
-    const e2 =   hot('--------x--y--|');
-    const e2subs =   '       ^      !';
-    const expected = '--a--b--x--y--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('--a--b-|');
+      const e1subs =   '^------!';
+      const e2 =   hot('--------x--y--|');
+      const e2subs =   '-------^------!';
+      const expected = '--a--b--x--y--|';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit elements from second source regardless of completion time ' +
   'when second source is cold observable', () => {
-    const e1 =   hot('--a--b--c---|');
-    const e1subs =   '^           !';
-    const e2 =  cold('-x-y-z-|');
-    const e2subs =   '            ^      !';
-    const expected = '--a--b--c----x-y-z-|';
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('--a--b--c---|');
+      const e1subs =   '^-----------!';
+      const e2 =  cold('-x-y-z-|');
+      const e2subs =   '------------^------!';
+      const expected = '--a--b--c----x-y-z-|';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not emit collapsing element from second source', () => {
-    const e1 =   hot('--a--b--c--|');
-    const e1subs =   '^          !';
-    const e2 =   hot('--------x--y--z--|');
-    const e2subs =   '           ^     !';
-    const expected = '--a--b--c--y--z--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('--a--b--c--|');
+      const e1subs =   '^----------!';
+      const e2 =   hot('--------x--y--z--|');
+      const e2subs =   '-----------^-----!';
+      const expected = '--a--b--c--y--z--|';
 
-    const result = of(e1, e2).pipe(concatAll());
+      const result = of(e1, e2).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should be able to work on a different scheduler', () => {
-    const e1 =   cold('---a|');
-    const e1subs =    '^   !';
-    const e2 =   cold(    '---b--|');
-    const e2subs =    '    ^     !';
-    const e3 =   cold(          '---c--|');
-    const e3subs =    '          ^     !';
-    const expected =  '---a---b-----c--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a|');
+      const e1subs =    '^---!';
+      const e2 =   cold(    '---b--|');
+      const e2subs =    '----^-----!';
+      const e3 =   cold(          '---c--|');
+      const e3subs =    '----------^-----!';
+      const expected =  '---a---b-----c--|';
 
-    const result = of(e1, e2, e3, rxTestScheduler).pipe(concatAll());
+      const result = of(e1, e2, e3, rxTestScheduler).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(e3.subscriptions).toBe(e3subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(e3.subscriptions).toBe(e3subs);
+    });
   });
 
   it('should concatAll a nested observable with a single inner observable', () => {
-    const e1 =   cold('---a-|');
-    const e1subs =    '^    !';
-    const expected =  '---a-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a-|');
+      const e1subs =    '^----!';
+      const expected =  '---a-|';
 
-    const result = of(e1).pipe(concatAll());
+      const result = of(e1).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should concatAll a nested observable with a single inner observable, and a scheduler', () => {
-    const e1 =   cold('---a-|');
-    const e1subs =    '^    !';
-    const expected =  '---a-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   cold('---a-|');
+      const e1subs =    '^----!';
+      const expected =  '---a-|';
 
-    const result = of(e1, rxTestScheduler).pipe(concatAll());
+      const result = of(e1, rxTestScheduler).pipe(concatAll());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   type(() => {

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -19,11 +19,11 @@ describe('concatAll operator', () => {
 
   asDiagram('concatAll')('should concat an observable of observables', () => {
     testScheduler.run(({ cold, hot, expectObservable }) => {
-      const x = cold(    '----a------b------|                 ');
-      const y = cold(                      '---c-d---|        ');
-      const z = cold(                               '---e--f-|');
+      const x = cold('    ----a------b------|                 ');
+      const y = cold('                      ---c-d---|        ');
+      const z = cold('                               ---e--f-|');
       const outer = hot('-x---y----z------|              ', { x: x, y: y, z: z });
-      const expected =  '-----a------b---------c-d------e--f-|';
+      const expected = ' -----a------b---------c-d------e--f-|';
 
       const result = outer.pipe(concatAll());
 
@@ -96,12 +96,12 @@ describe('concatAll operator', () => {
   it('should concat merging a hot observable of non-overlapped observables', () => {
     testScheduler.run(({ cold, hot, expectObservable }) => {
       const values = {
-        x: cold(       'a-b---------|'),
-        y: cold(                 'c-d-e-f-|'),
-        z: cold(                          'g-h-i-j-k-|')
+        x: cold('       a-b---------|'),
+        y: cold('                 c-d-e-f-|'),
+        z: cold('                          g-h-i-j-k-|')
       };
 
-      const e1 =   hot('--x---------y--------z--------|', values);
+      const e1 = hot('  --x---------y--------z--------|', values);
       const expected = '--a-b---------c-d-e-f-g-h-i-j-k-|';
 
       expectObservable(e1.pipe(concatAll())).toBe(expected);
@@ -111,9 +111,9 @@ describe('concatAll operator', () => {
   it('should raise error if inner observable raises error', () => {
     testScheduler.run(({ cold, hot, expectObservable }) => {
       const values = {
-        x: cold(       'a-b---------|'),
-        y: cold(                 'c-d-e-f-#'),
-        z: cold(                          'g-h-i-j-k-|')
+        x: cold('      a-b---------|'),
+        y: cold('                c-d-e-f-#'),
+        z: cold('                         g-h-i-j-k-|')
       };
       const e1 =   hot('--x---------y--------z--------|', values);
       const expected = '--a-b---------c-d-e-f-#';
@@ -125,10 +125,10 @@ describe('concatAll operator', () => {
   it('should raise error if outer observable raises error', () => {
     testScheduler.run(({ cold, hot, expectObservable }) => {
       const values = {
-        y: cold(       'a-b---------|'),
-        z: cold(                 'c-d-e-f-|'),
+        y: cold('       a-b---------|'),
+        z: cold('                 c-d-e-f-|'),
       };
-      const e1 =   hot('--y---------z---#    ', values);
+      const e1 = hot('  --y---------z---#    ', values);
       const expected = '--a-b---------c-#';
 
       expectObservable(e1.pipe(concatAll())).toBe(expected);
@@ -137,11 +137,11 @@ describe('concatAll operator', () => {
 
   it('should complete without emit if both sources are empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold(  '----|');
-      const e2subs =    '--^---!';
-      const expected =  '------|';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('    ----|');
+      const e2subs = '   --^---!';
+      const expected = ' ------|';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -169,11 +169,11 @@ describe('concatAll operator', () => {
 
   it('should not complete if second source does not completes', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold('---');
-      const e2subs =    '--^';
-      const expected =  '---';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('  ---');
+      const e2subs = '   --^';
+      const expected = ' ---';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -201,11 +201,11 @@ describe('concatAll operator', () => {
 
   it('should raise error when first source is empty, second source raises error', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold(  '----#');
-      const e2subs =    '--^---!';
-      const expected =  '------#';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('    ----#');
+      const e2subs = '   --^---!';
+      const expected = ' ------#';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -217,11 +217,11 @@ describe('concatAll operator', () => {
 
   it('should raise error when first source raises error, second source is empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---#');
-      const e1subs =    '^--!';
-      const e2 =   cold('----|');
+      const e1 = cold('  ---#');
+      const e1subs = '   ^--!';
+      const e2 = cold('  ----|');
       const e2subs: string[] = [];
-      const expected =  '---#';
+      const expected = ' ---#';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -233,9 +233,9 @@ describe('concatAll operator', () => {
 
   it('should raise first error when both source raise error', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---#');
-      const e1subs =    '^--!';
-      const e2 =   cold('------#');
+      const e1 = cold('  ---#');
+      const e1subs = '   ^--!';
+      const e2 = cold('  ------#');
       const e2subs: string[] = [];
       const expected =  '---#';
 
@@ -249,11 +249,11 @@ describe('concatAll operator', () => {
 
   it('should concat if first source emits once, second source is empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--a--|');
-      const e1subs =    '^----!';
-      const e2 =   cold(     '--------|');
-      const e2subs =    '-----^-------!';
-      const expected =  '--a----------|';
+      const e1 = cold('  --a--|');
+      const e1subs = '   ^----!';
+      const e2 = cold('       --------|');
+      const e2subs = '   -----^-------!';
+      const expected = ' --a----------|';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -265,11 +265,11 @@ describe('concatAll operator', () => {
 
   it('should concat if first source is empty, second source emits once', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--|');
-      const e1subs =    '^-!';
-      const e2 =   cold(  '--a--|');
-      const e2subs =    '--^----!';
-      const expected =  '----a--|';
+      const e1 = cold('  --|');
+      const e1subs = '   ^-!';
+      const e2 = cold('    --a--|');
+      const e2subs = '   --^----!';
+      const expected = ' ----a--|';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -282,11 +282,11 @@ describe('concatAll operator', () => {
   it('should emit element from first source, and should not complete if second ' +
   'source does not completes', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--a--|');
-      const e1subs =    '^----!';
-      const e2 =   cold(     '-');
-      const e2subs =    '-----^';
-      const expected =  '--a---';
+      const e1 = cold('  --a--|');
+      const e1subs = '   ^----!';
+      const e2 = cold('       -');
+      const e2subs = '   -----^';
+      const expected = ' --a---';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -314,11 +314,11 @@ describe('concatAll operator', () => {
 
   it('should emit elements from each source when source emit once', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a|');
-      const e1subs =    '^---!';
-      const e2 =   cold(    '-----b--|');
-      const e2subs =    '----^-------!';
-      const expected =  '---a-----b--|';
+      const e1 = cold('  ---a|');
+      const e1subs = '   ^---!';
+      const e2 = cold('      -----b--|');
+      const e2subs = '   ----^-------!';
+      const expected = ' ---a-----b--|';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -330,12 +330,12 @@ describe('concatAll operator', () => {
 
   it('should unsubscribe to inner source if outer is unsubscribed early', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a-a--a|            ');
-      const e1subs =    '^--------!            ';
-      const e2 =   cold(         '-----b-b--b-|');
-      const e2subs =    '---------^-------!    ';
-      const unsub =     '-----------------!    ';
-      const expected =  '---a-a--a-----b-b     ';
+      const e1 = cold('  ---a-a--a|            ');
+      const e1subs = '   ^--------!            ';
+      const e2 = cold('           -----b-b--b-|');
+      const e2subs = '   ---------^-------!    ';
+      const unsub = '    -----------------!    ';
+      const expected = ' ---a-a--a-----b-b     ';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -347,12 +347,12 @@ describe('concatAll operator', () => {
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a-a--a|            ');
-      const e1subs =    '^--------!            ';
-      const e2 =   cold(         '-----b-b--b-|');
-      const e2subs =    '---------^-------!    ';
-      const expected =  '---a-a--a-----b-b-    ';
-      const unsub =     '-----------------!    ';
+      const e1 = cold('  ---a-a--a|            ');
+      const e1subs = '   ^--------!            ';
+      const e2 = cold('           -----b-b--b-|');
+      const e2subs = '   ---------^-------!    ';
+      const expected = ' ---a-a--a-----b-b-    ';
+      const unsub = '    -----------------!    ';
 
       const result = of(e1, e2).pipe(
         mergeMap((x) => of(x)),
@@ -368,11 +368,11 @@ describe('concatAll operator', () => {
 
   it('should raise error from first source and does not emit from second source', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--#');
-      const e1subs =    '^-!';
-      const e2 =   cold('----a--|');
+      const e1 = cold('  --#');
+      const e1subs = '   ^-!';
+      const e2 = cold('  ----a--|');
       const e2subs: string[] = [];
-      const expected =  '--#';
+      const expected = ' --#';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -384,11 +384,11 @@ describe('concatAll operator', () => {
 
   it('should emit element from first source then raise error from second source', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('--a--|');
-      const e1subs =    '^----!';
-      const e2 =   cold(     '-------#');
-      const e2subs =    '-----^------!';
-      const expected =  '--a---------#';
+      const e1 = cold('  --a--|');
+      const e1subs = '   ^----!';
+      const e2 = cold('       -------#');
+      const e2subs = '   -----^------!';
+      const expected = ' --a---------#';
 
       const result = of(e1, e2).pipe(concatAll());
 
@@ -401,10 +401,10 @@ describe('concatAll operator', () => {
   it('should emit all elements from both hot observable sources if first source ' +
   'completes before second source starts emit', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('--a--b-|');
-      const e1subs =   '^------!';
-      const e2 =   hot('--------x--y--|');
-      const e2subs =   '-------^------!';
+      const e1 = hot('  --a--b-|');
+      const e1subs = '  ^------!';
+      const e2 = hot('  --------x--y--|');
+      const e2subs = '  -------^------!';
       const expected = '--a--b--x--y--|';
 
       const result = of(e1, e2).pipe(concatAll());
@@ -418,10 +418,10 @@ describe('concatAll operator', () => {
   it('should emit elements from second source regardless of completion time ' +
   'when second source is cold observable', () => {
     testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('--a--b--c---|');
-      const e1subs =   '^-----------!';
-      const e2 =  cold('-x-y-z-|');
-      const e2subs =   '------------^------!';
+      const e1 = hot('  --a--b--c---|');
+      const e1subs = '  ^-----------!';
+      const e2 = cold(' -x-y-z-|');
+      const e2subs = '  ------------^------!';
       const expected = '--a--b--c----x-y-z-|';
 
       const result = of(e1, e2).pipe(concatAll());
@@ -434,10 +434,10 @@ describe('concatAll operator', () => {
 
   it('should not emit collapsing element from second source', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('--a--b--c--|');
-      const e1subs =   '^----------!';
-      const e2 =   hot('--------x--y--z--|');
-      const e2subs =   '-----------^-----!';
+      const e1 = hot('  --a--b--c--|');
+      const e1subs = '  ^----------!';
+      const e2 = hot('  --------x--y--z--|');
+      const e2subs = '  -----------^-----!';
       const expected = '--a--b--c--y--z--|';
 
       const result = of(e1, e2).pipe(concatAll());
@@ -450,13 +450,13 @@ describe('concatAll operator', () => {
 
   it('should be able to work on a different scheduler', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a|');
-      const e1subs =    '^---!';
-      const e2 =   cold(    '---b--|');
-      const e2subs =    '----^-----!';
-      const e3 =   cold(          '---c--|');
-      const e3subs =    '----------^-----!';
-      const expected =  '---a---b-----c--|';
+      const e1 = cold('  ---a|');
+      const e1subs = '   ^---!';
+      const e2 = cold('      ---b--|');
+      const e2subs = '   ----^-----!';
+      const e3 = cold('            ---c--|');
+      const e3subs = '   ----------^-----!';
+      const expected = ' ---a---b-----c--|';
 
       const result = of(e1, e2, e3, rxTestScheduler).pipe(concatAll());
 
@@ -469,9 +469,9 @@ describe('concatAll operator', () => {
 
   it('should concatAll a nested observable with a single inner observable', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a-|');
-      const e1subs =    '^----!';
-      const expected =  '---a-|';
+      const e1 = cold('  ---a-|');
+      const e1subs = '   ^----!';
+      const expected = ' ---a-|';
 
       const result = of(e1).pipe(concatAll());
 
@@ -482,9 +482,9 @@ describe('concatAll operator', () => {
 
   it('should concatAll a nested observable with a single inner observable, and a scheduler', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 =   cold('---a-|');
-      const e1subs =    '^----!';
-      const expected =  '---a-|';
+      const e1 = cold('  ---a-|');
+      const e1subs = '   ^----!';
+      const expected = ' ---a-|';
 
       const result = of(e1, rxTestScheduler).pipe(concatAll());
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Uses run mode for `concatAll` operator tests.

**Related issue (if exists):**
