### PR TITLE
Replace deprecated sinon sandbox factory method

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -250,7 +250,7 @@ describe('Observable', () => {
     });
 
     it('should run unsubscription logic when an error is sent asynchronously and subscribe is called with no arguments', (done) => {
-      const sandbox = sinon.sandbox.create();
+      const sandbox = sinon.createSandbox();
       const fakeTimer = sandbox.useFakeTimers();
 
       let unsubscribeCalled = false;

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -15,7 +15,7 @@ describe('ajax', () => {
   let sandbox: sinon.SinonSandbox;
 
   beforeEach(() => {
-    sandbox = sinon.sandbox.create();
+    sandbox = sinon.createSandbox();
     gXHR = global.XMLHttpRequest;
     rXHR = root.XMLHttpRequest;
 

--- a/spec/observables/interval-spec.ts
+++ b/spec/observables/interval-spec.ts
@@ -63,7 +63,7 @@ describe('interval', () => {
   });
 
   it('should create an observable emitting periodically with the AsapScheduler', (done: MochaDone) => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     const period = 10;
     const events = [0, 1, 2, 3, 4, 5];
@@ -90,7 +90,7 @@ describe('interval', () => {
   });
 
   it('should create an observable emitting periodically with the QueueScheduler', (done: MochaDone) => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     const period = 10;
     const events = [0, 1, 2, 3, 4, 5];
@@ -117,7 +117,7 @@ describe('interval', () => {
   });
 
   it('should create an observable emitting periodically with the AnimationFrameScheduler', (done: MochaDone) => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     const period = 10;
     const events = [0, 1, 2, 3, 4, 5];

--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -397,7 +397,7 @@ describe('catchError operator', () => {
 
     beforeEach(() => {
       trueSetTimeout = global.setTimeout;
-      sandbox = sinon.sandbox.create();
+      sandbox = sinon.createSandbox();
       timers = sandbox.useFakeTimers();
     });
 

--- a/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -12,7 +12,7 @@ describe('Scheduler.animationFrame', () => {
 
   it('should act like the async scheduler if delay > 0', () => {
     let actionHappened = false;
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     animationFrame.schedule(() => {
       actionHappened = true;
@@ -27,7 +27,7 @@ describe('Scheduler.animationFrame', () => {
 
   it('should cancel animationFrame actions when unsubscribed', () => {
     let actionHappened = false;
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     animationFrame.schedule(() => {
       actionHappened = true;

--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -12,7 +12,7 @@ describe('Scheduler.asap', () => {
 
   it('should act like the async scheduler if delay > 0', () => {
     let actionHappened = false;
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     asap.schedule(() => {
       actionHappened = true;
@@ -27,7 +27,7 @@ describe('Scheduler.asap', () => {
 
   it('should cancel asap actions when delay > 0', () => {
     let actionHappened = false;
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     asap.schedule(() => {
       actionHappened = true;
@@ -41,7 +41,7 @@ describe('Scheduler.asap', () => {
   });
 
   it('should reuse the interval for recursively scheduled actions with the same delay', () => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
     const stubSetInterval = (<any> sinon.stub(global, 'setInterval')).callThrough();
@@ -68,7 +68,7 @@ describe('Scheduler.asap', () => {
   });
 
   it('should not reuse the interval for recursively scheduled actions with a different delay', () => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
     const stubSetInterval = (<any> sinon.stub(global, 'setInterval')).callThrough();

--- a/spec/schedulers/QueueScheduler-spec.ts
+++ b/spec/schedulers/QueueScheduler-spec.ts
@@ -8,7 +8,7 @@ const queue = queueScheduler;
 describe('Scheduler.queue', () => {
   it('should act like the async scheduler if delay > 0', () => {
     let actionHappened = false;
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     queue.schedule(() => {
       actionHappened = true;
@@ -22,7 +22,7 @@ describe('Scheduler.queue', () => {
   });
 
   it('should switch from synchronous to asynchronous at will', () => {
-    const sandbox = sinon.sandbox.create();
+    const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
 
     let asyncExec = false;


### PR DESCRIPTION
**Description:**
Migrate from the deprecated `sinon.sandbox.create()` to `sinon.createSandbox()`. This PR upstreams internal changes to unblock Google's migration to sinon 8.1.