### PR TITLE
fix: revert #5458

### DIFF
--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -152,6 +152,7 @@ function shareReplayOperator<T>({
   let refCount = 0;
   let subscription: Subscription | undefined;
   let hasError = false;
+  let isComplete = false;
 
   return function shareReplayOperation(this: Subscriber<T>, source: Observable<T>) {
     refCount++;
@@ -167,6 +168,7 @@ function shareReplayOperator<T>({
           subject!.error(err);
         },
         complete() {
+          isComplete = true;
           subscription = undefined;
           subject!.complete();
         },
@@ -178,7 +180,7 @@ function shareReplayOperator<T>({
     this.add(() => {
       refCount--;
       innerSub.unsubscribe();
-      if (subscription && useRefCount && refCount === 0) {
+      if (subscription && !isComplete && useRefCount && refCount === 0) {
         subscription.unsubscribe();
         subscription = undefined;
         subject = undefined;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing test and reverts #5458 - which removed the `isComplete` variable from `shareReplay`. With the reversion, the test passes. There was an existing test that attempted to test what's tested by the new test, but there was a subtle difference because of this problem: https://github.com/ReactiveX/rxjs/issues/5523

**Related issue (if exists):** #5458
