### PR TITLE
fix: use N-args tuple for combineLatestWith and zipWith

### DIFF
--- a/spec-dtslint/operators/combineLatestWith-spec.ts
+++ b/spec-dtslint/operators/combineLatestWith-spec.ts
@@ -51,7 +51,7 @@ describe('combineLatestWith', () => {
       const e = of('j', 'k', 'l');
       const f = of('m', 'n', 'o');
       const g = of('p', 'q', 'r');
-      const res = a.pipe(combineLatestWith(b, c, d, e, f, g)); // $ExpectType Observable<(string | number)[]>
+      const res = a.pipe(combineLatestWith(b, c, d, e, f, g)); // $ExpectType Observable<[number, string, string, string, string, string, string]>
     });
   });
 });

--- a/spec-dtslint/operators/zipWith-spec.ts
+++ b/spec-dtslint/operators/zipWith-spec.ts
@@ -1,0 +1,57 @@
+import { of } from 'rxjs';
+import { zipWith } from 'rxjs/operators';
+
+describe('zipWith', () => {
+  describe('without project parameter', () => {
+    it('should infer correctly with 1 param', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const res = a.pipe(zipWith(b)); // $ExpectType Observable<[number, string]>
+    });
+
+    it('should infer correctly with 2 params', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = of('d', 'e', 'f');
+      const res = a.pipe(zipWith(b, c)); // $ExpectType Observable<[number, string, string]>
+    });
+
+    it('should infer correctly with 3 params', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = of('d', 'e', 'f');
+      const d = of('g', 'h', 'i');
+      const res = a.pipe(zipWith(b, c, d)); // $ExpectType Observable<[number, string, string, string]>
+    });
+
+    it('should infer correctly with 4 params', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = of('d', 'e', 'f');
+      const d = of('g', 'h', 'i');
+      const e = of('j', 'k', 'l');
+      const res = a.pipe(zipWith(b, c, d, e)); // $ExpectType Observable<[number, string, string, string, string]>
+    });
+
+    it('should infer correctly with 5 params', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = of('d', 'e', 'f');
+      const d = of('g', 'h', 'i');
+      const e = of('j', 'k', 'l');
+      const f = of('m', 'n', 'o');
+      const res = a.pipe(zipWith(b, c, d, e, f)); // $ExpectType Observable<[number, string, string, string, string, string]>
+    });
+
+    it('should accept N params', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = of('d', 'e', 'f');
+      const d = of('g', 'h', 'i');
+      const e = of('j', 'k', 'l');
+      const f = of('m', 'n', 'o');
+      const g = of('p', 'q', 'r');
+      const res = a.pipe(zipWith(b, c, d, e, f, g)); // $ExpectType Observable<[number, string, string, string, string, string, string]>
+    });
+  });
+});

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -3,7 +3,7 @@ import { isArray } from '../util/isArray';
 import { CombineLatestOperator } from '../observable/combineLatest';
 import { from } from '../observable/from';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray, ObservedValueTupleFromArray, Unshift } from '../types';
 
 /* tslint:disable:max-line-length */
 /** @deprecated use {@link combineLatestWith} */
@@ -58,16 +58,6 @@ export function combineLatest<T, R>(...observables: Array<ObservableInput<any> |
     new CombineLatestOperator(project)
   ) as Observable<R>;
 }
-/* tslint:disable:max-line-length */
-export function combineLatestWith<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
-export function combineLatestWith<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
-export function combineLatestWith<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, [T, T2, T3, T4]>;
-export function combineLatestWith<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, [T, T2, T3, T4, T5]>;
-export function combineLatestWith<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]> ;
-export function combineLatestWith<T, A extends ObservableInput<any>[]>(
-  ...otherSources: A
-): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>>;
-/* tslint:enable:max-line-length */
 
 /**
  * Create an observable that combines the latest values from all passed observables and the source
@@ -107,6 +97,6 @@ export function combineLatestWith<T, A extends ObservableInput<any>[]>(
  */
 export function combineLatestWith<T, A extends ObservableInput<any>[]>(
   ...otherSources: A
-): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>> {
+): OperatorFunction<T, Unshift<ObservedValueTupleFromArray<A>, T>> {
   return combineLatest(...otherSources);
 }

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -3,7 +3,7 @@ import { isArray } from '../util/isArray';
 import { CombineLatestOperator } from '../observable/combineLatest';
 import { from } from '../observable/from';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, ObservedValuesFromArray } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray } from '../types';
 
 /* tslint:disable:max-line-length */
 /** @deprecated use {@link combineLatestWith} */
