### PR TITLE
chore: fix build errors

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -92,8 +92,10 @@ export interface Observer<T> {
 
 export interface SchedulerLike {
   now(): number;
-  schedule<T = undefined>(work: (this: SchedulerAction<T>, state: T) => void, delay?: number, state?: T): Subscription;
+  schedule(work: (this: SchedulerAction<undefined>) => void, delay?: number ): Subscription;
+  schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number, state: T): Subscription;
 }
+
 export interface SchedulerAction<T> extends Subscription {
   schedule(state?: T, delay?: number): Subscription;
 }


### PR DESCRIPTION
I'm getting build errors since our updates to strictness. They revolved around the call signatures of SchedulerLike and SchedulerAction in a few operators. This resolves that by being a little more explicit.