### PR TITLE
docs: add `partition` to the operators list

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -146,6 +146,7 @@ These are Observable creation operators that also have join functionality -- emi
 - [`concat`](/api/index/function/concat)
 - [`forkJoin`](/api/index/function/forkJoin)
 - [`merge`](/api/index/function/merge)
+- [`partition`](/api/index/function/partition)
 - [`race`](/api/index/function/race)
 - [`zip`](/api/index/function/zip)
 


### PR DESCRIPTION
**Description:**

This PR add one missing operator that should listed on `operators.md` page.

**Related issue (if exists):**

Closed: #5341