### PR TITLE
feat(FrankenSubject): adds type (DO NOT MERGE YET)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Subject } from './internal/Subject';
 export { BehaviorSubject } from './internal/BehaviorSubject';
 export { ReplaySubject } from './internal/ReplaySubject';
 export { AsyncSubject } from './internal/AsyncSubject';
+export { FrankenSubject } from './internal/FrankenSubject';
 
 /* Schedulers */
 export { asap as asapScheduler } from './internal/scheduler/asap';

--- a/src/internal/FrankenSubject.ts
+++ b/src/internal/FrankenSubject.ts
@@ -1,0 +1,53 @@
+import { Observable } from './Observable';
+import { Observer, PartialObserver, ObservableInput } from './types';
+import { hostReportError } from './util/hostReportError';
+import { from } from './observable/from';
+
+/**
+ * Glues any observer to any observable to make a "subject".
+ *
+ * Assembles the parts like Frankenstein to make your own monster.
+ *
+ * Developer's note: `FrankenSubject` does NOT extend `Subject`, therefor
+ * `instanceof Subject` checks will not work.
+ */
+export class FrankenSubject<In, Out> extends Observable<Out> implements Observer<In> {
+  private _closed = false;
+
+  get closed() {
+    return this._closed;
+  }
+
+  constructor(private observer: PartialObserver<In>, source: ObservableInput<Out>) {
+    super();
+    this.source = from(source);
+  }
+
+  next(value: In): void {
+    if (!this.closed) {
+      this.observer.next?.(value);
+    }
+  }
+
+  error(err: any): void {
+    if (!this._closed) {
+      this._closed = true;
+      if (typeof this.observer.error === 'function') {
+        this.observer.error(err);
+      } else {
+        hostReportError(err);
+      }
+    }
+  }
+
+  complete(): void {
+    if (!this._closed) {
+      this._closed = true;
+      this.observer.complete?.();
+    }
+  }
+
+  asObservable() {
+    return this.source;
+  }
+}

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -41,13 +41,10 @@ export class Subject<T = void> extends Observable<T> implements SubscriptionLike
 
   thrownError: any = null;
 
-  constructor() {
-    super();
-  }
-
-  /**@nocollapse
-   * @deprecated use new Subject() instead
-  */
+  /**
+   * @nocollapse
+   * @deprecated use {@link FrankenSubject} instead
+   */
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
   }
@@ -146,9 +143,6 @@ export class Subject<T = void> extends Observable<T> implements SubscriptionLike
   }
 }
 
-/**
- * @class AnonymousSubject<T>
- */
 export class AnonymousSubject<T> extends Subject<T> {
   constructor(protected destination?: Observer<T>, source?: Observable<T>) {
     super();


### PR DESCRIPTION
- updates deprecation message for `Subject.create`, as it was incorrect.

- Adds some documentation for `FrankenSubject`

NOTE: No tests yet. Requires discussion. This is something that could be used to create better types for WebSocketSubject, etc.
