### PR TITLE
fix(Subject): standard default generic

### DIFF
--- a/spec-dtslint/Subject-spec.ts
+++ b/spec-dtslint/Subject-spec.ts
@@ -1,0 +1,38 @@
+import { Subject } from 'rxjs';
+
+it('should have the proper types for Subject<number>', () => {
+  const subject = new Subject<number>(); // $ExpectType Subject<number>
+  const r = subject.next(123); // $ExpectType void
+  subject.next('test'); // $ExpectError
+  subject.next(); // $ExpectError
+});
+
+it('should have the proper types for new Subject<void>()', () => {
+  const subject = new Subject<void>(); // $ExpectType Subject<void>
+  const r = subject.next(); // $ExpectType void
+  const r2 = subject.next(undefined); // $ExpectType void
+  subject.next('test'); // $ExpectError
+});
+
+it('should have the proper types for new Subject()', () => {
+  const subject = new Subject(); // $ExpectType Subject<unknown>
+  const r = subject.next(); // $ExpectError
+  const r2 = subject.next('test'); // $ExpectType void
+});
+
+it('should have the proper subscription types for new Subject<number>()', () => {
+  const a = new Subject<number>(); // $ExpectType Subject<number>
+  const r = a.next(123); // $ExpectType void
+  a.next('test'); // $ExpectError
+  const subs /* $ExpectType Subscription */ = a.subscribe((out) => {
+    const x = out; // $ExpectType number
+  });
+});
+
+it('should have the proper subscription types for new Subject()', () => {
+  const a = new Subject(); // $ExpectType Subject<unknown>
+  const r = a.next('test'); // $ExpectType void
+  const subs /* $ExpectType Subscription */ = a.subscribe((out) => {
+    const x = out; // $ExpectType unknown
+  });
+});

--- a/spec-dtslint/Subject-spec.ts
+++ b/spec-dtslint/Subject-spec.ts
@@ -24,7 +24,8 @@ it('should have the proper subscription types for new Subject<number>()', () => 
   const a = new Subject<number>(); // $ExpectType Subject<number>
   const r = a.next(123); // $ExpectType void
   a.next('test'); // $ExpectError
-  const subs /* $ExpectType Subscription */ = a.subscribe((out) => {
+  const subs = a.subscribe((out) => { // $ExpectType Subscription
+    // $ExpectType Subscription
     const x = out; // $ExpectType number
   });
 });
@@ -32,7 +33,7 @@ it('should have the proper subscription types for new Subject<number>()', () => 
 it('should have the proper subscription types for new Subject()', () => {
   const a = new Subject(); // $ExpectType Subject<unknown>
   const r = a.next('test'); // $ExpectType void
-  const subs /* $ExpectType Subscription */ = a.subscribe((out) => {
+  const subs = a.subscribe((out) => { // $ExpectType Subscription
     const x = out; // $ExpectType unknown
   });
 });

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -22,10 +22,8 @@ export class SubjectSubscriber<T> extends Subscriber<T> {
  *
  * Every Subject is an Observable and an Observer. You can subscribe to a
  * Subject, and you can call next to feed values as well as error and complete.
- *
- * @class Subject<T>
  */
-export class Subject<T = void> extends Observable<T> implements SubscriptionLike {
+export class Subject<T> extends Observable<T> implements SubscriptionLike {
 
   [rxSubscriberSymbol]() {
     return new SubjectSubscriber(this);


### PR DESCRIPTION
- Aligns Subject generics with TS generics like those from JavaScript's `Set`, such that if it is not provided it is `unknown`
- Adds dtslint tests
- Ensures that calling `subject.next()` works for `new Subject<void>()`


Defaulting to `void` was incorrect and was causing people issues.