### PR TITLE
Fix/share replay ref count sync

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -267,20 +267,14 @@ describe('shareReplay operator', () => {
   });
 
   it('should not skip values on a sync source', () => {
-    const a = from(['a', 'b', 'c', 'd']);
-    // We would like for the previous line to read like this:
-    //
-    // const a = cold('(abcd|)');
-    //
-    // However, that would synchronously emit multiple values at frame 0,
-    // but it's not synchronous upon-subscription.
+    const source = from(['a', 'b', 'c', 'd']);
     // TODO: revisit once https://github.com/ReactiveX/rxjs/issues/5523 is fixed
+    // const source = cold(    '(abcd|)');
+    const subscriptions = cold('x-------x');
+    const expected =           '(abcd)--d';
 
-    const x = cold(  'x-------x');
-    const expected = '(abcd)--d';
-
-    const shared = a.pipe(shareReplay(1));
-    const result = x.pipe(mergeMapTo(shared));
+    const shared = source.pipe(shareReplay(1));
+    const result = subscriptions.pipe(mergeMapTo(shared));
     expectObservable(result).toBe(expected);
   });
 

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -219,6 +219,21 @@ describe('shareReplay operator', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
+  it('should not restart due to unsubscriptions if refCount is true when the source completes synchronously', () => {
+    const source = from(['a', 'b', 'c']); // TODO: revisit once https://github.com/ReactiveX/rxjs/issues/5523 is fixed
+
+    // const source = cold('(abc|)');
+    const sub1 =           '^------!       ';
+    const expected1 =      '(abc|)         ';
+    const sub2 =           '-----------^!  ';
+    const expected2 =      '-----------(c|)';
+
+    const shared = source.pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+    expectObservable(shared, sub1).toBe(expected1);
+    expectObservable(shared, sub2).toBe(expected2);
+  });
+
   it('should default to refCount being false', () => {
     const source = cold('a-b-c-d-e-f-g-h-i-j');
     const sourceSubs =  '^------------------';

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -178,7 +178,7 @@ function shareReplayOperator<T>({
     this.add(() => {
       refCount--;
       innerSub.unsubscribe();
-      if (subscription && useRefCount && refCount === 0) {
+      if (subscription && !subscription.closed && useRefCount && refCount === 0) {
         subscription.unsubscribe();
         subscription = undefined;
         subject = undefined;


### PR DESCRIPTION
**Description:**
Bug fix: shareReplay with refCount sync sources shouldn't restart

**Related issue (if exists):**
It addresses #5548 
