### PR TITLE
Feature: AbortSignal support

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -261,6 +261,8 @@ export declare type InteropObservable<T> = {
 
 export declare function interval(period?: number, scheduler?: SchedulerLike): Observable<number>;
 
+export declare function isAbortError(value: any): boolean;
+
 export declare function isObservable<T>(obj: any): obj is Observable<T>;
 
 export declare function lastValueFrom<T>(source: Observable<T>): Promise<T>;
@@ -361,8 +363,8 @@ export declare class Observable<T> implements Subscribable<T> {
     constructor(subscribe?: (this: Observable<T>, subscriber: Subscriber<T>) => TeardownLogic);
     protected _subscribe(subscriber: Subscriber<any>): TeardownLogic;
     protected _trySubscribe(sink: Subscriber<T>): TeardownLogic;
-    forEach(next: (value: T) => void): Promise<void>;
-    forEach(next: (value: T) => void, promiseCtor: PromiseConstructorLike): Promise<void>;
+    forEach(nextHandler: (value: T) => void, signal?: AbortSignal): Promise<void>;
+    forEach(nextHandler: (value: T) => void, promiseCtor: PromiseConstructorLike): Promise<void>;
     protected lift<R>(operator?: Operator<T, R>): Observable<R>;
     pipe(): Observable<T>;
     pipe<A>(op1: OperatorFunction<T, A>): Observable<A>;
@@ -376,6 +378,7 @@ export declare class Observable<T> implements Subscribable<T> {
     pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): Observable<I>;
     pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>, ...operations: OperatorFunction<any, any>[]): Observable<unknown>;
     subscribe(observer?: PartialObserver<T>): Subscription;
+    subscribe(observer: PartialObserver<T> | null | undefined, signal: AbortSignal | null | undefined): Subscription;
     subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
     subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
     subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;

--- a/package-lock.json
+++ b/package-lock.json
@@ -2598,6 +2598,12 @@
         "through": "~2.3.1"
       }
     },
+    "event-target-polyfill": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/event-target-polyfill/-/event-target-polyfill-0.0.2.tgz",
+      "integrity": "sha512-m7I5gwno/p6H0wRJ7jsjJnbdcA8Do3mAf57vUphb1X+DUHAEMhjUmg8MBAaFsB/BtUCXUl70mUPr0Iw3dvdaqQ==",
+      "dev": true
+    },
     "events": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/events/-/events-3.0.0.tgz",
@@ -8756,6 +8762,15 @@
         "flat": "^4.1.0",
         "lodash": "^4.17.15",
         "yargs": "^13.3.0"
