### PR TITLE
docs(overview): corrected grammatical error

### DIFF
--- a/docs_app/content/guide/overview.md
+++ b/docs_app/content/guide/overview.md
@@ -12,7 +12,7 @@ The essential concepts in RxJS which solve async event management are:
 - **Observer:** is a collection of callbacks that knows how to listen to values delivered by the Observable.
 - **Subscription:** represents the execution of an Observable, is primarily useful for cancelling the execution.
 - **Operators:** are pure functions that enable a functional programming style of dealing with collections with operations like `map`, `filter`, `concat`, `reduce`, etc.
-- **Subject:** is the equivalent to an EventEmitter, and the only way of multicasting a value or event to multiple Observers.
+- **Subject:** is equivalent to an EventEmitter, and the only way of multicasting a value or event to multiple Observers.
 - **Schedulers:** are centralized dispatchers to control concurrency, allowing us to coordinate when computation happens on e.g. `setTimeout` or `requestAnimationFrame` or others.
 
 ## First examples


### PR DESCRIPTION
Corrected a grammatical error in the overview page document. **"the"** should not be used here.