### PR TITLE
feat(fetch): add selector

### DIFF
--- a/spec-dtslint/observables/dom/fetch-spec.ts
+++ b/spec-dtslint/observables/dom/fetch-spec.ts
@@ -1,0 +1,18 @@
+import { fromFetch } from 'rxjs/fetch';
+import { a$ } from '../../helpers';
+
+it('should emit the fetch Response by default', () => {
+  const a = fromFetch("a"); // $ExpectType Observable<Response>
+});
+
+it('should support a selector that returns a Response promise', () => {
+  const a = fromFetch("a", { selector: response => response.text() }); // $ExpectType Observable<string>
+});
+
+it('should support a selector that returns an arbitrary type', () => {
+  const a = fromFetch("a", { selector: response => a$ }); // $ExpectType Observable<A>
+});
+
+it('should error for selectors that don\'t return an ObservableInput', () => {
+  const a = fromFetch("a", { selector: response => 42 }); // $ExpectError
+});

--- a/spec-dtslint/tsconfig.json
+++ b/spec-dtslint/tsconfig.json
@@ -6,7 +6,11 @@
     "noEmit": true,
     "paths": {
       "rxjs": ["../dist/types"],
-      "rxjs/operators": ["../dist/types/operators"]
+      "rxjs/ajax": ["../dist/types/ajax"],
+      "rxjs/fetch": ["../dist/types/fetch"],
+      "rxjs/operators": ["../dist/types/operators"],
+      "rxjs/testing": ["../dist/types/testing"],
+      "rxjs/webSocket": ["../dist/types/webSocket"]
     },
     "skipLibCheck": true,
     "strict": true,

