### PR TITLE
chore: disable suppressImplicitAnyIndexErrors

### DIFF
--- a/spec/helpers/interop-helper-spec.ts
+++ b/spec/helpers/interop-helper-spec.ts
@@ -6,13 +6,13 @@ import { asInteropObservable, asInteropSubscriber } from './interop-helper';
 
 describe('interop helper', () => {
   it('should simulate interop observables', () => {
-    const observable = asInteropObservable(of(42));
+    const observable: any = asInteropObservable(of(42));
     expect(observable).to.not.be.instanceOf(Observable);
     expect(observable[symbolObservable]).to.be.a('function');
   });
 
   it('should simulate interop subscribers', () => {
-    const subscriber = asInteropSubscriber(new Subscriber());
+    const subscriber: any = asInteropSubscriber(new Subscriber());
     expect(subscriber).to.not.be.instanceOf(Subscriber);
     expect(subscriber[symbolSubscriber]).to.be.undefined;
   });

--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -8,7 +8,7 @@ import * as sinon from 'sinon';
 import { expect } from 'chai';
 
 export function lowerCaseO<T>(...args: Array<any>): Observable<T> {
-  const o = {
+  const o: any = {
     subscribe(observer: any) {
       args.forEach(v => observer.next(v));
       observer.complete();

--- a/spec/helpers/testScheduler-ui.ts
+++ b/spec/helpers/testScheduler-ui.ts
@@ -264,7 +264,7 @@ if (global.Mocha) {
 //overrides JSON.toStringfy to serialize error object
 Object.defineProperty(Error.prototype, 'toJSON', {
   value: function (this: any) {
-    const alt = {};
+    const alt: Record<string, any> = {};
 
     Object.getOwnPropertyNames(this).forEach(function (this: any, key: string) {
       if (key !== 'stack') {

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -1242,7 +1242,7 @@ class MockXMLHttpRequest {
     this.triggerEvent('readystatechange');
   }
 
-  triggerEvent(name: any, eventObj?: any): void {
+  triggerEvent(this: any, name: any, eventObj?: any): void {
     // TODO: create a better default event
     const e: any = eventObj || { type: name };
 
@@ -1251,7 +1251,7 @@ class MockXMLHttpRequest {
     }
   }
 
-  triggerUploadEvent(name: any, eventObj?: any): void {
+  triggerUploadEvent(this: any, name: any, eventObj?: any): void {
     // TODO: create a better default event
     const e: any = eventObj || {};
 
@@ -1285,7 +1285,7 @@ class MockXMLHttpRequestInternetExplorer extends MockXMLHttpRequest {
     return super.defaultResponseValue();
   }
 
-  triggerUploadEvent(name: any, eventObj?: any): void {
+  triggerUploadEvent(this: any, name: any, eventObj?: any): void {
     // TODO: create a better default event
     const e: any = eventObj || {};
     if (this['on' + name]) {

--- a/spec/observables/dom/fetch-spec.ts
+++ b/spec/observables/dom/fetch-spec.ts
@@ -184,17 +184,17 @@ describe('fromFetch', () => {
     expect(MockAbortController.created).to.equal(0);
     let subscription = fetch$.subscribe();
     expect(MockAbortController.created).to.equal(1);
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.false;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.false;
 
     subscription.unsubscribe();
-    expect(mockFetch.calls[0].init.signal.aborted).to.be.true;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.true;
 
     subscription = fetch$.subscribe();
     expect(MockAbortController.created).to.equal(2);
-    expect(mockFetch.calls[1].init.signal.aborted).to.be.false;
+    expect(mockFetch.calls[1].init!.signal!.aborted).to.be.false;
 
     subscription.unsubscribe();
-    expect(mockFetch.calls[1].init.signal.aborted).to.be.true;
+    expect(mockFetch.calls[1].init!.signal!.aborted).to.be.true;
   });
 
   it('should allow passing of init object', done => {

--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -771,7 +771,7 @@ class MockWebSocket {
     }
   }
 
-  trigger(name: string, e: any) {
+  trigger(this: any, name: string, e: any) {
     if (this['on' + name]) {
       this['on' + name](e);
     }

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -63,7 +63,7 @@ describe('from', () => {
   });
 
   const fakeArrayObservable = <T>(...values: T[]) => {
-    let arr = ['bad array!'];
+    let arr: any = ['bad array!'];
     arr[observable] = () =>  {
       return {
         subscribe: (observer: Observer<T>) => {
@@ -140,7 +140,7 @@ describe('from', () => {
     });
     it(`should accept a function`, (done) => {
       const subject = new Subject();
-      const handler = (...args: any[]) => subject.next(...args);
+      const handler: any = (...args: any[]) => subject.next(...args);
       handler[observable] = () => subject;
       let nextInvoked = false;
 

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -94,7 +94,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =   '^                               !       ';
     const expected = '--a-a-a-a---b--b--b-------c-c-c-----(d|)';
 
-    const observableLookup = { a: a, b: b, c: c, d: d };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d };
     const source = e1.pipe(concatMap((value) => observableLookup[value]));
 
     expectObservable(source).toBe(expected);
@@ -324,7 +324,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                                      !               ';
     const expected =       '---2--3--4--5----6-----2--3-1------2--3-4-5--------1-2|';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(concatMap((value) => observableLookup[value]));
 
@@ -357,7 +357,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                                      !               ' ;
     const expected =       '---2--3--4--5----6-----2--3----------------------------';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(concatMap((value) => observableLookup[value]));
 
@@ -390,7 +390,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g---             ');
     const e1subs =         '^                                                      ';
     const expected =       '---2--3--4--5----6-----2--3-1------2--3-4-5--------1-2-';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(concatMap((value) => observableLookup[value]));
 
@@ -423,7 +423,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g#               ');
     const e1subs =         '^                                      !               ';
     const expected =       '---2--3--4--5----6-----2--3-1------2--3#               ';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(concatMap((value) => observableLookup[value]));
 
@@ -456,7 +456,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                  !                                   ';
     const expected =       '---2--3--4--5----6-#                                   ';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(concatMap((value) => observableLookup[value]));
 
@@ -490,7 +490,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =         '^                             !                        ';
     const unsub =          '                              !                        ';
     const expected =       '---2--3--4--5----6-----2--3-1--                        ';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(concatMap((value) => observableLookup[value]));
 
@@ -524,7 +524,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1subs =         '^                             !                        ';
     const unsub =          '                              !                        ';
     const expected =       '---2--3--4--5----6-----2--3-1--                        ';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(
       mergeMap(x => of(x)),
@@ -561,7 +561,7 @@ describe('Observable.prototype.concatMap', () => {
     const e1 =   hot('-a-b--^-c-----d------e----------------f-----g|               ');
     const e1subs =         '^                          !                           ';
     const expected =       '---2--3--4--5----6-----2--3#                           ';
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(
       concatMap((value) => {

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -142,7 +142,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                                            !';
     const expected = '-----a--b--c---------------------g--h--i-----|';
 
-    const observableLookup = { x: x, y: y, z: z };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y, z: z };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -165,7 +165,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                                 !           ';
     const expected = '-----a--b--c---------------------g-           ';
 
-    const observableLookup = { x: x, y: y, z: z };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y, z: z };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -188,7 +188,7 @@ describe('exhaustMap', () => {
     const expected = '-----a--b--c---------------------g-           ';
     const unsub =    '                                  !           ';
 
-    const observableLookup = { x: x, y: y, z: z };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y, z: z };
 
     const result = e1.pipe(
       mergeMap(x => of(x)),
@@ -215,7 +215,7 @@ describe('exhaustMap', () => {
     const expected = '-----a--b--c---------------------g-           ';
     const unsub =    '                                  !           ';
 
-    const observableLookup = { x: x, y: y, z: z };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y, z: z };
 
     // This test is the same as the previous test, but the observable is
     // manipulated to make it look like an interop observable - an observable
@@ -272,7 +272,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                                        !   ';
     const expected = '-----a--b--c---------------------g--h--i-----';
 
-    const observableLookup = { x: x, y: y, z: z };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y, z: z };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -292,7 +292,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                            !';
     const expected = '-----------a--b--c--d--e-----|';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -311,7 +311,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                      !             ';
     const expected = '-----------a--b--c--d--#             ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -332,7 +332,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                            !         ';
     const expected = '-----------c--d--e-----j---k---l---m--|';
 
-    const observableLookup = { x: x, y: y, z: z };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y, z: z };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -352,7 +352,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                            !';
     const expected = '-----------------------------|';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -371,7 +371,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                            !';
     const expected = '------------------------------';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -390,7 +390,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                             !';
     const expected = '-------------------------------';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -409,7 +409,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                  !          ';
     const expected = '-------------------#          ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 
@@ -426,7 +426,7 @@ describe('exhaustMap', () => {
     const e1subs =   '^                  !       ';
     const expected = '-----------a--b--c-#       ';
 
-    const observableLookup = { x: x };
+    const observableLookup: Record<string, Observable<string>>  = { x: x };
 
     const result = e1.pipe(exhaustMap(value => observableLookup[value]));
 

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -368,7 +368,7 @@ describe('expand operator', () => {
         return <any>EMPTY;
       }
 
-      const ish = {
+      const ish: any = {
         subscribe: (observer: Observer<number>) => {
           observer.next(x + x);
           observer.complete();

--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -26,8 +26,8 @@ describe('groupBy operator', () => {
     return str.split('').reverse().join('');
   }
 
-  function mapObject(obj: object, fn: Function) {
-    const out = {};
+  function mapObject(obj: Record<string, any>, fn: Function) {
+    const out: Record<string, any> = {};
     for (const p in obj) {
       if (obj.hasOwnProperty(p)) {
         out[p] = fn(obj[p]);
@@ -607,7 +607,7 @@ describe('groupBy operator', () => {
       z: TestScheduler.parseMarbles(z, values)
     };
 
-    const unsubscriptionFrames = {
+    const unsubscriptionFrames: Record<string, number> = {
       foo: TestScheduler.parseMarblesAsSubscriptions(unsubw).unsubscribedFrame,
       bar: TestScheduler.parseMarblesAsSubscriptions(unsubx).unsubscribedFrame,
       baz: TestScheduler.parseMarblesAsSubscriptions(unsuby).unsubscribedFrame,
@@ -1185,14 +1185,14 @@ describe('groupBy operator', () => {
       z: TestScheduler.parseMarbles(z, values)
     };
 
-    const unsubscriptionFrames = {
+    const unsubscriptionFrames: Record<string, number> = {
       foo: TestScheduler.parseMarblesAsSubscriptions(unsubv).unsubscribedFrame,
       bar: TestScheduler.parseMarblesAsSubscriptions(unsubw).unsubscribedFrame,
       baz: TestScheduler.parseMarblesAsSubscriptions(unsubx).unsubscribedFrame,
       qux: TestScheduler.parseMarblesAsSubscriptions(unsuby).unsubscribedFrame,
       foo2: TestScheduler.parseMarblesAsSubscriptions(unsubz).unsubscribedFrame
     };
-    const hasUnsubscribed = {};
+    const hasUnsubscribed: Record<string, boolean> = {};
 
     const source = e1.pipe(
       groupBy(
@@ -1261,7 +1261,7 @@ describe('groupBy operator', () => {
        y: TestScheduler.parseMarbles(y, values),
      };
 
-     const subscriptionFrames = {
+     const subscriptionFrames: Record<string, number> = {
        foo: TestScheduler.parseMarblesAsSubscriptions(subv).subscribedFrame,
        bar: TestScheduler.parseMarblesAsSubscriptions(subw).subscribedFrame,
        baz: TestScheduler.parseMarblesAsSubscriptions(subx).subscribedFrame,

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -115,7 +115,7 @@ describe('mergeMap', () => {
     const e1subs =   '^                               !       ';
     const expected = '----a---(ab)(ab)(ab)c---c---(cd)c---(c|)';
 
-    const observableLookup = { a: a, b: b, c: c, d: d };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d };
     const source = e1.pipe(mergeMap((value) => observableLookup[value]));
 
     expectObservable(source).toBe(expected);
@@ -271,7 +271,7 @@ describe('mergeMap', () => {
     const expected = '-----------a--b--c--d-                ';
     const unsub =    '                     !                ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>>  = { x: x, y: y };
 
     // This test manipulates the observable to make it look like an interop
     // observable - an observable from a foreign library. Interop subscribers
@@ -390,7 +390,7 @@ describe('mergeMap', () => {
     const bsubs =      '                     ^                   !                    ';
     const csubs =      '                                         ^                   !';
     const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
-    const inners = { a: hotA, b: hotB, c: hotC };
+    const inners: Record<string, Observable<string>> = { a: hotA, b: hotB, c: hotC };
 
     function project(x: string) { return inners[x]; }
     const result = e1.pipe(mergeMap(project, 1));
@@ -413,7 +413,7 @@ describe('mergeMap', () => {
     const bsubs =      '         ^                   !            ';
     const csubs =      '                     ^                   !';
     const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
-    const inners = { a: hotA, b: hotB, c: hotC };
+    const inners: Record<string, Observable<string>> = { a: hotA, b: hotB, c: hotC };
 
     function project(x: string) { return inners[x]; }
     const result = e1.pipe(mergeMap(project, 2));
@@ -472,7 +472,7 @@ describe('mergeMap', () => {
     const bsubs =      '                     ^                   !                    ';
     const csubs =      '                                         ^                   !';
     const expected =   '-----i---j---k---l-------i---j---k---l-------i---j---k---l---|';
-    const inners = { a: hotA, b: hotB, c: hotC };
+    const inners: Record<string, Observable<string>> = { a: hotA, b: hotB, c: hotC };
 
     function project(x: string) { return inners[x]; }
     const result = e1.pipe(mergeMap(project, 1));
@@ -495,7 +495,7 @@ describe('mergeMap', () => {
     const bsubs =      '         ^                   !            ';
     const csubs =      '                     ^                   !';
     const expected =   '-----i---j---(ki)(lj)k---(li)j---k---l---|';
-    const inners = { a: hotA, b: hotB, c: hotC };
+    const inners: Record<string, Observable<string>> = { a: hotA, b: hotB, c: hotC };
 
     function project(x: string) { return inners[x]; }
     const result = e1.pipe(mergeMap(project, 2));
@@ -519,7 +519,7 @@ describe('mergeMap', () => {
     const e1subs =         '^                                      !';
     const expected =       '---2--3--4--5---1--2--3--2--3--6--4--5---1-2--|';
 
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(mergeMap((value) => observableLookup[value]));
 
@@ -539,7 +539,7 @@ describe('mergeMap', () => {
     const e1subs =         '^                                      !';
     const expected =       '---2--3--4--5---1--2--3--2--3--6--4--5---1-2----';
 
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(mergeMap((value) => observableLookup[value]));
 
@@ -559,7 +559,7 @@ describe('mergeMap', () => {
     const e1subs =         '^                                               ';
     const expected =       '---2--3--4--5---1--2--3--2--3--6--4--5---1-2----';
 
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(mergeMap((value) => observableLookup[value]));
 
@@ -579,7 +579,7 @@ describe('mergeMap', () => {
     const e1subs =         '^                                      !       ';
     const expected =       '---2--3--4--5---1--2--3--2--3--6--4--5-#       ';
 
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(mergeMap((value) => observableLookup[value]));
 
@@ -599,7 +599,7 @@ describe('mergeMap', () => {
     const e1subs =         '^                                !             ';
     const expected =       '---2--3--4--5---1--2--3--2--3--6-#             ';
 
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
 
     const result = e1.pipe(mergeMap((value) => observableLookup[value]));
 
@@ -620,7 +620,7 @@ describe('mergeMap', () => {
     const e1subs =         '^                             !                ';
     const expected =       '---2--3--4--5---1--2--3--2--3--                ';
 
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
     const source = e1.pipe(mergeMap((value) => observableLookup[value]));
 
     expectObservable(source, unsub).toBe(expected);
@@ -639,7 +639,7 @@ describe('mergeMap', () => {
     const e1subs =         '^              !                               ';
     const expected =       '---2--3--4--5--#                               ';
 
-    const observableLookup = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
+    const observableLookup: Record<string, Observable<string>>  = { a: a, b: b, c: c, d: d, e: e, f: f, g: g };
     let invoked = 0;
     const source = e1.pipe(mergeMap((value) => {
       invoked++;

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -104,7 +104,7 @@ describe('switchMap', () => {
     const e1subs =   '^                            !        ';
     const expected = '-----------a--b--c----f---g---h---i--|';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -136,7 +136,7 @@ describe('switchMap', () => {
     const unsub =    '                     !                ';
     const expected = '-----------a--b--c----                ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -156,7 +156,7 @@ describe('switchMap', () => {
     const expected = '-----------a--b--c----                ';
     const unsub =    '                     !                ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(
       mergeMap(x => of(x)),
@@ -180,7 +180,7 @@ describe('switchMap', () => {
     const expected = '-----------a--b--c----                ';
     const unsub =    '                     !                ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     // This test is the same as the previous test, but the observable is
     // manipulated to make it look like an interop observable - an observable
@@ -234,7 +234,7 @@ describe('switchMap', () => {
     const e1subs =   '^                            !       ';
     const expected = '-----------a--b--c----f---g---h---i--';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -253,7 +253,7 @@ describe('switchMap', () => {
     const e1subs =   '^                            !';
     const expected = '------------f---g---h---i----|';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -272,7 +272,7 @@ describe('switchMap', () => {
     const e1subs =   '^                !                   ';
     const expected = '-----------a--b--#                   ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -291,7 +291,7 @@ describe('switchMap', () => {
     const e1subs =   '^                            !        ';
     const expected = '-----------c--d--e----f---g---h---i--|';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -310,7 +310,7 @@ describe('switchMap', () => {
     const e1subs =   '^                            !';
     const expected = '-----------------------------|';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -329,7 +329,7 @@ describe('switchMap', () => {
     const e1subs =   '^                            !';
     const expected = '------------------------------';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -348,7 +348,7 @@ describe('switchMap', () => {
     const e1subs =   '^                            !';
     const expected = '-----------------------------|';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -367,7 +367,7 @@ describe('switchMap', () => {
     const e1subs =   '^                  !          ';
     const expected = '-------------------#          ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -386,7 +386,7 @@ describe('switchMap', () => {
     const e1subs =   '^                  !          ';
     const expected = '-------------------#          ';
 
-    const observableLookup = { x: x, y: y };
+    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 
@@ -436,7 +436,7 @@ describe('switchMap', () => {
     const e1subs =   '^                  !       ';
     const expected = '-----------a--b--c-#       ';
 
-    const observableLookup = { x: x };
+    const observableLookup: Record<string, Observable<string>> = { x: x };
 
     const result = e1.pipe(switchMap(value => observableLookup[value]));
 

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -173,7 +173,7 @@ export class AjaxObservable<T> extends Observable<T> {
     } else {
       for (const prop in urlOrRequest) {
         if (urlOrRequest.hasOwnProperty(prop)) {
-          request[prop] = urlOrRequest[prop];
+          (request as any)[prop] = (urlOrRequest as any)[prop];
         }
       }
     }
@@ -204,13 +204,13 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
     // force CORS if requested
     if (!request.crossDomain && !this.getHeader(headers, 'X-Requested-With')) {
-      headers['X-Requested-With'] = 'XMLHttpRequest';
+      (headers as any)['X-Requested-With'] = 'XMLHttpRequest';
     }
 
     // ensure content type is set
     let contentTypeHeader = this.getHeader(headers, 'Content-Type');
     if (!contentTypeHeader && !(root.FormData && request.body instanceof root.FormData) && typeof request.body !== 'undefined') {
-      headers['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
+      (headers as any)['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
     }
 
     // properly serialize body
@@ -302,7 +302,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
   private setHeaders(xhr: XMLHttpRequest, headers: Object) {
     for (let key in headers) {
       if (headers.hasOwnProperty(key)) {
-        xhr.setRequestHeader(key, headers[key]);
+        xhr.setRequestHeader(key, (headers as any)[key]);
       }
     }
   }
@@ -310,7 +310,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
   private getHeader(headers: {}, headerName: string): any {
     for (let key in headers) {
       if (key.toLowerCase() === headerName.toLowerCase()) {
-        return headers[key];
+        return (headers as any)[key];
       }
     }
 

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -172,7 +172,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
       } else {
         for (let key in urlConfigOrSource) {
           if (urlConfigOrSource.hasOwnProperty(key)) {
-            config[key] = urlConfigOrSource[key];
+            (config as any)[key] = (urlConfigOrSource as any)[key];
           }
         }
       }

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -190,7 +190,7 @@ function forkJoinInternal(sources: ObservableInput<any>[], keys: string[] | null
           if (completed === len || !hasValue) {
             if (emitted === len) {
               subscriber.next(keys ?
-                keys.reduce((result, key, i) => (result[key] = values[i], result), {}) :
+                keys.reduce((result, key, i) => ((result as any)[key] = values[i], result), {}) :
                 values);
             }
             subscriber.complete();

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -223,7 +223,7 @@ function setupSubscription<T>(sourceObj: FromEventTarget<T>, eventName: string,
     unsubscribe = () => source.removeListener(eventName, handler as NodeEventHandler);
   } else if (sourceObj && (sourceObj as any).length) {
     for (let i = 0, len = (sourceObj as any).length; i < len; i++) {
-      setupSubscription(sourceObj[i], eventName, handler, subscriber, options);
+      setupSubscription((sourceObj as any)[i], eventName, handler, subscriber, options);
     }
   } else {
     throw new TypeError('Invalid event target');

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -57,7 +57,7 @@ export function pairs<T>(obj: Object, scheduler?: SchedulerLike): Observable<[st
       for (let i = 0; i < keys.length && !subscriber.closed; i++) {
         const key = keys[i];
         if (obj.hasOwnProperty(key)) {
-          subscriber.next([key, obj[key]]);
+          subscriber.next([key, (obj as any)[key]]);
         }
       }
       subscriber.complete();
@@ -81,7 +81,7 @@ export function dispatch<T>(this: SchedulerAction<any>,
   if (!subscriber.closed) {
     if (index < keys.length) {
       const key = keys[index];
-      subscriber.next([key, obj[key]]);
+      subscriber.next([key, (obj as any)[key]]);
       subscription.add(this.schedule({ keys, index: index + 1, subscriber, subscription, obj }));
     } else {
       subscriber.complete();

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -54,7 +54,7 @@ export function pluck<T, R>(...properties: string[]): OperatorFunction<T, R> {
 }
 
 function plucker(props: string[], length: number): (x: string) => any {
-  const mapper = (x: string) => {
+  const mapper = (x: any) => {
     let currentProp = x;
     for (let i = 0; i < length; i++) {
       const p = currentProp[props[i]];

--- a/src/internal/scheduled/scheduleIterable.ts
+++ b/src/internal/scheduled/scheduleIterable.ts
@@ -17,7 +17,7 @@ export function scheduleIterable<T>(input: Iterable<T>, scheduler: SchedulerLike
       }
     });
     sub.add(scheduler.schedule(() => {
-      iterator = input[Symbol_iterator]();
+      iterator = (input as any)[Symbol_iterator]();
       sub.add(scheduler.schedule(function () {
         if (subscriber.closed) {
           return;

--- a/src/internal/scheduled/scheduleObservable.ts
+++ b/src/internal/scheduled/scheduleObservable.ts
@@ -7,7 +7,7 @@ export function scheduleObservable<T>(input: InteropObservable<T>, scheduler: Sc
   return new Observable<T>(subscriber => {
     const sub = new Subscription();
     sub.add(scheduler.schedule(() => {
-      const observable: Subscribable<T> = input[Symbol_observable]();
+      const observable: Subscribable<T> = (input as any)[Symbol_observable]();
       sub.add(observable.subscribe({
         next(value) { sub.add(scheduler.schedule(() => subscriber.next(value))); },
         error(err) { sub.add(scheduler.schedule(() => subscriber.error(err))); },

--- a/src/internal/util/subscribeTo.ts
+++ b/src/internal/util/subscribeTo.ts
@@ -12,13 +12,13 @@ import { Subscription } from '../Subscription';
 import { Subscriber } from '../Subscriber';
 
 export const subscribeTo = <T>(result: ObservableInput<T>): (subscriber: Subscriber<T>) => Subscription | void => {
-  if (!!result && typeof result[Symbol_observable] === 'function') {
+  if (!!result && typeof (result as any)[Symbol_observable] === 'function') {
     return subscribeToObservable(result as any);
   } else if (isArrayLike(result)) {
     return subscribeToArray(result);
   } else if (isPromise(result)) {
     return subscribeToPromise(result);
-  } else if (!!result && typeof result[Symbol_iterator] === 'function') {
+  } else if (!!result && typeof (result as any)[Symbol_iterator] === 'function') {
     return subscribeToIterable(result as any);
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;

--- a/src/internal/util/subscribeToIterable.ts
+++ b/src/internal/util/subscribeToIterable.ts
@@ -2,7 +2,7 @@ import { Subscriber } from '../Subscriber';
 import { iterator as Symbol_iterator } from '../symbol/iterator';
 
 export const subscribeToIterable = <T>(iterable: Iterable<T>) => (subscriber: Subscriber<T>) => {
-  const iterator = iterable[Symbol_iterator]();
+  const iterator = (iterable as any)[Symbol_iterator]();
   do {
     const item = iterator.next();
     if (item.done) {

--- a/src/internal/util/subscribeToObservable.ts
+++ b/src/internal/util/subscribeToObservable.ts
@@ -7,7 +7,7 @@ import { observable as Symbol_observable } from '../symbol/observable';
  * @param obj An object that implements Symbol.observable
  */
 export const subscribeToObservable = <T>(obj: any) => (subscriber: Subscriber<T>) => {
-  const obs = obj[Symbol_observable]();
+  const obs = (obj as any)[Symbol_observable]();
   if (typeof obs.subscribe !== 'function') {
     // Should be caught by observable subscribe function error handling.
     throw new TypeError('Provided object does not correctly implement Symbol.observable');

--- a/src/internal/util/toSubscriber.ts
+++ b/src/internal/util/toSubscriber.ts
@@ -13,8 +13,8 @@ export function toSubscriber<T>(
       return (<Subscriber<T>> nextOrObserver);
     }
 
-    if (nextOrObserver[rxSubscriberSymbol]) {
-      return nextOrObserver[rxSubscriberSymbol]();
+    if ((nextOrObserver as any)[rxSubscriberSymbol]) {
+      return (nextOrObserver as any)[rxSubscriberSymbol]();
     }
   }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "sourceMap": true,
     "strict": true,
     "noImplicitReturns": true,
-    "suppressImplicitAnyIndexErrors": true,
     "moduleResolution": "node",
     "stripInternal": false,
     "noEmit": true,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR disables the `suppressImplicitAnyIndexErrors` TypeScript option - which is another escape hatch for non-strict code.

**Related issue (if exists):** #5240 (somewhat related)