### PR TITLE
docs(windowTime): fix documentation issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Reactive Extensions Library for JavaScript. This is a rewrite of [Reactive-Exten
 
 - [Code of Conduct](CODE_OF_CONDUCT.md)
 - [Contribution Guidelines](CONTRIBUTING.md)
-- [Maintainer Guidelines](doc_app/content/maintainer-guidelines.md)
+- [Maintainer Guidelines](docs_app/content/maintainer-guidelines.md)
 - [API Documentation](https://rxjs.dev/)
 
 ## Versions In This Repository

--- a/spec-dtslint/operators/startWith-spec.ts
+++ b/spec-dtslint/operators/startWith-spec.ts
@@ -1,6 +1,6 @@
 import { of, asyncScheduler  } from 'rxjs';
 import { startWith } from 'rxjs/operators';
-import { a, b, c, d, e, f, g, h } from '../helpers';
+import { A, B, a, b, c, d, e, f, g, h } from '../helpers';
 
 it('should infer correctly with N values', () => {
   const r0 = of(a).pipe(startWith()); // $ExpectType Observable<A>
@@ -13,7 +13,7 @@ it('should infer correctly with N values', () => {
   const r7 = of(a).pipe(startWith(b, c, d, e, f, g, h)); // $ExpectType Observable<A | B | C | D | E | F | G | H>
 });
 
-it('should infer correctly with only a scheduler', () => {
+it('should infer correctly with a scheduler', () => {
   const r = of(a).pipe(startWith(asyncScheduler)); // $ExpectType Observable<A>
   const r1 = of(a).pipe(startWith(b, asyncScheduler)); // $ExpectType Observable<A | B>
   const r2 = of(a).pipe(startWith(b, c, asyncScheduler)); // $ExpectType Observable<A | B | C>
@@ -22,3 +22,9 @@ it('should infer correctly with only a scheduler', () => {
   const r5 = of(a).pipe(startWith(b, c, d, e, f, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E | F>
   const r6 = of(a).pipe(startWith(b, c, d, e, f, g, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E | F | G>
   });
+
+it('should infer correctly with a single specified type', () => {
+  const r0 = of(a).pipe(startWith<A>(a)); // $ExpectType Observable<A>
+  const r1 = of(a).pipe(startWith<A|B>(b)); // $ExpectType Observable<A | B>
+  const r2 = of(a).pipe(startWith<A|B>(a)); // $ExpectType Observable<A | B>
+});

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -19,7 +19,7 @@ export function startWith<T, D, E, F, G, H>(v1: D, v2: E, v3: F, v4: G, v5: H, s
 /** @deprecated use {@link scheduled} and {@link concatAll} (e.g. `scheduled([[a, b, c], source], scheduler).pipe(concatAll())`) */
 export function startWith<T, D, E, F, G, H, I>(v1: D, v2: E, v3: F, v4: G, v5: H, v6: I, scheduler: SchedulerLike): OperatorFunction<T, T | D | E | F | G | H | I>;
 
-export function startWith<T, A extends any[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>>;
+export function startWith<T, A extends any[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>>;
 
 /**
  * Returns an observable that, at the moment of subscription, will synchronously emit all

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -8,7 +8,6 @@ import { isNumeric } from '../util/isNumeric';
 import { isScheduler } from '../util/isScheduler';
 import { OperatorFunction, SchedulerLike, SchedulerAction } from '../types';
 
-
 export function windowTime<T>(windowTimeSpan: number,
                               scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
 export function windowTime<T>(windowTimeSpan: number,

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -8,6 +8,16 @@ import { isNumeric } from '../util/isNumeric';
 import { isScheduler } from '../util/isScheduler';
 import { OperatorFunction, SchedulerLike, SchedulerAction } from '../types';
 
+
+export function windowTime<T>(windowTimeSpan: number,
+                              scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
+export function windowTime<T>(windowTimeSpan: number,
+                              windowCreationInterval: number,
+                              scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
+export function windowTime<T>(windowTimeSpan: number,
+                              windowCreationInterval: number,
+                              maxWindowSize: number,
+                              scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
 /**
  * Branch out the source Observable values as a nested Observable periodically
  * in time.
@@ -87,16 +97,6 @@ import { OperatorFunction, SchedulerLike, SchedulerAction } from '../types';
  * intervals that determine window boundaries.
  * @returnAn observable of windows, which in turn are Observables.
  */
-export function windowTime<T>(windowTimeSpan: number,
-                              scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
-export function windowTime<T>(windowTimeSpan: number,
-                              windowCreationInterval: number,
-                              scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
-export function windowTime<T>(windowTimeSpan: number,
-                              windowCreationInterval: number,
-                              maxWindowSize: number,
-                              scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
-
 export function windowTime<T>(windowTimeSpan: number): OperatorFunction<T, Observable<T>> {
   let scheduler: SchedulerLike = async;
   let windowCreationInterval: number | null = null;


### PR DESCRIPTION
Due to the wrong position of the windowTime tsdoc comments in the docs it is listing all the information just for that single overload instead of the general information block