### PR TITLE
test(shareReplay): shot not skep values from a sync source

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -265,4 +265,15 @@ describe('shareReplay operator', () => {
         done();
       });
   });
+
+  it('should not skip values on a sync source', () => {
+    const a = cold(  '(abcd|)');
+    const x = cold(  'x-------x');
+    const expected = '(abcd)--d';
+
+    const shared = a.pipe(shareReplay(1));
+    const result = x.pipe(mergeMapTo(shared));
+    expectObservable(result).toBe(expected);
+  });
+
 });


### PR DESCRIPTION
DO NOT MERGE

**Description:**
This PR demonstrates that the original test used on #5521 unfortunately does not accomplish its goal.
