### PR TITLE
Timer fix unhappy numbers

### DIFF
--- a/spec/observables/timer-spec.ts
+++ b/spec/observables/timer-spec.ts
@@ -1,108 +1,169 @@
-import { cold, expectObservable, time } from '../helpers/marble-testing';
 import { timer, NEVER, merge } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { mergeMap, take, concat } from 'rxjs/operators';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {timer} */
 describe('timer', () => {
+  let rxTest: TestScheduler;
+
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
   it('should create an observable emitting periodically', () => {
-    const e1 = timer(60, 20, rxTestScheduler).pipe(
-      take(4), // make it actually finite, so it can be rendered
-      concat(NEVER) // but pretend it's infinite by not completing
-    );
-    const expected = '------a-b-c-d-';
-    const values = {
-      a: 0,
-      b: 1,
-      c: 2,
-      d: 3,
-    };
-    expectObservable(e1).toBe(expected, values);
+    rxTest.run(({ expectObservable }) => {
+      const e1 = timer(6, 2, rxTest).pipe(
+        take(4), // make it actually finite, so it can be rendered
+        concat(NEVER) // but pretend it's infinite by not completing
+      );
+      const expected = '------a-b-c-d-';
+      const values = {
+        a: 0,
+        b: 1,
+        c: 2,
+        d: 3,
+      };
+      expectObservable(e1).toBe(expected, values);
+    });
   });
 
   it('should schedule a value of 0 then complete', () => {
-    const dueTime = time('-----|');
-    const expected =     '-----(x|)';
+    rxTest.run(({ expectObservable }) => {
+      const dueTime = 5; // -----|
+      const expected = '    -----(x|)';
 
-    const source = timer(dueTime, undefined, rxTestScheduler);
-    expectObservable(source).toBe(expected, {x: 0});
+      const source = timer(dueTime, undefined, rxTest);
+      expectObservable(source).toBe(expected, { x: 0 });
+    });
   });
 
   it('should emit a single value immediately', () => {
-    const dueTime = time('|');
-    const expected =     '(x|)';
+    rxTest.run(({ expectObservable }) => {
+      const dueTime = 0;
+      const expected = '(x|)';
 
-    const source = timer(dueTime, rxTestScheduler);
-    expectObservable(source).toBe(expected, {x: 0});
+      const source = timer(dueTime, rxTest);
+      expectObservable(source).toBe(expected, { x: 0 });
+    });
   });
 
   it('should start after delay and periodically emit values', () => {
-    const dueTime = time('----|');
-    const period  = time(    '--|');
-    const expected =     '----a-b-c-d-(e|)';
+    rxTest.run(({ expectObservable }) => {
+      const dueTime = 4; // ----|
+      const period = 2; //       -|-|-|-|
+      const expected = '    ----a-b-c-d-(e|)';
 
-    const source = timer(dueTime, period, rxTestScheduler).pipe(take(5));
-    const values = { a: 0, b: 1, c: 2, d: 3, e: 4};
-    expectObservable(source).toBe(expected, values);
+      const source = timer(dueTime, period, rxTest).pipe(take(5));
+      const values = { a: 0, b: 1, c: 2, d: 3, e: 4 };
+      expectObservable(source).toBe(expected, values);
+    });
   });
 
   it('should start immediately and periodically emit values', () => {
-    const dueTime = time('|');
-    const period  = time('---|');
-    const expected =     'a--b--c--d--(e|)';
+    rxTest.run(({ expectObservable }) => {
+      const dueTime = 0; //|
+      const period = 3; //  --|--|--|--|
+      const expected = '   a--b--c--d--(e|)';
 
-    const source = timer(dueTime, period, rxTestScheduler).pipe(take(5));
-    const values = { a: 0, b: 1, c: 2, d: 3, e: 4};
-    expectObservable(source).toBe(expected, values);
+      const source = timer(dueTime, period, rxTest).pipe(take(5));
+      const values = { a: 0, b: 1, c: 2, d: 3, e: 4 };
+      expectObservable(source).toBe(expected, values);
+    });
   });
 
   it('should stop emiting values when subscription is done', () => {
-    const dueTime = time('|');
-    const period  = time('---|');
-    const expected = 'a--b--c--d--e';
-    const unsub   =  '^            !';
+    rxTest.run(({ expectObservable }) => {
+      const dueTime = 0; //|
+      const period = 3; //  --|--|--|--|
+      const expected = '   a--b--c--d--e';
+      const unsub = '      ^------------!';
 
-    const source = timer(dueTime, period, rxTestScheduler);
-    const values = { a: 0, b: 1, c: 2, d: 3, e: 4};
-    expectObservable(source, unsub).toBe(expected, values);
+      const source = timer(dueTime, period, rxTest);
+      const values = { a: 0, b: 1, c: 2, d: 3, e: 4 };
+      expectObservable(source, unsub).toBe(expected, values);
+    });
   });
 
   it('should schedule a value at a specified Date', () => {
-    const offset = time('----|');
-    const expected =    '----(a|)';
+    rxTest.run(({ expectObservable }) => {
+      const offset = 4; // ----|
+      const expected = '   ----(a|)';
 
-    const dueTime = new Date(rxTestScheduler.now() + offset);
-    const source = timer(dueTime, null as any, rxTestScheduler);
-    expectObservable(source).toBe(expected, {a: 0});
+      const dueTime = new Date(rxTest.now() + offset);
+      const source = timer(dueTime, undefined, rxTest);
+      expectObservable(source).toBe(expected, { a: 0 });
+    });
   });
 
   it('should start after delay and periodically emit values', () => {
-    const offset = time('----|');
-    const period = time(    '--|');
-    const expected =    '----a-b-c-d-(e|)';
+    rxTest.run(({ expectObservable }) => {
+      const offset = 4; // ----|
+      const period = 2; //      -|-|-|-|
+      const expected = '   ----a-b-c-d-(e|)';
 
-    const dueTime = new Date(rxTestScheduler.now() + offset);
-    const source = timer(dueTime, period, rxTestScheduler).pipe(take(5));
-    const values = { a: 0, b: 1, c: 2, d: 3, e: 4};
-    expectObservable(source).toBe(expected, values);
+      const dueTime = new Date(rxTest.now() + offset);
+      const source = timer(dueTime, period, rxTest).pipe(take(5));
+      const values = { a: 0, b: 1, c: 2, d: 3, e: 4 };
+      expectObservable(source).toBe(expected, values);
+    });
   });
 
-  it('should still target the same date if a date is provided even for the ' +
-    'second subscription', () => {
+  it('should still target the same date if a date is provided even for the ' + 'second subscription', () => {
+    rxTest.run(({ cold, time, expectObservable }) => {
       const offset = time('----|    ');
-      const t1 = cold(    'a|       ');
-      const t2 = cold(    '--a|     ');
-      const expected =    '----(aa|)';
+      const t1 = cold('    a|       ');
+      const t2 = cold('    --a|     ');
+      const expected = '   ----(aa|)';
 
-      const dueTime = new Date(rxTestScheduler.now() + offset);
-      const source = timer(dueTime, null as any, rxTestScheduler);
+      const dueTime = new Date(rxTest.now() + offset);
+      const source = timer(dueTime, undefined, rxTest);
 
-      const testSource = merge(t1, t2).pipe(
-        mergeMap(() => source)
-      );
+      const testSource = merge(t1, t2).pipe(mergeMap(() => source));
 
-      expectObservable(testSource).toBe(expected, {a: 0});
+      expectObservable(testSource).toBe(expected, { a: 0 });
+    });
+  });
+
+  it('should accept Infinity as the first argument', () => {
+    rxTest.run(({ expectObservable }) => {
+      const source = timer(Infinity, undefined, rxTest);
+      const expected = '------';
+      expectObservable(source).toBe(expected);
+    });
+  });
+
+  it('should accept Infinity as the second argument', () => {
+    rxTest.run(({ expectObservable }) => {
+      rxTest.maxFrames = 20;
+      const source = timer(4, Infinity, rxTest);
+      const expected = '----a-';
+      expectObservable(source).toBe(expected, { a: 0 });
+    });
+  });
+
+  it('should accept negative numbers as the second argument, which should cause immediate completion', () => {
+    rxTest.run(({ expectObservable }) => {
+      const source = timer(4, -4, rxTest);
+      const expected = '----(a|)';
+      expectObservable(source).toBe(expected, { a: 0 });
+    });
+  });
+
+  it('should accept 0 as the second argument', () => {
+    rxTest.run(({ expectObservable }) => {
+      const source = timer(4, 0, rxTest).pipe(take(5));
+      const expected = '----(abcde|)';
+      expectObservable(source).toBe(expected, { a: 0, b: 1, c: 2, d: 3, e: 4 });
+    });
+  });
+
+  it('should emit after a delay of 0 for Date objects in the past', () => {
+    rxTest.run(({ expectObservable }) => {
+      const expected = '(a|)';
+      const threeSecondsInThePast = new Date(rxTest.now() - 3000);
+      const source = timer(threeSecondsInThePast, undefined, rxTest);
+      expectObservable(source).toBe(expected, { a: 0 });
+    });
   });
 });

--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -1,101 +1,184 @@
 import { Observable } from '../Observable';
 import { SchedulerAction, SchedulerLike } from '../types';
-import { async } from '../scheduler/async';
-import { isNumeric } from '../util/isNumeric';
+import { async as asyncScheduler } from '../scheduler/async';
 import { isScheduler } from '../util/isScheduler';
 import { Subscriber } from '../Subscriber';
+import { isValidDate } from '../util/isDate';
 
 /**
- * Creates an Observable that starts emitting after an `dueTime` and
- * emits ever increasing numbers after each `period` of time thereafter.
+ * Creates an observable that emits incrementing numbers, starting at `0`, over time.
  *
  * <span class="informal">Its like {@link index/interval}, but you can specify when
- * should the emissions start.</span>
+ * should the emissions start (either by delay or exact date).</span>
  *
  * ![](timer.png)
  *
- * `timer` returns an Observable that emits an infinite sequence of ascending
- * integers, with a constant interval of time, `period` of your choosing
- * between those emissions. The first emission happens after the specified
- * `dueTime`. The initial delay may be a `Date`. By default, this
- * operator uses the {@link asyncScheduler} {@link SchedulerLike} to provide a notion of time, but you
- * may pass any {@link SchedulerLike} to it. If `period` is not specified, the output
- * Observable emits only one value, `0`. Otherwise, it emits an infinite
- * sequence.
+ * Will return an observable that emits incrementing numbers over time, starting a `0`,
+ * or just a single number `0` after a specified delay or start time.
+ *
+ * If no scheduler is provided, {@link index/asyncScheduler} will be the assumed default.
+ *
+ * When the first value of `0` is emitted is determined by a calculation based off of the
+ * `dueTime`:
+ *
+ * 1. If the `dueTime` is a *valid* `Date` object, the first emission will be after a delay
+ * calculated by subtracting the current timestamp (provided by the scheduler), from the numeric
+ * value of the `Date`, which will be an epoch number in milliseconds.
+ * 2. If the `dueTime` is a number, the first emission will be after a delay equal to that number.
+ * 3. If the result of either 1 or 2 above is negative, that is the `dueTime` is a `Date` in the
+ * past, OR a negative number, the result is the first emission will be scheduled after a delay
+ * of `0`.
+ *
+ * When subsequent values are emitted is determined by the `period` argument:
+ *
+ * 1. If their is no `period` argument, there will be no further emissions.
+ * 2. If the `period` argument is `0`, each new emission will be scheduled with a delay of `0`.
+ * 3. If the `period` argument is a postive number, each new emission will be scheduled with a
+ * delay equal to that number.
+ * 4. If the `period` argument is negative, there will be no further emissions.
+ *
+ * **Known Issues**:
+ *
+ * If a `scheduler` is provided that returns a timsstamp other than an epoch from `now()`, and
+ * a `Date` object is passed to the `dueTime` argument, the calculation for when the first emission
+ * should occur will be incorrect. In this case, it would be best to do your own calculations
+ * ahead of time, and pass a `number` in as the `dueTime`.
+ *
+ * Once the first value is emitted, if a `period` was provided
  *
  * ## Examples
- * ### Emits ascending numbers, one every second (1000ms), starting after 3 seconds
- * ```ts
- * import { timer } from 'rxjs';
  *
- * const numbers = timer(3000, 1000);
- * numbers.subscribe(x => console.log(x));
+ * ### Wait 3 seconds and start another observable
+ *
+ * You might want to use `timer` to delay subscription to an
+ * observable by a set amount of time. Here we use a timer with
+ * {@link concatMapTo} or {@link concatMap} in order to wait
+ * a few seconds and start a subscription to a source.
+ *
+ * ```ts
+ * import { timer, of } from 'rxjs';
+ * import { concatMapTo } from 'rxjs/operators';
+ *
+ * // This could be any observable
+ * const source = of(1, 2, 3);
+ *
+ * const result = timer(3000).pipe(
+ *   concatMapTo(source)
+ * )
+ * .subscribe(console.log);
  * ```
  *
- * ### Emits one number after five seconds
- * ```ts
- * import { timer } from 'rxjs';
+ * ### Take all of the values until the start of the next minute
  *
- * const numbers = timer(5000);
- * numbers.subscribe(x => console.log(x));
+ * Using the a date as the trigger for the first emission, you can
+ * do things like wait until midnight to fire an event, or in this case,
+ * wait until a new minute starts (chosen so the example wouldn't take
+ * too long to run) in order to stop watching a stream. Leveraging
+ * {@link takeUntil}.
+ *
+ * ```ts
+ * import { interval, timer } from 'rxjs';
+ * import { takeUntil } from 'rxjs/operators';
+ *
+ * // Build a Date object that marks the
+ * // next minute.
+ * const currentDate = new Date();
+ * const startOfNextMinute = new Date(
+ *   currentDate.getFullYear(),
+ *   currentDate.getMonth(),
+ *   currentDate.getDate(),
+ *   currentDate.getHours(),
+ *   currentDate.getMinutes() + 1,
+ * )
+ *
+ * // This could be any observable stream
+ * const source = interval(1000);
+ *
+ * const result = source.pipe(
+ *   takeUntil(timer(startOfNextMinute))
+ * );
+ *
+ * result.subscribe(console.log);
  * ```
+ *
+ * ### Start an interval that starts right away
+ *
+ * Since {@link index/interval} waits for the passed delay before starting,
+ * sometimes that's not ideal. You may want to start an interval immediately.
+ * `timer` works well for this. Here we have both side-by-side so you can
+ * see them in comparison.
+ *
+ * ```ts
+ * import { timer, interval } from 'rxjs';
+ *
+ * timer(0, 1000).subscribe(n => console.log('timer', n));
+ * interval(1000).subscribe(n => console.log('interval', n));
+ * ```
+ *
  * @see {@link index/interval}
  * @see {@link delay}
  *
- * @param {number|Date} [dueTime] The initial delay time specified as a Date object or as an integer denoting
+ * @param dueTime The initial delay time specified as a Date object or as an integer denoting
  * milliseconds to wait before emitting the first value of `0`.
- * @param {number|SchedulerLike} [periodOrScheduler] The period of time between emissions of the
+ * @param periodOrScheduler The period of time between emissions of the
  * subsequent numbers.
- * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for scheduling
+ * @param scheduler The {@link SchedulerLike} to use for scheduling
  * the emission of values, and providing a notion of "time".
- * @return {Observable} An Observable that emits a `0` after the
+ * @return An Observable that emits a `0` after the
  * `dueTime` and ever increasing numbers after each `period` of time
  * thereafter.
- * @static true
- * @name timer
- * @owner Observable
  */
-export function timer(dueTime: number | Date = 0,
-                      periodOrScheduler?: number | SchedulerLike,
-                      scheduler?: SchedulerLike): Observable<number> {
+export function timer(
+  dueTime: number | Date = 0,
+  periodOrScheduler?: number | SchedulerLike,
+  scheduler?: SchedulerLike
+): Observable<number> {
+  // Negative periods will complete after the due time.
   let period = -1;
-  if (isNumeric(periodOrScheduler)) {
-    period = Number(periodOrScheduler) < 1 && 1 || Number(periodOrScheduler);
-  } else if (isScheduler(periodOrScheduler)) {
-    scheduler = periodOrScheduler as any;
+
+  if (periodOrScheduler != null) {
+    if (isScheduler(periodOrScheduler)) {
+      scheduler = periodOrScheduler;
+    } else {
+      period = periodOrScheduler;
+    }
   }
 
   if (!isScheduler(scheduler)) {
-    scheduler = async;
+    scheduler = asyncScheduler;
   }
 
-  return new Observable(subscriber => {
-    const due = isNumeric(dueTime)
-      ? (dueTime as number)
-      : (+dueTime - scheduler!.now());
+  return new Observable((subscriber) => {
+    // If a valid date is passed, calculate how long to wait before
+    // executing the first value... otherwise, if it's a number just schedule
+    // that many milliseconds (or scheduler-specified unit size) in the future.
+    const due = Math.max(0, isValidDate(dueTime) ? +dueTime - scheduler!.now() : dueTime);
 
-    return scheduler!.schedule(dispatch as any, due, {
-      index: 0, period, subscriber
+    return scheduler!.schedule<TimerState>(dispatch as any, due, {
+      counter: 0,
+      period,
+      subscriber,
     });
   });
 }
 
 interface TimerState {
-  index: number;
+  counter: number;
   period: number;
   subscriber: Subscriber<number>;
 }
 
 function dispatch(this: SchedulerAction<TimerState>, state: TimerState) {
-  const { index, period, subscriber } = state;
-  subscriber.next(index);
+  const { period, subscriber } = state;
+  const counter = state.counter++;
+  subscriber.next(counter);
 
-  if (subscriber.closed) {
-    return;
-  } else if (period === -1) {
-    return subscriber.complete();
+  if (!subscriber.closed) {
+    if (period < 0) {
+      // Periods scheduled with a negative number will just complete.
+      return subscriber.complete();
+    }
+
+    this.schedule(state, period);
   }
-
-  state.index = index + 1;
-  this.schedule(state, period);
 }

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -1,5 +1,5 @@
 import { async } from '../scheduler/async';
-import { isDate } from '../util/isDate';
+import { isValidDate } from '../util/isDate';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
@@ -58,7 +58,7 @@ import { MonoTypeOperatorFunction, PartialObserver, SchedulerAction, SchedulerLi
  */
 export function delay<T>(delay: number|Date,
                          scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
-  const absoluteDelay = isDate(delay);
+  const absoluteDelay = isValidDate(delay);
   const delayFor = absoluteDelay ? (+delay - scheduler.now()) : Math.abs(<number>delay);
   return (source: Observable<T>) => source.lift(new DelayOperator(delayFor, scheduler));
 }

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -2,7 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { async } from '../scheduler/async';
 import { Observable } from '../Observable';
-import { isDate } from '../util/isDate';
+import { isValidDate } from '../util/isDate';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
@@ -67,7 +67,7 @@ export function timeoutWith<T, R>(due: number | Date,
                                   withObservable: ObservableInput<R>,
                                   scheduler: SchedulerLike = async): OperatorFunction<T, T | R> {
   return (source: Observable<T>) => {
-    let absoluteTimeout = isDate(due);
+    let absoluteTimeout = isValidDate(due);
     let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
     return source.lift(new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));
   };

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -74,17 +74,23 @@ export class VirtualAction<T> extends AsyncAction<T> {
   }
 
   public schedule(state?: T, delay: number = 0): Subscription {
-    if (!this.id) {
-      return super.schedule(state, delay);
+    if (Number.isFinite(delay)) {
+      if (!this.id) {
+        return super.schedule(state, delay);
+      }
+      this.active = false;
+      // If an action is rescheduled, we save allocations by mutating its state,
+      // pushing it to the end of the scheduler queue, and recycling the action.
+      // But since the VirtualTimeScheduler is used for testing, VirtualActions
+      // must be immutable so they can be inspected later.
+      const action = new VirtualAction(this.scheduler, this.work);
+      this.add(action);
+      return action.schedule(state, delay);
+    } else {
+      // If someone schedules something with Infinity, it'll never happen. So we
+      // don't even schedule it.
+      return Subscription.EMPTY;
     }
-    this.active = false;
-    // If an action is rescheduled, we save allocations by mutating its state,
-    // pushing it to the end of the scheduler queue, and recycling the action.
-    // But since the VirtualTimeScheduler is used for testing, VirtualActions
-    // must be immutable so they can be inspected later.
-    const action = new VirtualAction(this.scheduler, this.work);
-    this.add(action);
-    return action.schedule(state, delay);
   }
 
   protected requestAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay: number = 0): any {

--- a/src/internal/util/isDate.ts
+++ b/src/internal/util/isDate.ts
@@ -1,3 +1,10 @@
-export function isDate(value: any): value is Date {
-  return value instanceof Date && !isNaN(+value);
+/**
+ * Checks to see if a value is not only a `Date` object,
+ * but a *valid* `Date` object that can be converted to a
+ * number. For example, `new Date('blah')` is indeed an
+ * `instanceof Date`, however it cannot be converted to a
+ * number.
+ */
+export function isValidDate(value: any): value is Date {
+  return value instanceof Date && !isNaN(value as any);
 }


### PR DESCRIPTION
Fixes for `TestScheduler` and `VirtualTimeScheduler`:
- Resolves an issue where scheduling at non-finite numbers would result in marbles showing up in tests that had a `frame` of `null`.

Fixes for `timer`:
- Adds tests for cases where `Infinity` could be passed
- Adds a test for dueTime `Date` objects in the past
- Completely rewrites and improves documentation and updates examples
- Renames internal utility function `isDate` to `isValidDate` to better convey what it is doing and why


This is just part of my march through the code to fix up things that were using `isNumeric`, which I find highly suspect.