### PR TITLE
docs(switchAll): adding closing comment

### DIFF
--- a/src/internal/operators/switchAll.ts
+++ b/src/internal/operators/switchAll.ts
@@ -50,7 +50,7 @@ export function switchAll<R>(): OperatorFunction<any, R>;
  *  ...
  *  click
  *  ...
- * */
+ */
  * ```
  *
  * @see {@link combineAll}

--- a/src/internal/operators/switchAll.ts
+++ b/src/internal/operators/switchAll.ts
@@ -50,6 +50,7 @@ export function switchAll<R>(): OperatorFunction<any, R>;
  *  ...
  *  click
  *  ...
+ * */
  * ```
  *
  * @see {@link combineAll}


### PR DESCRIPTION
Added '*/' closing comments at line 54 for stackblitz as it shows error as
Error in index.ts (24:5)
'*/' expected.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `doc/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] It should also be inserted in the operator decision tree file `doc/decision-tree-widget/tree.yml`
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
