### PR TITLE
Stricter type definition of Subject

### DIFF
--- a/doc/subject.md
+++ b/doc/subject.md
@@ -341,3 +341,39 @@ subject.complete();
 ```
 
 The AsyncSubject is similar to the [`last()`](../class/es6/Observable.js~Observable.html#instance-method-last) operator, in that it waits for the `complete` notification in order to deliver a single value.
+
+## Void subject
+
+Sometimes the emitted value doesn't matter as much as the fact that a value was emitted.
+
+For instance, the code below signals that one second has passed.
+
+```ts
+const subject = new Subject<string>();
+setTimeout(() => subject.next('dummy'), 1000);
+```
+
+Passing a dummy value this way is clumsy and can confuse users.
+
+By declaring a _void subject_, you signal that the value is irrelevant. Only the event itself matters.
+
+```ts
+const subject = new Subject<void>();
+setTimeout(() => subject.next(), 1000);
+```
+
+A complete example with context is shown below:
+
+```ts
+import { Subject } from 'rxjs';
+
+const subject = new Subject(); // Shorthand for Subject<void>
+
+subject.subscribe({
+  next: () => console.log('One second has passed')
+});
+
+setTimeout(() => subject.next(), 1000);
+```
+
+<span class="informal">Before version 7, the default type of Subject values was `any`. `Subject<any>` disables type checking of the emitted values, whereas `Subject<void>` prevents accidental access to the emitted value. If you want the old behavior, then replace `Subject` with `Subject<any>`.</span>

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -271,7 +271,7 @@ describe('Subject', () => {
   });
 
   it('should not allow values to be nexted after it is unsubscribed', (done: MochaDone) => {
-    const subject = new Subject();
+    const subject = new Subject<string>();
     const expected = ['foo'];
 
     subject.subscribe(function (x) {
@@ -397,7 +397,7 @@ describe('Subject', () => {
 
   it('should be an Observer which can be given to Observable.subscribe', (done: MochaDone) => {
     const source = of(1, 2, 3, 4, 5);
-    const subject = new Subject();
+    const subject = new Subject<number>();
     const expected = [1, 2, 3, 4, 5];
 
     subject.subscribe(
@@ -414,7 +414,7 @@ describe('Subject', () => {
 
   it('should be usable as an Observer of a finite delayed Observable', (done: MochaDone) => {
     const source = of(1, 2, 3).pipe(delay(50));
-    const subject = new Subject();
+    const subject = new Subject<number>();
 
     const expected = [1, 2, 3];
 
@@ -431,7 +431,7 @@ describe('Subject', () => {
   });
 
   it('should throw ObjectUnsubscribedError when emit after unsubscribed', () => {
-    const subject = new Subject();
+    const subject = new Subject<string>();
     subject.unsubscribe();
 
     expect(() => {

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -6,6 +6,30 @@ import { delay } from 'rxjs/operators';
 
 /** @test {Subject} */
 describe('Subject', () => {
+
+  it('should allow next with empty, undefined or any when created with no type', (done: MochaDone) => {
+    const subject = new Subject();
+    subject.subscribe(x => {
+      expect(x).to.be.a('undefined');
+    }, null, done);
+
+    const data: any = {};
+    subject.next();
+    subject.next(undefined);
+    subject.next(data);
+    subject.complete();
+  });
+
+  it('should allow empty next when created with void type', (done: MochaDone) => {
+    const subject = new Subject<void>();
+    subject.subscribe(x => {
+      expect(x).to.be.a('undefined');
+    }, null, done);
+
+    subject.next();
+    subject.complete();
+  });
+
   it('should pump values right on through itself', (done: MochaDone) => {
     const subject = new Subject<string>();
     const expected = ['foo', 'bar'];

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -13,7 +13,7 @@ describe('Subject', () => {
       expect(x).to.be.a('undefined');
     }, null, done);
 
-    const data: any = {};
+    const data: any = undefined;
     subject.next();
     subject.next(undefined);
     subject.next(data);

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -139,8 +139,8 @@ describe('from', () => {
       expect(nextInvoked).to.equal(false);
     });
     it(`should accept a function`, (done) => {
-      const subject = new Subject();
-      const handler: any = (...args: any[]) => subject.next(...args);
+      const subject = new Subject<any>();
+      const handler: any = (arg: any) => subject.next(arg);
       handler[observable] = () => subject;
       let nextInvoked = false;
 

--- a/spec/operators/bufferCount-spec.ts
+++ b/spec/operators/bufferCount-spec.ts
@@ -45,7 +45,7 @@ describe('bufferCount operator', () => {
   });
 
   it('should buffer properly (issue #2062)', () => {
-    const item$ = new Subject();
+    const item$ = new Subject<number>();
     const results: any[] = [];
     item$.pipe(
       bufferCount(3, 1)

--- a/spec/operators/skipUntil-spec.ts
+++ b/spec/operators/skipUntil-spec.ts
@@ -247,7 +247,7 @@ describe('skipUntil', () => {
     const e1 =   hot( '--a--b--c--d--e--|');
     const e1subs =   ['^                !',
                       '^                !']; // for the explicit subscribe some lines below
-    const skip = new Subject();
+    const skip = new Subject<string>();
     const expected =  '-----------------|';
 
     e1.subscribe((x: string) => {

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -25,7 +25,7 @@ export class SubjectSubscriber<T> extends Subscriber<T> {
  *
  * @class Subject<T>
  */
-export class Subject<T> extends Observable<T> implements SubscriptionLike {
+export class Subject<T = void> extends Observable<T> implements SubscriptionLike {
 
   [rxSubscriberSymbol]() {
     return new SubjectSubscriber(this);
@@ -58,7 +58,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     return <any>subject;
   }
 
-  next(value?: T) {
+  next(value: T) {
     if (this.closed) {
       throw new ObjectUnsubscribedError();
     }

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -60,7 +60,7 @@ class RepeatWhenOperator<T> implements Operator<T, T> {
  */
 class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
-  private notifications: Subject<any> | null = null;
+  private notifications: Subject<void> | null = null;
   private retries: Observable<any> | null = null;
   private retriesSubscription: Subscription | null | undefined = null;
   private sourceIsBeingSubscribedTo: boolean = true;

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -6,7 +6,7 @@ import { Subject } from '../Subject';
 import { MonoTypeOperatorFunction } from '../types';
 
 function shareSubjectFactory() {
-  return new Subject();
+  return new Subject<any>();
 }
 
 /**

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -165,7 +165,7 @@ interface CloseState<T> {
 class CountedSubject<T> extends Subject<T> {
   private _numberOfNextedValues: number = 0;
 
-  next(value?: T): void {
+  next(value: T): void {
     this._numberOfNextedValues++;
     super.next(value);
   }


### PR DESCRIPTION
**Description:**

Make type definition of `Subject` more strict to avoid common bugs when using Subject.

**Related issue (if exists):**

This issue been discussed extensively in #2852 and #5066 .

**Sensitive points**

As discussed in the issues linked above, it is possible to omit the argument to `next` when the Subject is of type `Subject<void>`.
When the template type is anything other than `void`, then an argument for `next` is required.

The primary case where this can be a problem is when people instantiate `Subject<any>` and then use `subject.next()` with no arguments. This will break.

The present change makes the default template type of Subject `void` instead of `any`. This means that when you write `new Subject()`, you get a `Subject<void>` (instead of `Subject<any>`) and are therefore able to write `subject.next()` or `subject.next(value)` if `value` is either `any` or `undefined`.

Other good candidates for default template type are `unknown` and `any`. We can discuss whether `void` is the best choice here, I am not completely sure yet.

