### PR TITLE
docs: Fix simple typo, stoted -> stored

### DIFF
--- a/docs_app/tools/transforms/README.md
+++ b/docs_app/tools/transforms/README.md
@@ -46,5 +46,5 @@ you are working on.
 
 ## Templates
 
-All the templates for the angular.io dgeni transformations are stoted in the `tools/transforms/templates`
+All the templates for the angular.io dgeni transformations are stored in the `tools/transforms/templates`
 folder. See the [README](./templates/README.md).


### PR DESCRIPTION
There is a small typo in docs_app/tools/transforms/README.md.

Should read `stored` rather than `stoted`.

