### PR TITLE
docs(defer): mention analogy to function calls

### DIFF
--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -19,7 +19,10 @@ import { empty } from './empty';
  * typically with an Observable factory function. It does this afresh for each
  * subscriber, so although each subscriber may think it is subscribing to the
  * same Observable, in fact each subscriber gets its own individual
- * Observable.
+ * Observable. This is not different to other creation operators -- i.e. 
+ * a `subscribe` call can be seen as a function call -- but plays an 
+ * important role when one wants to return a Subject (or a subtype of Subject)
+ * as they are then not shared amongst subscribers neither.
  *
  * ## Example
  * ### Subscribe to either an Observable of clicks or an Observable of interval, at random


### PR DESCRIPTION
... and that the creation behaviour is important in case of Subject creation

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
