### PR TITLE
fix(Subject): no default generic

### DIFF
--- a/spec-dtslint/AsyncSubject-spec.ts
+++ b/spec-dtslint/AsyncSubject-spec.ts
@@ -1,0 +1,42 @@
+import { AsyncSubject } from 'rxjs';
+
+describe('AsyncSubject', () => {
+  it('should handle no generic appropriately', () => {
+    const s1 = new AsyncSubject(); // $ExpectType AsyncSubject<unknown>
+    s1.next(); // $ExpectError
+    s1.next('test'); // $ExpectType void
+    s1.subscribe(value => {
+      const x = value; // $ExpectType unknown
+    });
+  });
+
+  it('should handle a generic of string appropriately', () => {
+    const s1 = new AsyncSubject<string>(); // $ExpectType AsyncSubject<string>
+    s1.next(); // $ExpectError
+    s1.next('test'); // $ExpectType void
+    s1.next(32); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType string
+    });
+  });
+
+  it('should handle a generic of void appropriately', () => {
+    const s1 = new AsyncSubject<void>(); // $ExpectType AsyncSubject<void>
+    s1.next(); // $ExpectType void
+    s1.next(undefined); // $ExpectType void
+    s1.next('test'); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType void
+    });
+  });
+
+  describe('asObservable', () => {
+    it('should return an observable of the same generic type', () => {
+      const s1 = new AsyncSubject();
+      const o1 = s1.asObservable(); // $ExpectType Observable<unknown>
+
+      const s2 = new AsyncSubject<string>();
+      const o2 = s2.asObservable(); // $ExpectType Observable<string>
+    });
+  });
+});

--- a/spec-dtslint/BehaviorSubject-spec.ts
+++ b/spec-dtslint/BehaviorSubject-spec.ts
@@ -1,0 +1,40 @@
+import { BehaviorSubject } from 'rxjs';
+
+describe('BehaviorSubject', () => {
+  it('should handle no generic appropriately', () => {
+    const s1 = new BehaviorSubject(); // $ExpectError
+  });
+
+  it('should handle an argument of string appropriately', () => {
+    const init = 'some string';
+    const s1 = new BehaviorSubject(init); // $ExpectType BehaviorSubject<string>
+    s1.next(); // $ExpectError
+    s1.next('test'); // $ExpectType void
+    s1.next(32); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType string
+    });
+    const v = s1.getValue(); // $ExpectType string
+  });
+
+  it('should handle a generic of void appropriately', () => {
+    const s1 = new BehaviorSubject<void>(undefined); // $ExpectType BehaviorSubject<void>
+    s1.next(); // $ExpectType void
+    s1.next('test'); // $ExpectError
+    s1.next(32); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType void
+    });
+    const v = s1.getValue(); // $ExpectType void
+  });
+
+  describe('asObservable', () => {
+    it('should return an observable of the same generic type', () => {
+      const s1 = new BehaviorSubject('test');
+      const o1 = s1.asObservable(); // $ExpectType Observable<string>
+
+      const s2 = new BehaviorSubject<void>(undefined);
+      const o2 = s2.asObservable(); // $ExpectType Observable<void>
+    });
+  });
+});

--- a/spec-dtslint/ReplaySubject-spec.ts
+++ b/spec-dtslint/ReplaySubject-spec.ts
@@ -1,0 +1,42 @@
+import { ReplaySubject } from 'rxjs';
+
+describe('ReplaySubject', () => {
+  it('should handle no generic appropriately', () => {
+    const s1 = new ReplaySubject(); // $ExpectType ReplaySubject<unknown>
+    s1.next(); // $ExpectError
+    s1.next('test'); // $ExpectType void
+    s1.subscribe(value => {
+      const x = value; // $ExpectType unknown
+    });
+  });
+
+  it('should handle a generic of string appropriately', () => {
+    const s1 = new ReplaySubject<string>(); // $ExpectType ReplaySubject<string>
+    s1.next(); // $ExpectError
+    s1.next('test'); // $ExpectType void
+    s1.next(32); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType string
+    });
+  });
+
+  it('should handle a generic of void appropriately', () => {
+    const s1 = new ReplaySubject<void>(); // $ExpectType ReplaySubject<void>
+    s1.next(); // $ExpectType void
+    s1.next(undefined); // $ExpectType void
+    s1.next('test'); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType void
+    });
+  });
+
+  describe('asObservable', () => {
+    it('should return an observable of the same generic type', () => {
+      const s1 = new ReplaySubject();
+      const o1 = s1.asObservable(); // $ExpectType Observable<unknown>
+
+      const s2 = new ReplaySubject<string>();
+      const o2 = s2.asObservable(); // $ExpectType Observable<string>
+    });
+  });
+});

