### PR TITLE
docs: small improvements

### DIFF
--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -41,7 +41,7 @@ export function race(...observables: ObservableInput<any>[]): Observable<unknown
  * source observable.
  *
  * If one of the used source observable throws an errors before a first notification
- * the race operator will also also throw an error, no matter if another source observable
+ * the race operator will also throw an error, no matter if another source observable
  * could potentially win the race.
  *
  * `race` can be useful for selecting the response from the fastest network connection for
@@ -64,7 +64,7 @@ export function race(...observables: ObservableInput<any>[]): Observable<unknown
  *   winner => console.log(winner)
  * );
  *
- * // result:
+ * // Outputs
  * // a series of 'fast one'
  * ```
  *

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -14,29 +14,48 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * ![](subscribeOn.png)
  *
  * ## Example
+ *
  * Given the following code:
- * ```javascript
+ *
+ * ```ts
  * import { of, merge } from 'rxjs';
  *
- * const a = of(1, 2, 3, 4);
- * const b = of(5, 6, 7, 8, 9);
+ * const a = of(1, 2, 3);
+ * const b = of(4, 5, 6);
+ *
  * merge(a, b).subscribe(console.log);
+ *
+ * // Outputs
+ * // 1
+ * // 2
+ * // 3
+ * // 4
+ * // 5
+ * // 6
  * ```
  *
  * Both Observable `a` and `b` will emit their values directly and synchronously once they are subscribed to.
- * This will result in the output of `1 2 3 4 5 6 7 8 9`.
  *
- * But if we instead us the `subscribeOn` operator declaring that we want to use the {@link asyncScheduler} for values emited by Observable `a`:
- * ```javascript
+ * If we instead use the `subscribeOn` operator declaring that we want to use the {@link asyncScheduler} for values emited by Observable `a`:
+ *
+ * ```ts
  * import { of, merge, asyncScheduler } from 'rxjs';
  * import { subscribeOn } from 'rxjs/operators';
  *
- * const a = of(1, 2, 3, 4).pipe(subscribeOn(asyncScheduler));
- * const b = of(5, 6, 7, 8, 9);
+ * const a = of(1, 2, 3).pipe(subscribeOn(asyncScheduler));
+ * const b = of(4, 5, 6);
+ *
  * merge(a, b).subscribe(console.log);
+ *
+ * // Outputs
+ * // 4
+ * // 5
+ * // 6
+ * // 1
+ * // 2
+ * // 3
  * ```
  *
- * The output will instead be `5 6 7 8 9 1 2 3 4`.
  * The reason for this is that Observable `b` emits its values directly and synchronously like before
  * but the emissions from `a` are scheduled on the event loop because we are now using the {@link asyncScheduler} for that specific Observable.
  *


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Small changes to docs and examples for `subscribeOn` and `race`.

**Related issue (if exists):**
