### PR TITLE
test: add v8 subscriber-should-stay-closed test

### DIFF
--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { concat, defer, Observable, of, throwError, EMPTY, from } from 'rxjs';
-import { catchError, map, mergeMap, takeWhile } from 'rxjs/operators';
+import { catchError, delay, map, mergeMap, takeWhile } from 'rxjs/operators';
 import * as sinon from 'sinon';
 import { createObservableInputs } from '../helpers/test-helper';
 import { TestScheduler } from 'rxjs/testing';
@@ -430,4 +430,33 @@ describe('catchError operator', () => {
     });
   });
 
+  // TODO(v8): see https://github.com/ReactiveX/rxjs/issues/5115
+  // The re-implementation in version 8 should fix the problem in the
+  // referenced issue. Closed subscribers should remain closed.
+  /*
+  it('issue #5115', (done: MochaDone) => {
+    const source = new Observable<string>(observer => {
+      observer.error(new Error('kaboom!'));
+      observer.complete();
+    });
+
+    const sourceWithDelay = new Observable<string>(observer => {
+      observer.next('delayed');
+      observer.complete();
+    }).pipe(delay(0));
+
+    const values: string[] = [];
+    source.pipe(
+      catchError(err => sourceWithDelay)
+    )
+    .subscribe(
+      value => values.push(value),
+      err => done(err),
+      () => {
+        expect(values).to.deep.equal(['delayed']);
+        done();
+      }
+    );
+  });
+  */
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a (commented-out) test that reproduces the problem in the issue linked below. It's not possible to easily fix the bug in the current implementation, but the re-implementation that's planned for v8 should take this situation into account and the test should be made to pass.

**Related issue (if exists):** #5115