### PR TITLE
refactor(Observable): Update property and method types

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -698,7 +698,7 @@ describe('Observable.lift', () => {
       }
     };
 
-    NEVER.lift(myOperator)
+    (NEVER as any).lift(myOperator)
       .subscribe()
       .unsubscribe();
 
@@ -883,8 +883,8 @@ describe('Observable.lift', () => {
       class LogObservable<T> extends Observable<T> {
         lift<R>(operator: Operator<T, R>): Observable<R> {
           const observable = new LogObservable<R>();
-          (<any>observable).source = this;
-          (<any>observable).operator = new LogOperator(operator);
+          observable.source = this;
+          observable.operator = new LogOperator(operator);
           return observable;
         }
       }

--- a/spec/helpers/interop-helper.ts
+++ b/spec/helpers/interop-helper.ts
@@ -11,7 +11,7 @@ export function asInteropObservable<T>(observable: Observable<T>): Observable<T>
   return new Proxy(observable, {
     get(target: Observable<T>, key: string | number | symbol) {
       if (key === 'lift') {
-        const { lift } = target;
+        const { lift } = target as any;
         return interopLift(lift);
       }
       if (key === 'subscribe') {

--- a/src/internal/Operator.ts
+++ b/src/internal/Operator.ts
@@ -1,6 +1,9 @@
 import { Subscriber } from './Subscriber';
 import { TeardownLogic } from './types';
 
+/***
+ * @deprecated Internal implementation detail, do not use.
+ */
 export interface Operator<T, R> {
   call(subscriber: Subscriber<R>, source: any): TeardownLogic;
 }

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -8,6 +8,7 @@ import { Operator } from '../Operator';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { fromArray } from './fromArray';
+import { lift } from '../util/lift';
 
 const NONE = {};
 
@@ -233,7 +234,7 @@ export function combineLatest<O extends ObservableInput<any>, R>(
     observables = observables[0] as any;
   }
 
-  return fromArray(observables, scheduler).lift(new CombineLatestOperator<ObservedValueOf<O>, R>(resultSelector));
+  return lift(fromArray(observables, scheduler), new CombineLatestOperator<ObservedValueOf<O>, R>(resultSelector));
 }
 
 export class CombineLatestOperator<T, R> implements Operator<T, R> {

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -9,6 +9,7 @@ import { TeardownLogic, ObservableInput, ObservedValueUnionFromArray } from '../
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
+import { lift } from '../util/lift';
 
 export function race<A extends ObservableInput<any>[]>(observables: A): Observable<ObservedValueUnionFromArray<A>>;
 export function race<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
@@ -65,7 +66,7 @@ export function race<T>(...observables: (ObservableInput<T> | ObservableInput<T>
     }
   }
 
-  return fromArray(observables, undefined).lift(new RaceOperator<T>());
+  return lift(fromArray(observables, undefined), new RaceOperator<T>());
 }
 
 export class RaceOperator<T> implements Operator<T, T> {

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -9,6 +9,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { iterator as Symbol_iterator } from '../../internal/symbol/iterator';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated resultSelector is no longer supported, pipe to map instead */
@@ -85,7 +86,7 @@ export function zip<O extends ObservableInput<any>, R>(
   if (typeof last === 'function') {
     resultSelector = observables.pop() as typeof resultSelector;
   }
-  return fromArray(observables, undefined).lift(new ZipOperator(resultSelector));
+  return lift(fromArray(observables, undefined), new ZipOperator(resultSelector));
 }
 
 export class ZipOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -6,6 +6,7 @@ import { MonoTypeOperatorFunction, SubscribableOrPromise, TeardownLogic } from '
 
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
+import { lift } from '../util/lift';
 
 /**
  * Ignores source values for a duration determined by another Observable, then
@@ -54,7 +55,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  */
 export function audit<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T> {
   return function auditOperatorFunction(source: Observable<T>) {
-    return source.lift(new AuditOperator(durationSelector));
+    return lift(source, new AuditOperator(durationSelector));
   };
 }
 

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -5,6 +5,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Buffers the source Observable values until `closingNotifier` emits.
@@ -47,7 +48,7 @@ import { OperatorFunction } from '../types';
  */
 export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
   return function bufferOperatorFunction(source: Observable<T>) {
-    return source.lift(new BufferOperator<T>(closingNotifier));
+    return lift(source, new BufferOperator<T>(closingNotifier));
   };
 }
 

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { OperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Buffers the source Observable values until the size hits the maximum
@@ -59,7 +60,7 @@ import { OperatorFunction, TeardownLogic } from '../types';
  */
 export function bufferCount<T>(bufferSize: number, startBufferEvery: number | null = null): OperatorFunction<T, T[]> {
   return function bufferCountOperatorFunction(source: Observable<T>) {
-    return source.lift(new BufferCountOperator<T>(bufferSize, startBufferEvery));
+    return lift(source, new BufferCountOperator<T>(bufferSize, startBufferEvery));
   };
 }
 

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -5,6 +5,7 @@ import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { isScheduler } from '../util/isScheduler';
 import { OperatorFunction, SchedulerAction, SchedulerLike } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function bufferTime<T>(bufferTimeSpan: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
@@ -88,7 +89,7 @@ export function bufferTime<T>(bufferTimeSpan: number): OperatorFunction<T, T[]> 
   }
 
   return function bufferTimeOperatorFunction(source: Observable<T>) {
-    return source.lift(new BufferTimeOperator<T>(bufferTimeSpan, bufferCreationInterval, maxBufferSize, scheduler));
+    return lift(source, new BufferTimeOperator<T>(bufferTimeSpan, bufferCreationInterval, maxBufferSize, scheduler));
   };
 }
 

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -6,6 +6,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { OperatorFunction, SubscribableOrPromise } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Buffers the source Observable values starting from an emission from
@@ -57,7 +58,7 @@ export function bufferToggle<T, O>(
   closingSelector: (value: O) => SubscribableOrPromise<any>
 ): OperatorFunction<T, T[]> {
   return function bufferToggleOperatorFunction(source: Observable<T>) {
-    return source.lift(new BufferToggleOperator<T, O>(openings, closingSelector));
+    return lift(source, new BufferToggleOperator<T, O>(openings, closingSelector));
   };
 }
 

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -6,6 +6,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Buffers the source Observable values, using a factory function of closing
@@ -50,7 +51,7 @@ import { OperatorFunction } from '../types';
  */
 export function bufferWhen<T>(closingSelector: () => Observable<any>): OperatorFunction<T, T[]> {
   return function (source: Observable<T>) {
-    return source.lift(new BufferWhenOperator(closingSelector));
+    return lift(source, new BufferWhenOperator(closingSelector));
   };
 }
 

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -6,6 +6,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function catchError<T, O extends ObservableInput<any>>(selector: (err: any, caught: Observable<T>) => O): OperatorFunction<T, T | ObservedValueOf<O>>;
@@ -108,8 +109,9 @@ export function catchError<T, O extends ObservableInput<any>>(
 ): OperatorFunction<T, T | ObservedValueOf<O>> {
   return function catchErrorOperatorFunction(source: Observable<T>): Observable<T | ObservedValueOf<O>> {
     const operator = new CatchOperator(selector);
-    const caught = source.lift(operator);
-    return (operator.caught = caught as Observable<T>);
+    const caught = lift(source, operator);
+    operator.caught = caught;
+    return caught;
   };
 }
 

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -1,6 +1,7 @@
 import { CombineLatestOperator } from '../observable/combineLatest';
 import { Observable } from '../Observable';
 import { OperatorFunction, ObservableInput } from '../types';
+import { lift } from '../util/lift';
 
 export function combineAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export function combineAll<T>(): OperatorFunction<any, T[]>;
@@ -53,5 +54,5 @@ export function combineAll<R>(project: (...values: Array<any>) => R): OperatorFu
  * @name combineAll
  */
 export function combineAll<T, R>(project?: (...values: Array<any>) => R): OperatorFunction<T, R> {
-  return (source: Observable<T>) => source.lift(new CombineLatestOperator(project));
+  return (source: Observable<T>) => lift(source, new CombineLatestOperator(project));
 }

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -4,6 +4,7 @@ import { CombineLatestOperator } from '../observable/combineLatest';
 import { from } from '../observable/from';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
+import { lift, stankyLift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated use {@link combineLatestWith} */
@@ -53,10 +54,11 @@ export function combineLatest<T, R>(...observables: Array<ObservableInput<any> |
     observables = (<any>observables[0]).slice();
   }
 
-  return (source: Observable<T>) => source.lift.call(
+  return (source: Observable<T>) => stankyLift(
+    source,
     from([source, ...observables]),
     new CombineLatestOperator(project)
-  ) as Observable<R>;
+  );
 }
 
 /**

--- a/src/internal/operators/concat.ts
+++ b/src/internal/operators/concat.ts
@@ -1,6 +1,7 @@
 import {  concat as concatStatic } from '../observable/concat';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike } from '../types';
+import { stankyLift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated remove in v8. Use {@link concatWith} */
@@ -25,8 +26,8 @@ export function concat<T, R>(...observables: Array<ObservableInput<any> | Schedu
  * @deprecated remove in v8. Use {@link concatWith}
  */
 export function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | undefined>): OperatorFunction<T, R> {
-  return (source: Observable<T>) => source.lift.call(
+  return (source: Observable<T>) => stankyLift(
+    source,
     concatStatic(source, ...(observables as any[])),
-    undefined
-  ) as Observable<R>;
+  );
 }

--- a/src/internal/operators/concatWith.ts
+++ b/src/internal/operators/concatWith.ts
@@ -1,6 +1,7 @@
 import { concat as concatStatic } from '../observable/concat';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray } from '../types';
+import { stankyLift } from '../util/lift';
 
 export function concatWith<T>(): OperatorFunction<T, T>;
 export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T>;
@@ -44,8 +45,8 @@ export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources:
  * @param otherSources Other observable sources to subscribe to, in sequence, after the original source is complete.
  */
 export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T> {
-  return (source: Observable<T>) => source.lift.call(
-    concatStatic(source, ...otherSources),
-    undefined
-  ) as Observable<ObservedValueUnionFromArray<A> | T>;
+  return (source: Observable<T>) => stankyLift(
+    source,
+    concatStatic(source, ...otherSources)
+  );
 }

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -2,6 +2,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Observer, OperatorFunction } from '../types';
 import { Subscriber } from '../Subscriber';
+import { lift } from '../util/lift';
 /**
  * Counts the number of emissions on the source and emits that number when the
  * source completes.
@@ -62,7 +63,7 @@ import { Subscriber } from '../Subscriber';
  */
 
 export function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number> {
-  return (source: Observable<T>) => source.lift(new CountOperator(predicate, source));
+  return (source: Observable<T>) => lift(source, new CountOperator(predicate, source));
 }
 
 class CountOperator<T> implements Operator<T, number> {

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -7,6 +7,7 @@ import { MonoTypeOperatorFunction, SubscribableOrPromise, TeardownLogic } from '
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
+import { lift } from '../util/lift';
 
 /**
  * Emits a notification from the source Observable only after a particular time span
@@ -67,7 +68,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
  * @name debounce
  */
 export function debounce<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new DebounceOperator(durationSelector));
+  return (source: Observable<T>) => lift(source, new DebounceOperator(durationSelector));
 }
 
 class DebounceOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -4,6 +4,7 @@ import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { async } from '../scheduler/async';
 import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Emits a notification from the source Observable only after a particular time span
@@ -64,7 +65,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
  * @name debounceTime
  */
 export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new DebounceTimeOperator(dueTime, scheduler));
+  return (source: Observable<T>) => lift(source, new DebounceTimeOperator(dueTime, scheduler));
 }
 
 class DebounceTimeOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function defaultIfEmpty<T, R = T>(defaultValue?: R): OperatorFunction<T, T | R>;
