### PR TITLE
fix(shareReplay): with refCount restart when source completes

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -199,6 +199,23 @@ describe('shareReplay operator', () => {
     expectObservable(shared, sub2).toBe(expected2);
   });
 
+  it('should restart due to unsubscriptions if refCount is true and the source completes first', () => {
+    const source =  cold(   '1-(2|)      ');
+    const shared = source.pipe(
+      shareReplay({refCount: true, bufferSize: 1}),
+    );
+    const subscriber1 = hot('a---|       ').pipe(mergeMapTo(shared));
+    const unsub1 =          '     !      ';
+    const expected1   =     '1-2-|       ';
+
+    const subscriber2 = hot('      c---| ').pipe(mergeMapTo(shared));
+    const unsub2 =          '           !';
+    const expected2   =     '      1-2-| ';
+
+    expectObservable(subscriber1, unsub1).toBe(expected1);
+    expectObservable(subscriber2, unsub2).toBe(expected2);
+  });
+
   it('should default to refCount being false', () => {
     const source = cold('a-b-c-d-e-f-g-h-i-j');
     const sub1 =        '^------!';

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -152,7 +152,6 @@ function shareReplayOperator<T>({
   let refCount = 0;
   let subscription: Subscription | undefined;
   let hasError = false;
-  let isComplete = false;
 
   return function shareReplayOperation(this: Subscriber<T>, source: Observable<T>) {
     refCount++;
@@ -166,7 +165,6 @@ function shareReplayOperator<T>({
           subject!.error(err);
         },
         complete() {
-          isComplete = true;
           subscription = undefined;
           subject!.complete();
         },
@@ -177,10 +175,12 @@ function shareReplayOperator<T>({
     this.add(() => {
       refCount--;
       innerSub.unsubscribe();
-      if (subscription && !isComplete && useRefCount && refCount === 0) {
-        subscription.unsubscribe();
-        subscription = undefined;
+      if (useRefCount && refCount === 0) {
         subject = undefined;
+        if (subscription) {
+          subscription.unsubscribe();
+          subscription = undefined;
+        }
       }
     });
   };


### PR DESCRIPTION
... and the source completes first

**Description:**

It addresses #5455 

**Related issue (if exists):** #5455 
