### PR TITLE
docs(groupBy): update groupBy docs

### DIFF
--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -25,7 +25,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  * {@link GroupedObservable} for this key is created and emits.
  *
  * A {@link GroupedObservable} represents values belonging to the same group represented by a common key. The common
- * key is available as the key field of a {@link GroupedObservable} instance.
+ * key is available as the `key` field of a {@link GroupedObservable} instance.
  *
  * The elements emitted by {@link GroupedObservable}s are by default the items emitted by the Observable, or elements
  * returned by the elementSelector function.
@@ -46,7 +46,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  *   {id: 3, name: 'TSLint'}
  * ).pipe(
  *   groupBy(p => p.id),
- *   mergeMap((group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], []))),
+ *   mergeMap((group$) => group$.pipe(reduce((acc, cur) => [...acc, cur], [])))
  * )
  * .subscribe(p => console.log(p));
  *
@@ -95,6 +95,8 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?:
  * @param {function(grouped: GroupedObservable<K,R>): Observable<any>} [durationSelector]
  * A function that returns an Observable to determine how long each group should
  * exist.
+ * @param {function(): Subject<R>} [subjectSelector] Factory function to create an
+ * intermediate Subject through which grouped elements are emitted.
  * @return {Observable<GroupedObservable<K,R>>} An Observable that emits
  * GroupedObservables, each of which corresponds to a unique key value and each
  * of which emits those items from the source Observable that share that key


### PR DESCRIPTION
I have three small changes/additions in `groupBy` docs:

* added better formatting for GroupedObservable's `key` field;
* removed extra comma from example;
* added subjectSelector param to docs.