@@ -43,7 +44,7 @@ export function defaultIfEmpty<T, R = T>(defaultValue?: R): OperatorFunction<T, 
  * @name defaultIfEmpty
  */
 export function defaultIfEmpty<T, R>(defaultValue: R | null = null): OperatorFunction<T, T | R> {
-  return (source: Observable<T>) => source.lift(new DefaultIfEmptyOperator(defaultValue)) as Observable<T | R>;
+  return (source: Observable<T>) => lift(source, new DefaultIfEmptyOperator(defaultValue)) as Observable<T | R>;
 }
 
 class DefaultIfEmptyOperator<T, R> implements Operator<T, T | R> {

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -9,6 +9,7 @@ import {
   SchedulerLike,
   TeardownLogic
 } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Delays the emission of items from the source Observable by a given timeout or
@@ -60,7 +61,7 @@ import {
  */
 export function delay<T>(delay: number | Date, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
   const delayFor = isValidDate(delay) ? +delay - scheduler.now() : Math.abs(delay);
-  return (source: Observable<T>) => source.lift(new DelayOperator(delayFor, scheduler));
+  return (source: Observable<T>) => lift(source, new DelayOperator(delayFor, scheduler));
 }
 
 class DelayOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -6,6 +6,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated In future versions, empty notifiers will no longer re-emit the source value on the output observable. */
@@ -76,10 +77,9 @@ export function delayWhen<T>(delayDurationSelector: (value: T, index: number) =>
                              subscriptionDelay?: Observable<any>): MonoTypeOperatorFunction<T> {
   if (subscriptionDelay) {
     return (source: Observable<T>) =>
-      new SubscriptionDelayObservable(source, subscriptionDelay)
-        .lift(new DelayWhenOperator(delayDurationSelector));
+      lift(new SubscriptionDelayObservable(source, subscriptionDelay), new DelayWhenOperator(delayDurationSelector));
   }
-  return (source: Observable<T>) => source.lift(new DelayWhenOperator(delayDurationSelector));
+  return (source: Observable<T>) => lift(source, new DelayWhenOperator(delayDurationSelector));
 }
 
 class DelayWhenOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -3,6 +3,7 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { observeNotification } from '../Notification';
 import { OperatorFunction, ObservableNotification, ValueFromNotification } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Converts an Observable of {@link ObservableNotification} objects into the emissions
@@ -53,7 +54,7 @@ import { OperatorFunction, ObservableNotification, ValueFromNotification } from 
  */
 export function dematerialize<N extends ObservableNotification<any>>(): OperatorFunction<N, ValueFromNotification<N>> {
   return function dematerializeOperatorFunction(source: Observable<N>) {
-    return source.lift(new DeMaterializeOperator<N>());
+    return lift(source, new DeMaterializeOperator<N>());
   };
 }
 

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -5,6 +5,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that emits all items emitted by the source Observable that are distinct by comparison from previous items.
@@ -75,7 +76,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  */
 export function distinct<T, K>(keySelector?: (value: T) => K,
                                flushes?: Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new DistinctOperator(keySelector, flushes));
+  return (source: Observable<T>) => lift(source, new DistinctOperator(keySelector, flushes));
 }
 
 class DistinctOperator<T, K> implements Operator<T, T> {

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function distinctUntilChanged<T>(compare?: (x: T, y: T) => boolean): MonoTypeOperatorFunction<T>;
@@ -63,7 +64,7 @@ export function distinctUntilChanged<T, K>(compare: (x: K, y: K) => boolean, key
  * @name distinctUntilChanged
  */
 export function distinctUntilChanged<T, K>(compare?: (x: K, y: K) => boolean, keySelector?: (x: T) => K): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new DistinctUntilChangedOperator<T, K>(compare, keySelector));
+  return (source: Observable<T>) => lift(source, new DistinctUntilChangedOperator<T, K>(compare, keySelector));
 }
 
 class DistinctUntilChangedOperator<T, K> implements Operator<T, T> {

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Observer, OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
@@ -30,7 +31,7 @@ import { Observer, OperatorFunction } from '../types';
  */
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                          thisArg?: any): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) => source.lift(new EveryOperator(predicate, thisArg, source));
+  return (source: Observable<T>) => lift(source, new EveryOperator(predicate, thisArg, source));
 }
 
 class EveryOperator<T> implements Operator<T, boolean> {

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -5,6 +5,7 @@ import { Subscription } from '../Subscription';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 export function exhaust<T>(): OperatorFunction<ObservableInput<T>, T>;
 export function exhaust<R>(): OperatorFunction<any, R>;
@@ -53,7 +54,7 @@ export function exhaust<R>(): OperatorFunction<any, R>;
  * @name exhaust
  */
 export function exhaust<T>(): OperatorFunction<any, T> {
-  return (source: Observable<T>) => source.lift(new SwitchFirstOperator<T>());
+  return (source: Observable<T>) => lift(source, new SwitchFirstOperator<T>());
 }
 
 class SwitchFirstOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -8,6 +8,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
 import { from } from '../observable/from';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function exhaustMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O): OperatorFunction<T, ObservedValueOf<O>>;
