### PR TITLE
Modified package.json to use shorter repository location syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,10 +45,7 @@
     "api_guardian:update": "ts-api-guardian --outDir api_guard dist/types/index.d.ts dist/types/ajax/index.d.ts dist/types/fetch/index.d.ts dist/types/operators/index.d.ts dist/types/testing/index.d.ts dist/types/webSocket/index.d.ts",
     "api_guardian": "ts-api-guardian --verifyDir api_guard dist/types/index.d.ts dist/types/ajax/index.d.ts dist/types/fetch/index.d.ts dist/types/operators/index.d.ts dist/types/testing/index.d.ts dist/types/webSocket/index.d.ts"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/reactivex/rxjs.git"
-  },
+  "repository": "reactivex/rxjs",
   "keywords": [
     "Rx",
     "RxJS",


### PR DESCRIPTION
Like mentioned in the npm package.json specification [here](https://docs.npmjs.com/files/package.json): 
`For GitHub, GitHub gist, Bitbucket, or GitLab repositories you can use the same shortcut syntax you use for npm install`

This also resolves a problem when installing via CITGM.