### PR TITLE
feat: add ObservedValueUnion/TupleFromArray

### DIFF
--- a/spec-dtslint/observables/of-spec.ts
+++ b/spec-dtslint/observables/of-spec.ts
@@ -56,7 +56,7 @@ it('should support mixed type of 9 params', () => {
 });
 
 it('should support mixed type of 13 params', () => {
-  const res = of(a, b, c, d, e, f, g, h, i, j, '', true, 123, [1, 2, 3]); // $ExpectType Observable<string | number | boolean | A | B | C | D | E | F | G | number[] | H | I | J>
+  const res = of(a, b, c, d, e, f, g, h, i, j, '', true, 123, 10n); // $ExpectType Observable<string | number | bigint | boolean | A | B | C | D | E | F | G | H | I | J>
 });
 
 it('should support a rest of params', () => {

--- a/spec-dtslint/types-spec.ts
+++ b/spec-dtslint/types-spec.ts
@@ -1,0 +1,67 @@
+import {
+  Observable,
+  ObservedValueOf,
+  ObservedValueUnionFromArray,
+  ObservedValueTupleFromArray,
+  Unshift
+} from 'rxjs';
+import { A, B, C } from './helpers';
+
+describe('ObservedValueOf', () => {
+  it('should infer from an observable', () => {
+    let explicit: ObservedValueOf<Observable<A>>;
+    let inferred = explicit!; // $ExpectType A
+  });
+
+  it('should infer from an array', () => {
+    let explicit: ObservedValueOf<A[]>;
+    let inferred = explicit!; // $ExpectType A
+  });
+
+  it('should infer from a promise', () => {
+    let explicit: ObservedValueOf<Promise<A>>;
+    let inferred = explicit!; // $ExpectType A
+  });
+});
+
+describe('ObservedUnionFromArray', () => {
+  it('should infer from an array of observables', () => {
+    let explicit: ObservedValueUnionFromArray<[Observable<A>, Observable<B>]>;
+    let inferred = explicit!; // $ExpectType A | B
+  });
+
+  it('should infer from an array of arrays', () => {
+    let explicit: ObservedValueUnionFromArray<[A[], B[]]>;
+    let inferred = explicit!; // $ExpectType A | B
+  });
+
+  it('should infer from an array of promises', () => {
+    let explicit: ObservedValueUnionFromArray<[Promise<A>, Promise<B>]>;
+    let inferred = explicit!; // $ExpectType A | B
+  });
+});
+
+describe('ObservedTupleFromArray', () => {
+  it('should infer from an array of observables', () => {
+    let explicit: ObservedValueTupleFromArray<[Observable<A>, Observable<B>]>;
+    let inferred = explicit!; // $ExpectType [A, B]
+  });
+
+  it('should infer from an array of arrays', () => {
+    let explicit: ObservedValueTupleFromArray<[A[], B[]]>;
+    let inferred = explicit!; // $ExpectType [A, B]
+  });
+
+  it('should infer from an array of promises', () => {
+    let explicit: ObservedValueTupleFromArray<[Promise<A>, Promise<B>]>;
+    let inferred = explicit!; // $ExpectType [A, B]
+  });
+});
+
+describe('Unshift', () => {
+  it('should add the type to the beginning of the tuple', () => {
+    let tuple: ObservedValueTupleFromArray<[Observable<A>, Observable<B>]>;
+    let explicit: Unshift<typeof tuple, C>;
+    let inferred = explicit!; // $ExpectType [C, A, B]
+  });
+});

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValuesFromArray } from '../types';
+import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValueUnionFromArray } from '../types';
 import { of } from './of';
 import { concatAll } from '../operators/concatAll';
 
@@ -17,7 +17,7 @@ export function concat<O1 extends ObservableInput<any>, O2 extends ObservableInp
 /** @deprecated remove in v8. Passing a scheduler to concat is deprecated, please use {@link scheduled} and {@link concatAll} `scheduled([o1, o2], scheduler).pipe(concatAll())` */
 export function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4> | ObservedValueOf<O5> | ObservedValueOf<O6>>;
 
