### PR TITLE
test(type): deprecate legacy type test

### DIFF
--- a/spec/helpers/testScheduler-ui.ts
+++ b/spec/helpers/testScheduler-ui.ts
@@ -117,17 +117,6 @@ module.exports = function(suite: any) {
       return suite;
     };
 
-    /**
-     * Describe a test case to test type definition
-     * sanity on build time. Recommended only for
-     * exceptional type definition won't be used in test cases.
-     */
-
-    context.type = function(title: any, fn: any) {
-      //intentionally does not execute to avoid unexpected side effect occurs by subscription,
-      //or infinite source. Suffecient to check build time only.
-    };
-
     function stringify(x: any): string {
       return JSON.stringify(x, function (key: string, value: any) {
         if (Array.isArray(value)) {

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -3,8 +3,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { queueScheduler as rxQueueScheduler, combineLatest, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 
-declare const type: Function;
-
 const queueScheduler = rxQueueScheduler;
 
 /** @test {combineLatest} */

--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -3,8 +3,6 @@ import { forkJoin, of } from 'rxjs';
 import { lowerCaseO } from '../helpers/test-helper';
 import { hot, expectObservable, expectSubscriptions, cold } from '../helpers/marble-testing';
 
-declare const type: Function;
-
 /** @test {forkJoin} */
 describe('forkJoin', () => {
   it('should join the last values of the provided observables into an array', () => {

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -1,11 +1,10 @@
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
-import { asyncScheduler, of, from, Observable, asapScheduler, Observer, observable, Subject, EMPTY } from 'rxjs';
+import { asyncScheduler, of, from, Observer, observable, Subject } from 'rxjs';
 import { first, concatMap, delay } from 'rxjs/operators';
 
 // tslint:disable:no-any
 declare const expectObservable: any;
-declare const type: any;
 declare const rxTestScheduler: TestScheduler;
 // tslint:enable:no-any
 
@@ -33,20 +32,6 @@ describe('from', () => {
     };
 
     expect(r).to.throw();
-  });
-
-  type('should return T for InteropObservable objects', () => {
-    /* tslint:disable:no-unused-variable */
-    const o1: Observable<number> = from([] as number[], asapScheduler);
-    const o2: Observable<{ a: string }> = from(EMPTY);
-    const o3: Observable<{ b: number }> = from(new Promise<{b: number}>(resolve => resolve()));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should return T for arrays', () => {
-    /* tslint:disable:no-unused-variable */
-    const o1: Observable<number> = from([] as number[], asapScheduler);
-    /* tslint:enable:no-unused-variable */
   });
 
   const fakervable = <T>(...values: T[]) => ({

--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -1,11 +1,8 @@
 import { expect } from 'chai';
 import { expectObservable } from '../helpers/marble-testing';
-import { Observable, fromEvent, NEVER, timer } from 'rxjs';
-import { NodeStyleEventEmitter, NodeCompatibleEventEmitter, NodeEventHandler } from 'rxjs/internal/observable/fromEvent';
+import { fromEvent, NEVER, timer } from 'rxjs';
 import { mapTo, take, concat } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-
-declare const type: Function;
 
 declare const rxTestScheduler: TestScheduler;
 
@@ -393,47 +390,6 @@ describe('fromEvent', () => {
       fromEvent(obj, 'foo').subscribe();
       done();
     }).to.not.throw(TypeError);
-  });
-
-  type('should support node style event emitters interfaces', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: NodeStyleEventEmitter;
-    let b: Observable<any> = fromEvent(a!, 'mock');
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support node compatible event emitters interfaces', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: NodeCompatibleEventEmitter;
-    let b: Observable<any> = fromEvent(a!, 'mock');
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support node style event emitters objects', () => {
-    /* tslint:disable:no-unused-variable */
-    interface NodeEventEmitter {
-      addListener(eventType: string | symbol, handler: NodeEventHandler): this;
-      removeListener(eventType: string | symbol, handler: NodeEventHandler): this;
-    }
-    let a: NodeEventEmitter;
-    let b: Observable<any> = fromEvent(a!, 'mock');
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support React Native event emitters', () => {
-    /* tslint:disable:no-unused-variable */
-    interface EmitterSubscription {
-      context: any;
-    }
-    interface ReactNativeEventEmitterListener {
-      addListener(eventType: string, listener: (...args: any[]) => any, context?: any): EmitterSubscription;
-    }
-    interface ReactNativeEventEmitter extends ReactNativeEventEmitterListener {
-      removeListener(eventType: string, listener: (...args: any[]) => any): void;
-    }
-    let a: ReactNativeEventEmitter;
-    let b: Observable<any> = fromEvent(a!, 'mock');
-    /* tslint:enable:no-unused-variable */
   });
 
 });

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -1,8 +1,6 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { queueScheduler as rxQueueScheduler, zip, from, of, Observable } from 'rxjs';
-
-declare const type: Function;
+import { queueScheduler as rxQueueScheduler, zip, from, of } from 'rxjs';
 
 declare const Symbol: any;
 
@@ -575,54 +573,5 @@ describe('static zip', () => {
     zip(a, b).subscribe((vals: Array<number>) => {
       expect(vals).to.deep.equal(r[i++]);
     }, null, done);
-  });
-
-  type('should support observables', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: Observable<number>;
-    let b: Observable<string>;
-    let c: Observable<boolean>;
-    let o1: Observable<[number, string, boolean]> = zip(a!, b!, c!);
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support mixed observables and promises', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: Promise<number>;
-    let b: Observable<string>;
-    let c: Promise<boolean>;
-    let d: Observable<string[]>;
-    let o1: Observable<[number, string, boolean, string[]]> = zip(a!, b!, c!, d!);
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support arrays of promises', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: Promise<number>[];
-    let o1: Observable<number[]> = zip(a!);
-    let o2: Observable<number[]> = zip(...a!);
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support arrays of observables', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: Observable<number>[];
-    let o1: Observable<number[]> = zip(a!);
-    let o2: Observable<number[]> = zip(...a!);
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should return Array<T> when given a single promise', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: Promise<number>;
-    let o1: Observable<number[]> = zip(a!);
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should return Array<T> when given a single observable', () => {
-    /* tslint:disable:no-unused-variable */
-    let a: Observable<number>;
-    let o1: Observable<number[]> = zip(a!);
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/combineAll-spec.ts
+++ b/spec/operators/combineAll-spec.ts
@@ -1,10 +1,8 @@
 import { expect } from 'chai';
-import { queueScheduler, of, Observable } from 'rxjs';
+import { queueScheduler, of } from 'rxjs';
 import { combineAll, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
-
-declare const type: Function;
 
 /** @test {combineAll} */
 describe('combineAll operator', () => {
@@ -542,103 +540,5 @@ describe('combineAll operator', () => {
       expect(r.length).to.equal(0);
       done();
     });
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number[]> = of(source1, source2, source3).pipe(combineAll());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3).pipe(
-      combineAll((...args) => args.reduce((acc, x) => acc + x, 0))
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number[]> = of(source1, source2, source3).pipe(
-      combineAll()
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3).pipe(
-      combineAll((...args) => args.reduce((acc, x) => acc + x, 0))
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string[]> = of(<any>source1, <any>source2, <any>source3).pipe(
-      combineAll<string>()
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3).pipe(
-      combineAll<string>((...args) => args.reduce((acc, x) => acc + x, 0))
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string[]> = of(<any>source1, <any>source2, <any>source3).pipe(
-      combineAll<string>()
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3).pipe(
-      combineAll<string>((...args) => args.reduce((acc, x) => acc + x, 0))
-    );
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
-import { from, throwError, of, Observable } from 'rxjs';
+import { from, throwError, of } from 'rxjs';
 import { concatAll, take, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
-declare const type: Function;
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {concatAll} */
@@ -522,59 +521,5 @@ describe('concatAll operator', () => {
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3).pipe(
-      concatAll()
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3).pipe(
-      concatAll()
-    );
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(
-      <any>source1,
-      <any>source2,
-      <any>source3
-    ).pipe(concatAll<string>());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(
-      <any>source1,
-      <any>source2,
-      <any>source3
-    ).pipe(concatAll<string>());
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -1,10 +1,8 @@
 import { expect } from 'chai';
-import { NEVER, timer, of, EMPTY, concat, Subject, Observable } from 'rxjs';
+import { NEVER, timer, of, EMPTY, concat, Subject } from 'rxjs';
 import { debounce, mergeMap, mapTo } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-
-declare const type: Function;
 
 declare const rxTestScheduler: TestScheduler;
 
@@ -432,21 +430,5 @@ describe('debounce operator', () => {
     source.next(1);
 
     expect(results).to.deep.equal([1, 2]);
-  });
-
-  type('should support selectors of the same type', () => {
-    /* tslint:disable:no-unused-variable */
-    let o: Observable<number>;
-    let s: Observable<number>;
-    let r: Observable<number> = o!.pipe(debounce((n) => s));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support selectors of a different type', () => {
-    /* tslint:disable:no-unused-variable */
-    let o: Observable<number>;
-    let s: Observable<string>;
-    let r: Observable<number> = o!.pipe(debounce((n) => s));
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/exhaust-spec.ts
+++ b/spec/operators/exhaust-spec.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import { exhaust, mergeMap } from 'rxjs/operators';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { of, Observable } from 'rxjs';
-
-declare const type: Function;
+import { of } from 'rxjs';
 
 /** @test {exhaust} */
 describe('exhaust operator', () => {
@@ -213,51 +211,5 @@ describe('exhaust operator', () => {
       }, () => {
         done(new Error('should not be called'));
       });
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3)
-      .pipe(exhaust());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3)
-      .pipe(exhaust());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3)
-      .pipe(exhaust<string>());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3)
-      .pipe(exhaust<string>());
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -4,8 +4,6 @@ import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { Subscribable, EMPTY, Observable, of, Observer, asapScheduler, asyncScheduler } from 'rxjs';
 
-declare const type: Function;
-
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {expand} */

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -5,8 +5,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { of, timer, interval, NEVER, Observable } from 'rxjs';
 import { asInteropObservable } from '../helpers/interop-helper';
 
-declare const type: Function;
-
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {finalize} */

--- a/spec/operators/mergeAll-spec.ts
+++ b/spec/operators/mergeAll-spec.ts
@@ -3,8 +3,6 @@ import { mergeAll, mergeMap, take } from 'rxjs/operators';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { throwError, from, of, queueScheduler } from 'rxjs';
 
-declare const type: Function;
-
 /** @test {mergeAll} */
 describe('mergeAll oeprator', () => {
   it('should merge a hot observable of cold observables', () => {

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { mergeMapTo, map } from 'rxjs/operators';
-import { from, of, Observable } from 'rxjs';
-
-declare const type: Function;
+import { from, of } from 'rxjs';
 
 /** @test {mergeMapTo} */
 describe('mergeMapTo', () => {
@@ -367,15 +365,5 @@ describe('mergeMapTo', () => {
     });
 
     expect(completed).to.be.true;
-  });
-
-  type('should support type signatures', () => {
-    let o: Observable<number>;
-    let m: Observable<string>;
-
-    /* tslint:disable:no-unused-variable */
-    let a1: Observable<string> = o!.pipe(mergeMapTo(m!));
-    let a2: Observable<string> = o!.pipe(mergeMapTo(m!, 3));
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -4,8 +4,6 @@ import { Subject, ReplaySubject, of, ConnectableObservable, zip, concat, Subscri
 import { TestScheduler } from 'rxjs/testing';
 import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
 
-declare const type: Function;
-
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {multicast} */
@@ -700,51 +698,6 @@ describe('multicast operator', () => {
           expect(expected.length).to.equal(0);
           done();
         });
-    });
-  });
-
-  describe('typings', () => {
-    type('should infer the type', () => {
-      /* tslint:disable:no-unused-variable */
-      const source = of(1, 2, 3);
-      const result: ConnectableObservable<number> = source.pipe(multicast(() => new Subject<number>())) as ConnectableObservable<number>;
-      /* tslint:enable:no-unused-variable */
-    });
-
-    type('should infer the type with a selector', () => {
-      /* tslint:disable:no-unused-variable */
-      const source = of(1, 2, 3);
-      const result: Observable<number> = source.pipe(multicast(() => new Subject<number>(), s => s.pipe(map(x => x))));
-      /* tslint:enable:no-unused-variable */
-    });
-
-    type('should infer the type with a type-changing selector', () => {
-      /* tslint:disable:no-unused-variable */
-      const source = of(1, 2, 3);
-      const result: Observable<string> = source.pipe(multicast(() => new Subject<number>(), s => s.pipe(map(x => x + '!'))));
-      /* tslint:enable:no-unused-variable */
-    });
-
-    type('should infer the type for the pipeable operator', () => {
-      /* tslint:disable:no-unused-variable */
-      const source = of(1, 2, 3);
-      // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-      const result: ConnectableObservable<number> = multicast(() => new Subject<number>())(source);
-      /* tslint:enable:no-unused-variable */
-    });
-
-    type('should infer the type for the pipeable operator with a selector', () => {
-      /* tslint:disable:no-unused-variable */
-      const source = of(1, 2, 3);
-      const result: Observable<number> = source.pipe(multicast(() => new Subject<number>(), s => s.pipe(map(x => x))));
-      /* tslint:enable:no-unused-variable */
-    });
-
-    type('should infer the type for the pipeable operator with a type-changing selector', () => {
-      /* tslint:disable:no-unused-variable */
-      const source = of(1, 2, 3);
-      const result: Observable<string> = source.pipe(multicast(() => new Subject<number>(), s => s.pipe(map(x => x + '!'))));
-      /* tslint:enable:no-unused-variable */
     });
   });
 });

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { publish, zip, mergeMapTo, mergeMap, tap, refCount, retry, repeat, map } from 'rxjs/operators';
+import { publish, zip, mergeMapTo, mergeMap, tap, refCount, retry, repeat } from 'rxjs/operators';
 import { ConnectableObservable, of, Subscription, Observable } from 'rxjs';
-
-declare const type: Function;
 
 /** @test {publish} */
 describe('publish operator', () => {
@@ -338,48 +336,5 @@ describe('publish operator', () => {
     expect(results2).to.deep.equal([1, 2, 3, 4]);
     expect(subscriptions).to.equal(1);
     done();
-  });
-
-  type('should infer the type', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: ConnectableObservable<number> = source.pipe(publish()) as ConnectableObservable<number>;
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type with a selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<number> = source.pipe(publish(s => s.pipe(map(x => x))));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type with a type-changing selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<string> = source.pipe(publish(s => s.pipe(map(x => x + '!'))));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type for the pipeable operator', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: ConnectableObservable<number> = publish<number>()(source);
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type for the pipeable operator with a selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<number> = source.pipe(publish(s => s.pipe(map(x => x))));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type for the pipeable operator with a type-changing selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<string> = source.pipe(publish(s => s.pipe(map(x => x + '!'))));
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -3,8 +3,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { publishBehavior, mergeMapTo, tap, mergeMap, refCount, retry, repeat } from 'rxjs/operators';
 import { ConnectableObservable, of, Subscription, Observable } from 'rxjs';
 
-declare const type: Function;
-
 /** @test {publishBehavior} */
 describe('publishBehavior operator', () => {
   it('should mirror a simple source Observable', () => {
@@ -345,20 +343,5 @@ describe('publishBehavior operator', () => {
 
     expect(results).to.deep.equal([]);
     done();
-  });
-
-  type('should infer the type', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: ConnectableObservable<number> = source.pipe(publishBehavior(0)) as ConnectableObservable<number>;
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type for the pipeable operator', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: ConnectableObservable<number> = publishBehavior(0)(source);
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -3,8 +3,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { publishLast, mergeMapTo, tap, mergeMap, refCount, retry } from 'rxjs/operators';
 import { ConnectableObservable, of, Subscription, Observable } from 'rxjs';
 
-declare const type: Function;
-
 /** @test {publishLast} */
 describe('publishLast operator', () => {
   it('should emit last notification of a simple source Observable', () => {
@@ -262,20 +260,5 @@ describe('publishLast operator', () => {
     expect(results2).to.deep.equal([4]);
     expect(subscriptions).to.equal(1);
     done();
-  });
-
-  type('should infer the type', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: ConnectableObservable<number> = source.pipe(publishLast()) as ConnectableObservable<number>;
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type for the pipeable operator', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-    const result: ConnectableObservable<unknown> = publishLast()(source);
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -3,8 +3,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { throwError, ConnectableObservable, EMPTY, NEVER, of, Observable, Subscription } from 'rxjs';
 import { publishReplay, mergeMapTo, tap, mergeMap, refCount, retry, repeat, map } from 'rxjs/operators';
 
-declare const type: Function;
-
 /** @test {publishReplay} */
 describe('publishReplay operator', () => {
   it('should mirror a simple source Observable', () => {
@@ -489,48 +487,5 @@ describe('publishReplay operator', () => {
 
     expectObservable(published).toBe(expected, undefined, error);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  type('should infer the type', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: ConnectableObservable<number> = source.pipe(publishReplay(1)) as ConnectableObservable<number>;
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type with a selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<number> = source.pipe(publishReplay(1, undefined, s => s.pipe(map(x => x))));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type with a type-changing selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<string> = source.pipe(publishReplay(1, undefined, s => s.pipe(map(x => x + '!'))));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  // TODO: https://github.com/ReactiveX/rxjs/issues/2972
-  // type('should infer the type for the pipeable operator', () => {
-  //   /* tslint:disable:no-unused-variable */
-  //   const source =of(1, 2, 3);
-  //   const result: ConnectableObservable<number> = publishReplay<number>(1)(source);
-  //   /* tslint:enable:no-unused-variable */
-  // });
-
-  type('should infer the type for the pipeable operator with a selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<number> = source.pipe(publishReplay(1, undefined, s => s.pipe(map(x => x))));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should infer the type for the pipeable operator with a type-changing selector', () => {
-    /* tslint:disable:no-unused-variable */
-    const source = of(1, 2, 3);
-    const result: Observable<string> = source.pipe(publishReplay(1, undefined, s => s.pipe(map(x => x + '!'))));
-    /* tslint:enable:no-unused-variable */
   });
 });

--- a/spec/operators/reduce-spec.ts
+++ b/spec/operators/reduce-spec.ts
@@ -3,8 +3,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { reduce, mergeMap } from 'rxjs/operators';
 import { range, of } from 'rxjs';
 
-declare const type: Function;
-
 /** @test {reduce} */
 describe('reduce operator', () => {
   it('should reduce', () => {

--- a/spec/operators/switch-spec.ts
+++ b/spec/operators/switch-spec.ts
@@ -3,8 +3,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { Observable, of, NEVER, queueScheduler, Subject } from 'rxjs';
 import { map, switchAll, mergeMap } from 'rxjs/operators';
 
-declare const type: Function;
-
 /** @test {switch} */
 describe('switchAll', () => {
   it('should switch a hot observable of cold observables', () => {

--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { throttle, mergeMap, mapTo } from 'rxjs/operators';
-import { of, concat, timer, Observable } from 'rxjs';
-
-declare const type: Function;
+import { of, concat, timer } from 'rxjs';
 
 /** @test {throttle} */
 describe('throttle operator', () =>  {
@@ -328,22 +326,6 @@ describe('throttle operator', () =>  {
         done(new Error('should not be called'));
       }
     );
-  });
-
-  type('should support selectors of the same type', () => {
-    /* tslint:disable:no-unused-variable */
-    let o: Observable<number>;
-    let s: Observable<number>;
-    let r: Observable<number> = o!.pipe(throttle((n) => s));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type('should support selectors of a different type', () => {
-    /* tslint:disable:no-unused-variable */
-    let o: Observable<number>;
-    let s: Observable<string>;
-    let r: Observable<number> = o!.pipe(throttle((n) => s));
-    /* tslint:enable:no-unused-variable */
   });
 
   describe('throttle(fn, { leading: true, trailing: true })', () => {

--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -2,8 +2,6 @@ import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/mar
 import { toArray, mergeMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 
-declare const type: Function;
-
 /** @test {toArray} */
 describe('toArray operator', () => {
   it('should reduce the values of an observable into an array', () => {
@@ -113,13 +111,5 @@ describe('toArray operator', () => {
 
     expectObservable(e1.pipe(toArray())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  type('should infer the element type', () => {
-    const typeValue = {
-      val: 3
-    };
-
-    of(typeValue).pipe(toArray()).subscribe(x => { x[0].val.toString(); });
   });
 });

--- a/spec/operators/window-spec.ts
+++ b/spec/operators/window-spec.ts
@@ -3,8 +3,6 @@ import { window, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { EMPTY, of, Observable } from 'rxjs';
 
-declare const type: Function;
-
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {window} */

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -1,9 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { zipAll, mergeMap } from 'rxjs/operators';
-import { queueScheduler, of, zip, Observable } from 'rxjs';
-
-declare const type: Function;
+import { queueScheduler, of, zip } from 'rxjs';
 
 /** @test {zipAll} */
 describe('zipAll operator', () => {
@@ -726,97 +724,5 @@ describe('zipAll operator', () => {
     const expected =   '|';
 
     expectObservable(source.pipe(zipAll())).toBe(expected);
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number[]> = of(source1, source2, source3)
-      .pipe(zipAll());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3)
-      .pipe(zipAll((...args) => args.reduce((acc, x) => acc + x, 0)));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number[]> = of(source1, source2, source3)
-      .pipe(zipAll());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<number> = of(source1, source2, source3)
-      .pipe(zipAll((...args) => args.reduce((acc, x) => acc + x, 0)));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string[]> = of(<any>source1, <any>source2, <any>source3)
-      .pipe(zipAll<string>());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3)
-      .pipe(zipAll<string>((...args) => args.reduce((acc, x) => acc + x, 0)));
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string[]> = of(<any>source1, <any>source2, <any>source3)
-      .pipe(zipAll<string>());
-    /* tslint:enable:no-unused-variable */
-  });
-
-  type(() => {
-    // coerce type to a specific type
-    /* tslint:disable:no-unused-variable */
-    const source1 = of(1, 2, 3);
-    const source2 = [1, 2, 3];
-    const source3 = new Promise<number>(d => d(1));
-
-    let result: Observable<string> = of(<any>source1, <any>source2, <any>source3)
-      .pipe(zipAll<string>((...args) => args.reduce((acc, x) => acc + x, 0)));
-    /* tslint:enable:no-unused-variable */
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I believe our test cases for types have been migrated to dts-lint, prior legacy test using dummy fn just left behind. Trying to clear things up.


**Related issue (if exists):**
