### PR TITLE
Example code is wrong.

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -18,7 +18,7 @@ For example, the operator called [`map`](/api/operators/map) is analogous to the
 import { of } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-map(x => x * x)(of(1, 2, 3)).subscribe((v) => console.log(`value: ${v}`));
+of(1, 2, 3).pipe(map(x => x * x)).subscribe((v) => console.log(`value: ${v}`));
 
 // Logs:
 // value: 1 
@@ -33,7 +33,7 @@ will emit `1`, `4`, `9`.  Another useful operator is [`first`](/api/operators/fi
 import { of } from 'rxjs';
 import { first } from 'rxjs/operators';
 
-first()(of(1, 2, 3)).subscribe((v) => console.log(`value: ${v}`));
+of(1, 2, 3).pipe(first()).subscribe((v) => console.log(`value: ${v}`));
 
 // Logs:
 // value: 1 


### PR DESCRIPTION
operator map and the first example are wrong.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