--- a/spec/observables/dom/fetch-spec.ts
+++ b/spec/observables/dom/fetch-spec.ts
@@ -270,36 +270,9 @@ describe('fromFetch', () => {
       ...OK_RESPONSE,
       text: () => Promise.resolve('bar')
     };
-    const fetch$ = fromFetch('/foo', undefined, response => response.text());
-    expect(mockFetch.calls.length).to.equal(0);
-    expect(MockAbortController.created).to.equal(0);
-
-    fetch$.subscribe({
-      next: text => {
-        expect(text).to.equal('bar');
-      },
-      error: done,
-      complete: () => {
-        // Wait until the complete and the subsequent unsubscribe are finished
-        // before testing these expectations:
-        setTimeout(() => {
-          expect(MockAbortController.created).to.equal(1);
-          expect(mockFetch.calls.length).to.equal(1);
-          expect(mockFetch.calls[0].input).to.equal('/foo');
-          expect(mockFetch.calls[0].init!.signal).not.to.be.undefined;
-          expect(mockFetch.calls[0].init!.signal!.aborted).to.be.false;
-          done();
-        }, 0);
-      }
+    const fetch$ = fromFetch('/foo', {
+      selector: response => response.text()
     });
-  });
-
-  it('should support a selector without an init argument', done => {
-    mockFetch.respondWith = {
-      ...OK_RESPONSE,
-      text: () => Promise.resolve('bar')
-    };
-    const fetch$ = fromFetch('/foo', response => response.text());
     expect(mockFetch.calls.length).to.equal(0);
     expect(MockAbortController.created).to.equal(0);
 
@@ -328,7 +301,9 @@ describe('fromFetch', () => {
       ...OK_RESPONSE,
       text: () => Promise.resolve('bar')
     };
-    const fetch$ = fromFetch('/foo', undefined, response => response.text());
+    const fetch$ = fromFetch('/foo', {
+      selector: response => response.text()
+    });
     expect(mockFetch.calls.length).to.equal(0);
     expect(MockAbortController.created).to.equal(0);
     const subscription = fetch$.subscribe();

--- a/spec/observables/dom/fetch-spec.ts
+++ b/spec/observables/dom/fetch-spec.ts
@@ -264,4 +264,53 @@ describe('fromFetch', () => {
       }
     });
   });
+
+  it('should support a selector', done => {
+    mockFetch.respondWith = {
+      ...OK_RESPONSE,
+      text: () => Promise.resolve('bar')
+    };
+    const fetch$ = fromFetch('/foo', undefined, response => response.text());
+    expect(mockFetch.calls.length).to.equal(0);
+    expect(MockAbortController.created).to.equal(0);
+
+    fetch$.subscribe({
+      next: text => {
+        expect(text).to.equal('bar');
+      },
+      error: done,
+      complete: () => {
+        // Wait until the complete and the subsequent unsubscribe are finished
+        // before testing these expectations:
+        setTimeout(() => {
+          expect(MockAbortController.created).to.equal(1);
+          expect(mockFetch.calls.length).to.equal(1);
+          expect(mockFetch.calls[0].input).to.equal('/foo');
+          expect(mockFetch.calls[0].init!.signal).not.to.be.undefined;
+          expect(mockFetch.calls[0].init!.signal!.aborted).to.be.false;
+          done();
+        }, 0);
+      }
+    });
+  });
+
+  it('should abort when unsubscribed and a selector is specified', () => {
+    mockFetch.respondWith = {
+      ...OK_RESPONSE,
+      text: () => Promise.resolve('bar')
+    };
+    const fetch$ = fromFetch('/foo', undefined, response => response.text());
+    expect(mockFetch.calls.length).to.equal(0);
+    expect(MockAbortController.created).to.equal(0);
+    const subscription = fetch$.subscribe();
+
+    expect(MockAbortController.created).to.equal(1);
+    expect(mockFetch.calls.length).to.equal(1);
+    expect(mockFetch.calls[0].input).to.equal('/foo');
+    expect(mockFetch.calls[0].init!.signal).not.to.be.undefined;
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.false;
+
+    subscription.unsubscribe();
+    expect(mockFetch.calls[0].init!.signal!.aborted).to.be.true;
+  });
 });

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -87,7 +87,7 @@ export function fromFetch(
  *  complete: () => console.log('done')
  * });
  * ```
- * 
+ *
  * @param input The resource you would like to fetch. Can be a url or a request object.
  * @param init A configuration object for the fetch.
  * [See MDN for more details](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -3,21 +3,17 @@ import { Subscription } from '../../Subscription';
 import { from } from '../../observable/from';
 import { ObservableInput } from '../../types';
 
+export function fromFetch<T>(
+  input: string | Request,
+  init: RequestInit & {
+    selector: (response: Response) => ObservableInput<T>
+  }
+): Observable<T>;
+
 export function fromFetch(
   input: string | Request,
   init?: RequestInit
 ): Observable<Response>;
-
-export function fromFetch<T>(
-  input: string | Request,
-  selector: (response: Response) => ObservableInput<T>
-): Observable<T>;
-
-export function fromFetch<T>(
-  input: string | Request,
-  init: RequestInit | undefined,
-  selector: (response: Response) => ObservableInput<T>
-): Observable<T>;
 
 /**
  * Uses [the Fetch API](https://developer.mozilla.org/en-US/docs/Web/API/Fetch_API) to
@@ -71,16 +67,11 @@ export function fromFetch<T>(
  */
 export function fromFetch<T>(
   input: string | Request,
-  initOrSelector?: RequestInit | ((response: Response) => ObservableInput<T>),
-  selector?: (response: Response) => ObservableInput<T>
+  initWithSelector: RequestInit & {
+    selector?: (response: Response) => ObservableInput<T>
+  } = {}
 ): Observable<Response | T> {
-  let init: RequestInit | undefined;
-  if (typeof initOrSelector === 'function') {
-    init = undefined;
-    selector = initOrSelector;
-  } else {
-    init = initOrSelector;
-  }
+  const { selector, ...init } = initWithSelector;
   return new Observable<Response | T>(subscriber => {
     const controller = new AbortController();
     const signal = controller.signal;

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -10,6 +10,11 @@ export function fromFetch(
 
 export function fromFetch<T>(
   input: string | Request,
+  selector: (response: Response) => ObservableInput<T>
+): Observable<T>;
+
+export function fromFetch<T>(
+  input: string | Request,
   init: RequestInit | undefined,
   selector: (response: Response) => ObservableInput<T>
 ): Observable<T>;
@@ -66,9 +71,16 @@ export function fromFetch<T>(
  */
 export function fromFetch<T>(
   input: string | Request,
-  init?: RequestInit,
+  initOrSelector?: RequestInit | ((response: Response) => ObservableInput<T>),
   selector?: (response: Response) => ObservableInput<T>
 ): Observable<Response | T> {
+  let init: RequestInit | undefined;
+  if (typeof initOrSelector === 'function') {
+    init = undefined;
+    selector = initOrSelector;
+  } else {
+    init = initOrSelector;
+  }
   return new Observable<Response | T>(subscriber => {
     const controller = new AbortController();
     const signal = controller.signal;

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -56,9 +56,38 @@ export function fromFetch(
  * data$.subscribe({
  *  next: result => console.log(result),
  *  complete: () => console.log('done')
- * })
+ * });
  * ```
  *