--- a/spec-dtslint/Subject-spec.ts
+++ b/spec-dtslint/Subject-spec.ts
@@ -1,0 +1,42 @@
+import { Subject } from 'rxjs';
+
+describe('Subject', () => {
+  it('should handle no generic appropriately', () => {
+    const s1 = new Subject(); // $ExpectType Subject<unknown>
+    s1.next(); // $ExpectError
+    s1.next('test'); // $ExpectType void
+    s1.subscribe(value => {
+      const x = value; // $ExpectType unknown
+    });
+  });
+
+  it('should handle a generic of string appropriately', () => {
+    const s1 = new Subject<string>(); // $ExpectType Subject<string>
+    s1.next(); // $ExpectError
+    s1.next('test'); // $ExpectType void
+    s1.next(32); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType string
+    });
+  });
+
+  it('should handle a generic of void appropriately', () => {
+    const s1 = new Subject<void>(); // $ExpectType Subject<void>
+    s1.next(); // $ExpectType void
+    s1.next(undefined); // $ExpectType void
+    s1.next('test'); // $ExpectError
+    s1.subscribe(value => {
+      const x = value; // $ExpectType void
+    });
+  });
+
+  describe('asObservable', () => {
+    it('should return an observable of the same generic type', () => {
+      const s1 = new Subject();
+      const o1 = s1.asObservable(); // $ExpectType Observable<unknown>
+
+      const s2 = new Subject<string>();
+      const o2 = s2.asObservable(); // $ExpectType Observable<string>
+    });
+  });
+});

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -7,14 +7,13 @@ import { delay } from 'rxjs/operators';
 /** @test {Subject} */
 describe('Subject', () => {
 
-  it('should allow next with empty, undefined or any when created with no type', (done: MochaDone) => {
+  it('should allow next with undefined or any when created with no type', (done: MochaDone) => {
     const subject = new Subject();
     subject.subscribe(x => {
       expect(x).to.be.a('undefined');
     }, null, done);
 
     const data: any = undefined;
-    subject.next();
     subject.next(undefined);
     subject.next(data);
     subject.complete();

--- a/spec/observables/dom/animationFrames-spec.ts
+++ b/spec/observables/dom/animationFrames-spec.ts
@@ -124,7 +124,7 @@ describe('animationFrame', () => {
   });
 
   it('should compose with takeUntil', () => {
-    const subject = new Subject();
+    const subject = new Subject<void>();
     const results: any[] = [];
     const source$ = animationFrames();
     expect(requestAnimationFrame).not.to.have.been.called;

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -190,7 +190,7 @@ describe('take operator', () => {
 
   it('should complete when the source is reentrant', () => {
     let completed = false;
-    const source = new Subject();
+    const source = new Subject<void>();
     source.pipe(take(5)).subscribe({
       next() {
         source.next();

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -25,7 +25,7 @@ export class SubjectSubscriber<T> extends Subscriber<T> {
  *
  * @class Subject<T>
  */
-export class Subject<T = void> extends Observable<T> implements SubscriptionLike {
+export class Subject<T> extends Observable<T> implements SubscriptionLike {
 
   [rxSubscriberSymbol]() {
     return new SubjectSubscriber(this);
@@ -41,13 +41,10 @@ export class Subject<T = void> extends Observable<T> implements SubscriptionLike
 
   thrownError: any = null;
 
-  constructor() {
-    super();
-  }
-
-  /**@nocollapse
+  /**
+   * @nocollapse
    * @deprecated use new Subject() instead
-  */
+   */
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
   }


### PR DESCRIPTION
- Changes Subject to not have a default generic of `void`
- Adds dtslint tests for Subject, ReplaySubject, BehaviorSubject, and AsyncSubject

BREAKING CHANGE: `new Subject()` will return `Subject<unknown>`.
