### PR TITLE
docs: don't mark operators as methods

### DIFF
--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -93,8 +93,7 @@ export function of<A extends Array<any>>(...args: A): Observable<ValueFromArray<
  * @param {...T} values A comma separated list of arguments you want to be emitted
  * @return {Observable} An Observable that emits the arguments
  * described above and then completes.
- * @method of
- * @owner Observable
+ * @name of
  */
 
 export function of<T>(...args: Array<T | SchedulerLike>): Observable<T> {

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -50,8 +50,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * duration, returned as an Observable or a Promise.
  * @return {Observable<T>} An Observable that performs rate-limiting of
  * emissions from the source Observable.
- * @method audit
- * @owner Observable
+ * @name audit
  */
 export function audit<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T> {
   return function auditOperatorFunction(source: Observable<T>) {

--- a/src/internal/operators/auditTime.ts
+++ b/src/internal/operators/auditTime.ts
@@ -49,8 +49,7 @@ import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
  * managing the timers that handle the rate-limiting behavior.
  * @return {Observable<T>} An Observable that performs rate-limiting of
  * emissions from the source Observable.
- * @method auditTime
- * @owner Observable
+ * @name auditTime
  */
 export function auditTime<T>(duration: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
   return audit(() => timer(duration, scheduler));

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -43,8 +43,7 @@ import { OperatorFunction } from '../types';
  * buffer to be emitted on the output Observable.
  * @return {Observable<T[]>} An Observable of buffers, which are arrays of
  * values.
- * @method buffer
- * @owner Observable
+ * @name buffer
  */
 export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
   return function bufferOperatorFunction(source: Observable<T>) {

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -55,8 +55,7 @@ import { OperatorFunction, TeardownLogic } from '../types';
  * on every other value from the source. A new buffer is started at the
  * beginning of the source by default.
  * @return {Observable<T[]>} An Observable of arrays of buffered values.
- * @method bufferCount
- * @owner Observable
+ * @name bufferCount
  */
 export function bufferCount<T>(bufferSize: number, startBufferEvery: number | null = null): OperatorFunction<T, T[]> {
   return function bufferCountOperatorFunction(source: Observable<T>) {

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -66,8 +66,7 @@ export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: nu
  * @param {SchedulerLike} [scheduler=async] The scheduler on which to schedule the
  * intervals that determine buffer boundaries.
  * @return {Observable<T[]>} An observable of arrays of buffered values.
- * @method bufferTime
- * @owner Observable
+ * @name bufferTime
  */
 export function bufferTime<T>(bufferTimeSpan: number): OperatorFunction<T, T[]> {
   let length: number = arguments.length;

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -50,8 +50,7 @@ import { OperatorFunction, SubscribableOrPromise } from '../types';
  * which, when it emits, signals that the associated buffer should be emitted
  * and cleared.
  * @return {Observable<T[]>} An observable of arrays of buffered values.
- * @method bufferToggle
- * @owner Observable
+ * @name bufferToggle
  */
 export function bufferToggle<T, O>(
   openings: SubscribableOrPromise<O>,

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -46,8 +46,7 @@ import { OperatorFunction } from '../types';
  * @param {function(): Observable} closingSelector A function that takes no
  * arguments and returns an Observable that signals buffer closure.
  * @return {Observable<T[]>} An observable of arrays of buffered values.
- * @method bufferWhen
- * @owner Observable
+ * @name bufferWhen
  */
 export function bufferWhen<T>(closingSelector: () => Observable<any>): OperatorFunction<T, T[]> {
   return function (source: Observable<T>) {

--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -60,8 +60,7 @@ export function concatAll<R>(): OperatorFunction<any, R>;
  *
  * @return {Observable} An Observable emitting values from all the inner
  * Observables concatenated.
- * @method concatAll
- * @owner Observable
+ * @name concatAll
  */
 export function concatAll<T>(): OperatorFunction<ObservableInput<T>, T> {
   return mergeAll<T>(1);

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -66,8 +66,7 @@ export function concatMap<T, R, O extends ObservableInput<any>>(project: (value:
  * projection function (and the optional deprecated `resultSelector`) to each item emitted
  * by the source Observable and taking values from each projected inner
  * Observable sequentially.
- * @method concatMap
- * @owner Observable
+ * @name concatMap
  */
 export function concatMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -62,8 +62,7 @@ export function concatMapTo<T, R, O extends ObservableInput<any>>(observable: O,
  * @return {Observable} An observable of values merged together by joining the
  * passed observable with itself, one after the other, for each value emitted
  * from the source.
- * @method concatMapTo
- * @owner Observable
+ * @name concatMapTo
  */
 export function concatMapTo<T, R, O extends ObservableInput<any>>(
   innerObservable: O,

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -58,8 +58,7 @@ import { Subscriber } from '../Subscriber';
  * - `source`: the source Observable instance itself.
  * @return {Observable} An Observable of one number that represents the count as
  * described above.
- * @method count
- * @owner Observable
+ * @name count
  */
 
 export function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number> {

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -64,8 +64,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * @return {Observable} An Observable that delays the emissions of the source
  * Observable by the specified duration Observable returned by
  * `durationSelector`, and may drop some values if they occur too frequently.
- * @method debounce
- * @owner Observable
+ * @name debounce
  */
 export function debounce<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new DebounceOperator(durationSelector));

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -61,8 +61,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * @return {Observable} An Observable that delays the emissions of the source
  * Observable by the specified `dueTime`, and may drop some values if they occur
  * too frequently.
- * @method debounceTime
- * @owner Observable
+ * @name debounceTime
  */
 export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new DebounceTimeOperator(dueTime, scheduler));

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -40,8 +40,7 @@ export function defaultIfEmpty<T, R = T>(defaultValue?: R): OperatorFunction<T, 
  * @return {Observable} An Observable that emits either the specified
  * `defaultValue` if the source Observable emits no items, or the values emitted
  * by the source Observable.
- * @method defaultIfEmpty
- * @owner Observable
+ * @name defaultIfEmpty
  */
 export function defaultIfEmpty<T, R>(defaultValue: R | null = null): OperatorFunction<T, T | R> {
   return (source: Observable<T>) => source.lift(new DefaultIfEmptyOperator(defaultValue)) as Observable<T | R>;

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -54,8 +54,7 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  * managing the timers that handle the time-shift for each item.
  * @return {Observable} An Observable that delays the emissions of the source
  * Observable by the specified timeout or Date.
- * @method delay
- * @owner Observable
+ * @name delay
  */
 export function delay<T>(delay: number|Date,
                          scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -70,8 +70,7 @@ export function delayWhen<T>(delayDurationSelector: (value: T, index: number) =>
  * @return {Observable} An Observable that delays the emissions of the source
  * Observable by an amount of time specified by the Observable returned by
  * `delayDurationSelector`.
- * @method delayWhen
- * @owner Observable
+ * @name delayWhen
  */
 export function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>,
                              subscriptionDelay?: Observable<any>): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -47,8 +47,7 @@ import { OperatorFunction } from '../types';
  *
  * @return {Observable} An Observable that emits items and notifications
  * embedded in Notification objects emitted by the source Observable.
- * @method dematerialize
- * @owner Observable
+ * @name dematerialize
  */
 export function dematerialize<T>(): OperatorFunction<Notification<T>, T> {
   return function dematerializeOperatorFunction(source: Observable<Notification<T>>) {

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -71,8 +71,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @param {function} [keySelector] Optional function to select which value you want to check as distinct.
  * @param {Observable} [flushes] Optional Observable for flushing the internal HashSet of the operator.
  * @return {Observable} An Observable that emits items from the source Observable with distinct values.
- * @method distinct
- * @owner Observable
+ * @name distinct
  */
 export function distinct<T, K>(keySelector?: (value: T) => K,
                                flushes?: Observable<any>): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -60,8 +60,7 @@ export function distinctUntilChanged<T, K>(compare: (x: K, y: K) => boolean, key
  * @param {function} [compare] Optional comparison function called to test if an item is distinct from the previous item in the source.
  * A return value of true indicates that it is the same, and a return value of false means they are different.
  * @return {Observable} An Observable that emits items from the source Observable with distinct values.
- * @method distinctUntilChanged
- * @owner Observable
+ * @name distinctUntilChanged
  */
 export function distinctUntilChanged<T, K>(compare?: (x: K, y: K) => boolean, keySelector?: (x: T) => K): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new DistinctUntilChangedOperator<T, K>(compare, keySelector));

--- a/src/internal/operators/distinctUntilKeyChanged.ts
+++ b/src/internal/operators/distinctUntilKeyChanged.ts
@@ -73,8 +73,7 @@ export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare: (
  * @param {string} key String key for object property lookup on each item.
  * @param {function} [compare] Optional comparison function called to test if an item is distinct from the previous item in the source.
  * @return {Observable} An Observable that emits items from the source Observable with distinct values based on the key specified.
- * @method distinctUntilKeyChanged
- * @owner Observable
+ * @name distinctUntilKeyChanged
  */
 export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare?: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T> {
   return distinctUntilChanged((x: T, y: T) => compare ? compare(x[key], y[key]) : x[key] === y[key]);

--- a/src/internal/operators/elementAt.ts
+++ b/src/internal/operators/elementAt.ts
@@ -51,8 +51,7 @@ import { take } from './take';
  * @param {T} [defaultValue] The default value returned for missing indices.
  * @return {Observable} An Observable that emits a single item, if it is found.
  * Otherwise, will emit the default value if given. If not, then emits an error.
- * @method elementAt
- * @owner Observable
+ * @name elementAt
  */
 export function elementAt<T>(index: number, defaultValue?: T): MonoTypeOperatorFunction<T> {
   if (index < 0) { throw new ArgumentOutOfRangeError(); }

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -26,8 +26,7 @@ import { Observer, OperatorFunction } from '../types';
  * @param {function} predicate A function for determining if an item meets a specified condition.
  * @param {any} [thisArg] Optional object to use for `this` in the callback.
  * @return {Observable} An Observable of booleans that determines if all items of the source Observable meet the condition specified.
- * @method every
- * @owner Observable
+ * @name every
  */
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                          thisArg?: any): OperatorFunction<T, boolean> {

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -50,8 +50,7 @@ export function exhaust<R>(): OperatorFunction<any, R>;
  *
  * @return {Observable} An Observable that takes a source of Observables and propagates the first observable
  * exclusively until it completes before subscribing to the next.
- * @method exhaust
- * @owner Observable
+ * @name exhaust
  */
 export function exhaust<T>(): OperatorFunction<any, T> {
   return (source: Observable<T>) => source.lift(new SwitchFirstOperator<T>());

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -59,8 +59,7 @@ export function exhaustMap<T, I, R>(project: (value: T, index: number) => Observ
  * @return {Observable} An Observable containing projected Observables
  * of each item of the source, ignoring projected Observables that start before
  * their preceding Observable has completed.
- * @method exhaustMap
- * @owner Observable
+ * @name exhaustMap
  */
 export function exhaustMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -61,8 +61,7 @@ export function expand<T>(project: (value: T, index: number) => ObservableInput<
  * result of applying the projection function to each value emitted on the
  * output Observable and merging the results of the Observables obtained
  * from this transformation.
- * @method expand
- * @owner Observable
+ * @name expand
  */
 export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>,
                              concurrent: number = Number.POSITIVE_INFINITY,

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -57,8 +57,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  *
  * @param {function} callback Function to be called when source terminates.
  * @return {Observable} An Observable that mirrors the source, but will call the specified function on termination.
- * @method finally
- * @owner Observable
+ * @name finally
  */
 export function finalize<T>(callback: () => void): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new FinallyOperator(callback));

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -43,8 +43,7 @@ export function find<T>(predicate: (value: T, index: number, source: Observable<
  * in the `predicate` function.
  * @return {Observable<T>} An Observable of the first item that matches the
  * condition.
- * @method find
- * @owner Observable
+ * @name find
  */
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                         thisArg?: any): OperatorFunction<T, T | undefined> {

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -38,8 +38,7 @@ import { OperatorFunction } from '../types';
  * in the `predicate` function.
  * @return {Observable} An Observable of the index of the first item that
  * matches the condition.
- * @method find
- * @owner Observable
+ * @name find
  */
 export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                              thisArg?: any): OperatorFunction<T, number> {

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -73,8 +73,7 @@ export function first<T, D = T>(
  * was found on the source.
  * @return {Observable<T|R>} An Observable of the first item that matches the
  * condition.
- * @method first
- * @owner Observable
+ * @name first
  */
 export function first<T, D>(
   predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -99,8 +99,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  * GroupedObservables, each of which corresponds to a unique key value and each
  * of which emits those items from the source Observable that share that key
  * value.
- * @method groupBy
- * @owner Observable
+ * @name groupBy
  */
 export function groupBy<T, K, R>(keySelector: (value: T) => K,
                                  elementSelector?: ((value: T) => R) | void,

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -33,8 +33,7 @@ import { OperatorFunction } from '../types';
  * ```
  * @return {Observable} An empty Observable that only calls `complete`
  * or `error`, based on which one is called by the source Observable.
- * @method ignoreElements
- * @owner Observable
+ * @name ignoreElements
  */
 export function ignoreElements(): OperatorFunction<any, never> {
   return function ignoreElementsOperatorFunction(source: Observable<any>) {

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -64,8 +64,7 @@ import { OperatorFunction } from '../types';
  * @see {@link index/EMPTY}
  *
  * @return {OperatorFunction<T, boolean>} An Observable of a boolean value indicating whether observable was empty or not.
- * @method isEmpty
- * @owner Observable
+ * @name isEmpty
  */
 
 export function isEmpty<T>(): OperatorFunction<T, boolean> {

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -39,8 +39,7 @@ import { OperatorFunction } from '../types';
  * `project` function.
  * @return {Observable<R>} An Observable that emits the values from the source
  * Observable transformed by the given `project` function.
- * @method map
- * @owner Observable
+ * @name map
  */
 export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): OperatorFunction<T, R> {
   return function mapOperation(source: Observable<T>): Observable<R> {

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -36,8 +36,7 @@ export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
  * @param {any} value The value to map each source value to.
  * @return {Observable} An Observable that emits the given `value` every time
  * the source Observable emits something.
- * @method mapTo
- * @owner Observable
+ * @name mapTo
  */
 export function mapTo<R>(value: R): OperatorFunction<any, R> {
   return (source: Observable<any>) => source.lift(new MapToOperator(value));

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -51,8 +51,7 @@ import { OperatorFunction } from '../types';
  * @return {Observable<Notification<T>>} An Observable that emits
  * {@link Notification} objects that wrap the original emissions from the source
  * Observable with metadata.
- * @method materialize
- * @owner Observable
+ * @name materialize
  */
 export function materialize<T>(): OperatorFunction<T, Notification<T>> {
   return function materializeOperatorFunction(source: Observable<T>) {

--- a/src/internal/operators/max.ts
+++ b/src/internal/operators/max.ts
@@ -43,8 +43,7 @@ import { MonoTypeOperatorFunction } from '../types';
  * @param {Function} [comparer] - Optional comparer function that it will use instead of its default to compare the
  * value of two items.
  * @return {Observable} An Observable that emits item with the largest value.
- * @method max
- * @owner Observable
+ * @name max
  */
 export function max<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T> {
   const max: (x: T, y: T) => T = (typeof comparer === 'function')

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -57,8 +57,7 @@ import { OperatorFunction, ObservableInput } from '../types';
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits values coming from all the
  * inner Observables emitted by the source Observable.
- * @method mergeAll
- * @owner Observable
+ * @name mergeAll
  */
 export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<ObservableInput<T>, T> {
   return mergeMap(identity, concurrent);

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -70,8 +70,7 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(project: (value: 
  * projection function (and the optional deprecated `resultSelector`) to each item
  * emitted by the source Observable and merging the results of the Observables
  * obtained from this transformation.
- * @method mergeMap
- * @owner Observable
+ * @name mergeMap
  */
 export function mergeMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -45,8 +45,7 @@ export function mergeMapTo<T, R, O extends ObservableInput<any>>(innerObservable
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits items from the given
  * `innerObservable`
- * @method mergeMapTo
- * @owner Observable
+ * @name mergeMapTo
  */
 export function mergeMapTo<T, R, O extends ObservableInput<any>>(
   innerObservable: O,

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -43,8 +43,7 @@ import { ObservableInput, OperatorFunction } from '../types';
  * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of
  * input Observables being subscribed to concurrently.
  * @return {Observable<R>} An observable of the accumulated values.
- * @method mergeScan
- * @owner Observable
+ * @name mergeScan
  */
 export function mergeScan<T, R>(accumulator: (acc: R, value: T, index: number) => ObservableInput<R>,
                                 seed: R,

--- a/src/internal/operators/min.ts
+++ b/src/internal/operators/min.ts
@@ -42,8 +42,7 @@ import { MonoTypeOperatorFunction } from '../types';
  * @param {Function} [comparer] - Optional comparer function that it will use instead of its default to compare the
  * value of two items.
  * @return {Observable<R>} An Observable that emits item with the smallest value.
- * @method min
- * @owner Observable
+ * @name min
  */
 export function min<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T> {
   const min: (x: T, y: T) => T = (typeof comparer === 'function')

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -28,8 +28,7 @@ export function multicast<T, O extends ObservableInput<any>>(SubjectFactory: (th
  * @return {Observable} An Observable that emits the results of invoking the selector
  * on the items emitted by a `ConnectableObservable` that shares a single subscription to
  * the underlying stream.
- * @method multicast
- * @owner Observable
+ * @name multicast
  */
 export function multicast<T, R>(subjectOrSubjectFactory: Subject<T> | (() => Subject<T>),
                                 selector?: (source: Observable<T>) => Observable<R>): OperatorFunction<T, R> {

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -55,8 +55,7 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  * @return {Observable<T>} Observable that emits the same notifications as the source Observable,
  * but with provided scheduler.
  *
- * @method observeOn
- * @owner Observable
+ * @name observeOn
  */
 export function observeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return function observeOnOperatorFunction(source: Observable<T>): Observable<T> {

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -86,8 +86,7 @@ export function onErrorResumeNext<T, R>(array: ObservableInput<any>[]): Operator
  * @param {...ObservableInput} observables Observables passed either directly or as an array.
  * @return {Observable} An Observable that emits values from source Observable, but - if it errors - subscribes
  * to the next passed Observable and so on, until it completes or runs out of Observables.
- * @method onErrorResumeNext
- * @owner Observable
+ * @name onErrorResumeNext
  */
 
 export function onErrorResumeNext<T, R>(...nextSources: Array<ObservableInput<any> |

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -43,8 +43,7 @@ import { OperatorFunction } from '../types';
  *
  * @return {Observable<Array<T>>} An Observable of pairs (as arrays) of
  * consecutive values from the source Observable.
- * @method pairwise
- * @owner Observable
+ * @name pairwise
  */
 export function pairwise<T>(): OperatorFunction<T, [T, T]> {
   return (source: Observable<T>) => source.lift(new PairwiseOperator());

--- a/src/internal/operators/partition.ts
+++ b/src/internal/operators/partition.ts
@@ -47,8 +47,7 @@ import { UnaryFunction } from '../types';
  * @return {[Observable<T>, Observable<T>]} An array with two Observables: one
  * with values that passed the predicate, and another with values that did not
  * pass the predicate.
- * @method partition
- * @owner Observable
+ * @name partition
  * @deprecated use `partition` static creation function instead
  */
 export function partition<T>(predicate: (value: T, index: number) => boolean,

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -42,8 +42,7 @@ export function pluck<T>(...properties: string[]): OperatorFunction<T, unknown>;
  * @param {...string} properties The nested properties to pluck from each source
  * value (an object).
  * @return {Observable} A new Observable of property values from the source values.
- * @method pluck
- * @owner Observable
+ * @name pluck
  */
 export function pluck<T, R>(...properties: string[]): OperatorFunction<T, R> {
   const length = properties.length;

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -55,10 +55,7 @@ export function publish<T>(selector: MonoTypeOperatorFunction<T>): MonoTypeOpera
  * as needed, without causing multiple subscriptions to the source sequence.
  * Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
  * @return A ConnectableObservable that upon connection causes the source Observable to emit items to its Observers.
- * @method publish
- * @owner Observable
- *
- *
+ * @name publish
  */
 export function publish<T, R>(selector?: OperatorFunction<T, R>): MonoTypeOperatorFunction<T> | OperatorFunction<T, R> {
   return selector ?

--- a/src/internal/operators/publishBehavior.ts
+++ b/src/internal/operators/publishBehavior.ts
@@ -7,8 +7,7 @@ import { UnaryFunction } from '../types';
 /**
  * @param value
  * @return {ConnectableObservable<T>}
- * @method publishBehavior
- * @owner Observable
+ * @name publishBehavior
  */
 export function publishBehavior<T>(value: T):  UnaryFunction<Observable<T>, ConnectableObservable<T>> {
   return (source: Observable<T>) => multicast(new BehaviorSubject<T>(value))(source) as ConnectableObservable<T>;

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -58,8 +58,7 @@ import { UnaryFunction } from '../types';
  *
  * @return {ConnectableObservable} An observable sequence that contains the elements of a
  * sequence produced by multicasting the source sequence.
- * @method publishLast
- * @owner Observable
+ * @name publishLast
  */
 
 export function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>> {

--- a/src/internal/operators/race.ts
+++ b/src/internal/operators/race.ts
@@ -19,8 +19,7 @@ export function race<T, R>(...observables: Array<Observable<any> | Array<Observa
  * error or complete notification from the combination of this Observable and supplied Observables.
  * @param {...Observables} ...observables Sources used to race for which Observable emits first.
  * @return {Observable} An Observable that mirrors the output of the first Observable to emit an item.
- * @method race
- * @owner Observable
+ * @name race
  * @deprecated Deprecated in favor of static {@link race}.
  */
 export function race<T>(...observables: (Observable<T> | Observable<T>[])[]): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/reduce.ts
+++ b/src/internal/operators/reduce.ts
@@ -59,8 +59,7 @@ export function reduce<V, A, S = A>(accumulator: (acc: A|S, value: V, index: num
  * @param {A} [seed] The initial accumulation value.
  * @return {Observable<A>} An Observable that emits a single value that is the
  * result of accumulating the values emitted by the source Observable.
- * @method reduce
- * @owner Observable
+ * @name reduce
  */
 export function reduce<V, A>(accumulator: (acc: V | A, value: V, index: number) => A, seed?: any): OperatorFunction<V, V | A> {
   // providing a seed of `undefined` *should* be valid and trigger

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -57,8 +57,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * an empty Observable.
  * @return {Observable} An Observable that will resubscribe to the source stream when the source stream completes
  * , at most count times.
- * @method repeat
- * @owner Observable
+ * @name repeat
  */
 export function repeat<T>(count: number = -1): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => {

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -37,8 +37,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @param {function(notifications: Observable): Observable} notifier - Receives an Observable of notifications with
  * which a user can `complete` or `error`, aborting the repetition.
  * @return {Observable} The source Observable modified with repeat logic.
- * @method repeatWhen
- * @owner Observable
+ * @name repeatWhen
  */
 export function repeatWhen<T>(notifier: (notifications: Observable<any>) => Observable<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new RepeatWhenOperator(notifier));

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -53,8 +53,7 @@ export interface RetryConfig {
  * @param {number} count - Number of retry attempts before failing.
  * @param {boolean} resetOnSuccess - When set to `true` every successful emission will reset the error count
  * @return {Observable} The source Observable modified with the retry logic.
- * @method retry
- * @owner Observable
+ * @name retry
  */
 export function retry<T>(count?: number): MonoTypeOperatorFunction<T>;
 export function retry<T>(config: RetryConfig): MonoTypeOperatorFunction<T>;

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -60,8 +60,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @param {function(errors: Observable): Observable} notifier - Receives an Observable of notifications with which a
  * user can `complete` or `error`, aborting the retry.
  * @return {Observable} The source Observable modified with retry logic.
- * @method retryWhen
- * @owner Observable
+ * @name retryWhen
  */
 export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new RetryWhenOperator(notifier, source));

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -44,8 +44,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @return {Observable<T>} An Observable that emits the results of sampling the
  * values emitted by the source Observable whenever the notifier Observable
  * emits value or completes.
- * @method sample
- * @owner Observable
+ * @name sample
  */
 export function sample<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SampleOperator(notifier));

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -43,8 +43,7 @@ import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic
  * managing the timers that handle the sampling.
  * @return {Observable<T>} An Observable that emits the results of sampling the
  * values emitted by the source Observable at the specified time interval.
- * @method sampleTime
- * @owner Observable
+ * @name sampleTime
  */
 export function sampleTime<T>(period: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SampleTimeOperator(period, scheduler));

--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -49,8 +49,7 @@ export function scan<V, A, S>(accumulator: (acc: A|S, value: V, index: number) =
  * The accumulator function called on each source value.
  * @param {V|A} [seed] The initial accumulation value.
  * @return {Observable<A>} An observable of the accumulated values.
- * @method scan
- * @owner Observable
+ * @name scan
  */
 export function scan<V, A, S>(accumulator: (acc: V|A|S, value: V, index: number) => A, seed?: S): OperatorFunction<V, V|A> {
   let hasSeed = false;

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -59,8 +59,7 @@ import { Observer, OperatorFunction } from '../types';
  * @param {function} [comparator] An optional function to compare each value pair
  * @return {Observable} An Observable of a single boolean value representing whether or not
  * the values emitted by both observables were equal in sequence.
- * @method sequenceEqual
- * @owner Observable
+ * @name sequenceEqual
  */
 export function sequenceEqual<T>(compareTo: Observable<T>,
                                  comparator?: (a: T, b: T) => boolean): OperatorFunction<T, boolean> {

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -55,8 +55,7 @@ function shareSubjectFactory() {
  * @see {@link map}
  *
  * @return {Observable<T>} An Observable that upon connection causes the source Observable to emit items to its Observers.
- * @method share
- * @owner Observable
+ * @name share
  */
 export function share<T>(): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => refCount()(multicast(shareSubjectFactory)(source)) as Observable<T>;

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -121,8 +121,7 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
  * will be invoked on.
  * @return {Observable} An observable sequence that contains the elements of a sequence produced
  * by multicasting the source sequence within a selector function.
- * @method shareReplay
- * @owner Observable
+ * @name shareReplay
  */
 export function shareReplay<T>(
   configOrBufferSize?: ShareReplayConfig | number,

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -48,8 +48,7 @@ import { Observer, MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @return {Observable<T>} An Observable that emits the single item emitted by the source Observable that matches
  * the predicate or `undefined` when no items match.
  *
- * @method single
- * @owner Observable
+ * @name single
  */
 export function single<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SingleOperator(predicate, source));

--- a/src/internal/operators/skip.ts
+++ b/src/internal/operators/skip.ts
@@ -10,9 +10,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  *
  * @param {Number} count - The number of times, items emitted by source Observable should be skipped.
  * @return {Observable} An Observable that skips values emitted by the source Observable.
- *
- * @method skip
- * @owner Observable
+ * @name skip
  */
 export function skip<T>(count: number): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SkipOperator(count));

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -39,8 +39,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @param {number} count Number of elements to skip from the end of the source Observable.
  * @returns {Observable<T>} An Observable that skips the last count values
  * emitted by the source Observable.
- * @method skipLast
- * @owner Observable
+ * @name skipLast
  */
 export function skipLast<T>(count: number): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SkipLastOperator(count));

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -43,8 +43,7 @@ import { Subscription } from '../Subscription';
  * be mirrored by the resulting Observable.
  * @return {Observable<T>} An Observable that skips items from the source Observable until the second Observable emits
  * an item, then emits the remaining items.
- * @method skipUntil
- * @owner Observable
+ * @name skipUntil
  */
 export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SkipUntilOperator(notifier));

--- a/src/internal/operators/skipWhile.ts
+++ b/src/internal/operators/skipWhile.ts
@@ -12,8 +12,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @param {Function} predicate - A function to test each item emitted from the source Observable.
  * @return {Observable<T>} An Observable that begins emitting items emitted by the source Observable when the
  * specified predicate becomes false.
- * @method skipWhile
- * @owner Observable
+ * @name skipWhile
  */
 export function skipWhile<T>(predicate: (value: T, index: number) => boolean): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new SkipWhileOperator(predicate));

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -62,8 +62,7 @@ export function startWith<T, D = T>(...array: Array<D | SchedulerLike>): Operato
  * the emissions of the `next` notifications.
  * @return {Observable} An Observable that emits the items in the specified Iterable and then emits the items
  * emitted by the source Observable.
- * @method startWith
- * @owner Observable
+ * @name startWith
  */
 export function startWith<T, D>(...array: Array<D | SchedulerLike>): OperatorFunction<T, T | D> {
   const scheduler = array[array.length - 1] as SchedulerLike;

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -61,9 +61,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  *
  * @param {SchedulerLike} scheduler - The {@link SchedulerLike} to perform subscription actions on.
  * @return {Observable<T>} The source Observable modified so that its subscriptions happen on the specified {@link SchedulerLike}.
- .
- * @method subscribeOn
- * @owner Observable
+ * @name subscribeOn
  */
 export function subscribeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return function subscribeOnOperatorFunction(source: Observable<T>): Observable<T> {

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -76,8 +76,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(project: (value:
  * projection function (and the optional deprecated `resultSelector`) to each item
  * emitted by the source Observable and taking only the values from the most recently
  * projected inner Observable.
- * @method switchMap
- * @owner Observable
+ * @name switchMap
  */
 export function switchMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -46,8 +46,7 @@ export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * `innerObservable` (and optionally transformed through the deprecated `resultSelector`)
  * every time a value is emitted on the source Observable, and taking only the values
  * from the most recently projected inner Observable.
- * @method switchMapTo
- * @owner Observable
+ * @name switchMapTo
  */
 export function switchMapTo<T, I, R>(
   innerObservable: ObservableInput<I>,

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -48,8 +48,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @return {Observable<T>} An Observable that emits only the first `count`
  * values emitted by the source Observable, or all of the values from the source
  * if the source emits fewer than `count` values.
- * @method take
- * @owner Observable
+ * @name take
  */
 export function take<T>(count: number): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => {

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -44,8 +44,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * the sequence of values emitted by the source Observable.
  * @return {Observable<T>} An Observable that emits at most the last count
  * values emitted by the source Observable.
- * @method takeLast
- * @owner Observable
+ * @name takeLast
  */
 export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
   return function takeLastOperatorFunction(source: Observable<T>): Observable<T> {

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -45,8 +45,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * source Observable.
  * @return {Observable<T>} An Observable that emits the values from the source
  * Observable until such time as `notifier` emits its first value.
- * @method takeUntil
- * @owner Observable
+ * @name takeUntil
  */
 export function takeUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new TakeUntilOperator(notifier));

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -48,8 +48,7 @@ export function takeWhile<T>(predicate: (value: T, index: number) => boolean, in
  * @return {Observable<T>} An Observable that emits the values from the source
  * Observable so long as each value satisfies the condition defined by the
  * `predicate`, then completes.
- * @method takeWhile
- * @owner Observable
+ * @name takeWhile
  */
 export function takeWhile<T>(
     predicate: (value: T, index: number) => boolean,

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -62,8 +62,7 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * to `{ leading: true, trailing: false }`.
  * @return {Observable<T>} An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.
- * @method throttle
- * @owner Observable
+ * @name throttle
  */
 export function throttle<T>(durationSelector: (value: T) => SubscribableOrPromise<any>,
                             config: ThrottleConfig = defaultThrottleConfig): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -82,8 +82,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * `trailing` behavior. Defaults to `{ leading: true, trailing: false }`.
  * @return {Observable<T>} An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.
- * @method throttleTime
- * @owner Observable
+ * @name throttleTime
  */
 export function throttleTime<T>(duration: number,
                                 scheduler: SchedulerLike = async,

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -48,7 +48,7 @@ import { map } from './map';
  *
  * @param {SchedulerLike} [scheduler] Scheduler used to get the current time.
  * @return {Observable<{ interval: number, value: T }>} Observable that emit infomation about value and interval
- * @method timeInterval
+ * @name timeInterval
  */
 export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunction<T, TimeInterval<T>> {
   return (source: Observable<T>) => defer(() => {

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -79,8 +79,7 @@ import { throwError } from '../observable/throwError';
  *                          or Date specifying before when Observable should complete
  * @param {SchedulerLike} [scheduler] Scheduler controlling when timeout checks occur.
  * @return {Observable<T>} Observable that mirrors behaviour of source, unless timeout checks fail.
- * @method timeout
- * @owner Observable
+ * @name timeout
  */
 export function timeout<T>(due: number | Date,
                            scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -61,8 +61,7 @@ export function timeoutWith<T, R>(due: number | Date, withObservable: Observable
  * @param {SchedulerLike} [scheduler] Scheduler controlling when timeout checks occur.
  * @return {Observable<T>} Observable that mirrors behaviour of source or, when timeout check fails, of an Observable
  *                          passed as a second parameter.
- * @method timeoutWith
- * @owner Observable
+ * @name timeoutWith
  */
 export function timeoutWith<T, R>(due: number | Date,
                                   withObservable: ObservableInput<R>,

--- a/src/internal/operators/timestamp.ts
+++ b/src/internal/operators/timestamp.ts
@@ -33,8 +33,7 @@ import { map } from './map';
  *
  * @param scheduler
  * @return {Observable<Timestamp<any>>|WebSocketSubject<T>|Observable<T>}
- * @method timestamp
- * @owner Observable
+ * @name timestamp
  */
 export function timestamp<T>(scheduler: SchedulerLike = async): OperatorFunction<T, Timestamp<T>> {
   return map((value: T) => new Timestamp(value, scheduler.now()));

--- a/src/internal/operators/toArray.ts
+++ b/src/internal/operators/toArray.ts
@@ -37,8 +37,7 @@ function toArrayReducer<T>(arr: T[], item: T, index: number): T[] {
  *
  * ```
 * @return An array from an observable sequence.
-* @method toArray
-* @owner Observable
+* @name toArray
 */
 export function toArray<T>(): OperatorFunction<T, T[]> {
   return reduce(toArrayReducer, [] as T[]);

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -47,8 +47,7 @@ import { Operator } from '../Operator';
  * previous window and starts a new window.
  * @return {Observable<Observable<T>>} An Observable of windows, which are
  * Observables emitting values of the source Observable.
- * @method window
- * @owner Observable
+ * @name window
  */
 export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T, Observable<T>> {
   return function windowOperatorFunction(source: Observable<T>) {

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -64,8 +64,7 @@ import { OperatorFunction } from '../types';
  * beginning of the source by default.
  * @return {Observable<Observable<T>>} An Observable of windows, which in turn
  * are Observable of values.
- * @method windowCount
- * @owner Observable
+ * @name windowCount
  */
 export function windowCount<T>(windowSize: number,
                                startWindowEvery: number = 0): OperatorFunction<T, Observable<T>> {

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -53,8 +53,7 @@ import { OperatorFunction } from '../types';
  * associated window should complete.
  * @return {Observable<Observable<T>>} An observable of windows, which in turn
  * are Observables.
- * @method windowToggle
- * @owner Observable
+ * @name windowToggle
  */
 export function windowToggle<T, O>(openings: Observable<O>,
                                    closingSelector: (openValue: O) => Observable<any>): OperatorFunction<T, Observable<T>> {

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -50,8 +50,7 @@ import { OperatorFunction } from '../types';
  * `complete`) when to close the previous window and start a new one.
  * @return {Observable<Observable<T>>} An observable of windows, which in turn
  * are Observables.
- * @method windowWhen
- * @owner Observable
+ * @name windowWhen
  */
 export function windowWhen<T>(closingSelector: () => Observable<any>): OperatorFunction<T, Observable<T>> {
   return function windowWhenOperatorFunction(source: Observable<T>) {

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -65,8 +65,7 @@ export function withLatestFrom<T, R>(array: ObservableInput<any>[], project: (..
  * @return {Observable} An Observable of projected values from the most recent
  * values from each input Observable, or an array of the most recent values from
  * each input Observable.
- * @method withLatestFrom
- * @owner Observable
+ * @name withLatestFrom
  */
 export function withLatestFrom<T, R>(...args: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, R> {
   return (source: Observable<T>) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes the JS/TSDoc for operators, as they aren't methods on `Observable.prototype` anymore.

**Related issue:** None
