### PR TITLE
chore: fix iif typings to infer never

### DIFF
--- a/spec-dtslint/observables/iif-spec.ts
+++ b/spec-dtslint/observables/iif-spec.ts
@@ -1,0 +1,21 @@
+import { iif, of } from 'rxjs';
+
+it('should accept function as first parameter', () => {
+  // Typescript limitation: cannot infer default value in params
+  // e.g.: const a = iif(() => false, EMPTY, EMPTY) // $ExpectType Observable<never>
+  // However, test below does not infer Observable<never> if no params is passed
+  // although the default value for second and third param is EMPTY observable
+  const a = iif(() => false); // $ExpectType Observable<{}>
+});
+
+it('should infer correctly with 2 parameters', () => {
+  const a = iif(() => false, of(1)); // $ExpectType Observable<number | {}>
+});
+
+it('should infer correctly with 3 parameters', () => {
+  const a = iif(() => false, of(1), of(2)); // $ExpectType Observable<number>
+});
+
+it('should infer correctly with 3 parameters of different types', () => {
+  const a = iif(() => false, of(1), of('a')); // $ExpectType Observable<string | number>
+});

--- a/spec-dtslint/observables/iif-spec.ts
+++ b/spec-dtslint/observables/iif-spec.ts
@@ -1,15 +1,11 @@
 import { iif, of } from 'rxjs';
 
 it('should accept function as first parameter', () => {
-  // Typescript limitation: cannot infer default value in params
-  // e.g.: const a = iif(() => false, EMPTY, EMPTY) // $ExpectType Observable<never>
-  // However, test below does not infer Observable<never> if no params is passed
-  // although the default value for second and third param is EMPTY observable
-  const a = iif(() => false); // $ExpectType Observable<{}>
+  const a = iif(() => false); // $ExpectType Observable<never>
 });
 
 it('should infer correctly with 2 parameters', () => {
-  const a = iif(() => false, of(1)); // $ExpectType Observable<number | {}>
+  const a = iif(() => false, of(1)); // $ExpectType Observable<number>
 });
 
 it('should infer correctly with 3 parameters', () => {

--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -90,7 +90,10 @@ import { SubscribableOrPromise } from '../types';
  * @static true
  * @name iif
  * @owner Observable
- */
+*/
+/* tslint:disable:max-line-length */
+export function iif<T = never, F = never>(condition: () => boolean, trueResult?: SubscribableOrPromise<T>, falseResult?: SubscribableOrPromise<F>): Observable<T | F>;
+/* tslint:enable:max-line-length */
 export function iif<T, F>(
   condition: () => boolean,
   trueResult: SubscribableOrPromise<T> = EMPTY,

--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -91,10 +91,7 @@ import { SubscribableOrPromise } from '../types';
  * @name iif
  * @owner Observable
 */
-/* tslint:disable:max-line-length */
-export function iif<T = never, F = never>(condition: () => boolean, trueResult?: SubscribableOrPromise<T>, falseResult?: SubscribableOrPromise<F>): Observable<T | F>;
-/* tslint:enable:max-line-length */
-export function iif<T, F>(
+export function iif<T = never, F = never>(
   condition: () => boolean,
   trueResult: SubscribableOrPromise<T> = EMPTY,
   falseResult: SubscribableOrPromise<F> = EMPTY


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR combines the changes in #4478 and #4520 - cherry picking the commits and making minor changes - so that the typings changes and the dtslint tests are in the same PR.

With these changes, when optional arguments are not passed to `iif`, they are inferred to be `never` rather than `{}`.

**Related issue (if exists):** #4494