### PR TITLE
docs(isEmpty): improve documentation

### DIFF
--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -4,10 +4,10 @@ import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
 
 /**
- * Emits false if the input observable emits any values, or emits true if the
- * input observable completes without emitting any values.
+ * Emits `false` if the input Observable emits any values, or emits `true` if the
+ * input Observable completes without emitting any values.
  *
- * <span class="informal">Tells whether any values are emitted by an observable</span>
+ * <span class="informal">Tells whether any values are emitted by an Observable.</span>
  *
  * ![](isEmpty.png)
  *
@@ -23,42 +23,47 @@ import { OperatorFunction } from '../types';
  *
  * ## Examples
  *
- * Emit `false` for a non-empty Observable
- * ```javascript
+ * Emit `false` for a non-empty Observable.
+ *
+ * ```ts
  * import { Subject } from 'rxjs';
  * import { isEmpty } from 'rxjs/operators';
  *
  * const source = new Subject<string>();
  * const result = source.pipe(isEmpty());
+ *
  * source.subscribe(x => console.log(x));
  * result.subscribe(x => console.log(x));
+ *
  * source.next('a');
  * source.next('b');
  * source.next('c');
  * source.complete();
  *
- * // Results in:
+ * // Outputs
  * // a
  * // false
  * // b
  * // c
  * ```
  *
- * Emit `true` for an empty Observable
- * ```javascript
+ * Emit `true` for an empty Observable.
+ *
+ * ```ts
  * import { EMPTY } from 'rxjs';
  * import { isEmpty } from 'rxjs/operators';
  *
  * const result = EMPTY.pipe(isEmpty());
  * result.subscribe(x => console.log(x));
- * // Results in:
+ *
+ * // Outputs
  * // true
  * ```
  *
  * @see {@link count}
- * @see {@link EMPTY}
+ * @see {@link index/EMPTY}
  *
- * @return {OperatorFunction<T, boolean>} An Observable of a boolean value indicating whether observable was empty or not
+ * @return {OperatorFunction<T, boolean>} An Observable of a boolean value indicating whether observable was empty or not.
  * @method isEmpty
  * @owner Observable
  */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

* Change code examples to `ts`
* Fix link to `EMPTY`
* General improvements

**Related issue (if exists):**
