### PR TITLE
fix(timeout): defer error creation until timeout occurs

### DIFF
--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -3,6 +3,9 @@ import { TimeoutError } from '../util/TimeoutError';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { timeoutWith } from './timeoutWith';
 import { throwError } from '../observable/throwError';
+import { defer } from '../observable/defer';
+
+function timeoutErrFactory() { return throwError(new TimeoutError()); }
 
 /**
  *
@@ -83,5 +86,5 @@ import { throwError } from '../observable/throwError';
  */
 export function timeout<T>(due: number | Date,
                            scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
-  return timeoutWith(due, throwError(new TimeoutError()), scheduler);
+  return timeoutWith(due, defer(timeoutErrFactory), scheduler);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR try to change timing behavior of `timeout` operator creating its timeout error object. Instead of eagerly creating new object each time operator is being called, now it defers creation until timeout's being raised.
Initially thought of using constant timeouterror object, but that'll make fixed stack instead of actual point of error being thrown.

**Related issue (if exists):**

- closes #5491
