### PR TITLE
fix: finalize after unsubscription from source

### DIFF
--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { finalize, map, share } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { of, timer, interval, NEVER } from 'rxjs';
+import { of, timer, interval, NEVER, Observable } from 'rxjs';
 import { asInteropObservable } from '../helpers/interop-helper';
 
 declare const type: Function;
@@ -180,5 +180,17 @@ describe('finalize operator', () => {
       finalize(() => finalized.push('sink'))
     ).subscribe();
     expect(finalized).to.deep.equal(['source', 'sink']);
+  });
+
+  it('should finalize after the teardown', () => {
+    const order: string[] = [];
+    const source = new Observable<void>(() => {
+      return () => order.push('teardown');
+    });
+    const subscription = source.pipe(
+      finalize(() => order.push('finalize'))
+    ).subscribe();
+    subscription.unsubscribe();
+    expect(order).to.deep.equal(['teardown', 'finalize']);
   });
 });

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -172,4 +172,13 @@ describe('finalize operator', () => {
     subscription.unsubscribe();
     expect(finalized).to.be.true;
   });
+
+  it('should finalize sources before sinks', () => {
+    const finalized: string[] = [];
+    of(42).pipe(
+      finalize(() => finalized.push('source')),
+      finalize(() => finalized.push('sink'))
+    ).subscribe();
+    expect(finalized).to.deep.equal(['source', 'sink']);
+  });
 });

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -193,4 +193,16 @@ describe('finalize operator', () => {
     subscription.unsubscribe();
     expect(order).to.deep.equal(['teardown', 'finalize']);
   });
+
+  it('should finalize after the teardown with synchronous completion', () => {
+    const order: string[] = [];
+    const source = new Observable<void>(subscriber => {
+      subscriber.complete();
+      return () => order.push('teardown');
+    });
+    source.pipe(
+      finalize(() => order.push('finalize'))
+    ).subscribe();
+    expect(order).to.deep.equal(['teardown', 'finalize']);
+  });
 });

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -1,6 +1,5 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 import { subscribeWith } from '../util/subscribeWith';

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -79,8 +79,15 @@ class FinallyOperator<T> implements Operator<T, T> {
  * @extends {Ignored}
  */
 class FinallySubscriber<T> extends Subscriber<T> {
-  constructor(destination: Subscriber<T>, callback: () => void) {
+  constructor(destination: Subscriber<T>, private callback?: () => void) {
     super(destination);
-    this.add(new Subscription(callback));
+  }
+  unsubscribe() {
+    super.unsubscribe();
+    const { callback } = this;
+    if (callback) {
+      callback();
+      this.callback = undefined;
+    }
   }
 }

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -68,25 +68,8 @@ class FinallyOperator<T> implements Operator<T, T> {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return subscribeWith(source, new FinallySubscriber(subscriber, this.callback));
-  }
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class FinallySubscriber<T> extends Subscriber<T> {
-  constructor(destination: Subscriber<T>, private callback?: () => void) {
-    super(destination);
-  }
-  unsubscribe() {
-    super.unsubscribe();
-    const { callback } = this;
-    if (callback) {
-      callback();
-      this.callback = undefined;
-    }
+    const subscription = subscribeWith(source, subscriber);
+    subscription.add(this.callback);
+    return subscription;
   }
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] If possible, write a `asDiagram` test case too, for PNG diagram generation purposes
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes the implementation of `finalize` so that the callback passed to the operator is not called until *after* the subscriber unsubscribes from its source. The effect of this is that - with this change - finalization happens in same order as completion and unsubscription.

Specifically, with unsubscription, we can be sure that when a subscription's `unsubscribe` method returns, every source observable in the chain will have been guaranteed to have been unsubscribed.

Without this change, `finalize`'s behaviour is very different to that of unsubsciption.

The problem is that when `finalize` calls its callback, the observable to which it is applied is still subscribed to any sources and any `finalize` operators applied to sources further up the composed chain will not have called their finalization callbacks.

Aside from this behaviour being surprising, it makes `finalize` pretty much useless for resource management. For example, if there are observables that use and release some resource:

```ts
const a = /* whatever */.pipe(finalize(() => /* release some sub-resource */));
const b = /* whatever */.pipe(finalize(() => /* release some sub-resource */));
```

and are composed into another observable:

```ts
const c = merge(a, b).pipe(finalize(() => /* release the resource */);
```

the `finalize` calls will not do what you would expect, as the calls to release the sub-resources in `a` and `b` will happen *after* the release of the resource itself occurs in `c` and - depending upon the resource - that can effect an error.

**Why the call order is weird without this change:**

The order in which the callbacks are called is weird because the `finalize` operator adds the callback to the `Subscription`:

https://github.com/ReactiveX/rxjs/blob/dfa239d41b97504312fa95e13f4d593d95b49c4b/src/internal/operators/finalize.ts#L80-L85

It's added in the `Subscription` constructor, so the callback is the **first** teardown in the subscription. The subscription to the source is going to be added **after** that:

https://github.com/ReactiveX/rxjs/blob/dfa239d41b97504312fa95e13f4d593d95b49c4b/src/internal/operators/finalize.ts#L70-L72

https://github.com/ReactiveX/rxjs/blob/dfa239d41b97504312fa95e13f4d593d95b49c4b/src/internal/Observable.ts#L212-L222

**It's a breaking change:**

Although the re-ordering of the `finalize` calls broke none of the existing tests, this is a breaking change, but it's a change for the better, IMO.

**Related issue (if exists):** See #5372 and issues linked therein.