### PR TITLE
fix syntax errors in spec-dtslint

### DIFF
--- a/spec-dtslint/operators/publishBehavior-spec.ts
+++ b/spec-dtslint/operators/publishBehavior-spec.ts
@@ -10,5 +10,5 @@ it('should infer correctly with parameter', () => {
 });
 
 it('should enforce type on parameter', () => {
-  const a = of(1, 2, 3).pipe(publishBehavior('a'); // $ExpectError
+  const a = of(1, 2, 3).pipe(publishBehavior('a')); // $ExpectError
 });

--- a/spec-dtslint/operators/tap-spec.ts
+++ b/spec-dtslint/operators/tap-spec.ts
@@ -16,5 +16,5 @@ it('should not accept empty observer', () => {
 });
 
 it('should enforce type for next observer function', () => {
-  const a = of(1, 2, 3).pipe(tap({ next: (x: string) => { })); // $ExpectError
+  const a = of(1, 2, 3).pipe(tap({ next: (x: string) => { } })); // $ExpectError
 });


### PR DESCRIPTION
Just noticed that the code isn't syntactically correct there.