@@ -74,7 +75,7 @@ export function exhaustMap<T, R, O extends ObservableInput<any>>(
     );
   }
   return (source: Observable<T>) =>
-    source.lift(new ExhaustMapOperator(project));
+    lift(source, new ExhaustMapOperator(project));
 }
 
 class ExhaustMapOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -6,6 +6,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, SchedulerLike } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: SchedulerLike): OperatorFunction<T, R>;
@@ -68,7 +69,7 @@ export function expand<T, R>(project: (value: T, index: number) => ObservableInp
                              scheduler?: SchedulerLike): OperatorFunction<T, R> {
   concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
 
-  return (source: Observable<T>) => source.lift(new ExpandOperator(project, concurrent, scheduler));
+  return (source: Observable<T>) => lift(source, new ExpandOperator(project, concurrent, scheduler));
 }
 
 export class ExpandOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { OperatorFunction, MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function filter<T, S extends T>(predicate: (value: T, index: number) => value is S,
@@ -56,7 +57,7 @@ export function filter<T>(predicate: (value: T, index: number) => boolean,
 export function filter<T>(predicate: (value: T, index: number) => boolean,
                           thisArg?: any): MonoTypeOperatorFunction<T> {
   return function filterOperatorFunction(source: Observable<T>): Observable<T> {
-    return source.lift(new FilterOperator(predicate, thisArg));
+    return lift(source, new FilterOperator(predicate, thisArg));
   };
 }
 

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
@@ -59,7 +60,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name finally
  */
 export function finalize<T>(callback: () => void): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new FinallyOperator(callback));
+  return (source: Observable<T>) => lift(source, new FinallyOperator(callback));
 }
 
 class FinallyOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -2,6 +2,7 @@ import {Observable} from '../Observable';
 import {Operator} from '../Operator';
 import {Subscriber} from '../Subscriber';
 import {OperatorFunction} from '../types';
+import { lift } from '../util/lift';
 
 export function find<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S,
                                      thisArg?: any): OperatorFunction<T, S | undefined>;
