### PR TITLE
chore(jsdoc): fix jsdoc comment

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -29,7 +29,7 @@ export class Observable<T> implements Subscribable<T> {
 
   /**
    * @constructor
-   * @param {Function} subscribe the function that is called when the Observable is
+   * @param {Function} [subscribe] the function that is called when the Observable is
    * initially subscribed to. This function is given a Subscriber, to which new values
    * can be `next`ed, or an `error` method can be called to raise an error, or
    * `complete` can be called to notify of a successful completion.
@@ -47,7 +47,7 @@ export class Observable<T> implements Subscribable<T> {
    * @static true
    * @owner Observable
    * @method create
-   * @param {Function} subscribe? the subscriber function to be passed to the Observable constructor
+   * @param {Function} [subscribe] the subscriber function to be passed to the Observable constructor
    * @return {Observable} a new cold observable
    * @nocollapse
    * @deprecated use new Observable() instead
@@ -200,7 +200,7 @@ export class Observable<T> implements Subscribable<T> {
    * @param {Function} error (optional) A handler for a terminal event resulting from an error. If no error handler is provided,
    *  the error will be thrown as unhandled.
    * @param {Function} complete (optional) A handler for a terminal event resulting from successful completion.
-   * @return {ISubscription} a subscription reference to the registered handlers
+   * @return {Subscription} a subscription reference to the registered handlers
    * @method subscribe
    */
   subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
@@ -251,9 +251,9 @@ export class Observable<T> implements Subscribable<T> {
 
   /**
    * @method forEach
-   * @param next a handler for each value emitted by the observable
-   * @param [promiseCtor] a constructor function used to instantiate the Promise
-   * @return a promise that either resolves on observable completion or
+   * @param {Function} next a handler for each value emitted by the observable
+   * @param {PromiseConstructorLike} [promiseCtor] a constructor function used to instantiate the Promise
+   * @return {Promise} a promise that either resolves on observable completion or
    *  rejects with the handled error
    */
   forEach(next: (value: T) => void, promiseCtor?: PromiseConstructorLike): Promise<void> {
@@ -357,9 +357,9 @@ export class Observable<T> implements Subscribable<T> {
    * `complete` with the last emission.
    *
    * @method toPromise
-   * @param [promiseCtor] a constructor function used to instantiate
+   * @param {PromiseConstructorLike} [promiseCtor] a constructor function used to instantiate
    * the Promise
-   * @return A Promise that resolves with the last value emit, or
+   * @return {Promise} A Promise that resolves with the last value emit, or
    * rejects on an error.
    */
   toPromise(promiseCtor?: PromiseConstructorLike): Promise<T> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
