### PR TITLE
fix(ReplaySubject): allow subclasses to override next method

### DIFF
--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -13,6 +13,38 @@ describe('ReplaySubject', () => {
     expect(subject).to.be.instanceof(Subject);
   });
 
+  describe('inheritance', () => {
+    it('should allow subclasses to override the next method', () => {
+      let wasMethodCalled = false;
+      class SubClassReplaySubject<T> extends ReplaySubject<T> {
+        next(value: T) {
+          wasMethodCalled = true;
+          super.next(value);
+        }
+      }
+      const subject = new SubClassReplaySubject<number>(1);
+
+      subject.next(1);
+
+      expect(wasMethodCalled).to.equal(true);
+    });
+
+    it('should allow subclasses to call the superclass next method', () => {
+      class SubClassReplaySubject<T> extends ReplaySubject<T> {
+        subNext(value: T) {
+          super.next(value);
+        }
+      }
+      const subject = new SubClassReplaySubject<number>(1);
+      subject.subNext(1);
+      let result = 0;
+
+      subject.subscribe(x => result = x);
+
+      expect(result).to.equal(1);
+    });
+  });
+
   it('should add the observer before running subscription code', () => {
     const subject = new ReplaySubject<number>();
     subject.next(1);

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -18,6 +18,7 @@ export class ReplaySubject<T> extends Subject<T> {
   private _bufferSize: number;
   private _windowTime: number;
   private _infiniteTimeWindow: boolean = false;
+  private _replaySubjectNext: (value: T) => void;
 
   constructor(bufferSize: number = Number.POSITIVE_INFINITY,
               windowTime: number = Number.POSITIVE_INFINITY,
@@ -29,10 +30,14 @@ export class ReplaySubject<T> extends Subject<T> {
     if (windowTime === Number.POSITIVE_INFINITY) {
       this._infiniteTimeWindow = true;
       /** @override */
-      this.next = this.nextInfiniteTimeWindow;
+      this._replaySubjectNext = this.nextInfiniteTimeWindow;
     } else {
-      this.next = this.nextTimeWindow;
+      this._replaySubjectNext = this.nextTimeWindow;
     }
+  }
+
+  public next(value: T): void {
+    this._replaySubjectNext(value);
   }
 
   private nextInfiniteTimeWindow(value: T): void {


### PR DESCRIPTION
Previously subclass `next` method would be overwriten by the ReplaySubject constructor.
This change also allows subclasses to call `super.next(value)` and
invoke the ReplaySubject `next` method instead of the Subject `next`
method.
