### PR TITLE
docs(fetch): example code return different type

### DIFF
--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -28,7 +28,7 @@ import { Observable } from '../../Observable';
  *      return response.json();
  *    } else {
  *      // Server is returning a status requiring the client to try something else.
- *      return of({ error: true, message: `Error ${response.status}` });
+ *      return { error: true, message: `Error ${response.status}` };
  *    }
  *  }),
  *  catchError(err => {


### PR DESCRIPTION
if and else return different type's data, whether is this a bug?

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
