### PR TITLE
chore: revert SchedulerLike interface changes

### DIFF
--- a/spec/Scheduler-spec.ts
+++ b/spec/Scheduler-spec.ts
@@ -23,8 +23,8 @@ describe('Scheduler.queue', () => {
     let call2 = false;
     (queue as QueueScheduler).active = false;
     queue.schedule(function (state) {
-      call1 = state.call1;
-      call2 = state.call2;
+      call1 = state!.call1;
+      call2 = state!.call2;
       if (!call2) {
         this.schedule({ call1: true, call2: true });
       }

--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -54,7 +54,7 @@ describe('Scheduler.asap', () => {
         this.schedule(state, state.period);
       }
     }
-    asap.schedule(dispatch, period, state);
+    asap.schedule(dispatch as any, period, state);
     expect(state).to.have.property('index', 0);
     expect(stubSetInterval).to.have.property('callCount', 1);
     fakeTimer.tick(period);
@@ -82,7 +82,7 @@ describe('Scheduler.asap', () => {
         this.schedule(state, state.period);
       }
     }
-    asap.schedule(dispatch, period, state);
+    asap.schedule(dispatch as any, period, state);
     expect(state).to.have.property('index', 0);
     expect(stubSetInterval).to.have.property('callCount', 1);
     fakeTimer.tick(period);

--- a/spec/schedulers/QueueScheduler-spec.ts
+++ b/spec/schedulers/QueueScheduler-spec.ts
@@ -29,7 +29,7 @@ describe('Scheduler.queue', () => {
     let state: Array<number> = [];
 
     queue.schedule(function (index) {
-      state.push(index);
+      state.push(index!);
       if (index === 0) {
         this.schedule(1, 100);
       } else if (index === 1) {

--- a/spec/schedulers/VirtualTimeScheduler-spec.ts
+++ b/spec/schedulers/VirtualTimeScheduler-spec.ts
@@ -11,7 +11,7 @@ describe('VirtualTimeScheduler', () => {
   it('should schedule things in order when flushed if each this is scheduled synchrously', () => {
     const v = new VirtualTimeScheduler();
     const invoked: number[] = [];
-    const invoke = (state: number) => {
+    const invoke: any = (state: number) => {
       invoked.push(state);
     };
     v.schedule(invoke, 0, 1);
@@ -28,7 +28,7 @@ describe('VirtualTimeScheduler', () => {
   it('should schedule things in order when flushed if each this is scheduled at random', () => {
     const v = new VirtualTimeScheduler();
     const invoked: number[] = [];
-    const invoke = (state: number) => {
+    const invoke: any = (state: number) => {
       invoked.push(state);
     };
     v.schedule(invoke, 0, 1);
@@ -46,7 +46,7 @@ describe('VirtualTimeScheduler', () => {
   it('should schedule things in order when there are negative delays', () => {
     const v = new VirtualTimeScheduler();
     const invoked: number[] = [];
-    const invoke = (state: number) => {
+    const invoke: any = (state: number) => {
       invoked.push(state);
     };
     v.schedule(invoke, 0, 1);
@@ -66,7 +66,7 @@ describe('VirtualTimeScheduler', () => {
     let count = 0;
     const expected = [100, 200, 300];
 
-    v.schedule<string>(function (this: SchedulerAction<string>, state: string) {
+    v.schedule<string>(function (this: SchedulerAction<string>, state?: string) {
       if (++count === 3) {
         return;
       }
@@ -84,7 +84,7 @@ describe('VirtualTimeScheduler', () => {
     const messages: string[] = [];
 
     const action: VirtualAction<string> = <VirtualAction<string>> v.schedule(
-      state => messages.push(state),
+      state => messages.push(state!),
       10,
       'first message'
     );
@@ -104,7 +104,7 @@ describe('VirtualTimeScheduler', () => {
 
     messages.forEach((message, index) => {
       v.schedule(
-        (state: string) => actualMessages.push(state),
+        state => actualMessages.push(state!),
         index * MAX_FRAMES,
         message
       );
@@ -125,7 +125,7 @@ describe('VirtualTimeScheduler', () => {
 
     messages.forEach((message, index) => {
       v.schedule(
-        state => actualMessages.push(state),
+        state => actualMessages.push(state!),
         index * MAX_FRAMES,
         message
       );

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -62,7 +62,7 @@ export class Scheduler implements SchedulerLike {
    * @return {Subscription} A subscription in order to be able to unsubscribe
    * the scheduled work.
    */
-  public schedule<T = undefined>(work: (this: SchedulerAction<T>, state: T) => void, delay: number = 0, state?: T): Subscription {
-    return new this.SchedulerAction<T>(this, work).schedule(state!, delay);
+  public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
+    return new this.SchedulerAction<T>(this, work).schedule(state, delay);
   }
 }

--- a/src/internal/observable/SubscribeOnObservable.ts
+++ b/src/internal/observable/SubscribeOnObservable.ts
@@ -45,7 +45,7 @@ export class SubscribeOnObservable<T> extends Observable<T> {
     const source = this.source;
     const scheduler = this.scheduler;
 
-    return scheduler.schedule<DispatchArg<any>>(SubscribeOnObservable.dispatch, delay, {
+    return scheduler.schedule<DispatchArg<any>>(SubscribeOnObservable.dispatch as any, delay, {
       source, subscriber
     });
   }

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -224,7 +224,7 @@ export function bindCallback<T>(
         const state: DispatchState<T> = {
           args, subscriber, params,
         };
-        return scheduler.schedule<DispatchState<T>>(dispatch, 0, state);
+        return scheduler.schedule<DispatchState<T>>(dispatch as any, 0, state);
       }
     });
   };
@@ -253,7 +253,7 @@ function dispatch<T>(this: SchedulerAction<DispatchState<T>>, state: DispatchSta
 
     const handler = (...innerArgs: any[]) => {
       const value = innerArgs.length <= 1 ? innerArgs[0] : innerArgs;
-      this.add(scheduler.schedule<NextState<T>>(dispatchNext, 0, { value, subject: subject! }));
+      this.add(scheduler.schedule<NextState<T>>(dispatchNext as any, 0, { value, subject: subject! }));
     };
 
     try {

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -208,7 +208,7 @@ export function bindNodeCallback<T>(
         }
         return subject.subscribe(subscriber);
       } else {
-        return scheduler.schedule<DispatchState<T>>(dispatch, 0, { params, subscriber, context });
+        return scheduler.schedule<DispatchState<T>>(dispatch as any, 0, { params, subscriber, context });
       }
     });
   };
@@ -239,17 +239,17 @@ function dispatch<T>(this: SchedulerAction<DispatchState<T>>, state: DispatchSta
     const handler = (...innerArgs: any[]) => {
       const err = innerArgs.shift();
       if (err) {
-        this.add(scheduler.schedule<DispatchErrorArg<T>>(dispatchError, 0, { err, subject }));
+        this.add(scheduler.schedule<DispatchErrorArg<T>>(dispatchError as any, 0, { err, subject }));
       } else {
         const value = innerArgs.length <= 1 ? innerArgs[0] : innerArgs;
-        this.add(scheduler.schedule<DispatchNextArg<T>>(dispatchNext, 0, { value, subject }));
+        this.add(scheduler.schedule<DispatchNextArg<T>>(dispatchNext as any, 0, { value, subject }));
       }
     };
 
     try {
       callbackFunc.apply(context, [...args, handler]);
     } catch (err) {
-      this.add(scheduler.schedule<DispatchErrorArg<T>>(dispatchError, 0, { err, subject }));
+      this.add(scheduler.schedule<DispatchErrorArg<T>>(dispatchError as any, 0, { err, subject }));
     }
   }
 

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -361,7 +361,7 @@ export function generate<T, S>(initialStateOrOptions: S | GenerateOptions<T, S>,
   return new Observable<T>(subscriber => {
     let state = initialState;
     if (scheduler) {
-      return scheduler.schedule<SchedulerState<T, S>>(dispatch, 0, {
+      return scheduler.schedule<SchedulerState<T, S>>(dispatch as any, 0, {
         subscriber,
         iterate: iterate!,
         condition,

--- a/src/internal/observable/interval.ts
+++ b/src/internal/observable/interval.ts
@@ -64,7 +64,7 @@ export function interval(period = 0,
 
   return new Observable<number>(subscriber => {
     subscriber.add(
-      scheduler.schedule(dispatch, period, { subscriber, counter: 0, period })
+      scheduler.schedule(dispatch as any, period, { subscriber, counter: 0, period })
     );
     return subscriber;
   });

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -67,8 +67,11 @@ export function pairs<T>(obj: Object, scheduler?: SchedulerLike): Observable<[st
       const keys = Object.keys(obj);
       const subscription = new Subscription();
       subscription.add(
-        scheduler.schedule<{ keys: string[], index: number, subscriber: Subscriber<[string, T]>, subscription: Subscription, obj: Object }>
-          (dispatch, 0, { keys, index: 0, subscriber, subscription, obj }));
+        scheduler.schedule<{ keys: string[], index: number, subscriber: Subscriber<[string, T]>, subscription: Subscription, obj: Object }>(
+          dispatch as any,
+          0,
+          { keys, index: 0, subscriber, subscription, obj }
+        ));
       return subscription;
     });
   }

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -70,7 +70,7 @@ export function throwError(error: any, scheduler?: SchedulerLike): Observable<ne
   if (!scheduler) {
     return new Observable(subscriber => subscriber.error(error));
   } else {
-    return new Observable(subscriber => scheduler.schedule(dispatch, 0, { error, subscriber }));
+    return new Observable(subscriber => scheduler.schedule(dispatch as any, 0, { error, subscriber }));
   }
 }
 

--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -74,7 +74,7 @@ export function timer(dueTime: number | Date = 0,
       ? (dueTime as number)
       : (+dueTime - scheduler!.now());
 
-    return scheduler!.schedule(dispatch, due, {
+    return scheduler!.schedule(dispatch as any, due, {
       index: 0, period, subscriber
     });
   });

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -147,8 +147,8 @@ class BufferTimeSubscriber<T> extends Subscriber<T> {
     } else {
       const closeState = { subscriber: this, context };
       const creationState: DispatchCreateArg<T> = { bufferTimeSpan, bufferCreationInterval, subscriber: this, scheduler };
-      this.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(dispatchBufferClose, bufferTimeSpan, closeState));
-      this.add(scheduler.schedule<DispatchCreateArg<T>>(dispatchBufferCreation, bufferCreationInterval!, creationState));
+      this.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(dispatchBufferClose as any, bufferTimeSpan, closeState));
+      this.add(scheduler.schedule<DispatchCreateArg<T>>(dispatchBufferCreation as any, bufferCreationInterval!, creationState));
     }
   }
 
@@ -239,7 +239,11 @@ function dispatchBufferCreation<T>(this: SchedulerAction<DispatchCreateArg<T>>, 
   const context = subscriber.openContext();
   const action = <SchedulerAction<DispatchCreateArg<T>>>this;
   if (!subscriber.closed) {
-    subscriber.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(dispatchBufferClose, bufferTimeSpan, { subscriber, context }));
+    subscriber.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(
+      dispatchBufferClose as any,
+      bufferTimeSpan,
+      { subscriber, context }
+    ));
     action.schedule(state, bufferCreationInterval!);
   }
 }

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -97,7 +97,7 @@ class DebounceTimeSubscriber<T> extends Subscriber<T> {
     this.clearDebounce();
     this.lastValue = value;
     this.hasValue = true;
-    this.add(this.debouncedSubscription = this.scheduler.schedule(dispatchNext, this.dueTime, this));
+    this.add(this.debouncedSubscription = this.scheduler.schedule(dispatchNext as any, this.dueTime, this));
   }
 
   protected _complete() {

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -118,7 +118,7 @@ class DelaySubscriber<T> extends Subscriber<T> {
   private _schedule(scheduler: SchedulerLike): void {
     this.active = true;
     const destination = this.destination as Subscription;
-    destination.add(scheduler.schedule<DelayState<T>>(DelaySubscriber.dispatch, this.delay, {
+    destination.add(scheduler.schedule<DelayState<T>>(DelaySubscriber.dispatch as any, this.delay, {
       source: this, destination: this.destination, scheduler: scheduler
     }));
   }

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -135,7 +135,11 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
         } else {
           const state: DispatchArg<T, R> = { subscriber: this, result, value, index };
           const destination = this.destination as Subscription;
-          destination.add(this.scheduler.schedule<DispatchArg<T, R>>(ExpandSubscriber.dispatch, 0, state));
+          destination.add(this.scheduler.schedule<DispatchArg<T, R>>(
+            ExpandSubscriber.dispatch as any,
+            0,
+            state
+          ));
         }
       } catch (e) {
         destination.error(e);

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -95,7 +95,7 @@ export class ObserveOnSubscriber<T> extends Subscriber<T> {
   private scheduleMessage(notification: Notification<any>): void {
     const destination = this.destination as Subscription;
     destination.add(this.scheduler.schedule(
-      ObserveOnSubscriber.dispatch,
+      ObserveOnSubscriber.dispatch as any,
       this.delay,
       new ObserveOnMessage(notification, this.destination)
     ));

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -130,7 +130,7 @@ class ThrottleTimeSubscriber<T> extends Subscriber<T> {
         this._hasTrailingValue = true;
       }
     } else {
-      this.add(this.throttled = this.scheduler.schedule<DispatchArg<T>>(dispatchNext, this.duration, { subscriber: this }));
+      this.add(this.throttled = this.scheduler.schedule<DispatchArg<T>>(dispatchNext as any, this.duration, { subscriber: this }));
       if (this.leading) {
         this.destination.next(value);
       } else if (this.trailing) {

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -123,7 +123,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.action = (<SchedulerAction<TimeoutWithSubscriber<T, R>>> action.schedule(this, this.waitFor));
     } else {
       this.add(this.action = (<SchedulerAction<TimeoutWithSubscriber<T, R>>> this.scheduler.schedule<TimeoutWithSubscriber<T, R>>(
-        TimeoutWithSubscriber.dispatchTimeout, this.waitFor, this
+        TimeoutWithSubscriber.dispatchTimeout as any, this.waitFor, this
       )));
     }
   }

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -192,13 +192,13 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
 
     const window = this.openWindow();
     if (windowCreationInterval !== null && windowCreationInterval >= 0) {
-      const closeState: CloseState<T> = { subscriber: this, window, context: <any>null };
+      const closeState: CloseState<T> = { subscriber: this, window, context: null! };
       const creationState: CreationState<T> = { windowTimeSpan, windowCreationInterval, subscriber: this, scheduler };
-      this.add(scheduler.schedule<CloseState<T>>(dispatchWindowClose, windowTimeSpan, closeState));
-      this.add(scheduler.schedule<CreationState<T>>(dispatchWindowCreation, windowCreationInterval, creationState));
+      this.add(scheduler.schedule<CloseState<T>>(dispatchWindowClose as any, windowTimeSpan, closeState));
+      this.add(scheduler.schedule<CreationState<T>>(dispatchWindowCreation as any, windowCreationInterval, creationState));
     } else {
       const timeSpanOnlyState: TimeSpanOnlyState<T> = { subscriber: this, window, windowTimeSpan };
-      this.add(scheduler.schedule<TimeSpanOnlyState<T>>(dispatchWindowTimeSpanOnly, windowTimeSpan, timeSpanOnlyState));
+      this.add(scheduler.schedule<TimeSpanOnlyState<T>>(dispatchWindowTimeSpanOnly as any, windowTimeSpan, timeSpanOnlyState));
     }
   }
 
@@ -268,9 +268,9 @@ function dispatchWindowCreation<T>(this: SchedulerAction<CreationState<T>>, stat
   const { windowTimeSpan, subscriber, scheduler, windowCreationInterval } = state;
   const window = subscriber.openWindow();
   const action = this;
-  let context: CloseWindowContext<T> = { action, subscription: <any>null };
+  let context: CloseWindowContext<T> = { action, subscription: null! };
   const timeSpanState: CloseState<T> = { subscriber, window, context };
-  context.subscription = scheduler.schedule<CloseState<T>>(dispatchWindowClose, windowTimeSpan, timeSpanState);
+  context.subscription = scheduler.schedule<CloseState<T>>(dispatchWindowClose as any, windowTimeSpan, timeSpanState);
   action.add(context.subscription);
   action.schedule(state, windowCreationInterval);
 }

--- a/src/internal/scheduler/Action.ts
+++ b/src/internal/scheduler/Action.ts
@@ -9,15 +9,15 @@ import { SchedulerAction } from '../types';
  *
  * ```ts
  * class Action<T> extends Subscription {
- *   new (scheduler: Scheduler, work: (state: T) => void);
- *   schedule(state: T, delay: number = 0): Subscription;
+ *   new (scheduler: Scheduler, work: (state?: T) => void);
+ *   schedule(state?: T, delay: number = 0): Subscription;
  * }
  * ```
  *
  * @class Action<T>
  */
 export class Action<T> extends Subscription {
-  constructor(scheduler: Scheduler, work: (this: SchedulerAction<T>, state: T) => void) {
+  constructor(scheduler: Scheduler, work: (this: SchedulerAction<T>, state?: T) => void) {
     super();
   }
   /**
@@ -30,7 +30,7 @@ export class Action<T> extends Subscription {
    * time unit is implicit and defined by the Scheduler.
    * @return {void}
    */
-  public schedule(state: T, delay: number = 0): Subscription {
+  public schedule(state?: T, delay: number = 0): Subscription {
     return this;
   }
 }

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -10,7 +10,7 @@ import { SchedulerAction } from '../types';
 export class AnimationFrameAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AnimationFrameScheduler,
-              protected work: (this: SchedulerAction<T>, state: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -10,7 +10,7 @@ import { SchedulerAction } from '../types';
 export class AsapAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: AsapScheduler,
-              protected work: (this: SchedulerAction<T>, state: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -17,7 +17,7 @@ export class AsyncAction<T> extends Action<T> {
   protected pending: boolean = false;
 
   constructor(protected scheduler: AsyncScheduler,
-              protected work: (this: SchedulerAction<T>, state: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 

--- a/src/internal/scheduler/AsyncScheduler.ts
+++ b/src/internal/scheduler/AsyncScheduler.ts
@@ -34,7 +34,7 @@ export class AsyncScheduler extends Scheduler {
     });
   }
 
-  public schedule<T = undefined>(work: (this: SchedulerAction<T>, state: T) => void, delay: number = 0, state?: T): Subscription {
+  public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
     if (AsyncScheduler.delegate && AsyncScheduler.delegate !== this) {
       return AsyncScheduler.delegate.schedule(work, delay, state);
     } else {

--- a/src/internal/scheduler/QueueAction.ts
+++ b/src/internal/scheduler/QueueAction.ts
@@ -11,11 +11,11 @@ import { SchedulerAction } from '../types';
 export class QueueAction<T> extends AsyncAction<T> {
 
   constructor(protected scheduler: QueueScheduler,
-              protected work: (this: SchedulerAction<T>, state: T) => void) {
+              protected work: (this: SchedulerAction<T>, state?: T) => void) {
     super(scheduler, work);
   }
 
-  public schedule(state: T, delay: number = 0): Subscription {
+  public schedule(state?: T, delay: number = 0): Subscription {
     if (delay > 0) {
       return super.schedule(state, delay);
     }

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -67,7 +67,7 @@ export class VirtualAction<T> extends AsyncAction<T> {
   protected active: boolean = true;
 
   constructor(protected scheduler: VirtualTimeScheduler,
-              protected work: (this: SchedulerAction<T>, state: T) => void,
+              protected work: (this: SchedulerAction<T>, state?: T) => void,
               protected index: number = scheduler.index += 1) {
     super(scheduler, work);
     this.index = scheduler.index = index;

--- a/src/internal/testing/ColdObservable.ts
+++ b/src/internal/testing/ColdObservable.ts
@@ -40,9 +40,14 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
     for (let i = 0; i < messagesLength; i++) {
       const message = this.messages[i];
       subscriber.add(
-        this.scheduler.schedule(({ message, subscriber }) => { message.notification.observe(subscriber); },
+        this.scheduler.schedule(
+          state => {
+            const { message, subscriber } = state!;
+            message.notification.observe(subscriber);
+          },
           message.frame,
-          { message, subscriber })
+          { message, subscriber }
+        )
       );
     }
   }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -92,8 +92,7 @@ export interface Observer<T> {
 
 export interface SchedulerLike {
   now(): number;
-  schedule(work: (this: SchedulerAction<undefined>) => void, delay?: number ): Subscription;
-  schedule<T>(work: (this: SchedulerAction<T>, state: T) => void, delay: number, state: T): Subscription;
+  schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay?: number, state?: T): Subscription;
 }
 
 export interface SchedulerAction<T> extends Subscription {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR reverts the changes made to the `SchedulerLike` interface. As discussed in the core-team Slack channel - with @MichaelJamesParsons - the changes broke user-land schedulers. (Angular Zone-related schedulers are not uncommon.)

Although the typing of the `SchedulerLike` interface in arguably incorrect, it might be best to leave it as-is and delay any changes to the scheduler infrastructure until version 8.

The reversion has necessitated the liberal use of `as any` assertions, as all of the dispatch/work functions assume a `state` that is not `undefined`. This problem was hidden until the `strict` typescript option was enabled. I did try a few other approaches - including using a conditional type instead of the `as any` assertion - but they didn't work out.

**Related issue:** None