@@ -66,7 +66,7 @@ export function combineLatestWith<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3
 export function combineLatestWith<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]> ;
 export function combineLatestWith<T, A extends ObservableInput<any>[]>(
   ...otherSources: A
-): OperatorFunction<T, Array<T | ObservedValuesFromArray<A>>>;
+): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -107,6 +107,6 @@ export function combineLatestWith<T, A extends ObservableInput<any>[]>(
  */
 export function combineLatestWith<T, A extends ObservableInput<any>[]>(
   ...otherSources: A
-): OperatorFunction<T, Array<T | ObservedValuesFromArray<A>>> {
+): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>> {
   return combineLatest(...otherSources);
 }

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -1,6 +1,6 @@
 import { merge as mergeStatic } from '../observable/merge';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike, ObservedValuesFromArray } from '../types';
+import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike, ObservedValueUnionFromArray } from '../types';
 
 /* tslint:disable:max-line-length */
 
@@ -64,7 +64,7 @@ export function merge<T, R>(...observables: Array<ObservableInput<any> | Schedul
 }
 
 export function mergeWith<T>(): OperatorFunction<T, T>;
-export function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, (T | ObservedValuesFromArray<A>)>;
+export function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, (T | ObservedValueUnionFromArray<A>)>;
 
 /**
  * Merge the values from all observables to an single observable result.
@@ -105,6 +105,6 @@ export function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: 
  * ```
  * @param otherSources the sources to combine the current source with.
  */
-export function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, (T | ObservedValuesFromArray<A>)> {
+export function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, (T | ObservedValueUnionFromArray<A>)> {
   return merge(...otherSources);
 }

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -1,6 +1,6 @@
 import { zip as zipStatic } from '../observable/zip';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, ObservedValuesFromArray } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray } from '../types';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link zipWith} */
@@ -51,7 +51,7 @@ export function zipWith<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<
 export function zipWith<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, [T, T2, T3, T4]>;
 export function zipWith<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, [T, T2, T3, T4, T5]>;
 export function zipWith<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]> ;
-export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A): OperatorFunction<T, Array<T | ObservedValuesFromArray<A>>>;
+export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>>;
 /* tslint:enable:max-line-length */
 /**
  * Subscribes to the source, and the observable inputs provided as arguments, and combines their values, by index, into arrays.
@@ -73,6 +73,6 @@ export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A):
  *
  * @param otherInputs other observable inputs to collate values from.
  */
-export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A): OperatorFunction<T, Array<T | ObservedValuesFromArray<A>>> {
+export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>> {
   return zip(...otherInputs);
 }

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -1,6 +1,6 @@
 import { zip as zipStatic } from '../observable/zip';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Unshift } from '../types';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link zipWith} */
@@ -45,14 +45,6 @@ export function zip<T, R>(...observables: Array<ObservableInput<any> | ((...valu
   };
 }
 
-/* tslint:disable:max-line-length */
-export function zipWith<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
-export function zipWith<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
-export function zipWith<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, [T, T2, T3, T4]>;
-export function zipWith<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, [T, T2, T3, T4, T5]>;
-export function zipWith<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]> ;
-export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>>;
-/* tslint:enable:max-line-length */
 /**
  * Subscribes to the source, and the observable inputs provided as arguments, and combines their values, by index, into arrays.
  *
@@ -73,6 +65,8 @@ export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A):
  *
  * @param otherInputs other observable inputs to collate values from.
  */
-export function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A): OperatorFunction<T, Array<T | ObservedValueUnionFromArray<A>>> {
+export function zipWith<T, A extends ObservableInput<any>[]>(
+  ...otherInputs: A
+): OperatorFunction<T, Unshift<ObservedValueTupleFromArray<A>, T>> {
   return zip(...otherInputs);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes `combineLatestWith` and `zipWith` by:

* removing the overload signatures; and
* replacing them with a single signature that uses the `ObservedValueTupleFromArray` and `Unshift` types.

The return type for N-args usage is now a correctly-typed tuple - instead of an array with union-type elements.

**Related <s>issue</s> PR:** #5254