### PR TITLE
interval to timer

### DIFF
--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -26,12 +26,12 @@ import { OperatorFunction } from '../types';
  * Emit an array of the last clicks every [1-5] random seconds
  *
  * ```ts
- * import { fromEvent, interval } from 'rxjs';
+ * import { fromEvent, timer } from 'rxjs';
  * import { bufferWhen } from 'rxjs/operators';
  *
  * const clicks = fromEvent(document, 'click');
  * const buffered = clicks.pipe(bufferWhen(() =>
- *   interval(1000 + Math.random() * 4000)
+ *   timer(1000 + Math.random() * 4000)
  * ));
  * buffered.subscribe(x => console.log(x));
  * ```


### PR DESCRIPTION
bufferWhen(), instead of taking an observable to trigger the start of each new buffer, accepts a closing selector method that's re-invoked every time the buffer is closed, and the resulting observable is used to determine when the next buffer should close.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
