### PR TITLE
refactor(generate): rename parameter

### DIFF
--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -336,7 +336,7 @@ export function generate<T, S>(options: GenerateOptions<T, S>): Observable<T>;
 export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
                                condition?: ConditionFunc<S>,
                                iterate?: IterateFunc<S>,
-                               resultSelectorOrObservable?: (ResultFunc<S, T>) | SchedulerLike,
+                               resultSelectorOrScheduler?: (ResultFunc<S, T>) | SchedulerLike,
                                scheduler?: SchedulerLike): Observable<T> {
 
   let resultSelector: ResultFunc<S, T>;
@@ -349,13 +349,13 @@ export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
     iterate = options.iterate;
     resultSelector = options.resultSelector || identity as ResultFunc<S, T>;
     scheduler = options.scheduler;
-  } else if (resultSelectorOrObservable === undefined || isScheduler(resultSelectorOrObservable)) {
+  } else if (resultSelectorOrScheduler === undefined || isScheduler(resultSelectorOrScheduler)) {
     initialState = initialStateOrOptions as S;
     resultSelector = identity as ResultFunc<S, T>;
-    scheduler = resultSelectorOrObservable as SchedulerLike;
+    scheduler = resultSelectorOrScheduler as SchedulerLike;
   } else {
     initialState = initialStateOrOptions as S;
-    resultSelector = resultSelectorOrObservable as ResultFunc<S, T>;
+    resultSelector = resultSelectorOrScheduler as ResultFunc<S, T>;
   }
 
   return new Observable<T>(subscriber => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I read the code and realised that the name of one of the parameters of the `generate` function are is incorrect,

So basically I renamed `resultSelectorOrObservable` -> `resultSelectorOrScheduler`,
Just for clarity.

**Related issue (if exists):**
