### PR TITLE
feat(dequeueReplay): add DequeueReplaySubject and dequeueReplay operator

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -222,6 +222,7 @@ Also see the [Join Creation Operators](#join-creation-operators) section above.
 
 ### Multicasting Operators
 
+- [`dequeueReplay`](/api/operators/dequeueReplay)
 - [`multicast`](/api/operators/multicast)
 - [`publish`](/api/operators/publish)
 - [`publishBehavior`](/api/operators/publishBehavior)

--- a/spec/operators/dequeueReplay-spec.ts
+++ b/spec/operators/dequeueReplay-spec.ts
@@ -1,0 +1,183 @@
+import { EMPTY, NEVER, Observable } from 'rxjs';
+import { dequeueReplay } from 'rxjs/operators';
+import { cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+
+declare function asDiagram(arg: string): Function;
+
+/** @test {dequeueReplay} */
+describe.only('dequeueReplay operator', () => {
+
+  asDiagram('dequeueReplay')('should emit only values that have not been dequeued for' +
+    ' subsequent subscribers', () => {
+    const source = cold( '-a-b--------');
+    const dequeue = cold( '----b');
+    const dequeueSub =    '-^';
+    const sub1 =         '^---';
+    const sub1Expected = '-a-b';
+    const sub2 =         '------^-';
+    const sub2Expected = '------a';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectSubscriptions(dequeue.subscriptions).toBe(dequeueSub);
+    expectObservable(dequeueTest, sub1).toBe(sub1Expected);
+    expectObservable(dequeueTest, sub2).toBe(sub2Expected);
+  });
+
+  it('should emit values to active subscribers as they are emitted from the source', () => {
+    const dequeue = cold('-');
+    const source = cold( '-a-b-c|');
+    const expected =     '-a-b-c|';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+  });
+
+  it('should emit values to a new subscriber that were queued before its subscription', () => {
+    const dequeue = cold('-');
+    const source = cold( '-a');
+    const sub1 =         '^---!';
+    const sub1Expected = '-a';
+    const sub2 =         '----^!';
+    const sub2Expected = '----a';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest, sub1).toBe(sub1Expected);
+    expectObservable(dequeueTest, sub2).toBe(sub2Expected);
+  });
+
+  it('should emit multiple values queued before second subscription', () => {
+    const dequeue = cold('-');
+    const source = cold( '-a-b');
+    const sub1 =         '^-!';
+    const sub1Expected = '-a';
+    const sub2 =         '----^-!';
+    const sub2Expected = '----(ab)';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest, sub1).toBe(sub1Expected);
+    expectObservable(dequeueTest, sub2).toBe(sub2Expected);
+  });
+
+  it('should error when the source observable errors', () => {
+    const dequeue = cold('-');
+    const source = cold( '-a-#');
+    const expected =     '-a-#';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+  });
+
+  it('should error when the dequeue observable errors', () => {
+    const dequeue = cold('--#');
+    const source = cold( '-a');
+    const expected =     '-a-#';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+  });
+
+  it('should complete when there is a buffered value and both the source and dequeue observables complete', () => {
+    const dequeue = cold('--|');
+    const source = cold( '-a|');
+    const expected =     '-a|';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+  });
+
+  it('should complete when the source observable completes', () => {
+    const dequeue = cold('-');
+    const source = cold( '-a|');
+    const expected =     '-a|';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+  });
+
+  it('should remain subscribed to the dequeue trigger if the source completes, but there are buffered values', () => {
+    const dequeue = cold('-');
+    const dequeueSub =   '-^';
+    const source = cold( '-a|');
+    const expected =     '-a|';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+    expectSubscriptions(dequeue.subscriptions).toBe(dequeueSub);
+  });
+
+  it('should unsubscribe from the dequeue trigger when the source observable completes and all remaining buffered ' +
+    'values are dequeued', () => {
+    const dequeue = cold('---a');
+    const dequeueSub =   '-^--!';
+    const source = cold( '-a|');
+    const expected =     '-a|';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+    expectSubscriptions(dequeue.subscriptions).toBe(dequeueSub);
+  });
+
+  it('should not emit any values and complete with an empty source', () => {
+    const dequeue = EMPTY;
+    const source = EMPTY;
+    const expected = '|';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+  });
+
+  it('should not emit any values and never complete or error with a "never" source', () => {
+    const dequeue = EMPTY;
+    const source = NEVER;
+    const expected = '-';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest).toBe(expected);
+  });
+
+  it('should always emit all values with a "never" dequeue source', () => {
+    const dequeue = NEVER as Observable<string>;
+    const source = cold('a-b-c-d-e-f-g-h');
+    const subA =        '^';
+    const expectedA =   'a-b-c-d-e-f-g-h';
+    const subB =        '---------------^';
+    const expectedB =   '---------------(abcdefgh)';
+    const subC =        '--------------------^';
+    const expectedC =   '--------------------(abcdefgh)';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest, subA).toBe(expectedA);
+    expectObservable(dequeueTest, subB).toBe(expectedB);
+    expectObservable(dequeueTest, subC).toBe(expectedC);
+  });
+
+  it('should always emit all values with an "empty" dequeue source', () => {
+    const dequeue = EMPTY as Observable<string>;
+    const source = cold('a-b-c-d-e-f-g-h');
+    const subA =        '^';
+    const expectedA =   'a-b-c-d-e-f-g-h';
+    const subB =        '---------------^';
+    const expectedB =   '---------------(abcdefgh)';
+    const subC =        '--------------------^';
+    const expectedC =   '--------------------(abcdefgh)';
+
+    const dequeueTest = source.pipe(dequeueReplay(dequeue));
+
+    expectObservable(dequeueTest, subA).toBe(expectedA);
+    expectObservable(dequeueTest, subB).toBe(expectedB);
+    expectObservable(dequeueTest, subC).toBe(expectedC);
+  });
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,6 +11,7 @@ export { Subject } from './internal/Subject';
 export { BehaviorSubject } from './internal/BehaviorSubject';
 export { ReplaySubject } from './internal/ReplaySubject';
 export { AsyncSubject } from './internal/AsyncSubject';
