### PR TITLE
docs(subscription): Improving subscription.add() documentation

### DIFF
--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -108,8 +108,9 @@ export class Subscription implements SubscriptionLike {
   }
 
   /**
-   * Adds a tear down to be called during the unsubscribe() of this
-   * Subscription. Can also be used to add a child subscription.
+   * Adds a tear down to be called when the subscription terminates
+   * (on complete, error, or during unsubscribe()). Can also be used
+   * to add a child subscription.
    *
    * If the tear down being added is a subscription that is already
    * unsubscribed, is the same reference `add` is being called on, or is


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Currently the documentation claims that `subscription.add()` will call teardown logic during unsubscribe, this is only part of the story as teardown logic is also called when the subscription terminates for any reason.
