### PR TITLE
feat(ajax): implement url params inside ajax body

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -676,6 +676,35 @@ describe('ajax', () => {
       expect(complete).to.be.true;
     });
 
+    it('request for url and params should succeed on 200', () => {
+      const expected = { foo: 'bar' };
+      let result;
+      let complete = false;
+      const obj: AjaxRequest = {
+        url: 'http://talk-to-me-goose',
+        method: 'GET',
+        params: {baz: 'foo'}
+      };
+      ajax(obj).subscribe(x => {
+          result = x.response;
+        }, null, () => {
+          complete = true;
+        });
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      expect(request.url).to.equal('http://talk-to-me-goose?baz=foo');
+
+      request.respondWith({
+        'status': 200,
+        'contentType': 'application/json',
+        'responseText': JSON.stringify(expected)
+      });
+
+      expect(result).to.deep.equal(expected);
+      expect(complete).to.be.true;
+    });
+
     it('should succeed on 204 No Content', () => {
       const expected: null = null;
       let result;

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -179,7 +179,7 @@ export class AjaxObservable<T> extends Observable<T> {
         }
       }
       const requestParams = urlOrRequest.params;
-      if (requestParams) {
+      if (requestParams && urlOrRequest.url) {
         const url = new URL(urlOrRequest.url);
         for (const param in requestParams) {
           if (requestParams.hasOwnProperty(param)) {

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -19,6 +19,7 @@ export interface AjaxRequest {
   createXHR?: () => XMLHttpRequest;
   progressSubscriber?: Subscriber<any>;
   responseType?: string;
+  params?: { [param: string]: string };
 }
 
 function getCORSRequest(): XMLHttpRequest {
@@ -126,6 +127,7 @@ export class AjaxObservable<T> extends Observable<T> {
    *   - headers: Optional headers
    *   - crossDomain: true if a cross domain request, else false
    *   - createXHR: a function to override if you need to use an alternate
+   *   - params: Optional URL Query Parameters
    *   XMLHttpRequest implementation.
    *   - resultSelector: a function to use to alter the output value type of
    *   the Observable. Gets {@link AjaxResponse} as an argument.
@@ -175,6 +177,16 @@ export class AjaxObservable<T> extends Observable<T> {
         if (urlOrRequest.hasOwnProperty(prop)) {
           request[prop] = urlOrRequest[prop];
         }
+      }
+      const requestParams = urlOrRequest.params;
+      if (requestParams) {
+        const url = new URL(urlOrRequest.url);
+        for (const param in requestParams) {
+          if (requestParams.hasOwnProperty(param)) {
+            url.searchParams.set(param, requestParams[param]);
+          }
+        }
+        request.url += url.search;
       }
     }
 


### PR DESCRIPTION
implement url query params to make it easy for user to pass it dynamically as an object and not to make it by himself and joining it with the url