### PR TITLE
update toPromise documentation with undefined

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -354,13 +354,14 @@ export class Observable<T> implements Subscribable<T> {
 
   /**
    * Subscribe to this Observable and get a Promise resolving on
-   * `complete` with the last emission.
+   * `complete` with the last emission (if any).
    *
    * @method toPromise
    * @param [promiseCtor] a constructor function used to instantiate
    * the Promise
    * @return A Promise that resolves with the last value emit, or
-   * rejects on an error.
+   * rejects on an error. If there were no emissions, Promise
+   * resolves with undefined.
    */
   toPromise(promiseCtor?: PromiseConstructorLike): Promise<T | undefined> {
     promiseCtor = getPromiseCtor(promiseCtor);


### PR DESCRIPTION
update documentation since toPromise signature was changed

I have not stated in the docs when this change was introduced. Should I do that?

Closes #5277 