### PR TITLE
fix: don't reassign closed-over parameter in fromFetch

### DIFF
--- a/spec/observables/dom/fetch-spec.ts
+++ b/spec/observables/dom/fetch-spec.ts
@@ -176,6 +176,25 @@ describe('fromFetch', () => {
     expect(mockFetch.calls[0].init.signal.aborted).to.be.true;
   });
 
+  it('should not immediately abort repeat subscribers', () => {
+    const fetch$ = fromFetch('/foo');
+    expect(mockFetch.calls.length).to.equal(0);
+    expect(MockAbortController.created).to.equal(0);
+    let subscription = fetch$.subscribe();
+    expect(MockAbortController.created).to.equal(1);
+    expect(mockFetch.calls[0].init.signal.aborted).to.be.false;
+
+    subscription.unsubscribe();
+    expect(mockFetch.calls[0].init.signal.aborted).to.be.true;
+
+    subscription = fetch$.subscribe();
+    expect(MockAbortController.created).to.equal(2);
+    expect(mockFetch.calls[1].init.signal.aborted).to.be.false;
+
+    subscription.unsubscribe();
+    expect(mockFetch.calls[1].init.signal.aborted).to.be.true;
+  });
+
   it('should allow passing of init object', done => {
     const fetch$ = fromFetch('/foo', {method: 'HEAD'});
     fetch$.subscribe({

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -58,6 +58,7 @@ export function fromFetch(input: string | Request, init?: RequestInit): Observab
     let abortable = true;
     let unsubscribed = false;
 
+    let perSubscriberInit;
     if (init) {
       // If a signal is provided, just have it teardown. It's a cancellation token, basically.
       if (init.signal) {
@@ -72,12 +73,14 @@ export function fromFetch(input: string | Request, init?: RequestInit): Observab
           init.signal.addEventListener('abort', outerSignalHandler);
         }
       }
-      init = { ...init, signal };
+      // init cannot be mutated or reassigned as it's closed over by the
+      // subscriber callback and is shared between subscribers.
+      perSubscriberInit = { ...init, signal };
     } else {
-      init = { signal };
+      perSubscriberInit = { signal };
     }
 
-    fetch(input, init).then(response => {
+    fetch(input, perSubscriberInit).then(response => {
       abortable = false;
       subscriber.next(response);
       subscriber.complete();

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -58,7 +58,7 @@ export function fromFetch(input: string | Request, init?: RequestInit): Observab
     let abortable = true;
     let unsubscribed = false;
 
-    let perSubscriberInit;
+    let perSubscriberInit: RequestInit;
     if (init) {
       // If a signal is provided, just have it teardown. It's a cancellation token, basically.
       if (init.signal) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes the problem reported in #5233. It:

* adds a failing test; and
* uses a local variable instead of reassigning to a closed-over parameter that's shared between subscribers.

**Related issue (if exists):** #5233
