### PR TITLE
fix(pluck): operator breaks with null/undefined inputs.

### DIFF
--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -196,4 +196,14 @@ describe('pluck operator', () => {
     expectObservable(r).toBe(expected, {y: 'abc'});
     expectSubscriptions(a.subscriptions).toBe(asubs);
   });
+
+  it('should not break on null values', () => {
+    const a =   cold('--x--|', {x: null});
+    const asubs =    '^    !';
+    const expected = '--y--|';
+
+    const r = a.pipe(pluck('prop'));
+    expectObservable(r).toBe(expected, {y: undefined});
+    expectSubscriptions(a.subscriptions).toBe(asubs);
+  });
 });

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -51,7 +51,7 @@ export function pluck<T, R>(...properties: Array<string | number | symbol>): Ope
   return map((x) => {
     let currentProp: any = x;
     for (let i = 0; i < length; i++) {
-      const p = currentProp?.[properties[i]] ?? undefined;
+      const p = currentProp?.[properties[i]];
       if (typeof p !== 'undefined') {
         currentProp = p;
       } else {

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -51,7 +51,7 @@ export function pluck<T, R>(...properties: Array<string | number | symbol>): Ope
   return map((x) => {
     let currentProp: any = x;
     for (let i = 0; i < length; i++) {
-      const p = currentProp[properties[i]];
+      const p = currentProp?.[properties[i]] ?? undefined;
       if (typeof p !== 'undefined') {
         currentProp = p;
       } else {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Add a fix to prevent the pluck operator from breaking on null or undefined inputs. 

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/5505