### PR TITLE
chore: type repeatWhen notifier as void

### DIFF
--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -39,12 +39,12 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @return {Observable} The source Observable modified with repeat logic.
  * @name repeatWhen
  */
-export function repeatWhen<T>(notifier: (notifications: Observable<any>) => Observable<any>): MonoTypeOperatorFunction<T> {
+export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Observable<any>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => source.lift(new RepeatWhenOperator(notifier));
 }
 
 class RepeatWhenOperator<T> implements Operator<T, T> {
-  constructor(protected notifier: (notifications: Observable<any>) => Observable<any>) {
+  constructor(protected notifier: (notifications: Observable<void>) => Observable<any>) {
   }
 
   call(subscriber: Subscriber<T>, source: any): TeardownLogic {
@@ -65,7 +65,7 @@ class RepeatWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
   private sourceIsBeingSubscribedTo: boolean = true;
 
   constructor(destination: Subscriber<R>,
-              private notifier: (notifications: Observable<any>) => Observable<any>,
+              private notifier: (notifications: Observable<void>) => Observable<any>,
               private source: Observable<T>) {
     super(destination);
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR makes a trivial change to the type of the `notifications` observable passed to the `notifier` in `repeatWhen`. The observable emits when the source completes and it does not emit a value - there is an internal `Subject<void>` that's used for notifications.

This PR types the `notifications` as `Observable<void>` instead of `Observable<any>`.

No dtslint test is added because there is no inference involved here.

**Related issue (if exists):** None
