### PR TITLE
docs(defer): improve documentation and use EMPTY

### DIFF
--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { ObservedValueOf, ObservableInput } from '../types';
 import { from } from './from'; // lol
-import { empty } from './empty';
+import { EMPTY } from './empty';
 
 /**
  * Creates an Observable that, on subscribe, calls an Observable factory to
@@ -13,13 +13,13 @@ import { empty } from './empty';
  *
  * ![](defer.png)
  *
- * `defer` allows you to create the Observable only when the Observer
- * subscribes, and create a fresh Observable for each Observer. It waits until
- * an Observer subscribes to it, and then it generates an Observable,
- * typically with an Observable factory function. It does this afresh for each
- * subscriber, so although each subscriber may think it is subscribing to the
- * same Observable, in fact each subscriber gets its own individual
- * Observable.
+ * `defer` allows you to create an Observable only when the Observer
+ * subscribes. It waits until an Observer subscribes to it, calls the given
+ * factory function to get an Observable -- where a factory function typically
+ * generates a new Observable -- and subscribes the Observer to this Observable.
+ * In case the factory function returns a falsy value, then EMPTY is used as
+ * Observable instead. Last but not least, an exception during the factory
+ * function call is transferred to the Observer by calling `error`.
  *
  * ## Example
  * ### Subscribe to either an Observable of clicks or an Observable of interval, at random
@@ -61,7 +61,7 @@ export function defer<R extends ObservableInput<any> | void>(observableFactory: 
       subscriber.error(err);
       return undefined;
     }
-    const source = input ? from(input as ObservableInput<ObservedValueOf<R>>) : empty();
+    const source = input ? from(input as ObservableInput<ObservedValueOf<R>>) : EMPTY;
     return source.subscribe(subscriber);
   });
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Use EMPTY instead of deprecated function `empty()`

**Related issue (if exists):**
#5258
