### PR TITLE
docs(forkJoin): add `the` and other improvements

### DIFF
--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -63,7 +63,7 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * second value is the last one emitted by the second observable and so on.
  *
  * If you pass a dictionary of observables to the operator, then the resulting
- * objects will have the same keys as the dictionary passed, with their last values they hadve emitted
+ * objects will have the same keys as the dictionary passed, with their last values they have emitted
  * located at the corresponding key.
  *
  * That means `forkJoin` will not emit more than once and it will complete after that. If you need to emit combined
@@ -81,10 +81,10 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * If any given observable errors at some point, `forkJoin` will error as well and immediately unsubscribe
  * from the other observables.
  *
- * Optionally `forkJoin` accepts a resultSelector function, that will be called with values which normally
- * would land in the emitted array. Whatever is returned by the resultSelector, will appear in the output
- * observable instead. This means that the default resultSelector can be thought of as a function that takes
- * all its arguments and puts them into an array. Note that the resultSelector will be called only
+ * Optionally `forkJoin` accepts a `resultSelector` function, that will be called with values which normally
+ * would land in the emitted array. Whatever is returned by the `resultSelector`, will appear in the output
+ * observable instead. This means that the default `resultSelector` can be thought of as a function that takes
+ * all its arguments and puts them into an array. Note that the `resultSelector` will be called only
  * when `forkJoin` is supposed to emit a result.
  *
  * ## Examples

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -52,40 +52,40 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * ![](forkJoin.png)
  *
  * `forkJoin` is an operator that takes any number of input observables which can be passed either as an array
- * or a dictionary of input observables. If no input observables are provided, resulting stream will complete
+ * or a dictionary of input observables. If no input observables are provided, then the resulting stream will complete
  * immediately.
  *
  * `forkJoin` will wait for all passed observables to emit and complete and then it will emit an array or an object with last
  * values from corresponding observables.
  *
- * If you pass an array of `n` observables to the operator, resulting
- * array will have `n` values, where first value is the last thing emitted by the first observable,
- * second value is the last thing emitted by the second observable and so on.
+ * If you pass an array of `n` observables to the operator, then the resulting
+ * array will have `n` values, where the first value is the last one emitted by the first observable,
+ * second value is the last one emitted by the second observable and so on.
  *
- * If you pass a dictionary of observables to the operator, resulting
- * objects will have the same keys as the dictionary passed, with their last values they've emitted
+ * If you pass a dictionary of observables to the operator, then the resulting
+ * objects will have the same keys as the dictionary passed, with their last values they hadve emitted
  * located at the corresponding key.
  *
  * That means `forkJoin` will not emit more than once and it will complete after that. If you need to emit combined
- * values not only at the end of lifecycle of passed observables, but also throughout it, try out {@link combineLatest}
+ * values not only at the end of the lifecycle of passed observables, but also throughout it, try out {@link combineLatest}
  * or {@link zip} instead.
  *
- * In order for resulting array to have the same length as the number of input observables, whenever any of
- * that observables completes without emitting any value, `forkJoin` will complete at that moment as well
+ * In order for the resulting array to have the same length as the number of input observables, whenever any of
+ * the given observables completes without emitting any value, `forkJoin` will complete at that moment as well
  * and it will not emit anything either, even if it already has some last values from other observables.
- * Conversely, if there is an observable that never completes, `forkJoin` will never complete as well,
- * unless at any point some other observable completes without emitting value, which brings us back to
- * the previous case. Overall, in order for `forkJoin` to emit a value, all observables passed as arguments
+ * Conversely, if there is an observable that never completes, `forkJoin` will never complete either,
+ * unless at any point some other observable completes without emitting a value, which brings us back to
+ * the previous case. Overall, in order for `forkJoin` to emit a value, all given observables
  * have to emit something at least once and complete.
  *
- * If any input observable errors at some point, `forkJoin` will error as well and all other observables
- * will be immediately unsubscribed.
+ * If any given observable errors at some point, `forkJoin` will error as well and immediately unsubscribe
+ * from the other observables.
  *
- * Optionally `forkJoin` accepts project function, that will be called with values which normally
- * would land in emitted array. Whatever is returned by project function, will appear in output
- * observable instead. This means that default project can be thought of as a function that takes
- * all its arguments and puts them into an array. Note that project function will be called only
- * when output observable is supposed to emit a result.
+ * Optionally `forkJoin` accepts a resultSelector function, that will be called with values which normally
+ * would land in the emitted array. Whatever is returned by the resultSelector, will appear in the output
+ * observable instead. This means that the default resultSelector can be thought of as a function that takes
+ * all its arguments and puts them into an array. Note that the resultSelector will be called only
+ * when `forkJoin` is supposed to emit a result.
  *
  * ## Examples
  *


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
