### PR TITLE
feat(webSocketSubject): adding support for closing the socket using a…

### DIFF
--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -379,11 +379,16 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   }
 
   unsubscribe() {
-    const { _socket } = this;
-    if (_socket && _socket.readyState === 1) {
-      _socket.close();
-    }
+    this.closeSocket();
     this._resetState();
     super.unsubscribe();
+  }
+
+  closeSocket(code = 1000, message =  '') {
+    const { _socket } = this;
+
+    if (_socket && _socket.readyState === 1) {
+      _socket.close(code, message);
+    }
   }
 }


### PR DESCRIPTION
Adding support for closing internal socket with custom error code and message:
```js
import { webSocket } from "rxjs/webSocket";

const webSocketSubjectConfig = {
    closeObserver: {
        next(closeEvent) {
            // Printing custom error and code
            console.log(closeEvent);
        }
    }
};

const wsSubject = webSocket(webSocketSubjectConfig);
wsSubject.close(3000, "custom evil reason!");
```

**Motivation**
Currently we have no way to close the inner socket with a custom error or message that provides to our users a better understanding about what could be possible went wrong with the connection.

 Issue related #4087