### PR TITLE
[WIP] fix: ensure all interop operators are chained correctly

### DIFF
--- a/spec/helpers/interop-helper.ts
+++ b/spec/helpers/interop-helper.ts
@@ -1,4 +1,4 @@
-import { Observable, Subscriber, Subscription } from 'rxjs';
+import { Observable, Operator, Subscriber, Subscription } from 'rxjs';
 import { rxSubscriber as symbolSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
 
 /**
@@ -10,6 +10,10 @@ import { rxSubscriber as symbolSubscriber } from 'rxjs/internal/symbol/rxSubscri
 export function asInteropObservable<T>(observable: Observable<T>): Observable<T> {
   return new Proxy(observable, {
     get(target: Observable<T>, key: string | number | symbol) {
+      if (key === 'lift') {
+        const { lift } = target;
+        return interopLift(lift);
+      }
       if (key === 'subscribe') {
         const { subscribe } = target;
         return interopSubscribe(subscribe);
@@ -17,9 +21,10 @@ export function asInteropObservable<T>(observable: Observable<T>): Observable<T>
       return Reflect.get(target, key);
     },
     getPrototypeOf(target: Observable<T>) {
-      const { subscribe, ...rest } = Object.getPrototypeOf(target);
+      const { lift, subscribe, ...rest } = Object.getPrototypeOf(target);
       return {
         ...rest,
+        lift: interopLift(lift),
         subscribe: interopSubscribe(subscribe)
       };
     }
@@ -44,6 +49,18 @@ export function asInteropSubscriber<T>(subscriber: Subscriber<T>): Subscriber<T>
       return rest;
     }
   });
+}
+
+function interopLift<T, R>(lift: (operator: Operator<T, R>) => Observable<R>) {
+  return function (this: Observable<T>, operator: Operator<T, R>): Observable<R> {
+    const observable = lift.call(this, operator);
+    const { call } = observable.operator;
+    observable.operator.call = function (this: Operator<T, R>, subscriber: Subscriber<T>, source: any) {
+      return call.call(this, asInteropSubscriber(subscriber), source);
+    };
+    observable.source = asInteropObservable(observable.source);
+    return asInteropObservable(observable);
+  };
 }
 
 function interopSubscribe<T>(subscribe: (...args: any[]) => Subscription) {

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -2,7 +2,8 @@ import { expect } from 'chai';
 import { finalize, map, share } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { of, timer, interval } from 'rxjs';
+import { of, timer, interval, NEVER } from 'rxjs';
+import { asInteropObservable } from '../helpers/interop-helper';
 
 declare const type: Function;
 
@@ -160,5 +161,15 @@ describe('finalize operator', () => {
     // manually flush so `finalize()` has chance to execute before the test is over.
     rxTestScheduler.flush();
     expect(executed).to.be.true;
+  });
+
+  it('should handle interop source observables', () => {
+    // https://github.com/ReactiveX/rxjs/issues/5237
+    let finalized = false;
+    const subscription = asInteropObservable(NEVER).pipe(
+      finalize(() => finalized = true)
+    ).subscribe();
+    subscription.unsubscribe();
+    expect(finalized).to.be.true;
   });
 });

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -69,7 +69,15 @@ class FinallyOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source.subscribe(new FinallySubscriber(subscriber, this.callback));
+    // The returned subscription will usually be the FinallySubscriber.
+    // However, interop subscribers will be wrapped and for
+    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+    const finallySubscriber = new FinallySubscriber(subscriber, this.callback);
+    const subscription = source.subscribe(finallySubscriber);
+    if (subscription !== finallySubscriber) {
+      subscription.add(finallySubscriber);
+    }
+    return subscription;
   }
 }
 

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -3,6 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { subscribeAndChainOperator } from '../util/subscribeAndChainOperator';
 
 /**
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
@@ -69,15 +70,10 @@ class FinallyOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    // The returned subscription will usually be the FinallySubscriber.
-    // However, interop subscribers will be wrapped and for
-    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-    const finallySubscriber = new FinallySubscriber(subscriber, this.callback);
-    const subscription = source.subscribe(finallySubscriber);
-    if (subscription !== finallySubscriber) {
-      subscription.add(finallySubscriber);
-    }
-    return subscription;
+    return subscribeAndChainOperator(
+      new FinallySubscriber(subscriber, this.callback),
+      source
+    );
   }
 }
 

--- a/src/internal/util/subscribeAndChainOperator.ts
+++ b/src/internal/util/subscribeAndChainOperator.ts
@@ -1,0 +1,21 @@
+import { Observable } from '../Observable';
+import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
+
+/**
+ * Subscribes an operator's subscriber to its source and ensures that
+ * unsubscription is chained for interop operators.
+ */
+export function subscribeAndChainOperator<T>(
+  subscriber: Subscriber<T>,
+  source: Observable<T>
+): Subscription {
+  const subscription = source.subscribe(subscriber);
+  // The returned subscription will usually be the operator's subscriber.
+  // However, interop subscribers will be wrapped and for
+  // unsubscriptions to chain correctly, the wrapper needs to be added, too.
+  if (subscription !== subscriber) {
+    subscription.add(subscriber);
+  }
+  return subscription;
+}


### PR DESCRIPTION
**WIP:**

https://github.com/ReactiveX/rxjs/pull/5333 is likely a better solution to the problem.

---

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the fix in #5239 so that it can be applied to all operators - or at least to those that need unsubscription to be chained.

The problem is outlined in the linked issue, but AFAICT the problem is not specific to the `finalize` operator. For example, the `buffer` operator's subscriber adds a subscription that depends upon unsubscription being chained correctly:

https://github.com/ReactiveX/rxjs/blob/56e7cebd211d93b9958e1ec508052beb8927604a/src/internal/operators/buffer.ts#L73-L76

And `windowTime` adds scheduled actions:

https://github.com/ReactiveX/rxjs/blob/56e7cebd211d93b9958e1ec508052beb8927604a/src/internal/operators/windowTime.ts#L189-L206

IMO, all operator subscriptions made within an operator's `call` method should be made using `subscribeAndChainOperator`.

ATM, this PR's branch is based on #5239, so it includes that PR's commits. The last two commits are the changes introduced in this PR.

**Related issue (if exists):** #5239
