### PR TITLE
doc(typo): use the correct form of "its"

### DIFF
--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -97,9 +97,9 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * // - First timer1 and timer2 will run concurrently
  * // - timer1 will emit a value every 1000ms for 10 iterations
  * // - timer2 will emit a value every 2000ms for 6 iterations
- * // - after timer1 hits it's max iteration, timer2 will
+ * // - after timer1 hits its max iteration, timer2 will
  * //   continue, and timer3 will start to run concurrently with timer2
- * // - when timer2 hits it's max iteration it terminates, and
+ * // - when timer2 hits its max iteration it terminates, and
  * //   timer3 will continue to emit a value every 500ms until it is complete
  * ```
  *


### PR DESCRIPTION
**Description:**

"it's" means "it is", and "its" is the proper form for possession.