+      }
+    },
+    "yet-another-abortcontroller-polyfill": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/yet-another-abortcontroller-polyfill/-/yet-another-abortcontroller-polyfill-0.0.2.tgz",
+      "integrity": "sha512-2teltdB/BcTs8NmFMpm2H0xlfDaobtTAwmWW5eKvIByLO3cwsyKi7s8BXTe+HMocPA/YwtR7tJEQMLV3lEBhvg==",
+      "dev": true,
+      "requires": {
+        "event-target-polyfill": "0.0.2"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -8765,13 +8765,10 @@
       }
     },
     "yet-another-abortcontroller-polyfill": {
-      "version": "0.0.2",
-      "resolved": "https://registry.npmjs.org/yet-another-abortcontroller-polyfill/-/yet-another-abortcontroller-polyfill-0.0.2.tgz",
-      "integrity": "sha512-2teltdB/BcTs8NmFMpm2H0xlfDaobtTAwmWW5eKvIByLO3cwsyKi7s8BXTe+HMocPA/YwtR7tJEQMLV3lEBhvg==",
-      "dev": true,
-      "requires": {
-        "event-target-polyfill": "0.0.2"
-      }
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/yet-another-abortcontroller-polyfill/-/yet-another-abortcontroller-polyfill-0.0.3.tgz",
+      "integrity": "sha512-B4O92xxxZP6QhNMVYKv4qZcFbTB1txXQT2lUPq38e9TMuGQhGl2Ow+NN/XflY7aT4v4H/NZI1VTJT7B6YHc5iw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -150,7 +150,8 @@
     "typedoc": "^0.17.8",
     "typescript": "~3.9.2",
     "validate-commit-msg": "2.14.0",
-    "webpack": "^4.31.0"
+    "webpack": "^4.31.0",
+    "yet-another-abortcontroller-polyfill": "0.0.2"
   },
   "files": [
     "dist/bundles",

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "escape-string-regexp": "1.0.5",
     "eslint": "4.18.2",
     "eslint-plugin-jasmine": "^2.10.1",
+    "event-target-polyfill": "0.0.2",
     "fs-extra": "^8.1.0",
     "glob": "7.1.2",
     "google-closure-compiler-js": "20170218.0.0",
@@ -151,7 +152,7 @@
     "typescript": "~3.9.2",
     "validate-commit-msg": "2.14.0",
     "webpack": "^4.31.0",
-    "yet-another-abortcontroller-polyfill": "0.0.2"
+    "yet-another-abortcontroller-polyfill": "0.0.3"
   },
   "files": [
     "dist/bundles",

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -5,6 +5,7 @@ import { Observable, config, Subscription, noop, Subscriber, Operator, NEVER, Su
 import { map, multicast, refCount, filter, count, tap, combineLatest, concat, merge, race, zip, catchError, mergeMap, finalize, mergeAll } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from './helpers/observableMatcher';
+import 'event-target-polyfill';
 import 'yet-another-abortcontroller-polyfill';
 
 function expectFullObserver(val: any) {

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -66,6 +66,26 @@ describe('Observable', () => {
   });
 
   describe('forEach', () => {
+    it('should support AbortSignal', async () => {
+      const results: number[] = []
+      const ac = new AbortController();
+      try {
+      await of(1, 2, 3, 4, 5).forEach(
+        n => {
+          results.push(n);
+          if (n === 3) {
+            ac.abort();
+          }
+        },
+        ac.signal
+      ) 
+      } catch (err) {
+        expect(err.name).to.equal('AbortError');
+      }
+      expect(results).to.deep.equal([1, 2, 3]);
+    });
+
+
     it('should iterate and return a Promise', (done) => {
       const expected = [1, 2, 3];
       const result = of(1, 2, 3)
@@ -200,7 +220,7 @@ describe('Observable', () => {
     });
   });
 
-  describe.only('subscribe with abortSignal', () => {
+  describe('subscribe with abortSignal', () => {
     it('should allow unsubscription with the abortSignal', (done) => {
       const source = new Observable<number>(subscriber => {
         let i = 0;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,5 @@
 /* Observable */
-export { Observable } from './internal/Observable';
+export { Observable, isAbortError } from './internal/Observable';
 export { ConnectableObservable } from './internal/observable/ConnectableObservable';
 export { GroupedObservable } from './internal/operators/groupBy';
 export { Operator } from './internal/Operator';

--- a/src/internal/util/AbortError.ts
+++ b/src/internal/util/AbortError.ts
@@ -1,0 +1,31 @@
+export interface AbortError extends Error {
+}
+
+export interface AbortErrorCtor {
+  new(): AbortError;
+}
+
+const AbortErrorImpl = (() => {
+  function AbortErrorImpl(this: Error) {
+    Error.call(this);
+    this.message = 'Abort exception';
+    this.name = 'AbortError';
+    return this;
+  }
+
+  AbortErrorImpl.prototype = Object.create(Error.prototype);
+
+  return AbortErrorImpl;
+})();
+
+/**
+ * An error thrown when an Observable or a sequence was queried but has no
+ * elements.
+ *
+ * @see {@link first}
+ * @see {@link last}
+ * @see {@link single}
+ *
+ * @class AbortError
+ */
+export const AbortError: AbortErrorCtor = AbortErrorImpl as any;


### PR DESCRIPTION
This is a flag in the ground for adding support for `AbortSignal` to RxJS.

This is a non-breaking change that adds support for passing AbortSignal to both `subscribe` and `forEach` calls of Observable. See commits.

Related #5545 and #3122 