### PR TITLE
chore: tweak tsconfig options

### DIFF
--- a/spec-dtslint/tsconfig.json
+++ b/spec-dtslint/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "baseUrl": ".",
-    "lib": ["es2015", "dom"],
+    "lib": ["esnext", "dom"],
     "module": "commonjs",
     "noEmit": true,
     "noImplicitAny": true,
@@ -12,6 +12,6 @@
     },
     "skipLibCheck": true,
     "strict": true,
-    "target": "es2015"
+    "target": "esnext"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,10 +13,10 @@
     "stripInternal": false,
     "noEmit": true,
     "lib": [
-      "es5",
-      "es2018",
+      "esnext",
       "dom"
     ],
+    "target": "esnext",
     "baseUrl": ".",
     "paths": {
       "rxjs": ["./src/index"],


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR tweaks the options in the root and dtslint `tsconfig.json` files so that the latest builtin types are included - via the `lib` option - and so that the default `target` is no longer the TypeScript default of `es3` (!!!). The problem with the latter is that IDE's pick up the root `tsconfig` and if the `target` is inferred to be `es3`, errors like this are shown:

<img width="559" alt="error" src="https://user-images.githubusercontent.com/3878593/72655907-5e428a80-39e3-11ea-80ee-2abf1da2933c.png">


**Related issue (if exists):** None
