### PR TITLE
Deprecate toPromise.

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -348,8 +348,11 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /* tslint:disable:max-line-length */
+  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
   toPromise<T>(this: Observable<T>): Promise<T | undefined>;
+  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
   toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T | undefined>;
+  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
   toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;
   /* tslint:enable:max-line-length */
 
@@ -364,6 +367,7 @@ export class Observable<T> implements Subscribable<T> {
    * rejects on an error. If there were no emissions, Promise
    * resolves with undefined.
    */
+  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
   toPromise(promiseCtor?: PromiseConstructorLike): Promise<T | undefined> {
     promiseCtor = getPromiseCtor(promiseCtor);
 

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -366,8 +366,8 @@ export class Observable<T> implements Subscribable<T> {
    * @return A Promise that resolves with the last value emit, or
    * rejects on an error. If there were no emissions, Promise
    * resolves with undefined.
+   * @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead
    */
-  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
   toPromise(promiseCtor?: PromiseConstructorLike): Promise<T | undefined> {
     promiseCtor = getPromiseCtor(promiseCtor);
 


### PR DESCRIPTION
Link to firstValueFrom or lastValueFrom instead.
