### PR TITLE
Export RunHelpers from 'rxjs/testing'

### DIFF
--- a/src/testing/index.ts
+++ b/src/testing/index.ts
@@ -1,1 +1,2 @@
 export { TestScheduler } from '../internal/testing/TestScheduler';
+export { RunHelpers } from '../internal/testing/TestScheduler';


### PR DESCRIPTION
Adding export for RunHelpers from 'rxjs/testing'.

Closes #5319