+ * ### Use with Chunked Transfer Encoding
+ *
+ * With HTTP responses that use [chunked transfer encoding](https://tools.ietf.org/html/rfc7230#section-3.3.1),
+ * the promise returned by `fetch` will resolve as soon as the response's headers are
+ * received.
+ *
+ * That means the `fromFetch` observable will emit a `Response` - and will
+ * then complete - before the body is received. When one of the methods on the
+ * `Response` - like `text()` or `json()` - is called, the returned promise will not
+ * resolve until the entire body has been received. Unsubscribing from any observable
+ * that uses the promise as an observable input will not abort the request.
+ *
+ * To facilitate aborting the retrieval of responses that use chunked transfer encoding,
+ * a `selector` can be specified via the `init` parameter:
+ *
+ * ```ts
+ * import { of } from 'rxjs';
+ * import { fromFetch } from 'rxjs/fetch';
+ *
+ * const data$ = fromFetch('https://api.github.com/users?per_page=5', {
+ *   selector: response => response.json()
+ * });
+ *
+ * data$.subscribe({
+ *  next: result => console.log(result),
+ *  complete: () => console.log('done')
+ * });
+ * ```
+ * 
  * @param input The resource you would like to fetch. Can be a url or a request object.
  * @param init A configuration object for the fetch.
  * [See MDN for more details](https://developer.mozilla.org/en-US/docs/Web/API/WindowOrWorkerGlobalScope/fetch#Parameters)


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds an optional selector  to `fromFetch` so that it's better able to support chunked transfer encoding.

When chunked transfer encoding is used, the headers are received and the `Response` is resolved before the entire content is received. Without a using selector, it's not possible to abort the promises returned from the `Response`'s methods - `text`, `json`, `blob`, et al.

```ts
const mapped = fromFetch('/foo').pipe(
  mergeMap(res => res.text())
);
```

In the above snippet, once the headers are received, the `Response` will be emitted and mapped to the `text()` promise. Whilst the chunked content is being received, the `fromFetch` will complete, so explicit unsubscription from the `mapped` observable will not abort the `text()` promise and all of the content will be retrieved.

```ts
const selected = fromFetch('/foo', undefined, res => res.text());
```

When a selector is used - as above - explicit unsubscription from the `selected` observable will abort the `text()` promise and the browser will stop the request and will not download further data.

For more information, see the linked issue - #4744 - and I've created a harness here if anyone wants to play around with this stuff: https://github.com/cartant/rxjs-issue-4744

<s>Also, this PR includes some of the changes made in #5305. I'll rebase this once/if that PR is merged.</s>

**Related issue:** #4744