-export function concat<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValuesFromArray<A>>;
+export function concat<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
 
 /* tslint:enable:max-line-length */
 /**

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { ObservableInput, ObservedValuesFromArray, ObservedValueOf, SubscribableOrPromise } from '../types';
+import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf, SubscribableOrPromise } from '../types';
 import { isArray } from '../util/isArray';
 import { map } from '../operators/map';
 import { isObject } from '../util/isObject';
@@ -30,7 +30,7 @@ export function forkJoin<A, B, C>(sources: [ObservableInput<A>, ObservableInput<
 export function forkJoin<A, B, C, D>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>]): Observable<[A, B, C, D]>;
 export function forkJoin<A, B, C, D, E>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>]): Observable<[A, B, C, D, E]>;
 export function forkJoin<A, B, C, D, E, F>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>, ObservableInput<F>]): Observable<[A, B, C, D, E, F]>;
-export function forkJoin<A extends ObservableInput<any>[]>(sources: A): Observable<ObservedValuesFromArray<A>[]>;
+export function forkJoin<A extends ObservableInput<any>[]>(sources: A): Observable<ObservedValueUnionFromArray<A>[]>;
 
 // forkJoin({})
 export function forkJoin(sourcesObject: {}): Observable<never>;

--- a/src/internal/operators/concatWith.ts
+++ b/src/internal/operators/concatWith.ts
@@ -1,9 +1,9 @@
 import { concat as concatStatic } from '../observable/concat';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, ObservedValuesFromArray } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray } from '../types';
 
 export function concatWith<T>(): OperatorFunction<T, T>;
-export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValuesFromArray<A> | T>;
+export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T>;
 
 /**
  * Emits all of the values from the source observable, then, once it completes, subscribes
@@ -43,9 +43,9 @@ export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources:
  *
  * @param otherSources Other observable sources to subscribe to, in sequence, after the original source is complete.
  */
-export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValuesFromArray<A> | T> {
+export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T> {
   return (source: Observable<T>) => source.lift.call(
     concatStatic(source, ...otherSources),
     undefined
-  ) as Observable<ObservedValuesFromArray<A> | T>;
+  ) as Observable<ObservedValueUnionFromArray<A> | T>;
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -108,12 +108,40 @@ export interface SchedulerAction<T> extends Subscription {
 export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
 
 /**
- * Extracts the generic type from an `ObservableInput<any>[]`.
+ * Extracts a union of element types from an `ObservableInput<any>[]`.
  * If you have `O extends ObservableInput<any>[]` and you pass in
  * `Observable<string>[]` or `Promise<string>[]` you would get
- * back a type of `string`
+ * back a type of `string`.
+ * If you pass in `[Observable<string>, Observable<number>]` you would
+ * get back a type of `string | number`.
  */
-export type ObservedValuesFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
+export type ObservedValueUnionFromArray<X> =
+  X extends Array<ObservableInput<infer T>>
+    ? T
+    : never;
+
+/** @deprecated use {@link ObservedValueUnionFromArray} */
+export type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
+
+/**
+ * Extracts a tuple of element types from an `ObservableInput<any>[]`.
+ * If you have `O extends ObservableInput<any>[]` and you pass in
+ * `[Observable<string>, Observable<number>]` you would get back a type
+ * of `[string, number]`.
+ */
+export type ObservedValueTupleFromArray<X> =
+  X extends Array<ObservableInput<any>>
+    ? { [K in keyof X]: ObservedValueOf<X[K]> }
+    : never;
+
+/**
+ * Adds a type to the beginning of a tuple.
+ * If you pass in `Unshift<[B, C], A>` you will get back `[A, B, C]`.
+ */
+export type Unshift<X extends any[], Y> =
+  ((arg: Y, ...rest: X) => any) extends ((...args: infer U) => any)
+    ? U
+    : never;
 
 /**
  * Extracts the generic value from an Array type.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR:

* Renames the `ObservedValuesFromArray` type to `ObservedValueUnionFromArray` and deprecates the former.
* Adds the `ObservedValueTupleFromArray` type.

The differences between the two are best shown by example:

```ts
type S = Observable<string>;
type N = Observable<number>;
ObservedValueUnionFromArray<[S, N]> // string | number
ObservedValueTupleFromArray<[S, N]> // [string, number]
```

It also adds an `Unshift` type - which adds a type to the beginning of a tuple - that should be useful in typing the `combineLatestWith` and `zipWith` operators.

These types should be sufficient to allow for N-args support in those operators:

```ts
export function zipWith<T, A extends ObservableInput<any>[]>(
  ...otherSources: A
): OperatorFunction<T, Unshift<ObservedValueTupleFromArray<A>, T>>;
```

**Related <s>issue</s> PRs:** #5249; #5251