### PR TITLE
refactor(subscribeToObservable): use subscribeWith util

### DIFF
--- a/spec/util/subscribeWith-spec.ts
+++ b/spec/util/subscribeWith-spec.ts
@@ -1,0 +1,20 @@
+import { expect } from 'chai';
+import { of, Subscriber, observable } from 'rxjs';
+import { subscribeWith } from 'rxjs/internal/util/subscribeWith';
+import { asInteropObservable, asInteropSubscriber } from '../helpers/interop-helper';
+
+describe('subscribeWith', () => {
+  it('should return the subscriber for interop observables', () => {
+    const observable = asInteropObservable(of(42));
+    const subscriber = new Subscriber<number>();
+    const subscription = subscribeWith(observable, subscriber);
+    expect(subscription).to.equal(subscriber);
+  });
+
+  it('should return the subscriber for interop subscribers', () => {
+    const observable = of(42);
+    const subscriber = asInteropSubscriber(new Subscriber<number>());
+    const subscription = subscribeWith(observable, subscriber);
+    expect(subscription).to.equal(subscriber);
+  });
+});

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -153,13 +153,7 @@ class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
       this._unsubscribeAndRecycle();
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined!);
       this.add(innerSubscriber);
-      const innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
-      // The returned subscription will usually be the subscriber that was
-      // passed. However, interop subscribers will be wrapped and for
-      // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-      if (innerSubscription !== innerSubscriber) {
-        this.add(innerSubscription);
-      }
+      subscribeToResult(this, result, undefined, undefined, innerSubscriber);
     }
   }
 }

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -124,13 +124,7 @@ class ExhaustMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    const innerSubscription = subscribeToResult<T, R>(this, result, undefined, undefined, innerSubscriber);
-    // The returned subscription will usually be the subscriber that was
-    // passed. However, interop subscribers will be wrapped and for
-    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-    if (innerSubscription !== innerSubscriber) {
-      destination.add(innerSubscription);
-    }
+    subscribeToResult<T, R>(this, result, undefined, undefined, innerSubscriber);
   }
 
   protected _complete(): void {

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -144,13 +144,7 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
-    // The returned subscription will usually be the subscriber that was
-    // passed. However, interop subscribers will be wrapped and for
-    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-    if (innerSubscription !== innerSubscriber) {
-      destination.add(innerSubscription);
-    }
+    subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
   }
 
   protected _complete(): void {

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -105,13 +105,7 @@ export class MergeScanSubscriber<T, R> extends OuterSubscriber<T, R> {
     const innerSubscriber = new InnerSubscriber(this, value, index);
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
-    const innerSubscription = subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
-    // The returned subscription will usually be the subscriber that was
-    // passed. However, interop subscribers will be wrapped and for
-    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-    if (innerSubscription !== innerSubscriber) {
-      destination.add(innerSubscription);
-    }
+    subscribeToResult<T, R>(this, ish, undefined, undefined, innerSubscriber);
   }
 
   protected _complete(): void {

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -161,13 +161,7 @@ class OnErrorResumeNextSubscriber<T, R> extends OuterSubscriber<T, R> {
       const innerSubscriber = new InnerSubscriber(this, undefined, undefined!);
       const destination = this.destination as Subscription;
       destination.add(innerSubscriber);
-      const innerSubscription = subscribeToResult(this, next, undefined, undefined, innerSubscriber);
-      // The returned subscription will usually be the subscriber that was
-      // passed. However, interop subscribers will be wrapped and for
-      // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-      if (innerSubscription !== innerSubscriber) {
-        destination.add(innerSubscription);
-      }
+      subscribeToResult(this, next, undefined, undefined, innerSubscriber);
     } else {
       this.destination.complete();
     }

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -73,14 +73,7 @@ class SkipUntilSubscriber<T, R> extends OuterSubscriber<T, R> {
     const innerSubscriber = new InnerSubscriber(this, undefined, undefined!);
     this.add(innerSubscriber);
     this.innerSubscription = innerSubscriber;
-    const innerSubscription = subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
-    // The returned subscription will usually be the subscriber that was
-    // passed. However, interop subscribers will be wrapped and for
-    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-    if (innerSubscription !== innerSubscriber) {
-      this.add(innerSubscription);
-      this.innerSubscription = innerSubscription;
-    }
+    subscribeToResult(this, notifier, undefined, undefined, innerSubscriber);
   }
 
   protected _next(value: T) {

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -136,12 +136,6 @@ class SwitchMapSubscriber<T, R> extends OuterSubscriber<T, R> {
     const destination = this.destination as Subscription;
     destination.add(innerSubscriber);
     this.innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
-    // The returned subscription will usually be the subscriber that was
-    // passed. However, interop subscribers will be wrapped and for
-    // unsubscriptions to chain correctly, the wrapper needs to be added, too.
-    if (this.innerSubscription !== innerSubscriber) {
-      destination.add(this.innerSubscription);
-    }
   }
 
   protected _complete(): void {

--- a/src/internal/util/subscribeToObservable.ts
+++ b/src/internal/util/subscribeToObservable.ts
@@ -12,6 +12,16 @@ export const subscribeToObservable = <T>(obj: any) => (subscriber: Subscriber<T>
     // Should be caught by observable subscribe function error handling.
     throw new TypeError('Provided object does not correctly implement Symbol.observable');
   } else {
-    return obs.subscribe(subscriber);
+    const subscription = obs.subscribe(subscriber);
+    // With observables internal to this package, the returned subscription
+    // will be the subscriber that was passed to the subscribe call. Ensure
+    // that the interop behaviour is the same - that the passed-in subscriber
+    // is returned from this function - and if the received subscription is not
+    // the subscriber that was passed in, add it to ensure that unsubscription
+    // is correctly chained.
+    if (subscription !== subscriber) {
+      subscriber.add(subscription);
+    }
+    return subscriber;
   }
 };

--- a/src/internal/util/subscribeToObservable.ts
+++ b/src/internal/util/subscribeToObservable.ts
@@ -1,5 +1,6 @@
 import { Subscriber } from '../Subscriber';
 import { observable as Symbol_observable } from '../symbol/observable';
+import { subscribeWith } from './subscribeWith';
 
 /**
  * Subscribes to an object that implements Symbol.observable with the given
@@ -12,16 +13,6 @@ export const subscribeToObservable = <T>(obj: any) => (subscriber: Subscriber<T>
     // Should be caught by observable subscribe function error handling.
     throw new TypeError('Provided object does not correctly implement Symbol.observable');
   } else {
-    const subscription = obs.subscribe(subscriber);
-    // With observables internal to this package, the returned subscription
-    // will be the subscriber that was passed to the subscribe call. Ensure
-    // that the interop behaviour is the same - that the passed-in subscriber
-    // is returned from this function - and if the received subscription is not
-    // the subscriber that was passed in, add it to ensure that unsubscription
-    // is correctly chained.
-    if (subscription !== subscriber) {
-      subscriber.add(subscription);
-    }
-    return subscriber;
+    return subscribeWith(obs, subscriber);
   }
 };

--- a/src/internal/util/subscribeWith.ts
+++ b/src/internal/util/subscribeWith.ts
@@ -2,35 +2,43 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 
+/**
+ * Subscribes a subscriber to an observable and ensures the subscriber is
+ * returned as the subscription.
+ *
+ * When an instance of a subscriber from within this package is passed to the
+ * subscribe method of an observable from within this package, the returned
+ * subscription is the subscriber instance.
+ *
+ * Operator implementations depend upon this behaviour, so it's important
+ * that interop subscribers and observables behave in a similar manner. If
+ * they do not, unsubscription chains can be broken.
+ *
+ * This function ensures that if the subscription returned from the subscribe
+ * call is not the subscriber itself, the subscription is added to the
+ * subscriber and the subscriber is returned. Doing so will ensure that the
+ * unsubscription chain is not broken.
+ *
+ * This function needs to be used wherever an interop observable or
+ * subscriber could be encountered. There are two such places:
+ * - within `subscribeToObservable`; and
+ * - within the `call` method of each operator's `Operator` class.
+ *
+ * Within `subscribeToObservable` the observables are almost always going to
+ * be interop - as they're obtained via the `Symbol.observable` property.
+ *
+ * Within the `call` method, the operator's subscriber will be interop -
+ * relative to the source observable - if the operator is imported from a
+ * package that uses a different version of RxJS.
+ *
+ * @param observable the observable to subscribe to
+ * @param subscriber the subscriber to be subscribed
+ * @returns the passed-in subscriber (as the subscription)
+ */
 export function subscribeWith<T>(
   observable: Observable<T>,
   subscriber: Subscriber<T>
 ): Subscription {
-  // When an instance of a subscriber from within this package is passed to the
-  // subscribe method of an observable from within this package, the returned
-  // subscription is the subscriber instance.
-  //
-  // Operator implementations depend upon this behaviour, so it's important
-  // that interop subscribers and observables behave in a similar manner. If
-  // they do not, unsubscription chains can be broken.
-  //
-  // This function ensures that if the subscription returned from the subscribe
-  // call is not the subscriber itself, the subscription is added to the
-  // subscriber and the subscriber is returned. Doing so will ensure that the
-  // unsubscription chain is not broken.
-  //
-  // This function needs to be used wherever an interop observable or
-  // subscriber could be encountered. There are two such places:
-  //
-  // - within `subscribeToObservable`; and
-  // - within the `call` method of each operator's `Operator` class.
-  //
-  // Within `subscribeToObservable` the observables are almost always going to
-  // be interop - as they're obtained via the `Symbol.observable` property.
-  //
-  // Within the `call` method, the operator's subscriber will be interop -
-  // relative to the source observable - if the operator is imported from a
-  // package that uses a different version of RxJS.
   const subscription = observable.subscribe(subscriber);
   if (subscription !== subscriber) {
     subscriber.add(subscription);

--- a/src/internal/util/subscribeWith.ts
+++ b/src/internal/util/subscribeWith.ts
@@ -1,0 +1,39 @@
+import { Observable } from '../Observable';
+import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
+
+export function subscribeWith<T>(
+  observable: Observable<T>,
+  subscriber: Subscriber<T>
+): Subscription {
+  // When an instance of a subscriber from within this package is passed to the
+  // subscribe method of an observable from within this package, the returned
+  // subscription is the subscriber instance.
+  //
+  // Operator implementations depend upon this behaviour, so it's important
+  // that interop subscribers and observables behave in a similar manner. If
+  // they do not, unsubscription chains can be broken.
+  //
+  // This function ensures that if the subscription returned from the subscribe
+  // call is not the subscriber itself, the subscription is added to the
+  // subscriber and the subscriber is returned. Doing so will ensure that the
+  // unsubscription chain is not broken.
+  //
+  // This function needs to be used wherever an interop observable or
+  // subscriber could be encountered. There are two such places:
+  //
+  // - within `subscribeToObservable`; and
+  // - within the `call` method of each operator's `Operator` class.
+  //
+  // Within `subscribeToObservable` the observables are almost always going to
+  // be interop - as they're obtained via the `Symbol.observable` property.
+  //
+  // Within the `call` method, the operator's subscriber will be interop -
+  // relative to the source observable - if the operator is imported from a
+  // package that uses a different version of RxJS.
+  const subscription = observable.subscribe(subscriber);
+  if (subscription !== subscriber) {
+    subscriber.add(subscription);
+  }
+  return subscriber;
+}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the fix to #5051 that was made in #5059.

Instead of testing for interop subscribers/subscriptions in operator implementations, this refactor moves the test into `subscribeToObservable` - which is where the interop subscription takes place - and ensures that function behaves like `subscribe` calls made to this package's observables.

That is, it ensures that the subscriber that's passed in is what's returned. If the subscription that's received is not the subscriber, said subscription is added to the subscriber so that unsubscription chains correctly.

The code is much simpler and all of the tests that were added in #5059 pass.

---

I've made some changes to this PR, as it can be used to resolve the problem that #5239 and #5243 sought to address.

It's explained in this comment:

https://github.com/ReactiveX/rxjs/blob/ba08e584dcefdf4119f6a8f4fa6b9a83cbc8b1d4/src/internal/util/subscribeWith.ts#L5-L37

Essentially, the `subscribeWith` util can be used to ensure that subscription chains are not broken - by interop observalbes - in `subscribeToObservable` or in any operator's `call` method.

This PR does not make any changes to operator `call` implementations. I'll do that in a separate PR, if this PR passes review.

If you look at the change made in #5239, it should be clear that the implementation of `subscribeWith` will solve the problem in a similar manner to the change that's in that PR:

https://github.com/ReactiveX/rxjs/blob/b92d1db4f5b3a8aa7fcad11c27eb05e64fd1a63b/src/internal/operators/finalize.ts#L75-L80

**Related issue:** #5051