### PR TITLE
null out _unsubscribe after unsubscription

### DIFF
--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -116,4 +116,17 @@ describe('Subscriber', () => {
     expect(subscriberUnsubscribed).to.be.true;
     expect(subscriptionUnsubscribed).to.be.true;
   });
+
+  it('should have idempotent unsubscription', () => {
+    let count = 0;
+    const subscriber = new Subscriber();
+    subscriber.add(() => ++count);
+    expect(count).to.equal(0);
+
+    subscriber.unsubscribe();
+    expect(count).to.equal(1);
+
+    subscriber.unsubscribe();
+    expect(count).to.equal(1);
+  });
 });

--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -159,5 +159,17 @@ describe('Subscription', () => {
         done();
       });
     });
+
+    it('Should have idempotent unsubscription', () => {
+      let count = 0;
+      const subscription = new Subscription(() => ++count);
+      expect(count).to.equal(0);
+
+      subscription.unsubscribe();
+      expect(count).to.equal(1);
+
+      subscription.unsubscribe();
+      expect(count).to.equal(1);
+    });
   });
 });

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -39,7 +39,16 @@ export class Subscription implements SubscriptionLike {
    */
   constructor(unsubscribe?: () => void) {
     if (unsubscribe) {
-      (<any> this)._unsubscribe = unsubscribe;
+      // Wrap the unsubscribe teardown in a function so that the argument can
+      // be nulled. It's not possible to null the _unsubscribe member as there
+      // are many classes that are derived from Subscriber (which derives from
+      // Subscription) that implement an _unsubscribe method as a mechanism for
+      // obtaining unsubscription notifications and some of those subscribers
+      // are recycled.
+      (<any> this)._unsubscribe = () => {
+        unsubscribe!();
+        unsubscribe = undefined;
+      };
     }
   }
 
@@ -63,7 +72,6 @@ export class Subscription implements SubscriptionLike {
     // null out _subscriptions first so any child subscriptions that attempt
     // to remove themselves from this subscription will noop
     this._subscriptions = null;
-    (<any> this)._unsubscribe = null;
 
     if (_parentOrParents instanceof Subscription) {
       _parentOrParents.remove(this);

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -63,13 +63,6 @@ export class Subscription implements SubscriptionLike {
     // null out _subscriptions first so any child subscriptions that attempt
     // to remove themselves from this subscription will noop
     this._subscriptions = null;
-    // It's not possible to null the _unsubscribe member as there are many
-    // classes that are derived from Subscriber (which derives from
-    // Subscription) that implement an _unsubscribe method as a mechanism for
-    // obtaining unsubscription notifications and some of those subscribers are
-    // recycled. Deleting the member will release the reference to any teardown
-    // functions passed in the constructor and will leave any methods intact.
-    delete (this as any)._unsubscribe;
 
     if (_parentOrParents instanceof Subscription) {
       _parentOrParents.remove(this);
@@ -81,6 +74,14 @@ export class Subscription implements SubscriptionLike {
     }
 
     if (isFunction(_unsubscribe)) {
+      // It's not possible to null the _unsubscribe member as there are many
+      // classes that are derived from Subscriber (which derives from
+      // Subscription) that implement an _unsubscribe method as a mechanism for
+      // obtaining unsubscription notifications and some of those subscribers
+      // are recycled. Deleting the member will release the reference to any
+      // teardown functions passed in the constructor and will leave any
+      // methods intact.
+      delete (this as any)._unsubscribe;
       try {
         _unsubscribe.call(this);
       } catch (e) {

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -74,14 +74,15 @@ export class Subscription implements SubscriptionLike {
     }
 
     if (isFunction(_unsubscribe)) {
-      // It's not possible to null the _unsubscribe member as there are many
-      // classes that are derived from Subscriber (which derives from
-      // Subscription) that implement an _unsubscribe method as a mechanism for
-      // obtaining unsubscription notifications and some of those subscribers
-      // are recycled. Deleting the member will release the reference to any
-      // teardown functions passed in the constructor and will leave any
-      // methods intact.
-      delete (this as any)._unsubscribe;
+      // It's only possible to null _unsubscribe - to release the reference to
+      // any teardown function passed in the constructor - if it is actually an
+      // instance property, as there are some classes that are derived from
+      // Subscriber (which derives from Subscription) that implement an
+      // _unsubscribe method as a mechanism for obtaining unsubscription
+      // notifications and some of those subscribers are recycled.
+      if (this.hasOwnProperty('_unsubscribe')) {
+        (this as any)._unsubscribe = undefined;
+      }
       try {
         _unsubscribe.call(this);
       } catch (e) {

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -39,6 +39,7 @@ export class Subscription implements SubscriptionLike {
    */
   constructor(unsubscribe?: () => void) {
     if (unsubscribe) {
+      (this as any)._ctorUnsubscribe = true;
       (this as any)._unsubscribe = unsubscribe;
     }
   }
@@ -56,7 +57,7 @@ export class Subscription implements SubscriptionLike {
       return;
     }
 
-    let { _parentOrParents, _unsubscribe, _subscriptions } = (this as any);
+    let { _parentOrParents, _ctorUnsubscribe, _unsubscribe, _subscriptions } = (this as any);
 
     this.closed = true;
     this._parentOrParents = null;
@@ -75,12 +76,15 @@ export class Subscription implements SubscriptionLike {
 
     if (isFunction(_unsubscribe)) {
       // It's only possible to null _unsubscribe - to release the reference to
-      // any teardown function passed in the constructor - if it is actually an
-      // instance property, as there are some classes that are derived from
-      // Subscriber (which derives from Subscription) that implement an
-      // _unsubscribe method as a mechanism for obtaining unsubscription
-      // notifications and some of those subscribers are recycled.
-      if (this.hasOwnProperty('_unsubscribe')) {
+      // any teardown function passed in the constructor - if the property was
+      // actually assigned in the constructor, as there are some classes that
+      // are derived from Subscriber (which derives from Subscription) that
+      // implement an _unsubscribe method as a mechanism for obtaining
+      // unsubscription notifications and some of those subscribers are
+      // recycled. Also, in some of those subscribers, _unsubscribe switches
+      // from a prototype method to an instance property - see notifyNext in
+      // RetryWhenSubscriber.
+      if (_ctorUnsubscribe) {
         (this as any)._unsubscribe = undefined;
       }
       try {

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -63,6 +63,7 @@ export class Subscription implements SubscriptionLike {
     // null out _subscriptions first so any child subscriptions that attempt
     // to remove themselves from this subscription will noop
     this._subscriptions = null;
+    (<any> this)._unsubscribe = null;
 
     if (_parentOrParents instanceof Subscription) {
       _parentOrParents.remove(this);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
`null` out the `unsubscribe` callback after unsubscribing.

The `any` is kind of ugly but that is also how it's assigned in the constructor.

**Related issue (if exists):** Fixes #5464
