### PR TITLE
chore: bump CI typescript version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,11 +58,18 @@ jobs:
       - attach_workspace: *attach_options
       - run: npm run dtslint
 
-  typescript3:
+  # Ideally, this package should support typescript@next. However, in the past
+  # that hasn't always been possible and frequent problems with nightly
+  # TypeScript builds resulted in CI failures being deliberately ignored.
+  # Instead, we should aim to keep the TypeScript version specified here as
+  # high as possible, but it should be known to be good. That is, it should be
+  # the upper bound - the latest version of TypeScript that we can be confident
+  # we can support. 
+  typescriptLatestSupported:
     <<: *defaults
     steps:
       - attach_workspace: *attach_options
-      - run: npm i --no-save typescript@3.5.*
+      - run: npm i --no-save typescript@3.7.2
       - run: npm run compile
 
 workflows:
@@ -79,7 +86,7 @@ workflows:
       - dtslint:
           requires:
             - build
-      - typescript3:
+      - typescriptLatestSupported:
           requires:
             - lint
             - test


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR bumps the explicit version of TypeScript used in the CI tests and adds a comment about the purpose of the test.

Prior to the change in this PR, the explicit TypeScript version was 3.5. As per the comment, this version should always be equal to or greater than the minimum-supported TypeScript version - the version of TypeScript in the `package.json`.

**Related issue (if exists):** #5166