### PR TITLE
refactor(EMPTY): replace deprecated empty imports with EMPTY constant

### DIFF
--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -1,6 +1,6 @@
 import { PartialObserver } from './types';
 import { Observable } from './Observable';
-import { empty } from './observable/empty';
+import { EMPTY } from './observable/empty';
 import { of } from './observable/of';
 import { throwError } from './observable/throwError';
 
@@ -104,7 +104,7 @@ export class Notification<T> {
       case 'E':
         return throwError(this.error);
       case 'C':
-        return empty();
+        return EMPTY;
     }
     throw new Error('unexpected notification kind value');
   }

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -1,7 +1,7 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
-import { empty } from '../observable/empty';
+import { EMPTY } from '../observable/empty';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 
 /**
@@ -63,7 +63,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 export function repeat<T>(count: number = -1): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => {
     if (count === 0) {
-      return empty();
+      return EMPTY;
     } else if (count < 0) {
       return source.lift(new RepeatOperator(-1, source));
     } else {

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -1,7 +1,7 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
-import { empty } from '../observable/empty';
+import { EMPTY } from '../observable/empty';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 
@@ -54,7 +54,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 export function take<T>(count: number): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => {
     if (count === 0) {
-      return empty();
+      return EMPTY;
     } else {
       return source.lift(new TakeOperator(count));
     }

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -1,7 +1,7 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
-import { empty } from '../observable/empty';
+import { EMPTY } from '../observable/empty';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 
@@ -50,7 +50,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
   return function takeLastOperatorFunction(source: Observable<T>): Observable<T> {
     if (count === 0) {
-      return empty();
+      return EMPTY;
     } else {
       return source.lift(new TakeLastOperator(count));
     }


### PR DESCRIPTION
Replaced `empty` import leftovers with `EMPTY` constant.