### PR TITLE
chore: add default varargs type to endWith

### DIFF
--- a/spec-dtslint/operators/endWith-spec.ts
+++ b/spec-dtslint/operators/endWith-spec.ts
@@ -1,6 +1,6 @@
 import { of, asyncScheduler } from 'rxjs';
 import { endWith } from 'rxjs/operators';
-import { a, b, c, d, e, f, g, h } from '../helpers';
+import { A, B, a, b, c, d, e, f, g, h } from '../helpers';
 
 it('should support a scheduler', () => {
   const r = of(a).pipe(endWith(asyncScheduler)); // $ExpectType Observable<A>
@@ -15,4 +15,10 @@ it('should infer type for N values', () => {
   const r5 = of(a).pipe(endWith(b, c, d, e, f)); // $ExpectType Observable<A | B | C | D | E | F>
   const r6 = of(a).pipe(endWith(b, c, d, e, f, g)); // $ExpectType Observable<A | B | C | D | E | F | G>
   const r7 = of(a).pipe(endWith(b, c, d, e, f, g, h)); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+});
+
+it('should infer correctly with a single specified type', () => {
+  const r0 = of(a).pipe(endWith<A>(a)); // $ExpectType Observable<A>
+  const r1 = of(a).pipe(endWith<A|B>(b)); // $ExpectType Observable<A | B>
+  const r2 = of(a).pipe(endWith<A|B>(a)); // $ExpectType Observable<A | B>
 });

--- a/spec-dtslint/operators/startWith-spec.ts
+++ b/spec-dtslint/operators/startWith-spec.ts
@@ -21,7 +21,7 @@ it('should infer correctly with a scheduler', () => {
   const r4 = of(a).pipe(startWith(b, c, d, e, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E>
   const r5 = of(a).pipe(startWith(b, c, d, e, f, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E | F>
   const r6 = of(a).pipe(startWith(b, c, d, e, f, g, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E | F | G>
-  });
+});
 
 it('should infer correctly with a single specified type', () => {
   const r0 = of(a).pipe(startWith<A>(a)); // $ExpectType Observable<A>

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -19,7 +19,7 @@ export function endWith<T, A, B, C, D, E>(v1: A, v2: B, v3: C, v4: D, v5: E, sch
 /** @deprecated use {@link scheduled} and {@link concatAll} (e.g. `scheduled([source, [a, b, c]], scheduler).pipe(concatAll())`) */
 export function endWith<T, A, B, C, D, E, F>(v1: A, v2: B, v3: C, v4: D, v5: E, v6: F, scheduler: SchedulerLike): OperatorFunction<T, T | A | B | C | D | E | F>;
 
-export function endWith<T, A extends any[]>(...args: A): OperatorFunction<T, T | ValueFromArray<A>>;
+export function endWith<T, A extends any[] = T[]>(...args: A): OperatorFunction<T, T | ValueFromArray<A>>;
 
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR makes a change to the `endWith` signature that's similar to the one made to `startWith` - in #5383 - and adds a dtslint test.

**Related issue (if exists):** #5383
