### PR TITLE
feat: add raceWith

### DIFF
--- a/spec-dtslint/operators/raceWith-spec.ts
+++ b/spec-dtslint/operators/raceWith-spec.ts
@@ -1,0 +1,16 @@
+import { raceWith } from 'rxjs/operators';
+import { a$, b, b$, c, c$, d$, e$, f$ } from '../helpers';
+
+describe('raceWith', () => {
+  it('should support N arguments of different types', () => {
+    const o1 = a$.pipe(raceWith(b$)); // $ExpectType Observable<A | B>
+    const o2 = a$.pipe(raceWith(b$, c$)); // $ExpectType Observable<A | B | C>
+    const o3 = a$.pipe(raceWith(b$, c$, d$)); // $ExpectType Observable<A | B | C | D>
+    const o4 = a$.pipe(raceWith(b$, c$, d$, e$)); // $ExpectType Observable<A | B | C | D | E>
+    const o5 = a$.pipe(raceWith(b$, c$, d$, e$, f$)); // $ExpectType Observable<A | B | C | D | E | F>
+  });
+});
+
+it('should race observable inputs', () => {
+  const o = a$.pipe(raceWith(Promise.resolve(b), [c])); // $ExpectType Observable<A | B | C>
+});

--- a/spec/operators/raceWith-spec.ts
+++ b/spec/operators/raceWith-spec.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { EMPTY, NEVER, of, timer, defer, Observable, throwError } from 'rxjs';
-import { race, mergeMap, map, finalize, startWith } from 'rxjs/operators';
+import { raceWith, mergeMap, map, finalize, startWith } from 'rxjs/operators';
 