@@ -50,7 +51,7 @@ export function find<T>(predicate: (value: T, index: number, source: Observable<
   if (typeof predicate !== 'function') {
     throw new TypeError('predicate is not a function');
   }
-  return (source: Observable<T>) => source.lift(new FindValueOperator(predicate, source, false, thisArg)) as Observable<T | undefined>;
+  return (source: Observable<T>) => lift(source, new FindValueOperator(predicate, source, false, thisArg)) as Observable<T | undefined>;
 }
 
 export class FindValueOperator<T> implements Operator<T, T | number | undefined> {

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -1,6 +1,7 @@
 import { Observable } from '../Observable';
 import { FindValueOperator } from '../operators/find';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 /**
  * Emits only the index of the first value emitted by the source Observable that
  * meets some condition.
@@ -42,5 +43,5 @@ import { OperatorFunction } from '../types';
  */
 export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean,
                              thisArg?: any): OperatorFunction<T, number> {
-  return (source: Observable<T>) => source.lift(new FindValueOperator(predicate, source, true, thisArg)) as Observable<any>;
+  return (source: Observable<T>) => lift(source, new FindValueOperator(predicate, source, true, thisArg)) as Observable<any>;
 }

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -4,6 +4,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function groupBy<T, K extends T>(keySelector: (value: T) => value is K): OperatorFunction<T, GroupedObservable<true, K> | GroupedObservable<false, Exclude<T, K>>>;
@@ -109,7 +110,7 @@ export function groupBy<T, K, R>(keySelector: (value: T) => K,
                                  durationSelector?: (grouped: GroupedObservable<K, R>) => Observable<any>,
                                  subjectSelector?: () => Subject<R>): OperatorFunction<T, GroupedObservable<K, R>> {
   return (source: Observable<T>) =>
-    source.lift(new GroupByOperator(keySelector, elementSelector, durationSelector, subjectSelector));
+    lift(source, new GroupByOperator(keySelector, elementSelector, durationSelector, subjectSelector));
 }
 
 export interface RefCountSubscription {

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -2,6 +2,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Ignores all items emitted by the source Observable and only passes calls of `complete` or `error`.
@@ -37,7 +38,7 @@ import { OperatorFunction } from '../types';
  */
 export function ignoreElements(): OperatorFunction<any, never> {
   return function ignoreElementsOperatorFunction(source: Observable<any>) {
-    return source.lift(new IgnoreElementsOperator());
+    return lift(source, new IgnoreElementsOperator());
   };
 }
 

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Emits `false` if the input Observable emits any values, or emits `true` if the
@@ -68,7 +69,7 @@ import { OperatorFunction } from '../types';
  */
 
 export function isEmpty<T>(): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) => source.lift(new IsEmptyOperator());
+  return (source: Observable<T>) => lift(source, new IsEmptyOperator());
 }
 
 class IsEmptyOperator implements Operator<any, boolean> {

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Applies a given `project` function to each value emitted by the source
@@ -46,7 +47,7 @@ export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any
     if (typeof project !== 'function') {
       throw new TypeError('argument is not a function. Are you looking for `mapTo()`?');
     }
-    return source.lift(new MapOperator(project, thisArg));
+    return lift(source, new MapOperator(project, thisArg));
   };
 }
 

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 export function mapTo<R>(value: R): OperatorFunction<any, R>;
 /** @deprecated remove in v8. Use mapTo<R>(value: R): OperatorFunction<any, R> signature instead **/
@@ -39,7 +40,7 @@ export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
  * @name mapTo
  */
 export function mapTo<R>(value: R): OperatorFunction<any, R> {
-  return (source: Observable<any>) => source.lift(new MapToOperator(value));
+  return (source: Observable<any>) => lift(source, new MapToOperator(value));
 }
 
 class MapToOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -3,6 +3,7 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Notification } from '../Notification';
 import { OperatorFunction, ObservableNotification } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Represents all of the notifications from the source Observable as `next`
@@ -60,7 +61,7 @@ import { OperatorFunction, ObservableNotification } from '../types';
  */
 export function materialize<T>(): OperatorFunction<T, Notification<T> & ObservableNotification<T>> {
   return function materializeOperatorFunction(source: Observable<T>) {
-    return source.lift(new MaterializeOperator<T>());
+    return lift(source, new MaterializeOperator<T>());
   };
 }
 

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -8,6 +8,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
 import { from } from '../observable/from';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function mergeMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, concurrent?: number): OperatorFunction<T, ObservedValueOf<O>>;
@@ -86,7 +87,7 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(
   } else if (typeof resultSelector === 'number') {
     concurrent = resultSelector;
   }
-  return (source: Observable<T>) => source.lift(new MergeMapOperator(project, concurrent));
+  return (source: Observable<T>) => lift(source, new MergeMapOperator(project, concurrent));
 }
 
 export class MergeMapOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -6,6 +6,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { ObservableInput, OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Applies an accumulator function over the source Observable where the
@@ -48,7 +49,7 @@ import { ObservableInput, OperatorFunction } from '../types';
 export function mergeScan<T, R>(accumulator: (acc: R, value: T, index: number) => ObservableInput<R>,
                                 seed: R,
                                 concurrent: number = Infinity): OperatorFunction<T, R> {
-  return (source: Observable<T>) => source.lift(new MergeScanOperator(accumulator, seed, concurrent));
+  return (source: Observable<T>) => lift(source, new MergeScanOperator(accumulator, seed, concurrent));
 }
 
 export class MergeScanOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -1,6 +1,7 @@
 import { merge as mergeStatic } from '../observable/merge';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike, ObservedValueUnionFromArray } from '../types';
