### PR TITLE
chore: enable fully strict TypeScript option

### DIFF
--- a/spec-dtslint/tsconfig.json
+++ b/spec-dtslint/tsconfig.json
@@ -4,8 +4,6 @@
     "lib": ["es2015", "dom"],
     "module": "commonjs",
     "noEmit": true,
-    "noImplicitAny": true,
-    "noImplicitThis": true,
     "paths": {
       "rxjs": ["../dist/types"],
       "rxjs/operators": ["../dist/types/operators"]

--- a/spec/Notification-spec.ts
+++ b/spec/Notification-spec.ts
@@ -145,7 +145,7 @@ describe('Notification', () => {
       const value = 'a';
       let observed = false;
       const n = Notification.createNext(value);
-      const observer = Subscriber.create((x: string) => {
+      const observer = Subscriber.create((x?: string) => {
         expect(x).to.equal(value);
         observed = true;
       }, (err: any) => {
@@ -161,7 +161,7 @@ describe('Notification', () => {
     it('should accept observer for error Notification', () => {
       let observed = false;
       const n = Notification.createError<string>();
-      const observer = Subscriber.create((x: string) => {
+      const observer = Subscriber.create((x?: string) => {
         throw 'should not be called';
       }, (err: any) => {
         observed = true;
@@ -176,7 +176,7 @@ describe('Notification', () => {
     it('should accept observer for complete Notification', () => {
       let observed = false;
       const n = Notification.createComplete();
-      const observer = Subscriber.create((x: string) => {
+      const observer = Subscriber.create((x?: string) => {
         throw 'should not be called';
       }, (err: any) => {
         throw 'should not be called';
@@ -240,7 +240,7 @@ describe('Notification', () => {
       const value = 'a';
       let observed = false;
       const n = Notification.createNext(value);
-      const observer = Subscriber.create((x: string) => {
+      const observer = Subscriber.create((x?: string) => {
         expect(x).to.equal(value);
         observed = true;
       }, (err: any) => {

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -871,7 +871,7 @@ describe('Observable.lift', () => {
         next(value?: T): void {
           log.push('next ' + value);
           if (!this.isStopped) {
-            this._next(value);
+            this._next(value!);
           }
         }
       }

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -84,7 +84,7 @@ describe('Subscriber', () => {
   });
 
   it('should call complete observer without any arguments', () => {
-    let argument: Array<any> = null;
+    let argument: Array<any> | null = null;
 
     const observer = {
       complete: (...args: Array<any>) => {

--- a/spec/helpers/marble-testing.ts
+++ b/spec/helpers/marble-testing.ts
@@ -28,7 +28,7 @@ export function cold(marbles: string, values?: any, error?: any): ColdObservable
 }
 
 export function expectObservable(observable: Observable<any>,
-                                 unsubscriptionMarbles: string = null): ({ toBe: observableToBeFn }) {
+                                 unsubscriptionMarbles: string | null = null): ({ toBe: observableToBeFn }) {
   if (!global.rxTestScheduler) {
     throw 'tried to use expectObservable() in async test';
   }

--- a/spec/helpers/tests2png/diagram-test-runner.ts
+++ b/spec/helpers/tests2png/diagram-test-runner.ts
@@ -67,7 +67,7 @@ function postProcessOutputMessage(msg: TestMessage) {
 }
 
 function makeFilename(operatorLabel: string) {
-  return /^(\w+)/.exec(operatorLabel)[1] + '.png';
+  return /^(\w+)/.exec(operatorLabel)![1] + '.png';
 }
 
 type glitFn = (description: string, fn: () => void ) => any;

--- a/spec/helpers/tests2png/painter.ts
+++ b/spec/helpers/tests2png/painter.ts
@@ -1,7 +1,7 @@
 /*eslint-disable no-param-reassign, no-use-before-define*/
-// @ts-ignore
+// @ts-ignore: Could not find a declaration file for module
 import * as gm from 'gm';
-// @ts-ignore
+// @ts-ignore: Could not find a declaration file for module
 import * as Color from 'color';
 import { cloneDeep, isEqual} from 'lodash';
 import { TestMessage } from '../../../src/internal/testing/TestMessage';

--- a/spec/helpers/tests2png/painter.ts
+++ b/spec/helpers/tests2png/painter.ts
@@ -84,22 +84,22 @@ function areEqualStreamData(leftStreamData: TestStream, rightStreamData: TestStr
 
 function measureObservableArrow(maxFrame: number, streamData: TestStream): { startX: number, endX: number } {
   let startX = CANVAS_PADDING +
-    MESSAGES_WIDTH * (streamData.subscription.start / maxFrame);
+    MESSAGES_WIDTH * (streamData.subscription!.start / maxFrame);
   let MAX_MESSAGES_WIDTH = CANVAS_WIDTH - CANVAS_PADDING;
   let lastMessageFrame = streamData.messages
     .reduce(function (acc, msg) {
       let frame = msg.frame;
       return frame > acc ? frame : acc;
     }, 0);
-  let subscriptionEndX = typeof streamData.subscription.end === 'number' ? CANVAS_PADDING +
-      MESSAGES_WIDTH * (streamData.subscription.end / maxFrame) +
+  let subscriptionEndX = typeof streamData.subscription!.end === 'number' ? CANVAS_PADDING +
+      MESSAGES_WIDTH * (streamData.subscription!.end / maxFrame) +
       OBSERVABLE_END_PADDING : undefined;
   let streamEndX = startX +
     MESSAGES_WIDTH * (lastMessageFrame / maxFrame) +
     OBSERVABLE_END_PADDING;
-  let endX = (streamData.subscription.end === '100%') ?
+  let endX = (streamData.subscription!.end === '100%') ?
     MAX_MESSAGES_WIDTH :
-    Math.max(streamEndX, subscriptionEndX);
+    Math.max(streamEndX, subscriptionEndX!);
 
   return {startX: startX, endX: endX};
 }
@@ -205,7 +205,7 @@ function drawMarble(out: GMObject, x: number, y: number, inclination: number, co
   out = out.fill(outlineColor);
   out = out.font('helvetica', 28);
   out = out.draw(
-    'translate ' + (x - CANVAS_WIDTH * 0.5) + ',' + (y + inclination - canvasHeight * 0.5),
+    'translate ' + (x - CANVAS_WIDTH * 0.5) + ',' + (y + inclination - canvasHeight! * 0.5),
     'gravity Center',
     'text 0,0',
     stringifyContent(content));
@@ -238,7 +238,7 @@ function drawComplete(out: GMObject, x: number, y: number,
                       maxFrame: number, angle: number, streamData: TestStream,
                       isSpecial: boolean, isGhost: boolean) {
   let startX = CANVAS_PADDING +
-    MESSAGES_WIDTH * (streamData.subscription.start / maxFrame);
+    MESSAGES_WIDTH * (streamData.subscription!.start / maxFrame);
   let isOverlapping = streamData.messages.some(function (msg) {
     if (msg.notification.kind !== 'N') { return false; }
     let msgX = startX + MESSAGES_WIDTH * (msg.frame / maxFrame);
@@ -272,7 +272,7 @@ function drawNestedObservable(out: GMObject, maxFrame: number, y: number, stream
 
 function drawObservableMessages(out: GMObject, maxFrame: number, baseY: number, angle: number, streamData: TestStream, isSpecial: boolean): GMObject {
   let startX = CANVAS_PADDING +
-    MESSAGES_WIDTH * (streamData.subscription.start / maxFrame);
+    MESSAGES_WIDTH * (streamData.subscription!.start / maxFrame);
   let messages = streamData.messages;
 
   messages.slice().reverse().forEach(function (message: TestMessage, reversedIndex: number) {
@@ -291,11 +291,11 @@ function drawObservableMessages(out: GMObject, maxFrame: number, baseY: number, 
       if (isNestedStreamData(message)) {
         out = drawNestedObservable(out, maxFrame, y, message.notification.value);
       } else {
-        out = drawMarble(out, x, y, inclination, message.notification.value, isSpecial, streamData.isGhost);
+        out = drawMarble(out, x, y, inclination, message.notification.value, isSpecial, streamData.isGhost!);
       }
       break;
-    case 'E': out = drawError(out, x, y, startX, angle, isSpecial, streamData.isGhost); break;
-    case 'C': out = drawComplete(out, x, y, maxFrame, angle, streamData, isSpecial, streamData.isGhost); break;
+    case 'E': out = drawError(out, x, y, startX, angle, isSpecial, streamData.isGhost!); break;
+    case 'C': out = drawComplete(out, x, y, maxFrame, angle, streamData, isSpecial, streamData.isGhost!); break;
     default: break;
     }
   });
@@ -320,7 +320,7 @@ function drawOperator(out: GMObject, label: string, y: number): GMObject {
   out = out.fill(BLACK_COLOR);
   out = out.font('helvetica', 54);
   out = out.draw(
-    'translate 0,' + (y + OPERATOR_HEIGHT * 0.5 - canvasHeight * 0.5),
+    'translate 0,' + (y + OPERATOR_HEIGHT * 0.5 - canvasHeight! * 0.5),
     'gravity Center',
     'text 0,0',
     stringifyContent(label));
@@ -336,10 +336,10 @@ function removeDuplicateInputs(inputStreams: TestStream[], outputStreams: TestSt
           inputStream.cold &&
           isEqual(msg.notification.value.messages, inputStream.cold.messages);
         if (passes) {
-          if (inputStream.cold.subscriptions.length) {
+          if (inputStream.cold!.subscriptions.length) {
             msg.notification.value.subscription = {
-              start: inputStream.cold.subscriptions[0].subscribedFrame,
-              end: inputStream.cold.subscriptions[0].unsubscribedFrame
+              start: inputStream.cold!.subscriptions[0].subscribedFrame,
+              end: inputStream.cold!.subscriptions[0].unsubscribedFrame
             };
           }
         }

--- a/spec/observables/IteratorObservable-spec.ts
+++ b/spec/observables/IteratorObservable-spec.ts
@@ -11,10 +11,10 @@ declare const rxTestScheduler: TestScheduler;
 describe('fromIterable', () => {
   it('should not accept null (or truthy-equivalent to null) iterator', () => {
     expect(() => {
-      fromIterable(null, undefined);
+      fromIterable(null as any, undefined);
     }).to.throw(Error, 'Iterable cannot be null');
     expect(() => {
-      fromIterable(void 0, undefined);
+      fromIterable(void 0 as any, undefined);
     }).to.throw(Error, 'Iterable cannot be null');
   });
 
@@ -47,7 +47,7 @@ describe('fromIterable', () => {
 
     rxTestScheduler.flush();
     expect(v1).to.deep.equal(expected);
-    expect(v2).to.deep.equal(expected);
+    expect(v2!).to.deep.equal(expected);
   });
 
   it('should finalize generators if the subscription ends', () => {

--- a/spec/observables/SubscribeOnObservable-spec.ts
+++ b/spec/observables/SubscribeOnObservable-spec.ts
@@ -28,8 +28,8 @@ describe('SubscribeOnObservable', () => {
   });
 
   it('should create observable via staic create function', () => {
-    const s = new SubscribeOnObservable(null, null, rxTestScheduler);
-    const r = SubscribeOnObservable.create(null, null, rxTestScheduler);
+    const s = new SubscribeOnObservable(null as any, null as any, rxTestScheduler);
+    const r = SubscribeOnObservable.create(null as any, null as any, rxTestScheduler);
 
     expect(s).to.deep.equal(r);
   });

--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -60,7 +60,7 @@ describe('bindCallback', () => {
 
       boundCallback(42)
         .subscribe({
-          next(value) { results.push(value); },
+          next(value: any) { results.push(value); },
           complete() { results.push('done'); },
         });
 

--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -281,7 +281,7 @@ describe('bindNodeCallback', () => {
 
   it('should not swallow post-callback errors', () => {
     function badFunction(callback: (error: Error, answer: number) => void): void {
-      callback(null, 42);
+      callback(null as any, 42);
       throw new Error('kaboom');
     }
     const consoleStub = sinon.stub(console, 'warn');

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -191,7 +191,7 @@ describe('static combineLatest', () => {
   it('should work with empty and error', () => {
     const e1 =   hot('----------|'); //empty
     const e1subs =   '^     !';
-    const e2 =   hot('------#', null, 'shazbot!'); //error
+    const e2 =   hot('------#', undefined, 'shazbot!'); //error
     const e2subs =   '^     !';
     const expected = '------#';
 
@@ -203,7 +203,7 @@ describe('static combineLatest', () => {
   });
 
   it('should work with error and empty', () => {
-    const e1 =   hot('--^---#', null, 'too bad, honk'); //error
+    const e1 =   hot('--^---#', undefined, 'too bad, honk'); //error
     const e1subs =     '^   !';
     const e2 =   hot('--^--------|'); //empty
     const e2subs =     '^   !';
@@ -219,7 +219,7 @@ describe('static combineLatest', () => {
   it('should work with hot and throw', () => {
     const e1 =    hot('-a-^--b--c--|', { a: 1, b: 2, c: 3});
     const e1subs =       '^ !';
-    const e2 =    hot('---^-#', null, 'bazinga');
+    const e2 =    hot('---^-#', undefined, 'bazinga');
     const e2subs =       '^ !';
     const expected =     '--#';
 
@@ -231,7 +231,7 @@ describe('static combineLatest', () => {
   });
 
   it('should work with throw and hot', () => {
-    const e1 =    hot('---^-#', null, 'bazinga');
+    const e1 =    hot('---^-#', undefined, 'bazinga');
     const e1subs =       '^ !';
     const e2 =    hot('-a-^--b--c--|', { a: 1, b: 2, c: 3});
     const e2subs =       '^ !';
@@ -245,9 +245,9 @@ describe('static combineLatest', () => {
   });
 
   it('should work with throw and throw', () => {
-    const e1 =    hot('---^----#', null, 'jenga');
+    const e1 =    hot('---^----#', undefined, 'jenga');
     const e1subs =       '^ !';
-    const e2 =    hot('---^-#', null, 'bazinga');
+    const e2 =    hot('---^-#', undefined, 'bazinga');
     const e2subs =       '^ !';
     const expected =     '--#';
 
@@ -261,7 +261,7 @@ describe('static combineLatest', () => {
   it('should work with error and throw', () => {
     const e1 =    hot('-a-^--b--#', { a: 1, b: 2 }, 'wokka wokka');
     const e1subs =       '^ !';
-    const e2 =    hot('---^-#', null, 'flurp');
+    const e2 =    hot('---^-#', undefined, 'flurp');
     const e2subs =       '^ !';
     const expected =     '--#';
 
@@ -273,7 +273,7 @@ describe('static combineLatest', () => {
   });
 
   it('should work with throw and error', () => {
-    const e1 =    hot('---^-#', null, 'flurp');
+    const e1 =    hot('---^-#', undefined, 'flurp');
     const e1subs =       '^ !';
     const e2 =    hot('-a-^--b--#', { a: 1, b: 2 }, 'wokka wokka');
     const e2subs =       '^ !';
@@ -289,7 +289,7 @@ describe('static combineLatest', () => {
   it('should work with never and throw', () => {
     const e1 =    hot('---^-----------');
     const e1subs =       '^     !';
-    const e2 =    hot('---^-----#', null, 'wokka wokka');
+    const e2 =    hot('---^-----#', undefined, 'wokka wokka');
     const e2subs =       '^     !';
     const expected =     '------#';
 
@@ -301,7 +301,7 @@ describe('static combineLatest', () => {
   });
 
   it('should work with throw and never', () => {
-    const e1 =    hot('---^----#', null, 'wokka wokka');
+    const e1 =    hot('---^----#', undefined, 'wokka wokka');
     const e1subs =       '^    !';
     const e2 =    hot('---^-----------');
     const e2subs =       '^    !';
@@ -317,7 +317,7 @@ describe('static combineLatest', () => {
   it('should work with some and throw', () => {
     const e1 =    hot('---^----a---b--|', { a: 1, b: 2 });
     const e1subs =       '^  !';
-    const e2 =    hot('---^--#', null, 'wokka wokka');
+    const e2 =    hot('---^--#', undefined, 'wokka wokka');
     const e2subs =       '^  !';
     const expected =     '---#';
 
@@ -329,7 +329,7 @@ describe('static combineLatest', () => {
   });
 
   it('should work with throw and some', () => {
-    const e1 =    hot('---^--#', null, 'wokka wokka');
+    const e1 =    hot('---^--#', undefined, 'wokka wokka');
     const e1subs =       '^  !';
     const e2 =    hot('---^----a---b--|', { a: 1, b: 2 });
     const e2subs =       '^  !';
@@ -345,7 +345,7 @@ describe('static combineLatest', () => {
   it('should handle throw after complete left', () => {
     const left =  hot('--a--^--b---|', { a: 1, b: 2 });
     const leftSubs =       '^      !';
-    const right = hot('-----^--------#', null, 'bad things');
+    const right = hot('-----^--------#', undefined, 'bad things');
     const rightSubs =      '^        !';
     const expected =       '---------#';
 
@@ -357,7 +357,7 @@ describe('static combineLatest', () => {
   });
 
   it('should handle throw after complete right', () => {
-    const left =   hot('-----^--------#', null, 'bad things');
+    const left =   hot('-----^--------#', undefined, 'bad things');
     const leftSubs =        '^        !';
     const right =  hot('--a--^--b---|', { a: 1, b: 2 });
     const rightSubs =       '^      !';

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -241,8 +241,8 @@ describe('ajax', () => {
       'responseText': JSON.stringify(expected)
     });
 
-    expect(result.xhr).exist;
-    expect(result.response).to.deep.equal(JSON.stringify({ foo: 'bar' }));
+    expect(result!.xhr).exist;
+    expect(result!.response).to.deep.equal(JSON.stringify({ foo: 'bar' }));
     expect(complete).to.be.true;
   });
 
@@ -335,8 +335,8 @@ describe('ajax', () => {
       'responseText': 'Wee! I am text!'
     });
 
-    expect(result.xhr).exist;
-    expect(result.response).to.deep.equal('Wee! I am text!');
+    expect(result!.xhr).exist;
+    expect(result!.response).to.deep.equal('Wee! I am text!');
     expect(complete).to.be.true;
   });
 
@@ -758,7 +758,7 @@ describe('ajax', () => {
       });
 
       expect(request.data).to.equal('foo=bar&hi=there%20you');
-      expect(result.response).to.deep.equal(expected);
+      expect(result!.response).to.deep.equal(expected);
       expect(complete).to.be.true;
     });
 
@@ -790,7 +790,7 @@ describe('ajax', () => {
 
       expect(request.data)
         .to.equal('test=https%3A%2F%2Fgoogle.com%2Fsearch%3Fq%3DencodeURI%2Bvs%2BencodeURIComponent');
-      expect(result.response).to.deep.equal(expected);
+      expect(result!.response).to.deep.equal(expected);
       expect(complete).to.be.true;
     });
 
@@ -821,7 +821,7 @@ describe('ajax', () => {
         'responseText': expected
       });
 
-      expect(result.response).to.equal(expected);
+      expect(result!.response).to.equal(expected);
       expect(complete).to.be.true;
     });
 
@@ -853,7 +853,7 @@ describe('ajax', () => {
           'contentType': 'application/json'
       });
 
-      expect(result.response).to.equal(expected);
+      expect(result!.response).to.equal(expected);
       expect(complete).to.be.true;
     });
 
@@ -1119,7 +1119,7 @@ class MockXMLHttpRequest {
 
   static clearRequest(): void {
     MockXMLHttpRequest.requests.length = 0;
-    MockXMLHttpRequest.recentRequest = null;
+    MockXMLHttpRequest.recentRequest = null!;
   }
 
   private previousRequest: MockXMLHttpRequest;

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -1135,6 +1135,7 @@ class MockXMLHttpRequest {
 
   private responseHeaders: any;
   protected status: any;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   protected responseText: string;
   protected response: any;
 
@@ -1144,9 +1145,13 @@ class MockXMLHttpRequest {
   requestHeaders: any = {};
   withCredentials: boolean = false;
 
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   onreadystatechange: (e: ProgressEvent) => any;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   onerror: (e: ErrorEvent) => any;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   onprogress: (e: ProgressEvent) => any;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   ontimeout: (e: ProgressEvent) => any;
   upload: XMLHttpRequestUpload = <any>{ };
 
@@ -1156,6 +1161,7 @@ class MockXMLHttpRequest {
     MockXMLHttpRequest.requests.push(this);
   }
 
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   timeout: number;
 
   send(data: any): void {

--- a/spec/observables/dom/fetch-spec.ts
+++ b/spec/observables/dom/fetch-spec.ts
@@ -9,14 +9,16 @@ const OK_RESPONSE = {
 function mockFetchImpl(input: string | Request, init?: RequestInit): Promise<Response> {
   (mockFetchImpl as MockFetch).calls.push({ input, init });
   return new Promise<any>((resolve, reject) => {
-    if (init.signal) {
-      if (init.signal.aborted) {
-        reject(new MockDOMException());
-        return;
+    if (init) {
+      if (init.signal) {
+        if (init.signal.aborted) {
+          reject(new MockDOMException());
+          return;
+        }
+        init.signal.addEventListener('abort', () => {
+          reject(new MockDOMException());
+        });
       }
-      init.signal.addEventListener('abort', () => {
-        reject(new MockDOMException());
-      });
     }
     Promise.resolve(null).then(() => {
       resolve((mockFetchImpl as any).respondWith);
@@ -70,7 +72,7 @@ class MockAbortSignal {
   _signal() {
     this.aborted = true;
     while (this._listeners.length > 0) {
-      this._listeners.shift()();
+      this._listeners.shift()!();
     }
   }
 }
@@ -126,8 +128,8 @@ describe('fromFetch', () => {
           expect(MockAbortController.created).to.equal(1);
           expect(mockFetch.calls.length).to.equal(1);
           expect(mockFetch.calls[0].input).to.equal('/foo');
-          expect(mockFetch.calls[0].init.signal).not.to.be.undefined;
-          expect(mockFetch.calls[0].init.signal.aborted).to.be.false;
+          expect(mockFetch.calls[0].init!.signal).not.to.be.undefined;
+          expect(mockFetch.calls[0].init!.signal!.aborted).to.be.false;
           done();
         }, 0);
       }
@@ -156,8 +158,8 @@ describe('fromFetch', () => {
     expect(MockAbortController.created).to.equal(1);
     expect(mockFetch.calls.length).to.equal(1);
     expect(mockFetch.calls[0].input).to.equal('/foo');
-    expect(mockFetch.calls[0].init.signal).not.to.be.undefined;
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.false;
+    expect(mockFetch.calls[0].init!.signal).not.to.be.undefined;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.false;
   });
 
   it('should abort when unsubscribed', () => {
@@ -169,11 +171,11 @@ describe('fromFetch', () => {
     expect(MockAbortController.created).to.equal(1);
     expect(mockFetch.calls.length).to.equal(1);
     expect(mockFetch.calls[0].input).to.equal('/foo');
-    expect(mockFetch.calls[0].init.signal).not.to.be.undefined;
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.false;
+    expect(mockFetch.calls[0].init!.signal).not.to.be.undefined;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.false;
 
     subscription.unsubscribe();
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.true;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.true;
   });
 
   it('should allow passing of init object', done => {
@@ -182,7 +184,7 @@ describe('fromFetch', () => {
       error: done,
       complete: done,
     });
-    expect(mockFetch.calls[0].init.method).to.equal('HEAD');
+    expect(mockFetch.calls[0].init!.method).to.equal('HEAD');
   });
 
   it('should pass in a signal with the init object without mutating the init', done => {
@@ -192,9 +194,9 @@ describe('fromFetch', () => {
       error: done,
       complete: done,
     });
-    expect(mockFetch.calls[0].init.method).to.equal(myInit.method);
+    expect(mockFetch.calls[0].init!.method).to.equal(myInit.method);
     expect(mockFetch.calls[0].init).not.to.equal(myInit);
-    expect(mockFetch.calls[0].init.signal).not.to.be.undefined;
+    expect(mockFetch.calls[0].init!.signal).not.to.be.undefined;
   });
 
   it('should treat passed signals as a cancellation token which triggers an error', done => {
@@ -208,7 +210,7 @@ describe('fromFetch', () => {
       }
     });
     controller.abort();
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.true;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.true;
     // The subscription will not be closed until the error fires when the promise resolves.
     expect(subscription.closed).to.be.false;
   });
@@ -224,7 +226,7 @@ describe('fromFetch', () => {
         done();
       }
     });
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.true;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.true;
     // The subscription will not be closed until the error fires when the promise resolves.
     expect(subscription.closed).to.be.false;
   });

--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -713,7 +713,7 @@ class MockWebSocket {
   static get lastSocket(): MockWebSocket {
     const socket = MockWebSocket.sockets;
     const length = socket.length;
-    return length > 0 ? socket[length - 1] : undefined;
+    return length > 0 ? socket[length - 1] : undefined!;
   }
 
   static clearSockets(): void {
@@ -738,8 +738,7 @@ class MockWebSocket {
   get lastMessageSent(): string {
     const sent = this.sent;
     const length = sent.length;
-
-    return length > 0 ? sent[length - 1] : undefined;
+    return length > 0 ? sent[length - 1] : undefined!;
   }
 
   triggerClose(e: any): void {

--- a/spec/observables/from-promise-spec.ts
+++ b/spec/observables/from-promise-spec.ts
@@ -41,7 +41,7 @@ describe('from (fromPromise)', () => {
         (x) => { expect(x).to.equal(42); },
         (x) => {
           done(new Error('should not be called'));
-        }, null);
+        }, undefined);
     setTimeout(() => {
       observable
         .subscribe(
@@ -127,7 +127,7 @@ describe('from (fromPromise)', () => {
         (x) => {
           done(new Error('should not be called'));
         },
-        null);
+        undefined);
     setTimeout(() => {
       observable
         .subscribe(

--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -388,7 +388,7 @@ describe('fromEvent', () => {
       on() { /*noop*/ }
       off() { /*noop*/ }
     }
-    NullProtoEventTarget.prototype.toString = null;
+    NullProtoEventTarget.prototype.toString = null!;
     const obj: NullProtoEventTarget = new NullProtoEventTarget();
 
     expect(() => {
@@ -400,14 +400,14 @@ describe('fromEvent', () => {
   type('should support node style event emitters interfaces', () => {
     /* tslint:disable:no-unused-variable */
     let a: NodeStyleEventEmitter;
-    let b: Observable<any> = fromEvent(a, 'mock');
+    let b: Observable<any> = fromEvent(a!, 'mock');
     /* tslint:enable:no-unused-variable */
   });
 
   type('should support node compatible event emitters interfaces', () => {
     /* tslint:disable:no-unused-variable */
     let a: NodeCompatibleEventEmitter;
-    let b: Observable<any> = fromEvent(a, 'mock');
+    let b: Observable<any> = fromEvent(a!, 'mock');
     /* tslint:enable:no-unused-variable */
   });
 
@@ -418,7 +418,7 @@ describe('fromEvent', () => {
       removeListener(eventType: string | symbol, handler: NodeEventHandler): this;
     }
     let a: NodeEventEmitter;
-    let b: Observable<any> = fromEvent(a, 'mock');
+    let b: Observable<any> = fromEvent(a!, 'mock');
     /* tslint:enable:no-unused-variable */
   });
 
@@ -434,7 +434,7 @@ describe('fromEvent', () => {
       removeListener(eventType: string, listener: (...args: any[]) => any): void;
     }
     let a: ReactNativeEventEmitter;
-    let b: Observable<any> = fromEvent(a, 'mock');
+    let b: Observable<any> = fromEvent(a!, 'mock');
     /* tslint:enable:no-unused-variable */
   });
 

--- a/spec/observables/timer-spec.ts
+++ b/spec/observables/timer-spec.ts
@@ -75,7 +75,7 @@ describe('timer', () => {
     const expected =    '----(a|)';
 
     const dueTime = new Date(rxTestScheduler.now() + offset);
-    const source = timer(dueTime, null, rxTestScheduler);
+    const source = timer(dueTime, null as any, rxTestScheduler);
     expectObservable(source).toBe(expected, {a: 0});
   });
 
@@ -98,7 +98,7 @@ describe('timer', () => {
       const expected =    '----(aa|)';
 
       const dueTime = new Date(rxTestScheduler.now() + offset);
-      const source = timer(dueTime, null, rxTestScheduler);
+      const source = timer(dueTime, null as any, rxTestScheduler);
 
       const testSource = merge(t1, t2).pipe(
         mergeMap(() => source)

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -461,7 +461,7 @@ describe('static zip', () => {
   it('should work with empty and error', () => {
     const a = cold(  '|');
     const asubs =    '(^!)';
-    const b = hot(   '------#', null, 'too bad');
+    const b = hot(   '------#', undefined, 'too bad');
     const bsubs =    '(^!)';
     const expected = '|';
 
@@ -471,7 +471,7 @@ describe('static zip', () => {
   });
 
   it('should work with error and empty', () => {
-    const a = hot(   '------#', null, 'too bad');
+    const a = hot(   '------#', undefined, 'too bad');
     const asubs =    '(^!)';
     const b = cold(  '|');
     const bsubs =    '(^!)';
@@ -519,9 +519,9 @@ describe('static zip', () => {
   });
 
   it('should work with error and error', () => {
-    const a =    hot('------#', null, 'too bad');
+    const a =    hot('------#', undefined, 'too bad');
     const asubs =    '^     !';
-    const b =    hot('----------#', null, 'too bad 2');
+    const b =    hot('----------#', undefined, 'too bad 2');
     const bsubs =    '^     !';
     const expected = '------#';
 
@@ -582,7 +582,7 @@ describe('static zip', () => {
     let a: Observable<number>;
     let b: Observable<string>;
     let c: Observable<boolean>;
-    let o1: Observable<[number, string, boolean]> = zip(a, b, c);
+    let o1: Observable<[number, string, boolean]> = zip(a!, b!, c!);
     /* tslint:enable:no-unused-variable */
   });
 
@@ -592,37 +592,37 @@ describe('static zip', () => {
     let b: Observable<string>;
     let c: Promise<boolean>;
     let d: Observable<string[]>;
-    let o1: Observable<[number, string, boolean, string[]]> = zip(a, b, c, d);
+    let o1: Observable<[number, string, boolean, string[]]> = zip(a!, b!, c!, d!);
     /* tslint:enable:no-unused-variable */
   });
 
   type('should support arrays of promises', () => {
     /* tslint:disable:no-unused-variable */
     let a: Promise<number>[];
-    let o1: Observable<number[]> = zip(a);
-    let o2: Observable<number[]> = zip(...a);
+    let o1: Observable<number[]> = zip(a!);
+    let o2: Observable<number[]> = zip(...a!);
     /* tslint:enable:no-unused-variable */
   });
 
   type('should support arrays of observables', () => {
     /* tslint:disable:no-unused-variable */
     let a: Observable<number>[];
-    let o1: Observable<number[]> = zip(a);
-    let o2: Observable<number[]> = zip(...a);
+    let o1: Observable<number[]> = zip(a!);
+    let o2: Observable<number[]> = zip(...a!);
     /* tslint:enable:no-unused-variable */
   });
 
   type('should return Array<T> when given a single promise', () => {
     /* tslint:disable:no-unused-variable */
     let a: Promise<number>;
-    let o1: Observable<number[]> = zip(a);
+    let o1: Observable<number[]> = zip(a!);
     /* tslint:enable:no-unused-variable */
   });
 
   type('should return Array<T> when given a single observable', () => {
     /* tslint:disable:no-unused-variable */
     let a: Observable<number>;
-    let o1: Observable<number[]> = zip(a);
+    let o1: Observable<number[]> = zip(a!);
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/buffer-spec.ts
+++ b/spec/operators/buffer-spec.ts
@@ -101,7 +101,7 @@ describe('Observable.prototype.buffer', () => {
 
   it('should work with error', () => {
     testScheduler.run(({ hot, expectObservable }) => {
-      const a = hot('---^-------#', null, new Error('too bad'));
+      const a = hot('---^-------#', undefined, new Error('too bad'));
       const b = hot('---^--------');
       const expected = '--------#';
       expectObservable(a.pipe(buffer(b))).toBe(expected, null, new Error('too bad'));
@@ -110,7 +110,7 @@ describe('Observable.prototype.buffer', () => {
 
   it('should work with error and non-empty selector', () => {
     testScheduler.run(({ hot, expectObservable }) => {
-      const a = hot('---^-------#', null, new Error('too bad'));
+      const a = hot('---^-------#', undefined, new Error('too bad'));
       const b = hot('---^---a----');
       const expected = '----a---#';
       expectObservable(a.pipe(buffer(b))).toBe(expected, { a: [] }, new Error('too bad'));
@@ -211,7 +211,7 @@ describe('Observable.prototype.buffer', () => {
   it('should work with non-empty and empty selector error', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
-      const b = hot('--------^----------------#', null, new Error('too bad'));
+      const b = hot('--------^----------------#', undefined, new Error('too bad'));
       const expected = '     -----------------#';
       expectObservable(a.pipe(buffer(b))).toBe(expected, null, new Error('too bad'));
     });

--- a/spec/operators/combineLatest-spec.ts
+++ b/spec/operators/combineLatest-spec.ts
@@ -209,7 +209,7 @@ describe('combineLatest operator', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ----------|'); //empty
       const e1subs = '  ^-----!';
-      const e2 = hot('  ------#', null, 'shazbot!'); //error
+      const e2 = hot('  ------#', undefined, 'shazbot!'); //error
       const e2subs = '  ^-----!';
       const expected = '------#';
 
@@ -223,7 +223,7 @@ describe('combineLatest operator', () => {
 
   it('should work with error and empty', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('--^---#', null, 'too bad, honk'); //error
+      const e1 = hot('--^---#', undefined, 'too bad, honk'); //error
       const e1subs = '  ^---!';
       const e2 = hot('--^--------|'); //empty
       const e2subs = '  ^---!';
@@ -241,7 +241,7 @@ describe('combineLatest operator', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('-a-^--b--c--|', { a: 1, b: 2, c: 3});
       const e1subs = '   ^-!';
-      const e2 = hot('---^-#', null, 'bazinga');
+      const e2 = hot('---^-#', undefined, 'bazinga');
       const e2subs = '   ^-!';
       const expected = ' --#';
 
@@ -255,7 +255,7 @@ describe('combineLatest operator', () => {
 
   it('should work with throw and hot', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('---^-#', null, 'bazinga');
+      const e1 = hot('---^-#', undefined, 'bazinga');
       const e1subs = '   ^-!';
       const e2 = hot('-a-^--b--c--|', { a: 1, b: 2, c: 3});
       const e2subs = '   ^-!';
@@ -271,9 +271,9 @@ describe('combineLatest operator', () => {
 
   it('should work with throw and throw', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('---^----#', null, 'jenga');
+      const e1 = hot('---^----#', undefined, 'jenga');
       const e1subs = '   ^-!';
-      const e2 = hot('---^-#', null, 'bazinga');
+      const e2 = hot('---^-#', undefined, 'bazinga');
       const e2subs = '   ^-!';
       const expected = ' --#';
 
@@ -289,7 +289,7 @@ describe('combineLatest operator', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('-a-^--b--#', { a: 1, b: 2 }, 'wokka wokka');
       const e1subs = '   ^-!';
-      const e2 = hot('---^-#', null, 'flurp');
+      const e2 = hot('---^-#', undefined, 'flurp');
       const e2subs = '   ^-!';
       const expected = ' --#';
 
@@ -303,7 +303,7 @@ describe('combineLatest operator', () => {
 
   it('should work with throw and error', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('---^-#', null, 'flurp');
+      const e1 = hot('---^-#', undefined, 'flurp');
       const e1subs = '   ^-!';
       const e2 = hot('-a-^--b--#', { a: 1, b: 2 }, 'wokka wokka');
       const e2subs = '   ^-!';
@@ -321,7 +321,7 @@ describe('combineLatest operator', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('---^-----------');
       const e1subs = '   ^-----!';
-      const e2 = hot('---^-----#', null, 'wokka wokka');
+      const e2 = hot('---^-----#', undefined, 'wokka wokka');
       const e2subs = '   ^-----!';
       const expected = ' ------#';
 
@@ -335,7 +335,7 @@ describe('combineLatest operator', () => {
 
   it('should work with throw and never', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('---^----#', null, 'wokka wokka');
+      const e1 = hot('---^----#', undefined, 'wokka wokka');
       const e1subs = '   ^----!';
       const e2 = hot('---^-----------');
       const e2subs = '   ^----!';
@@ -353,7 +353,7 @@ describe('combineLatest operator', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('   ---^----a---b--|', { a: 1, b: 2 });
       const e1subs = '      ^--!';
-      const e2 = hot('   ---^--#', null, 'wokka wokka');
+      const e2 = hot('   ---^--#', undefined, 'wokka wokka');
       const e2subs = '      ^--!';
       const expected = '    ---#';
 
@@ -367,7 +367,7 @@ describe('combineLatest operator', () => {
 
   it('should work with throw and some', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('---^--#', null, 'wokka wokka');
+      const e1 = hot('---^--#', undefined, 'wokka wokka');
       const e1subs = '   ^--!';
       const e2 = hot('---^----a---b--|', { a: 1, b: 2 });
       const e2subs = '   ^--!';
@@ -385,7 +385,7 @@ describe('combineLatest operator', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const left = hot(' --a--^--b---|', { a: 1, b: 2 });
       const leftSubs = '      ^------!';
-      const right = hot('-----^--------#', null, 'bad things');
+      const right = hot('-----^--------#', undefined, 'bad things');
       const rightSubs = '     ^--------!';
       const expected = '      ---------#';
 
@@ -399,7 +399,7 @@ describe('combineLatest operator', () => {
 
   it('should handle throw after complete right', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const left = hot('  -----^--------#', null, 'bad things');
+      const left = hot('  -----^--------#', undefined, 'bad things');
       const leftSubs = '       ^--------!';
       const right = hot(' --a--^--b---|', { a: 1, b: 2 });
       const rightSubs = '      ^------!';

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -207,7 +207,7 @@ describe('debounce operator', () => {
                      '               ^    !        ',
                      '                    ^ !      '];
 
-    expectObservable(e1.pipe(debounce(() => selector.shift()))).toBe(expected);
+    expectObservable(e1.pipe(debounce(() => selector.shift()!))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     for (let i = 0; i < selectorSubs.length; i++) {
       expectSubscriptions(selector[i].subscriptions).toBe(selectorSubs[i]);
@@ -230,7 +230,7 @@ describe('debounce operator', () => {
                      '               ^    ! ',
                      '                    ^!'];
 
-    expectObservable(e1.pipe(debounce(() => selector.shift()))).toBe(expected);
+    expectObservable(e1.pipe(debounce(() => selector.shift()!))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     for (let i = 0; i < selectorSubs.length; i++) {
       expectSubscriptions(selector[i].subscriptions).toBe(selectorSubs[i]);
@@ -249,7 +249,7 @@ describe('debounce operator', () => {
                    '                 ^ !          ',
                    '                          ^  !'];
 
-    expectObservable(e1.pipe(debounce(() => selector.shift()))).toBe(expected);
+    expectObservable(e1.pipe(debounce(() => selector.shift()!))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     for (let i = 0; i < selectorSubs.length; i++) {
       expectSubscriptions(selector[i].subscriptions).toBe(selectorSubs[i]);
@@ -270,7 +270,7 @@ describe('debounce operator', () => {
                    '                          ^  !        ',
                    '                                    ^!'];
 
-    expectObservable(e1.pipe(debounce(() => selector.shift()))).toBe(expected);
+    expectObservable(e1.pipe(debounce(() => selector.shift()!))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     for (let i = 0; i < selectorSubs.length; i++) {
       expectSubscriptions(selector[i].subscriptions).toBe(selectorSubs[i]);
@@ -295,7 +295,7 @@ describe('debounce operator', () => {
       }
     }
 
-    expectObservable(e1.pipe(debounce(selectorFunction))).toBe(expected);
+    expectObservable(e1.pipe(debounce(selectorFunction as any))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     for (let i = 0; i < selectorSubs.length; i++) {
       expectSubscriptions(selector[i].subscriptions).toBe(selectorSubs[i]);
@@ -336,7 +336,7 @@ describe('debounce operator', () => {
                    '                 ^ !                 ',
                    '                          ^  !       '];
 
-    expectObservable(e1.pipe(debounce(() => selector.shift()))).toBe(expected);
+    expectObservable(e1.pipe(debounce(() => selector.shift()!))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     for (let i = 0; i < selectorSubs.length; i++) {
       expectSubscriptions(selector[i].subscriptions).toBe(selectorSubs[i]);
@@ -359,7 +359,7 @@ describe('debounce operator', () => {
                      '                   ^!              ',
                      '                    ^    !         '];
 
-    expectObservable(e1.pipe(debounce(() => selector.shift()))).toBe(expected);
+    expectObservable(e1.pipe(debounce(() => selector.shift()!))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     for (let i = 0; i < selectorSubs.length; i++) {
       expectSubscriptions(selector[i].subscriptions).toBe(selectorSubs[i]);
@@ -439,7 +439,7 @@ describe('debounce operator', () => {
     /* tslint:disable:no-unused-variable */
     let o: Observable<number>;
     let s: Observable<number>;
-    let r: Observable<number> = o.pipe(debounce((n) => s));
+    let r: Observable<number> = o!.pipe(debounce((n) => s));
     /* tslint:enable:no-unused-variable */
   });
 
@@ -447,7 +447,7 @@ describe('debounce operator', () => {
     /* tslint:disable:no-unused-variable */
     let o: Observable<number>;
     let s: Observable<string>;
-    let r: Observable<number> = o.pipe(debounce((n) => s));
+    let r: Observable<number> = o!.pipe(debounce((n) => s));
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -186,7 +186,7 @@ describe('delay operator', () => {
       const result = e1.pipe(
         repeatWhen(notifications => {
           const delayed = notifications.pipe(delay(duration, testScheduler));
-          subscribeSpy = sinon.spy(delayed['source'], 'subscribe');
+          subscribeSpy = sinon.spy((delayed as any)['source'], 'subscribe');
           return delayed;
         }),
         skip(1),

--- a/spec/operators/distinct-spec.ts
+++ b/spec/operators/distinct-spec.ts
@@ -171,7 +171,7 @@ describe('distinct operator', () => {
     const e2subs =   '^                   !';
     const expected = '--a--b--------a--b--|';
 
-    expectObservable((<any>e1).pipe(distinct(null, e2))).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null as any, e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -183,7 +183,7 @@ describe('distinct operator', () => {
     const e2subs =   '^            !';
     const expected = '--a--b-------#';
 
-    expectObservable((<any>e1).pipe(distinct(null, e2))).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null as any, e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -196,7 +196,7 @@ describe('distinct operator', () => {
     const unsub =    '           !         ';
     const expected = '--a--b------';
 
-    expectObservable((<any>e1).pipe(distinct(null, e2)), unsub).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null as any, e2)), unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
@@ -208,7 +208,7 @@ describe('distinct operator', () => {
     const e2subs =   '^                   !';
     const expected = '--a--b--------a--b--|';
 
-    expectObservable((<any>e1).pipe(distinct(null, e2))).toBe(expected);
+    expectObservable((<any>e1).pipe(distinct(null as any, e2))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });

--- a/spec/operators/distinctUntilChanged-spec.ts
+++ b/spec/operators/distinctUntilChanged-spec.ts
@@ -212,7 +212,7 @@ describe('distinctUntilChanged operator', () => {
       return x;
     };
 
-    expectObservable(e1.pipe(distinctUntilChanged(null, keySelector))).toBe(expected);
+    expectObservable(e1.pipe(distinctUntilChanged(null as any, keySelector))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 });

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -126,9 +126,9 @@ describe('find operator', () => {
     const unsub =      '      !     ';
 
     const result = source.pipe(
-      mergeMap((x: string) => of(x)),
-      find((value: string) => value === 'z'),
-      mergeMap((x: string) => of(x))
+      mergeMap(x => of(x)),
+      find(value => value === 'z'),
+      mergeMap(x => of(x))
     );
 
     expectObservable(result, unsub).toBe(expected);
@@ -189,21 +189,21 @@ describe('find operator', () => {
 
       const foo: Foo = new Foo();
       of(foo).pipe(find(foo => foo.baz === 42))
-        .subscribe(x => x.baz); // x is still Foo
+        .subscribe(x => x!.baz); // x is still Foo
       of(foo).pipe(find(isBar))
-        .subscribe(x => x.bar); // x is Bar!
+        .subscribe(x => x!.bar); // x is Bar!
 
       const foobar: Bar = new Foo(); // type is interface, not the class
       of(foobar).pipe(find(foobar => foobar.bar === 'name'))
-        .subscribe(x => x.bar); // <-- x is still Bar
+        .subscribe(x => x!.bar); // <-- x is still Bar
       of(foobar).pipe(find(isBar))
-        .subscribe(x => x.bar); // <--- x is Bar!
+        .subscribe(x => x!.bar); // <--- x is Bar!
 
       const barish = { bar: 'quack', baz: 42 }; // type can quack like a Bar
       of(barish).pipe(find(x => x.bar === 'quack'))
-        .subscribe(x => x.bar); // x is still { bar: string; baz: number; }
+        .subscribe(x => x!.bar); // x is still { bar: string; baz: number; }
       of(barish).pipe(find(isBar))
-        .subscribe(bar => bar.bar); // x is Bar!
+        .subscribe(bar => bar!.bar); // x is Bar!
     }
 
     // type guards with primitive types
@@ -214,7 +214,7 @@ describe('find operator', () => {
       const isString = (x: string | number): x is string => typeof x === 'string';
 
       xs.pipe(find(isString))
-        .subscribe(s => s.length); // s is string
+        .subscribe(s => s!.length); // s is string
 
       // In contrast, this type of regular boolean predicate still maintains the original type
       xs.pipe(find(x => typeof x === 'number'))

--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -45,7 +45,7 @@ describe('groupBy operator', () => {
     of(1, 2, 3).pipe(
       groupBy((x: number) => x % 2)
     ).subscribe((g: any) => {
-        const expectedGroup = expectedGroups.shift();
+        const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {
@@ -63,7 +63,7 @@ describe('groupBy operator', () => {
     of(1, 2, 3).pipe(
       groupBy((x: number) => x % 2, (x: number) => x + '!')
     ).subscribe((g: any) => {
-        const expectedGroup = expectedGroups.shift();
+        const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {
@@ -107,12 +107,12 @@ describe('groupBy operator', () => {
     ];
 
     of(1, 2, 3).pipe(
-      groupBy((x: number) => x % 2, null, null, () => new ReplaySubject(1)),
+      groupBy((x: number) => x % 2, null as any, null as any, () => new ReplaySubject(1)),
       // Ensure each inner group reaches the destination after the first event
       // has been next'd to the group
       delay(5)
     ).subscribe((g: any) => {
-        const expectedGroup = expectedGroups.shift();
+        const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {
@@ -1477,7 +1477,7 @@ describe('groupBy operator', () => {
 
     result
       .subscribe((g: any) => {
-        const expectedGroup = expectedGroups.shift();
+        const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {

--- a/spec/operators/mapTo-spec.ts
+++ b/spec/operators/mapTo-spec.ts
@@ -36,7 +36,7 @@ describe('mapTo operator', () => {
   });
 
   it('should propagate errors from observable that emits only errors', () => {
-    const a =   cold('--#', null, 'too bad');
+    const a =   cold('--#', undefined, 'too bad');
     const asubs =    '^ !';
     const expected = '--#';
 

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -825,10 +825,10 @@ describe('mergeMap', () => {
     let o: Observable<number>;
 
     /* tslint:disable:no-unused-variable */
-    let a1: Observable<string> = o.pipe(mergeMap(x => x.toString()));
-    let a2: Observable<string> = o.pipe(mergeMap(x => x.toString(), 3));
-    let a3: Observable<{ o: number; i: string; }> = o.pipe(mergeMap(x => x.toString(), (o, i) => ({ o, i })));
-    let a4: Observable<{ o: number; i: string; }> = o.pipe(mergeMap(x => x.toString(), (o, i) => ({ o, i }), 3));
+    let a1: Observable<string> = o!.pipe(mergeMap(x => x.toString()));
+    let a2: Observable<string> = o!.pipe(mergeMap(x => x.toString(), 3));
+    let a3: Observable<{ o: number; i: string; }> = o!.pipe(mergeMap(x => x.toString(), (o, i) => ({ o, i })));
+    let a4: Observable<{ o: number; i: string; }> = o!.pipe(mergeMap(x => x.toString(), (o, i) => ({ o, i }), 3));
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -376,8 +376,8 @@ describe('mergeMapTo', () => {
     let m: Observable<string>;
 
     /* tslint:disable:no-unused-variable */
-    let a1: Observable<string> = o.pipe(mergeMapTo(m));
-    let a2: Observable<string> = o.pipe(mergeMapTo(m, 3));
+    let a1: Observable<string> = o!.pipe(mergeMapTo(m!));
+    let a2: Observable<string> = o!.pipe(mergeMapTo(m!, 3));
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/mergeScan-spec.ts
+++ b/spec/operators/mergeScan-spec.ts
@@ -21,7 +21,7 @@ describe('mergeScan', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), []));
+    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), [] as string[]));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -38,7 +38,7 @@ describe('mergeScan', () => {
       w: ['b', 'c', 'd']
     };
 
-    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), []));
+    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), [] as string[]));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -59,7 +59,7 @@ describe('mergeScan', () => {
     };
 
     const source = e1.pipe(mergeScan((acc, x) =>
-      of(acc.concat(x)).pipe(delay(20, rxTestScheduler)), []));
+      of(acc.concat(x)).pipe(delay(20, rxTestScheduler)), [] as string[]));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -80,7 +80,7 @@ describe('mergeScan', () => {
     };
 
     const source = e1.pipe(mergeScan((acc, x) =>
-      of(acc.concat(x)).pipe(delay(50, rxTestScheduler)), []));
+      of(acc.concat(x)).pipe(delay(50, rxTestScheduler)), [] as string[]));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -101,7 +101,7 @@ describe('mergeScan', () => {
     };
 
     const source = e1.pipe(mergeScan((acc, x) =>
-      of(acc.concat(x)).pipe(delay(50, rxTestScheduler)), []));
+      of(acc.concat(x)).pipe(delay(50, rxTestScheduler)), [] as string[]));
 
     expectObservable(source, e1subs).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -129,7 +129,7 @@ describe('mergeScan', () => {
           of([...acc, x]).pipe(
             delay(50, rxTestScheduler)
           )
-        , []),
+        , [] as string[]),
         mergeMap(function (x) { return of(x); })
       );
 
@@ -177,7 +177,7 @@ describe('mergeScan', () => {
         throw new Error('bad!');
       }
       return of(acc.concat(x));
-    }, []));
+    }, [] as string[]));
 
     expectObservable(source).toBe(expected, values, new Error('bad!'));
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -229,7 +229,7 @@ describe('mergeScan', () => {
       u: <string[]>[]
     };
 
-    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), []));
+    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), [] as string[]));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -240,7 +240,7 @@ describe('mergeScan', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), []));
+    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), [] as string[]));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -251,7 +251,7 @@ describe('mergeScan', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), []));
+    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), [] as string[]));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -270,7 +270,7 @@ describe('mergeScan', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), []));
+    const source = e1.pipe(mergeScan((acc, x) => of(acc.concat(x)), [] as string[]));
 
     expectObservable(source, sub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(sub);
@@ -428,7 +428,7 @@ describe('mergeScan', () => {
 
     e1.pipe(mergeScan((acc, x, index) => {
       recorded.push(index);
-      return of(x);
+      return of(index);
     }, 0)).subscribe();
 
     expect(recorded).to.deep.equal([0, 1, 2, 3]);

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -82,7 +82,6 @@ describe('pluck operator', () => {
     const expected = '--r-x--y-z---w-|';
     const values: { [key: string]: number | undefined } = {r: 1, x: undefined, y: undefined, z: undefined, w: 5};
 
-    // @ts-ignore
     const r = a.pipe(pluck('a', 'b', 'c'));
     expectObservable(r).toBe(expected, values);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -90,7 +89,6 @@ describe('pluck operator', () => {
 
   it('should throw an error if not property is passed', () => {
     expect(() => {
-      // @ts-ignore
       of({prop: 1}, {prop: 2}).pipe(pluck());
     }).to.throw(Error, 'list of properties cannot be empty.');
   });
@@ -100,7 +98,6 @@ describe('pluck operator', () => {
     const asubs =    '(^!)';
     const expected = '#';
 
-    // @ts-ignore
     const r = a.pipe(pluck('whatever'));
     expectObservable(r).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -123,7 +120,6 @@ describe('pluck operator', () => {
 
     const invoked = 0;
     const r = a.pipe(
-      // @ts-ignore
       pluck('whatever'),
       tap(null, null, () => {
         expect(invoked).to.equal(0);

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -276,7 +276,7 @@ describe('publishLast operator', () => {
     /* tslint:disable:no-unused-variable */
     const source = of(1, 2, 3);
     // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: ConnectableObservable<{}> = publishLast()(source);
+    const result: ConnectableObservable<unknown> = publishLast()(source);
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { reduce, mergeMap } from 'rxjs/operators';
-import { range, of, Observable } from 'rxjs';
+import { range, of } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;

--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { scan, mergeMap, finalize, reduce } from 'rxjs/operators';
-import { of, Observable } from 'rxjs';
+import { scan, mergeMap, finalize } from 'rxjs/operators';
+import { of } from 'rxjs';
 
 declare const type: Function;
 declare const asDiagram: Function;
@@ -39,7 +39,7 @@ describe('scan operator', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = e1.pipe(scan((acc: any, x: string) => [].concat(acc, x), []));
+    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -93,7 +93,7 @@ describe('scan operator', () => {
       w: ['b', 'c', 'd']
     };
 
-    const source = e1.pipe(scan((acc: any, x: string) => [].concat(acc, x), []));
+    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
     expectObservable(source).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -113,12 +113,12 @@ describe('scan operator', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = e1.pipe(scan((acc: any, x: string) => {
+    const source = e1.pipe(scan((acc, x) => {
       if (x === 'd') {
         throw 'bad!';
       }
-      return [].concat(acc, x);
-    }, []));
+      return acc.concat(x);
+    }, [] as string[]));
 
     expectObservable(source).toBe(expected, values, 'bad!');
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -129,7 +129,7 @@ describe('scan operator', () => {
     const e1subs =   '(^!)';
     const expected = '|';
 
-    const source = e1.pipe(scan((acc: any, x: string) => [].concat(acc, x), []));
+    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -140,7 +140,7 @@ describe('scan operator', () => {
     const e1subs =   '^';
     const expected = '-';
 
-    const source = e1.pipe(scan((acc: any, x: string) => [].concat(acc, x), []));
+    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -151,7 +151,7 @@ describe('scan operator', () => {
     const e1subs =   '(^!)';
     const expected = '#';
 
-    const source = e1.pipe(scan((acc: any, x: string) => [].concat(acc, x), []));
+    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -171,7 +171,7 @@ describe('scan operator', () => {
       z: ['b', 'c', 'd', 'e', 'f', 'g']
     };
 
-    const source = e1.pipe(scan((acc: any, x: string) => [].concat(acc, x), []));
+    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
     expectObservable(source, unsub).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -193,7 +193,7 @@ describe('scan operator', () => {
 
     const source = e1.pipe(
       mergeMap((x: string) => of(x)),
-      scan((acc: any, x: string) => [].concat(acc, x), []),
+      scan((acc, x) => acc.concat(x), [] as string[]),
       mergeMap((x: string[]) => of(x))
     );
 

--- a/spec/operators/skipLast-spec.ts
+++ b/spec/operators/skipLast-spec.ts
@@ -98,7 +98,7 @@ describe('skipLast operator', () => {
   });
 
   it('should propagate error from the source observable', () => {
-    const e1 = hot('---^---#', null, 'too bad');
+    const e1 = hot('---^---#', undefined, 'too bad');
     const e1subs =    '^   !';
     const expected =  '----#';
 

--- a/spec/operators/skipWhile-spec.ts
+++ b/spec/operators/skipWhile-spec.ts
@@ -52,7 +52,7 @@ describe('skipWhile operator', () => {
     const sourceSubs =    '^               !';
     const expected =      '-2--3--4--5--6--|';
 
-    expectObservable(source.pipe(skipWhile(() => undefined))).toBe(expected);
+    expectObservable(source.pipe(skipWhile(() => undefined as any))).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -360,7 +360,7 @@ describe('switchMap', () => {
 
   it('should switch inner never and throw', () => {
     const x = cold('-');
-    const y = cold('#', null, 'sad');
+    const y = cold('#', undefined, 'sad');
     const xsubs =    '         ^         !          ';
     const ysubs =    '                   (^!)       ';
     const e1 =   hot('---------x---------y---------|');
@@ -379,7 +379,7 @@ describe('switchMap', () => {
 
   it('should switch inner empty and throw', () => {
     const x = cold('|');
-    const y = cold('#', null, 'sad');
+    const y = cold('#', undefined, 'sad');
     const xsubs =    '         (^!)                 ';
     const ysubs =    '                   (^!)       ';
     const e1 =   hot('---------x---------y---------|');

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -93,7 +93,7 @@ describe('take operator', () => {
 
   it('should propagate error from the source observable', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('---^---#', null, 'too bad');
+      const e1 = hot('---^---#', undefined, 'too bad');
       const e1subs = '   ^---!';
       const expected = ' ----#';
 

--- a/spec/operators/takeLast-spec.ts
+++ b/spec/operators/takeLast-spec.ts
@@ -105,7 +105,7 @@ describe('takeLast operator', () => {
   });
 
   it('should propagate error from the source observable', () => {
-    const e1 = hot('---^---#', null, 'too bad');
+    const e1 = hot('---^---#', undefined, 'too bad');
     const e1subs =    '^   !';
     const expected =  '----#';
 

--- a/spec/operators/takeWhile-spec.ts
+++ b/spec/operators/takeWhile-spec.ts
@@ -50,7 +50,7 @@ describe('takeWhile operator', () => {
     const e1subs =     '^ !            ';
     const expected =   '--|            ';
 
-    expectObservable(e1.pipe(takeWhile(() => null))).toBe(expected);
+    expectObservable(e1.pipe(takeWhile(() => null as any))).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 

--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -335,7 +335,7 @@ describe('throttle operator', () =>  {
     /* tslint:disable:no-unused-variable */
     let o: Observable<number>;
     let s: Observable<number>;
-    let r: Observable<number> = o.pipe(throttle((n) => s));
+    let r: Observable<number> = o!.pipe(throttle((n) => s));
     /* tslint:enable:no-unused-variable */
   });
 
@@ -343,7 +343,7 @@ describe('throttle operator', () =>  {
     /* tslint:disable:no-unused-variable */
     let o: Observable<number>;
     let s: Observable<string>;
-    let r: Observable<number> = o.pipe(throttle((n) => s));
+    let r: Observable<number> = o!.pipe(throttle((n) => s));
     /* tslint:enable:no-unused-variable */
   });
 

--- a/spec/operators/windowTime-spec.ts
+++ b/spec/operators/windowTime-spec.ts
@@ -40,7 +40,7 @@ describe('windowTime operator', () => {
     const z = cold(                                '-g-----|');
     const values = { x, y, z };
 
-    const result = source.pipe(windowTime(timeSpan, null, 2, rxTestScheduler));
+    const result = source.pipe(windowTime(timeSpan, null as any, 2, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(source.subscriptions).toBe(subs);

--- a/spec/operators/zip-spec.ts
+++ b/spec/operators/zip-spec.ts
@@ -456,7 +456,7 @@ describe('zip operator', () => {
   it('should work with empty and error', () => {
     const a = cold(  '|');
     const asubs =    '(^!)';
-    const b = hot(   '------#', null, 'too bad');
+    const b = hot(   '------#', undefined, 'too bad');
     const bsubs =    '(^!)';
     const expected = '|';
 
@@ -466,7 +466,7 @@ describe('zip operator', () => {
   });
 
   it('should work with error and empty', () => {
-    const a = hot(   '------#', null, 'too bad');
+    const a = hot(   '------#', undefined, 'too bad');
     const asubs =    '(^!)';
     const b = cold(  '|');
     const bsubs =    '(^!)';
@@ -514,9 +514,9 @@ describe('zip operator', () => {
   });
 
   it('should work with error and error', () => {
-    const a =    hot('------#', null, 'too bad');
+    const a =    hot('------#', undefined, 'too bad');
     const asubs =    '^     !';
-    const b =    hot('----------#', null, 'too bad 2');
+    const b =    hot('----------#', undefined, 'too bad 2');
     const bsubs =    '^     !';
     const expected = '------#';
 
@@ -595,7 +595,7 @@ describe('zip operator', () => {
     /* tslint:disable:no-unused-variable */
     let o: Observable<number>;
     let z: Observable<number>[];
-    let a: Observable<number[]> = o.pipe(zip(...z));
+    let a: Observable<number[]> = o!.pipe(zip(...z!));
     /* tslint:enable:no-unused-variable */
   });
 
@@ -603,7 +603,7 @@ describe('zip operator', () => {
     /* tslint:disable:no-unused-variable */
     let o: Observable<number>;
     let z: Observable<number>[];
-    let a: Observable<string[]> = o.pipe(zip(...z, (...r) => r.map(v => v.toString())));
+    let a: Observable<string[]> = o!.pipe(zip(...z!, (...r) => r.map(v => v.toString())));
     /* tslint:enable:no-unused-variable */
   });
 
@@ -611,7 +611,7 @@ describe('zip operator', () => {
     /* tslint:disable:no-unused-variable */
     let o: Observable<number>;
     let z: Observable<number>[];
-    let a: Observable<string[]> = o.pipe(zip(z, (...r: any[]) => r.map(v => v.toString())));
+    let a: Observable<string[]> = o!.pipe(zip(z!, (...r: any[]) => r.map(v => v.toString())));
     /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -571,7 +571,7 @@ describe('zipAll operator', () => {
   it('should work with empty and error', () => {
     const a = cold(  '|');
     const asubs =    '(^!)';
-    const b = hot(   '------#', null, 'too bad');
+    const b = hot(   '------#', undefined, 'too bad');
     const bsubs =    '(^!)';
     const expected = '|';
 
@@ -581,7 +581,7 @@ describe('zipAll operator', () => {
   });
 
   it('should work with error and empty', () => {
-    const a = hot(   '------#', null, 'too bad');
+    const a = hot(   '------#', undefined, 'too bad');
     const asubs =    '(^!)';
     const b = cold(  '|');
     const bsubs =    '(^!)';
@@ -629,9 +629,9 @@ describe('zipAll operator', () => {
   });
 
   it('should work with error and error', () => {
-    const a =    hot('------#', null, 'too bad');
+    const a =    hot('------#', undefined, 'too bad');
     const asubs =    '^     !';
-    const b =    hot('----------#', null, 'too bad 2');
+    const b =    hot('----------#', undefined, 'too bad 2');
     const bsubs =    '^     !';
     const expected = '------#';
 

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -132,13 +132,13 @@ describe('TestScheduler', () => {
 
   describe('createTime()', () => {
     it('should parse a simple time marble string to a number', () => {
-      const scheduler = new TestScheduler(null);
+      const scheduler = new TestScheduler(null!);
       const time = scheduler.createTime('-----|');
       expect(time).to.equal(50);
     });
 
     it('should throw if not given good marble input', () => {
-      const scheduler = new TestScheduler(null);
+      const scheduler = new TestScheduler(null!);
       expect(() => {
         scheduler.createTime('-a-b-#');
       }).to.throw();
@@ -148,7 +148,7 @@ describe('TestScheduler', () => {
   describe('createColdObservable()', () => {
     it('should create a cold observable', () => {
       const expected = ['A', 'B'];
-      const scheduler = new TestScheduler(null);
+      const scheduler = new TestScheduler(null!);
       const source = scheduler.createColdObservable('--a---b--|', { a: 'A', b: 'B' });
       expect(source).to.be.an.instanceOf(Observable);
       source.subscribe(x => {
@@ -162,7 +162,7 @@ describe('TestScheduler', () => {
   describe('createHotObservable()', () => {
     it('should create a hot observable', () => {
       const expected = ['A', 'B'];
-      const scheduler = new TestScheduler(null);
+      const scheduler = new TestScheduler(null!);
       const source = scheduler.createHotObservable('--a---b--|', { a: 'A', b: 'B' });
       expect(source).to.be.an.instanceof(Subject);
       source.subscribe(x => {

--- a/spec/util/subscribeToResult-spec.ts
+++ b/spec/util/subscribeToResult-spec.ts
@@ -13,8 +13,8 @@ describe('subscribeToResult', () => {
 
     const subscription = subscribeToResult(subscriber, result);
 
-    expect(expected).to.be.equal(42);
-    expect(subscription.closed).to.be.true;
+    expect(expected!).to.be.equal(42);
+    expect(subscription!.closed).to.be.true;
   });
 
   it('should subscribe to observables that are an instanceof Observable', (done) => {
@@ -116,7 +116,7 @@ describe('subscribeToResult', () => {
     const subscriber = new OuterSubscriber((x: number) => expected = x);
 
     subscribeToResult(subscriber, iterable);
-    expect(expected).to.be.equal(42);
+    expect(expected!).to.be.equal(42);
   });
 
   it('should subscribe to to an object that implements Symbol.observable', (done) => {

--- a/src/internal/AsyncSubject.ts
+++ b/src/internal/AsyncSubject.ts
@@ -9,7 +9,7 @@ import { Subscription } from './Subscription';
  * @class AsyncSubject<T>
  */
 export class AsyncSubject<T> extends Subject<T> {
-  private value: T = null;
+  private value: T | null = null;
   private hasNext: boolean = false;
   private hasCompleted: boolean = false;
 
@@ -42,7 +42,7 @@ export class AsyncSubject<T> extends Subject<T> {
   complete(): void {
     this.hasCompleted = true;
     if (this.hasNext) {
-      super.next(this.value);
+      super.next(this.value!);
     }
     super.complete();
   }

--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -31,6 +31,9 @@ export enum NotificationKind {
 export class Notification<T> {
   hasValue: boolean;
 
+  constructor(kind: 'N', value?: T);
+  constructor(kind: 'E', value: undefined, error: any);
+  constructor(kind: 'C');
   constructor(public kind: 'N' | 'E' | 'C', public value?: T, public error?: any) {
     this.hasValue = kind === 'N';
   }
@@ -43,7 +46,7 @@ export class Notification<T> {
   observe(observer: PartialObserver<T>): any {
     switch (this.kind) {
       case 'N':
-        return observer.next && observer.next(this.value);
+        return observer.next && observer.next(this.value!);
       case 'E':
         return observer.error && observer.error(this.error);
       case 'C':
@@ -63,7 +66,7 @@ export class Notification<T> {
     const kind = this.kind;
     switch (kind) {
       case 'N':
-        return next && next(this.value);
+        return next && next(this.value!);
       case 'E':
         return error && error(this.error);
       case 'C':
@@ -97,7 +100,7 @@ export class Notification<T> {
     const kind = this.kind;
     switch (kind) {
       case 'N':
-        return of(this.value);
+        return of(this.value!);
       case 'E':
         return throwError(this.error);
       case 'C':

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -203,9 +203,9 @@ export class Observable<T> implements Subscribable<T> {
    * @return {ISubscription} a subscription reference to the registered handlers
    * @method subscribe
    */
-  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void),
-            error?: (error: any) => void,
-            complete?: () => void): Subscription {
+  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
+            error?: ((error: any) => void) | null,
+            complete?: (() => void) | null): Subscription {
 
     const { operator } = this;
     const sink = toSubscriber(observerOrNext, error, complete);

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -22,10 +22,10 @@ export class Observable<T> implements Subscribable<T> {
   public _isScalar: boolean = false;
 
   /** @deprecated This is an internal implementation detail, do not use. */
-  source: Observable<any>;
+  source: Observable<any> | undefined;
 
   /** @deprecated This is an internal implementation detail, do not use. */
-  operator: Operator<any, T>;
+  operator: Operator<any, T> | undefined;
 
   /**
    * @constructor
@@ -63,7 +63,7 @@ export class Observable<T> implements Subscribable<T> {
    * @param {Operator} operator the operator defining the operation to take on the observable
    * @return {Observable} a new observable with the Operator applied
    */
-  lift<R>(operator: Operator<T, R>): Observable<R> {
+  lift<R>(operator?: Operator<T, R>): Observable<R> {
     const observable = new Observable<R>();
     observable.source = this;
     observable.operator = operator;

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -62,8 +62,8 @@ export class Scheduler implements SchedulerLike {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
-  public schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay: number): Subscription;
-  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number, state: T): Subscription;
+  public schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay?: number): Subscription;
+  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number | undefined, state: T): Subscription;
   public schedule<T>(work: (this: SchedulerAction<T | undefined>, state: T | undefined) => void, delay: number = 0, state?: T): Subscription {
     return new this.SchedulerAction<T>(this, work).schedule(state, delay);
   }

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -62,6 +62,8 @@ export class Scheduler implements SchedulerLike {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
+  public schedule(work: (this: SchedulerAction<void>) => void, delay: number): Subscription;
+  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number, state: T): Subscription;
   public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
     return new this.SchedulerAction<T>(this, work).schedule(state, delay);
   }

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -62,7 +62,7 @@ export class Scheduler implements SchedulerLike {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
-  public schedule(work: (this: SchedulerAction<void>) => void, delay: number): Subscription;
+  public schedule(work: (this: SchedulerAction<undefined>) => void, delay: number): Subscription;
   public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number, state: T): Subscription;
   public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
     return new this.SchedulerAction<T>(this, work).schedule(state, delay);

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -62,9 +62,7 @@ export class Scheduler implements SchedulerLike {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
-  public schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay?: number): Subscription;
-  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number | undefined, state: T): Subscription;
-  public schedule<T>(work: (this: SchedulerAction<T | undefined>, state: T | undefined) => void, delay: number = 0, state?: T): Subscription {
-    return new this.SchedulerAction<T>(this, work).schedule(state, delay);
+  public schedule<T = undefined>(work: (this: SchedulerAction<T>, state: T) => void, delay: number = 0, state?: T): Subscription {
+    return new this.SchedulerAction<T>(this, work).schedule(state!, delay);
   }
 }

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -62,9 +62,9 @@ export class Scheduler implements SchedulerLike {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
-  public schedule(work: (this: SchedulerAction<undefined>) => void, delay: number): Subscription;
+  public schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay: number): Subscription;
   public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number, state: T): Subscription;
-  public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
+  public schedule<T>(work: (this: SchedulerAction<T | undefined>, state: T | undefined) => void, delay: number = 0, state?: T): Subscription {
     return new this.SchedulerAction<T>(this, work).schedule(state, delay);
   }
 }

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -67,7 +67,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
       const len = observers.length;
       const copy = observers.slice();
       for (let i = 0; i < len; i++) {
-        copy[i].next(value);
+        copy[i].next(value!);
       }
     }
   }
@@ -105,7 +105,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
   unsubscribe() {
     this.isStopped = true;
     this.closed = true;
-    this.observers = null;
+    this.observers = null!;
   }
 
   /** @deprecated This is an internal implementation detail, do not use. */
@@ -165,14 +165,14 @@ export class AnonymousSubject<T> extends Subject<T> {
   error(err: any) {
     const { destination } = this;
     if (destination && destination.error) {
-      this.destination.error(err);
+      this.destination!.error(err);
     }
   }
 
   complete() {
     const { destination } = this;
     if (destination && destination.complete) {
-      this.destination.complete();
+      this.destination!.complete();
     }
   }
 
@@ -180,7 +180,7 @@ export class AnonymousSubject<T> extends Subject<T> {
   _subscribe(subscriber: Subscriber<T>): Subscription {
     const { source } = this;
     if (source) {
-      return this.source.subscribe(subscriber);
+      return this.source!.subscribe(subscriber);
     } else {
       return Subscription.EMPTY;
     }

--- a/src/internal/SubjectSubscription.ts
+++ b/src/internal/SubjectSubscription.ts
@@ -24,7 +24,7 @@ export class SubjectSubscription<T> extends Subscription {
     const subject = this.subject;
     const observers = subject.observers;
 
-    this.subject = null;
+    this.subject = null!;
 
     if (!observers || observers.length === 0 || subject.isStopped || subject.closed) {
       return;

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -55,9 +55,9 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
    * @param {function(): void} [complete] The `complete` callback of an
    * Observer.
    */
-  constructor(destinationOrNext?: PartialObserver<any> | ((value: T) => void),
-              error?: (e?: any) => void,
-              complete?: () => void) {
+  constructor(destinationOrNext?: PartialObserver<any> | ((value: T) => void) | null,
+              error?: ((e?: any) => void) | null,
+              complete?: (() => void) | null) {
     super();
 
     switch (arguments.length) {
@@ -96,7 +96,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
    */
   next(value?: T): void {
     if (!this.isStopped) {
-      this._next(value);
+      this._next(value!);
     }
   }
 
@@ -152,7 +152,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribeAndRecycle(): Subscriber<T> {
     const {  _parentOrParents } = this;
-    this._parentOrParents = null;
+    this._parentOrParents = null!;
     this.unsubscribe();
     this.closed = false;
     this.isStopped = false;
@@ -171,12 +171,12 @@ export class SafeSubscriber<T> extends Subscriber<T> {
   private _context: any;
 
   constructor(private _parentSubscriber: Subscriber<T>,
-              observerOrNext?: PartialObserver<T> | ((value: T) => void),
-              error?: (e?: any) => void,
-              complete?: () => void) {
+              observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
+              error?: ((e?: any) => void) | null,
+              complete?: (() => void) | null) {
     super();
 
-    let next: ((value: T) => void);
+    let next: ((value: T) => void) | undefined;
     let context: any = this;
 
     if (isFunction(observerOrNext)) {
@@ -195,9 +195,9 @@ export class SafeSubscriber<T> extends Subscriber<T> {
     }
 
     this._context = context;
-    this._next = next;
-    this._error = error;
-    this._complete = complete;
+    this._next = next!;
+    this._error = error!;
+    this._complete = complete!;
   }
 
   next(value?: T): void {
@@ -296,7 +296,7 @@ export class SafeSubscriber<T> extends Subscriber<T> {
   _unsubscribe(): void {
     const { _parentSubscriber } = this;
     this._context = null;
-    this._parentSubscriber = null;
+    this._parentSubscriber = null!;
     _parentSubscriber.unsubscribe();
   }
 }

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -1,6 +1,6 @@
 import { isFunction } from './util/isFunction';
 import { empty as emptyObserver } from './Observer';
-import { Observer, PartialObserver, TeardownLogic } from './types';
+import { Observer, PartialObserver } from './types';
 import { Subscription } from './Subscription';
 import { rxSubscriber as rxSubscriberSymbol } from '../internal/symbol/rxSubscriber';
 import { config } from './config';
@@ -45,7 +45,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
   /** @internal */ syncErrorThrowable: boolean = false;
 
   protected isStopped: boolean = false;
-  protected destination: PartialObserver<any> | Subscriber<any>; // this `any` is the escape hatch to erase extra type param (e.g. R)
+  protected destination: Observer<any> | Subscriber<any>; // this `any` is the escape hatch to erase extra type param (e.g. R)
 
   /**
    * @param {Observer|function(value: T): void} [destinationOrNext] A partially

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -30,9 +30,9 @@ export class Subscription implements SubscriptionLike {
   public closed: boolean = false;
 
   /** @internal */
-  protected _parentOrParents: Subscription | Subscription[] = null;
+  protected _parentOrParents: Subscription | Subscription[] | null = null;
   /** @internal */
-  private _subscriptions: SubscriptionLike[] = null;
+  private _subscriptions: SubscriptionLike[] | null = null;
 
   /**
    * @param {function(): void} [unsubscribe] A function describing how to
@@ -51,7 +51,7 @@ export class Subscription implements SubscriptionLike {
    * @return {void}
    */
   unsubscribe(): void {
-    let errors: any[];
+    let errors: any[] | undefined;
 
     if (this.closed) {
       return;

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -9,7 +9,7 @@ export const config = {
    * The promise constructor used by default for methods such as
    * {@link toPromise} and {@link forEach}
    */
-  Promise: undefined as PromiseConstructorLike,
+  Promise: undefined! as PromiseConstructorLike,
 
   /**
    * If true, turns on synchronous error rethrowing, which is a deprecated behavior

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -11,7 +11,7 @@ import { refCount as higherOrderRefCount } from '../operators/refCount';
  */
 export class ConnectableObservable<T> extends Observable<T> {
 
-  protected _subject: Subject<T>;
+  protected _subject: Subject<T> | undefined;
   protected _refCount: number = 0;
   protected _connection: Subscription | null | undefined;
   /** @internal */
@@ -32,7 +32,7 @@ export class ConnectableObservable<T> extends Observable<T> {
     if (!subject || subject.isStopped) {
       this._subject = this.subjectFactory();
     }
-    return this._subject;
+    return this._subject!;
   }
 
   connect(): Subscription {

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -13,7 +13,7 @@ export class ConnectableObservable<T> extends Observable<T> {
 
   protected _subject: Subject<T>;
   protected _refCount: number = 0;
-  protected _connection: Subscription;
+  protected _connection: Subscription | null | undefined;
   /** @internal */
   _isComplete = false;
 
@@ -87,7 +87,7 @@ class ConnectableSubscriber<T> extends SubjectSubscriber<T> {
   protected _unsubscribe() {
     const connectable = <any>this.connectable;
     if (connectable) {
-      this.connectable = null;
+      this.connectable = null!;
       const connection = connectable._connection;
       connectable._refCount = 0;
       connectable._subject = null;
@@ -120,7 +120,7 @@ class RefCountOperator<T> implements Operator<T, T> {
 
 class RefCountSubscriber<T> extends Subscriber<T> {
 
-  private connection: Subscription;
+  private connection: Subscription | null | undefined;
 
   constructor(destination: Subscriber<T>,
               private connectable: ConnectableObservable<T>) {
@@ -135,7 +135,7 @@ class RefCountSubscriber<T> extends Subscriber<T> {
       return;
     }
 
-    this.connectable = null;
+    this.connectable = null!;
     const refCount = (<any> connectable)._refCount;
     if (refCount <= 0) {
       this.connection = null;

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -193,20 +193,20 @@ export function bindCallback<T>(
 
   return function (this: any, ...args: any[]): Observable<T> {
     const context = this;
-    let subject: AsyncSubject<T>;
+    let subject: AsyncSubject<T> | undefined;
     const params = {
       context,
-      subject,
+      subject: undefined,
       callbackFunc,
-      scheduler,
+      scheduler: scheduler!,
     };
     return new Observable<T>(subscriber => {
       if (!scheduler) {
         if (!subject) {
           subject = new AsyncSubject<T>();
           const handler = (...innerArgs: any[]) => {
-            subject.next(innerArgs.length <= 1 ? innerArgs[0] : innerArgs);
-            subject.complete();
+            subject!.next(innerArgs.length <= 1 ? innerArgs[0] : innerArgs);
+            subject!.complete();
           };
 
           try {
@@ -240,7 +240,7 @@ interface ParamsContext<T> {
   callbackFunc: Function;
   scheduler: SchedulerLike;
   context: any;
-  subject: AsyncSubject<T>;
+  subject?: AsyncSubject<T>;
 }
 
 function dispatch<T>(this: SchedulerAction<DispatchState<T>>, state: DispatchState<T>) {
@@ -253,7 +253,7 @@ function dispatch<T>(this: SchedulerAction<DispatchState<T>>, state: DispatchSta
 
     const handler = (...innerArgs: any[]) => {
       const value = innerArgs.length <= 1 ? innerArgs[0] : innerArgs;
-      this.add(scheduler.schedule<NextState<T>>(dispatchNext, 0, { value, subject }));
+      this.add(scheduler.schedule<NextState<T>>(dispatchNext, 0, { value, subject: subject! }));
     };
 
     try {

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -155,7 +155,7 @@ export function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLi
  */
 export function bindNodeCallback<T>(
   callbackFunc: Function,
-  resultSelector: Function|SchedulerLike,
+  resultSelector?: Function|SchedulerLike,
   scheduler?: SchedulerLike
 ): (...args: any[]) => Observable<T> {
 
@@ -172,10 +172,10 @@ export function bindNodeCallback<T>(
 
   return function(this: any, ...args: any[]): Observable<T> {
     const params: ParamsState<T> = {
-      subject: undefined,
+      subject: undefined!,
       args,
       callbackFunc,
-      scheduler,
+      scheduler: scheduler!,
       context: this,
     };
     return new Observable<T>(subscriber => {

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -254,7 +254,7 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
   private active: number = 0;
   private values: any[] = [];
   private observables: any[] = [];
-  private toRespond: number;
+  private toRespond: number | undefined;
 
   constructor(destination: Subscriber<R>, private resultSelector?: (...values: Array<any>) => R) {
     super(destination);

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -216,8 +216,8 @@ export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((
 export function combineLatest<O extends ObservableInput<any>, R>(
   ...observables: (O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike)[]
 ): Observable<R> {
-  let resultSelector: (...values: Array<any>) => R =  null;
-  let scheduler: SchedulerLike = null;
+  let resultSelector: ((...values: Array<any>) => R) | undefined =  undefined;
+  let scheduler: SchedulerLike | undefined = undefined;
 
   if (isScheduler(observables[observables.length - 1])) {
     scheduler = observables.pop() as SchedulerLike;
@@ -308,7 +308,7 @@ export class CombineLatestSubscriber<T, R> extends OuterSubscriber<T, R> {
   private _tryResultSelector(values: any[]) {
     let result: any;
     try {
-      result = this.resultSelector.apply(this, values);
+      result = this.resultSelector!.apply(this, values);
     } catch (err) {
       this.destination.error(err);
       return;

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -193,6 +193,7 @@ export class AjaxObservable<T> extends Observable<T> {
  * @extends {Ignored}
  */
 export class AjaxSubscriber<T> extends Subscriber<Event> {
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   private xhr: XMLHttpRequest;
   private done: boolean = false;
 
@@ -444,6 +445,7 @@ export class AjaxResponse {
   response: any;
 
   /** @type {string} The raw responseText */
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   responseText: string;
 
   /** @type {string} The responseType (e.g. 'json', 'arraybuffer', or 'xml') */

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -10,7 +10,7 @@ export interface AjaxRequest {
   user?: string;
   async?: boolean;
   method?: string;
-  headers?: Object;
+  headers?: object;
   timeout?: number;
   password?: string;
   hasContent?: boolean;
@@ -48,7 +48,7 @@ function getXMLHttpRequest(): XMLHttpRequest {
           //suppress exceptions
         }
       }
-      return new root.ActiveXObject(progId);
+      return new root.ActiveXObject(progId!);
     } catch (e) {
       throw new Error('XMLHttpRequest is not supported by your browser');
     }
@@ -65,7 +65,7 @@ export interface AjaxCreationMethod {
   getJSON<T>(url: string, headers?: Object): Observable<T>;
 }
 
-export function ajaxGet(url: string, headers: Object = null) {
+export function ajaxGet(url: string, headers?: object) {
   return new AjaxObservable<AjaxResponse>({ method: 'GET', url, headers });
 }
 
@@ -236,7 +236,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       request: { user, method, url, async, password, headers, body }
     } = this;
     try {
-      const xhr = this.xhr = request.createXHR();
+      const xhr = this.xhr = request.createXHR!();
 
       // set up the events before open XHR
       // https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest
@@ -245,14 +245,14 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       this.setupEvents(xhr, request);
       // open XHR
       if (user) {
-        xhr.open(method, url, async, user, password);
+        xhr.open(method!, url!, async!, user, password);
       } else {
-        xhr.open(method, url, async);
+        xhr.open(method!, url!, async!);
       }
 
       // timeout, responseType and withCredentials can be set once the XHR is open
       if (async) {
-        xhr.timeout = request.timeout;
+        xhr.timeout = request.timeout!;
         xhr.responseType = request.responseType as any;
       }
 
@@ -261,7 +261,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       }
 
       // set headers
-      this.setHeaders(xhr, headers);
+      this.setHeaders(xhr, headers!);
 
       // finally send the request
       if (body) {
@@ -451,7 +451,7 @@ export class AjaxResponse {
 
   constructor(public originalEvent: Event, public xhr: XMLHttpRequest, public request: AjaxRequest) {
     this.status = xhr.status;
-    this.responseType = xhr.responseType || request.responseType;
+    this.responseType = xhr.responseType || request.responseType!;
     this.response = parseXhrResponse(this.responseType, xhr);
   }
 }

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -150,12 +150,14 @@ export type WebSocketMessage = string | ArrayBuffer | Blob | ArrayBufferView;
 
 export class WebSocketSubject<T> extends AnonymousSubject<T> {
 
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   private _config: WebSocketSubjectConfig<T>;
 
   /** @deprecated This is an internal implementation detail, do not use. */
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   _output: Subject<T>;
 
-  private _socket: WebSocket | null;
+  private _socket: WebSocket | null = null;
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>) {
     super();

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -155,7 +155,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   /** @deprecated This is an internal implementation detail, do not use. */
   _output: Subject<T>;
 
-  private _socket: WebSocket;
+  private _socket: WebSocket | null;
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>) {
     super();
@@ -253,11 +253,11 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     const { WebSocketCtor, protocol, url, binaryType } = this._config;
     const observer = this._output;
 
-    let socket: WebSocket = null;
+    let socket: WebSocket | null = null;
     try {
       socket = protocol ?
-        new WebSocketCtor(url, protocol) :
-        new WebSocketCtor(url);
+        new WebSocketCtor!(url, protocol) :
+        new WebSocketCtor!(url);
       this._socket = socket;
       if (binaryType) {
         this._socket.binaryType = binaryType;
@@ -277,7 +277,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     socket.onopen = (e: Event) => {
       const { _socket } = this;
       if (!_socket) {
-        socket.close();
+        socket!.close();
         this._resetState();
         return;
       }
@@ -290,12 +290,12 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
 
       this.destination = Subscriber.create<T>(
         (x) => {
-          if (socket.readyState === 1) {
+          if (socket!.readyState === 1) {
             try {
               const { serializer } = this._config;
-              socket.send(serializer(x));
+              socket!.send(serializer!(x!));
               } catch (e) {
-              this.destination.error(e);
+              this.destination!.error(e);
             }
           }
         },
@@ -305,7 +305,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
             closingObserver.next(undefined);
           }
           if (e && e.code) {
-            socket.close(e.code, e.reason);
+            socket!.close(e.code, e.reason);
           } else {
             observer.error(new TypeError(WEBSOCKETSUBJECT_INVALID_ERROR_OBJECT));
           }
@@ -316,7 +316,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
           if (closingObserver) {
             closingObserver.next(undefined);
           }
-          socket.close();
+          socket!.close();
           this._resetState();
         }
       ) as Subscriber<any>;
@@ -347,7 +347,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     socket.onmessage = (e: MessageEvent) => {
       try {
         const { deserializer } = this._config;
-        observer.next(deserializer(e));
+        observer.next(deserializer!(e));
       } catch (err) {
         observer.error(err);
       }

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -49,8 +49,8 @@ export interface AddEventListenerOptions extends EventListenerOptions {
 /* tslint:disable:max-line-length */
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions): Observable<T>;
+export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, resultSelector?: (...args: any[]) => T): Observable<T>;
+export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options?: EventListenerOptions): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions, resultSelector: (...args: any[]) => T): Observable<T>;
 /* tslint:enable:max-line-length */
@@ -188,8 +188,8 @@ export function fromEvent<T>(
   }
   if (resultSelector) {
     // DEPRECATED PATH
-    return fromEvent<T>(target, eventName, <EventListenerOptions | undefined>options).pipe(
-      map(args => isArray(args) ? resultSelector(...args) : resultSelector(args))
+    return fromEvent<T>(target, eventName, options as EventListenerOptions | undefined).pipe(
+      map(args => isArray(args) ? resultSelector!(...args) : resultSelector!(args))
     );
   }
 
@@ -208,7 +208,7 @@ export function fromEvent<T>(
 function setupSubscription<T>(sourceObj: FromEventTarget<T>, eventName: string,
                               handler: (...args: any[]) => void, subscriber: Subscriber<T>,
                               options?: EventListenerOptions) {
-  let unsubscribe: () => void;
+  let unsubscribe: (() => void) | undefined;
   if (isEventTarget(sourceObj)) {
     const source = sourceObj;
     sourceObj.addEventListener(eventName, handler, options);

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -363,7 +363,7 @@ export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
     if (scheduler) {
       return scheduler.schedule<SchedulerState<T, S>>(dispatch, 0, {
         subscriber,
-        iterate,
+        iterate: iterate!,
         condition,
         resultSelector,
         state
@@ -396,7 +396,7 @@ export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
         break;
       }
       try {
-        state = iterate(state);
+        state = iterate!(state);
       } catch (err) {
         subscriber.error(err);
         return undefined;

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -132,7 +132,7 @@ export function merge<T, R>(...observables: Array<ObservableInput<any> | Schedul
     concurrent = <number>observables.pop();
   }
 
-  if (scheduler === null && observables.length === 1 && observables[0] instanceof Observable) {
+  if (!scheduler && observables.length === 1 && observables[0] instanceof Observable) {
     return <Observable<R>>observables[0];
   }
 

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -119,9 +119,9 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * @name merge
  * @owner Observable
  */
-export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number>): Observable<R> {
+export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number | undefined>): Observable<R> {
  let concurrent = Number.POSITIVE_INFINITY;
- let scheduler: SchedulerLike = null;
+ let scheduler: SchedulerLike | undefined = undefined;
   let last: any = observables[observables.length - 1];
   if (isScheduler(last)) {
     scheduler = <SchedulerLike>observables.pop();

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -121,11 +121,11 @@ export class RaceSubscriber<T> extends OuterSubscriber<T, T> {
         let subscription = subscribeToResult(this, observable, observable as any, i);
 
         if (this.subscriptions) {
-          this.subscriptions.push(subscription);
+          this.subscriptions.push(subscription!);
         }
         this.add(subscription);
       }
-      this.observables = null;
+      this.observables = null!;
     }
   }
 
@@ -144,7 +144,7 @@ export class RaceSubscriber<T> extends OuterSubscriber<T, T> {
         }
       }
 
-      this.subscriptions = null;
+      this.subscriptions = null!;
     }
 
     this.destination.next(innerValue);

--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -72,9 +72,9 @@ export function timer(dueTime: number | Date = 0,
   return new Observable(subscriber => {
     const due = isNumeric(dueTime)
       ? (dueTime as number)
-      : (+dueTime - scheduler.now());
+      : (+dueTime - scheduler!.now());
 
-    return scheduler.schedule(dispatch, due, {
+    return scheduler!.schedule(dispatch, due, {
       index: 0, period, subscriber
     });
   });

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -80,16 +80,17 @@ export function zip<R>(...observables: Array<ObservableInput<any> | ((...values:
 export function zip<O extends ObservableInput<any>, R>(
   ...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R)>
 ): Observable<ObservedValueOf<O>[]|R> {
-  const resultSelector = <((...ys: Array<any>) => R)> observables[observables.length - 1];
-  if (typeof resultSelector === 'function') {
-    observables.pop();
+  const last = observables[observables.length - 1];
+  let resultSelector: ((...ys: Array<any>) => R) | undefined = undefined;
+  if (typeof last === 'function') {
+    resultSelector = observables.pop() as typeof resultSelector;
   }
   return fromArray(observables, undefined).lift(new ZipOperator(resultSelector));
 }
 
 export class ZipOperator<T, R> implements Operator<T, R> {
 
-  resultSelector: (...values: Array<any>) => R;
+  resultSelector?: (...values: Array<any>) => R;
 
   constructor(resultSelector?: (...values: Array<any>) => R) {
     this.resultSelector = resultSelector;
@@ -107,7 +108,7 @@ export class ZipOperator<T, R> implements Operator<T, R> {
  */
 export class ZipSubscriber<T, R> extends Subscriber<T> {
   private values: any;
-  private resultSelector: (...values: Array<any>) => R;
+  private resultSelector?: (...values: Array<any>) => R;
   private iterators: LookAheadIterator<any>[] = [];
   private active = 0;
 
@@ -115,7 +116,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
               resultSelector?: (...values: Array<any>) => R,
               values: any = Object.create(null)) {
     super(destination);
-    this.resultSelector = (typeof resultSelector === 'function') ? resultSelector : null;
+    this.resultSelector = resultSelector;
     this.values = values;
   }
 
@@ -207,7 +208,7 @@ export class ZipSubscriber<T, R> extends Subscriber<T> {
   protected _tryresultSelector(args: any[]) {
     let result: any;
     try {
-      result = this.resultSelector.apply(this, args);
+      result = this.resultSelector!.apply(this, args);
     } catch (err) {
       this.destination.error(err);
       return;
@@ -240,7 +241,7 @@ class StaticIterator<T> implements LookAheadIterator<T> {
 
   hasCompleted() {
     const nextResult = this.nextResult;
-    return nextResult && nextResult.done;
+    return nextResult && !!nextResult.done;
   }
 }
 
@@ -298,7 +299,7 @@ class ZipBufferIterator<T, R> extends OuterSubscriber<T, R> implements LookAhead
     if (buffer.length === 0 && this.isComplete) {
       return { value: null, done: true };
     } else {
-      return { value: buffer.shift(), done: false };
+      return { value: buffer.shift()!, done: false };
     }
   }
 

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -75,9 +75,9 @@ class AuditOperator<T> implements Operator<T, T> {
  */
 class AuditSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  private value: T;
+  private value: T | null;
   private hasValue: boolean = false;
-  private throttled: Subscription;
+  private throttled: Subscription | null;
 
   constructor(destination: Subscriber<T>,
               private durationSelector: (value: T) => SubscribableOrPromise<any>) {

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -75,9 +75,9 @@ class AuditOperator<T> implements Operator<T, T> {
  */
 class AuditSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  private value: T | null;
+  private value: T | null = null;
   private hasValue: boolean = false;
-  private throttled: Subscription | null;
+  private throttled: Subscription | null = null;
 
   constructor(destination: Subscriber<T>,
               private durationSelector: (value: T) => SubscribableOrPromise<any>) {

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -58,7 +58,7 @@ import { OperatorFunction, TeardownLogic } from '../types';
  * @method bufferCount
  * @owner Observable
  */
-export function bufferCount<T>(bufferSize: number, startBufferEvery: number = null): OperatorFunction<T, T[]> {
+export function bufferCount<T>(bufferSize: number, startBufferEvery: number | null = null): OperatorFunction<T, T[]> {
   return function bufferCountOperatorFunction(source: Observable<T>) {
     return source.lift(new BufferCountOperator<T>(bufferSize, startBufferEvery));
   };
@@ -67,7 +67,7 @@ export function bufferCount<T>(bufferSize: number, startBufferEvery: number = nu
 class BufferCountOperator<T> implements Operator<T, T[]> {
   private subscriberClass: any;
 
-  constructor(private bufferSize: number, private startBufferEvery: number) {
+  constructor(private bufferSize: number, private startBufferEvery: number | null) {
     if (!startBufferEvery || bufferSize === startBufferEvery) {
       this.subscriberClass = BufferCountSubscriber;
     } else {
@@ -147,7 +147,7 @@ class BufferSkipCountSubscriber<T> extends Subscriber<T> {
     const { buffers, destination } = this;
 
     while (buffers.length > 0) {
-      let buffer = buffers.shift();
+      let buffer = buffers.shift()!;
       if (buffer.length > 0) {
         destination.next(buffer);
       }

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -109,7 +109,7 @@ class BufferTimeOperator<T> implements Operator<T, T[]> {
 
 class Context<T> {
   buffer: T[] = [];
-  closeAction: Subscription;
+  closeAction: Subscription | undefined;
 }
 
 interface DispatchCreateArg<T> {
@@ -192,8 +192,8 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
   protected onBufferFull(context: Context<T>) {
     this.closeContext(context);
     const closeAction = context.closeAction;
-    closeAction.unsubscribe();
-    this.remove(closeAction);
+    closeAction!.unsubscribe();
+    this.remove(closeAction!);
 
     if (!this.closed && this.timespanOnly) {
       context = this.openContext();

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -78,7 +78,7 @@ export function bufferTime<T>(bufferTimeSpan: number): OperatorFunction<T, T[]> 
     length--;
   }
 
-  let bufferCreationInterval: number = null;
+  let bufferCreationInterval: number | null = null;
   if (length >= 2) {
     bufferCreationInterval = arguments[1];
   }
@@ -95,7 +95,7 @@ export function bufferTime<T>(bufferTimeSpan: number): OperatorFunction<T, T[]> 
 
 class BufferTimeOperator<T> implements Operator<T, T[]> {
   constructor(private bufferTimeSpan: number,
-              private bufferCreationInterval: number,
+              private bufferCreationInterval: number | null,
               private maxBufferSize: number,
               private scheduler: SchedulerLike) {
   }
@@ -114,7 +114,7 @@ class Context<T> {
 
 interface DispatchCreateArg<T> {
   bufferTimeSpan: number;
-  bufferCreationInterval: number;
+  bufferCreationInterval: number | null;
   subscriber: BufferTimeSubscriber<T>;
   scheduler: SchedulerLike;
 }
@@ -135,7 +135,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
 
   constructor(destination: Subscriber<T[]>,
               private bufferTimeSpan: number,
-              private bufferCreationInterval: number,
+              private bufferCreationInterval: number | null,
               private maxBufferSize: number,
               private scheduler: SchedulerLike) {
     super(destination);
@@ -148,14 +148,14 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
       const closeState = { subscriber: this, context };
       const creationState: DispatchCreateArg<T> = { bufferTimeSpan, bufferCreationInterval, subscriber: this, scheduler };
       this.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(dispatchBufferClose, bufferTimeSpan, closeState));
-      this.add(scheduler.schedule<DispatchCreateArg<T>>(dispatchBufferCreation, bufferCreationInterval, creationState));
+      this.add(scheduler.schedule<DispatchCreateArg<T>>(dispatchBufferCreation, bufferCreationInterval!, creationState));
     }
   }
 
   protected _next(value: T) {
     const contexts = this.contexts;
     const len = contexts.length;
-    let filledBufferContext: Context<T>;
+    let filledBufferContext: Context<T> | undefined;
     for (let i = 0; i < len; i++) {
       const context = contexts[i];
       const buffer = context.buffer;
@@ -178,7 +178,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
   protected _complete() {
     const { contexts, destination } = this;
     while (contexts.length > 0) {
-      const context = contexts.shift();
+      const context = contexts.shift()!;
       destination.next(context.buffer);
     }
     super._complete();
@@ -186,7 +186,7 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
 
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribe() {
-    this.contexts = null;
+    this.contexts = null!;
   }
 
   protected onBufferFull(context: Context<T>) {
@@ -240,7 +240,7 @@ function dispatchBufferCreation<T>(this: SchedulerAction<DispatchCreateArg<T>>, 
   const action = <SchedulerAction<DispatchCreateArg<T>>>this;
   if (!subscriber.closed) {
     subscriber.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(dispatchBufferClose, bufferTimeSpan, { subscriber, context }));
-    action.schedule(state, bufferCreationInterval);
+    action.schedule(state, bufferCreationInterval!);
   }
 }
 

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -104,25 +104,25 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
   protected _error(err: any): void {
     const contexts = this.contexts;
     while (contexts.length > 0) {
-      const context = contexts.shift();
+      const context = contexts.shift()!;
       context.subscription.unsubscribe();
-      context.buffer = null;
-      context.subscription = null;
+      context.buffer = null!;
+      context.subscription = null!;
     }
-    this.contexts = null;
+    this.contexts = null!;
     super._error(err);
   }
 
   protected _complete(): void {
     const contexts = this.contexts;
     while (contexts.length > 0) {
-      const context = contexts.shift();
+      const context = contexts.shift()!;
       this.destination.next(context.buffer);
       context.subscription.unsubscribe();
-      context.buffer = null;
-      context.subscription = null;
+      context.buffer = null!;
+      context.subscription = null!;
     }
-    this.contexts = null;
+    this.contexts = null!;
     super._complete();
   }
 

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -94,7 +94,7 @@ class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
 
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribe() {
-    this.buffer = null;
+    this.buffer = null!;
     this.subscribing = false;
   }
 

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -71,9 +71,9 @@ class BufferWhenOperator<T> implements Operator<T, T[]> {
  * @extends {Ignored}
  */
 class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
-  private buffer: T[];
+  private buffer: T[] | undefined;
   private subscribing: boolean = false;
-  private closingSubscription: Subscription;
+  private closingSubscription: Subscription | undefined;
 
   constructor(destination: Subscriber<T[]>, private closingSelector: () => Observable<any>) {
     super(destination);
@@ -81,7 +81,7 @@ class BufferWhenSubscriber<T> extends OuterSubscriber<T, any> {
   }
 
   protected _next(value: T) {
-    this.buffer.push(value);
+    this.buffer!.push(value);
   }
 
   protected _complete() {

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -114,13 +114,13 @@ export function catchError<T, O extends ObservableInput<any>>(
 }
 
 class CatchOperator<T, R> implements Operator<T, T | R> {
-  caught: Observable<T>;
+  caught: Observable<T> | undefined;
 
   constructor(private selector: (err: any, caught: Observable<T>) => ObservableInput<T | R>) {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
-    return source.subscribe(new CatchSubscriber(subscriber, this.selector, this.caught));
+    return source.subscribe(new CatchSubscriber(subscriber, this.selector, this.caught!));
   }
 }
 

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -151,7 +151,7 @@ class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
         return;
       }
       this._unsubscribeAndRecycle();
-      const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+      const innerSubscriber = new InnerSubscriber(this, undefined, undefined!);
       this.add(innerSubscriber);
       const innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
       // The returned subscription will usually be the subscriber that was

--- a/src/internal/operators/combineLatest.ts
+++ b/src/internal/operators/combineLatest.ts
@@ -44,7 +44,7 @@ export function combineLatest<T, TOther, R>(array: ObservableInput<TOther>[], pr
 export function combineLatest<T, R>(...observables: Array<ObservableInput<any> |
                                                     Array<ObservableInput<any>> |
                                                     ((...values: Array<any>) => R)>): OperatorFunction<T, R> {
-  let project: (...values: Array<any>) => R = null;
+  let project: ((...values: Array<any>) => R) | undefined = undefined;
   if (typeof observables[observables.length - 1] === 'function') {
     project = <(...values: Array<any>) => R>observables.pop();
   }

--- a/src/internal/operators/concat.ts
+++ b/src/internal/operators/concat.ts
@@ -24,7 +24,7 @@ export function concat<T, R>(...observables: Array<ObservableInput<any> | Schedu
 /**
  * @deprecated remove in v8. Use {@link concatWith}
  */
-export function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike>): OperatorFunction<T, R> {
+export function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | undefined>): OperatorFunction<T, R> {
   return (source: Observable<T>) => source.lift.call(
     concatStatic(source, ...(observables as any[])),
     undefined

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -73,5 +73,8 @@ export function concatMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector?: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, ObservedValueOf<O>|R> {
-  return mergeMap(project, resultSelector, 1);
+  if (typeof resultSelector === 'function') {
+    return mergeMap(project, resultSelector, 1);
+  }
+  return mergeMap(project, 1);
 }

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -69,5 +69,8 @@ export function concatMapTo<T, R, O extends ObservableInput<any>>(
   innerObservable: O,
   resultSelector?: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, ObservedValueOf<O>|R> {
-  return concatMap(() => innerObservable, resultSelector);
+  if (typeof resultSelector === 'function') {
+    return concatMap(() => innerObservable, resultSelector);
+  }
+  return concatMap(() => innerObservable);
 }

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -67,8 +67,8 @@ export function count<T>(predicate?: (value: T, index: number, source: Observabl
 }
 
 class CountOperator<T> implements Operator<T, number> {
-  constructor(private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-              private source?: Observable<T>) {
+  constructor(private predicate: ((value: T, index: number, source: Observable<T>) => boolean) | undefined,
+              private source: Observable<T>) {
   }
 
   call(subscriber: Subscriber<number>, source: any): any {
@@ -86,8 +86,8 @@ class CountSubscriber<T> extends Subscriber<T> {
   private index: number = 0;
 
   constructor(destination: Observer<number>,
-              private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-              private source?: Observable<T>) {
+              private predicate: ((value: T, index: number, source: Observable<T>) => boolean) | undefined,
+              private source: Observable<T>) {
     super(destination);
   }
 
@@ -103,7 +103,7 @@ class CountSubscriber<T> extends Subscriber<T> {
     let result: any;
 
     try {
-      result = this.predicate(value, this.index++, this.source);
+      result = this.predicate!(value, this.index++, this.source);
     } catch (err) {
       this.destination.error(err);
       return;

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -86,9 +86,9 @@ class DebounceOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
-  private value: T;
+  private value: T | null = null;
   private hasValue: boolean = false;
-  private durationSubscription: Subscription = null;
+  private durationSubscription: Subscription | null | undefined = null;
 
   constructor(destination: Subscriber<R>,
               private durationSelector: (value: T) => SubscribableOrPromise<any>) {
@@ -153,7 +153,7 @@ class DebounceSubscriber<T, R> extends OuterSubscriber<T, R> {
       // emits synchronously
       this.value = null;
       this.hasValue = false;
-      super._next(value);
+      super._next(value!);
     }
   }
 }

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -83,8 +83,8 @@ class DebounceTimeOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class DebounceTimeSubscriber<T> extends Subscriber<T> {
-  private debouncedSubscription: Subscription = null;
-  private lastValue: T = null;
+  private debouncedSubscription: Subscription | null = null;
+  private lastValue: T | null = null;
   private hasValue: boolean = false;
 
   constructor(destination: Subscriber<T>,

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -43,7 +43,7 @@ export function defaultIfEmpty<T, R = T>(defaultValue?: R): OperatorFunction<T, 
  * @method defaultIfEmpty
  * @owner Observable
  */
-export function defaultIfEmpty<T, R>(defaultValue: R = null): OperatorFunction<T, T | R> {
+export function defaultIfEmpty<T, R>(defaultValue: R | null = null): OperatorFunction<T, T | R> {
   return (source: Observable<T>) => source.lift(new DefaultIfEmptyOperator(defaultValue)) as Observable<T | R>;
 }
 

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -97,7 +97,7 @@ class DelaySubscriber<T> extends Subscriber<T> {
     const destination = state.destination;
 
     while (queue.length > 0 && (queue[0].time - scheduler.now()) <= 0) {
-      queue.shift().notification.observe(destination);
+      queue.shift()!.notification.observe(destination);
     }
 
     if (queue.length > 0) {

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -80,7 +80,7 @@ export function distinct<T, K>(keySelector?: (value: T) => K,
 }
 
 class DistinctOperator<T, K> implements Operator<T, T> {
-  constructor(private keySelector: (value: T) => K, private flushes: Observable<any>) {
+  constructor(private keySelector?: (value: T) => K, private flushes?: Observable<any>) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -96,7 +96,7 @@ class DistinctOperator<T, K> implements Operator<T, T> {
 export class DistinctSubscriber<T, K> extends OuterSubscriber<T, T> {
   private values = new Set<K>();
 
-  constructor(destination: Subscriber<T>, private keySelector: (value: T) => K, flushes: Observable<any>) {
+  constructor(destination: Subscriber<T>, private keySelector?: (value: T) => K, flushes?: Observable<any>) {
     super(destination);
 
     if (flushes) {
@@ -126,7 +126,7 @@ export class DistinctSubscriber<T, K> extends OuterSubscriber<T, T> {
     let key: K;
     const { destination } = this;
     try {
-      key = this.keySelector(value);
+      key = this.keySelector!(value);
     } catch (err) {
       destination.error(err);
       return;

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -83,7 +83,7 @@ class DistinctUntilChangedOperator<T, K> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class DistinctUntilChangedSubscriber<T, K> extends Subscriber<T> {
-  private key: K;
+  private key: K | undefined;
   private hasKey: boolean = false;
 
   constructor(destination: Subscriber<T>,

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -68,8 +68,8 @@ export function distinctUntilChanged<T, K>(compare?: (x: K, y: K) => boolean, ke
 }
 
 class DistinctUntilChangedOperator<T, K> implements Operator<T, T> {
-  constructor(private compare: (x: K, y: K) => boolean,
-              private keySelector: (x: T) => K) {
+  constructor(private compare?: (x: K, y: K) => boolean,
+              private keySelector?: (x: T) => K) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -87,8 +87,8 @@ class DistinctUntilChangedSubscriber<T, K> extends Subscriber<T> {
   private hasKey: boolean = false;
 
   constructor(destination: Subscriber<T>,
-              compare: (x: K, y: K) => boolean,
-              private keySelector: (x: T) => K) {
+              compare?: (x: K, y: K) => boolean,
+              private keySelector?: (x: T) => K) {
     super(destination);
     if (typeof compare === 'function') {
       this.compare = compare;

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -36,8 +36,8 @@ export function every<T>(predicate: (value: T, index: number, source: Observable
 
 class EveryOperator<T> implements Operator<T, boolean> {
   constructor(private predicate: (value: T, index: number, source: Observable<T>) => boolean,
-              private thisArg?: any,
-              private source?: Observable<T>) {
+              private thisArg: any,
+              private source: Observable<T>) {
   }
 
   call(observer: Subscriber<boolean>, source: any): any {
@@ -56,7 +56,7 @@ class EverySubscriber<T> extends Subscriber<T> {
   constructor(destination: Observer<boolean>,
               private predicate: (value: T, index: number, source: Observable<T>) => boolean,
               private thisArg: any,
-              private source?: Observable<T>) {
+              private source: Observable<T>) {
     super(destination);
     this.thisArg = thisArg || this;
   }

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -66,7 +66,7 @@ export function expand<T>(project: (value: T, index: number) => ObservableInput<
  */
 export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,
-                             scheduler: SchedulerLike = undefined): OperatorFunction<T, R> {
+                             scheduler?: SchedulerLike): OperatorFunction<T, R> {
   concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;
 
   return (source: Observable<T>) => source.lift(new ExpandOperator(project, concurrent, scheduler));
@@ -75,7 +75,7 @@ export function expand<T, R>(project: (value: T, index: number) => ObservableInp
 export class ExpandOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => ObservableInput<R>,
               private concurrent: number,
-              private scheduler: SchedulerLike) {
+              private scheduler?: SchedulerLike) {
   }
 
   call(subscriber: Subscriber<R>, source: any): any {
@@ -104,7 +104,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => ObservableInput<R>,
               private concurrent: number,
-              private scheduler: SchedulerLike) {
+              private scheduler?: SchedulerLike) {
     super(destination);
     if (concurrent < Number.POSITIVE_INFINITY) {
       this.buffer = [];

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -99,7 +99,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
   private index: number = 0;
   private active: number = 0;
   private hasCompleted: boolean = false;
-  private buffer: any[];
+  private buffer: any[] | undefined;
 
   constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => ObservableInput<R>,
@@ -141,7 +141,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
         destination.error(e);
       }
     } else {
-      this.buffer.push(value);
+      this.buffer!.push(value);
     }
   }
 

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -137,7 +137,7 @@ class GroupByOperator<T, K, R> implements Operator<T, GroupedObservable<K, R>> {
  * @extends {Ignored}
  */
 class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscription {
-  private groups: Map<K, Subject<T | R>> = null;
+  private groups: Map<K, Subject<T | R>> | null = null;
   public attemptedToUnsubscribe: boolean = false;
   public count: number = 0;
 
@@ -178,7 +178,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
         this.error(err);
       }
     } else {
-      element = <any>value;
+      element = value as any;
     }
 
     if (!group) {
@@ -199,7 +199,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
     }
 
     if (!group.closed) {
-      group.next(element);
+      group.next(element!);
     }
   }
 
@@ -228,7 +228,7 @@ class GroupBySubscriber<T, K, R> extends Subscriber<T> implements RefCountSubscr
   }
 
   removeGroup(key: K): void {
-    this.groups.delete(key);
+    this.groups!.delete(key);
   }
 
   unsubscribe() {
@@ -260,7 +260,7 @@ class GroupDurationSubscriber<K, T> extends Subscriber<T> {
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribe() {
     const { parent, key } = this;
-    this.key = this.parent = null;
+    this.key = this.parent = null!;
     if (parent) {
       parent.removeGroup(key);
     }

--- a/src/internal/operators/merge.ts
+++ b/src/internal/operators/merge.ts
@@ -36,9 +36,9 @@ export function merge<T, R>(...observables: Array<ObservableInput<any> | Schedul
 /**
  * @deprecated Deprecated in favor of static {@link merge}.
  */
-export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number>): OperatorFunction<T, R> {
+export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number | undefined>): OperatorFunction<T, R> {
   return (source: Observable<T>) => source.lift.call(
-    mergeStatic(source, ...observables),
+    mergeStatic(source, ...(observables as any[])),
     undefined
   ) as Observable<R>;
 }

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -173,7 +173,7 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     this.remove(innerSub);
     this.active--;
     if (buffer.length > 0) {
-      this._next(buffer.shift());
+      this._next(buffer.shift()!);
     } else if (this.active === 0 && this.hasCompleted) {
       this.destination.complete();
     }

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -113,14 +113,14 @@ export function onErrorResumeNextStatic<R>(array: ObservableInput<any>[]): Obser
 export function onErrorResumeNextStatic<T, R>(...nextSources: Array<ObservableInput<any> |
   Array<ObservableInput<any>> |
   ((...values: Array<any>) => R)>): Observable<R> {
-  let source: ObservableInput<any> = null;
+  let source: ObservableInput<any> | null = null;
 
   if (nextSources.length === 1 && isArray(nextSources[0])) {
     nextSources = <Array<ObservableInput<any>>>nextSources[0];
   }
-  source = nextSources.shift();
+  source = nextSources.shift()!;
 
-  return from(source, null).lift(new OnErrorResumeNextOperator<T, R>(nextSources));
+  return from(source, null!).lift(new OnErrorResumeNextOperator<T, R>(nextSources));
 }
 
 class OnErrorResumeNextOperator<T, R> implements Operator<T, R> {
@@ -159,7 +159,7 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
   private subscribeToNextSource(): void {
     const next = this.nextSources.shift();
     if (!!next) {
-      const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+      const innerSubscriber = new InnerSubscriber(this, undefined, undefined!);
       const destination = this.destination as Subscription;
       destination.add(innerSubscriber);
       const innerSubscription = subscribeToResult(this, next, undefined, undefined, innerSubscriber);

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -62,7 +62,7 @@ class PairwiseOperator<T> implements Operator<T, [T, T]> {
  * @extends {Ignored}
  */
 class PairwiseSubscriber<T> extends Subscriber<T> {
-  private prev: T;
+  private prev: T | undefined;
   private hasPrev: boolean = false;
 
   constructor(destination: Subscriber<[T, T]>) {
@@ -73,7 +73,7 @@ class PairwiseSubscriber<T> extends Subscriber<T> {
     let pair: [T, T] | undefined;
 
     if (this.hasPrev) {
-      pair = [this.prev, value];
+      pair = [this.prev!, value];
     } else {
       this.hasPrev = true;
     }

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -21,5 +21,5 @@ export function publishReplay<T, R>(bufferSize?: number,
   const selector = typeof selectorOrScheduler === 'function' ? selectorOrScheduler : undefined;
   const subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
 
-  return (source: Observable<T>) => multicast(() => subject, selector)(source) as ConnectableObservable<R>;
+  return (source: Observable<T>) => multicast(() => subject, selector!)(source) as ConnectableObservable<R>;
 }

--- a/src/internal/operators/reduce.ts
+++ b/src/internal/operators/reduce.ts
@@ -62,7 +62,7 @@ export function reduce<V, A, S = A>(accumulator: (acc: A|S, value: V, index: num
  * @method reduce
  * @owner Observable
  */
-export function reduce<V, A>(accumulator: (acc: V | A, value: V, index?: number) => A, seed?: any): OperatorFunction<V, V | A> {
+export function reduce<V, A>(accumulator: (acc: V | A, value: V, index: number) => A, seed?: any): OperatorFunction<V, V | A> {
   // providing a seed of `undefined` *should* be valid and trigger
   // hasSeed! so don't use `seed !== undefined` checks!
   // For this reason, we have to check it here at the original call site

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -85,7 +85,7 @@ class RefCountOperator<T> implements Operator<T, T> {
 
 class RefCountSubscriber<T> extends Subscriber<T> {
 
-  private connection: Subscription | null;
+  private connection: Subscription | null = null;
 
   constructor(destination: Subscriber<T>,
               private connectable: ConnectableObservable<T>) {

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -85,7 +85,7 @@ class RefCountOperator<T> implements Operator<T, T> {
 
 class RefCountSubscriber<T> extends Subscriber<T> {
 
-  private connection: Subscription;
+  private connection: Subscription | null;
 
   constructor(destination: Subscriber<T>,
               private connectable: ConnectableObservable<T>) {
@@ -100,14 +100,14 @@ class RefCountSubscriber<T> extends Subscriber<T> {
       return;
     }
 
-    this.connectable = null;
-    const refCount = (<any> connectable)._refCount;
+    this.connectable = null!;
+    const refCount = (connectable as any)._refCount;
     if (refCount <= 0) {
       this.connection = null;
       return;
     }
 
-    (<any> connectable)._refCount = refCount - 1;
+    (connectable as any)._refCount = refCount - 1;
     if (refCount > 1) {
       this.connection = null;
       return;

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -60,9 +60,9 @@ class RepeatWhenOperator<T> implements Operator<T, T> {
  */
 class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  private notifications: Subject<any>;
-  private retries: Observable<any>;
-  private retriesSubscription: Subscription;
+  private notifications: Subject<any> | null = null;
+  private retries: Observable<any> | null = null;
+  private retriesSubscription: Subscription | null | undefined = null;
   private sourceIsBeingSubscribedTo: boolean = true;
 
   constructor(destination: Subscriber<R>,
@@ -96,7 +96,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
       }
 
       this._unsubscribeAndRecycle();
-      this.notifications.next();
+      this.notifications!.next();
     }
   }
 
@@ -118,7 +118,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
   _unsubscribeAndRecycle(): Subscriber<T> {
     const { _unsubscribe } = this;
 
-    this._unsubscribe = null;
+    this._unsubscribe = null!;
     super._unsubscribeAndRecycle();
     this._unsubscribe = _unsubscribe;
 

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -84,9 +84,9 @@ class RetryWhenOperator<T> implements Operator<T, T> {
  */
 class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  private errors: Subject<any>;
-  private retries: Observable<any>;
-  private retriesSubscription: Subscription;
+  private errors: Subject<any> | null = null;
+  private retries: Observable<any> | null = null;
+  private retriesSubscription: Subscription | null | undefined = null;
 
   constructor(destination: Subscriber<R>,
               private notifier: (errors: Observable<any>) => Observable<any>,
@@ -98,7 +98,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     if (!this.isStopped) {
 
       let errors = this.errors;
-      let retries: any = this.retries;
+      let retries = this.retries;
       let retriesSubscription = this.retriesSubscription;
 
       if (!retries) {
@@ -121,7 +121,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.retries = retries;
       this.retriesSubscription = retriesSubscription;
 
-      errors.next(err);
+      errors!.next(err);
     }
   }
 
@@ -144,7 +144,7 @@ class RetryWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
              innerSub: InnerSubscriber<T, R>): void {
     const { _unsubscribe } = this;
 
-    this._unsubscribe = null;
+    this._unsubscribe = null!;
     this._unsubscribeAndRecycle();
     this._unsubscribe = _unsubscribe;
 

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -69,7 +69,7 @@ class SampleOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class SampleSubscriber<T, R> extends OuterSubscriber<T, R> {
-  private value: T;
+  private value: T | undefined;
   private hasValue: boolean = false;
 
   protected _next(value: T) {

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -66,7 +66,7 @@ class SampleTimeOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class SampleTimeSubscriber<T> extends Subscriber<T> {
-  lastValue: T;
+  lastValue: T | undefined;
   hasValue: boolean = false;
 
   constructor(destination: Subscriber<T>,

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -69,7 +69,7 @@ export function sequenceEqual<T>(compareTo: Observable<T>,
 
 export class SequenceEqualOperator<T> implements Operator<T, boolean> {
   constructor(private compareTo: Observable<T>,
-              private comparator: (a: T, b: T) => boolean) {
+              private comparator?: (a: T, b: T) => boolean) {
   }
 
   call(subscriber: Subscriber<boolean>, source: any): any {
@@ -89,7 +89,7 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
 
   constructor(destination: Observer<R>,
               private compareTo: Observable<T>,
-              private comparator: (a: T, b: T) => boolean) {
+              private comparator?: (a: T, b: T) => boolean) {
     super(destination);
     (this.destination as Subscription).add(compareTo.subscribe(new SequenceEqualCompareToSubscriber(destination, this)));
   }
@@ -115,8 +115,8 @@ export class SequenceEqualSubscriber<T, R> extends Subscriber<T> {
   checkValues() {
     const { _a, _b, comparator } = this;
     while (_a.length > 0 && _b.length > 0) {
-      let a = _a.shift();
-      let b = _b.shift();
+      let a = _a.shift()!;
+      let b = _b.shift()!;
       let areEqual = false;
       try {
         areEqual = comparator ? comparator(a, b) : a === b;

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -161,15 +161,15 @@ function shareReplayOperator<T>({
       hasError = false;
       subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
       subscription = source.subscribe({
-        next(value) { subject.next(value); },
+        next(value) { subject!.next(value); },
         error(err) {
           hasError = true;
-          subject.error(err);
+          subject!.error(err);
         },
         complete() {
           isComplete = true;
           subscription = undefined;
-          subject.complete();
+          subject!.complete();
         },
       });
     }

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -56,8 +56,8 @@ export function single<T>(predicate?: (value: T, index: number, source: Observab
 }
 
 class SingleOperator<T> implements Operator<T, T> {
-  constructor(private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-              private source?: Observable<T>) {
+  constructor(private predicate: ((value: T, index: number, source: Observable<T>) => boolean) | undefined,
+              private source: Observable<T>) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -76,8 +76,8 @@ class SingleSubscriber<T> extends Subscriber<T> {
   private index: number = 0;
 
   constructor(destination: Observer<T>,
-              private predicate?: (value: T, index: number, source: Observable<T>) => boolean,
-              private source?: Observable<T>) {
+              private predicate: ((value: T, index: number, source: Observable<T>) => boolean) | undefined,
+              private source: Observable<T>) {
     super(destination);
   }
 
@@ -102,7 +102,7 @@ class SingleSubscriber<T> extends Subscriber<T> {
 
   private tryNext(value: T, index: number): void {
     try {
-      if (this.predicate(value, index, this.source)) {
+      if (this.predicate!(value, index, this.source)) {
         this.applySingleValue(value);
       }
     } catch (err) {

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -72,7 +72,7 @@ class SingleOperator<T> implements Operator<T, T> {
  */
 class SingleSubscriber<T> extends Subscriber<T> {
   private seenValue: boolean = false;
-  private singleValue: T;
+  private singleValue: T | undefined;
   private index: number = 0;
 
   constructor(destination: Observer<T>,

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -67,11 +67,11 @@ class SkipUntilOperator<T> implements Operator<T, T> {
 class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private hasValue: boolean = false;
-  private innerSubscription: Subscription;
+  private innerSubscription: Subscription | undefined;
 
   constructor(destination: Subscriber<R>, notifier: ObservableInput<any>) {
     super(destination);
-    const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+    const innerSubscriber = new InnerSubscriber(this, undefined, undefined!);
     this.add(innerSubscriber);
     this.innerSubscription = innerSubscriber;
     const innerSubscription = subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -109,7 +109,7 @@ class SwitchMapOperator<T, R> implements Operator<T, R> {
  */
 class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   private index: number = 0;
-  private innerSubscription: Subscription;
+  private innerSubscription: Subscription | null | undefined;
 
   constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => ObservableInput<R>) {
@@ -154,13 +154,13 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
   }
 
   protected _unsubscribe() {
-    this.innerSubscription = null;
+    this.innerSubscription = null!;
   }
 
   notifyComplete(innerSub: Subscription): void {
     const destination = this.destination as Subscription;
     destination.remove(innerSub);
-    this.innerSubscription = null;
+    this.innerSubscription = null!;
     if (this.isStopped) {
       super._complete();
     }

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -64,18 +64,18 @@ export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T
  * specified Observer or callback(s) for each item.
  * @name tap
  */
-export function tap<T>(nextOrObserver?: PartialObserver<T> | ((x: T) => void),
-                       error?: (e: any) => void,
-                       complete?: () => void): MonoTypeOperatorFunction<T> {
+export function tap<T>(nextOrObserver?: PartialObserver<T> | ((x: T) => void) | null,
+                       error?: ((e: any) => void) | null,
+                       complete?: (() => void) | null): MonoTypeOperatorFunction<T> {
   return function tapOperatorFunction(source: Observable<T>): Observable<T> {
     return source.lift(new DoOperator(nextOrObserver, error, complete));
   };
 }
 
 class DoOperator<T> implements Operator<T, T> {
-  constructor(private nextOrObserver?: PartialObserver<T> | ((x: T) => void),
-              private error?: (e: any) => void,
-              private complete?: () => void) {
+  constructor(private nextOrObserver?: PartialObserver<T> | ((x: T) => void) | null,
+              private error?: ((e: any) => void) | null,
+              private complete?: (() => void) | null) {
   }
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
     return source.subscribe(new TapSubscriber(subscriber, this.nextOrObserver, this.error, this.complete));
@@ -98,9 +98,9 @@ class TapSubscriber<T> extends Subscriber<T> {
   private _tapComplete: (() => void) = noop;
 
   constructor(destination: Subscriber<T>,
-              observerOrNext?: PartialObserver<T> | ((value: T) => void),
-              error?: (e?: any) => void,
-              complete?: () => void) {
+              observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
+              error?: ((e?: any) => void) | null,
+              complete?: (() => void) | null) {
       super(destination);
       this._tapError = error || noop;
       this._tapComplete = complete || noop;

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -67,7 +67,7 @@ export const defaultThrottleConfig: ThrottleConfig = {
  */
 export function throttle<T>(durationSelector: (value: T) => SubscribableOrPromise<any>,
                             config: ThrottleConfig = defaultThrottleConfig): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new ThrottleOperator(durationSelector, config.leading, config.trailing));
+  return (source: Observable<T>) => source.lift(new ThrottleOperator(durationSelector, !!config.leading, !!config.trailing));
 }
 
 class ThrottleOperator<T> implements Operator<T, T> {
@@ -89,8 +89,8 @@ class ThrottleOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
-  private _throttled: Subscription;
-  private _sendValue: T;
+  private _throttled: Subscription | null | undefined;
+  private _sendValue: T | null;
   private _hasValue = false;
 
   constructor(protected destination: Subscriber<T>,
@@ -116,8 +116,8 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
   private send() {
     const { _hasValue, _sendValue } = this;
     if (_hasValue) {
-      this.destination.next(_sendValue);
-      this.throttle(_sendValue);
+      this.destination.next(_sendValue!);
+      this.throttle(_sendValue!);
     }
     this._hasValue = false;
     this._sendValue = null;
@@ -130,7 +130,7 @@ class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
     }
   }
 
-  private tryDurationSelector(value: T): SubscribableOrPromise<any> {
+  private tryDurationSelector(value: T): SubscribableOrPromise<any> | null {
     try {
       return this.durationSelector(value);
     } catch (err) {

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -90,7 +90,7 @@ class ThrottleOperator<T> implements Operator<T, T> {
  */
 class ThrottleSubscriber<T, R> extends OuterSubscriber<T, R> {
   private _throttled: Subscription | null | undefined;
-  private _sendValue: T | null;
+  private _sendValue: T | null = null;
   private _hasValue = false;
 
   constructor(protected destination: Subscriber<T>,

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -111,7 +111,7 @@ class ThrottleTimeOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class ThrottleTimeSubscriber<T> extends Subscriber<T> {
-  private throttled: Subscription | null;
+  private throttled: Subscription | null = null;
   private _hasTrailingValue: boolean = false;
   private _trailingValue: T | null = null;
 

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -88,7 +88,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
 export function throttleTime<T>(duration: number,
                                 scheduler: SchedulerLike = async,
                                 config: ThrottleConfig = defaultThrottleConfig): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new ThrottleTimeOperator(duration, scheduler, config.leading, config.trailing));
+  return (source: Observable<T>) => source.lift(new ThrottleTimeOperator(duration, scheduler, !!config.leading, !!config.trailing));
 }
 
 class ThrottleTimeOperator<T> implements Operator<T, T> {
@@ -111,9 +111,9 @@ class ThrottleTimeOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class ThrottleTimeSubscriber<T> extends Subscriber<T> {
-  private throttled: Subscription;
+  private throttled: Subscription | null;
   private _hasTrailingValue: boolean = false;
-  private _trailingValue: T = null;
+  private _trailingValue: T | null = null;
 
   constructor(destination: Subscriber<T>,
               private duration: number,
@@ -159,7 +159,7 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
       }
       throttled.unsubscribe();
       this.remove(throttled);
-      this.throttled = null;
+      this.throttled = null!;
     }
   }
 }

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -56,8 +56,8 @@ export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunct
       // TODO(benlesh): correct these typings.
       scan(
         ({ current }, value) => ({ value, current: scheduler.now(), last: current }),
-        { current: scheduler.now(), value: undefined,  last: undefined }
-      ) as any,
+        { current: scheduler.now(), value: undefined,  last: undefined } as any
+      ) as OperatorFunction<T, any>,
       map<any, TimeInterval<T>>(({ current, last, value }) => new TimeInterval(value, current - last)),
     );
   });

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -95,7 +95,7 @@ class TimeoutWithOperator<T> implements Operator<T, T> {
  */
 class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  private action: SchedulerAction<TimeoutWithSubscriber<T, R>> = null;
+  private action: SchedulerAction<TimeoutWithSubscriber<T, R>> | null = null;
 
   constructor(destination: Subscriber<T>,
               private absoluteTimeout: boolean,
@@ -138,7 +138,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribe() {
     this.action = null;
-    this.scheduler = null;
-    this.withObservable = null;
+    this.scheduler = null!;
+    this.withObservable = null!;
   }
 }

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -115,7 +115,7 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
 
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribe() {
-    this.window = null;
+    this.window = null!;
   }
 
   private openWindow(): void  {

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -113,7 +113,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     }
     const c = this.count - windowSize + 1;
     if (c >= 0 && c % startWindowEvery === 0 && !this.closed) {
-      windows.shift().complete();
+      windows.shift()!.complete();
     }
     if (++this.count % startWindowEvery === 0 && !this.closed) {
       const window = new Subject<T>();
@@ -126,7 +126,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     const windows = this.windows;
     if (windows) {
       while (windows.length > 0 && !this.closed) {
-        windows.shift().error(err);
+        windows.shift()!.error(err);
       }
     }
     this.destination.error(err);
@@ -136,7 +136,7 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
     const windows = this.windows;
     if (windows) {
       while (windows.length > 0 && !this.closed) {
-        windows.shift().complete();
+        windows.shift()!.complete();
       }
     }
     this.destination.complete();
@@ -144,6 +144,6 @@ class WindowCountSubscriber<T> extends Subscriber<T> {
 
   protected _unsubscribe() {
     this.count = 0;
-    this.windows = null;
+    this.windows = null!;
   }
 }

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -102,7 +102,7 @@ export function windowTime<T>(windowTimeSpan: number,
 
 export function windowTime<T>(windowTimeSpan: number): OperatorFunction<T, Observable<T>> {
   let scheduler: SchedulerLike = async;
-  let windowCreationInterval: number = null;
+  let windowCreationInterval: number | null = null;
   let maxWindowSize: number = Number.POSITIVE_INFINITY;
 
   if (isScheduler(arguments[3])) {
@@ -222,7 +222,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
   protected _error(err: any): void {
     const windows = this.windows;
     while (windows.length > 0) {
-      windows.shift().error(err);
+      windows.shift()!.error(err);
     }
     this.destination.error(err);
   }
@@ -230,7 +230,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
   protected _complete(): void {
     const windows = this.windows;
     while (windows.length > 0) {
-      const window = windows.shift();
+      const window = windows.shift()!;
       if (!window.closed) {
         window.complete();
       }
@@ -273,7 +273,7 @@ function dispatchWindowCreation<T>(this: SchedulerAction<CreationState<T>>, stat
   action.schedule(state, windowCreationInterval);
 }
 
-function dispatchWindowClose<T>(state: CloseState<T>): void {
+function dispatchWindowClose<T>(this: SchedulerAction<CloseState<T>>, state: CloseState<T>): void {
   const { subscriber, window, context } = state;
   if (context && context.action && context.subscription) {
     context.action.remove(context.subscription);

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -86,7 +86,7 @@ interface WindowContext<T> {
  */
 class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
   private contexts: WindowContext<T>[] = [];
-  private openSubscription: Subscription;
+  private openSubscription: Subscription | undefined;
 
   constructor(destination: Subscriber<Observable<T>>,
               private openings: Observable<O>,
@@ -108,7 +108,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
   protected _error(err: any) {
 
     const { contexts } = this;
-    this.contexts = null;
+    this.contexts = null!;
 
     if (contexts) {
       const len = contexts.length;
@@ -126,7 +126,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
 
   protected _complete() {
     const { contexts } = this;
-    this.contexts = null;
+    this.contexts = null!;
     if (contexts) {
       const len = contexts.length;
       let index = -1;
@@ -142,7 +142,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribe() {
     const { contexts } = this;
-    this.contexts = null;
+    this.contexts = null!;
     if (contexts) {
       const len = contexts.length;
       let index = -1;
@@ -173,7 +173,7 @@ class WindowToggleSubscriber<T, O> extends OuterSubscriber<T, any> {
       this.contexts.push(context);
       const innerSubscription = subscribeToResult(this, closingNotifier, context as any);
 
-      if (innerSubscription.closed) {
+      if (innerSubscription!.closed) {
         this.closeWindow(this.contexts.length - 1);
       } else {
         (<any>innerSubscription).context = context;

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -75,7 +75,7 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
  */
 class WindowSubscriber<T> extends OuterSubscriber<T, any> {
   private window: Subject<T>;
-  private closingNotification: Subscription;
+  private closingNotification: Subscription | undefined;
 
   constructor(protected destination: Subscriber<Observable<T>>,
               private closingSelector: () => Observable<any>) {
@@ -119,7 +119,7 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     }
   }
 
-  private openWindow(innerSub: InnerSubscriber<T, any> = null): void {
+  private openWindow(innerSub: InnerSubscriber<T, any> | null = null): void {
     if (innerSub) {
       this.remove(innerSub);
       innerSub.unsubscribe();

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -74,7 +74,7 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
  * @extends {Ignored}
  */
 class WindowSubscriber<T> extends OuterSubscriber<T, any> {
-  private window: Subject<T>;
+  private window: Subject<T> | undefined;
   private closingNotification: Subscription | undefined;
 
   constructor(protected destination: Subscriber<Observable<T>>,
@@ -98,17 +98,17 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
   }
 
   protected _next(value: T): void {
-    this.window.next(value);
+    this.window!.next(value);
   }
 
   protected _error(err: any): void {
-    this.window.error(err);
+    this.window!.error(err);
     this.destination.error(err);
     this.unsubscribeClosingNotification();
   }
 
   protected _complete(): void {
-    this.window.complete();
+    this.window!.complete();
     this.destination.complete();
     this.unsubscribeClosingNotification();
   }

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -146,7 +146,7 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
   private _tryProject(args: any[]) {
     let result: any;
     try {
-      result = this.project.apply(this, args);
+      result = this.project!.apply(this, args);
     } catch (err) {
       this.destination.error(err);
       return;

--- a/src/internal/scheduled/scheduleIterable.ts
+++ b/src/internal/scheduled/scheduleIterable.ts
@@ -23,7 +23,7 @@ export function scheduleIterable<T>(input: Iterable<T>, scheduler: SchedulerLike
           return;
         }
         let value: T;
-        let done: boolean;
+        let done: boolean | undefined;
         try {
           const result = iterator.next();
           value = result.value;

--- a/src/internal/scheduler/Action.ts
+++ b/src/internal/scheduler/Action.ts
@@ -9,15 +9,15 @@ import { SchedulerAction } from '../types';
  *
  * ```ts
  * class Action<T> extends Subscription {
- *   new (scheduler: Scheduler, work: (state?: T) => void);
- *   schedule(state?: T, delay: number = 0): Subscription;
+ *   new (scheduler: Scheduler, work: (state: T) => void);
+ *   schedule(state: T, delay: number = 0): Subscription;
  * }
  * ```
  *
  * @class Action<T>
  */
 export class Action<T> extends Subscription {
-  constructor(scheduler: Scheduler, work: (this: SchedulerAction<T>, state?: T) => void) {
+  constructor(scheduler: Scheduler, work: (this: SchedulerAction<T>, state: T) => void) {
     super();
   }
   /**
@@ -30,7 +30,7 @@ export class Action<T> extends Subscription {
    * time unit is implicit and defined by the Scheduler.
    * @return {void}
    */
-  public schedule(state?: T, delay: number = 0): Subscription {
+  public schedule(state: T, delay: number = 0): Subscription {
     return this;
   }
 }

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -25,7 +25,7 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     // one. If an animation frame hasn't been requested yet, request one. Return
     // the current animation frame request id.
     return scheduler.scheduled || (scheduler.scheduled = requestAnimationFrame(
-      () => scheduler.flush(null)));
+      () => scheduler.flush(undefined)));
   }
   protected recycleAsyncId(scheduler: AnimationFrameScheduler, id?: any, delay: number = 0): any {
     // If delay exists and is greater than 0, or if the delay is null (the

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -10,7 +10,7 @@ import { SchedulerAction } from '../types';
 export class AnimationFrameAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AnimationFrameScheduler,
-              protected work: (this: SchedulerAction<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AnimationFrameScheduler.ts
+++ b/src/internal/scheduler/AnimationFrameScheduler.ts
@@ -11,7 +11,7 @@ export class AnimationFrameScheduler extends AsyncScheduler {
     let error: any;
     let index: number = -1;
     let count: number = actions.length;
-    action = action || actions.shift();
+    action = action || actions.shift()!;
 
     do {
       if (error = action.execute(action.state, action.delay)) {

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -25,7 +25,7 @@ export class AsapAction<T> extends AsyncAction<T> {
     // one. If a microtask hasn't been scheduled yet, schedule one now. Return
     // the current scheduled microtask id.
     return scheduler.scheduled || (scheduler.scheduled = Immediate.setImmediate(
-      scheduler.flush.bind(scheduler, null)
+      scheduler.flush.bind(scheduler, undefined)
     ));
   }
   protected recycleAsyncId(scheduler: AsapScheduler, id?: any, delay: number = 0): any {

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -10,7 +10,7 @@ import { SchedulerAction } from '../types';
 export class AsapAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AsapScheduler,
-              protected work: (this: SchedulerAction<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsapScheduler.ts
+++ b/src/internal/scheduler/AsapScheduler.ts
@@ -11,7 +11,7 @@ export class AsapScheduler extends AsyncScheduler {
     let error: any;
     let index: number = -1;
     let count: number = actions.length;
-    action = action || actions.shift();
+    action = action || actions.shift()!;
 
     do {
       if (error = action.execute(action.state, action.delay)) {

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -17,7 +17,7 @@ export class AsyncAction<T> extends Action<T> {
   protected pending: boolean = false;
 
   constructor(protected scheduler: AsyncScheduler,
-              protected work: (this: SchedulerAction<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -12,6 +12,7 @@ export class AsyncAction<T> extends Action<T> {
 
   public id: any;
   public state?: T;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   public delay: number;
   protected pending: boolean = false;
 

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -11,7 +11,7 @@ import { AsyncScheduler } from './AsyncScheduler';
 export class AsyncAction<T> extends Action<T> {
 
   public id: any;
-  public state: T;
+  public state?: T;
   public delay: number;
   protected pending: boolean = false;
 
@@ -72,7 +72,7 @@ export class AsyncAction<T> extends Action<T> {
     return setInterval(scheduler.flush.bind(scheduler, this), delay);
   }
 
-  protected recycleAsyncId(scheduler: AsyncScheduler, id: any, delay: number = 0): any {
+  protected recycleAsyncId(scheduler: AsyncScheduler, id: any, delay: number | null = 0): any {
     // If this action is rescheduled with the same delay time, don't clear the interval id.
     if (delay !== null && this.delay === delay && this.pending === false) {
       return id;
@@ -138,10 +138,10 @@ export class AsyncAction<T> extends Action<T> {
     const actions = scheduler.actions;
     const index = actions.indexOf(this);
 
-    this.work  = null;
-    this.state = null;
+    this.work  = null!;
+    this.state = null!;
     this.pending = false;
-    this.scheduler = null;
+    this.scheduler = null!;
 
     if (index !== -1) {
       actions.splice(index, 1);
@@ -151,6 +151,6 @@ export class AsyncAction<T> extends Action<T> {
       this.id = this.recycleAsyncId(scheduler, id, null);
     }
 
-    this.delay = null;
+    this.delay = null!;
   }
 }

--- a/src/internal/scheduler/AsyncScheduler.ts
+++ b/src/internal/scheduler/AsyncScheduler.ts
@@ -34,13 +34,11 @@ export class AsyncScheduler extends Scheduler {
     });
   }
 
-  public schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay?: number): Subscription;
-  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number | undefined, state: T): Subscription;
-  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number = 0, state?: T): Subscription {
+  public schedule<T = undefined>(work: (this: SchedulerAction<T>, state: T) => void, delay: number = 0, state?: T): Subscription {
     if (AsyncScheduler.delegate && AsyncScheduler.delegate !== this) {
-      return AsyncScheduler.delegate.schedule(work, delay, state!);
+      return AsyncScheduler.delegate.schedule(work, delay, state);
     } else {
-      return super.schedule(work, delay, state!);
+      return super.schedule(work, delay, state);
     }
   }
 

--- a/src/internal/scheduler/AsyncScheduler.ts
+++ b/src/internal/scheduler/AsyncScheduler.ts
@@ -34,11 +34,13 @@ export class AsyncScheduler extends Scheduler {
     });
   }
 
-  public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
+  public schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay?: number): Subscription;
+  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number | undefined, state: T): Subscription;
+  public schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number = 0, state?: T): Subscription {
     if (AsyncScheduler.delegate && AsyncScheduler.delegate !== this) {
-      return AsyncScheduler.delegate.schedule(work, delay, state);
+      return AsyncScheduler.delegate.schedule(work, delay, state!);
     } else {
-      return super.schedule(work, delay, state);
+      return super.schedule(work, delay, state!);
     }
   }
 
@@ -58,12 +60,12 @@ export class AsyncScheduler extends Scheduler {
       if (error = action.execute(action.state, action.delay)) {
         break;
       }
-    } while (action = actions.shift()); // exhaust the scheduler queue
+    } while (action = actions.shift()!); // exhaust the scheduler queue
 
     this.active = false;
 
     if (error) {
-      while (action = actions.shift()) {
+      while (action = actions.shift()!) {
         action.unsubscribe();
       }
       throw error;

--- a/src/internal/scheduler/QueueAction.ts
+++ b/src/internal/scheduler/QueueAction.ts
@@ -11,11 +11,11 @@ import { SchedulerAction } from '../types';
 export class QueueAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: QueueScheduler,
-              protected work: (this: SchedulerAction<T>, state?: T) => void) {
+              protected work: (this: SchedulerAction<T>, state: T) => void) {
     super(scheduler, work);
   }
 
-  public schedule(state?: T, delay: number = 0): Subscription {
+  public schedule(state: T, delay: number = 0): Subscription {
     if (delay > 0) {
       return super.schedule(state, delay);
     }

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -67,7 +67,7 @@ export class VirtualAction<T> extends AsyncAction<T> {
   protected active: boolean = true;
 
   constructor(protected scheduler: VirtualTimeScheduler,
-              protected work: (this: SchedulerAction<T>, state?: T) => void,
+              protected work: (this: SchedulerAction<T>, state: T) => void,
               protected index: number = scheduler.index += 1) {
     super(scheduler, work);
     this.index = scheduler.index = index;

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -42,7 +42,7 @@ export class VirtualTimeScheduler extends AsyncScheduler {
   public flush(): void {
 
     const {actions, maxFrames} = this;
-    let error: any, action: AsyncAction<any>;
+    let error: any, action: AsyncAction<any> | undefined;
 
     while ((action = actions[0]) && action.delay <= maxFrames) {
       actions.shift();

--- a/src/internal/testing/ColdObservable.ts
+++ b/src/internal/testing/ColdObservable.ts
@@ -15,7 +15,9 @@ import { Subscriber } from '../Subscriber';
 export class ColdObservable<T> extends Observable<T> implements SubscriptionLoggable {
   public subscriptions: SubscriptionLog[] = [];
   scheduler: Scheduler;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   logSubscribedFrame: () => number;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   logUnsubscribedFrame: (index: number) => void;
 
   constructor(public messages: TestMessage[],

--- a/src/internal/testing/HotObservable.ts
+++ b/src/internal/testing/HotObservable.ts
@@ -15,7 +15,9 @@ import { applyMixins } from '../util/applyMixins';
 export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable {
   public subscriptions: SubscriptionLog[] = [];
   scheduler: Scheduler;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   logSubscribedFrame: () => number;
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   logUnsubscribedFrame: (index: number) => void;
 
   constructor(public messages: TestMessage[],

--- a/src/internal/testing/SubscriptionLoggable.ts
+++ b/src/internal/testing/SubscriptionLoggable.ts
@@ -3,6 +3,7 @@ import { SubscriptionLog } from './SubscriptionLog';
 
 export class SubscriptionLoggable {
   public subscriptions: SubscriptionLog[] = [];
+  // @ts-ignore: Property has no initializer and is not definitely assigned
   scheduler: Scheduler;
 
   logSubscribedFrame(): number {

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -121,7 +121,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   expectObservable(observable: Observable<any>,
-                   subscriptionMarbles: string = null): ({ toBe: observableToBeFn }) {
+                   subscriptionMarbles: string | null = null): ({ toBe: observableToBeFn }) {
     const actual: TestMessage[] = [];
     const flushTest: FlushableTest = { actual, ready: false };
     const subscriptionParsed = TestScheduler.parseMarblesAsSubscriptions(subscriptionMarbles, this.runMode);
@@ -178,7 +178,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   flush() {
     const hotObservables = this.hotObservables;
     while (hotObservables.length > 0) {
-      hotObservables.shift().setup();
+      hotObservables.shift()!.setup();
     }
 
     super.flush();
@@ -193,7 +193,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   /** @nocollapse */
-  static parseMarblesAsSubscriptions(marbles: string, runMode = false): SubscriptionLog {
+  static parseMarblesAsSubscriptions(marbles: string | null, runMode = false): SubscriptionLog {
     if (typeof marbles !== 'string') {
       return new SubscriptionLog(Number.POSITIVE_INFINITY);
     }
@@ -270,7 +270,7 @@ export class TestScheduler extends VirtualTimeScheduler {
                     break;
                 }
 
-                advanceFrameBy(durationInMs / this.frameTimeFactor);
+                advanceFrameBy(durationInMs! / this.frameTimeFactor);
                 break;
               }
             }
@@ -321,7 +321,7 @@ export class TestScheduler extends VirtualTimeScheduler {
         nextFrame += count * this.frameTimeFactor;
       };
 
-      let notification: Notification<any>;
+      let notification: Notification<any> | undefined;
       const c = marbles[i];
       switch (c) {
         case ' ':
@@ -380,7 +380,7 @@ export class TestScheduler extends VirtualTimeScheduler {
                     break;
                 }
 
-                advanceFrameBy(durationInMs / this.frameTimeFactor);
+                advanceFrameBy(durationInMs! / this.frameTimeFactor);
                 break;
               }
             }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -93,7 +93,7 @@ export interface Observer<T> {
 export interface SchedulerLike {
   now(): number;
   schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay?: number): Subscription;
-  schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay?: number, state?: T): Subscription;
+  schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number | undefined, state: T): Subscription;
 }
 export interface SchedulerAction<T> extends Subscription {
   schedule(state?: T, delay?: number): Subscription;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -92,7 +92,8 @@ export interface Observer<T> {
 
 export interface SchedulerLike {
   now(): number;
-  schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay?: number, state?: T): Subscription;
+  schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay?: number): Subscription;
+  schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay?: number, state?: T): Subscription;
 }
 export interface SchedulerAction<T> extends Subscription {
   schedule(state?: T, delay?: number): Subscription;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -92,8 +92,7 @@ export interface Observer<T> {
 
 export interface SchedulerLike {
   now(): number;
-  schedule(work: (this: SchedulerAction<undefined>, state: undefined) => void, delay?: number): Subscription;
-  schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number | undefined, state: T): Subscription;
+  schedule<T = undefined>(work: (this: SchedulerAction<T>, state: T) => void, delay?: number, state?: T): Subscription;
 }
 export interface SchedulerAction<T> extends Subscription {
   schedule(state?: T, delay?: number): Subscription;

--- a/src/internal/util/canReportError.ts
+++ b/src/internal/util/canReportError.ts
@@ -15,7 +15,7 @@ export function canReportError(observer: Subscriber<any> | Subject<any>): boolea
     } else if (destination && destination instanceof Subscriber) {
       observer = destination;
     } else {
-      observer = null;
+      observer = null!;
     }
   }
   return true;

--- a/src/internal/util/subscribeToResult.ts
+++ b/src/internal/util/subscribeToResult.ts
@@ -25,7 +25,7 @@ export function subscribeToResult<T, R>(
   result: any,
   outerValue?: T,
   outerIndex?: number,
-  innerSubscriber: Subscriber<R> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex)
+  innerSubscriber: Subscriber<R> = new InnerSubscriber(outerSubscriber, outerValue, outerIndex!)
 ): Subscription | undefined {
   if (innerSubscriber.closed) {
     return undefined;

--- a/src/internal/util/toSubscriber.ts
+++ b/src/internal/util/toSubscriber.ts
@@ -4,9 +4,9 @@ import { empty as emptyObserver } from '../Observer';
 import { PartialObserver } from '../types';
 
 export function toSubscriber<T>(
-  nextOrObserver?: PartialObserver<T> | ((value: T) => void),
-  error?: (error: any) => void,
-  complete?: () => void): Subscriber<T> {
+  nextOrObserver?: PartialObserver<T> | ((value: T) => void) | null,
+  error?: ((error: any) => void) | null,
+  complete?: (() => void) | null): Subscriber<T> {
 
   if (nextOrObserver) {
     if (nextOrObserver instanceof Subscriber) {

--- a/src/internal/util/tryCatch.ts
+++ b/src/internal/util/tryCatch.ts
@@ -1,11 +1,11 @@
 import { errorObject } from './errorObject';
 
-let tryCatchTarget: Function;
+let tryCatchTarget: Function | undefined;
 
 function tryCatcher(this: any): any {
   errorObject.e = undefined;
   try {
-    return tryCatchTarget.apply(this, arguments);
+    return tryCatchTarget!.apply(this, arguments);
   } catch (e) {
     errorObject.e = e;
     return errorObject;
@@ -16,5 +16,5 @@ function tryCatcher(this: any): any {
 
 export function tryCatch<T extends Function>(fn: T): T {
   tryCatchTarget = fn;
-  return <any>tryCatcher;
+  return tryCatcher as Function as T;
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "strict": true,
-    "strictNullChecks": false,
     "strictPropertyInitialization": false,
     "noImplicitReturns": true,
     "suppressImplicitAnyIndexErrors": true,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,6 @@
     "preserveConstEnums": true,
     "sourceMap": true,
     "strict": true,
-    "strictPropertyInitialization": false,
     "noImplicitReturns": true,
     "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR enables the currently disabled sub-options under TypeScript's `strict` option. It's based on the branch from the #5241 PR. I'll rebase this once that PR is merged.

The changes in this PR are almost entirely type-related. There were only a few places in which I had to add `if` statements so that calls to wrapped operators were mapped to the appropriate signatures.

There are a lot of files, but the changes are small, so hopefully reviewing this will not be too painful. In any case, these aren't changes that can be done in a piecemeal fashion.

These changes are not ideal, as that was not my aim. I was primarily concerned with getting the `strict` option enabled without having to add additional logic - `undefined` or `null` guards, etc. Changes to make code more easily typechecked can be made when things are refactored/reimplemented in v8.

**Related issue (if exists):** #5240