+export { DequeueReplaySubject } from './internal/DequeueReplaySubject';
 
 /* Schedulers */
 export { asap as asapScheduler } from './internal/scheduler/asap';

--- a/src/internal/DequeueReplaySubject.ts
+++ b/src/internal/DequeueReplaySubject.ts
@@ -1,0 +1,75 @@
+import { Observable } from './Observable';
+import { Subject } from './Subject';
+import { Subscription } from './Subscription';
+import { PartialObserver } from './types';
+import { toSubscriber } from './util/toSubscriber';
+
+/**
+ * A variant of {@link Subject} that "replays" old values to new subscribers by emitting them when they first subscribe.
+ *
+ * While similar in behavior to {@link ReplaySubject}, `DequeueReplaySubject` allows the "old" values to be removed by
+ * specifying a "dequeue trigger" {@link Observable}. Any values emitted from the "dequeue trigger" are removed from the
+ * array of "old" values if they are present, and will not be emitted to future subscribers.
+ *
+ * `DequeueReplaySubject` subscribes to the "dequeue trigger" Observable the first time a value is emitted, before the
+ * value is added to the internal array of values, and before the value is re-emitted. This allows values to be
+ * "dequeued" immediately. The "dequeue trigger" subscription remains active until the `DequeueReplaySubject` completes
+ * AND all queued events have been dequeued, OR the "dequeue trigger" Observable errors. If the "dequeue trigger"
+ * errors, the `DequeueReplaySubject` will also emit the same error. If this behavior is undesired, pipe the
+ * "dequeue trigger" Observable through the {@link catchError} operator before passing it to the `DequeueReplaySubect`
+ * constructor.
+ *
+ * @see {@link dequeueReplay}
+ */
+export class DequeueReplaySubject<T> extends Subject<T> {
+  private readonly _events: T[] = [];
+  private _dequeueSub: Subscription | undefined = undefined;
+
+  constructor(private dequeueTrigger: Observable<T>) {
+    super();
+  }
+
+  next(value: T): void {
+    this._dequeue();
+    this._events.push(value);
+    super.next(value);
+  }
+
+  subscribe(observer?: PartialObserver<T>): Subscription;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
+  /** @deprecated Use an observer instead of an error callback */
+  subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
+  /** @deprecated Use an observer instead of a complete callback */
+  subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
+  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
+  subscribe(observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
+            error?: ((error: any) => void) | null,
+            complete?: (() => void) | null): Subscription {
+    const sink = toSubscriber(observerOrNext, error, complete);
+    this._events.forEach(sink.next.bind(sink));
+    return super.subscribe(sink);
+  }
+
+  /** @internal */
+  _dequeue(): void {
+    if (!this._dequeueSub) {
+      this._dequeueSub = this.dequeueTrigger.subscribe(
+        this._dequeueNext.bind(this),
+        this.error.bind(this),
+      );
+    }
+  }
+
+  /** @internal */
+  _dequeueNext(event: T): void {
+    const index = this._events.indexOf(event);
+    if (index >= 0) {
+      this._events.splice(index, 1);
+    }
+    if (this.isStopped && !this._events.length && this._dequeueSub) {
+      this._dequeueSub.unsubscribe();
+    }
+  }
+
+}

