### PR TITLE
feat(TestScheduler): add an animate "run mode" helper

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -618,7 +618,7 @@ export declare class VirtualAction<T> extends AsyncAction<T> {
     protected recycleAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     protected requestAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     schedule(state?: T, delay?: number): Subscription;
-    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 1 | 0 | -1;
+    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 0 | 1 | -1;
 }
 
 export declare class VirtualTimeScheduler extends AsyncScheduler {

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -618,7 +618,7 @@ export declare class VirtualAction<T> extends AsyncAction<T> {
     protected recycleAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     protected requestAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     schedule(state?: T, delay?: number): Subscription;
-    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 0 | 1 | -1;
+    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 1 | 0 | -1;
 }
 
 export declare class VirtualTimeScheduler extends AsyncScheduler {

--- a/api_guard/dist/types/testing/index.d.ts
+++ b/api_guard/dist/types/testing/index.d.ts
@@ -4,6 +4,7 @@ export interface RunHelpers {
     expectSubscriptions: typeof TestScheduler.prototype.expectSubscriptions;
     flush: typeof TestScheduler.prototype.flush;
     hot: typeof TestScheduler.prototype.createHotObservable;
+    repaints: (marbles: string) => void;
     time: typeof TestScheduler.prototype.createTime;
 }
 

--- a/api_guard/dist/types/testing/index.d.ts
+++ b/api_guard/dist/types/testing/index.d.ts
@@ -1,10 +1,10 @@
 export interface RunHelpers {
+    animate: (marbles: string) => void;
     cold: typeof TestScheduler.prototype.createColdObservable;
     expectObservable: typeof TestScheduler.prototype.expectObservable;
     expectSubscriptions: typeof TestScheduler.prototype.expectSubscriptions;
     flush: typeof TestScheduler.prototype.flush;
     hot: typeof TestScheduler.prototype.createHotObservable;
-    repaints: (marbles: string) => void;
     time: typeof TestScheduler.prototype.createTime;
 }
 

--- a/docs_app/content/guide/testing/marble-testing.md
+++ b/docs_app/content/guide/testing/marble-testing.md
@@ -56,6 +56,17 @@ Although `run()` executes entirely synchronously, the helper functions inside yo
 - `expectObservable(actual: Observable<T>, subscriptionMarbles?: string).toBe(marbleDiagram: string, values?: object, error?: any)` - schedules an assertion for when the TestScheduler flushes. Give `subscriptionMarbles` as parameter to change the schedule of subscription and unsubscription. If you don't provide the `subscriptionMarbles` parameter it will subscribe at the beginning and never unsubscribe. Read below about subscription marble diagram.
 - `expectSubscriptions(actualSubscriptionLogs: SubscriptionLog[]).toBe(subscriptionMarbles: string)` - like `expectObservable` schedules an assertion for when the testScheduler flushes. Both `cold()` and `hot()` return an observable with a property `subscriptions` of type `SubscriptionLog[]`. Give `subscriptions` as parameter to `expectSubscriptions` to assert whether it matches the `subscriptionsMarbles` marble diagram given in `toBe()`. Subscription marble diagrams are slightly different than Observable marble diagrams. Read more below.
 - `flush()` - immediately starts virtual time. Not often used since `run()` will automatically flush for you when your callback returns, but in some cases you may wish to flush more than once or otherwise have more control.
+- `animate()` - specifies when requested animation frames will be 'painted'. `animate` accepts a marble diagram and each value emission in the diagram indicates when a 'paint' occurs - at which time, any queued `requestAnimationFrame` callbacks will be executed. Call `animate` at the beginning of your test and align the marble diagrams so that it's clear when the callbacks will be executed:
+
+    ```ts
+    testScheduler.run(helpers => {
+      const { animate, cold } = helpers;
+      animate('              ---x---x---x---x');
+      const requests = cold('-r-------r------')
+      /* ... */
+      const expected = '     ---a-------b----';
+    });
+    ```
 
 ## Marble syntax
 

--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -1,7 +1,6 @@
 import { of, asyncScheduler, Observable, scheduled, ObservableInput } from 'rxjs';
 import { observable } from 'rxjs/internal/symbol/observable';
 import { iterator } from 'rxjs/internal/symbol/iterator';
-import * as sinon from 'sinon';
 import { expect } from 'chai';
 
 if (process && process.on) {
@@ -71,105 +70,4 @@ export const NO_SUBS: string[] = [];
  */
 export function assertDeepEquals (actual: any, expected: any) {
   expect(actual).to.deep.equal(expected);
-}
-
-let _raf: any;
-let _caf: any;
-let _id = 0;
-
-/**
- * A type used to test `requestAnimationFrame`
- */
-export interface RAFTestTools {
-  /**
-   * Synchronously fire the next scheduled animation frame
-   */
-  tick(): void;
-
-  /**
-   * Synchronously fire all scheduled animation frames
-   */
-  flush(): void;
-
-  /**
-   * Un-monkey-patch `requestAnimationFrame` and `cancelAnimationFrame`
-   */
-  restore(): void;
-}
-
-/**
- * Monkey patches `requestAnimationFrame` and `cancelAnimationFrame`, returning a
- * toolset to allow animation frames to be synchronously controlled.
- *
- * ### Usage
- * ```ts
- * let raf: RAFTestTools;
- *
- * beforeEach(() => {
- *   // patch requestAnimationFrame
- *   raf = stubRAF();
- * });
- *
- * afterEach(() => {
- *   // unpatch
- *   raf.restore();
- * });
- *
- * it('should fire handlers', () => {
- *   let test = false;
- *   // use requestAnimationFrame as normal
- *   requestAnimationFrame(() => test = true);
- *   // no frame has fired yet (this would be generally true anyhow)
- *   expect(test).to.equal(false);
- *   // manually fire the next animation frame
- *   raf.tick();
- *   // frame as fired
- *   expect(test).to.equal(true);
- *   // raf is now a SinonStub that can be asserted against
- *   expect(requestAnimationFrame).to.have.been.calledOnce;
- * });
- * ```
- */
-export function stubRAF(): RAFTestTools {
-  _raf = requestAnimationFrame;
-  _caf = cancelAnimationFrame;
-
-  const handlers: any[] = [];
-
-  (requestAnimationFrame as any) = sinon.stub().callsFake((handler: Function) => {
-    const id = _id++;
-    handlers.push({ id, handler });
-    return id;
-  });
-
-  (cancelAnimationFrame as any) = sinon.stub().callsFake((id: number) => {
-    const index = handlers.findIndex(x => x.id === id);
-    if (index >= 0) {
-      handlers.splice(index, 1);
-    }
-  });
-
-  function tick() {
-    if (handlers.length > 0) {
-      handlers.shift().handler();
-    }
-  }
-
-  function flush() {
-    while (handlers.length > 0) {
-      handlers.shift().handler();
-    }
-  }
-
-  return {
-    tick,
-    flush,
-    restore() {
-      (requestAnimationFrame as any) = _raf;
-      (cancelAnimationFrame as any) = _caf;
-      _raf = _caf = undefined;
-      handlers.length = 0;
-      _id = 0;
-    }
-  };
 }

--- a/spec/observables/dom/animationFrames-spec.ts
+++ b/spec/observables/dom/animationFrames-spec.ts
@@ -15,8 +15,8 @@ describe('animationFrames', () => {
   });
 
   it('should animate', function () {
-    testScheduler.run(({ cold, expectObservable, repaints, time }) => {
-      repaints('           ---x---x---x');
+    testScheduler.run(({ animate, cold, expectObservable, time }) => {
+      animate('            ---x---x---x');
       const mapped = cold('-m          ');
       const tm = time('    -|          ');
       const ta = time('    ---|        ');
@@ -42,8 +42,8 @@ describe('animationFrames', () => {
       }),
     };
 
-    testScheduler.run(({ cold, expectObservable, repaints }) => {
-      repaints('           ---x---x---x');
+    testScheduler.run(({ animate, cold, expectObservable }) => {
+      animate('            ---x---x---x');
       const mapped = cold('-m          ');
       const expected = '   ---a---b---c';
       const subs = '       ^----------!';
@@ -58,11 +58,11 @@ describe('animationFrames', () => {
   });
 
   it('should compose with take', () => {
-    testScheduler.run(({ cold, expectObservable, repaints, time }) => {
+    testScheduler.run(({ animate, cold, expectObservable, time }) => {
       const requestSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'requestAnimationFrame');
       const cancelSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'cancelAnimationFrame');
 
-      repaints('           ---x---x---x');
+      animate('            ---x---x---x');
       const mapped = cold('-m          ');
       const tm = time('    -|          ');
       const ta = time('    ---|        ');
@@ -84,11 +84,11 @@ describe('animationFrames', () => {
   });
 
   it('should compose with takeUntil', () => {
-    testScheduler.run(({ cold, expectObservable, hot, repaints, time }) => {
+    testScheduler.run(({ animate, cold, expectObservable, hot, time }) => {
       const requestSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'requestAnimationFrame');
       const cancelSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'cancelAnimationFrame');
 
-      repaints('           ---x---x---x');
+      animate('            ---x---x---x');
       const mapped = cold('-m          ');
       const tm = time('    -|          ');
       const ta = time('    ---|        ');

--- a/spec/observables/dom/animationFrames-spec.ts
+++ b/spec/observables/dom/animationFrames-spec.ts
@@ -1,166 +1,112 @@
+/** @prettier */
 import { expect } from 'chai';
-import { animationFrames, Subject } from 'rxjs';
 import * as sinon from 'sinon';
-import { take, takeUntil } from 'rxjs/operators';
-import { RAFTestTools, stubRAF } from '../../helpers/test-helper';
+import { animationFrames } from 'rxjs';
+import { mergeMapTo, take, takeUntil } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../../helpers/observableMatcher';
+import { requestAnimationFrameProvider } from 'rxjs/internal/scheduler/requestAnimationFrameProvider';
 
-describe('animationFrame', () => {
-  let raf: RAFTestTools;
-  let DateStub: sinon.SinonStub;
-  let now = 1000;
+describe('animationFrames', () => {
+  let testScheduler: TestScheduler;
 
   beforeEach(() => {
-    raf = stubRAF();
-    DateStub = sinon.stub(Date, 'now').callsFake(() => {
-      return ++now;
-    });
-  });
-
-  afterEach(() => {
-    raf.restore();
-    DateStub.restore();
+    testScheduler = new TestScheduler(observableMatcher);
   });
 
   it('should animate', function () {
-    const results: any[] = [];
-    const source$ = animationFrames();
+    testScheduler.run(({ cold, expectObservable, repaints, time }) => {
+      repaints('           ---x---x---x');
+      const mapped = cold('-m          ');
+      const tm = time('    -|          ');
+      const ta = time('    ---|        ');
+      const tb = time('    -------|    ');
+      const tc = time('    -----------|');
+      const expected = '   ---a---b---c';
+      const subs = '       ^----------!';
 
-    const subs = source$.subscribe({
-      next: ts => results.push(ts),
-      error: err => results.push(err),
-      complete: () => results.push('done'),
+      const result = mapped.pipe(mergeMapTo(animationFrames()));
+      expectObservable(result, subs).toBe(expected, {
+        a: ta - tm,
+        b: tb - tm,
+        c: tc - tm,
+      });
     });
-
-    expect(DateStub).to.have.been.calledOnce;
-
-    expect(results).to.deep.equal([]);
-
-    raf.tick();
-    expect(DateStub).to.have.been.calledTwice;
-    expect(results).to.deep.equal([1]);
-
-    raf.tick();
-    expect(DateStub).to.have.been.calledThrice;
-    expect(results).to.deep.equal([1, 2]);
-
-    raf.tick();
-    expect(results).to.deep.equal([1, 2, 3]);
-
-    // Stop the animation loop
-    subs.unsubscribe();
   });
 
   it('should use any passed timestampProvider', () => {
-    const results: any[] = [];
     let i = 0;
     const timestampProvider = {
       now: sinon.stub().callsFake(() => {
-        return [100, 200, 210, 300][i++];
-      })
+        return [50, 100, 200, 300][i++];
+      }),
     };
 
-    const source$ = animationFrames(timestampProvider);
+    testScheduler.run(({ cold, expectObservable, repaints }) => {
+      repaints('           ---x---x---x');
+      const mapped = cold('-m          ');
+      const expected = '   ---a---b---c';
+      const subs = '       ^----------!';
 
-    const subs = source$.subscribe({
-      next: ts => results.push(ts),
-      error: err => results.push(err),
-      complete: () => results.push('done'),
+      const result = mapped.pipe(mergeMapTo(animationFrames(timestampProvider)));
+      expectObservable(result, subs).toBe(expected, {
+        a: 50,
+        b: 150,
+        c: 250,
+      });
     });
-
-    expect(DateStub).not.to.have.been.called;
-    expect(timestampProvider.now).to.have.been.calledOnce;
-    expect(results).to.deep.equal([]);
-
-    raf.tick();
-    expect(DateStub).not.to.have.been.called;
-    expect(timestampProvider.now).to.have.been.calledTwice;
-    expect(results).to.deep.equal([100]);
-
-    raf.tick();
-    expect(DateStub).not.to.have.been.called;
-    expect(timestampProvider.now).to.have.been.calledThrice;
-    expect(results).to.deep.equal([100, 110]);
-
-    raf.tick();
-    expect(results).to.deep.equal([100, 110, 200]);
-
-    // Stop the animation loop
-    subs.unsubscribe();
   });
 
   it('should compose with take', () => {
-    const results: any[] = [];
-    const source$ = animationFrames();
-    expect(requestAnimationFrame).not.to.have.been.called;
+    testScheduler.run(({ cold, expectObservable, repaints, time }) => {
+      const requestSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'requestAnimationFrame');
+      const cancelSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'cancelAnimationFrame');
 
-    source$.pipe(
-      take(2),
-    ).subscribe({
-      next: ts => results.push(ts),
-      error: err => results.push(err),
-      complete: () => results.push('done'),
+      repaints('           ---x---x---x');
+      const mapped = cold('-m          ');
+      const tm = time('    -|          ');
+      const ta = time('    ---|        ');
+      const tb = time('    -------|    ');
+      const expected = '   ---a---b    ';
+
+      const result = mapped.pipe(mergeMapTo(animationFrames().pipe(take(2))));
+      expectObservable(result).toBe(expected, {
+        a: ta - tm,
+        b: tb - tm,
+      });
+
+      testScheduler.flush();
+      // Requests are made at tm and ta
+      expect(requestSpy.callCount).to.equal(2);
+      // Unsubscription effects request cancellation at tb
+      expect(cancelSpy.callCount).to.equal(1);
     });
-
-    expect(DateStub).to.have.been.calledOnce;
-    expect(requestAnimationFrame).to.have.been.calledOnce;
-
-    expect(results).to.deep.equal([]);
-
-    raf.tick();
-    expect(DateStub).to.have.been.calledTwice;
-    expect(requestAnimationFrame).to.have.been.calledTwice;
-    expect(results).to.deep.equal([1]);
-
-    raf.tick();
-    expect(DateStub).to.have.been.calledThrice;
-    // It shouldn't reschedule, because there are no more subscribers
-    // for the animation loop.
-    expect(requestAnimationFrame).to.have.been.calledTwice;
-    expect(results).to.deep.equal([1, 2, 'done']);
-
-    // Since there should be no more subscribers listening on the loop
-    // the latest animation frame should be cancelled.
-    expect(cancelAnimationFrame).to.have.been.calledOnce;
   });
 
   it('should compose with takeUntil', () => {
-    const subject = new Subject<void>();
-    const results: any[] = [];
-    const source$ = animationFrames();
-    expect(requestAnimationFrame).not.to.have.been.called;
+    testScheduler.run(({ cold, expectObservable, hot, repaints, time }) => {
+      const requestSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'requestAnimationFrame');
+      const cancelSpy = sinon.spy(requestAnimationFrameProvider.delegate!, 'cancelAnimationFrame');
 
-    source$.pipe(
-      takeUntil(subject),
-    ).subscribe({
-      next: ts => results.push(ts),
-      error: err => results.push(err),
-      complete: () => results.push('done'),
+      repaints('           ---x---x---x');
+      const mapped = cold('-m          ');
+      const tm = time('    -|          ');
+      const ta = time('    ---|        ');
+      const tb = time('    -------|    ');
+      const signal = hot(' ^--------s--');
+      const expected = '   ---a---b    ';
+
+      const result = mapped.pipe(mergeMapTo(animationFrames().pipe(takeUntil(signal))));
+      expectObservable(result).toBe(expected, {
+        a: ta - tm,
+        b: tb - tm,
+      });
+
+      testScheduler.flush();
+      // Requests are made at tm and ta and tb
+      expect(requestSpy.callCount).to.equal(3);
+      // Unsubscription effects request cancellation when signalled
+      expect(cancelSpy.callCount).to.equal(1);
     });
-
-    expect(DateStub).to.have.been.calledOnce;
-    expect(requestAnimationFrame).to.have.been.calledOnce;
-
-    expect(results).to.deep.equal([]);
-
-    raf.tick();
-    expect(DateStub).to.have.been.calledTwice;
-    expect(requestAnimationFrame).to.have.been.calledTwice;
-    expect(results).to.deep.equal([1]);
-
-    raf.tick();
-    expect(DateStub).to.have.been.calledThrice;
-    expect(requestAnimationFrame).to.have.been.calledThrice;
-    expect(results).to.deep.equal([1, 2]);
-    expect(cancelAnimationFrame).not.to.have.been.called;
-
-    // Complete the observable via `takeUntil`.
-    subject.next();
-    expect(cancelAnimationFrame).to.have.been.calledOnce;
-    expect(results).to.deep.equal([1, 2, 'done']);
-
-    raf.tick();
-    expect(DateStub).to.have.been.calledThrice;
-    expect(requestAnimationFrame).to.have.been.calledThrice;
-    expect(results).to.deep.equal([1, 2, 'done']);
   });
 });

--- a/spec/observables/dom/animationFrames-spec.ts
+++ b/spec/observables/dom/animationFrames-spec.ts
@@ -76,10 +76,10 @@ describe('animationFrames', () => {
       });
 
       testScheduler.flush();
-      // Requests are made at tm and ta
+      // Requests are made at times tm and ta
       expect(requestSpy.callCount).to.equal(2);
-      // Unsubscription effects request cancellation at tb
-      expect(cancelSpy.callCount).to.equal(1);
+      // No request cancellation is effected, as unsubscription occurs before rescheduling
+      expect(cancelSpy.callCount).to.equal(0);
     });
   });
 
@@ -103,7 +103,7 @@ describe('animationFrames', () => {
       });
 
       testScheduler.flush();
-      // Requests are made at tm and ta and tb
+      // Requests are made at times tm and ta and tb
       expect(requestSpy.callCount).to.equal(3);
       // Unsubscription effects request cancellation when signalled
       expect(cancelSpy.callCount).to.equal(1);

--- a/spec/operators/timeoutWith-spec.ts
+++ b/spec/operators/timeoutWith-spec.ts
@@ -1,4 +1,5 @@
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { dateTimestampProvider } from '../../src/internal/scheduler/dateTimestampProvider';
 import { timeoutWith, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of } from 'rxjs';
@@ -226,7 +227,7 @@ describe('timeoutWith operator', () => {
     const e2subs: string[] = [];
     const expected = '--a--b--c--d--e--|';
 
-    const timeoutValue = new Date(Date.now() + (expected.length + 2) * 10);
+    const timeoutValue = new Date(dateTimestampProvider.now() + (expected.length + 2) * 10);
 
     const result = e1.pipe(timeoutWith(timeoutValue, e2, rxTestScheduler));
 
@@ -242,7 +243,7 @@ describe('timeoutWith operator', () => {
     const e2subs: string[] = [];
     const expected = '---a---#';
 
-    const result = e1.pipe(timeoutWith(new Date(Date.now() + 100), e2, rxTestScheduler));
+    const result = e1.pipe(timeoutWith(new Date(dateTimestampProvider.now() + 100), e2, rxTestScheduler));
 
     expectObservable(result).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -501,40 +501,40 @@ describe('TestScheduler', () => {
       }).to.throw();
     });
 
-    describe('repaints', () => {
-      it('should throw if repaints() is not called when needed', () => {
+    describe('animate', () => {
+      it('should throw if animate() is not called when needed', () => {
         const testScheduler = new TestScheduler(assertDeepEquals);
         expect(() => testScheduler.run(() => {
           requestAnimationFrameProvider.schedule(() => { /* pointless lint rule */ });
         })).to.throw();
       });
 
-      it('should throw if repaints() is called more than once', () => {
+      it('should throw if animate() is called more than once', () => {
         const testScheduler = new TestScheduler(assertDeepEquals);
-        expect(() => testScheduler.run(({ repaints }) => {
-          repaints('--x');
-          repaints('--x');
+        expect(() => testScheduler.run(({ animate }) => {
+          animate('--x');
+          animate('--x');
         })).to.throw();
       });
 
-      it('should throw if repaints() completes', () => {
+      it('should throw if animate() completes', () => {
         const testScheduler = new TestScheduler(assertDeepEquals);
-        expect(() => testScheduler.run(({ repaints }) => {
-          repaints('--|');
+        expect(() => testScheduler.run(({ animate }) => {
+          animate('--|');
         })).to.throw();
       });
 
-      it('should throw if repaints() errors', () => {
+      it('should throw if animate() errors', () => {
         const testScheduler = new TestScheduler(assertDeepEquals);
-        expect(() => testScheduler.run(({ repaints }) => {
-          repaints('--#');
+        expect(() => testScheduler.run(({ animate }) => {
+          animate('--#');
         })).to.throw();
       });
 
-      it('should schedule async requests within repaints()', () => {
+      it('should schedule async requests within animate()', () => {
         const testScheduler = new TestScheduler(assertDeepEquals);
-        testScheduler.run(({ repaints }) => {
-          repaints('--x');
+        testScheduler.run(({ animate }) => {
+          animate('--x');
 
           const values: string[] = [];
           const { schedule } = requestAnimationFrameProvider;
@@ -553,10 +553,10 @@ describe('TestScheduler', () => {
         });
       });
 
-      it('should schedule sync requests within repaints()', () => {
+      it('should schedule sync requests within animate()', () => {
         const testScheduler = new TestScheduler(assertDeepEquals);
-        testScheduler.run(({ repaints }) => {
-          repaints('--x');
+        testScheduler.run(({ animate }) => {
+          animate('--x');
 
           const values: string[] = [];
           const { schedule } = requestAnimationFrameProvider;
@@ -572,10 +572,10 @@ describe('TestScheduler', () => {
         });
       });
 
-      it('should support request cancellation within repaints()', () => {
+      it('should support request cancellation within animate()', () => {
         const testScheduler = new TestScheduler(assertDeepEquals);
-        testScheduler.run(({ repaints }) => {
-          repaints('--x');
+        testScheduler.run(({ animate }) => {
+          animate('--x');
 
           const values: string[] = [];
           const { schedule } = requestAnimationFrameProvider;

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -4,6 +4,7 @@ import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
 import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
 import { SubjectSubscription } from './SubjectSubscription';
+import { dateTimestampProvider } from "./scheduler/dateTimestampProvider";
 
 /**
  * A variant of {@link Subject} that "replays" old values to new subscribers by emitting them when they first subscribe.
@@ -49,7 +50,7 @@ export class ReplaySubject<T> extends Subject<T> {
    */
   constructor(bufferSize: number = Infinity,
               windowTime: number = Infinity,
-              private timestampProvider: TimestampProvider = Date) {
+              private timestampProvider: TimestampProvider = dateTimestampProvider) {
     super();
     this._bufferSize = bufferSize < 1 ? 1 : bufferSize;
     this._windowTime = windowTime < 1 ? 1 : windowTime;
@@ -120,7 +121,7 @@ export class ReplaySubject<T> extends Subject<T> {
 
   private _getNow(): number {
     const { timestampProvider: scheduler } = this;
-    return scheduler ? scheduler.now() : Date.now();
+    return scheduler ? scheduler.now() : dateTimestampProvider.now();
   }
 
   private _trimBufferThenGetEvents(): ReplayEvent<T>[] {

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -1,6 +1,7 @@
 import { Action } from './scheduler/Action';
 import { Subscription } from './Subscription';
 import { SchedulerLike, SchedulerAction } from './types';
+import { dateTimestampProvider } from "./scheduler/dateTimestampProvider";
 
 /**
  * An execution context and a data structure to order tasks and schedule their
@@ -23,12 +24,7 @@ import { SchedulerLike, SchedulerAction } from './types';
  */
 export class Scheduler implements SchedulerLike {
 
-  /**
-   * Note: the extra arrow function wrapper is to make testing by overriding
-   * Date.now easier.
-   * @nocollapse
-   */
-  public static now: () => number = () => Date.now();
+  public static now: () => number = dateTimestampProvider.now;
 
   constructor(private SchedulerAction: typeof Action,
               now: () => number = Scheduler.now) {

--- a/src/internal/observable/dom/animationFrames.ts
+++ b/src/internal/observable/dom/animationFrames.ts
@@ -1,5 +1,6 @@
 import { Observable } from '../../Observable';
 import { TimestampProvider } from "../../types";
+import { dateTimestampProvider } from 'rxjs/internal/scheduler/dateTimestampProvider';
 
 /**
  * An observable of animation frames
@@ -73,8 +74,8 @@ import { TimestampProvider } from "../../types";
  *
  * @param timestampProvider An object with a `now` method that provides a numeric timestamp
  */
-export function animationFrames(timestampProvider: TimestampProvider = Date) {
-  return timestampProvider === Date ? DEFAULT_ANIMATION_FRAMES : animationFramesFactory(timestampProvider);
+export function animationFrames(timestampProvider: TimestampProvider = dateTimestampProvider) {
+  return timestampProvider === dateTimestampProvider ? DEFAULT_ANIMATION_FRAMES : animationFramesFactory(timestampProvider);
 }
 
 /**
@@ -100,4 +101,4 @@ function animationFramesFactory(timestampProvider: TimestampProvider) {
  * In the common case, where `Date` is passed to `animationFrames` as the default,
  * we use this shared observable to reduce overhead.
  */
-const DEFAULT_ANIMATION_FRAMES = animationFramesFactory(Date);
+const DEFAULT_ANIMATION_FRAMES = animationFramesFactory(dateTimestampProvider);

--- a/src/internal/observable/dom/animationFrames.ts
+++ b/src/internal/observable/dom/animationFrames.ts
@@ -1,9 +1,5 @@
 import { Observable } from '../../Observable';
-
-// TODO: move to types.ts
-export interface TimestampProvider {
-  now(): number;
-}
+import { TimestampProvider } from "../../types";
 
 /**
  * An observable of animation frames

--- a/src/internal/operators/timestamp.ts
+++ b/src/internal/operators/timestamp.ts
@@ -1,4 +1,5 @@
 import { OperatorFunction, TimestampProvider, Timestamp } from '../types';
+import { dateTimestampProvider } from '../scheduler/dateTimestampProvider';
 import { map } from './map';
 
 /**
@@ -32,6 +33,6 @@ import { map } from './map';
  *
  * @param timestampProvider An object with a `now()` method used to get the current timestamp.
  */
-export function timestamp<T>(timestampProvider: TimestampProvider = Date): OperatorFunction<T, Timestamp<T>> {
+export function timestamp<T>(timestampProvider: TimestampProvider = dateTimestampProvider): OperatorFunction<T, Timestamp<T>> {
   return map((value: T) => ({ value, timestamp: timestampProvider.now()}));
 }

--- a/src/internal/scheduler/dateTimestampProvider.ts
+++ b/src/internal/scheduler/dateTimestampProvider.ts
@@ -1,0 +1,14 @@
+import { TimestampProvider } from "../types";
+
+interface DateTimestampProvider extends TimestampProvider {
+  delegate: TimestampProvider | undefined;
+}
+
+export const dateTimestampProvider: DateTimestampProvider = {
+  now() {
+    // Use the variable rather than `this` so that the function can be called
+    // without being bound to the provider.
+    return (dateTimestampProvider.delegate || Date).now();
+  },
+  delegate: undefined
+};

--- a/src/internal/scheduler/dateTimestampProvider.ts
+++ b/src/internal/scheduler/dateTimestampProvider.ts
@@ -1,4 +1,5 @@
-import { TimestampProvider } from "../types";
+/** @prettier */
+import { TimestampProvider } from '../types';
 
 interface DateTimestampProvider extends TimestampProvider {
   delegate: TimestampProvider | undefined;
@@ -10,5 +11,5 @@ export const dateTimestampProvider: DateTimestampProvider = {
     // without being bound to the provider.
     return (dateTimestampProvider.delegate || Date).now();
   },
-  delegate: undefined
+  delegate: undefined,
 };

--- a/src/internal/scheduler/performanceTimestampProvider.ts
+++ b/src/internal/scheduler/performanceTimestampProvider.ts
@@ -1,0 +1,14 @@
+import { TimestampProvider } from "../types";
+
+interface PerformanceTimestampProvider extends TimestampProvider {
+  delegate: TimestampProvider | undefined;
+}
+
+export const performanceTimestampProvider: PerformanceTimestampProvider = {
+  now() {
+    // Use the variable rather than `this` so that the function can be called
+    // without being bound to the provider.
+    return (performanceTimestampProvider.delegate || performance).now();
+  },
+  delegate: undefined
+};

--- a/src/internal/scheduler/performanceTimestampProvider.ts
+++ b/src/internal/scheduler/performanceTimestampProvider.ts
@@ -1,4 +1,5 @@
-import { TimestampProvider } from "../types";
+/** @prettier */
+import { TimestampProvider } from '../types';
 
 interface PerformanceTimestampProvider extends TimestampProvider {
   delegate: TimestampProvider | undefined;
@@ -10,5 +11,5 @@ export const performanceTimestampProvider: PerformanceTimestampProvider = {
     // without being bound to the provider.
     return (performanceTimestampProvider.delegate || performance).now();
   },
-  delegate: undefined
+  delegate: undefined,
 };

--- a/src/internal/scheduler/requestAnimationFrameProvider.ts
+++ b/src/internal/scheduler/requestAnimationFrameProvider.ts
@@ -1,0 +1,26 @@
+import { Subscription } from "../Subscription";
+
+type RequestAnimationFrameProvider = {
+  schedule(callback: FrameRequestCallback): Subscription;
+  delegate: {
+    requestAnimationFrame: typeof requestAnimationFrame;
+    cancelAnimationFrame: typeof cancelAnimationFrame;
+  } | undefined;
+};
+
+export const requestAnimationFrameProvider: RequestAnimationFrameProvider = {
+  schedule(callback) {
+    let request = requestAnimationFrame;
+    let cancel = cancelAnimationFrame;
+    // Use the variable rather than `this` so that the function can be called
+    // without being bound to the provider.
+    const { delegate } = requestAnimationFrameProvider;
+    if (delegate) {
+      request = delegate.requestAnimationFrame;
+      cancel = delegate.cancelAnimationFrame;
+    }
+    const handle = request(callback);
+    return new Subscription(() => cancel(handle));
+  },
+  delegate: undefined
+};

--- a/src/internal/scheduler/requestAnimationFrameProvider.ts
+++ b/src/internal/scheduler/requestAnimationFrameProvider.ts
@@ -1,11 +1,14 @@
-import { Subscription } from "../Subscription";
+/** @prettier */
+import { Subscription } from '../Subscription';
 
 type RequestAnimationFrameProvider = {
   schedule(callback: FrameRequestCallback): Subscription;
-  delegate: {
-    requestAnimationFrame: typeof requestAnimationFrame;
-    cancelAnimationFrame: typeof cancelAnimationFrame;
-  } | undefined;
+  delegate:
+    | {
+        requestAnimationFrame: typeof requestAnimationFrame;
+        cancelAnimationFrame: typeof cancelAnimationFrame;
+      }
+    | undefined;
 };
 
 export const requestAnimationFrameProvider: RequestAnimationFrameProvider = {
@@ -22,5 +25,5 @@ export const requestAnimationFrameProvider: RequestAnimationFrameProvider = {
     const handle = request(callback);
     return new Subscription(() => cancel(handle));
   },
-  delegate: undefined
+  delegate: undefined,
 };

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -21,7 +21,7 @@ export interface RunHelpers {
   time: typeof TestScheduler.prototype.createTime;
   expectObservable: typeof TestScheduler.prototype.expectObservable;
   expectSubscriptions: typeof TestScheduler.prototype.expectSubscriptions;
-  repaints: (marbles: string) => void;
+  animate: (marbles: string) => void;
 }
 
 interface FlushableTest {
@@ -360,7 +360,7 @@ export class TestScheduler extends VirtualTimeScheduler {
         default:
           // Might be time progression syntax, or a value literal
           if (runMode && c.match(/^[0-9]$/)) {
-            // Time progression must be preceeded by at least one space
+            // Time progression must be preceded by at least one space
             // if it's not at the beginning of the diagram
             if (i === 0 || marbles[i - 1] === ' ') {
               const buffer = marbles.slice(i);
@@ -422,7 +422,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     requestAnimationFrameProvider.delegate = {
       requestAnimationFrame(callback) {
         if (!animationFramesQueue) {
-          throw new Error("repaints() was not called within run()");
+          throw new Error("animate() was not called within run()");
         }
         const handle = ++animationFramesHandle;
         animationFramesQueue.set(handle, callback);
@@ -430,17 +430,17 @@ export class TestScheduler extends VirtualTimeScheduler {
       },
       cancelAnimationFrame(handle) {
         if (!animationFramesQueue) {
-          throw new Error("repaints() was not called within run()");
+          throw new Error("animate() was not called within run()");
         }
         animationFramesQueue.delete(handle);
       }
     };
-    const repaints = (marbles: string) => {
+    const animate = (marbles: string) => {
       if (animationFramesQueue) {
-        throw new Error('repaints() must not be called more than once within run()');
+        throw new Error('animate() must not be called more than once within run()');
       }
       if (/[|#]/.test(marbles)) {
-        throw new Error('repaints() must not complete or error')
+        throw new Error('animate() must not complete or error')
       }
       animationFramesQueue = new Map<number, FrameRequestCallback>();
       const messages = TestScheduler.parseMarbles(marbles, undefined, undefined, undefined, true);
@@ -468,7 +468,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       time: this.createTime.bind(this),
       expectObservable: this.expectObservable.bind(this),
       expectSubscriptions: this.expectSubscriptions.bind(this),
-      repaints,
+      animate,
     };
     try {
       const ret = callback(helpers);

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -443,7 +443,7 @@ export class TestScheduler extends VirtualTimeScheduler {
         throw new Error('repaints() must not complete or error')
       }
       animationFramesQueue = new Map<number, FrameRequestCallback>();
-      const messages = TestScheduler.parseMarbles(marbles);
+      const messages = TestScheduler.parseMarbles(marbles, undefined, undefined, undefined, true);
       for (const message of messages) {
         this.schedule(() => {
           const now = this.now();

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -468,6 +468,14 @@ export class TestScheduler extends VirtualTimeScheduler {
     return { animate, delegate };
   }
 
+  /**
+   * The `run` method performs the test in 'run mode' - in which schedulers
+   * used within the test automatically delegate to the `TestScheduler`. That
+   * is, in 'run mode' there is no need to explicitly pass a `TestScheduler`
+   * instance to observable creators or operators.
+   *
+   * @see {@link /guide/testing/marble-testing}
+   */
   run<T>(callback: (helpers: RunHelpers) => T): T {
     const prevFrameTimeFactor = TestScheduler.frameTimeFactor;
     const prevMaxFrames = this.maxFrames;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR:

* Adds a `Date` timestamp provider.
* Adds a `performance` timestamp provider.
* Adds a `requestAnimationFrame` provider.
* All providers have `delegate` properties that are `undefined` by default but are used - by `TestScheduler#run` - to override the default behaviour. This mirrors the `delegate` implementation detail that's used with the schedulers.
* Removes the arrow function from the static `Scheduler.now` - it's unnecessary, as the `Date.now` call now occurs within the `dateTimestampProvider`.
* The `animationFrames` observable now uses the `requestAnimationFramesProvider`.
* `TestScheduler#run` sets the delegates for the providers, with the `requestAnimationFramesProvider`'s delegate working in conjunction with a `animate()` marble that's added to the run helpers:

    ```ts
    testScheduler.run(({ animate }) => {
      animate('---x---x---x---x---x');
      /* ... */
    });
    ```

    Each time an animation/repaint occurs, all queued `rAF` callbacks will be executed - in the order in which they were scheduled - and each will be passed the same timestamp - the `TestScheduler`'s `now` value - which is also what will be returned from the timestamp providers - as the `TestScheduler` itself is the delegate.

* Adds tests for the `animate` `run` helper.
* Updates API guardian for the inclusion of the `animate` `run` helper.
* Reimplements the `animationFrames` tests to use the `run` helper and the provider - which is spied upon - and removes the `rAF` mock.
* Fixes the `rAF` provider so that cancellation of already fulfilled requests (upon unsubscription) is not attempted.

**Related issue (if exists):** #5438 and #5475
