### PR TITLE
refactor(tap): rename DoOperator to TapOperator

### DIFF
--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -69,11 +69,11 @@ export function tap<T>(nextOrObserver?: PartialObserver<T> | ((x: T) => void) | 
                        error?: ((e: any) => void) | null,
                        complete?: (() => void) | null): MonoTypeOperatorFunction<T> {
   return function tapOperatorFunction(source: Observable<T>): Observable<T> {
-    return lift(source, new DoOperator(nextOrObserver, error, complete));
+    return lift(source, new TapOperator(nextOrObserver, error, complete));
   };
 }
 
-class DoOperator<T> implements Operator<T, T> {
+class TapOperator<T> implements Operator<T, T> {
   constructor(private nextOrObserver?: PartialObserver<T> | ((x: T) => void) | null,
               private error?: ((e: any) => void) | null,
               private complete?: (() => void) | null) {


### PR DESCRIPTION
Renaming `DoOperator` to `TapOperator` to follow the rest of the `tap` operator stuff: the `tap` itself is no longer `do` operator and the `TapSubscriber` is [no longer](https://github.com/ReactiveX/rxjs/commit/cd9626a4f93cac6f631d5a97dd9c9b2aa8e4b5db) `DoSubscriber`.

This is a leftover that some may love to keep, but if possible, it would be nice to have this merged so that `tap` is now completely renamed.