### PR TITLE
fix(SafeSubscriber): Propagate disposal to terminal Subscriber

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -599,6 +599,45 @@ describe('Observable', () => {
         console.log = _log;
       });
     });
+
+    it('should fully propogate disposal when subscribed with a Subscriber', () => {
+      let observableUnsubscribed = false;
+      let subscriberUnsubscribed = false;
+      let subscriptionUnsubscribed = false;
+
+      const subscriber = new Subscriber<any>();
+      // verify unsubscribe is called on the Subscriber
+      subscriber.add(() => subscriberUnsubscribed = true);
+      const source = new Observable(_ => () => observableUnsubscribed = true);
+      const subscription = source.subscribe(subscriber);
+      // verify unsubscribe is called on children of the returned Subscription
+      subscription.add(() => subscriptionUnsubscribed = true);
+
+      subscription.unsubscribe();
+
+      expect(observableUnsubscribed).to.be.true;
+      expect(subscriberUnsubscribed).to.be.true;
+      expect(subscriptionUnsubscribed).to.be.true;
+    });
+
+    it('should fully propogate disposal when subscribed with a Subscriber-like', () => {
+      let observableUnsubscribed = false;
+      let subscriberUnsubscribed = false;
+      let subscriptionUnsubscribed = false;
+
+      // verify unsubscribe is called on the "Subscriber" (quack-quack)
+      const subscriber = { unsubscribe: () => subscriberUnsubscribed = true };
+      const source = new Observable(_ => () => observableUnsubscribed = true);
+      const subscription = source.subscribe(<any> subscriber as Subscriber<any>);
+      // verify unsubscribe is called on children of the returned Subscription
+      subscription.add(() => subscriptionUnsubscribed = true);
+
+      subscription.unsubscribe();
+
+      expect(observableUnsubscribed).to.be.true;
+      expect(subscriberUnsubscribed).to.be.true;
+      expect(subscriptionUnsubscribed).to.be.true;
+    });
   });
 
   describe('pipe', () => {

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -600,7 +600,7 @@ describe('Observable', () => {
       });
     });
 
-    it('should fully propogate disposal when subscribed with a Subscriber', () => {
+    it('should fully propagate disposal when subscribed with a Subscriber', () => {
       let observableUnsubscribed = false;
       let subscriberUnsubscribed = false;
       let subscriptionUnsubscribed = false;
@@ -620,7 +620,7 @@ describe('Observable', () => {
       expect(subscriptionUnsubscribed).to.be.true;
     });
 
-    it('should fully propogate disposal when subscribed with a Subscriber-like', () => {
+    it('should fully propagate disposal when subscribed with a Subscriber-like', () => {
       let observableUnsubscribed = false;
       let subscriberUnsubscribed = false;
       let subscriptionUnsubscribed = false;

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -77,6 +77,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
           } else {
             this.syncErrorThrowable = true;
             this.destination = new SafeSubscriber<T>(this, <PartialObserver<any>> destinationOrNext);
+            this.add(<SafeSubscriber<T>> this.destination);
           }
           break;
         }

--- a/src/internal/util/toSubscriber.ts
+++ b/src/internal/util/toSubscriber.ts
@@ -18,8 +18,11 @@ export function toSubscriber<T>(
     }
   }
 
-  if (!nextOrObserver && !error && !complete) {
-    return new Subscriber(emptyObserver);
+  if (!error && !complete) {
+    if (!nextOrObserver) {
+      return new Subscriber(emptyObserver);
+    }
+    return new Subscriber(nextOrObserver);
   }
 
   return new Subscriber(nextOrObserver, error, complete);


### PR DESCRIPTION
**Description:**
Ensure the internal SafeSubscriber is disposed when an Observable is subscribed with a Subscriber or Subscriber-like object.

**Related issue (if exists):**
#2675

:heart: