### PR TITLE
docs(empty): make examples clearer

### DIFF
--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -29,7 +29,7 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  *
  * const result = empty().pipe(startWith(7));
  * result.subscribe(x => console.log(x));
- * 
+ *
  * // Outputs
  * // 7
  * ```

--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -11,8 +11,7 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * Creates an Observable that emits no items to the Observer and immediately
  * emits a complete notification.
  *
- * <span class="informal">Just emits 'complete', and nothing else.
- * </span>
+ * <span class="informal">Just emits 'complete', and nothing else.</span>
  *
  * ![](empty.png)
  *
@@ -21,16 +20,22 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * Observables, such as in a {@link mergeMap}.
  *
  * ## Examples
+ *
  * ### Emit the number 7, then complete
+ *
  * ```ts
  * import { empty } from 'rxjs';
  * import { startWith } from 'rxjs/operators';
  *
  * const result = empty().pipe(startWith(7));
  * result.subscribe(x => console.log(x));
+ * 
+ * // Outputs
+ * // 7
  * ```
  *
  * ### Map and flatten only odd numbers to the sequence 'a', 'b', 'c'
+ *
  * ```ts
  * import { empty, interval, of } from 'rxjs';
  * import { mergeMap } from 'rxjs/operators';
@@ -42,10 +47,10 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * result.subscribe(x => console.log(x));
  *
  * // Results in the following to the console:
- * // x is equal to the count on the interval eg(0,1,2,3,...)
+ * // x is equal to the count on the interval, e.g. (0, 1, 2, 3, ...)
  * // x will occur every 1000ms
- * // if x % 2 is equal to 1 print abc
- * // if x % 2 is not equal to 1 nothing will be output
+ * // if x % 2 is equal to 1, print a, b, c (each on its own)
+ * // if x % 2 is not equal to 1, nothing will be output
  * ```
  *
  * @see {@link Observable}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Make the examples a bit more clear.

**Related issue (if exists):**