+import { stankyLift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 
@@ -57,10 +58,10 @@ export function merge<T, R>(...observables: Array<ObservableInput<any> | Schedul
  * @deprecated use {@link mergeWith} or static {@link merge}
  */
 export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number | undefined>): OperatorFunction<T, R> {
-  return (source: Observable<T>) => source.lift.call(
-    mergeStatic(source, ...(observables as any[])),
-    undefined
-  ) as Observable<R>;
+  return (source: Observable<T>) => stankyLift(
+    source,
+    mergeStatic(source, ...(observables as any[]))
+  );
 }
 
 export function mergeWith<T>(): OperatorFunction<T, T>;

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -4,6 +4,7 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { ConnectableObservable, connectableObservableDescriptor } from '../observable/ConnectableObservable';
 import { OperatorFunction, UnaryFunction, ObservedValueOf, ObservableInput } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
@@ -43,7 +44,7 @@ export function multicast<T, R>(subjectOrSubjectFactory: Subject<T> | (() => Sub
     }
 
     if (typeof selector === 'function') {
-      return source.lift(new MulticastOperator(subjectFactory, selector));
+      return lift(source, new MulticastOperator(subjectFactory, selector));
     }
 
     const connectable: any = Object.create(source, connectableObservableDescriptor);

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -9,6 +9,7 @@ import {
   TeardownLogic,
   ObservableNotification,
 } from '../types';
+import { lift } from '../util/lift';
 
 /**
  *
@@ -64,7 +65,7 @@ import {
  */
 export function observeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return function observeOnOperatorFunction(source: Observable<T>): Observable<T> {
-    return source.lift(new ObserveOnOperator(scheduler, delay));
+    return lift(source, new ObserveOnOperator(scheduler, delay));
   };
 }
 

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -8,6 +8,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function onErrorResumeNext<T>(): OperatorFunction<T, T>;
@@ -95,7 +96,7 @@ export function onErrorResumeNext<T, R>(...nextSources: Array<ObservableInput<an
     nextSources = <Array<Observable<any>>>nextSources[0];
   }
 
-  return (source: Observable<T>) => source.lift(new OnErrorResumeNextOperator<T, R>(nextSources));
+  return (source: Observable<T>) => lift(source, new OnErrorResumeNextOperator<T, R>(nextSources));
 }
 
 /* tslint:disable:max-line-length */
@@ -119,7 +120,7 @@ export function onErrorResumeNextStatic<T, R>(...nextSources: Array<ObservableIn
   }
   source = nextSources.shift()!;
 
-  return from(source, null!).lift(new OnErrorResumeNextOperator<T, R>(nextSources));
+  return lift(from(source), new OnErrorResumeNextOperator<T, R>(nextSources));
 }
 
 class OnErrorResumeNextOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Groups pairs of consecutive emissions together and emits them as an array of
@@ -46,7 +47,7 @@ import { OperatorFunction } from '../types';
  * @name pairwise
  */
 export function pairwise<T>(): OperatorFunction<T, [T, T]> {
-  return (source: Observable<T>) => source.lift(new PairwiseOperator());
+  return (source: Observable<T>) => lift(source, new PairwiseOperator());
 }
 
 class PairwiseOperator<T> implements Operator<T, [T, T]> {

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -4,6 +4,7 @@ import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { Observable } from '../Observable';
+import { lift } from '../util/lift';
 
 /**
  * Make a {@link ConnectableObservable} behave like a ordinary observable and automates the way
@@ -60,7 +61,7 @@ import { Observable } from '../Observable';
  */
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return function refCountOperatorFunction(source: ConnectableObservable<T>): Observable<T> {
-    return source.lift(new RefCountOperator());
+    return lift(source, new RefCountOperator());
   } as MonoTypeOperatorFunction<T>;
 }
 

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -3,6 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { EMPTY } from '../observable/empty';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that will resubscribe to the source stream when the source stream completes, at most count times.
@@ -64,9 +65,9 @@ export function repeat<T>(count: number = -1): MonoTypeOperatorFunction<T> {
     if (count === 0) {
       return EMPTY;
     } else if (count < 0) {
-      return source.lift(new RepeatOperator(-1, source));
+      return lift(source, new RepeatOperator(-1, source));
     } else {
-      return source.lift(new RepeatOperator(count - 1, source));
+      return lift(source, new RepeatOperator(count - 1, source));
     }
   };
 }

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -9,6 +9,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that mirrors the source Observable with the exception of a `complete`. If the source
@@ -40,7 +41,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name repeatWhen
  */
 export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new RepeatWhenOperator(notifier));
+  return (source: Observable<T>) => lift(source, new RepeatWhenOperator(notifier));
 }
 
 class RepeatWhenOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -3,6 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 export interface RetryConfig {
   count: number;
@@ -66,7 +67,7 @@ export function retry<T>(configOrCount: number | RetryConfig = -1): MonoTypeOper
       count: configOrCount as number
     };
   }
-  return (source: Observable<T>) => source.lift(new RetryOperator(config.count, !!config.resetOnSuccess, source));
+  return (source: Observable<T>) => lift(source, new RetryOperator(config.count, !!config.resetOnSuccess, source));
 }
 
 class RetryOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -9,6 +9,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that mirrors the source Observable with the exception of an `error`. If the source Observable
@@ -63,7 +64,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name retryWhen
  */
 export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new RetryWhenOperator(notifier, source));
+  return (source: Observable<T>) => lift(source, new RetryWhenOperator(notifier, source));
 }
 
 class RetryWhenOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -6,6 +6,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Emits the most recently emitted value from the source Observable whenever
@@ -47,7 +48,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name sample
  */
 export function sample<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new SampleOperator(notifier));
+  return (source: Observable<T>) => lift(source, new SampleOperator(notifier));
 }
 
 class SampleOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -3,6 +3,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { async } from '../scheduler/async';
 import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Emits the most recently emitted value from the source Observable within
@@ -46,7 +47,7 @@ import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic
  * @name sampleTime
  */
 export function sampleTime<T>(period: number, scheduler: SchedulerLike = async): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new SampleTimeOperator(period, scheduler));
+  return (source: Observable<T>) => lift(source, new SampleTimeOperator(period, scheduler));
 }
 
 class SampleTimeOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function scan<V, A = V>(accumulator: (acc: A|V, value: V, index: number) => A): OperatorFunction<V, V|A>;
