### PR TITLE
docs(operators): fix `@return` docs

### DIFF
--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -46,7 +46,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @param durationSelector A function
  * that receives a value from the source Observable, for computing the silencing
  * duration, returned as an Observable or a Promise.
- * @return An Observable that performs rate-limiting of
+ * @return A function that returns an Observable that performs rate-limiting of
  * emissions from the source Observable.
  */
 export function audit<T>(durationSelector: (value: T) => ObservableInput<any>): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/auditTime.ts
+++ b/src/internal/operators/auditTime.ts
@@ -47,7 +47,7 @@ import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
  * by the optional `scheduler`.
  * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for
  * managing the timers that handle the rate-limiting behavior.
- * @return {Observable<T>} An Observable that performs rate-limiting of
+ * @return A function that returns an Observable that performs rate-limiting of
  * emissions from the source Observable.
  */
 export function auditTime<T>(duration: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -39,8 +39,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param {Observable<any>} closingNotifier An Observable that signals the
  * buffer to be emitted on the output Observable.
- * @return {Observable<T[]>} An Observable of buffers, which are arrays of
- * values.
+ * @return A function that returns an Observable of buffers, which are arrays
+ * of values.
  */
 export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -54,7 +54,7 @@ import { arrRemove } from '../util/arrRemove';
  * For example if `startBufferEvery` is `2`, then a new buffer will be started
  * on every other value from the source. A new buffer is started at the
  * beginning of the source by default.
- * @return {Observable<T[]>} An Observable of arrays of buffered values.
+ * @return A function that returns an Observable of arrays of buffered values.
  */
 export function bufferCount<T>(bufferSize: number, startBufferEvery: number | null = null): OperatorFunction<T, T[]> {
   // If no `startBufferEvery` value was supplied, then we're

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -74,7 +74,7 @@ export function bufferTime<T>(
  * @param {number} [maxBufferSize] The maximum buffer size.
  * @param {SchedulerLike} [scheduler=async] The scheduler on which to schedule the
  * intervals that determine buffer boundaries.
- * @return {Observable<T[]>} An observable of arrays of buffered values.
+ * @return A function that returns an Observable of arrays of buffered values.
  */
 export function bufferTime<T>(bufferTimeSpan: number, ...otherArgs: any[]): OperatorFunction<T, T[]> {
   const scheduler = popScheduler(otherArgs) ?? asyncScheduler;

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -48,7 +48,7 @@ import { arrRemove } from '../util/arrRemove';
  * the value emitted by the `openings` observable and returns a Subscribable or Promise,
  * which, when it emits, signals that the associated buffer should be emitted
  * and cleared.
- * @return An observable of arrays of buffered values.
+ * @return A function that returns an Observable of arrays of buffered values.
  */
 export function bufferToggle<T, O>(
   openings: ObservableInput<O>,

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -43,7 +43,7 @@ import { innerFrom } from '../observable/from';
  *
  * @param {function(): Observable} closingSelector A function that takes no
  * arguments and returns an Observable that signals buffer closure.
- * @return {Observable<T[]>} An observable of arrays of buffered values.
+ * @return A function that returns an Observable of arrays of buffered values.
  */
 export function bufferWhen<T>(closingSelector: () => ObservableInput<any>): OperatorFunction<T, T[]> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -97,11 +97,11 @@ export function catchError<T, O extends ObservableInput<any>>(
  * @see {@link retry }
  * @see {@link retryWhen}
  *
- *  @param {function} selector a function that takes as arguments `err`, which is the error, and `caught`, which
- *  is the source observable, in case you'd like to "retry" that observable by returning it again. Whatever observable
- *  is returned by the `selector` will be used to continue the observable chain.
- * @return {Observable} An observable that originates from either the source or the observable returned by the
- *  catch `selector` function.
+ * @param {function} selector a function that takes as arguments `err`, which is the error, and `caught`, which
+ * is the source observable, in case you'd like to "retry" that observable by returning it again. Whatever observable
+ * is returned by the `selector` will be used to continue the observable chain.
+ * @return A function that returns an Observable that originates from either
+ * the source or the Observable returned by the `selector` function.
  */
 export function catchError<T, O extends ObservableInput<any>>(
   selector: (err: any, caught: Observable<T>) => O

--- a/src/internal/operators/combineLatestAll.ts
+++ b/src/internal/operators/combineLatestAll.ts
@@ -6,6 +6,7 @@ export function combineLatestAll<T>(): OperatorFunction<ObservableInput<T>, T[]>
 export function combineLatestAll<T>(): OperatorFunction<any, T[]>;
 export function combineLatestAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
 export function combineLatestAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
+
 /**
  * Flattens an Observable-of-Observables by applying {@link combineLatest} when the Observable-of-Observables completes.
  *
@@ -50,6 +51,8 @@ export function combineLatestAll<R>(project: (...values: Array<any>) => R): Oper
  *
  * @param project optional function to map the most recent values from each inner Observable into a new result.
  * Takes each of the most recent values from each collected inner Observable as arguments, in order.
+ * @return A function that returns an Observable that flattens Observables
+ * emitted by the source Observable.
  */
 export function combineLatestAll<R>(project?: (...values: Array<any>) => R) {
   return joinAllInternals(combineLatest, project);

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -36,6 +36,8 @@ import { combineLatest } from './combineLatest';
  *
  * ```
  * @param otherSources the other sources to subscribe to.
+ * @return A function that returns an Observable that emits the latest
+ * emissions from both source and provided Observables.
  */
 export function combineLatestWith<T, A extends readonly unknown[]>(
   ...otherSources: [...ObservableInputTuple<A>]

--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -54,8 +54,8 @@ import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
  * @see {@link switchMap}
  * @see {@link zipAll}
  *
- * @return {Observable} An Observable emitting values from all the inner
- * Observables concatenated.
+ * @return A function that returns an Observable emitting values from all the
+ * inner Observables concatenated.
  */
 export function concatAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>> {
   return mergeAll(1);

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -71,10 +71,10 @@ export function concatMap<T, R, O extends ObservableInput<any>>(
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @return {Observable} An Observable that emits the result of applying the
- * projection function (and the optional deprecated `resultSelector`) to each item emitted
- * by the source Observable and taking values from each projected inner
- * Observable sequentially.
+ * @return A function that returns an Observable that emits the result of
+ * applying the projection function (and the optional deprecated
+ * `resultSelector`) to each item emitted by the source Observable and taking
+ * values from each projected inner Observable sequentially.
  */
 export function concatMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -66,9 +66,9 @@ export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @return {Observable} An observable of values merged together by joining the
- * passed observable with itself, one after the other, for each value emitted
- * from the source.
+ * @return A function that returns an Observable of values merged together by
+ * joining the passed Observable with itself, one after the other, for each
+ * value emitted from the source.
  */
 export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,

--- a/src/internal/operators/concatWith.ts
+++ b/src/internal/operators/concatWith.ts
@@ -38,6 +38,9 @@ import { concat } from './concat';
  * ```
  *
  * @param otherSources Other observable sources to subscribe to, in sequence, after the original source is complete.
+ * @return A function that returns an Observable that concatenates
+ * subscriptions to the source and provided Observables subscribing to the next
+ * only once the current subscription completes.
  */
 export function concatWith<T, A extends readonly unknown[]>(
   ...otherSources: [...ObservableInputTuple<A>]

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -52,6 +52,8 @@ import { reduce } from './reduce';
  * determine whether or not to increment the count. Return `true` to increment the count,
  * and return `false` to keep the count the same.
  * If the predicate is not provided, every value will be counted.
+ * @return A function that returns an Observable that emits one number that
+ * represents the count of emissions.
  */
 
 export function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number> {

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -58,8 +58,8 @@ import { innerFrom } from '../observable/from';
  * @param durationSelector A function
  * that receives a value from the source Observable, for computing the timeout
  * duration for each source value, returned as an Observable or a Promise.
- * @return An Observable that delays the emissions of the source
- * Observable by the specified duration Observable returned by
+ * @return A function that returns an Observable that delays the emissions of
+ * the source Observable by the specified duration Observable returned by
  * `durationSelector`, and may drop some values if they occur too frequently.
  */
 export function debounce<T>(durationSelector: (value: T) => ObservableInput<any>): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -57,9 +57,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * source value.
  * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for
  * managing the timers that handle the timeout for each value.
- * @return {Observable} An Observable that delays the emissions of the source
- * Observable by the specified `dueTime`, and may drop some values if they occur
- * too frequently.
+ * @return A function that returns an Observable that delays the emissions of
+ * the source Observable by the specified `dueTime`, and may drop some values
+ * if they occur too frequently.
  */
 export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = asyncScheduler): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -32,9 +32,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param defaultValue The default value used if the source
  * Observable is empty.
- * @return An Observable that emits either the specified
- * `defaultValue` if the source Observable emits no items, or the values emitted
- * by the source Observable.
+ * @return A function that returns an Observable that emits either the
+ * specified `defaultValue` if the source Observable emits no items, or the
+ * values emitted by the source Observable.
  */
 export function defaultIfEmpty<T, R>(defaultValue: R): OperatorFunction<T, T | R> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -48,8 +48,8 @@ import { timer } from '../observable/timer';
  * a `Date` until which the emission of the source items is delayed.
  * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for
  * managing the timers that handle the time-shift for each item.
- * @return {Observable} An Observable that delays the emissions of the source
- * Observable by the specified timeout or Date.
+ * @return A function that returns an Observable that delays the emissions of
+ * the source Observable by the specified timeout or Date.
  */
 export function delay<T>(due: number | Date, scheduler: SchedulerLike = asyncScheduler): MonoTypeOperatorFunction<T> {
   const duration = timer(due, scheduler);

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -72,9 +72,9 @@ export function delayWhen<T>(delayDurationSelector: (value: T, index: number) =>
  * until the Observable returned from this function emits a value.
  * @param {Observable} subscriptionDelay An Observable that triggers the
  * subscription to the source Observable once it emits any value.
- * @return {Observable} An Observable that delays the emissions of the source
- * Observable by an amount of time specified by the Observable returned by
- * `delayDurationSelector`.
+ * @return A function that returns an Observable that delays the emissions of
+ * the source Observable by an amount of time specified by the Observable
+ * returned by `delayDurationSelector`.
  */
 export function delayWhen<T>(
   delayDurationSelector: (value: T, index: number) => Observable<any>,

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -47,8 +47,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * ```
  * @see {@link materialize}
  *
- * @return {Observable} An Observable that emits items and notifications
- * embedded in Notification objects emitted by the source Observable.
+ * @return A function that returns an Observable that emits items and
+ * notifications embedded in Notification objects emitted by the source
+ * Observable.
  */
 export function dematerialize<N extends ObservableNotification<any>>(): OperatorFunction<N, ValueFromNotification<N>> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -68,7 +68,8 @@ import { noop } from '../util/noop';
  *
  * @param {function} [keySelector] Optional function to select which value you want to check as distinct.
  * @param {Observable} [flushes] Optional Observable for flushing the internal HashSet of the operator.
- * @return {Observable} An Observable that emits items from the source Observable with distinct values.
+ * @return A function that returns an Observable that emits items from the
+ * source Observable with distinct values.
  */
 export function distinct<T, K>(keySelector?: (value: T) => K, flushes?: Observable<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -90,6 +90,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param comparator A function used to compare the previous and current values for
  * equality. Defaults to a `===` check.
+ * @return A function that returns an Observable that emits items from the
+ * source Observable with distinct values.
  */
 export function distinctUntilChanged<T>(comparator?: (previous: T, current: T) => boolean): MonoTypeOperatorFunction<T>;
 
@@ -134,6 +136,8 @@ export function distinctUntilChanged<T>(comparator?: (previous: T, current: T) =
  * @param comparator A function used to compare the previous and current keys for
  * equality. Defaults to a `===` check.
  * @param keySelector Used to select a key value to be passed to the `comparator`.
+ * @return A function that returns an Observable that emits items from the
+ * source Observable with distinct values.
  */
 export function distinctUntilChanged<T, K>(
   comparator: (previous: K, current: K) => boolean,

--- a/src/internal/operators/distinctUntilKeyChanged.ts
+++ b/src/internal/operators/distinctUntilKeyChanged.ts
@@ -72,7 +72,8 @@ export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare: (
  *
  * @param {string} key String key for object property lookup on each item.
  * @param {function} [compare] Optional comparison function called to test if an item is distinct from the previous item in the source.
- * @return {Observable} An Observable that emits items from the source Observable with distinct values based on the key specified.
+ * @return A function that returns an Observable that emits items from the
+ * source Observable with distinct values based on the key specified.
  */
 export function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare?: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T> {
   return distinctUntilChanged((x: T, y: T) => compare ? compare(x[key], y[key]) : x[key] === y[key]);

--- a/src/internal/operators/elementAt.ts
+++ b/src/internal/operators/elementAt.ts
@@ -49,8 +49,9 @@ import { take } from './take';
  * @param {number} index Is the number `i` for the i-th source emission that has
  * happened since the subscription, starting from the number `0`.
  * @param {T} [defaultValue] The default value returned for missing indices.
- * @return {Observable} An Observable that emits a single item, if it is found.
- * Otherwise, will emit the default value if given. If not, then emits an error.
+ * @return A function that returns an Observable that emits a single item, if
+ * it is found. Otherwise, it will emit the default value if given. If not, it
+ * emits an error.
  */
 export function elementAt<T, D = T>(index: number, defaultValue?: D): OperatorFunction<T, T | D> {
   if (index < 0) {

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -55,7 +55,10 @@ export function endWith<T, A extends unknown[] = T[]>(...args: A): OperatorFunct
  * // "interval ended by click"
  * ```
  *
- * @param values - Items you want the modified Observable to emit last.
+ * @param values Items you want the modified Observable to emit last.
+ * @return A function that returns an Observable that emits all values from the
+ * source, then synchronously emits the provided value(s) immediately after the
+ * source completes.
  *
  * @see {@link startWith}
  * @see {@link concat}

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -35,7 +35,8 @@ export function every<T>(predicate: (value: T, index: number, source: Observable
  *
  * @param {function} predicate A function for determining if an item meets a specified condition.
  * @param {any} [thisArg] Optional object to use for `this` in the callback.
- * @return {Observable} An Observable of booleans that determines if all items of the source Observable meet the condition specified.
+ * @return A function that returns an Observable of booleans that determines if
+ * all items of the source Observable meet the condition specified.
  */
 export function every<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/internal/operators/exhaustAll.ts
+++ b/src/internal/operators/exhaustAll.ts
@@ -43,8 +43,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link exhaustMap}
  * @see {@link zipAll}
  *
- * @return {Observable} An Observable that takes a source of Observables and propagates the first observable
- * exclusively until it completes before subscribing to the next.
+ * @return A function that returns an Observable that takes a source of
+ * Observables and propagates the first Observable exclusively until it
+ * completes before subscribing to the next.
  */
 export function exhaustAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -61,9 +61,9 @@ export function exhaustMap<T, I, R>(
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @return {Observable} An Observable containing projected Observables
- * of each item of the source, ignoring projected Observables that start before
- * their preceding Observable has completed.
+ * @return A function that returns an Observable containing projected
+ * Observables of each item of the source, ignoring projected Observables that
+ * start before their preceding Observable has completed.
  */
 export function exhaustMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -64,9 +64,9 @@ export function expand<T, O extends ObservableInput<unknown>>(
  * Observables being subscribed to concurrently.
  * @param {SchedulerLike} [scheduler=null] The {@link SchedulerLike} to use for subscribing to
  * each projected inner Observable.
- * @return {Observable} An Observable that emits the source values and also
- * result of applying the projection function to each value emitted on the
- * output Observable and merging the results of the Observables obtained
+ * @return A function that returns an Observable that emits the source values
+ * and also result of applying the projection function to each value emitted on
+ * the output Observable and merging the results of the Observables obtained
  * from this transformation.
  */
 export function expand<T, O extends ObservableInput<unknown>>(

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -48,6 +48,8 @@ export function filter<T>(predicate: (value: T, index: number) => boolean): Mono
  * `0`.
  * @param thisArg An optional argument to determine the value of `this`
  * in the `predicate` function.
+ * @return A function that returns an Observable that emits items from the
+ * source Observable that satisfy the specified `predicate`.
  */
 export function filter<T>(predicate: (value: T, index: number) => boolean, thisArg?: any): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -53,7 +53,8 @@ import { operate } from '../util/lift';
  * ```
  *
  * @param {function} callback Function to be called when source terminates.
- * @return {Observable} An Observable that mirrors the source, but will call the specified function on termination.
+ * @return A function that returns an Observable that mirrors the source, but
+ * will call the specified function on termination.
  */
 export function finalize<T>(callback: () => void): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -51,8 +51,8 @@ export function find<T>(predicate: (value: T, index: number, source: Observable<
  * A function called with each item to test for condition matching.
  * @param {any} [thisArg] An optional argument to determine the value of `this`
  * in the `predicate` function.
- * @return {Observable<T>} An Observable of the first item that matches the
- * condition.
+ * @return A function that returns an Observable that emits the first item that
+ * matches the condition.
  */
 export function find<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -45,8 +45,8 @@ export function findIndex<T>(predicate: (value: T, index: number, source: Observ
  * A function called with each item to test for condition matching.
  * @param {any} [thisArg] An optional argument to determine the value of `this`
  * in the `predicate` function.
- * @return {Observable} An Observable of the index of the first item that
- * matches the condition.
+ * @return A function that returns an Observable that emits the index of the
+ * first item that matches the condition.
  */
 export function findIndex<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -70,8 +70,8 @@ export function first<T, D = T>(
  * An optional function called with each item to test for condition matching.
  * @param {R} [defaultValue] The default value emitted in case no valid value
  * was found on the source.
- * @return {Observable<T|R>} An Observable of the first item that matches the
- * condition.
+ * @return A function that returns an Observable that emits the first item that
+ * matches the condition.
  */
 export function first<T, D>(
   predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -110,10 +110,9 @@ export function groupBy<T, K, R>(
  * exist.
  * @param {function(): Subject<R>} [subjectSelector] Factory function to create an
  * intermediate Subject through which grouped elements are emitted.
- * @return {Observable<GroupedObservable<K,R>>} An Observable that emits
- * GroupedObservables, each of which corresponds to a unique key value and each
- * of which emits those items from the source Observable that share that key
- * value.
+ * @return A function that returns an Observable that emits GroupedObservables,
+ * each of which corresponds to a unique key value and each of which emits
+ * those items from the source Observable that share that key value.
  */
 export function groupBy<T, K, R>(
   keySelector: (value: T) => K,

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -31,8 +31,9 @@ import { noop } from '../util/noop';
  * // result:
  * // 'the end'
  * ```
- * @return {Observable} An empty Observable that only calls `complete`
- * or `error`, based on which one is called by the source Observable.
+ * @return A function that returns an empty Observable that only calls
+ * `complete` or `error`, based on which one is called by the source
+ * Observable.
  */
 export function ignoreElements(): OperatorFunction<any, never> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -62,7 +62,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link count}
  * @see {@link index/EMPTY}
  *
- * @return {OperatorFunction<T, boolean>} An Observable of a boolean value indicating whether observable was empty or not.
+ * @return A function that returns an Observable that emits boolean value
+ * indicating whether the source Observable was empty or not.
  */
 export function isEmpty<T>(): OperatorFunction<T, boolean> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -64,8 +64,9 @@ export function last<T, D = T>(
  * @param {function} [predicate] - The condition any source emitted item has to satisfy.
  * @param {any} [defaultValue] - An optional default value to provide if last
  * predicate isn't met or no values were emitted.
- * @return {Observable} An Observable that emits only the last item satisfying the given condition
- * from the source, or an NoSuchElementException if no such items are emitted.
+ * @return A function that returns an Observable that emits only the last item
+ * satisfying the given condition from the source, or a NoSuchElementException
+ * if no such items are emitted.
  * @throws - Throws if no items that match the predicate are emitted by the source Observable.
  */
 export function last<T, D>(

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -39,8 +39,8 @@ export function map<T, R, A>(project: (this: A, value: T, index: number) => R, t
  * subscription, starting from the number `0`.
  * @param {any} [thisArg] An optional argument to define what `this` is in the
  * `project` function.
- * @return {Observable<R>} An Observable that emits the values from the source
- * Observable transformed by the given `project` function.
+ * @return A function that returns an Observable that emits the values from the
+ * source Observable transformed by the given `project` function.
  */
 export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): OperatorFunction<T, R> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -33,8 +33,8 @@ export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
  * @see {@link map}
  *
  * @param {any} value The value to map each source value to.
- * @return {Observable} An Observable that emits the given `value` every time
- * the source Observable emits something.
+ * @return A function that returns an Observable that emits the given `value`
+ * every time the source Observable emits.
  */
 export function mapTo<R>(value: R): OperatorFunction<any, R> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -49,9 +49,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link Notification}
  * @see {@link dematerialize}
  *
- * @return {Observable<Notification<T>>} An Observable that emits
- * {@link Notification} objects that wrap the original emissions from the source
- * Observable with metadata.
+ * @return A function that returns an Observable that emits
+ * {@link Notification} objects that wrap the original emissions from the
+ * source Observable with metadata.
  *
  * @deprecated In version 8, materialize will start to emit {@link ObservableNotification} objects, and not
  * {@link Notification} instances. This means that methods that are not commonly used, like `Notification.observe`

--- a/src/internal/operators/max.ts
+++ b/src/internal/operators/max.ts
@@ -43,7 +43,8 @@ import { isFunction } from '../util/isFunction';
  *
  * @param {Function} [comparer] - Optional comparer function that it will use instead of its default to compare the
  * value of two items.
- * @return {Observable} An Observable that emits item with the largest value.
+ * @return A function that returns an Observable that emits item with the
+ * largest value.
  */
 export function max<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T> {
   return reduce(isFunction(comparer) ? (x, y) => (comparer(x, y) > 0 ? x : y) : (x, y) => (x > y ? x : y));

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -55,8 +55,8 @@ import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
  *
  * @param {number} [concurrent=Infinity] Maximum number of inner
  * Observables being subscribed to concurrently.
- * @return {Observable} An Observable that emits values coming from all the
- * inner Observables emitted by the source Observable.
+ * @return A function that returns an Observable that emits values coming from
+ * all the inner Observables emitted by the source Observable.
  */
 export function mergeAll<O extends ObservableInput<any>>(concurrent: number = Infinity): OperatorFunction<O, ObservedValueOf<O>> {
   return mergeMap(identity, concurrent);

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -73,10 +73,10 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(
  * Observable.
  * @param {number} [concurrent=Infinity] Maximum number of input
  * Observables being subscribed to concurrently.
- * @return {Observable} An Observable that emits the result of applying the
- * projection function (and the optional deprecated `resultSelector`) to each item
- * emitted by the source Observable and merging the results of the Observables
- * obtained from this transformation.
+ * @return A function that returns an Observable that emits the result of
+ * applying the projection function (and the optional deprecated
+ * `resultSelector`) to each item emitted by the source Observable and merging
+ * the results of the Observables obtained from this transformation.
  */
 export function mergeMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -43,14 +43,14 @@ export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(innerObserv
  * the source Observable.
  * @param {number} [concurrent=Infinity] Maximum number of input
  * Observables being subscribed to concurrently.
- * @return {Observable} An Observable that emits items from the given
- * `innerObservable`
+ * @return A function that returns an Observable that emits items from the
+ * given `innerObservable`.
  */
 export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,
   resultSelector?: ((outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R) | number,
   concurrent: number = Infinity
-): OperatorFunction<T, ObservedValueOf<O>|R> {
+): OperatorFunction<T, ObservedValueOf<O> | R> {
   if (isFunction(resultSelector)) {
     return mergeMap(() => innerObservable, resultSelector, concurrent);
   }

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -40,7 +40,7 @@ import { mergeInternals } from './mergeInternals';
  * @param seed The initial accumulation value.
  * @param {number} [concurrent=Infinity] Maximum number of
  * input Observables being subscribed to concurrently.
- * @return {Observable<R>} An observable of the accumulated values.
+ * @return A function that returns an Observable of the accumulated values.
  */
 export function mergeScan<T, R>(
   accumulator: (acc: R, value: T, index: number) => ObservableInput<R>,

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -39,6 +39,8 @@ import { merge } from './merge';
  * // "dblclick"
  * ```
  * @param otherSources the sources to combine the current source with.
+ * @return A function that returns an Observable that merges the values from
+ * all given Observables.
  */
 export function mergeWith<T, A extends readonly unknown[]>(
   ...otherSources: [...ObservableInputTuple<A>]

--- a/src/internal/operators/min.ts
+++ b/src/internal/operators/min.ts
@@ -42,7 +42,8 @@ import { isFunction } from '../util/isFunction';
  *
  * @param {Function} [comparer] - Optional comparer function that it will use instead of its default to compare the
  * value of two items.
- * @return {Observable<R>} An Observable that emits item with the smallest value.
+ * @return A function that returns an Observable that emits item with the
+ * smallest value.
  */
 export function min<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T> {
   return reduce(isFunction(comparer) ? (x, y) => (comparer(x, y) < 0 ? x : y) : (x, y) => (x < y ? x : y));

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -11,6 +11,7 @@ import { connect } from './connect';
  * from the source to all consumers.
  *
  * @param subject The subject to multicast through.
+ * @return A function that returns a {@link ConnectableObservable}
  * @deprecated This will be removed in version 8. Please use the {@link connectable} creation
  * function, which creates a connectable observable. If you were using the {@link refCount} operator
  * on the result of the `multicast` operator, then use the {@link share} operator, which is now
@@ -26,6 +27,7 @@ export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, 
  *
  * @param subject The subject used to multicast.
  * @param selector A setup function to setup the multicast
+ * @return A function that returns an observable that mirrors the observable returned by the selector.
  * @deprecated To be removed in version 8. Please use the new {@link connect} operator.
  * `multicast(subject, fn)` is equivalent to `connect({ connector: () => subject, setup: fn })`.
  */
@@ -42,6 +44,7 @@ export function multicast<T, O extends ObservableInput<any>>(
  * @param subjectFactory A factory that will be called to create the subject. Passing a function here
  * will cause the underlying subject to be "reset" on error, completion, or refCounted unsubscription of
  * the source.
+ * @return A function that returns a {@link ConnectableObservable}
  * @deprecated This will be removed in version 8. Please use the {@link connectable} creation
  * function, which creates a connectable observable. If you were using the {@link refCount} operator
  * on the result of the `multicast` operator, then use the {@link share} operator, which is now
@@ -57,6 +60,7 @@ export function multicast<T>(subjectFactory: () => Subject<T>): UnaryFunction<Ob
  *
  * @param subjectFactory A factory that creates the subject used to multicast.
  * @param selector A function to setup the multicast and select the output.
+ * @return A function that returns an observable that mirrors the observable returned by the selector.
  * @deprecated To be removed in version 8. Please use the new {@link connect} operator.
  * `multicast(subjectFactor, selector)` is equivalent to `connect(selector, { connector: subjectFactory })`.
  */

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -51,8 +51,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param {SchedulerLike} scheduler Scheduler that will be used to reschedule notifications from source Observable.
  * @param {number} [delay] Number of milliseconds that states with what delay every notification should be rescheduled.
- * @return {Observable<T>} Observable that emits the same notifications as the source Observable,
- * but with provided scheduler.
+ * @return A function that returns an Observable that emits the same
+ * notifications as the source Observable, but with provided scheduler.
  */
 export function observeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -75,9 +75,10 @@ export function onErrorResumeNext<T, A extends readonly unknown[]>(
  * @see {@link concat}
  * @see {@link catchError}
  *
- * @param {...ObservableInput} observables Observables passed either directly or as an array.
- * @return {Observable} An Observable that emits values from source Observable, but - if it errors - subscribes
- * to the next passed Observable and so on, until it completes or runs out of Observables.
+ * @param {...ObservableInput} nextSources Observables passed either directly or as an array.
+ * @return A function that returns an Observable that emits values from source
+ * Observable, but - if it errors - subscribes to the next passed Observable
+ * and so on, until it completes or runs out of Observables.
  */
 export function onErrorResumeNext<T, A extends readonly unknown[]>(
   ...sources: [[...ObservableInputTuple<A>]] | [...ObservableInputTuple<A>]

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -40,7 +40,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link buffer}
  * @see {@link bufferCount}
  *
- * @return {Observable<Array<T>>} An Observable of pairs (as arrays) of
+ * @return A function that returns an Observable of pairs (as arrays) of
  * consecutive values from the source Observable.
  */
 export function pairwise<T>(): OperatorFunction<T, [T, T]> {

--- a/src/internal/operators/partition.ts
+++ b/src/internal/operators/partition.ts
@@ -44,9 +44,9 @@ import { UnaryFunction } from '../types';
  * happened since the subscription, starting from the number `0`.
  * @param {any} [thisArg] An optional argument to determine the value of `this`
  * in the `predicate` function.
- * @return {[Observable<T>, Observable<T>]} An array with two Observables: one
- * with values that passed the predicate, and another with values that did not
- * pass the predicate.
+ * @return A function that returns an array with two Observables: one with
+ * values that passed the predicate, and another with values that did not pass
+ * the predicate.
  * @deprecated use `partition` static creation function instead
  */
 export function partition<T>(predicate: (value: T, index: number) => boolean,

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -40,7 +40,8 @@ export function pluck<T>(...properties: string[]): OperatorFunction<T, unknown>;
  *
  * @param properties The nested properties to pluck from each source
  * value.
- * @return A new Observable of property values from the source values.
+ * @return A function that returns an Observable of property values from the
+ * source values.
  * @deprecated Remove in v8. Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`.
  */
 export function pluck<T, R>(...properties: Array<string | number | symbol>): OperatorFunction<T, R> {

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -75,7 +75,8 @@ export function publish<T, O extends ObservableInput<any>>(selector: (shared: Ob
  * @param {Function} [selector] - Optional selector function which can use the multicasted source sequence as many times
  * as needed, without causing multiple subscriptions to the source sequence.
  * Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
- * @return A ConnectableObservable that upon connection causes the source Observable to emit items to its Observers.
+ * @return A function that returns a ConnectableObservable that upon connection
+ * causes the source Observable to emit items to its Observers.
  */
 export function publish<T, R>(selector?: OperatorFunction<T, R>): MonoTypeOperatorFunction<T> | OperatorFunction<T, R> {
   return selector ? connect(selector) : multicast(new Subject<T>());

--- a/src/internal/operators/publishBehavior.ts
+++ b/src/internal/operators/publishBehavior.ts
@@ -7,7 +7,7 @@ import { UnaryFunction } from '../types';
  * Creates a {@link ConnectableObservable} that utilizes a {@link BehaviorSubject}.
  * 
  * @param initialValue The initial value passed to the {@link BehaviorSubject}.
- * @return {ConnectableObservable<T>}
+ * @return A function that returns a {@link ConnectableObservable}
  * @deprecated to be removed in version 8. If you want to get a connectable observable that uses a 
  * {@link BehaviorSubject} under the hood, please use {@link connectable}. `source.pipe(publishBehavior(initValue))` 
  * is equivalent to: `connectable(source, () => new BehaviorSubject(initValue))`.

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -50,7 +50,12 @@ import { UnaryFunction } from '../types';
  * //    "Sub. B Complete"
  * ```
  *
- * @return A connectable observable sequence that contains the elements of a
+ * @see {@link ConnectableObservable}
+ * @see {@link publish}
+ * @see {@link publishReplay}
+ * @see {@link publishBehavior}
+ *
+ * @return A function that returns an Observable that emits elements of a
  * sequence produced by multicasting the source sequence.
  * @deprecated To be removed in version 8. If you're trying to create a connectable observable
  * with an {@link AsyncSubject} under the hood, please use the new {@link connectable} creation function.

--- a/src/internal/operators/race.ts
+++ b/src/internal/operators/race.ts
@@ -10,8 +10,9 @@ export function race<T, A extends readonly unknown[]>(...otherSources: [...Obser
 /**
  * Returns an Observable that mirrors the first source Observable to emit a next,
  * error or complete notification from the combination of this Observable and supplied Observables.
- * @param {...Observables} ...observables Sources used to race for which Observable emits first.
- * @return {Observable} An Observable that mirrors the output of the first Observable to emit an item.
+ * @param args Sources used to race for which Observable emits first.
+ * @return A function that returns an Observable that mirrors the output of the
+ * first Observable to emit an item.
  * @deprecated Deprecated use {@link raceWith}
  */
 export function race<T>(...args: any[]): OperatorFunction<T, unknown> {

--- a/src/internal/operators/raceWith.ts
+++ b/src/internal/operators/raceWith.ts
@@ -29,6 +29,8 @@ import { identity } from '../util/identity';
  * ```
  *
  * @param otherSources Sources used to race for which Observable emits first.
+ * @return A function that returns an Observable that mirrors the output of the
+ * first Observable to emit an item.
  */
 
 export function raceWith<T, A extends readonly unknown[]>(

--- a/src/internal/operators/reduce.ts
+++ b/src/internal/operators/reduce.ts
@@ -52,8 +52,8 @@ export function reduce<V, A, S = A>(accumulator: (acc: A | S, value: V, index: n
  * @param {function(acc: A, value: V, index: number): A} accumulator The accumulator function
  * called on each source value.
  * @param {A} [seed] The initial accumulation value.
- * @return {Observable<A>} An Observable that emits a single value that is the
- * result of accumulating the values emitted by the source Observable.
+ * @return A function that returns an Observable that emits a single value that
+ * is the result of accumulating the values emitted by the source Observable.
  */
 export function reduce<V, A>(accumulator: (acc: V | A, value: V, index: number) => A, seed?: any): OperatorFunction<V, V | A> {
   return operate(scanInternals(accumulator, seed, arguments.length >= 2, false, true));

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -53,6 +53,11 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * // Nothing happens until you call .connect() on the observable.
  * ```
  *
+ * @return A function that returns an Observable that automates the connection
+ * to ConnectableObservable.
+ * @see {@link ConnectableObservable}
+ * @see {@link share}
+ * @see {@link publish}
  * @deprecated to be removed in version 8. Use the updated {@link share} operator,
  * which now is highly configurable. How `share` is used will depend on the connectable
  * observable you created just prior to the `refCount` operator. For examples on how

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -55,8 +55,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param {number} [count] The number of times the source Observable items are repeated, a count of 0 will yield
  * an empty Observable.
- * @return {Observable} An Observable that will resubscribe to the source stream when the source stream completes
- * , at most count times.
+ * @return A function that returns an Observable that will resubscribe to the
+ * source stream when the source stream completes, at most `count` times.
  */
 export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
   return count <= 0

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -32,7 +32,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param {function(notifications: Observable): Observable} notifier - Receives an Observable of notifications with
  * which a user can `complete` or `error`, aborting the repetition.
- * @return {Observable} The source Observable modified with repeat logic.
+ * @return A function that returns an Observable that that mirrors the source
+ * Observable with the exception of a `complete`.
  */
 export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Observable<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -52,7 +52,8 @@ export interface RetryConfig {
  *
  * @param {number} count - Number of retry attempts before failing.
  * @param {boolean} resetOnSuccess - When set to `true` every successful emission will reset the error count
- * @return {Observable} The source Observable modified with the retry logic.
+ * @return A function that returns an Observable that will resubscribe to the
+ * source stream when the source stream errors, at most `count` times.
  */
 export function retry<T>(count?: number): MonoTypeOperatorFunction<T>;
 export function retry<T>(config: RetryConfig): MonoTypeOperatorFunction<T>;

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -55,7 +55,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param {function(errors: Observable): Observable} notifier - Receives an Observable of notifications with which a
  * user can `complete` or `error`, aborting the retry.
- * @return {Observable} The source Observable modified with retry logic.
+ * @return A function that returns an Observable that mirrors the source
+ * Observable with the exception of an `error`.
  */
 export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -36,11 +36,11 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link sampleTime}
  * @see {@link throttle}
  *
- * @param {Observable<any>} notifier The Observable to use for sampling the
+ * @param notifier The Observable to use for sampling the
  * source Observable.
- * @return {Observable<T>} An Observable that emits the results of sampling the
- * values emitted by the source Observable whenever the notifier Observable
- * emits value.
+ * @return A function that returns an Observable that emits the results of
+ * sampling the values emitted by the source Observable whenever the notifier
+ * Observable emits value or completes.
  */
 export function sample<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -40,8 +40,9 @@ import { interval } from '../observable/interval';
  * time unit determined internally by the optional `scheduler`.
  * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for
  * managing the timers that handle the sampling.
- * @return {Observable<T>} An Observable that emits the results of sampling the
- * values emitted by the source Observable at the specified time interval.
+ * @return A function that returns an Observable that emits the results of
+ * sampling the values emitted by the source Observable at the specified time
+ * interval.
  * @deprecated To be removed in v8. Use `sample(interval(period, scheduler?))`, it's the same thing.
  */
 export function sampleTime<T>(period: number, scheduler: SchedulerLike = asyncScheduler): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -86,6 +86,7 @@ export function scan<V, A, S>(accumulator: (acc: A | S, value: V, index: number)
  * be used as the initial state, and emitted without going through the accumulator. All subsequent values
  * will be processed by the accumulator function. If this is provided, all values will go through
  * the accumulator function.
+ * @return A function that returns an Observable of the accumulated values.
  */
 export function scan<V, A, S>(accumulator: (acc: V | A | S, value: V, index: number) => A, seed?: S): OperatorFunction<V, V | A> {
   // providing a seed of `undefined` *should* be valid and trigger

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -56,8 +56,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param {Observable} compareTo The observable sequence to compare the source sequence to.
  * @param {function} [comparator] An optional function to compare each value pair
- * @return {Observable} An Observable of a single boolean value representing whether or not
- * the values emitted by both observables were equal in sequence.
+ * @return A function that returns an Observable that emits a single boolean
+ * value representing whether or not the values emitted by the source
+ * Observable and provided Observable were equal in sequence.
  */
 export function sequenceEqual<T>(
   compareTo: Observable<T>,

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -84,6 +84,12 @@ export function share<T>(options: ShareConfig<T>): MonoTypeOperatorFunction<T>;
  * // subscription 1:  9
  * // ... and so on
  * ```
+ *
+ * @see {@link api/index/function/interval}
+ * @see {@link map}
+ *
+ * @return A function that returns an Observable that upon connection causes
+ * the source Observable to emit items to its Observers.
  */
 export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
   options = options || {};

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -88,8 +88,7 @@ export function share<T>(options: ShareConfig<T>): MonoTypeOperatorFunction<T>;
  * @see {@link api/index/function/interval}
  * @see {@link map}
  *
- * @return A function that returns an Observable that upon connection causes
- * the source Observable to emit items to its Observers.
+ * @return A function that returns an Observable that mirrors the source.
  */
 export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
   options = options || {};

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -115,8 +115,9 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
  * @param {Number} [windowTime=Infinity] Maximum time length of the replay buffer in milliseconds.
  * @param {Scheduler} [scheduler] Scheduler where connected observers within the selector function
  * will be invoked on.
- * @return {Observable} An observable sequence that contains the elements of a sequence produced
- * by multicasting the source sequence within a selector function.
+ * @return A function that returns an Observable sequence that contains the
+ * elements of a sequence produced by multicasting the source sequence within a
+ * selector function.
  */
 export function shareReplay<T>(
   configOrBufferSize?: ShareReplayConfig | number,

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -88,8 +88,7 @@ export function single<T>(predicate?: (value: T, index: number, source: Observab
  * that one value comes from the source
  * @param {Function} predicate - A predicate function to evaluate items emitted by the source Observable.
  * @return A function that returns an Observable that emits the single item
- * emitted by the source Observable that matches the predicate or `undefined`
- * when no items match.
+ * emitted by the source Observable that matches the predicate.
  */
 export function single<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -87,8 +87,9 @@ export function single<T>(predicate?: (value: T, index: number, source: Observab
  * provided predicate. If no predicate is provided, will deliver a SequenceError if more
  * that one value comes from the source
  * @param {Function} predicate - A predicate function to evaluate items emitted by the source Observable.
- * @return {Observable<T>} An Observable that emits the single item emitted by the source Observable that matches
- * the predicate or `undefined` when no items match.
+ * @return A function that returns an Observable that emits the single item
+ * emitted by the source Observable that matches the predicate or `undefined`
+ * when no items match.
  */
 export function single<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/skip.ts
+++ b/src/internal/operators/skip.ts
@@ -29,7 +29,8 @@ import { filter } from './filter';
  * @see {@link skipLast}
  *
  * @param {Number} count - The number of times, items emitted by source Observable should be skipped.
- * @return {Observable} An Observable that skips values emitted by the source Observable.
+ * @return A function that returns an Observable that skips the first `count`
+ * values emitted by the source Observable.
  */
 export function skip<T>(count: number): MonoTypeOperatorFunction<T> {
   return filter((_, index) => count <= index);

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -43,7 +43,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link take}
  *
  * @param skipCount Number of elements to skip from the end of the source Observable.
- * @returns An Observable that skips the last count values emitted by the source Observable.
+ * @return A function that returns an Observable that skips the last `count`
+ * values emitted by the source Observable.
  */
 export function skipLast<T>(skipCount: number): MonoTypeOperatorFunction<T> {
   return skipCount <= 0

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -39,8 +39,9 @@ import { noop } from '../util/noop';
  *
  * @param {Observable} notifier - The second Observable that has to emit an item before the source Observable's elements begin to
  * be mirrored by the resulting Observable.
- * @return {Observable<T>} An Observable that skips items from the source Observable until the second Observable emits
- * an item, then emits the remaining items.
+ * @return A function that returns an Observable that skips items from the
+ * source Observable until the second Observable emits an item, then emits the
+ * remaining items.
  */
 export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/skipWhile.ts
+++ b/src/internal/operators/skipWhile.ts
@@ -44,8 +44,8 @@ export function skipWhile<T>(predicate: (value: T, index: number) => boolean): M
  * @see {@link skipLast}
  *
  * @param {Function} predicate - A function to test each item emitted from the source Observable.
- * @return {Observable<T>} An Observable that begins emitting items emitted by the source Observable when the
- * specified predicate becomes false.
+ * @return A function that returns an Observable that begins emitting items
+ * emitted by the source Observable when the specified predicate becomes false.
  */
 export function skipWhile<T>(predicate: (value: T, index: number) => boolean): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -50,6 +50,8 @@ export function startWith<T, A extends readonly unknown[] = T[]>(...values: A): 
  * ```
  *
  * @param values Items you want the modified Observable to emit first.
+ * @return A function that returns an Observable that synchronously emits
+ * provided values before subscribing to the source Observable.
  *
  * @see {@link endWith}
  * @see {@link finalize}

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -58,7 +58,8 @@ import { operate } from '../util/lift';
  *
  * @param scheduler The {@link SchedulerLike} to perform subscription actions on.
  * @param delay A delay to pass to the scheduler to delay subscriptions
- * @return The source Observable modified so that its subscriptions happen on the specified {@link SchedulerLike}.
+ * @return A function that returns an Observable modified so that its
+ * subscriptions happen on the specified {@link SchedulerLike}.
  */
 export function subscribeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/switchAll.ts
+++ b/src/internal/operators/switchAll.ts
@@ -55,6 +55,10 @@ import { identity } from '../util/identity';
  * @see {@link switchMap}
  * @see {@link switchMapTo}
  * @see {@link mergeAll}
+ *
+ * @return A function that returns an Observable that converts a higher-order
+ * Observable into a first-order Observable producing values only from the most
+ * recent Observable sequence.
  */
 
 export function switchAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>> {

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -75,10 +75,10 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
  * @param {function(value: T, ?index: number): ObservableInput} project A function
  * that, when applied to an item emitted by the source Observable, returns an
  * Observable.
- * @return {Observable} An Observable that emits the result of applying the
- * projection function (and the optional deprecated `resultSelector`) to each item
- * emitted by the source Observable and taking only the values from the most recently
- * projected inner Observable.
+ * @return A function that returns an Observable that emits the result of
+ * applying the projection function (and the optional deprecated
+ * `resultSelector`) to each item emitted by the source Observable and taking
+ * only the values from the most recently projected inner Observable.
  */
 export function switchMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -49,10 +49,11 @@ export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
  *
  * @param {ObservableInput} innerObservable An Observable to replace each value from
  * the source Observable.
- * @return {Observable} An Observable that emits items from the given
- * `innerObservable` (and optionally transformed through the deprecated `resultSelector`)
- * every time a value is emitted on the source Observable, and taking only the values
- * from the most recently projected inner Observable.
+ * @return A function that returns an Observable that emits items from the
+ * given `innerObservable` (and optionally transformed through the deprecated
+ * `resultSelector`) every time a value is emitted on the source Observable,
+ * and taking only the values from the most recently projected inner
+ * Observable.
  */
 export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,

--- a/src/internal/operators/switchScan.ts
+++ b/src/internal/operators/switchScan.ts
@@ -19,7 +19,7 @@ import { operate } from '../util/lift';
  * @param accumulator
  * The accumulator function called on each source value.
  * @param seed The initial accumulation value.
- * @return An observable of the accumulated values.
+ * @return A function that returns an observable of the accumulated values.
  */
 export function switchScan<T, R, O extends ObservableInput<any>>(
   accumulator: (acc: R, value: T, index: number) => O,

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -40,9 +40,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link skip}
  *
  * @param count The maximum number of `next` values to emit.
- * @return An Observable that emits only the first `count`
- * values emitted by the source Observable, or all of the values from the source
- * if the source emits fewer than `count` values.
+ * @return A function that returns an Observable that emits only the first
+ * `count` values emitted by the source Observable, or all of the values from
+ * the source if the source emits fewer than `count` values.
  */
 export function take<T>(count: number): MonoTypeOperatorFunction<T> {
   return count <= 0

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -40,8 +40,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  *
  * @param count The maximum number of values to emit from the end of
  * the sequence of values emitted by the source Observable.
- * @return An Observable that emits at most the last count
- * values emitted by the source Observable.
+ * @return A function that returns an Observable that emits at most the last
+ * `count` values emitted by the source Observable.
  */
 export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
   return count <= 0

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -39,8 +39,8 @@ import { noop } from '../util/noop';
  * @param {Observable} notifier The Observable whose first emitted value will
  * cause the output Observable of `takeUntil` to stop emitting values from the
  * source Observable.
- * @return {Observable<T>} An Observable that emits the values from the source
- * Observable until such time as `notifier` emits its first value.
+ * @return A function that returns an Observable that emits the values from the
+ * source Observable until `notifier` emits its first value.
  */
 export function takeUntil<T>(notifier: ObservableInput<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -50,9 +50,9 @@ export function takeWhile<T>(predicate: (value: T, index: number) => boolean, in
  * Also takes the (zero-based) index as the second argument.
  * @param {boolean} inclusive When set to `true` the value that caused
  * `predicate` to return `false` will also be emitted.
- * @return {Observable<T>} An Observable that emits the values from the source
- * Observable so long as each value satisfies the condition defined by the
- * `predicate`, then completes.
+ * @return A function that returns an Observable that emits values from the
+ * source Observable so long as each value satisfies the condition defined by
+ * the `predicate`, then completes.
  */
 export function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive = false): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -104,6 +104,8 @@ export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T
  * @param observerOrNext A next handler or partial observer
  * @param error An error handler
  * @param complete A completion handler
+ * @return A function that returns an Observable identical to the source, but
+ * runs the specified Observer or callback(s) for each item.
  */
 export function tap<T>(
   observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -56,8 +56,8 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * duration for each source value, returned as an Observable or a Promise.
  * @param config a configuration object to define `leading` and `trailing` behavior. Defaults
  * to `{ leading: true, trailing: false }`.
- * @return An Observable that performs the throttle operation to
- * limit the rate of emissions from the source.
+ * @return A function that returns an Observable that performs the throttle
+ * operation to limit the rate of emissions from the source.
  */
 export function throttle<T>(
   durationSelector: (value: T) => ObservableInput<any>,

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -77,8 +77,8 @@ import { timer } from '../observable/timer';
  * managing the timers that handle the throttling. Defaults to {@link asyncScheduler}.
  * @param config a configuration object to define `leading` and
  * `trailing` behavior. Defaults to `{ leading: true, trailing: false }`.
- * @return An Observable that performs the throttle operation to
- * limit the rate of emissions from the source.
+ * @return A function that returns an Observable that performs the throttle
+ * operation to limit the rate of emissions from the source.
  */
 export function throttleTime<T>(
   duration: number,

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -32,6 +32,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @param errorFactory A factory function called to produce the
  * error to be thrown when the source observable completes without emitting a
  * value.
+ * @return A function that returns an Observable that throws an error if the
+ * source Observable completed without emitting.
  */
 export function throwIfEmpty<T>(errorFactory: () => any = defaultErrorFactory): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -47,7 +47,8 @@ import { map } from './map';
  * ```
  *
  * @param {SchedulerLike} [scheduler] Scheduler used to get the current time.
- * @return {Observable<{ interval: number, value: T }>} Observable that emit infomation about value and interval
+ * @return A function that returns an Observable that emits information about
+ * value and interval.
  */
 export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunction<T, TimeInterval<T>> {
   return (source: Observable<T>) => defer(() => {

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -299,6 +299,9 @@ export function timeout<T>(each: number, scheduler?: SchedulerLike): MonoTypeOpe
  * <span class="informal">Timeouts on Observable that doesn't emit values fast enough.</span>
  *
  * ![](timeout.png)
+ *
+ * @return A function that returns an Observable that mirrors behaviour of the
+ * source Observable, unless timeout happens when it throws an error.
  */
 export function timeout<T, O extends ObservableInput<any>, M>(
   config: number | Date | TimeoutConfig<T, O, M>,

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -76,6 +76,9 @@ export function timeoutWith<T, R>(dueBy: Date, switchTo: ObservableInput<R>, sch
  * @param waitFor The time allowed between values from the source before timeout is triggered.
  * @param switchTo The observable to switch to when timeout occurs.
  * @param scheduler The scheduler to use with time-related operations within this operator. Defaults to {@link asyncScheduler}
+ * @return A function that returns an Observable that mirrors behaviour of the
+ * source Observable, unless timeout happens when it starts emitting values
+ * from the Observable passed as a second parameter.
  * @deprecated This will be removed in v8. Use the configuration object with {@link timeout} instead: `timeoutWith(100, a$, scheduler)` -> `timeout({ each: 100, with: () => a$, scheduler })`
  */
 export function timeoutWith<T, R>(waitFor: number, switchTo: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;

--- a/src/internal/operators/timestamp.ts
+++ b/src/internal/operators/timestamp.ts
@@ -32,6 +32,8 @@ import { map } from './map';
  * ```
  *
  * @param timestampProvider An object with a `now()` method used to get the current timestamp.
+ * @return A function that returns an Observable that attaches a timestamp to
+ * each item emitted by the source Observable indicating when it was emitted.
  */
 export function timestamp<T>(timestampProvider: TimestampProvider = dateTimestampProvider): OperatorFunction<T, Timestamp<T>> {
   return map((value: T) => ({ value, timestamp: timestampProvider.now()}));

--- a/src/internal/operators/toArray.ts
+++ b/src/internal/operators/toArray.ts
@@ -29,10 +29,11 @@ const arrReducer = (arr: any[], value: any) => (arr.push(value), arr);
  * const subscribe = example.subscribe(val => console.log(val));
  *
  * // output: [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
- *
  * ```
-* @return An array from an observable sequence.
-*/
+ *
+ * @return A function that returns an Observable that emits an array of items
+ * emitted by the source Observable when source completes.
+ */
 export function toArray<T>(): OperatorFunction<T, T[]> {
   // Because arrays are mutable, and we're mutating the array in this
   // reducer process, we have to escapulate the creation of the initial

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -43,7 +43,7 @@ import { noop } from '../util/noop';
  *
  * @param {Observable<any>} windowBoundaries An Observable that completes the
  * previous window and starts a new window.
- * @return {Observable<Observable<T>>} An Observable of windows, which are
+ * @return A function that returns an Observable of windows, which are
  * Observables emitting values of the source Observable.
  */
 export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T, Observable<T>> {

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -62,8 +62,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * For example if `startWindowEvery` is `2`, then a new window will be started
  * on every other value from the source. A new window is started at the
  * beginning of the source by default.
- * @return {Observable<Observable<T>>} An Observable of windows, which in turn
- * are Observable of values.
+ * @return A function that returns an Observable of windows, which in turn are
+ * Observable of values.
  */
 export function windowCount<T>(windowSize: number, startWindowEvery: number = 0): OperatorFunction<T, Observable<T>> {
   const startEvery = startWindowEvery > 0 ? startWindowEvery : windowSize;

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -97,7 +97,8 @@ export function windowTime<T>(
  * values each window can emit before completion.
  * @param scheduler The scheduler on which to schedule the
  * intervals that determine window boundaries.
- * @return An observable of windows, which in turn are Observables.
+ * @return A function that returns an Observable of windows, which in turn are
+ * Observables.
  */
 export function windowTime<T>(windowTimeSpan: number, ...otherArgs: any[]): OperatorFunction<T, Observable<T>> {
   const scheduler = popScheduler(otherArgs) ?? asyncScheduler;

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -51,8 +51,8 @@ import { arrRemove } from '../util/arrRemove';
  * the value emitted by the `openings` observable and returns an Observable,
  * which, when it emits a next notification, signals that the
  * associated window should complete.
- * @return {Observable<Observable<T>>} An observable of windows, which in turn
- * are Observables.
+ * @return A function that returns an Observable of windows, which in turn are
+ * Observables.
  */
 export function windowToggle<T, O>(
   openings: ObservableInput<O>,

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -46,8 +46,8 @@ import { innerFrom } from '../observable/from';
  * @param {function(): Observable} closingSelector A function that takes no
  * arguments and returns an Observable that signals (on either `next` or
  * `complete`) when to close the previous window and start a new one.
- * @return {Observable<Observable<T>>} An observable of windows, which in turn
- * are Observables.
+ * @return A function that returns an Observable of windows, which in turn are
+ * Observables.
  */
 export function windowWhen<T>(closingSelector: () => ObservableInput<any>): OperatorFunction<T, Observable<T>> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -50,9 +50,9 @@ export function withLatestFrom<T, O extends unknown[], R>(
  * first parameter is a value from the source Observable. (e.g.
  * `a.pipe(withLatestFrom(b, c), map(([a1, b1, c1]) => a1 + b1 + c1))`). If this is not
  * passed, arrays will be emitted on the output Observable.
- * @return {Observable} An Observable of projected values from the most recent
- * values from each input Observable, or an array of the most recent values from
- * each input Observable.
+ * @return A function that returns an Observable of projected values from the
+ * most recent values from each input Observable, or an array of the most
+ * recent values from each input Observable.
  */
 export function withLatestFrom<T, R>(...inputs: any[]): OperatorFunction<T, R | any[]> {
   const project = popResultSelector(inputs) as ((...args: any[]) => R) | undefined;

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -20,6 +20,9 @@ import { zip } from './zip';
  * In many cases, authors want `combineLatestWith` and not `zipWith`.
  *
  * @param otherInputs other observable inputs to collate values from.
+ * @return A function that returns an Observable that emits items by index
+ * combined from the source Observable and provided Observables, in form of an
+ * array.
  */
 export function zipWith<T, A extends readonly unknown[]>(...otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>> {
   return zip(...otherInputs);


### PR DESCRIPTION
With this PR I'd like to fix the most operators' docs that were never fixed since pipeable operators were introduced. The old docs were pointing that operators were returning Observables which is not the case anymore. So I mostly added couple of words saying that operators are returning functions that return an Observable that does something.

I also fixed types that operator functions return, mostly from some `Observable` type to some `OperatorFunction` type. The official docs are actually correctly inferring return type, but the sentences were not in compliance with the type (e.g. [`map`](https://rxjs.dev/api/operators/map)'s `#Returns` section).

I also added couple of new `@return` and `@name` for some of the operators that were missing them and I modified some `@return` docs to better describe what returned Observables are doing.

From the `src/internal/operators` folder, these files were left unchanged:
* `publishBehavior.ts`
* `publishReplay.ts`
* `concat.ts`
* `zipAll.ts`

as they lack documentation.