### PR TITLE
style(docs): top menu position: fixed on external resources page

### DIFF
--- a/docs_app/src/styles/1-layouts/_top-menu.scss
+++ b/docs_app/src/styles/1-layouts/_top-menu.scss
@@ -38,8 +38,7 @@ aio-shell.page-home mat-toolbar.mat-toolbar {
 // MARKETING PAGES OVERRIDE: TOPNAV TOOLBAR AND HAMBURGER
 aio-shell.page-home mat-toolbar.mat-toolbar,
 aio-shell.page-features mat-toolbar.mat-toolbar,
-aio-shell.page-events mat-toolbar.mat-toolbar,
-aio-shell.page-resources mat-toolbar.mat-toolbar {
+aio-shell.page-events mat-toolbar.mat-toolbar {
   box-shadow: none;
 
   // FIXED TOPNAV TOOLBAR FOR SMALL MOBILE


### PR DESCRIPTION
**Description:**
Top menu had position: absolute what was leading to its disappearing on scrolling

**Related issue (if exists):**
(#5336)