### PR TITLE
docs: update non-working examples in firstValueFrom and lastValueFrom

### DIFF
--- a/src/internal/firstValueFrom.ts
+++ b/src/internal/firstValueFrom.ts
@@ -23,7 +23,7 @@ import { Subscription } from './Subscription';
  *
  * async function execute() {
  *    const source$ = interval(2000);
- *    const firstNumber = await firstValueFrom(source);
+ *    const firstNumber = await firstValueFrom(source$);
  *    console.log(`The first number is ${firstNumber}`);
  * }
  *
@@ -35,11 +35,11 @@ import { Subscription } from './Subscription';
  *
  * @param source the observable to convert to a promise
  */
-export function firstValueFrom<T>(source$: Observable<T>) {
+export function firstValueFrom<T>(source: Observable<T>) {
   return new Promise<T>((resolve, reject) => {
     const subs = new Subscription();
     subs.add(
-      source$.subscribe({
+      source.subscribe({
         next: value => {
           resolve(value);
           subs.unsubscribe();

--- a/src/internal/lastValueFrom.ts
+++ b/src/internal/lastValueFrom.ts
@@ -23,7 +23,7 @@ import { EmptyError } from './util/EmptyError';
  *
  * async function execute() {
  *    const source$ = interval(2000).pipe(take(10));
- *    const finalNumber = await lastValueFrom(source);
+ *    const finalNumber = await lastValueFrom(source$);
  *    console.log(`The final number is ${finalNumber}`);
  * }
  *


### PR DESCRIPTION
I updated examples for `firstValueFrom` and `lastValueFrom` which were bad. I also changed parameter name in `firstValueFrom` from `source$` to `source` because:
- `lastValueFrom` is also using `source`;
- the documentation uses `@param source`;
- although it's common to add `$` to Observable variables outside RxJS world, I couldn't find any other place inside RxJS that adds `$` to Observable parameters so I wanted to be consistent with the rest of the library.