### PR TITLE
docs(combineLatest): changed examples of code to not use deprecated code

### DIFF
--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -111,46 +111,45 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  *
  * ![](combineLatest.png)
  *
- * `combineLatest` combines the values from all the Observables passed as
- * arguments. This is done by subscribing to each Observable in order and,
+ * `combineLatest` combines the values from all the Observables passed in the
+ * observables array. This is done by subscribing to each Observable in order and,
  * whenever any Observable emits, collecting an array of the most recent
- * values from each Observable. So if you pass `n` Observables to operator,
- * returned Observable will always emit an array of `n` values, in order
- * corresponding to order of passed Observables (value from the first Observable
- * on the first place and so on).
+ * values from each Observable. So if you pass `n` Observables to this operator,
+ * the returned Observable will always emit an array of `n` values, in an order
+ * corresponding to the order of the passed Observables (the value from the first Observable
+ * will be at index 0 of the array and so on).
  *
- * Static version of `combineLatest` accepts either an array of Observables
- * or each Observable can be put directly as an argument. Note that array of
- * Observables is good choice, if you don't know beforehand how many Observables
- * you will combine. Passing empty array will result in Observable that
+ * Static version of `combineLatest` accepts an array of Observables. Note that an array of
+ * Observables is a good choice, if you don't know beforehand how many Observables
+ * you will combine. Passing an empty array will result in an Observable that
  * completes immediately.
  *
- * To ensure output array has always the same length, `combineLatest` will
+ * To ensure the output array always has the same length, `combineLatest` will
  * actually wait for all input Observables to emit at least once,
  * before it starts emitting results. This means if some Observable emits
  * values before other Observables started emitting, all these values but the last
  * will be lost. On the other hand, if some Observable does not emit a value but
  * completes, resulting Observable will complete at the same moment without
- * emitting anything, since it will be now impossible to include value from
- * completed Observable in resulting array. Also, if some input Observable does
+ * emitting anything, since it will now be impossible to include a value from the
+ * completed Observable in the resulting array. Also, if some input Observable does
  * not emit any value and never completes, `combineLatest` will also never emit
  * and never complete, since, again, it will wait for all streams to emit some
  * value.
  *
  * If at least one Observable was passed to `combineLatest` and all passed Observables
- * emitted something, resulting Observable will complete when all combined
- * streams complete. So even if some Observable completes, result of
+ * emitted something, the resulting Observable will complete when all combined
+ * streams complete. So even if some Observable completes, the result of
  * `combineLatest` will still emit values when other Observables do. In case
- * of completed Observable, its value from now on will always be the last
+ * of a completed Observable, its value from now on will always be the last
  * emitted value. On the other hand, if any Observable errors, `combineLatest`
  * will error immediately as well, and all other Observables will be unsubscribed.
  *
- * `combineLatest` accepts as optional parameter `project` function, which takes
- * as arguments all values that would normally be emitted by resulting Observable.
+ * `combineLatest` accepts as an optional parameter a `project` function, which takes
+ * as arguments all values that would normally be emitted by the resulting Observable.
  * `project` can return any kind of value, which will be then emitted by Observable
- * instead of default array. Note that `project` does not take as argument that array
- * of values, but values themselves. That means default `project` can be imagined
- * as function that takes all its arguments and puts them into an array.
+ * instead of a default array. Note that `project` does not take as an argument that array
+ * of values, but values themselves. That means the default `project` can be imagined
+ * as a function that takes all its arguments and puts them into an array.
  *
  * ## Examples
  * ### Combine two timer Observables
@@ -159,7 +158,7 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  *
  * const firstTimer = timer(0, 1000); // emit 0, 1, 2... after every second, starting from now
  * const secondTimer = timer(500, 1000); // emit 0, 1, 2... after every second, starting 0,5s from now
- * const combinedTimers = combineLatest(firstTimer, secondTimer);
+ * const combinedTimers = combineLatest([firstTimer, secondTimer]);
  * combinedTimers.subscribe(value => console.log(value));
  * // Logs
  * // [0, 0] after 0.5s
@@ -196,7 +195,7 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  *
  * const weight = of(70, 72, 76, 79, 75);
  * const height = of(1.76, 1.77, 1.78);
- * const bmi = combineLatest(weight, height).pipe(
+ * const bmi = combineLatest([weight, height]).pipe(
  *   map(([w, h]) => w / (h * h)),
  * );
  * bmi.subscribe(x => console.log('BMI is ' + x));
@@ -211,10 +210,8 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
  * @see {@link merge}
  * @see {@link withLatestFrom}
  *
- * @param {ObservableInput} observable1 An input Observable to combine with other Observables.
- * @param {ObservableInput} observable2 An input Observable to combine with other Observables.
- * More than one input Observables may be given as arguments
- * or an array of Observables may be given as the first argument.
+ * @param {ObservableInput} [observables] An array of input Observables to combine with each other.
+ * An array of Observables must be given as the first argument.
  * @param {function} [project] An optional function to project the values from
  * the combined latest values into a new value on the output Observable.
  * @param {SchedulerLike} [scheduler=null] The {@link SchedulerLike} to use for subscribing to


### PR DESCRIPTION
In a recent commit [https://github.com/ReactiveX/rxjs/commit/6661c796ea6f2918d4e6c0b68dfbecd4fbb7da74](url), a whole bunch of combineLatest calling forms were deprecated, but the docs weren't updated. I've now updated the docs for combineLatest to remove any references to the old way.
