### PR TITLE
fix: chain subscriptions from interop observables for 6.x

### DIFF
--- a/spec/helpers/interop-helper-spec.ts
+++ b/spec/helpers/interop-helper-spec.ts
@@ -1,0 +1,19 @@
+import { expect } from 'chai';
+import { Observable, of, Subscriber } from 'rxjs';
+import { observable as symbolObservable } from 'rxjs/internal/symbol/observable';
+import { rxSubscriber as symbolSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
+import { asInteropObservable, asInteropSubscriber } from './interop-helper';
+
+describe('interop helper', () => {
+  it('should simulate interop observables', () => {
+    const observable = asInteropObservable(of(42));
+    expect(observable).to.not.be.instanceOf(Observable);
+    expect(observable[symbolObservable]).to.be.a('function');
+  });
+
+  it('should simulate interop subscribers', () => {
+    const subscriber = asInteropSubscriber(new Subscriber());
+    expect(subscriber).to.not.be.instanceOf(Subscriber);
+    expect(subscriber[symbolSubscriber]).to.be.undefined;
+  });
+});

--- a/spec/helpers/interop-helper.ts
+++ b/spec/helpers/interop-helper.ts
@@ -1,0 +1,57 @@
+import { Observable, Subscriber, Subscription } from 'rxjs';
+import { rxSubscriber as symbolSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
+
+/**
+ * Returns an observable that will be deemed by this package's implementation
+ * to be an observable that requires interop. The returned observable will fail
+ * the `instanceof Observable` test and will deem any `Subscriber` passed to
+ * its `subscribe` method to be untrusted.
+ */
+export function asInteropObservable<T>(observable: Observable<T>): Observable<T> {
+  return new Proxy(observable, {
+    get(target: Observable<T>, key: string | number | symbol) {
+      if (key === 'subscribe') {
+        const { subscribe } = target;
+        return interopSubscribe(subscribe);
+      }
+      return Reflect.get(target, key);
+    },
+    getPrototypeOf(target: Observable<T>) {
+      const { subscribe, ...rest } = Object.getPrototypeOf(target);
+      return {
+        ...rest,
+        subscribe: interopSubscribe(subscribe)
+      };
+    }
+  });
+}
+
+/**
+ * Returns a subscriber that will be deemed by this package's implementation to
+ * be untrusted. The returned subscriber will fail the `instanceof Subscriber`
+ * test and will not include the symbol that identifies trusted subscribers.
+ */
+export function asInteropSubscriber<T>(subscriber: Subscriber<T>): Subscriber<T> {
+  return new Proxy(subscriber, {
+    get(target: Subscriber<T>, key: string | number | symbol) {
+      if (key === symbolSubscriber) {
+        return undefined;
+      }
+      return Reflect.get(target, key);
+    },
+    getPrototypeOf(target: Subscriber<T>) {
+      const { [symbolSubscriber]: symbol, ...rest } = Object.getPrototypeOf(target);
+      return rest;
+    }
+  });
+}
+
+function interopSubscribe<T>(subscribe: (...args: any[]) => Subscription) {
+  return function (this: Observable<T>, ...args: any[]): Subscription {
+    const [arg] = args;
+    if (arg instanceof Subscriber) {
+      return subscribe.call(this, asInteropSubscriber(arg));
+    }
+    return subscribe.apply(this, args);
+  };
+}

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -2,6 +2,7 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { concat, defer, Observable, of, from } from 'rxjs';
 import { exhaustMap, mergeMap, takeWhile, map } from 'rxjs/operators';
 import { expect } from 'chai';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare function asDiagram(arg: string): Function;
 
@@ -192,6 +193,39 @@ describe('exhaustMap', () => {
     const result = e1.pipe(
       mergeMap(x => of(x)),
       exhaustMap(value => observableLookup[value]),
+      mergeMap(x => of(x))
+    );
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+    expectSubscriptions(z.subscriptions).toBe(zsubs);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chains with interop inners when result is unsubscribed explicitly', () => {
+    const x = cold(     '--a--b--c--|                               ');
+    const xsubs =    '   ^          !                               ';
+    const y = cold(               '--d--e--f--|                     ');
+    const ysubs: string[] = [];
+    const z = cold(                                 '--g--h--i--|   ');
+    const zsubs =    '                               ^  !           ';
+    const e1 =   hot('---x---------y-----------------z-------------|');
+    const e1subs =   '^                                 !           ';
+    const expected = '-----a--b--c---------------------g-           ';
+    const unsub =    '                                  !           ';
+
+    const observableLookup = { x: x, y: y, z: z };
+
+    // This test is the same as the previous test, but the observable is
+    // manipulated to make it look like an interop observable - an observable
+    // from a foreign library. Interop subscribers are treated differently:
+    // they are wrapped in a safe subscriber. This test ensures that
+    // unsubscriptions are chained all the way to the interop subscriber.
+
+    const result = e1.pipe(
+      mergeMap(x => of(x)),
+      exhaustMap(value => asInteropObservable(observableLookup[value])),
       mergeMap(x => of(x))
     );
 

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { switchMap, mergeMap, map, takeWhile } from 'rxjs/operators';
 import { concat, defer, of, Observable } from 'rxjs';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare function asDiagram(arg: string): Function;
 
@@ -160,6 +161,36 @@ describe('switchMap', () => {
     const result = e1.pipe(
       mergeMap(x => of(x)),
       switchMap(value => observableLookup[value]),
+      mergeMap(x => of(x)),
+    );
+
+    expectObservable(result, unsub).toBe(expected);
+    expectSubscriptions(x.subscriptions).toBe(xsubs);
+    expectSubscriptions(y.subscriptions).toBe(ysubs);
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
+
+  it('should not break unsubscription chains with interop inners when result is unsubscribed explicitly', () => {
+    const x =   cold(         '--a--b--c--d--e--|           ');
+    const xsubs =    '         ^         !                  ';
+    const y =   cold(                   '---f---g---h---i--|');
+    const ysubs =    '                   ^ !                ';
+    const e1 =   hot('---------x---------y---------|        ');
+    const e1subs =   '^                    !                ';
+    const expected = '-----------a--b--c----                ';
+    const unsub =    '                     !                ';
+
+    const observableLookup = { x: x, y: y };
+
+    // This test is the same as the previous test, but the observable is
+    // manipulated to make it look like an interop observable - an observable
+    // from a foreign library. Interop subscribers are treated differently:
+    // they are wrapped in a safe subscriber. This test ensures that
+    // unsubscriptions are chained all the way to the interop subscriber.
+
+    const result = e1.pipe(
+      mergeMap(x => of(x)),
+      switchMap(value => asInteropObservable(observableLookup[value])),
       mergeMap(x => of(x)),
     );
 

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -1,3 +1,6 @@
 {
-  "extends": "../tsconfig.json"
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "lib": ["esnext", "dom"]
+  }
 }

--- a/spec/util/toSubscriber-spec.ts
+++ b/spec/util/toSubscriber-spec.ts
@@ -12,7 +12,7 @@ describe('toSubscriber', () => {
     expect(sub2.closed).to.be.true;
   });
 
-it('should not be closed when other subscriber created with same observer instance completes', () => {
+  it('should not be closed when other subscriber created with same observer instance completes', () => {
     let observer = {
       next: function () { /*noop*/ }
     };

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -137,7 +137,13 @@ class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
       this._unsubscribeAndRecycle();
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
       this.add(innerSubscriber);
-      subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+      const innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+      // The returned subscription will usually be the subscriber that was
+      // passed. However, interop subscribers will be wrapped and for
+      // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+      if (innerSubscription !== innerSubscriber) {
+        this.add(innerSubscription);
+      }
     }
   }
 }

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -122,10 +122,16 @@ class ExhaustMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(result: ObservableInput<R>, value: T, index: number): void {
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    subscribeToResult<T, R>(this, result, value, index, innerSubscriber);
+    const innerSubscription = subscribeToResult<T, R>(this, result, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+    if (innerSubscription !== innerSubscriber) {
+      destination.add(innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -142,10 +142,16 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(ish: ObservableInput<R>, value: T, index: number): void {
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
+    const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+    if (innerSubscription !== innerSubscriber) {
+      destination.add(innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -103,10 +103,16 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   private _innerSub(ish: any, value: T, index: number): void {
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    subscribeToResult<T, R>(this, ish, value, index, innerSubscriber);
+    const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+    if (innerSubscription !== innerSubscriber) {
+      destination.add(innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -162,7 +162,13 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
       const destination = this.destination as Subscription;
       destination.add(innerSubscriber);
-      subscribeToResult(this, next, undefined, undefined, innerSubscriber);
+      const innerSubscription = subscribeToResult(this, next, undefined, undefined, innerSubscriber);
+      // The returned subscription will usually be the subscriber that was
+      // passed. However, interop subscribers will be wrapped and for
+      // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+      if (innerSubscription !== innerSubscriber) {
+        destination.add(innerSubscription);
+      }
     } else {
       this.destination.complete();
     }

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -74,7 +74,14 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
     this.add(innerSubscriber);
     this.innerSubscription = innerSubscriber;
-    subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
+    const innerSubscription = subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+    if (innerSubscription !== innerSubscriber) {
+      this.add(innerSubscription);
+      this.innerSubscription = innerSubscription;
+    }
   }
 
   protected _next(value: T) {

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -133,10 +133,16 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (innerSubscription) {
       innerSubscription.unsubscribe();
     }
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    this.innerSubscription = subscribeToResult(this, result, value, index, innerSubscriber);
+    this.innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+    // The returned subscription will usually be the subscriber that was
+    // passed. However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+    if (this.innerSubscription !== innerSubscriber) {
+      destination.add(this.innerSubscription);
+    }
   }
 
   protected _complete(): void {

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -8,22 +8,30 @@ import { Observable } from '../Observable';
 export function subscribeToResult<T, R>(
   outerSubscriber: OuterSubscriber<T, R>,
   result: any,
+  outerValue: undefined,
+  outerIndex: undefined,
+  innerSubscriber: InnerSubscriber<T, R>
+): Subscription | undefined;
+
+export function subscribeToResult<T, R>(
+  outerSubscriber: OuterSubscriber<T, R>,
+  result: any,
   outerValue?: T,
-  outerIndex?: number,
-  destination?: Subscriber<any>
-): Subscription;
+  outerIndex?: number
+): Subscription | undefined;
+
 export function subscribeToResult<T, R>(
   outerSubscriber: OuterSubscriber<T, R>,
   result: any,
   outerValue?: T,
   outerIndex?: number,
-  destination: Subscriber<any> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
-): Subscription | void {
-  if (destination.closed) {
+  innerSubscriber: Subscriber<R> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
+): Subscription | undefined {
+  if (innerSubscriber.closed) {
     return undefined;
   }
   if (result instanceof Observable) {
-    return result.subscribe(destination);
+    return result.subscribe(innerSubscriber);
   }
-  return subscribeTo(result)(destination);
+  return subscribeTo(result)(innerSubscriber) as Subscription;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** This PR cherry-picks #5059 and applies it to the `6.x` branch.

**Related issue (if exists):** #5059
