### PR TITLE
fix: resolve issue where Subject constructor errantly allowed an argu…

### DIFF
--- a/spec-dtslint/Subject-spec.ts
+++ b/spec-dtslint/Subject-spec.ts
@@ -30,6 +30,10 @@ describe('Subject', () => {
     });
   });
 
+  it('should not accept an argument in the ctor', () => {
+    const s1 = new Subject<number>(subscriber => { }); // $ExpectError
+  });
+
   describe('asObservable', () => {
     it('should return an observable of the same generic type', () => {
       const s1 = new Subject();

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -22,8 +22,6 @@ export class SubjectSubscriber<T> extends Subscriber<T> {
  *
  * Every Subject is an Observable and an Observer. You can subscribe to a
  * Subject, and you can call next to feed values as well as error and complete.
- *
- * @class Subject<T>
  */
 export class Subject<T> extends Observable<T> implements SubscriptionLike {
 
@@ -42,11 +40,18 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
   thrownError: any = null;
 
   /**
+   * Creates a "subject" by basically gluing an observer to an observable.
+   *
    * @nocollapse
-   * @deprecated use new Subject() instead
+   * @deprecated Recommended you do not use, will be removed at some point in the future. Plans for replacement still under discussion.
    */
   static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
+  }
+
+  constructor() {
+    // NOTE: This must be here to obscure Observable's constructor.
+    super();
   }
 
   lift<R>(operator: Operator<T, R>): Observable<R> {


### PR DESCRIPTION
…ment

- Adds a dtslint showing the issue
- Re-adds the constructor that was removed in error in a previous commit (unreleased)
- Adds a bit more detail the the deprecated `create` static method.
