### PR TITLE
Expose the `isPromise` utility function to the public API

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ export { pipe } from './internal/util/pipe';
 export { noop } from './internal/util/noop';
 export { identity } from './internal/util/identity';
 export { isObservable } from './internal/util/isObservable';
+export { isPromise } from './internal/util/isPromise';
 
 /* Error types */
 export { ArgumentOutOfRangeError } from './internal/util/ArgumentOutOfRangeError';


### PR DESCRIPTION
This could help people that deal with converting asynchronous primitives to observables.
In such cases, the `isObservable` function is used a lot and the check for a `Promise has to get implemented manually.

A common snippet could look like that:

```typescript
type potentialObservableValue<T> = Promise<T> | Observable<T> | undefined | null;
function isObservableValue<T>(nextValue: potentialObservableValue<T>): Observable<T> {
  if (nextValue === null || nextValue === undefined) {
    return of(undefined);
  }
  else if (isObservable(nextValue)) {
    return nextValue;
  } 
  else if (isPromise(nextValue)) {
    return from(nextValue);
  } 
  else {
    throw new Error('Wrong type!');
  }
}
```

Exposing `isPromise`  to the public API can help a lot and come in very handy.