### PR TITLE
chore: use `@internal` annotation

### DIFF
--- a/src/internal/AsyncSubject.ts
+++ b/src/internal/AsyncSubject.ts
@@ -13,7 +13,7 @@ export class AsyncSubject<T> extends Subject<T> {
   private hasNext: boolean = false;
   private hasCompleted: boolean = false;
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<any>): Subscription {
     if (this.hasError) {
       subscriber.error(this.thrownError);

--- a/src/internal/BehaviorSubject.ts
+++ b/src/internal/BehaviorSubject.ts
@@ -20,7 +20,7 @@ export class BehaviorSubject<T> extends Subject<T> {
     return this.getValue();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): Subscription {
     const subscription = super._subscribe(subscriber);
     if (subscription && !(<SubscriptionLike>subscription).closed) {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -21,10 +21,10 @@ export class Observable<T> implements Subscribable<T> {
   /** Internal implementation detail, do not use directly. */
   public _isScalar: boolean = false;
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   source: Observable<any>;
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   operator: Operator<any, T>;
 
   /**
@@ -232,7 +232,7 @@ export class Observable<T> implements Subscribable<T> {
     return sink;
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _trySubscribe(sink: Subscriber<T>): TeardownLogic {
     try {
       return this._subscribe(sink);

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -54,7 +54,7 @@ export class ReplaySubject<T> extends Subject<T> {
     super.next(value);
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): Subscription {
     // When `_infiniteTimeWindow === true` then the buffer is already trimmed
     const _infiniteTimeWindow = this._infiniteTimeWindow;

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -17,7 +17,7 @@ import { SchedulerLike, SchedulerAction } from './types';
  * ```
  *
  * @class Scheduler
- * @deprecated Scheduler is an internal implementation detail of RxJS, and
+ * @internal Scheduler is an internal implementation detail of RxJS, and
  * should not be used directly. Rather, create your own class and implement
  * {@link SchedulerLike}
  */

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -45,9 +45,10 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     super();
   }
 
-  /**@nocollapse
+  /**
+   * @nocollapse
    * @deprecated use new Subject() instead
-  */
+   */
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
   }
@@ -108,7 +109,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     this.observers = null;
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _trySubscribe(subscriber: Subscriber<T>): TeardownLogic {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
@@ -117,7 +118,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     }
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): Subscription {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
@@ -176,7 +177,7 @@ export class AnonymousSubject<T> extends Subject<T> {
     }
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -149,7 +149,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     this.unsubscribe();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribeAndRecycle(): Subscriber<T> {
     const {  _parentOrParents } = this;
     this._parentOrParents = null;

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -2,7 +2,7 @@ let _enable_super_gross_mode_that_will_cause_bad_things = false;
 
 /**
  * The global configuration object for RxJS, used to configure things
- * like what Promise contructor should used to create Promises
+ * like what Promise constructor should used to create Promises
  */
 export const config = {
   /**

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -22,7 +22,7 @@ export class ConnectableObservable<T> extends Observable<T> {
     super();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>) {
     return this.getSubject().subscribe(subscriber);
   }

--- a/src/internal/observable/SubscribeOnObservable.ts
+++ b/src/internal/observable/SubscribeOnObservable.ts
@@ -39,7 +39,7 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     }
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>) {
     const delay = this.delayTime;
     const source = this.source;

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -181,7 +181,7 @@ export class AjaxObservable<T> extends Observable<T> {
     this.request = request;
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): TeardownLogic {
     return new AjaxSubscriber(subscriber, this.request);
   }

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -152,7 +152,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
 
   private _config: WebSocketSubjectConfig<T>;
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _output: Subject<T>;
 
   private _socket: WebSocket;
@@ -354,7 +354,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     };
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -184,7 +184,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     super._complete();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     this.contexts = null;
   }

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -92,7 +92,7 @@ class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
     super._complete();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     this.buffer = null;
     this.subscribing = false;

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -183,7 +183,7 @@ class SubscriptionDelayObservable<T> extends Observable<T> {
     super();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>) {
     this.subscriptionDelay.subscribe(new SubscriptionDelaySubscriber(subscriber, this.source));
   }

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -257,7 +257,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
     this.complete();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     const { parent, key } = this;
     this.key = this.parent = null;
@@ -283,7 +283,7 @@ export class GroupedObservable<K, T> extends Observable<T> {
     super();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<T>) {
     const subscription = new Subscription();
     const { refCountSubscription, groupSubject } = this;

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -100,7 +100,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     const { notifications, retriesSubscription } = this;
     if (notifications) {
@@ -114,7 +114,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.retries = null;
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribeAndRecycle(): Subscriber<T> {
     const { _unsubscribe } = this;
 

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -125,7 +125,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     const { errors, retriesSubscription } = this;
     if (errors) {

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -135,7 +135,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
     super._next(value);
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     this.action = null;
     this.scheduler = null;

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -113,7 +113,7 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     this.destination.complete();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     this.window = null;
   }

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -139,7 +139,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
     super._complete();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
     const { contexts } = this;
     this.contexts = null;

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -130,7 +130,7 @@ export class AsyncAction<T> extends Action<T> {
     }
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _unsubscribe() {
 
     const id = this.id;

--- a/src/internal/testing/HotObservable.ts
+++ b/src/internal/testing/HotObservable.ts
@@ -24,7 +24,7 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     this.scheduler = scheduler;
   }
 
-  /** @deprecated This is an internal implementation detail, do not use. */
+  /** @internal This is an internal implementation detail, do not use. */
   _subscribe(subscriber: Subscriber<any>): Subscription {
     const subject: HotObservable<T> = this;
     const index = subject.logSubscribedFrame();

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -31,7 +31,7 @@ export type subscriptionLogsToBeFn = (marbles: string | string[]) => void;
 export class TestScheduler extends VirtualTimeScheduler {
   /**
    * The number of virtual time units each character in a marble diagram represents. If
-   * the test scheduler is being used in "run mode", via the `run` method, this is temporarly
+   * the test scheduler is being used in "run mode", via the `run` method, this is temporarily
    * set to `1` for the duration of the `run` block, then set back to whatever value it was.
    * @nocollapse
    */
@@ -355,7 +355,7 @@ export class TestScheduler extends VirtualTimeScheduler {
         default:
           // Might be time progression syntax, or a value literal
           if (runMode && c.match(/^[0-9]$/)) {
-            // Time progression must be preceeded by at least one space
+            // Time progression must be preceded by at least one space
             // if it's not at the beginning of the diagram
             if (i === 0 || marbles[i - 1] === ' ') {
               const buffer = marbles.slice(i);

--- a/src/tsconfig.types.json
+++ b/src/tsconfig.types.json
@@ -8,8 +8,7 @@
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "../dist/types",
-    "emitDeclarationOnly": true,
-    "stripInternal": true
+    "emitDeclarationOnly": true
   },
   "exclude": [
     "./internal/umd.ts"

--- a/src/tsconfig.types.json
+++ b/src/tsconfig.types.json
@@ -8,7 +8,8 @@
     "declaration": true,
     "declarationMap": true,
     "declarationDir": "../dist/types",
-    "emitDeclarationOnly": true
+    "emitDeclarationOnly": true,
+    "stripInternal": true
   },
   "exclude": [
     "./internal/umd.ts"


### PR DESCRIPTION
Hi, 

This PR replaces the `@deprecated` annotation by `@internal` in combination with the `stripInternal` tsc option to remove internal members from generated `d.ts` file.

This will prevent TypeScript users from using internal implementation.

Related issue: #5171