@@ -63,7 +64,7 @@ export function scan<V, A, S>(accumulator: (acc: V|A|S, value: V, index: number)
   }
 
   return function scanOperatorFunction(source: Observable<V>) {
-    return source.lift(new ScanOperator(accumulator, seed, hasSeed));
+    return lift(source, new ScanOperator(accumulator, seed, hasSeed));
   };
 }
 

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -4,6 +4,7 @@ import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 
 import { Observer, OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Compares all values of two observables in sequence using an optional comparator function
@@ -63,7 +64,7 @@ import { Observer, OperatorFunction } from '../types';
  */
 export function sequenceEqual<T>(compareTo: Observable<T>,
                                  comparator?: (a: T, b: T) => boolean): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) => source.lift(new SequenceEqualOperator(compareTo, comparator));
+  return (source: Observable<T>) => lift(source, new SequenceEqualOperator(compareTo, comparator));
 }
 
 export class SequenceEqualOperator<T> implements Operator<T, boolean> {

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -3,6 +3,7 @@ import { ReplaySubject } from '../ReplaySubject';
 import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { Subscriber } from '../Subscriber';
+import { lift } from '../util/lift';
 
 export interface ShareReplayConfig {
   bufferSize?: number;
@@ -139,7 +140,7 @@ export function shareReplay<T>(
       scheduler
     };
   }
-  return (source: Observable<T>) => source.lift(shareReplayOperator(config));
+  return (source: Observable<T>) => lift(source, shareReplayOperator(config));
 }
 
 function shareReplayOperator<T>({

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -5,6 +5,7 @@ import { EmptyError } from '../util/EmptyError';
 import { MonoTypeOperatorFunction } from '../types';
 import { SequenceError } from '../util/SequenceError';
 import { NotFoundError } from '../util/NotFoundError';
+import { lift } from '../util/lift';
 
 const defaultPredicate = () => true;
 
@@ -91,7 +92,7 @@ const defaultPredicate = () => true;
 export function single<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean = defaultPredicate
 ): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(singleOperator(predicate));
+  return (source: Observable<T>) => lift(source, singleOperator(predicate));
 }
 
 function singleOperator<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean) {

--- a/src/internal/operators/skip.ts
+++ b/src/internal/operators/skip.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that skips the first `count` items emitted by the source Observable.
@@ -13,7 +14,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name skip
  */
 export function skip<T>(count: number): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new SkipOperator(count));
+  return (source: Observable<T>) => lift(source, new SkipOperator(count));
 }
 
 class SkipOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -3,6 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Skip the last `count` values emitted by the source Observable.
@@ -42,7 +43,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name skipLast
  */
 export function skipLast<T>(count: number): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new SkipLastOperator(count));
+  return (source: Observable<T>) => lift(source, new SkipLastOperator(count));
 }
 
 class SkipLastOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -6,6 +6,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { MonoTypeOperatorFunction, TeardownLogic, ObservableInput } from '../types';
 import { Subscription } from '../Subscription';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that skips items emitted by the source Observable until a second Observable emits an item.
@@ -46,7 +47,7 @@ import { Subscription } from '../Subscription';
  * @name skipUntil
  */
 export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new SkipUntilOperator(notifier));
+  return (source: Observable<T>) => lift(source, new SkipUntilOperator(notifier));
 }
 
 class SkipUntilOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/skipWhile.ts
+++ b/src/internal/operators/skipWhile.ts
@@ -2,6 +2,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Returns an Observable that skips all items emitted by the source Observable as long as a specified condition holds
@@ -15,7 +16,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name skipWhile
  */
 export function skipWhile<T>(predicate: (value: T, index: number) => boolean): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new SkipWhileOperator(predicate));
+  return (source: Observable<T>) => lift(source, new SkipWhileOperator(predicate));
 }
 
 class SkipWhileOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -5,6 +5,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic, SchedulerAction
 import { asap as asapScheduler } from '../scheduler/asap';
 import { Subscription } from '../Subscription';
 import { isScheduler } from '../util/isScheduler';
+import { lift } from '../util/lift';
 
 export interface DispatchArg<T> {
   source: Observable<T>;
@@ -106,7 +107,7 @@ class SubscribeOnObservable<T> extends Observable<T> {
  */
 export function subscribeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
   return function subscribeOnOperatorFunction(source: Observable<T>): Observable<T> {
-    return source.lift(new SubscribeOnOperator<T>(scheduler, delay));
+    return lift(source, new SubscribeOnOperator<T>(scheduler, delay));
   };
 }
 

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -8,6 +8,7 @@ import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
 import { from } from '../observable/from';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function switchMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O): OperatorFunction<T, ObservedValueOf<O>>;
@@ -89,7 +90,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
       ))
     );
   }
-  return (source: Observable<T>) => source.lift(new SwitchMapOperator(project));
+  return (source: Observable<T>) => lift(source, new SwitchMapOperator(project));
 }
 
 class SwitchMapOperator<T, R> implements Operator<T, R> {

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -4,6 +4,7 @@ import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
 import { EMPTY } from '../observable/empty';
+import { lift } from '../util/lift';
 
 /**
  * Emits only the first `count` values emitted by the source Observable.
@@ -57,7 +58,7 @@ export function take<T>(count: number): MonoTypeOperatorFunction<T> {
     throw new ArgumentOutOfRangeError;
   }
 
-  return (source: Observable<T>) => (count === 0) ? EMPTY : source.lift(new TakeOperator(count));
+  return (source: Observable<T>) => (count === 0) ? EMPTY : lift(source, new TakeOperator(count));
 }
 
 class TakeOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -4,6 +4,7 @@ import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { EMPTY } from '../observable/empty';
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Emits only the last `count` values emitted by the source Observable.
@@ -58,7 +59,7 @@ export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
     if (count === 0) {
       return EMPTY;
     } else {
-      return source.lift(new TakeLastOperator(count));
+      return lift(source, new TakeLastOperator(count));
     }
   };
 }

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -7,6 +7,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Emits the values emitted by the source Observable until a `notifier`
@@ -48,7 +49,7 @@ import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
  * @name takeUntil
  */
 export function takeUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new TakeUntilOperator(notifier));
+  return (source: Observable<T>) => lift(source, new TakeUntilOperator(notifier));
 }
 
 class TakeUntilOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -2,6 +2,7 @@ import { Operator } from '../Operator';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction, MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 export function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S): OperatorFunction<T, S>;
 export function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S, inclusive: false): OperatorFunction<T, S>;
