### PR TITLE
refactor(buffer): rename buffer to bufferWith

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -152,11 +152,11 @@ These are Observable creation operators that also have join functionality -- emi
 
 ### Transformation Operators
 
-- [`buffer`](/api/operators/buffer)
 - [`bufferCount`](/api/operators/bufferCount)
 - [`bufferTime`](/api/operators/bufferTime)
 - [`bufferToggle`](/api/operators/bufferToggle)
 - [`bufferWhen`](/api/operators/bufferWhen)
+- [`bufferWith`](/api/operators/bufferWith)
 - [`concatMap`](/api/operators/concatMap)
 - [`concatMapTo`](/api/operators/concatMapTo)
 - [`exhaust`](/api/operators/exhaust)

--- a/docs_app/tools/decision-tree-generator/src/tree.yml
+++ b/docs_app/tools/decision-tree-generator/src/tree.yml
@@ -185,7 +185,7 @@
           children:
             - label: and emit the group as an array
               children:
-                - label: buffer
+                - label: bufferWith
             - label: and emit the group as a nested Observable
               children:
                 - label: window

--- a/spec/operators/bufferWith-spec.ts
+++ b/spec/operators/bufferWith-spec.ts
@@ -1,0 +1,269 @@
+import { bufferWith, mergeMap, take } from 'rxjs/operators';
+import { EMPTY, NEVER, throwError, of } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+/** @test {bufferWith} */
+describe('Observable.prototype.bufferWith', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should emit buffers that close and reopen', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = hot('   -a-b-c-d-e-f-g-h-i-|');
+      const b = hot('   -----B-----B-----B-|');
+      const expected = '-----x-----y-----z-|';
+      const expectedValues = {
+        x: ['a', 'b', 'c'],
+        y: ['d', 'e', 'f'],
+        z: ['g', 'h', 'i']
+      };
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, expectedValues);
+    });
+  });
+
+  it('should work with empty and empty selector', () => {
+    testScheduler.run(({ expectObservable }) => {
+      const a = EMPTY;
+      const b = EMPTY;
+      const expected = '|';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected);
+    });
+  });
+
+  it('should work with empty and non-empty selector', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = EMPTY;
+      const b = hot('-----a-----');
+      const expected = '|';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected);
+    });
+  });
+
+  it('should work with non-empty and empty selector', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const b = EMPTY;
+      const expected = '|';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected);
+    });
+  });
+
+  it('should work with never and never selector', () => {
+    testScheduler.run(({ expectObservable }) => {
+      const a = NEVER;
+      const b = NEVER;
+      const expected = '-';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected);
+    });
+  });
+
+  it('should work with never and empty selector', () => {
+    testScheduler.run(({ expectObservable }) => {
+      const a = NEVER;
+      const b = EMPTY;
+      const expected = '|';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected);
+    });
+  });
+
+  it('should work with empty and never selector', () => {
+    testScheduler.run(({ expectObservable }) => {
+      const a = EMPTY;
+      const b = NEVER;
+      const expected = '|';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected);
+    });
+  });
+
+  it('should work with non-empty and throw selector', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = hot('---^--a--');
+      const b = throwError(new Error('too bad'));
+      const expected = '#';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, null, new Error('too bad'));
+    });
+  });
+
+  it('should work with throw and non-empty selector', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = throwError(new Error('too bad'));
+      const b = hot('---^--a--');
+      const expected = '#';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, null, new Error('too bad'));
+    });
+  });
+
+  it('should work with error', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = hot('---^-------#', undefined, new Error('too bad'));
+      const b = hot('---^--------');
+      const expected = '--------#';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, null, new Error('too bad'));
+    });
+  });
+
+  it('should work with error and non-empty selector', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = hot('---^-------#', undefined, new Error('too bad'));
+      const b = hot('---^---a----');
+      const expected = '----a---#';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, { a: [] }, new Error('too bad'));
+    });
+  });
+
+  it('should work with selector', () => {
+    // Buffer Boundaries Simple (RxJS 4)
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const b = hot('--------^--a-------b---cd---------e---f---|');
+      const expected = '     ---a-------b---cd---------e---f-|';
+      const expectedValues = {
+        a: ['3'],
+        b: ['4', '5'],
+        c: ['6'],
+        d: [] as string[],
+        e: ['7', '8', '9'],
+        f: ['0']
+      };
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, expectedValues);
+    });
+  });
+
+  it(' work with selector completed', () => {
+    // Buffshoulder Boundaries onCompletedBoundaries (RxJS 4)
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const subs = '         ^----------------!               ';
+      const b = hot('--------^--a-------b---cd|               ');
+      const expected = '     ---a-------b---cd|               ';
+      const expectedValues = {
+        a: ['3'],
+        b: ['4', '5'],
+        c: ['6'],
+        d: [] as string[]
+      };
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, expectedValues);
+      expectSubscriptions(a.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should allow unsubscribing the result Observable early', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const unsub = '        --------------!                  ';
+      const subs = '         ^-------------!                  ';
+      const b = hot('--------^--a-------b---cd|               ');
+      const expected = '     ---a-------b---                  ';
+      const expectedValues = {
+        a: ['3'],
+        b: ['4', '5']
+      };
+      expectObservable(a.pipe(bufferWith(b)), unsub).toBe(expected, expectedValues);
+      expectSubscriptions(a.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should not break unsubscription chains when unsubscribed explicitly', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const subs = '         ^-------------!                  ';
+      const b = hot('--------^--a-------b---cd|               ');
+      const expected = '     ---a-------b---                  ';
+      const unsub = '        --------------!                  ';
+      const expectedValues = {
+        a: ['3'],
+        b: ['4', '5']
+      };
+
+      const result = a.pipe(
+        mergeMap((x: any) => of(x)),
+        bufferWith(b),
+        mergeMap((x: any) => of(x)),
+      );
+
+      expectObservable(result, unsub).toBe(expected, expectedValues);
+      expectSubscriptions(a.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should work with non-empty and selector error', () => {
+    // Buffer Boundaries onErrorSource (RxJS 4)
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const a = hot('--1--2--^--3-----#', {'3': 3}, new Error('too bad'));
+      const subs = '         ^--------!';
+      const b = hot('--------^--a--b---');
+      const expected = '     ---a--b--#';
+      const expectedValues = {
+        a: [3],
+        b: [] as string[]
+      };
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, expectedValues, new Error('too bad'));
+      expectSubscriptions(a.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should work with non-empty and empty selector error', () => {
+    testScheduler.run(({ hot, expectObservable }) => {
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const b = hot('--------^----------------#', undefined, new Error('too bad'));
+      const expected = '     -----------------#';
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, null, new Error('too bad'));
+    });
+  });
+
+  it('should work with non-empty and selector error', () => {
+    // Buffer Boundaries onErrorBoundaries (RxJS 4)
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const obj = { a: true, b: true, c: true };
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const subs = '         ^----------------!';
+      const b = hot('--------^--a-------b---c-#', obj, new Error('too bad'));
+      const expected = '     ---a-------b---c-#';
+      const expectedValues = {
+        a: ['3'],
+        b: ['4', '5'],
+        c: ['6']
+      };
+      expectObservable(a.pipe(bufferWith(b))).toBe(expected, expectedValues, new Error('too bad'));
+      expectSubscriptions(a.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should unsubscribe notifier when source unsubscribed', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
+      const unsub = '        --------------!                  ';
+      const subs = '         ^-------------!                  ';
+      const b = hot('--------^--a-------b---cd|               ');
+      const bsubs = '        ^-------------!                  ';
+      const expected = '     ---a-------b---                  ';
+      const expectedValues = {
+        a: ['3'],
+        b: ['4', '5']
+      };
+
+      expectObservable(a.pipe(bufferWith(b)), unsub).toBe(expected, expectedValues);
+      expectSubscriptions(a.subscriptions).toBe(subs);
+      expectSubscriptions(b.subscriptions).toBe(bsubs);
+    });
+  });
+
+  it('should unsubscribe notifier when source unsubscribed', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const a = hot('   -a-b-c-d-e-f-g-h-i-|');
+      const b = hot('   -----1-----2-----3-|');
+      const bsubs = '   ^----!';
+      const expected = '-----(x|)';
+      const expectedValues = {
+        x: ['a', 'b', 'c'],
+      };
+
+      expectObservable(a.pipe(bufferWith(b), take(1))).toBe(expected, expectedValues);
+      expectSubscriptions(b.subscriptions).toBe(bsubs);
+    });
+  });
+});

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -1,11 +1,6 @@
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
-import { OuterSubscriber } from '../OuterSubscriber';
-import { InnerSubscriber } from '../InnerSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { bufferWith } from './bufferWith';
 
 /**
  * Buffers the source Observable values until `closingNotifier` emits.
@@ -45,45 +40,9 @@ import { lift } from '../util/lift';
  * @return {Observable<T[]>} An Observable of buffers, which are arrays of
  * values.
  * @name buffer
+ *
+ * @deprecated use {@link bufferWith}
  */
 export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
