### PR TITLE
docs(index): fix link to EMPTY

### DIFF
--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -62,7 +62,7 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * the emission of the complete notification.
  * @return An "empty" Observable: emits only the complete
  * notification.
- * @deprecated Deprecated in favor of using {@link index/EMPTY} constant, or {@link scheduled} (e.g. `scheduled([], scheduler)`)
+ * @deprecated Deprecated in favor of using {@link EMPTY} constant, or {@link scheduled} (e.g. `scheduled([], scheduler)`)
  */
 export function empty(scheduler?: SchedulerLike) {
   return scheduler ? emptyScheduled(scheduler) : EMPTY;


### PR DESCRIPTION
**Description:**

Fix the link to `EMPTY` in [`empty()` page](https://rxjs.dev/api/index/function/empty).

PS : maybe all [`@link index`](https://github.com/ReactiveX/rxjs/search?q=%22%40link+index%22&unscoped_q=%22%40link+index%22) links do not work.