### PR TITLE
refactor: Use Infinity

### DIFF
--- a/spec/operators/bufferTime-spec.ts
+++ b/spec/operators/bufferTime-spec.ts
@@ -26,7 +26,7 @@ describe('bufferTime operator', () => {
         z: [] as string[]
       };
 
-      const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, null, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -44,7 +44,7 @@ describe('bufferTime operator', () => {
         z: [] as string[]
       };
 
-      const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, null, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
     });
@@ -106,7 +106,7 @@ describe('bufferTime operator', () => {
         z: ['i', 'k']
       };
 
-      const result = e1.pipe(bufferTime(t, interval, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, interval, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
     });
@@ -158,7 +158,7 @@ describe('bufferTime operator', () => {
         f: [] as string[]
       };
 
-      const result = e1.pipe(bufferTime(t, interval, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, interval, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -186,7 +186,7 @@ describe('bufferTime operator', () => {
         e: [] as string[]
       };
 
-      const result = e1.pipe(bufferTime(t, interval, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, interval, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
     });
@@ -208,7 +208,7 @@ describe('bufferTime operator', () => {
         a: ['2', '3', '4']
       };
 
-      const result = e1.pipe(bufferTime(t, interval, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, interval, Infinity, testScheduler));
 
       expectObservable(result, unsub).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(subs);
@@ -233,7 +233,7 @@ describe('bufferTime operator', () => {
 
       const result = e1.pipe(
         mergeMap((x: any) => of(x)),
-        bufferTime(t, interval, Number.POSITIVE_INFINITY, testScheduler),
+        bufferTime(t, interval, Infinity, testScheduler),
         mergeMap((x: any) => of(x))
       );
 
@@ -250,7 +250,7 @@ describe('bufferTime operator', () => {
       const values = { b: [] as string[] };
       const t = time('----------|');
 
-      const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, null, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -264,7 +264,7 @@ describe('bufferTime operator', () => {
       const t = time('  ----------|                                  ');
       const expected = '----------a---------a---------a---------a----';
 
-      const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, null, Infinity, testScheduler));
 
       expectObservable(result, unsub).toBe(expected, { a: [] });
     });
@@ -276,7 +276,7 @@ describe('bufferTime operator', () => {
       const expected = '#';
       const t = time('----------|');
 
-      const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, null, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, undefined, new Error('haha'));
     });
@@ -292,7 +292,7 @@ describe('bufferTime operator', () => {
         w: ['a', 'b']
       };
 
-      const result = e1.pipe(bufferTime(t, null, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, null, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -316,7 +316,7 @@ describe('bufferTime operator', () => {
         y: ['e', 'f', 'g', 'h', 'i']
       };
 
-      const result = e1.pipe(bufferTime(t, interval, Number.POSITIVE_INFINITY, testScheduler));
+      const result = e1.pipe(bufferTime(t, interval, Infinity, testScheduler));
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -335,7 +335,7 @@ describe('bufferTime operator', () => {
       };
 
       const result = e1.pipe(
-        bufferTime(t, null, Number.POSITIVE_INFINITY, testScheduler),
+        bufferTime(t, null, Infinity, testScheduler),
         take(2)
       );
 

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -32,7 +32,7 @@ describe('expand operator', () => {
     const expected =  '--a-b-c-d|';
     const values = {a: 1, b: 2, c: 4, d: 8};
 
-    const result = e1.pipe(expand(x => x === 8 ? EMPTY : e2.pipe(map(c => c * x)), Number.POSITIVE_INFINITY, rxTestScheduler));
+    const result = e1.pipe(expand(x => x === 8 ? EMPTY : e2.pipe(map(c => c * x)), Infinity, rxTestScheduler));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -426,7 +426,7 @@ describe('publishReplay operator', () => {
     const selector = (observable: Observable<string>) => observable.pipe(map(v => 2 * +v));
     const source = cold('--1-2---3-4---|');
     const sourceSubs =  '^             !';
-    const published = source.pipe(publishReplay(1, Number.POSITIVE_INFINITY, selector));
+    const published = source.pipe(publishReplay(1, Infinity, selector));
     const expected =    '--a-b---c-d---|';
 
     expectObservable(published).toBe(expected, values);
@@ -439,7 +439,7 @@ describe('publishReplay operator', () => {
       throw error;
     };
     const source = cold('--1-2---3-4---|');
-    const published = source.pipe(publishReplay(1, Number.POSITIVE_INFINITY, selector));
+    const published = source.pipe(publishReplay(1, Infinity, selector));
 
     // The exception is thrown outside Rx chain (not as an error notification).
     expect(() => published.subscribe()).to.throw(error);
@@ -451,7 +451,7 @@ describe('publishReplay operator', () => {
     const selector = (observable: Observable<string>) => observable.pipe(mergeMapTo(innerObservable));
     const source = cold('--1--2---3---|');
     const sourceSubs =  '^          !';
-    const published = source.pipe(publishReplay(1, Number.POSITIVE_INFINITY, selector));
+    const published = source.pipe(publishReplay(1, Infinity, selector));
     const expected =    '----5-65-6-#';
 
     expectObservable(published).toBe(expected, undefined, error);
@@ -462,7 +462,7 @@ describe('publishReplay operator', () => {
     const selector = () => EMPTY;
     const source = cold('--1--2---3---|');
     const sourceSubs =  '(^!)';
-    const published = source.pipe(publishReplay(1, Number.POSITIVE_INFINITY, selector));
+    const published = source.pipe(publishReplay(1, Infinity, selector));
     const expected =    '|';
 
     expectObservable(published).toBe(expected);
@@ -473,7 +473,7 @@ describe('publishReplay operator', () => {
     const selector = () => NEVER;
     const source = cold('-');
     const sourceSubs =  '^';
-    const published = source.pipe(publishReplay(1, Number.POSITIVE_INFINITY, selector));
+    const published = source.pipe(publishReplay(1, Infinity, selector));
     const expected =    '-';
 
     expectObservable(published).toBe(expected);
@@ -485,7 +485,7 @@ describe('publishReplay operator', () => {
     const selector = () => throwError(error);
     const source = cold('--1--2---3---|');
     const sourceSubs =  '(^!)';
-    const published = source.pipe(publishReplay(1, Number.POSITIVE_INFINITY, selector));
+    const published = source.pipe(publishReplay(1, Infinity, selector));
     const expected =    '#';
 
     expectObservable(published).toBe(expected, undefined, error);

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -106,7 +106,7 @@ describe('TestScheduler', () => {
     it('should parse a subscription marble string with an unsubscription', () => {
       const result = TestScheduler.parseMarblesAsSubscriptions('---^-');
       expect(result.subscribedFrame).to.equal(30);
-      expect(result.unsubscribedFrame).to.equal(Number.POSITIVE_INFINITY);
+      expect(result.unsubscribedFrame).to.equal(Infinity);
     });
 
     it('should parse a subscription marble string with a synchronous unsubscription', () => {

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -194,7 +194,7 @@ describe('ReplaySubject', () => {
 
   describe('with windowTime=40', () => {
     it('should replay previous values since 40 time units ago when subscribed', () => {
-      const replaySubject = new ReplaySubject<string>(Number.POSITIVE_INFINITY, 40, rxTestScheduler);
+      const replaySubject = new ReplaySubject<string>(Infinity, 40, rxTestScheduler);
       function feedNextIntoSubject(x: string) { replaySubject.next(x); }
       function feedErrorIntoSubject(err: any) { replaySubject.error(err); }
       function feedCompleteIntoSubject() { replaySubject.complete(); }
@@ -218,7 +218,7 @@ describe('ReplaySubject', () => {
     });
 
     it('should replay last values since 40 time units ago when subscribed', () => {
-      const replaySubject = new ReplaySubject<string>(Number.POSITIVE_INFINITY, 40, rxTestScheduler);
+      const replaySubject = new ReplaySubject<string>(Infinity, 40, rxTestScheduler);
       function feedNextIntoSubject(x: string) { replaySubject.next(x); }
       function feedErrorIntoSubject(err: any) { replaySubject.error(err); }
       function feedCompleteIntoSubject() { replaySubject.complete(); }

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -47,14 +47,14 @@ export class ReplaySubject<T> extends Subject<T> {
    * @param timestampProvider An object with a `now()` method that provides the current timestamp. This is used to
    * calculate the amount of time something has been buffered.
    */
-  constructor(bufferSize: number = Number.POSITIVE_INFINITY,
-              windowTime: number = Number.POSITIVE_INFINITY,
+  constructor(bufferSize: number = Infinity,
+              windowTime: number = Infinity,
               private timestampProvider: TimestampProvider = Date) {
     super();
     this._bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;
 
-    if (windowTime === Number.POSITIVE_INFINITY) {
+    if (windowTime === Infinity) {
       this._infiniteTimeWindow = true;
       /** @override */
       this.next = this.nextInfiniteTimeWindow;

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -109,7 +109,7 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * @see {@link mergeScan}
  *
  * @param {...ObservableInput} observables Input Observables to merge together.
- * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
+ * @param {number} [concurrent=Infinity] Maximum number of input
  * Observables being subscribed to concurrently.
  * @param {SchedulerLike} [scheduler=null] The {@link SchedulerLike} to use for managing
  * concurrency of input Observables.
@@ -120,7 +120,7 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * @owner Observable
  */
 export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number | undefined>): Observable<R> {
- let concurrent = Number.POSITIVE_INFINITY;
+ let concurrent = Infinity;
  let scheduler: SchedulerLike | undefined = undefined;
   let last: any = observables[observables.length - 1];
   if (isScheduler(last)) {

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -82,7 +82,7 @@ export function bufferTime<T>(bufferTimeSpan: number): OperatorFunction<T, T[]> 
     bufferCreationInterval = arguments[1];
   }
 
-  let maxBufferSize: number = Number.POSITIVE_INFINITY;
+  let maxBufferSize: number = Infinity;
   if (length >= 3) {
     maxBufferSize = arguments[2];
   }

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -53,7 +53,7 @@ export function expand<T>(project: (value: T, index: number) => ObservableInput<
  * @param {function(value: T, index: number) => Observable} project A function
  * that, when applied to an item emitted by the source or the output Observable,
  * returns an Observable.
- * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
+ * @param {number} [concurrent=Infinity] Maximum number of input
  * Observables being subscribed to concurrently.
  * @param {SchedulerLike} [scheduler=null] The {@link SchedulerLike} to use for subscribing to
  * each projected inner Observable.
@@ -64,9 +64,9 @@ export function expand<T>(project: (value: T, index: number) => ObservableInput<
  * @name expand
  */
 export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>,
-                             concurrent: number = Number.POSITIVE_INFINITY,
+                             concurrent: number = Infinity,
                              scheduler?: SchedulerLike): OperatorFunction<T, R> {
-  concurrent = (concurrent || 0) < 1 ? Number.POSITIVE_INFINITY : concurrent;
+  concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
 
   return (source: Observable<T>) => source.lift(new ExpandOperator(project, concurrent, scheduler));
 }
@@ -105,7 +105,7 @@ export class ExpandSubscriber<T, R> extends OuterSubscriber<T, R> {
               private concurrent: number,
               private scheduler?: SchedulerLike) {
     super(destination);
-    if (concurrent < Number.POSITIVE_INFINITY) {
+    if (concurrent < Infinity) {
       this.buffer = [];
     }
   }

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -53,12 +53,12 @@ import { OperatorFunction, ObservableInput } from '../types';
  * @see {@link switchMap}
  * @see {@link zipAll}
  *
- * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of inner
+ * @param {number} [concurrent=Infinity] Maximum number of inner
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits values coming from all the
  * inner Observables emitted by the source Observable.
  * @name mergeAll
  */
-export function mergeAll<T>(concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<ObservableInput<T>, T> {
+export function mergeAll<T>(concurrent: number = Infinity): OperatorFunction<ObservableInput<T>, T> {
   return mergeMap(identity, concurrent);
 }

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -64,7 +64,7 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(project: (value: 
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
+ * @param {number} [concurrent=Infinity] Maximum number of input
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits the result of applying the
  * projection function (and the optional deprecated `resultSelector`) to each item
@@ -75,7 +75,7 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(project: (value: 
 export function mergeMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector?: ((outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R) | number,
-  concurrent: number = Number.POSITIVE_INFINITY
+  concurrent: number = Infinity
 ): OperatorFunction<T, ObservedValueOf<O>|R> {
   if (typeof resultSelector === 'function') {
     // DEPRECATED PATH
@@ -92,7 +92,7 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(
 
 export class MergeMapOperator<T, R> implements Operator<T, R> {
   constructor(private project: (value: T, index: number) => ObservableInput<R>,
-              private concurrent: number = Number.POSITIVE_INFINITY) {
+              private concurrent: number = Infinity) {
   }
 
   call(observer: Subscriber<R>, source: any): any {
@@ -115,7 +115,7 @@ export class MergeMapSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   constructor(destination: Subscriber<R>,
               private project: (value: T, index: number) => ObservableInput<R>,
-              private concurrent: number = Number.POSITIVE_INFINITY) {
+              private concurrent: number = Infinity) {
     super(destination);
   }
 

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -41,7 +41,7 @@ export function mergeMapTo<T, R, O extends ObservableInput<any>>(innerObservable
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of input
+ * @param {number} [concurrent=Infinity] Maximum number of input
  * Observables being subscribed to concurrently.
  * @return {Observable} An Observable that emits items from the given
  * `innerObservable`
@@ -50,7 +50,7 @@ export function mergeMapTo<T, R, O extends ObservableInput<any>>(innerObservable
 export function mergeMapTo<T, R, O extends ObservableInput<any>>(
   innerObservable: O,
   resultSelector?: ((outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R) | number,
-  concurrent: number = Number.POSITIVE_INFINITY
+  concurrent: number = Infinity
 ): OperatorFunction<T, ObservedValueOf<O>|R> {
   if (typeof resultSelector === 'function') {
     return mergeMap(() => innerObservable, resultSelector, concurrent);

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -40,14 +40,14 @@ import { ObservableInput, OperatorFunction } from '../types';
  * @param {function(acc: R, value: T): Observable<R>} accumulator
  * The accumulator function called on each source value.
  * @param seed The initial accumulation value.
- * @param {number} [concurrent=Number.POSITIVE_INFINITY] Maximum number of
+ * @param {number} [concurrent=Infinity] Maximum number of
  * input Observables being subscribed to concurrently.
  * @return {Observable<R>} An observable of the accumulated values.
  * @name mergeScan
  */
 export function mergeScan<T, R>(accumulator: (acc: R, value: T, index: number) => ObservableInput<R>,
                                 seed: R,
-                                concurrent: number = Number.POSITIVE_INFINITY): OperatorFunction<T, R> {
+                                concurrent: number = Infinity): OperatorFunction<T, R> {
   return (source: Observable<T>) => source.lift(new MergeScanOperator(accumulator, seed, concurrent));
 }
 

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -115,8 +115,8 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
  * @see {@link share}
  * @see {@link publishReplay}
  *
- * @param {Number} [bufferSize=Number.POSITIVE_INFINITY] Maximum element count of the replay buffer.
- * @param {Number} [windowTime=Number.POSITIVE_INFINITY] Maximum time length of the replay buffer in milliseconds.
+ * @param {Number} [bufferSize=Infinity] Maximum element count of the replay buffer.
+ * @param {Number} [windowTime=Infinity] Maximum time length of the replay buffer in milliseconds.
  * @param {Scheduler} [scheduler] Scheduler where connected observers within the selector function
  * will be invoked on.
  * @return {Observable} An observable sequence that contains the elements of a sequence produced
@@ -143,8 +143,8 @@ export function shareReplay<T>(
 }
 
 function shareReplayOperator<T>({
-  bufferSize = Number.POSITIVE_INFINITY,
-  windowTime = Number.POSITIVE_INFINITY,
+  bufferSize = Infinity,
+  windowTime = Infinity,
   refCount: useRefCount,
   scheduler
 }: ShareReplayConfig) {

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -100,7 +100,7 @@ export function windowTime<T>(windowTimeSpan: number,
 export function windowTime<T>(windowTimeSpan: number): OperatorFunction<T, Observable<T>> {
   let scheduler: SchedulerLike = async;
   let windowCreationInterval: number | null = null;
-  let maxWindowSize: number = Number.POSITIVE_INFINITY;
+  let maxWindowSize: number = Infinity;
 
   if (isScheduler(arguments[3])) {
     scheduler = arguments[3];
@@ -206,7 +206,7 @@ class WindowTimeSubscriber<T> extends Subscriber<T> {
     // If we have a max window size, we might end up mutating the
     // array while we're iterating over it. If that's the case, we'll
     // copy it, otherwise, we don't just to save memory allocation.
-    const windows = this.maxWindowSize < Number.POSITIVE_INFINITY ? this.windows.slice() : this.windows;
+    const windows = this.maxWindowSize < Infinity ? this.windows.slice() : this.windows;
     const len = windows.length;
     for (let i = 0; i < len; i++) {
       const window = windows[i];

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -30,7 +30,7 @@ export class VirtualTimeScheduler extends AsyncScheduler {
    * @param maxFrames The maximum number of frames to process before stopping. Used to prevent endless flush cycles.
    */
   constructor(SchedulerAction: typeof AsyncAction = VirtualAction as any,
-              public maxFrames: number = Number.POSITIVE_INFINITY) {
+              public maxFrames: number = Infinity) {
     super(SchedulerAction, () => this.frame);
   }
 

--- a/src/internal/testing/SubscriptionLog.ts
+++ b/src/internal/testing/SubscriptionLog.ts
@@ -1,5 +1,5 @@
 export class SubscriptionLog {
   constructor(public subscribedFrame: number,
-              public unsubscribedFrame: number = Number.POSITIVE_INFINITY) {
+              public unsubscribedFrame: number = Infinity) {
   }
 }

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -125,7 +125,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     const actual: TestMessage[] = [];
     const flushTest: FlushableTest = { actual, ready: false };
     const subscriptionParsed = TestScheduler.parseMarblesAsSubscriptions(subscriptionMarbles, this.runMode);
-    const subscriptionFrame = subscriptionParsed.subscribedFrame === Number.POSITIVE_INFINITY ?
+    const subscriptionFrame = subscriptionParsed.subscribedFrame === Infinity ?
       0 : subscriptionParsed.subscribedFrame;
     const unsubscriptionFrame = subscriptionParsed.unsubscribedFrame;
     let subscription: Subscription;
@@ -145,7 +145,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       });
     }, subscriptionFrame);
 
-    if (unsubscriptionFrame !== Number.POSITIVE_INFINITY) {
+    if (unsubscriptionFrame !== Infinity) {
       this.schedule(() => subscription.unsubscribe(), unsubscriptionFrame);
     }
 
@@ -195,12 +195,12 @@ export class TestScheduler extends VirtualTimeScheduler {
   /** @nocollapse */
   static parseMarblesAsSubscriptions(marbles: string | null, runMode = false): SubscriptionLog {
     if (typeof marbles !== 'string') {
-      return new SubscriptionLog(Number.POSITIVE_INFINITY);
+      return new SubscriptionLog(Infinity);
     }
     const len = marbles.length;
     let groupStart = -1;
-    let subscriptionFrame = Number.POSITIVE_INFINITY;
-    let unsubscriptionFrame = Number.POSITIVE_INFINITY;
+    let subscriptionFrame = Infinity;
+    let unsubscriptionFrame = Infinity;
     let frame = 0;
 
     for (let i = 0; i < len; i++) {
@@ -228,7 +228,7 @@ export class TestScheduler extends VirtualTimeScheduler {
           advanceFrameBy(1);
           break;
         case '^':
-          if (subscriptionFrame !== Number.POSITIVE_INFINITY) {
+          if (subscriptionFrame !== Infinity) {
             throw new Error('found a second subscription point \'^\' in a ' +
               'subscription marble diagram. There can only be one.');
           }
@@ -236,7 +236,7 @@ export class TestScheduler extends VirtualTimeScheduler {
           advanceFrameBy(1);
           break;
         case '!':
-          if (unsubscriptionFrame !== Number.POSITIVE_INFINITY) {
+          if (unsubscriptionFrame !== Infinity) {
             throw new Error('found a second subscription point \'^\' in a ' +
               'subscription marble diagram. There can only be one.');
           }
@@ -405,7 +405,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     const prevMaxFrames = this.maxFrames;
 
     TestScheduler.frameTimeFactor = 1;
-    this.maxFrames = Number.POSITIVE_INFINITY;
+    this.maxFrames = Infinity;
     this.runMode = true;
     AsyncScheduler.delegate = this;
 


### PR DESCRIPTION
We were using Number.POSITIVE_INFINITY, which is not only YELLING at me, but unnecessarily verbose. It technically was probably adding to bundle sizes, as well, but not very much. Either way, Infinity is better.

Also I just typed `git push origin infinity` and I felt super cool doing it.