### PR TITLE
docs(installation): improve installation page

### DIFF
--- a/docs_app/content/guide/installation.md
+++ b/docs_app/content/guide/installation.md
@@ -1,6 +1,6 @@
 # Installation Instructions
 
-Here are different ways you can install RxJs:
+Here are different ways you can install RxJS:
 
 ## ES6 via npm
 
@@ -8,31 +8,32 @@ Here are different ways you can install RxJs:
 npm install rxjs
 ```
 
+To import only what you need:
+
+```ts
+import { of } from 'rxjs';
+import { map } from 'rxjs/operators';
+
+of(1, 2, 3).pipe(map(x => x + '!!!')); // etc
+```
+
+* See [Pipeable Operators](/guide/v6/pipeable-operators) for more information.
+
 To import the entire core set of functionality:
 
-```js
+```ts
 import * as rxjs from 'rxjs';
 
 rxjs.of(1, 2, 3);
 ```
 
-To import only what you need using pipeable operators:
-
-```js
-import { of } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-of(1,2,3).pipe(map(x => x + '!!!')); // etc
-```
-* See [Pipeable Operator Documentation](https://github.com/ReactiveX/rxjs/blob/91088dae1df097be2370c73300ffa11b27fd0100/doc/pipeable-operators.md) for more information about pipeable operator.
-
-To use with globally imported bundle:
+To use with a globally imported bundle:
 
 ```js
 const { of } = rxjs;
 const { map } = rxjs.operators;
 
-of(1,2,3).pipe(map(x => x + '!!!')); // etc
+of(1, 2, 3).pipe(map(x => x + '!!!')); // etc
 ```
 
 ## CommonJS via npm
@@ -65,7 +66,7 @@ npm install @reactivex/rxjs@5.0.0-beta.1
 
 ## CDN
 
-For CDN, you can use [unpkg](https://unpkg.com/). Just replace version with the current version on the link below:
+For CDN, you can use [unpkg](https://unpkg.com/). Just replace *version* with the current version on the link below:
 
 For RxJS 5.0.0-beta.1 through beta.11: [https://unpkg.com/@reactivex/rxjs@version/dist/global/Rx.umd.js](https://unpkg.com/@reactivex/rxjs@version/dist/global/Rx.umd.js)
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** Improve installation page.

The idea behind swapping the `entire core set` example with `import only what you need` is to encourage people to use the second one since that's preferable. 

**Related issue (if exists):**