@@ -54,7 +55,7 @@ export function takeWhile<T>(
     predicate: (value: T, index: number) => boolean,
     inclusive = false): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) =>
-             source.lift(new TakeWhileOperator(predicate, inclusive));
+             lift(source, new TakeWhileOperator(predicate, inclusive));
 }
 
 class TakeWhileOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -4,6 +4,7 @@ import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, PartialObserver, TeardownLogic } from '../types';
 import { noop } from '../util/noop';
 import { isFunction } from '../util/isFunction';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Use an observer instead of a complete callback */
@@ -68,7 +69,7 @@ export function tap<T>(nextOrObserver?: PartialObserver<T> | ((x: T) => void) | 
                        error?: ((e: any) => void) | null,
                        complete?: (() => void) | null): MonoTypeOperatorFunction<T> {
   return function tapOperatorFunction(source: Observable<T>): Observable<T> {
-    return source.lift(new DoOperator(nextOrObserver, error, complete));
+    return lift(source, new DoOperator(nextOrObserver, error, complete));
   };
 }
 

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -8,6 +8,7 @@ import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 
 import { MonoTypeOperatorFunction, SubscribableOrPromise, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 export interface ThrottleConfig {
   leading?: boolean;
@@ -66,7 +67,7 @@ export const defaultThrottleConfig: ThrottleConfig = {
  */
 export function throttle<T>(durationSelector: (value: T) => SubscribableOrPromise<any>,
                             config: ThrottleConfig = defaultThrottleConfig): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new ThrottleOperator(durationSelector, !!config.leading, !!config.trailing));
+  return (source: Observable<T>) => lift(source, new ThrottleOperator(durationSelector, !!config.leading, !!config.trailing));
 }
 
 class ThrottleOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -5,6 +5,7 @@ import { async } from '../scheduler/async';
 import { Observable } from '../Observable';
 import { ThrottleConfig, defaultThrottleConfig } from './throttle';
 import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Emits a value from the source Observable, then ignores subsequent source
@@ -87,7 +88,7 @@ import { MonoTypeOperatorFunction, SchedulerLike, TeardownLogic } from '../types
 export function throttleTime<T>(duration: number,
                                 scheduler: SchedulerLike = async,
                                 config: ThrottleConfig = defaultThrottleConfig): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => source.lift(new ThrottleTimeOperator(duration, scheduler, !!config.leading, !!config.trailing));
+  return (source: Observable<T>) => lift(source, new ThrottleTimeOperator(duration, scheduler, !!config.leading, !!config.trailing));
 }
 
 class ThrottleTimeOperator<T> implements Operator<T, T> {

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -3,6 +3,7 @@ import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { TeardownLogic, MonoTypeOperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * If the source observable completes without emitting a value, it will emit
@@ -36,7 +37,7 @@ import { TeardownLogic, MonoTypeOperatorFunction } from '../types';
  */
 export function throwIfEmpty <T>(errorFactory: (() => any) = defaultErrorFactory): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) => {
-    return source.lift(new ThrowIfEmptyOperator(errorFactory));
+    return lift(source, new ThrowIfEmptyOperator(errorFactory));
   };
 }
 

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -6,6 +6,7 @@ import { isValidDate } from '../util/isDate';
 import { OuterSubscriber } from '../OuterSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function timeoutWith<T, R>(due: number | Date, withObservable: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;
@@ -69,7 +70,7 @@ export function timeoutWith<T, R>(due: number | Date,
   return (source: Observable<T>) => {
     let absoluteTimeout = isValidDate(due);
     let waitFor = absoluteTimeout ? (+due - scheduler.now()) : Math.abs(<number>due);
-    return source.lift(new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));
+    return lift(source, new TimeoutWithOperator(waitFor, absoluteTimeout, withObservable, scheduler));
   };
 }
 

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -6,6 +6,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { Operator } from '../Operator';
+import { lift } from '../util/lift';
 
 /**
  * Branch out the source Observable values as a nested Observable whenever
@@ -51,7 +52,7 @@ import { Operator } from '../Operator';
  */
 export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T, Observable<T>> {
   return function windowOperatorFunction(source: Observable<T>) {
-    return source.lift(new WindowOperator(windowBoundaries));
+    return lift(source, new WindowOperator(windowBoundaries));
   };
 }
 

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -3,6 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Branch out the source Observable values as a nested Observable with each
@@ -69,7 +70,7 @@ import { OperatorFunction } from '../types';
 export function windowCount<T>(windowSize: number,
                                startWindowEvery: number = 0): OperatorFunction<T, Observable<T>> {
   return function windowCountOperatorFunction(source: Observable<T>) {
-    return source.lift(new WindowCountOperator<T>(windowSize, startWindowEvery));
+    return lift(source, new WindowCountOperator<T>(windowSize, startWindowEvery));
   };
 }
 

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -7,6 +7,7 @@ import { Subscription } from '../Subscription';
 import { isNumeric } from '../util/isNumeric';
 import { isScheduler } from '../util/isScheduler';
 import { OperatorFunction, SchedulerLike, SchedulerAction } from '../types';
+import { lift } from '../util/lift';
 
 export function windowTime<T>(windowTimeSpan: number,
                               scheduler?: SchedulerLike): OperatorFunction<T, Observable<T>>;
