### PR TITLE
Add https://rxjs.xyz/

### DIFF
--- a/docs_app/content/resources.md
+++ b/docs_app/content/resources.md
@@ -4,6 +4,13 @@ This is a collection of resources that can be found to help with the learning pr
 
 **Note**: RxJS maintainers are not responsible for any of the following content that is not part of the official rxjs documentation site. Please adhere to the terms and copyrights of the sites and links listed.
 
+## Community Packages
+
+We occasionally have to reject feature requests for new APIs, as the core RxJS API is already large and imposing. Such rejections usually take the form of suggesting the creation of a user-land package, so that the feature’s utility and popularity can be gauged before considering its inclusion in the core.
+
+[There’s a site upon](https://rxjs.xyz/) which such user-land packages can be listed — and can be made a little more visible — these rejections will be a little less disappointing. [Browse the community packages at https://rxjs.xyz](https://rxjs.xyz/)
+
+
 ## Blogs
 
 ### 2018


### PR DESCRIPTION
Continuing the discussion from https://github.com/ReactiveX/rxjs/issues/5538 which was closed, I feel like there is a fragmentation problem where important context for making good use of RxJs is missing from the docs. This attempts to bridge the gap, and implements the suggestion I was trying to discuss before 5538 was abruptly closed, it takes a step in the right direction by making these 3rd party packages actually visible, so readers of the docs are actually aware there is more to the ecosystem than just what is shown on the official docs.