### PR TITLE
fix(startWith): fix incorrect types

### DIFF
--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -65,13 +65,13 @@ export function startWith<T, D = T>(...array: Array<D | SchedulerLike>): Operato
  * @method startWith
  * @owner Observable
  */
-export function startWith<T, D>(...array: Array<T | SchedulerLike>): OperatorFunction<T, T | D> {
+export function startWith<T, D>(...array: Array<D | SchedulerLike>): OperatorFunction<T, T | D> {
   const scheduler = array[array.length - 1] as SchedulerLike;
   if (isScheduler(scheduler)) {
     // deprecated path
     array.pop();
-    return (source: Observable<T>) => concat(array as T[], source, scheduler);
+    return (source: Observable<T>) => concat(array as D[], source, scheduler);
   } else {
-    return (source: Observable<T>) => concat(array as T[], source);
+    return (source: Observable<T>) => concat(array as D[], source);
   }
 }


### PR DESCRIPTION
**Description:**

I *think* (not sure) that the function definition of `startWith` is incorrectly typed. Because `startWith` has function overloads, this incorrect typing has no direct user impact. Except! this incorrect function signature is shown in the documentation for `startWith` (at the top), creating a source of confusion: https://rxjs-dev.firebaseapp.com/api/operators/startWith

This change can be thought of as a documentation fix, though it is also updates (fixes) the internal typing of the `startWith` operator function.

**Related issue (if exists):**
