### PR TITLE
feat(expand): Scheduler argument removed.

### DIFF
--- a/spec-dtslint/operators/expand-spec.ts
+++ b/spec-dtslint/operators/expand-spec.ts
@@ -21,10 +21,6 @@ it('should support concurrent parameter', () => {
   const o = of(1, 2, 3).pipe(expand(value => of(1), 47)); // $ExpectType Observable<number>
 });
 
-it('should support a scheduler', () => {
-  const o = of(1, 2, 3).pipe(expand(value => of(1), 47, asyncScheduler)); // $ExpectType Observable<number>
-});
-
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(expand()); // $ExpectError
 });
@@ -40,10 +36,6 @@ it('should enforce project return type', () => {
 
 it('should enforce concurrent type', () => {
   const o = of(1, 2, 3).pipe(expand(value => of(1), 'foo')); // $ExpectError
-});
-
-it('should enforce scheduler type', () => {
-  const o = of(1, 2, 3).pipe(expand(value => of(1), 47, 'foo')); // $ExpectError
 });
 
 // TODO(benlesh): Fix this when TypeScript is capable of handling typing this.

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -23,19 +23,6 @@ describe('expand operator', () => {
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
 
-  it('should work with scheduler', () => {
-    const e1 =    hot('--x----|  ', {x: 1});
-    const e1subs =    '^      !  ';
-    const e2 =   cold(  '--c|    ', {c: 2});
-    const expected =  '--a-b-c-d|';
-    const values = {a: 1, b: 2, c: 4, d: 8};
-
-    const result = e1.pipe(expand(x => x === 8 ? EMPTY : e2.pipe(map(c => c * x)), Infinity, rxTestScheduler));
-
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
   it('should map and recursively flatten', () => {
     const values = {
       a: 1,
@@ -409,7 +396,7 @@ describe('expand operator', () => {
       return cold(e2shape, { z: x + x });
     };
 
-    const result = e1.pipe(expand(project, undefined, undefined));
+    const result = e1.pipe(expand(project, undefined));
 
     expectObservable(result).toBe(expected, values);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);


### PR DESCRIPTION
Turns out it never, ever worked properly and no one ever complained about it. So I want to remove it.

Adds better examples and documentation.

BREAKING CHANGE: expand no longer accepts a scheduler argument. Because it never worked, and no one complained. Good riddance.
