### PR TITLE
chore(shareReplay): remove redundant variable `isComplete`

### DIFF
--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -152,7 +152,6 @@ function shareReplayOperator<T>({
   let refCount = 0;
   let subscription: Subscription | undefined;
   let hasError = false;
-  let isComplete = false;
 
   return function shareReplayOperation(this: Subscriber<T>, source: Observable<T>) {
     refCount++;
@@ -166,7 +165,6 @@ function shareReplayOperator<T>({
           subject!.error(err);
         },
         complete() {
-          isComplete = true;
           subscription = undefined;
           subject!.complete();
         },
@@ -177,7 +175,7 @@ function shareReplayOperator<T>({
     this.add(() => {
       refCount--;
       innerSub.unsubscribe();
-      if (subscription && !isComplete && useRefCount && refCount === 0) {
+      if (subscription && useRefCount && refCount === 0) {
         subscription.unsubscribe();
         subscription = undefined;
         subject = undefined;


### PR DESCRIPTION
**Description:**

This PR removes the redundant variable `isComplete` from the `shareReplay` operator. This variable became unnecessary after [this change](https://github.com/josepot/rxjs/commit/35e600fb031ba2814d65b586ca0664af85b179ba#diff-a3e23feeea8613de90d70844292403e3).
