### PR TITLE
update Operators.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ npm-debug.log
 # The check-side-effects package generates and deletes this file.
 # If the process is killed, it will be left behind.
 check-side-effects.tmp-input.js
+/.vs

--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -4,7 +4,7 @@ RxJS is mostly useful for its *operators*, even though the Observable is the fou
 
 Operators are **functions**. There are two kinds of operators:
 
-**Pipeable Operators** are the kind that can be piped to Observables  using the syntax `observableInstance.pipe(operator())`. These  include, [`filter(...)`](/api/operators/filter),  and  [`mergeMap(...)`](/api/operators/mergeMap). When called, they do not *change* the existing Observable instance. Instead, they return a *new* Observable, whose subscription logic is based on the first Observable.
+**Pipeable Operators** are the kind that can be piped to Observables using the syntax `observableInstance.pipe(operator())`. These include, [`filter(...)`](/api/operators/filter), and [`mergeMap(...)`](/api/operators/mergeMap). When called, they do not *change* the existing Observable instance. Instead, they return a *new* Observable, whose subscription logic is based on the first Observable.
 
 <span class="informal">A Pipeable Operator is a function that takes an Observable as its input and returns another Observable. It is a pure operation: the previous Observable stays unmodified.</span>
 
@@ -27,7 +27,7 @@ map(x => x * x)(of(1, 2, 3)).subscribe((v) => console.log(`value: ${v}`));
 
 ```
 
-will emit `1`, `4`, `9`.  Another useful operator is [`first`](/api/operators/first):
+will emit `1`, `4`, `9`. Another useful operator is [`first`](/api/operators/first):
 
 ```ts
 import { of } from 'rxjs';
