### PR TITLE
Fix AjaxTimeoutErrorImpl to extend AjaxError

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,7 +128,7 @@ from the main (upstream) repository:
 ## Unit Tests
 
 Unit tests are located under the [spec directory](/spec). Unit tests over synchronous operators and operations
-can be written in a standard [jasmine](http://jasmine.github.io/) style. Unit tests written against any
+can be written in a standard [chai](https://www.chaijs.com/) style. Unit tests written against any
 asynchronous operator should be written in [Marble Test Style outlined in detail here](doc/writing-marble-tests.md).
 
 Each operator under test must be in its own file to cover the following cases:

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -1082,6 +1082,27 @@ describe('ajax', () => {
       expect(request.headers).to.equal(headers);
     });
   });
+
+  describe('ajax error classes', () => {
+    describe('AjaxError', () => {
+      it('should extend Error class', () => {
+        const error = new AjaxError('Test error', new XMLHttpRequest(), {});
+        expect(error).to.be.an.instanceOf(Error);
+      });
+    });
+
+    describe('AjaxTimeoutError', () => {
+      it('should extend Error class', () => {
+        const error = new AjaxTimeoutError(new XMLHttpRequest(), {});
+        expect(error).to.be.an.instanceOf(Error);
+      });
+
+      it('should extend AjaxError class', () => {
+        const error = new AjaxTimeoutError(new XMLHttpRequest(), {});
+        expect(error).to.be.an.instanceOf(AjaxError);
+      });
+    });
+  });
 });
 
 class MockXMLHttpRequest {

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -536,11 +536,15 @@ export interface AjaxTimeoutErrorCtor {
   new(xhr: XMLHttpRequest, request: AjaxRequest): AjaxTimeoutError;
 }
 
-function AjaxTimeoutErrorImpl(this: any, xhr: XMLHttpRequest, request: AjaxRequest) {
-  AjaxError.call(this, 'ajax timeout', xhr, request);
-  this.name = 'AjaxTimeoutError';
-  return this;
-}
+const AjaxTimeoutErrorImpl = (() => {
+  function AjaxTimeoutErrorImpl(this: any, xhr: XMLHttpRequest, request: AjaxRequest) {
+    AjaxError.call(this, 'ajax timeout', xhr, request);
+    this.name = 'AjaxTimeoutError';
+    return this;
+  }
+  AjaxTimeoutErrorImpl.prototype = Object.create(AjaxError.prototype);
+  return AjaxTimeoutErrorImpl;
+})();
 
 /**
  * @see {@link ajax}


### PR DESCRIPTION
Fixed AjaxTimeoutError not inheriting AjaxError's and Eerror's
prototype. While the TypeScript typings were correct, actual code
using instanceof operator would fail.

The following statements are now true:
* AjaxError instanceof Error === true
* AjaxTimeoutError instanceof Error === true
* AjaxTimeoutError instanceof AjaxError === true
