### PR TITLE
docs(sitemap): pointing to rxjs.dev

### DIFF
--- a/docs_app/src/extra-files/stable/robots.txt
+++ b/docs_app/src/extra-files/stable/robots.txt
@@ -1,4 +1,4 @@
 # Allow all URLs (see http://www.robotstxt.org/robotstxt.html)
 User-agent: *
 Disallow:
-Sitemap: https://angular.io/generated/sitemap.xml
+Sitemap: https://rxjs.dev/generated/sitemap.xml

--- a/docs_app/tools/transforms/templates/sitemap.template.xml
+++ b/docs_app/tools/transforms/templates/sitemap.template.xml
@@ -2,6 +2,6 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   {%- for url in doc.urls %}
   <url>
-    <loc>https://rxjs-dev.firebaseapp.com/{$ url $}</loc>
+    <loc>https://rxjs.dev/{$ url $}</loc>
   </url>{% endfor %}
 </urlset>


### PR DESCRIPTION
The sitemap.xml generated in the docs build process was pointing to angular.io and the old firebase instance