### PR TITLE
fix: remove explicit types in toPromise spec

### DIFF
--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -4,7 +4,7 @@ import { of, EMPTY, throwError, config } from 'rxjs';
 /** @test {toPromise} */
 describe('Observable.toPromise', () => {
   it('should convert an Observable to a promise of its last value', (done: MochaDone) => {
-    of(1, 2, 3).toPromise(Promise).then((x: number) => {
+    of(1, 2, 3).toPromise(Promise).then(x => {
       expect(x).to.equal(3);
       done();
     });
@@ -33,7 +33,7 @@ describe('Observable.toPromise', () => {
       return new Promise(callback as any);
     } as any;
 
-    of(42).toPromise().then((x: number) => {
+    of(42).toPromise().then(x => {
       expect(wasCalled).to.be.true;
       expect(x).to.equal(42);
       done();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes explicit parameter types from arrow functions in the `toPromise` spec. With the changes made in #5072, `toPromise` is now typed as potentially resolving with `undefined`.

The problem is currently breaking CI for all PRs.

**Related issue (if exists):** N/A