### PR TITLE
feat(combineLatest): support for observable dictionaries (#5022)

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -139,6 +139,10 @@ export declare function combineLatest<O extends ObservableInput<any>, R>(array: 
 export declare function combineLatest<O extends ObservableInput<any>>(...observables: Array<O | SchedulerLike>): Observable<any[]>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>): Observable<R>;
 export declare function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
+export declare function combineLatest(sourcesObject: {}): Observable<never>;
+export declare function combineLatest<T, K extends keyof T>(sourcesObject: T): Observable<{
+    [K in keyof T]: ObservedValueOf<T[K]>;
+}>;
 
 export interface CompleteNotification {
     kind: 'C';

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -123,3 +123,13 @@ it('should accept 6 params and a result selector', () => {
 it('should accept 7 or more params and a result selector', () => {
   const o = combineLatest([a$, b$, c$, d$, e$, f$, g$, g$, g$], (a: any, b: any, c: any, d: any, e: any, f: any, g1: any, g2: any, g3: any) => new A()); // $ExpectType Observable<A>
 });
+
+describe('combineLatest({})', () => {
+  it('should properly type empty objects', () => {
+    const res = combineLatest({}); // $ExpectType Observable<never>
+  });
+
+  it('should work for the simple case', () => {
+    const res = combineLatest({ foo: a$, bar: b$, baz: c$ }); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
+  });
+});

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { queueScheduler as rxQueueScheduler, combineLatest, of } from 'rxjs';
-import { mergeMap } from 'rxjs/operators';
+import { map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
@@ -63,6 +63,20 @@ describe('static combineLatest', () => {
       const combined = combineLatest([firstSource, secondSource], (a: string, b: string) => '' + a + b);
 
       expectObservable(combined).toBe(expected, { u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg' });
+    });
+  });
+
+  it('should accept a dictionary of observables', () => {
+    rxTestScheduler.run(({ hot, expectObservable }) => {
+      const firstSource =  hot('----a----b----c----|');
+      const secondSource = hot('--d--e--f--g--|');
+      const expected = '        ----uv--wx-y--z----|';
+
+      const combined = combineLatest({a: firstSource, b: secondSource}).pipe(
+        map(({a, b}) => '' + a + b)
+      );  
+
+      expectObservable(combined).toBe(expected, {u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg'});
     });
   });
 


### PR DESCRIPTION
**Description:**
Support for passing a dictionary of observables to `combineLatest`, removing the need to pass an array then directly using `map` to turn it back into an object.

I mostly based this on the similar work that was done on `forkJoin`.

**Related issue (if exists):**
#5022 and #5362 