### PR TITLE
fix: support empty subscription marbles

### DIFF
--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -282,6 +282,18 @@ describe('TestScheduler', () => {
         expectSubscriptions(source.subscriptions).toBe(subs);
         source.subscribe();
       });
+
+      it('should support empty subscription marbles', () => {
+        const source = cold('---a---b-|');
+        const subs =        '----------';
+        expectSubscriptions(source.subscriptions).toBe(subs);
+      });
+
+      it('should support empty subscription marbles within arrays', () => {
+        const source = cold('---a---b-|');
+        const subs =       ['----------'];
+        expectSubscriptions(source.subscriptions).toBe(subs);
+      });
     });
 
     describe('end-to-end helper tests', () => {

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -170,7 +170,7 @@ export class TestScheduler extends VirtualTimeScheduler {
         flushTest.ready = true;
         flushTest.expected = marblesArray.map(marbles =>
           TestScheduler.parseMarblesAsSubscriptions(marbles, runMode)
-        );
+        ).filter(marbles => marbles.subscribedFrame !== Infinity);
       }
     };
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Correctly interprets subscription marble diagrams that do not include a subscribe character as not being subscription expectations. See related issue for more details.

This PR adds failing tests and then filters subscription logs that are associated with marbles that lack subscription characters.

**Related issue (if exists):** #5499