-  return function bufferOperatorFunction(source: Observable<T>) {
-    return lift(source, new BufferOperator<T>(closingNotifier));
-  };
-}
-
-class BufferOperator<T> implements Operator<T, T[]> {
-
-  constructor(private closingNotifier: Observable<any>) {
-  }
-
-  call(subscriber: Subscriber<T[]>, source: any): any {
-    return source.subscribe(new BufferSubscriber(subscriber, this.closingNotifier));
-  }
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class BufferSubscriber<T> extends OuterSubscriber<T, any> {
-  private buffer: T[] = [];
-
-  constructor(destination: Subscriber<T[]>, closingNotifier: Observable<any>) {
-    super(destination);
-    this.add(subscribeToResult(this, closingNotifier));
-  }
-
-  protected _next(value: T) {
-    this.buffer.push(value);
-  }
-
-  notifyNext(outerValue: T, innerValue: any,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, any>): void {
-    const buffer = this.buffer;
-    this.buffer = [];
-    this.destination.next(buffer);
-  }
+  return bufferWith<T>(closingNotifier);
 }

--- a/src/internal/operators/bufferWith.ts
+++ b/src/internal/operators/bufferWith.ts
@@ -1,0 +1,89 @@
+import { Operator } from '../Operator';
+import { Subscriber } from '../Subscriber';
+import { Observable } from '../Observable';
+import { OuterSubscriber } from '../OuterSubscriber';
+import { InnerSubscriber } from '../InnerSubscriber';
+import { subscribeToResult } from '../util/subscribeToResult';
+import { OperatorFunction } from '../types';
+import { lift } from '../util/lift';
+
+/**
+ * Buffers the source Observable values until `closingNotifier` emits.
+ *
+ * <span class="informal">Collects values from the past as an array, and emits
+ * that array only when another Observable emits.</span>
+ *
+ * ![](buffer.png)
+ *
+ * Buffers the incoming Observable values until the given `closingNotifier`
+ * Observable emits a value, at which point it emits the buffer on the output
+ * Observable and starts a new buffer internally, awaiting the next time
+ * `closingNotifier` emits.
+ *
+ * ## Example
+ *
+ * On every click, emit array of most recent interval events
+ *
+ * ```ts
+ * import { fromEvent, interval } from 'rxjs';
+ * import { bufferWith } from 'rxjs/operators';
+ *
+ * const clicks = fromEvent(document, 'click');
+ * const intervalEvents = interval(1000);
+ * const buffered = intervalEvents.pipe(bufferWith(clicks));
+ * buffered.subscribe(x => console.log(x));
+ * ```
+ *
+ * @see {@link bufferCount}
+ * @see {@link bufferTime}
+ * @see {@link bufferToggle}
+ * @see {@link bufferWhen}
+ * @see {@link window}
+ *
+ * @param {Observable<any>} closingNotifier An Observable that signals the
+ * buffer to be emitted on the output Observable.
+ * @return {Observable<T[]>} An Observable of buffers, which are arrays of
+ * values.
+ * @name bufferWith
+ */
+export function bufferWith<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
+  return function bufferOperatorFunction(source: Observable<T>) {
+    return lift(source, new BufferOperator<T>(closingNotifier));
+  };
+}
+
+class BufferOperator<T> implements Operator<T, T[]> {
+
+  constructor(private closingNotifier: Observable<any>) {
+  }
+
+  call(subscriber: Subscriber<T[]>, source: any): any {
+    return source.subscribe(new BufferSubscriber(subscriber, this.closingNotifier));
+  }
+}
+
+/**
+ * We need this JSDoc comment for affecting ESDoc.
+ * @ignore
+ * @extends {Ignored}
+ */
+class BufferSubscriber<T> extends OuterSubscriber<T, any> {
+  private buffer: T[] = [];
+
+  constructor(destination: Subscriber<T[]>, closingNotifier: Observable<any>) {
+    super(destination);
+    this.add(subscribeToResult(this, closingNotifier));
+  }
+
+  protected _next(value: T) {
+    this.buffer.push(value);
+  }
+
+  notifyNext(outerValue: T, innerValue: any,
+             outerIndex: number, innerIndex: number,
+             innerSub: InnerSubscriber<T, any>): void {
+    const buffer = this.buffer;
+    this.buffer = [];
+    this.destination.next(buffer);
+  }
+}

--- a/src/internal/operators/index.ts
+++ b/src/internal/operators/index.ts
@@ -5,6 +5,7 @@ export { bufferCount } from './bufferCount';
 export { bufferTime } from './bufferTime';
 export { bufferToggle } from './bufferToggle';
 export { bufferWhen } from './bufferWhen';
+export { bufferWith } from './bufferWith';
 export { catchError } from './catchError';
 export { combineAll } from './combineAll';
 export { combineLatest, combineLatestWith } from './combineLatestWith';

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -7,6 +7,7 @@ export { bufferCount } from '../internal/operators/bufferCount';
 export { bufferTime } from '../internal/operators/bufferTime';
 export { bufferToggle } from '../internal/operators/bufferToggle';
 export { bufferWhen } from '../internal/operators/bufferWhen';
+export { bufferWith } from '../internal/operators/bufferWith';
 export { catchError } from '../internal/operators/catchError';
 export { combineAll } from '../internal/operators/combineAll';
 export { combineLatest, combineLatestWith } from '../internal/operators/combineLatestWith';


### PR DESCRIPTION
**Description:** renames the buffer operator to bufferWith and marks buffer as deprecated

**Related issue (if exists):** #5296