### PR TITLE
test(shareReplay): don't restart when refCount if the source has completed

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -175,6 +175,7 @@ describe('shareReplay operator', () => {
 
   it('should not restart due to unsubscriptions if refCount is false', () => {
     const source = cold('a-b-c-d-e-f-g-h-i-j');
+    const sourceSubs =  '^------------------';
     const sub1 =        '^------!';
     const expected1 =   'a-b-c-d-';
     const sub2 =        '-----------^-------';
@@ -184,10 +185,14 @@ describe('shareReplay operator', () => {
 
     expectObservable(shared, sub1).toBe(expected1);
     expectObservable(shared, sub2).toBe(expected2);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
   it('should restart due to unsubscriptions if refCount is true', () => {
+    const sourceSubs = [];
     const source = cold('a-b-c-d-e-f-g-h-i-j');
+    sourceSubs.push(    '^------!----------------------');
+    sourceSubs.push(    '-----------^------------------');
     const sub1 =        '^------!';
     const expected1 =   'a-b-c-d-';
     const sub2 =        '-----------^------------------';
@@ -197,6 +202,7 @@ describe('shareReplay operator', () => {
 
     expectObservable(shared, sub1).toBe(expected1);
     expectObservable(shared, sub2).toBe(expected2);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
   it('should not restart due to unsubscriptions if refCount is true when the source has completed', () => {
@@ -216,6 +222,7 @@ describe('shareReplay operator', () => {
 
   it('should default to refCount being false', () => {
     const source = cold('a-b-c-d-e-f-g-h-i-j');
+    const sourceSubs =  '^------------------';
     const sub1 =        '^------!';
     const expected1 =   'a-b-c-d-';
     const sub2 =        '-----------^-------';
@@ -225,6 +232,7 @@ describe('shareReplay operator', () => {
 
     expectObservable(shared, sub1).toBe(expected1);
     expectObservable(shared, sub2).toBe(expected2);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
   it('should not break lift() composability', (done: MochaDone) => {

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -199,6 +199,21 @@ describe('shareReplay operator', () => {
     expectObservable(shared, sub2).toBe(expected2);
   });
 
+  it('should not restart due to unsubscriptions if refCount is true when the source has completed', () => {
+    const source = cold('a-(b|)         ');
+    const sourceSubs =  '^-!            ';
+    const sub1 =        '^------!       ';
+    const expected1 =   'a-(b|)         ';
+    const sub2 =        '-----------^!  ';
+    const expected2 =   '-----------(b|)';
+
+    const shared = source.pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+    expectObservable(shared, sub1).toBe(expected1);
+    expectObservable(shared, sub2).toBe(expected2);
+    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+  });
+
   it('should default to refCount being false', () => {
     const source = cold('a-b-c-d-e-f-g-h-i-j');
     const sub1 =        '^------!';


### PR DESCRIPTION
**Description:**
As discussed in #5455: it would be useful to have a test that removes the ambiguity on what should happen with the `shareReplay` operator if `refCount` is `true` once the source completes.

I've also added a second commit that gets rid of the redundant variable `isComplete`. This variable became unnecessary after [this change](https://github.com/josepot/rxjs/commit/35e600fb031ba2814d65b586ca0664af85b179ba#diff-a3e23feeea8613de90d70844292403e3). I guess that this second commit is a "nit pick", so I don't mind removing it from this PR. Although, it may marginally reduce the bundle size?

**Related issue**
#5455 
