### PR TITLE
feat(groupBy): Add typeguards support for groupBy

### DIFF
--- a/spec-dtslint/operators/groupBy-spec.ts
+++ b/spec-dtslint/operators/groupBy-spec.ts
@@ -1,5 +1,5 @@
 import { of, Subject, GroupedObservable } from 'rxjs';
-import { groupBy } from 'rxjs/operators';
+import { groupBy, mergeMap } from 'rxjs/operators';
 
 it('should infer correctly', () => {
   const o = of(1, 2, 3).pipe(groupBy(value => value.toString())); // $ExpectType Observable<GroupedObservable<string, number>>
@@ -46,4 +46,39 @@ it('should enforce types of duration selector', () => {
 it('should enforce types of subject selector', () => {
   const o = of(1, 2, 3).pipe(groupBy(value => value.toString(), undefined, undefined, () => 'nope')); // $ExpectError
   const p = of(1, 2, 3).pipe(groupBy(value => value.toString(), undefined, undefined, (value) => new Subject<string>())); // $ExpectError
+});
+
+it('should support a user-defined type guard', () => {
+  function isNumber(value: string | number): value is number {
+    return typeof value === 'number';
+  }
+  const o = of('a', 1, 'b', 2).pipe(
+    groupBy(isNumber),
+    mergeMap((group) => {
+      if (group.key) {
+        const inferred = group; // $ExpectType GroupedObservable<true, number>
+        return inferred;
+      } else {
+        const inferred = group; // $ExpectType GroupedObservable<false, string>
+        return inferred;
+      }
+    })
+  );
+  const inferred = o; // $ExpectType Observable<string | number>
+});
+
+it('should support an inline user-defined type guard', () => {
+  const o = of('a', 1, 'b', 2).pipe(
+    groupBy((value): value is number => typeof value === 'number'),
+    mergeMap((group) => {
+      if (group.key) {
+        const inferred = group; // $ExpectType GroupedObservable<true, number>
+        return inferred;
+      } else {
+        const inferred = group; // $ExpectType GroupedObservable<false, string>
+        return inferred;
+      }
+    })
+  );
+  const inferred = o; // $ExpectType Observable<string | number>
 });

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -6,7 +6,7 @@ import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
-export function groupBy<T, K extends T>(keySelector: (value: K) => value is K): OperatorFunction<T, GroupedObservable<true, K> | GroupedObservable<false, Exclude<T, K>>>;
+export function groupBy<T, K extends T>(keySelector: (value: T) => value is K): OperatorFunction<T, GroupedObservable<true, K> | GroupedObservable<false, Exclude<T, K>>>;
 export function groupBy<T, K>(keySelector: (value: T) => K): OperatorFunction<T, GroupedObservable<K, T>>;
 export function groupBy<T, K>(keySelector: (value: T) => K, elementSelector: void, durationSelector: (grouped: GroupedObservable<K, T>) => Observable<any>): OperatorFunction<T, GroupedObservable<K, T>>;
 export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?: (value: T) => R, durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>): OperatorFunction<T, GroupedObservable<K, R>>;

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -6,6 +6,7 @@ import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
+export function groupBy<T, K extends T>(keySelector: (value: K) => value is K): OperatorFunction<T, GroupedObservable<true, K> | GroupedObservable<false, Exclude<T, K>>>;
 export function groupBy<T, K>(keySelector: (value: T) => K): OperatorFunction<T, GroupedObservable<K, T>>;
 export function groupBy<T, K>(keySelector: (value: T) => K, elementSelector: void, durationSelector: (grouped: GroupedObservable<K, T>) => Observable<any>): OperatorFunction<T, GroupedObservable<K, T>>;
 export function groupBy<T, K, R>(keySelector: (value: T) => K, elementSelector?: (value: T) => R, durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>): OperatorFunction<T, GroupedObservable<K, R>>;


### PR DESCRIPTION
A couple of notes here. I couldn't figure out how to test this since it doesn't work in oldish versions of TS like 2.8 which is where the dtslint tests run. If there was some way to enable/disable for TS versions that would be one solution.

Note that in the example in #5439 you need to test `key === true` in order to get the type checking to work for both the if and else blocks. This may be related to https://github.com/Microsoft/TypeScript/issues/26852

Another item and this is probably a TS issue is that while all 4 of the following usages work, the 5th one, using an inline type guard with no explicit arg type, doesn't work. I'm guessing there's some TS weirdness going on that's probably a bug but I can't explain what is making it behave that way

```ts
function isNumberFromAny(input: any): input is number {
  return typeof input === 'number';
}

function isNumberFromStringOrNumber(input: string | number): input is number {
  return typeof input === 'number';
}

// Works!
of('a', 1, 'b', 2).pipe(
  groupBy((x: any): x is number => typeof x === 'number'),
  mergeMap(group => {
    if (group.key === true) {
        group.subscribe(x => x.toExponential(1)); // x is number here
    } else {
        group.subscribe(x => x.toLowerCase()); // x is string here
    }
    return group;
  })
);

// Works!
of('a', 1, 'b', 2).pipe(
  groupBy((x: string | number): x is number => typeof x === 'number'),
  mergeMap(group => {
    if (group.key === true) {
        group.subscribe(x => x.toExponential(1)); // x is number here
    } else {
        group.subscribe(x => x.toLowerCase()); // x is string here
    }
    return group;
  })
);

// Works!
of('a', 1, 'b', 2).pipe(
  groupBy(isNumberFromAny),
  mergeMap(group => {
    if (group.key === true) {
        group.subscribe(x => x.toExponential(1)); // x is number here
    } else {
        group.subscribe(x => x.toLowerCase()); // x is string here
    }
    return group;
  })
);


// Works!
of('a', 1, 'b', 2).pipe(
  groupBy(isNumberFromStringOrNumber),
  mergeMap(group => {
    if (group.key === true) {
        group.subscribe(x => x.toExponential(1)); // x is number here
    } else {
        group.subscribe(x => x.toLowerCase()); // x is string here
    }
    return group;
  })
);

// THIS IS BUSTED!
of('a', 1, 'b', 2).pipe(
  groupBy((x): x is number => typeof x === 'number'),
  mergeMap(group => {
    if (group.key === true) {
        // group is GroupedObservable<true, string | number>
        group.subscribe(x => x.toExponential(1))
    } else {
        // group is GroupedObservable<false, never>
        group.subscribe(x => x.toLowerCase())
    }
    return group;
  })
);
```