### PR TITLE
refactor: rename Unshift to Cons

### DIFF
--- a/spec-dtslint/types-spec.ts
+++ b/spec-dtslint/types-spec.ts
@@ -3,7 +3,9 @@ import {
   ObservedValueOf,
   ObservedValueUnionFromArray,
   ObservedValueTupleFromArray,
-  Unshift
+  Cons,
+  Head,
+  Tail
 } from 'rxjs';
 import { A, B, C } from './helpers';
 
@@ -58,10 +60,28 @@ describe('ObservedTupleFromArray', () => {
   });
 });
 
-describe('Unshift', () => {
-  it('should add the type to the beginning of the tuple', () => {
-    let tuple: ObservedValueTupleFromArray<[Observable<A>, Observable<B>]>;
-    let explicit: Unshift<typeof tuple, C>;
-    let inferred = explicit!; // $ExpectType [C, A, B]
+describe('Cons', () => {
+  it('should construct a tuple with the specified type at the head', () => {
+    let explicit: Cons<A, [B, C]>;
+    let inferred = explicit!; // $ExpectType [A, B, C]
+  });
+
+  it('should support rest tuples', () => {
+    let explicit: Cons<A, B[]>;
+    let inferred = explicit!; // $ExpectType [A, ...B[]]
+  });
+});
+
+describe('Head', () => {
+  it('should return the head of a tuple', () => {
+    let explicit: Head<[A, B, C]>;
+    let inferred = explicit!; // $ExpectType A
+  });
+});
+
+describe('Tail', () => {
+  it('should return the tail of a tuple', () => {
+    let explicit: Tail<[A, B, C]>;
+    let inferred = explicit!; // $ExpectType [B, C]
   });
 });

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -3,7 +3,7 @@ import { isArray } from '../util/isArray';
 import { CombineLatestOperator } from '../observable/combineLatest';
 import { from } from '../observable/from';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Unshift } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
 
 /* tslint:disable:max-line-length */
 /** @deprecated use {@link combineLatestWith} */
@@ -97,6 +97,6 @@ export function combineLatest<T, R>(...observables: Array<ObservableInput<any> |
  */
 export function combineLatestWith<T, A extends ObservableInput<any>[]>(
   ...otherSources: A
-): OperatorFunction<T, Unshift<ObservedValueTupleFromArray<A>, T>> {
+): OperatorFunction<T, Cons<T, ObservedValueTupleFromArray<A>>> {
   return combineLatest(...otherSources);
 }

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -1,6 +1,6 @@
 import { zip as zipStatic } from '../observable/zip';
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Unshift } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link zipWith} */
@@ -67,6 +67,6 @@ export function zip<T, R>(...observables: Array<ObservableInput<any> | ((...valu
  */
 export function zipWith<T, A extends ObservableInput<any>[]>(
   ...otherInputs: A
-): OperatorFunction<T, Unshift<ObservedValueTupleFromArray<A>, T>> {
+): OperatorFunction<T, Cons<T, ObservedValueTupleFromArray<A>>> {
   return zip(...otherInputs);
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -170,13 +170,31 @@ export type ObservedValueTupleFromArray<X> =
     : never;
 
 /**
- * Adds a type to the beginning of a tuple.
- * If you pass in `Unshift<[B, C], A>` you will get back `[A, B, C]`.
+ * Constructs a new tuple with the specified type at the head.
+ * If you declare `Cons<A, [B, C]>` you will get back `[A, B, C]`.
  */
-export type Unshift<X extends any[], Y> =
-  ((arg: Y, ...rest: X) => any) extends ((...args: infer U) => any)
+export type Cons<X, Y extends any[]> =
+  ((arg: X, ...rest: Y) => any) extends ((...args: infer U) => any)
     ? U
     : never;
+
+/**
+ * Extracts the head of a tuple.
+ * If you declare `Head<[A, B, C]>` you will get back `A`.
+ */
+export type Head<X extends any[]> =
+  ((...args: X) => any) extends ((arg: infer U, ...rest: any[]) => any)
+    ? U
+    : never;
+
+/**
+ * Extracts the tail of a tuple.
+ * If you declare `Tail<[A, B, C]>` you will get back `[B, C]`.
+ */
+export type Tail<X extends any[]> =
+((...args: X) => any) extends ((arg: any, ...rest: infer U) => any)
+  ? U
+  : never;
 
 /**
  * Extracts the generic value from an Array type.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR renames the `Unshift` type that was added in #5257 to the more conventional - for tuples - `Cons` and adds the related `Head` and `Tail` types - which I anticipate needing for the refactoring of some signatures to better handle N-args typing in some circumstances.

I originally went with `Unshift` 'cause that's the JS array-related terminology and thought that might be more familiar for folks. However, now that I anticipate needing the other typical tuple-manipulating types, I think the conventional names should be used.

**Related PR:** #5257