--- a/src/internal/operators/dequeueReplay.ts
+++ b/src/internal/operators/dequeueReplay.ts
@@ -1,0 +1,54 @@
+import { DequeueReplaySubject } from '../DequeueReplaySubject';
+import { Observable } from '../Observable';
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
+import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+
+/**
+ * Returns a new {@link Observable} that stores emitted values in an internal queue, and replays them to subsequent
+ * subscribers. The queued values are removed from the internal queue when they are emitted from `dequeueTrigger`.
+ *
+ * ![](dequeueReplay.png)
+ *
+ * @see {@link DequeueReplaySubject}
+ * @see {@link ReplaySubject}
+ * @see {@link publishReplay}
+ *
+ * @param dequeueTrigger An {@link Observable} that emits values to be removed from the internal queue of events
+ */
+export function dequeueReplay<T>(dequeueTrigger: Observable<T>, ): MonoTypeOperatorFunction<T> {
+  return (source: Observable<T>) => source.lift(new DequeueReplayOperator(dequeueTrigger));
+}
+
+class DequeueReplayOperator<T> implements Operator<T, T> {
+
+  private readonly subject: DequeueReplaySubject<T>;
+  private readonly sources: Set<any> = new Set<any>();
+  private sourceSub: Subscription | undefined = undefined;
+
+  constructor(dequeueTrigger: Observable<T>) {
+    this.subject = new DequeueReplaySubject<T>(dequeueTrigger);
+  }
+
+  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
+    this._addSource(source);
+    return this.subject.subscribe(subscriber);
+  }
+
+  _addSource(source: any): void {
+    if (this.sources.has(source)) {
+      return;
+    }
+
+    const sub = source.subscribe(this.subject);
+    this.sources.add(source);
+
+    if (this.sourceSub) {
+      this.sourceSub.add(sub);
+    } else {
+      this.sourceSub = sub;
+    }
+  }
+
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -22,6 +22,7 @@ export { defaultIfEmpty } from '../internal/operators/defaultIfEmpty';
 export { delay } from '../internal/operators/delay';
 export { delayWhen } from '../internal/operators/delayWhen';
 export { dematerialize } from '../internal/operators/dematerialize';
+export { dequeueReplay } from '../internal/operators/dequeueReplay';
 export { distinct } from '../internal/operators/distinct';
 export { distinctUntilChanged } from '../internal/operators/distinctUntilChanged';
 export { distinctUntilKeyChanged } from '../internal/operators/distinctUntilKeyChanged';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [x] Add the operator to Rx
- [x] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [x] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [x] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [x] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [x] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [x] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [x] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Add a new Subject subtype, DequeueReplaySubject, which can replay events like ReplaySubject, but also remove events from its internal buffer using a "dequeue trigger" Observable.