-/** @test {race} */
-describe('race operator', () => {
+/** @test {raceWith} */
+describe('raceWith operator', () => {
   it('should race cold and cold', () => {
     const e1 =  cold('---a-----b-----c----|');
     const e1subs =   '^                   !';
@@ -13,21 +13,7 @@ describe('race operator', () => {
     const e2subs =   '^  !';
     const expected = '---a-----b-----c----|';
 
-    const result = e1.pipe(race(e2));
-
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-  });
-
-  it('should race cold and cold and accept an Array of Observable argument', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
-
-    const result = e1.pipe(race([e2]));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -41,7 +27,7 @@ describe('race operator', () => {
     const e2subs =   '^  !';
     const expected = '---a-----b-----c----|';
 
-    const result = e1.pipe(race(e2));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -55,7 +41,7 @@ describe('race operator', () => {
     const e2subs =   '^  !';
     const expected = '---a-----b-----c----|';
 
-    const result = e1.pipe(race(e2));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -69,7 +55,7 @@ describe('race operator', () => {
     const e2subs =   '^                   !';
     const expected = '---a-----b-----c----|';
 
-    const result = e1.pipe(race(e2));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -83,7 +69,7 @@ describe('race operator', () => {
     const e2subs =   '^    !';
     const expected = '-----|';
 
-    const result = e1.pipe(race(e2));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -98,7 +84,7 @@ describe('race operator', () => {
     const expected = '---a-----b---';
     const unsub =    '            !';
 
-    const result = e1.pipe(race(e2));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result, unsub).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -115,7 +101,7 @@ describe('race operator', () => {
 
     const result = e1.pipe(
       mergeMap((x: string) => of(x)),
-      race(e2),
+      raceWith(e2),
       mergeMap((x: string) => of(x))
     );
 
@@ -130,7 +116,7 @@ describe('race operator', () => {
     const e1subs =   '^  !';
     const expected = '---|';
 
-    const source = e1.pipe(race(e2));
+    const source = e1.pipe(raceWith(e2));
 
     expectObservable(source).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -143,7 +129,7 @@ describe('race operator', () => {
     const e2subs =   '^  !';
     const expected = '---a-----#';
 
-    const result = e1.pipe(race(e2));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -157,7 +143,7 @@ describe('race operator', () => {
     const e2subs =   '^  !';
     const expected = '---#';
 
-    const result = e1.pipe(race(e2));
+    const result = e1.pipe(raceWith(e2));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -168,7 +154,7 @@ describe('race operator', () => {
     const e1 = of(true);
     const e2 = timer(200).pipe(map(_ => false));
 
-    e1.pipe(race(e2)).subscribe(x => {
+    e1.pipe(raceWith(e2)).subscribe(x => {
       expect(x).to.be.true;
     }, done, done);
   });
@@ -179,7 +165,7 @@ describe('race operator', () => {
     const e1 = of('a'); // Wins the race
     const e2 = defer(onSubscribe); // Should be ignored
 
-    e1.pipe(race(e2)).subscribe(onNext);
+    e1.pipe(raceWith(e2)).subscribe(onNext);
     expect(onNext.calledWithExactly('a')).to.be.true;
     expect(onSubscribe.called).to.be.false;
   });
@@ -190,7 +176,7 @@ describe('race operator', () => {
     const e1 = EMPTY; // Wins the race
     const e2 = defer(onSubscribe); // Should be ignored
 
-    e1.pipe(race(e2)).subscribe({ complete: onComplete });
+    e1.pipe(raceWith(e2)).subscribe({ complete: onComplete });
     expect(onComplete.calledWithExactly()).to.be.true;
     expect(onSubscribe.called).to.be.false;
   });
@@ -201,7 +187,7 @@ describe('race operator', () => {
     const e1 = throwError('kaboom'); // Wins the race
     const e2 = defer(onSubscribe); // Should be ignored
 
-    e1.pipe(race(e2)).subscribe({ error: onError });
+    e1.pipe(raceWith(e2)).subscribe({ error: onError });
     expect(onError.calledWithExactly('kaboom')).to.be.true;
     expect(onSubscribe.called).to.be.false;
   });
@@ -212,7 +198,7 @@ describe('race operator', () => {
     const e1 = NEVER.pipe(finalize(onUnsubscribe)); // Should be unsubscribed
     const e2 = of('b'); // Wins the race
 
-    e1.pipe(race(e2)).subscribe(onNext);
+    e1.pipe(raceWith(e2)).subscribe(onNext);
     expect(onNext.calledWithExactly('b')).to.be.true;
     expect(onUnsubscribe.calledOnce).to.be.true;
   });
@@ -223,7 +209,7 @@ describe('race operator', () => {
     const e1 = <Observable<never>>NEVER.pipe(startWith('a'), finalize(onUnsubscribe)); // Wins the race
     const e2 = NEVER; // Loses the race
 
-    const subscription = e1.pipe(race(e2)).subscribe(onNext);
+    const subscription = e1.pipe(raceWith(e2)).subscribe(onNext);
     expect(onNext.calledWithExactly('a')).to.be.true;
     expect(onUnsubscribe.called).to.be.false;
     subscription.unsubscribe();

--- a/src/internal/operators/index.ts
+++ b/src/internal/operators/index.ts
@@ -57,7 +57,7 @@ export { publish } from './publish';
 export { publishBehavior } from './publishBehavior';
 export { publishLast } from './publishLast';
 export { publishReplay } from './publishReplay';
-export { race } from './race';
+export { race, raceWith } from './raceWith';
 export { reduce } from './reduce';
 export { repeat } from './repeat';
 export { repeatWhen } from './repeatWhen';

--- a/src/internal/operators/raceWith.ts
+++ b/src/internal/operators/raceWith.ts
@@ -1,16 +1,16 @@
 import { Observable } from '../Observable';
 import { isArray } from '../util/isArray';
-import { MonoTypeOperatorFunction, OperatorFunction } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, ObservedValueUnionFromArray } from '../types';
 import { race as raceStatic } from '../observable/race';
 
 /* tslint:disable:max-line-length */
-/** @deprecated Deprecated in favor of static race. */
+/** @deprecated Deprecated use {@link raceWith} */
 export function race<T>(observables: Array<Observable<T>>): MonoTypeOperatorFunction<T>;
-/** @deprecated Deprecated in favor of static race. */
+/** @deprecated Deprecated use {@link raceWith} */
 export function race<T, R>(observables: Array<Observable<T>>): OperatorFunction<T, R>;
-/** @deprecated Deprecated in favor of static race. */
+/** @deprecated Deprecated use {@link raceWith} */
 export function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): MonoTypeOperatorFunction<T>;
-/** @deprecated Deprecated in favor of static race. */
+/** @deprecated Deprecated use {@link raceWith} */
 export function race<T, R>(...observables: Array<Observable<any> | Array<Observable<any>>>): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
@@ -19,8 +19,7 @@ export function race<T, R>(...observables: Array<Observable<any> | Array<Observa
  * error or complete notification from the combination of this Observable and supplied Observables.
  * @param {...Observables} ...observables Sources used to race for which Observable emits first.
  * @return {Observable} An Observable that mirrors the output of the first Observable to emit an item.
- * @name race
- * @deprecated Deprecated in favor of static {@link race}.
+ * @deprecated Deprecated use {@link raceWith}
  */
 export function race<T>(...observables: (Observable<T> | Observable<T>[])[]): MonoTypeOperatorFunction<T> {
   return function raceOperatorFunction(source: Observable<T>) {
@@ -34,5 +33,44 @@ export function race<T>(...observables: (Observable<T> | Observable<T>[])[]): Mo
       raceStatic(source, ...(observables as Observable<T>[])),
       undefined
     ) as Observable<T>;
+  };
+}
+
+/**
+ * Creates an Observable that mirrors the first source Observable to emit a next,
+ * error or complete notification from the combination of the Observable to which
+ * the operator is applied and supplied Observables.
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { interval } from 'rxjs';
+ * import { mapTo, raceWith } from 'rxjs/operators';
+ *
+ * const obs1 = interval(1000).pipe(mapTo('fast one'));
+ * const obs2 = interval(3000).pipe(mapTo('medium one'));
+ * const obs3 = interval(5000).pipe(mapTo('slow one'));
+ *
+ * obs2.pipe(
+ *   raceWith(obs3, obs1)
+ * ).subscribe(
+ *   winner => console.log(winner)
+ * );
+ *
+ * // Outputs
+ * // a series of 'fast one'
+ * ```
+ *
+ * @param otherSources Sources used to race for which Observable emits first.
+ */
+
+export function raceWith<T, A extends ObservableInput<any>[]>(
+  ...otherSources: A
+): OperatorFunction<T, T | ObservedValueUnionFromArray<A>> {
+  return function raceWithOperatorFunction(source: Observable<T>) {
+    return source.lift.call(
+      raceStatic(source, ...otherSources),
+      undefined
+    ) as Observable<T | ObservedValueUnionFromArray<A>>;
   };
 }

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -61,7 +61,7 @@ export { publish } from '../internal/operators/publish';
 export { publishBehavior } from '../internal/operators/publishBehavior';
 export { publishLast } from '../internal/operators/publishLast';
 export { publishReplay } from '../internal/operators/publishReplay';
-export { race } from '../internal/operators/race';
+export { race, raceWith } from '../internal/operators/raceWith';
 export { reduce } from '../internal/operators/reduce';
 export { repeat } from '../internal/operators/repeat';
 export { repeatWhen } from '../internal/operators/repeatWhen';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds `raceWith` - another operator deprecated because it had the same name as a static `Observable` creator.

The `raceWith` operator drops support for passing an array instead of using a rest parameter and spread. It's unclear why both are supported in the first place. TBH, this is something that we are going to have to sort out in the signature review: should these situations use rest parameters or arrays? This is something that can be sorted out elsewhere, but to make this consistent with the new `concatWith`, etc. this operator drops support for passing an array.

**Related issue:** None