@@ -39,7 +39,7 @@ first()(of(1, 2, 3)).subscribe((v) => console.log(`value: ${v}`));
 // value: 1 
 ```
 
-Note that `map` logically must be constructed on the fly, since it must be given the mapping function to.  By contrast, `first` could be a constant, but is nonetheless constructed on the fly.  As a general practice, all operators are constructed, whether they need arguments or not.
+Note that `map` logically must be constructed on the fly, since it must be given the mapping function to. By contrast, `first` could be a constant, but is nonetheless constructed on the fly. As a general practice, all operators are constructed, whether they need arguments or not.
 
 ## Piping
 
@@ -56,7 +56,6 @@ obs.pipe(
 
 As a stylistic matter, `op()(obs)` is never used, even if there is only one operator; `obs.pipe(op())` is universally preferred.
 
-
 ## Creation Operators
 
 **What are creation operators?** Distinct from pipeable operators, creation operators are functions that can be used to create an Observable with some common predefined behavior or by joining other Observables.
@@ -71,10 +70,9 @@ const observable = interval(1000 /* number of milliseconds */);
 
 See the list of [all static creation operators here](#creation-operators-list).
 
-
 ## Higher-order Observables
 
-Observables most commonly emit ordinary values like strings and numbers, but surprisingly often, it is necessary to handle Observables *of* Observables, so-called higher-order Observables.  For example, imagine you had an Observable emitting strings that were the URLs of files you wanted to see.  The code might look like this:
+Observables most commonly emit ordinary values like strings and numbers, but surprisingly often, it is necessary to handle Observables *of* Observables, so-called higher-order Observables. For example, imagine you had an Observable emitting strings that were the URLs of files you wanted to see. The code might look like this:
 
 ```ts
 const fileObservable = urlObservable.pipe(
@@ -82,9 +80,9 @@ const fileObservable = urlObservable.pipe(
 );
 ```
 
-`http.get()` returns an Observable (of string or string arrays probably) for each individual URL.  Now you have an Observables *of* Observables, a higher-order Observable.
+`http.get()` returns an Observable (of string or string arrays probably) for each individual URL. Now you have an Observables *of* Observables, a higher-order Observable.
 
-But how do you work with a higher-order Observable? Typically, by _flattening_: by (somehow) converting a higher-order Observable into an ordinary Observable.  For example:
+But how do you work with a higher-order Observable? Typically, by _flattening_: by (somehow) converting a higher-order Observable into an ordinary Observable. For example:
 
 ```ts
 const fileObservable = urlObservable.pipe(
@@ -93,15 +91,13 @@ const fileObservable = urlObservable.pipe(
 );
 ```
 
-The [`concatAll()`](/api/operators/concatAll) operator subscribes to each "inner" Observable that comes out of the "outer" Observable, and copies all the emitted values until that Observable completes, and goes on to the next one.  All of the values are in that way concatenated.  Other useful flattening operators (called [*join operators*](#join-operators)) are
+The [`concatAll()`](/api/operators/concatAll) operator subscribes to each "inner" Observable that comes out of the "outer" Observable, and copies all the emitted values until that Observable completes, and goes on to the next one. All of the values are in that way concatenated. Other useful flattening operators (called [*join operators*](#join-operators)) are
 
 * [`mergeAll()`](/api/operators/mergeAll) — subscribes to each inner Observable as it arrives, then emits each value as it arrives
 * [`switchAll()`](/api/operators/switchAll) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, but when the next inner Observable arrives, unsubscribes to the previous one, and subscribes to the new one.
 * [`exhaust()`](/api/operators/exhaust) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, discarding all newly arriving inner Observables until that first one completes, then waits for the next inner Observable.
 
 Just as many array library combine [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`flat()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) (or `flatten()`) into a single [`flatMap()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap), there are mapping equivalents of all the RxJS flattening operators [`concatMap()`](/api/operators/concatMap), [`mergeMap()`](/api/operators/mergeMap), [`switchMap()`](/api/operators/switchMap), and [`exhaustMap()`](/api/operators/exhaustMap).
-
-
 
 ## Marble diagrams
 
@@ -140,6 +136,7 @@ For a complete overview, see the [references page](/api).
 - [`iif`](/api/index/function/iif)
 
 ### <a id="join-creation-operators"></a>Join Creation Operators
+
 These are Observable creation operators that also have join functionality -- emitting values of multiple source Observables.
 
 - [`combineLatest`](/api/index/function/combineLatest)
@@ -148,6 +145,7 @@ These are Observable creation operators that also have join functionality -- emi
 - [`merge`](/api/index/function/merge)
 - [`race`](/api/index/function/race)
 - [`zip`](/api/index/function/zip)
+- [`partition`](/api/index/function/partition)
 
 ### Transformation Operators
 
@@ -168,7 +166,6 @@ These are Observable creation operators that also have join functionality -- emi
 - [`mergeMapTo`](/api/operators/mergeMapTo)
 - [`mergeScan`](/api/operators/mergeScan)
 - [`pairwise`](/api/operators/pairwise)
-- [`partition`](/api/operators/partition)
 - [`pluck`](/api/operators/pluck)
 - [`scan`](/api/operators/scan)
 - [`switchMap`](/api/operators/switchMap)
@@ -209,6 +206,7 @@ These are Observable creation operators that also have join functionality -- emi
 - [`throttleTime`](/api/operators/throttleTime)
 
 ### <a id="join-operators"></a>Join Operators
+
 Also see the [Join Creation Operators](#join-creation-operators) section above.
 
 - [`combineAll`](/api/operators/combineAll)
@@ -263,8 +261,6 @@ Also see the [Join Creation Operators](#join-creation-operators) section above.
 - [`min`](/api/operators/min)
 - [`reduce`](/api/operators/reduce)
 
-
-
 ## Creating custom observables
 
 ### Use the `pipe()` function to make new operators
@@ -275,7 +271,7 @@ For example, you could make a function that discarded odd values and doubled eve
 
 ```ts
 import { pipe } from 'rxjs';
-import { filter, map } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
 
 function discardOddDoubleEven() {
   return pipe(


### PR DESCRIPTION
make some changes as follows:
1. \s+ replace to single space.
2. `import { filter, map } from 'rxj';` package path error.