### PR TITLE
Expect observable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,5 @@ npm-debug.log
 # The check-side-effects package generates and deletes this file.
 # If the process is killed, it will be left behind.
 check-side-effects.tmp-input.js
+/.vs/rxjs/config/applicationhost.config
+/.vs

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -121,7 +121,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   expectObservable(observable: Observable<any>,
-    subscriptionMarbles: string = null): ({ toBe: observableToBeFn, actual: TestMessage[] }) {
+    subscriptionMarbles: string = null): ({ toBe: observableToBeFn, actual: object[] }) {
     const actual: TestMessage[] = [];
     const flushTest: FlushableTest = { actual, ready: false };
     const subscriptionParsed = TestScheduler.parseMarblesAsSubscriptions(subscriptionMarbles, this.runMode);

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -156,8 +156,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       toBe(marbles: string, values?: any, errorValue?: any) {
         flushTest.ready = true;
         flushTest.expected = TestScheduler.parseMarbles(marbles, values, errorValue, true, runMode);
-      }
-      , actual
+      }, actual
     };
   }
 

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -121,7 +121,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   expectObservable(observable: Observable<any>,
-                   subscriptionMarbles: string = null): ({ toBe: observableToBeFn }) {
+    subscriptionMarbles: string = null): ({ toBe: observableToBeFn, actual: TestMessage[] }) {
     const actual: TestMessage[] = [];
     const flushTest: FlushableTest = { actual, ready: false };
     const subscriptionParsed = TestScheduler.parseMarblesAsSubscriptions(subscriptionMarbles, this.runMode);
@@ -157,6 +157,7 @@ export class TestScheduler extends VirtualTimeScheduler {
         flushTest.ready = true;
         flushTest.expected = TestScheduler.parseMarbles(marbles, values, errorValue, true, runMode);
       }
+      , actual
     };
   }
 


### PR DESCRIPTION
write expected marbles is difficultly. tell whether result of pipeline is right is simpler than the figure out it's result. so suggest add `actual` prop that is testmessage[] into expectedObservable() function's return object.