### PR TITLE
chore: deprecate old config options

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -251,12 +251,64 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /**
-   * @method forEach
+   * Used as a NON-CANCELLABLE means of subscribing to an observable, for use with
+   * APIs that expect promises, like `async/await`. You cannot unsubscribe from this.
+   *
+   * **WARNING**: Only use this with observables you *know* will complete. If the source
+   * observable does not complete, you will end up with a promise that is hung up, and
+   * potentially all of the state of an async function hanging out in memory. To avoid
+   * this situation, look into adding something like {@link timeout}, {@link take},
+   * {@link takeWhile}, or {@link takeUntil} amongst others.
+   *
+   * ### Example:
+   *
+   * ```ts
+   * import { interval } from 'rxjs';
+   * import { take } from 'rxjs/operators';
+   *
+   * const source$ = interval(1000).pipe(take(4));
+   *
+   * async function getTotal() {
+   *    let total = 0;
+   *
+   *    await source$.forEach(value => {
+   *      total += value;
+   *      console.log('observable -> ', value);
+   *    });
+   *
+   *    return total;
+   * }
+   *
+   * getTotal().then(
+   *    total => console.log('Total:', total)
+   * )
+   *
+   * // Expected:
+   * // "observable -> 0"
+   * // "observable -> 1"
+   * // "observable -> 2"
+   * // "observable -> 3"
+   * // "Total: 6"
+   * ```
    * @param next a handler for each value emitted by the observable
-   * @param [promiseCtor] a constructor function used to instantiate the Promise
    * @return a promise that either resolves on observable completion or
    *  rejects with the handled error
    */
+  forEach(next: (value: T) => void): Promise<void>;
+
+  /**
+   * @param next a handler for each value emitted by the observable
+   * @param promiseCtor a constructor function used to instantiate the Promise
+   * @return a promise that either resolves on observable completion or
+   *  rejects with the handled error
+   * @deprecated remove in v8. Passing a Promise constructor will no longer be available
+   * in upcoming versions of RxJS. This is because it adds weight to the library, for very
+   * little benefit. If you need this functionality, it is recommended that you either
+   * polyfill Promise, or you create an adapter to convert the returned native promise
+   * to whatever promise implementation you wanted.
+   */
+  forEach(next: (value: T) => void, promiseCtor: PromiseConstructorLike): Promise<void>;
+
   forEach(next: (value: T) => void, promiseCtor?: PromiseConstructorLike): Promise<void> {
     promiseCtor = getPromiseCtor(promiseCtor);
 
@@ -359,6 +411,12 @@ export class Observable<T> implements Subscribable<T> {
   /**
    * Subscribe to this Observable and get a Promise resolving on
    * `complete` with the last emission (if any).
+   *
+   * **WARNING**: Only use this with observables you *know* will complete. If the source
+   * observable does not complete, you will end up with a promise that is hung up, and
+   * potentially all of the state of an async function hanging out in memory. To avoid
+   * this situation, look into adding something like {@link timeout}, {@link take},
+   * {@link takeWhile}, or {@link takeUntil} amongst others.
    *
    * @method toPromise
    * @param [promiseCtor] a constructor function used to instantiate

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -8,6 +8,10 @@ export const config = {
   /**
    * The promise constructor used by default for methods such as
    * {@link toPromise} and {@link forEach}
+   *
+   * @deprecated remove in v8. RxJS will no longer support this sort of injection of a
+   * Promise constructor. If you need a Promise implementation other than native promises,
+   * please polyfill/patch Promises as you see appropriate.
    */
   Promise: undefined! as PromiseConstructorLike,
 
@@ -18,6 +22,10 @@ export const config = {
    * where a multicast can be broken for all observers by a downstream consumer with
    * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BY TIME
    * FOR MIGRATION REASONS.
+   *
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
+   * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
+   * behaviors described above.
    */
   set useDeprecatedSynchronousErrorHandling(value: boolean) {
     if (value) {
@@ -29,6 +37,11 @@ export const config = {
     _enable_super_gross_mode_that_will_cause_bad_things = value;
   },
 
+  /**
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
+   * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
+   * behaviors described above.
+   */
   get useDeprecatedSynchronousErrorHandling() {
     return _enable_super_gross_mode_that_will_cause_bad_things;
   },

--- a/src/internal/firstValueFrom.ts
+++ b/src/internal/firstValueFrom.ts
@@ -13,6 +13,12 @@ import { Subscription } from './Subscription';
  * If the observable stream emits an error, the returned promise will reject
  * with that error.
  *
+ * **WARNING**: Only use this with observables you *know* will complete. If the source
+ * observable does not complete, you will end up with a promise that is hung up, and
+ * potentially all of the state of an async function hanging out in memory. To avoid
+ * this situation, look into adding something like {@link timeout}, {@link take},
+ * {@link takeWhile}, or {@link takeUntil} amongst others.
+ *
  * ### Example
  *
  * Wait for the first value from a stream and emit it from a promise in

--- a/src/internal/firstValueFrom.ts
+++ b/src/internal/firstValueFrom.ts
@@ -13,11 +13,12 @@ import { Subscription } from './Subscription';
  * If the observable stream emits an error, the returned promise will reject
  * with that error.
  *
- * **WARNING**: Only use this with observables you *know* will complete. If the source
- * observable does not complete, you will end up with a promise that is hung up, and
- * potentially all of the state of an async function hanging out in memory. To avoid
- * this situation, look into adding something like {@link timeout}, {@link take},
- * {@link takeWhile}, or {@link takeUntil} amongst others.
+ * **WARNING**: Only use this with observables you *know* will emit at least one value,
+ * *OR* complete. If the source observable does not emit one value or complete, you will
+ * end up with a promise that is hung up, and potentially all of the state of an
+ * async function hanging out in memory. To avoid this situation, look into adding
+ * something like {@link timeout}, {@link take}, {@link takeWhile}, or {@link takeUntil}
+ * amongst others.
  *
  * ### Example
  *

--- a/src/internal/lastValueFrom.ts
+++ b/src/internal/lastValueFrom.ts
@@ -12,6 +12,12 @@ import { EmptyError } from './util/EmptyError';
  * If the observable stream emits an error, the returned promise will reject
  * with that error.
  *
+ * **WARNING**: Only use this with observables you *know* will complete. If the source
+ * observable does not complete, you will end up with a promise that is hung up, and
+ * potentially all of the state of an async function hanging out in memory. To avoid
+ * this situation, look into adding something like {@link timeout}, {@link take},
+ * {@link takeWhile}, or {@link takeUntil} amongst others.
+ *
  * ### Example
  *
  * Wait for the last value from a stream and emit it from a promise in


### PR DESCRIPTION
We need to remove these configuration options for v8, to help streamline the library and reduce size. Adding deprecations messages that give a little bit about why they are deprecated and some workaround information

Also adds some additional blurbs to documentation for promise-related methods on Observable.

Also adds some documentation to forEach with an example.
