### PR TITLE
feat(fromEvent): improve type inference on event name

### DIFF
--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -4,9 +4,9 @@ import { isFunction } from '../util/isFunction';
 import { Subscriber } from '../Subscriber';
 import { map } from '../operators/map';
 
-export interface NodeStyleEventEmitter {
-  addListener: (eventName: string | symbol, handler: NodeEventHandler) => this;
-  removeListener: (eventName: string | symbol, handler: NodeEventHandler) => this;
+export interface NodeStyleEventEmitter<T extends string|symbol> {
+  addListener: (eventName: T, handler: NodeEventHandler) => this;
+  removeListener: (eventName: T, handler: NodeEventHandler) => this;
 }
 
 export type NodeEventHandler = (...args: any[]) => void;
@@ -14,19 +14,19 @@ export type NodeEventHandler = (...args: any[]) => void;
 // For APIs that implement `addListener` and `removeListener` methods that may
 // not use the same arguments or return EventEmitter values
 // such as React Native
-export interface NodeCompatibleEventEmitter {
-  addListener: (eventName: string, handler: NodeEventHandler) => void | {};
-  removeListener: (eventName: string, handler: NodeEventHandler) => void | {};
+export interface NodeCompatibleEventEmitter<T extends string> {
+  addListener: (eventName: T, handler: NodeEventHandler) => void | {};
+  removeListener: (eventName: T, handler: NodeEventHandler) => void | {};
 }
 
-export interface JQueryStyleEventEmitter {
-  on: (eventName: string, handler: Function) => void;
-  off: (eventName: string, handler: Function) => void;
+export interface JQueryStyleEventEmitter<T extends string> {
+  on: (eventName: T, handler: Function) => void;
+  off: (eventName: T, handler: Function) => void;
 }
 
-export interface HasEventTargetAddRemove<E> {
-  addEventListener(type: string, listener: ((evt: E) => void) | null, options?: boolean | AddEventListenerOptions): void;
-  removeEventListener(type: string, listener?: ((evt: E) => void) | null, options?: EventListenerOptions | boolean): void;
+export interface HasEventTargetAddRemove<E, T extends string> {
+  addEventListener(type: T, listener: ((evt: E) => void) | null, options?: boolean | AddEventListenerOptions): void;
+  removeEventListener(type: T, listener?: ((evt: E) => void) | null, options?: EventListenerOptions | boolean): void;
 }
 
 export type EventTargetLike<T> = HasEventTargetAddRemove<T> | NodeStyleEventEmitter | NodeCompatibleEventEmitter | JQueryStyleEventEmitter;


### PR DESCRIPTION
This change updates the type of the event name to be covariant with string. This permits using listeners that are defined as:

```
addEventListener(event: 'foo'|'bar', listener: ...)
```

Without this change, the following error is produced because the typings are too tight around `string`:

```
Argument of type 'BrowserWindow' is not assignable to parameter of type 'FromEventTarget<unknown>'.
  Type 'BrowserWindow' is not assignable to type 'JQueryStyleEventEmitter'.
    Types of property 'on' are incompatible.
      Type '{ (event: "always-on-top-changed", listener: (event: Event, isAlwaysOnTop: boolean) => void): BrowserWindow; (event: "app-command", listener: (event: Event, command: string) => void): BrowserWindow; (event: "blur", listener: Function): BrowserWindow; (event: "close", listener: (event: Event) => void): BrowserWindow;...' is not assignable to type '(eventName: string, handler: Function) => void'.
        Types of parameters 'event' and 'eventName' are incompatible.
          Type 'string' is not assignable to type '"always-on-top-changed"'.ts(2345)
```