@@ -118,7 +119,7 @@ export function windowTime<T>(windowTimeSpan: number): OperatorFunction<T, Obser
   }
 
   return function windowTimeOperatorFunction(source: Observable<T>) {
-    return source.lift(new WindowTimeOperator<T>(windowTimeSpan, windowCreationInterval, maxWindowSize, scheduler));
+    return lift(source, new WindowTimeOperator<T>(windowTimeSpan, windowCreationInterval, maxWindowSize, scheduler));
   };
 }
 

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -7,6 +7,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Branch out the source Observable values as a nested Observable starting from
@@ -57,7 +58,7 @@ import { OperatorFunction } from '../types';
  */
 export function windowToggle<T, O>(openings: Observable<O>,
                                    closingSelector: (openValue: O) => Observable<any>): OperatorFunction<T, Observable<T>> {
-  return (source: Observable<T>) => source.lift(new WindowToggleOperator<T, O>(openings, closingSelector));
+  return (source: Observable<T>) => lift(source, new WindowToggleOperator<T, O>(openings, closingSelector));
 }
 
 class WindowToggleOperator<T, O> implements Operator<T, Observable<T>> {

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -7,6 +7,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
 
 /**
  * Branch out the source Observable values as a nested Observable using a
@@ -54,7 +55,7 @@ import { OperatorFunction } from '../types';
  */
 export function windowWhen<T>(closingSelector: () => Observable<any>): OperatorFunction<T, Observable<T>> {
   return function windowWhenOperatorFunction(source: Observable<T>) {
-    return source.lift(new WindowOperator<T>(closingSelector));
+    return lift(source, new WindowOperator<T>(closingSelector));
   };
 }
 

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -5,6 +5,7 @@ import { OuterSubscriber } from '../OuterSubscriber';
 import { InnerSubscriber } from '../InnerSubscriber';
 import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
+import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function withLatestFrom<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
@@ -74,7 +75,7 @@ export function withLatestFrom<T, R>(...args: Array<ObservableInput<any> | ((...
       project = args.pop();
     }
     const observables = <Observable<any>[]>args;
-    return source.lift(new WithLatestFromOperator(observables, project));
+    return lift(source, new WithLatestFromOperator(observables, project));
   };
 }
 

--- a/src/internal/operators/zipAll.ts
+++ b/src/internal/operators/zipAll.ts
@@ -1,6 +1,7 @@
 import { ZipOperator } from '../observable/zip';
 import { Observable } from '../Observable';
 import { OperatorFunction, ObservableInput } from '../types';
+import { lift } from '../util/lift';
 
 export function zipAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export function zipAll<T>(): OperatorFunction<any, T[]>;
@@ -8,5 +9,5 @@ export function zipAll<T, R>(project: (...values: T[]) => R): OperatorFunction<O
 export function zipAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 
 export function zipAll<T, R>(project?: (...values: Array<any>) => R): OperatorFunction<T, R> {
-  return (source: Observable<T>) => source.lift(new ZipOperator(project));
+  return (source: Observable<T>) => lift(source, new ZipOperator(project));
 }

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -1,6 +1,7 @@
 import { zip as zipStatic } from '../observable/zip';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
+import { stankyLift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link zipWith} */
@@ -38,10 +39,10 @@ export function zip<T, TOther, R>(array: Array<ObservableInput<TOther>>, project
  */
 export function zip<T, R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, R> {
   return function zipOperatorFunction(source: Observable<T>) {
-    return source.lift.call(
-      zipStatic<R>(source, ...observables),
-      undefined
-    ) as Observable<R>;
+    return stankyLift(
+      source,
+      zipStatic<R>(source, ...observables)
+    );
   };
 }
 

--- a/src/internal/util/lift.ts
+++ b/src/internal/util/lift.ts
@@ -1,0 +1,54 @@
+/** @prettier */
+import { Observable } from '../Observable';
+import { Operator } from '../Operator';
+
+/**
+ * A utility to lift observables. Will also error if an observable is passed that does not
+ * have the lift mechanism.
+ *
+ * We _must_ do this for version 7, because it is what allows subclassed observables to compose through
+ * the operators that use this. That will be going away in v8.
+ *
+ * See https://github.com/ReactiveX/rxjs/issues/5571
+ * and https://github.com/ReactiveX/rxjs/issues/5431
+ *
+ * @param source The source observable to lift
+ * @param operator The operator to lift it with. Note that the operator possibly being undefined here
+ * is related to issues around the "stanky" lifting of static creation functions as operators, see below.
+ */
+export function lift<T, R>(source: Observable<T>, operator?: Operator<T, R>): Observable<R> {
+  if (hasLift(source)) {
+    return source.lift(operator);
+  }
+  throw new TypeError('Unable to lift unknown Observable type');
+}
+
+// TODO: Figure out proper typing for what we're doing below at some point.
+// For right now it's not that important, as it's internal implementation and not
+// public typings on a public API.
+
+/**
+ * A utility used to lift observables in the case that we are trying to convert a static observable
+ * creation function to an operator that appropriately uses lift. Ultimately this is a smell
+ * related to `lift`, hence the name.
+ *
+ * We _must_ do this for version 7, because it is what allows subclassed observables to compose through
+ * the operators that use this. That will be going away in v8.
+ *
+ * See https://github.com/ReactiveX/rxjs/issues/5571
+ * and https://github.com/ReactiveX/rxjs/issues/5431
+ *
+ * @param source the original observable source for the operator
+ * @param liftedSource the actual composed source we want to lift
+ * @param operator the operator to lift it with (often undefined in this case)
+ */
+export function stankyLift(source: Observable<any>, liftedSource: Observable<any>, operator?: Operator<any, any>): Observable<any> {
+  if (hasLift(source)) {
+    return source.lift.call(liftedSource, operator);
+  }
+  throw new TypeError('Unable to lift unknown Observable type');
+}
+
+function hasLift(source: any): source is { lift: InstanceType<typeof Observable>['lift'] } {
+  return source && typeof source.lift === 'function';
+}


### PR DESCRIPTION
- Removes `_isScalar` as it was unused
- makes `lift` `protected`. This is an internal implementation detail.
- makes `source` `protected`, this is an internal implementation detail.
- Refactors operators to use new utility functions that do the lift or provide a reasonable error if the observable someone is trying to use with the operator does not have a lift method. Adds documentation.

BREAKING CHANGE: `lift` no longer exposed. It was _NEVER_ documented that end users of the library should be creating operators using `lift`. Lift has a [variety of issues](https://github.com/ReactiveX/rxjs/issues/5431) and was always an internal implementation detail of rxjs that might have been used by a few power users in the early days when it had the most value. The value of `lift`, originally, was that subclassed `Observable`s would compose through all operators that implemented lift. The reality is that feature is not widely known, used, or supported, and it was never documented as it was very experimental when it was first added. Until the end of v7, `lift` will remain on Observable. Standard JavaScript users will notice no difference. However, TypeScript users might see complaints about `lift` not being a member of observable. To workaround this issue there are two things you can do: 1. Rewrite your operators as [outlined in the documentation](https://rxjs.dev/guide/operators), such that they return `new Observable`. or 2. cast your observable as `any` and access `lift` that way. Method 1 is recommended if you do not want things to break when we move to version 8.
