### PR TITLE
RFC: AsyncIterable Support

### DIFF
--- a/integration/side-effects/snapshots/esm/ajax.js
+++ b/integration/side-effects/snapshots/esm/ajax.js
@@ -1,1 +1,1 @@
-
+import "tslib";

--- a/integration/side-effects/snapshots/esm/fetch.js
+++ b/integration/side-effects/snapshots/esm/fetch.js
@@ -1,1 +1,1 @@
-
+import "tslib";

--- a/integration/side-effects/snapshots/esm/index.js
+++ b/integration/side-effects/snapshots/esm/index.js
@@ -1,3 +1,5 @@
+import "tslib";
+
 var NotificationKind;
 
 (function(NotificationKind) {

--- a/integration/side-effects/snapshots/esm/operators.js
+++ b/integration/side-effects/snapshots/esm/operators.js
@@ -1,3 +1,5 @@
+import "tslib";
+
 var NotificationKind;
 
 (function(NotificationKind) {

--- a/integration/side-effects/snapshots/esm/testing.js
+++ b/integration/side-effects/snapshots/esm/testing.js
@@ -1,3 +1,5 @@
+import "tslib";
+
 var NotificationKind;
 
 (function(NotificationKind) {

--- a/integration/side-effects/snapshots/esm/websocket.js
+++ b/integration/side-effects/snapshots/esm/websocket.js
@@ -1,3 +1,5 @@
+import "tslib";
+
 var NotificationKind;
 
 (function(NotificationKind) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -56,22 +56,28 @@
       }
     },
     "@babel/code-frame": {
-      "version": "7.5.5",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.5.5.tgz",
-      "integrity": "sha512-27d4lZoomVyo51VegxI20xZPuSHusqbQag/ztrBC7wegWoQ1nLREPVSKSW8byhTlzTKyNE4ifaTA6lCp7JjpFw==",
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+      "integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
       "dev": true,
       "requires": {
-        "@babel/highlight": "^7.0.0"
+        "@babel/highlight": "^7.8.3"
       }
     },
+    "@babel/helper-validator-identifier": {
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.0.tgz",
+      "integrity": "sha512-6G8bQKjOh+of4PV/ThDm/rRqlU7+IGoJuofpagU5GlEl29Vv0RGqqt86ZGRV8ZuSOY3o+8yXl5y782SMcG7SHw==",
+      "dev": true
+    },
     "@babel/highlight": {
-      "version": "7.5.0",
-      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
-      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "version": "7.9.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+      "integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
       "dev": true,
       "requires": {
+        "@babel/helper-validator-identifier": "^7.9.0",
         "chalk": "^2.0.0",
-        "esutils": "^2.0.2",
         "js-tokens": "^4.0.0"
       }
     },
@@ -1203,9 +1209,9 @@
           }
         },
         "@types/node": {
-          "version": "11.13.20",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.20.tgz",
-          "integrity": "sha512-JE0UpLWZTV1sGcaj0hN+Q0760OEjpgyFJ06DOMVW6qKBducKdJQaIw0TGL6ccj7VXRduIOHLWQi+tHwulZJHVQ==",
+          "version": "11.15.9",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.9.tgz",
+          "integrity": "sha512-NcOiyA/gxMAounNa4IPm/e13kYqU48onEarMnbLzz3ynEdlxFKYFoBbMBSefAHJR77r9MCtD88J0Z2TVtNsBbw==",
           "dev": true
         },
         "rollup": {
@@ -6777,9 +6783,9 @@
           "dev": true
         },
         "source-map-support": {
-          "version": "0.5.13",
-          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.13.tgz",
-          "integrity": "sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==",
+          "version": "0.5.16",
+          "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.16.tgz",
+          "integrity": "sha512-efyLRJDr68D9hBBNIPWFjhpFzURh+KJykQwvMyW5UiZzYwoF6l4YMMDIJJEyFWxWCqfyxLzz6tSfUFR+kXXsVQ==",
           "dev": true,
           "requires": {
             "buffer-from": "^1.0.0",

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Observer, TeardownLogic } from '../src/internal/types';
 import { cold, expectObservable, expectSubscriptions } from './helpers/marble-testing';
-import { Observable, config, Subscription, noop, Subscriber, Operator, NEVER, Subject, of, throwError, empty } from 'rxjs';
-import { map, multicast, refCount, filter, count, tap, combineLatest, concat, merge, race, zip } from 'rxjs/operators';
+import { Observable, config, Subscription, noop, Subscriber, Operator, NEVER, Subject, of, throwError, empty, interval } from 'rxjs';
+import { map, multicast, refCount, filter, count, tap, combineLatest, concat, merge, race, zip, take } from 'rxjs/operators';
 
 declare const asDiagram: any, rxTestScheduler: any;
 
@@ -946,3 +946,39 @@ describe('Observable.lift', () => {
     }
   });
 });
+
+if (Symbol && Symbol.asyncIterator) {
+  describe('async iterator support', () => {
+    it('should work for sync observables', async () => {
+      const source = of(1, 2, 3);
+      const results: number[] = [];
+      for await (const value of source) {
+        results.push(value);
+      }
+      expect(results).to.deep.equal([1, 2, 3]);
+    });
+
+    it('should throw if the observable errors', async () => {
+      const source = throwError(new Error('bad'));
+      let error: any;
+      try {
+        for await (const _ of source) {
+          // do nothing
+        }
+      } catch (err) {
+        error = err;
+      }
+      expect(error).to.be.an.instanceOf(Error);
+      expect(error.message).to.equal('bad');
+    });
+
+    it('should support async observables', async () => {
+      const source = interval(10).pipe(take(3));
+      const results: number[] = [];
+      for await (const value of source) {
+        results.push(value);
+      }
+      expect(results).to.deep.equal([0, 1, 2]);
+    });
+  });
+}

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -102,6 +102,34 @@ describe('from', () => {
     { name: 'arguments', value: getArguments('x') },
   ];
 
+  if (Symbol && Symbol.asyncIterator) {
+    const fakeAsyncIterator = (...values: any[]) => {
+      return {
+        [Symbol.asyncIterator]() {
+          let i = 0;
+          return {
+            next() {
+              const index = i++;
+              if (index < values.length) {
+                return Promise.resolve({ done: false, value: values[index] });
+              } else {
+                return Promise.resolve({ done: true });
+              }
+            },
+            [Symbol.asyncIterator]() {
+              return this;
+            }
+          };
+        }
+      };
+    };
+
+    sources.push({
+      name: 'async-iterator',
+      value: fakeAsyncIterator('x')
+    });
+  }
+
   for (const source of sources) {
     it(`should accept ${source.name}`, (done) => {
       let nextInvoked = false;

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -9,6 +9,7 @@ import { throwError } from './observable/throwError';
 import { observable as Symbol_observable } from './symbol/observable';
 import { pipeFromArray } from './util/pipe';
 import { config } from './config';
+import { asyncIteratorFrom } from './asyncIteratorFrom';
 
 /**
  * A representation of any set of values over any amount of time. This is the most basic building block
@@ -390,3 +391,24 @@ function getPromiseCtor(promiseCtor: PromiseConstructorLike | undefined) {
 
   return promiseCtor;
 }
+
+export interface Observable<T> {
+  [Symbol.asyncIterator](): AsyncIterableIterator<T>;
+}
+
+(function () {
+  /**
+   * We only add this symbol if the runtime supports it.
+   * Adding this adds support for subscribing to observables
+   * via `for await(const value of source$) {}`
+   *
+   * This passes muster in Node 9, which does not support
+   * async iterators. As well as working in Node 12, which does
+   * support the symbol.
+   */
+  if (Symbol && Symbol.asyncIterator) {
+    Observable.prototype[Symbol.asyncIterator] = function () {
+      return asyncIteratorFrom(this);
+    };
+  }
+})();

--- a/src/internal/asyncIteratorFrom.ts
+++ b/src/internal/asyncIteratorFrom.ts
@@ -1,0 +1,57 @@
+import { Observable } from './Observable';
+import { Deferred } from './util/deferred';
+
+export function asyncIteratorFrom<T>(source: Observable<T>): AsyncIterableIterator<T> {
+  const deferreds: Deferred<IteratorResult<T>>[] = [];
+  const values: T[] = [];
+  let hasError = false;
+  let error: any = null;
+  let completed = false;
+
+  source.subscribe({
+    next: value => {
+      if (deferreds.length > 0) {
+        deferreds.shift()!.resolve({ value, done: false });
+      } else {
+        values.push(value);
+      }
+    },
+    error: err => {
+      hasError = true;
+      error = err;
+      while (deferreds.length > 0) {
+        deferreds.shift()!.reject(err);
+      }
+    },
+    complete: () => {
+      completed = true;
+      while (deferreds.length > 0) {
+        deferreds.shift()!.resolve({ value: undefined, done: true });
+      }
+    },
+  });
+
+  return {
+    next(): Promise<IteratorResult<T>> {
+      if (values.length > 0) {
+        return Promise.resolve({ value: values.shift()!, done: false });
+      }
+
+      if (completed) {
+        return Promise.resolve({ value: undefined, done: true });
+      }
+
+      if (hasError) {
+        return Promise.reject(error);
+      }
+
+      const d = new Deferred<IteratorResult<T>>();
+      deferreds.push(d);
+      return d.promise;
+    },
+
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}

--- a/src/internal/scheduled/scheduleAsyncIterable.ts
+++ b/src/internal/scheduled/scheduleAsyncIterable.ts
@@ -1,0 +1,28 @@
+import { SchedulerLike } from '../types';
+import { Observable } from '../Observable';
+import { Subscription } from '../Subscription';
+
+export function scheduleAsyncIterable<T>(input: AsyncIterable<T>, scheduler: SchedulerLike) {
+  if (!input) {
+    throw new Error('Iterable cannot be null');
+  }
+  return new Observable<T>(subscriber => {
+    const sub = new Subscription();
+    sub.add(
+      scheduler.schedule(() => {
+        const iterator = input[Symbol.asyncIterator]();
+        sub.add(scheduler.schedule(function () {
+          iterator.next().then(result => {
+            if (result.done) {
+              subscriber.complete();
+            } else {
+              subscriber.next(result.value);
+              this.schedule();
+            }
+          });
+        }));
+      })
+    );
+    return sub;
+  });
+}

--- a/src/internal/scheduled/scheduled.ts
+++ b/src/internal/scheduled/scheduled.ts
@@ -8,6 +8,7 @@ import { isArrayLike } from '../util/isArrayLike';
 import { isIterable } from '../util/isIterable';
 import { ObservableInput, SchedulerLike } from '../types';
 import { Observable } from '../Observable';
+import { scheduleAsyncIterable } from './scheduleAsyncIterable';
 
 /**
  * Converts from a common {@link ObservableInput} type to an observable where subscription and emissions
@@ -30,8 +31,9 @@ export function scheduled<T>(input: ObservableInput<T>, scheduler: SchedulerLike
       return scheduleArray(input, scheduler);
     }  else if (isIterable(input) || typeof input === 'string') {
       return scheduleIterable(input, scheduler);
+    } else if (Symbol && Symbol.asyncIterator && typeof (input as any)[Symbol.asyncIterator] === 'function') {
+      return scheduleAsyncIterable(input as any, scheduler);
     }
   }
-
   throw new TypeError((input !== null && typeof input || input) + ' is not observable');
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -49,7 +49,7 @@ export interface Subscribable<T> {
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
 }
 
-export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Iterable<T>;
+export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Iterable<T> | AsyncIterableIterator<T>;
 
 /** @deprecated use {@link InteropObservable } */
 export type ObservableLike<T> = InteropObservable<T>;

--- a/src/internal/util/deferred.ts
+++ b/src/internal/util/deferred.ts
@@ -1,0 +1,8 @@
+export class Deferred<T> {
+  resolve: (value?: T | PromiseLike<T> | undefined) => void = null!;
+  reject: (reason?: any) => void = null!;
+  promise = new Promise<T>((a, b) => {
+    this.resolve = a;
+    this.reject = b;
+  });
+}

--- a/src/internal/util/subscribeTo.ts
+++ b/src/internal/util/subscribeTo.ts
@@ -10,6 +10,7 @@ import { iterator as Symbol_iterator } from '../symbol/iterator';
 import { observable as Symbol_observable } from '../symbol/observable';
 import { Subscription } from '../Subscription';
 import { Subscriber } from '../Subscriber';
+import { subscribeToAsyncIterable } from './subscribeToAsyncIterable';
 
 export const subscribeTo = <T>(result: ObservableInput<T>): (subscriber: Subscriber<T>) => Subscription | void => {
   if (!!result && typeof (result as any)[Symbol_observable] === 'function') {
@@ -20,6 +21,11 @@ export const subscribeTo = <T>(result: ObservableInput<T>): (subscriber: Subscri
     return subscribeToPromise(result);
   } else if (!!result && typeof (result as any)[Symbol_iterator] === 'function') {
     return subscribeToIterable(result as any);
+  } else if (
+    Symbol && Symbol.asyncIterator &&
+    !!result && typeof (result as any)[Symbol.asyncIterator] === 'function'
+  ) {
+    return subscribeToAsyncIterable(result as any);
   } else {
     const value = isObject(result) ? 'an invalid object' : `'${result}'`;
     const msg = `You provided ${value} where a stream was expected.`

--- a/src/internal/util/subscribeToAsyncIterable.ts
+++ b/src/internal/util/subscribeToAsyncIterable.ts
@@ -1,0 +1,14 @@
+import { Subscriber } from '../Subscriber';
+
+export function subscribeToAsyncIterable<T>(asyncIterable: AsyncIterable<T>) {
+  return (subscriber: Subscriber<T>) => {
+    process(asyncIterable, subscriber).catch(err => subscriber.error(err));
+  };
+}
+
+async function process<T>(asyncIterable: AsyncIterable<T>, subscriber: Subscriber<T>) {
+  for await (const value of asyncIterable) {
+    subscriber.next(value);
+  }
+  subscriber.complete();
+}


### PR DESCRIPTION
This adds support for the following:

`for await` loops consuming RxJS observables:

```ts
const ticker = interval(1000).pipe(take(100));

async function test() {
  for await (const number of ticker) {
    console.log(number);
  }
}

test();
```


RxJS consuming async iterables:
```ts
function snooze(ms) {
  return new Promise(resolve => setTimeout(snooze, ms));
}

async function* values() {
  for (let i = 0; i < 3; i++) {
    await snooze(1000);
    yield i;
  }
}

from(values()).subscribe(x => console.log(x));
of(1).pipe(mergeMap(() => values())).subscribe(x => console.log(x));
```

### Support

Async Iterables are currently supported in all major browsers, but not IE. They are also supported in Node 10 and higher.

The goal of the implementation is as such that it simply won't work in runtimes that do not support it. But as we drop support for older runtimes, possibly by version 8, it would "just work" and be in there.

### Motivation

As time goes on, using Observables with `for await` loops may prove ergonomic and useful.

### Negatives

If the observable emits at a pace faster than the loop completes, there will be a memory build up as the buffer gets more full. We could provide other methods that use different strategies (e.g. just the most recent value, etc), but leave this as the default.  Note that the loop itself may have several `await`s in it, that exacerbate the problem.

Using `for await` to subscribe to an observable forgoes true cancellation. However you can throw an error in the loop and that will kill the observable subscription.

### Other Thoughts

We could just expose `asyncIterableFrom` instead, but all that would do is hurt the ergonomics of the idea more than anything.

`for await`'ing an observable is fundamentally different from `await`-ing the observable (by making `Observable` a "thennable"), for a couple of reasons: 

1. `for await` will instaniate an async iterator from an async iterable (this means it could have side effects), where awaiting a promise is generally expected _not_ to have side effects.

2. There's no question about which value to return, we just yield nexted values... where as with awaiting a thennable observable, we would need to make a decision about what value it returned, if any.