### PR TITLE
fix: chain subscriptions for interop with finalize

### DIFF
--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import { finalize, map, share } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { of, timer, interval } from 'rxjs';
+import { of, timer, interval, NEVER } from 'rxjs';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare const type: Function;
 
@@ -160,5 +161,15 @@ describe('finalize operator', () => {
     // manually flush so `finalize()` has chance to execute before the test is over.
     rxTestScheduler.flush();
     expect(executed).to.be.true;
+  });
+
+  it('should handle interop source observables', () => {
+    // https://github.com/ReactiveX/rxjs/issues/5237
+    let finalized = false;
+    const subscription = asInteropObservable(NEVER).pipe(
+      finalize(() => finalized = true)
+    ).subscribe();
+    subscription.unsubscribe();
+    expect(finalized).to.be.true;
   });
 });

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -68,7 +68,15 @@ class FinallyOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source.subscribe(new FinallySubscriber(subscriber, this.callback));
+    // The returned subscription will usually be the FinallySubscriber.
+    // However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+    const finallySubscriber = new FinallySubscriber(subscriber, this.callback);
+    const subscription = source.subscribe(finallySubscriber);
+    if (subscription !== finallySubscriber) {
+      subscription.add(finallySubscriber);
+    }
+    return subscription;
   }
 }
 

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -3,6 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { subscribeWith } from '../util/subscribeWith';
 
 /**
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
@@ -68,15 +69,7 @@ class FinallyOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    // The returned subscription will usually be the FinallySubscriber.
-    // However, interop subscribers will be wrapped and for
-    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-    const finallySubscriber = new FinallySubscriber(subscriber, this.callback);
-    const subscription = source.subscribe(finallySubscriber);
-    if (subscription !== finallySubscriber) {
-      subscription.add(finallySubscriber);
-    }
-    return subscription;
+    return subscribeWith(source, new FinallySubscriber(subscriber, this.callback));
   }
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The change in this PR is very similar to the changes that were made in #5059: when an interop subscriber is created within `finalize`, it'll be wrapped when a subscription is made to the source observable in `FinallyOperator#call`. The interop subscriber needs to be added to the subscription so that unsubscription chains property and the finalize callback is invoked.

The adding of the interop subscription is now handled in `subscribeWith` - which was added in https://github.com/ReactiveX/rxjs/pull/5333.

This PR also includes a failing test that is fixed by the above change.

**Related issue (if exists):** #5237