### PR TITLE
docs(operators): add note about first() vs take(1)

### DIFF
--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -66,6 +66,7 @@ export function first<T, D = T>(
  *
  * @throws {EmptyError} Delivers an EmptyError to the Observer's `error`
  * callback if the Observable completes before any `next` notification was sent.
+ * This is how `first()` is different from {@link take}(1) which completes instead.
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} [predicate]
  * An optional function called with each item to test for condition matching.


### PR DESCRIPTION
**Description:**
In the docs for the `first` operator add a note that `first()` is different from `take(1)`. First throws `EmptyError` if there are no elements in the source.

see also https://twitter.com/fmalcher01/status/1213417124036784128

