### PR TITLE
docs(forkJoin): add example of empty array

### DIFF
--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -47,13 +47,14 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * an {@link Observable} that emits either an array of values in the exact same order as the passed array,
  * or a dictionary of values in the same shape as the passed dictionary.
  *
- * <span class="informal">Wait for Observables to complete and then combine last values they emitted; complete immediately if an empty array is passed.</span>
+ * <span class="informal">Wait for Observables to complete and then combine last values they emitted; 
+ * complete immediately if an empty array is passed.</span>
  *
  * ![](forkJoin.png)
  *
  * `forkJoin` is an operator that takes any number of input observables which can be passed either as an array
- * or a dictionary of input observables. If no input observables are provided (e.g. an empty array is passed), then the resulting stream will complete
- * immediately.
+ * or a dictionary of input observables. If no input observables are provided (e.g. an empty array is passed), 
+ * then the resulting stream will complete immediately.
  *
  * `forkJoin` will wait for all passed observables to emit and complete and then it will emit an array or an object with last
  * values from corresponding observables.

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -47,13 +47,13 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * an {@link Observable} that emits either an array of values in the exact same order as the passed array,
  * or a dictionary of values in the same shape as the passed dictionary.
  *
- * <span class="informal">Wait for Observables to complete and then combine last values they emitted; 
+ * <span class="informal">Wait for Observables to complete and then combine last values they emitted;
  * complete immediately if an empty array is passed.</span>
  *
  * ![](forkJoin.png)
  *
  * `forkJoin` is an operator that takes any number of input observables which can be passed either as an array
- * or a dictionary of input observables. If no input observables are provided (e.g. an empty array is passed), 
+ * or a dictionary of input observables. If no input observables are provided (e.g. an empty array is passed),
  * then the resulting stream will complete immediately.
  *
  * `forkJoin` will wait for all passed observables to emit and complete and then it will emit an array or an object with last

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -47,12 +47,12 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * an {@link Observable} that emits either an array of values in the exact same order as the passed array,
  * or a dictionary of values in the same shape as the passed dictionary.
  *
- * <span class="informal">Wait for Observables to complete and then combine last values they emitted.</span>
+ * <span class="informal">Wait for Observables to complete and then combine last values they emitted; complete immediately if an empty array is passed.</span>
  *
  * ![](forkJoin.png)
  *
  * `forkJoin` is an operator that takes any number of input observables which can be passed either as an array
- * or a dictionary of input observables. If no input observables are provided, then the resulting stream will complete
+ * or a dictionary of input observables. If no input observables are provided (e.g. an empty array is passed), then the resulting stream will complete
  * immediately.
  *
  * `forkJoin` will wait for all passed observables to emit and complete and then it will emit an array or an object with last


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
