### PR TITLE
docs: fixed showing type in docs of Subscription

### DIFF
--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -25,9 +25,8 @@ export class Subscription implements SubscriptionLike {
 
   /**
    * A flag to indicate whether this Subscription has already been unsubscribed.
-   * @param {boolean}
    */
-  public closed: boolean = false;
+  public closed = false;
 
   /** @internal */
   protected _parentOrParents: Subscription | Subscription[] = null;

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -25,7 +25,7 @@ export class Subscription implements SubscriptionLike {
 
   /**
    * A flag to indicate whether this Subscription has already been unsubscribed.
-   * @type {boolean}
+   * @param {boolean}
    */
   public closed: boolean = false;
 


### PR DESCRIPTION
**Description:**

Fix type definition to show in proper way in documentation.
(https://rxjs-dev.firebaseapp.com/api/index/class/Subscription#closed)
Before: 

```
class Subscription implements SubscriptionLike {
  .....
  closed: [object Object]
  ....
}
```

After:

```
class Subscription implements SubscriptionLike {
  .....
  closed: boolean
  ....
}
```

**Related issue (if exists):**

Fix #5035 