### PR TITLE
fix(publish,publishReplay) resolve sharing Subject when subscribing to different source observables

### DIFF
--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { throwError, ConnectableObservable, EMPTY, NEVER, of, Observable, Subscription } from 'rxjs';
+import { throwError, ConnectableObservable, EMPTY, NEVER, of, Observable, Subscription, pipe } from 'rxjs';
 import { publishReplay, mergeMapTo, tap, mergeMap, refCount, retry, repeat, map } from 'rxjs/operators';
 
 /** @test {publishReplay} */
@@ -487,5 +487,29 @@ describe('publishReplay operator', () => {
 
     expectObservable(published).toBe(expected, undefined, error);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+  });
+
+  it('should subscribe to its own source when using a shared pipeline', () => {
+    const source1 = cold('-1-2-3-4-5-|');
+    const source2 = cold('-6-7-8-9-0-|');
+    const expected1 =    '-1-2-3-4-5-|';
+    const expected2 =    '-6-7-8-9-0-|';
+    const source1Subs =  '^          !';
+    const source2Subs =  '^          !';
+
+    const sharedPipeLine = pipe(
+      publishReplay(1)
+     );
+
+    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+
+    expectObservable(published1).toBe(expected1);
+    expectSubscriptions(source1.subscriptions).toBe(source1Subs);
+    expectObservable(published2).toBe(expected2);
+    expectSubscriptions(source2.subscriptions).toBe(source2Subs);
+
+    published1.connect();
+    published2.connect();
   });
 });

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -59,6 +59,6 @@ export function publish<T>(selector: MonoTypeOperatorFunction<T>): MonoTypeOpera
  */
 export function publish<T, R>(selector?: OperatorFunction<T, R>): MonoTypeOperatorFunction<T> | OperatorFunction<T, R> {
   return selector ?
-    multicast(() => new Subject<T>(), selector) :
-    multicast(new Subject<T>());
+    (source: Observable<T>) => multicast(() => new Subject<T>(), selector)(source) :
+    (source: Observable<T>) => multicast(new Subject<T>())(source);
 }

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -19,7 +19,6 @@ export function publishReplay<T, R>(bufferSize?: number,
   }
 
   const selector = typeof selectorOrScheduler === 'function' ? selectorOrScheduler : undefined;
-  const subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
 
-  return (source: Observable<T>) => multicast(() => subject, selector!)(source) as ConnectableObservable<R>;
+  return (source: Observable<T>) => multicast(new ReplaySubject<T>(bufferSize, windowTime, scheduler), selector!)(source) as ConnectableObservable<R>;
 }


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes the issue when using the publish or publishReplay operator in a pipe that's shared with different source observables.

For more details see #5411 

- change publish operator to use factory
- change publishReplay operator to not share ReplaySubject


**Related issue (if exists):**
- fixes issue #5411