### PR TITLE
test: add test for #5105

### DIFF
--- a/spec/helpers/interop-helper.ts
+++ b/spec/helpers/interop-helper.ts
@@ -1,4 +1,4 @@
-import { Observable, Subscriber, Subscription } from 'rxjs';
+import { Observable, Subject, Subscriber, Subscription } from 'rxjs';
 import { rxSubscriber as symbolSubscriber } from 'rxjs/internal/symbol/rxSubscriber';
 
 /**
@@ -24,6 +24,15 @@ export function asInteropObservable<T>(observable: Observable<T>): Observable<T>
       };
     }
   });
+}
+
+/**
+ * Returns a subject that will be deemed by this package's implementation to
+ * be untrusted. The returned subject will not include the symbol that
+ * identifies trusted subjects.
+ */
+export function asInteropSubject<T>(subject: Subject<T>): Subject<T> {
+  return asInteropSubscriber(subject as any) as any;
 }
 
 /**

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -193,7 +193,11 @@ describe('BehaviorSubject', () => {
     source.subscribe(subject);
   });
 
-  it('should be an Observer which can be given to an interop source', (done: MochaDone) => {
+  it.skip('should be an Observer which can be given to an interop source', (done: MochaDone) => {
+    // This test reproduces a bug reported in this issue:
+    // https://github.com/ReactiveX/rxjs/issues/5105
+    // However, it cannot easily be fixed. See this comment:
+    // https://github.com/ReactiveX/rxjs/issues/5105#issuecomment-578405446
     const source = of(1, 2, 3, 4, 5);
     const subject = new BehaviorSubject(0);
     const expected = [0, 1, 2, 3, 4, 5];

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -2,6 +2,7 @@ import { expect } from 'chai';
 import { hot, expectObservable } from '../helpers/marble-testing';
 import { BehaviorSubject, Subject, ObjectUnsubscribedError, Observable, of } from 'rxjs';
 import { tap, mergeMapTo } from 'rxjs/operators';
+import { asInteropSubject } from '../helpers/interop-helper';
 
 /** @test {BehaviorSubject} */
 describe('BehaviorSubject', () => {
@@ -185,9 +186,28 @@ describe('BehaviorSubject', () => {
       }, (x) => {
         done(new Error('should not be called'));
       }, () => {
+        expect(subject.value).to.equal(5);
         done();
       });
 
     source.subscribe(subject);
+  });
+
+  it('should be an Observer which can be given to an interop source', (done: MochaDone) => {
+    const source = of(1, 2, 3, 4, 5);
+    const subject = new BehaviorSubject(0);
+    const expected = [0, 1, 2, 3, 4, 5];
+
+    subject.subscribe(
+      (x: number) => {
+        expect(x).to.equal(expected.shift());
+      }, (x) => {
+        done(new Error('should not be called'));
+      }, () => {
+        expect(subject.value).to.equal(5);
+        done();
+      });
+
+      source.subscribe(asInteropSubject(subject));
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing - but skipped - test for the bug reported in #5105 - which cannot be easily fixed.

The problem is that the subject isn't seen as a safe/trusted subscriber because the interop source won't see the per-package `Symbol` that identifies the subject as trusted.

And that means that the subject will be 'cloned' so that an `unsubscribe` method can be added to it:

https://github.com/ReactiveX/rxjs/blob/f8a487617d6eb96b6f702cc1546c0cac59927d4b/src/internal/Subscriber.ts#L189-L193

And that means the the subject's original state will remain unchanged.

**Related issue:** #5105