### PR TITLE
Fix types for catchError

### DIFF
--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -109,7 +109,7 @@ export function catchError<T, O extends ObservableInput<any>>(
 ): OperatorFunction<T, T | ObservedValueOf<O>> {
   return function catchErrorOperatorFunction(source: Observable<T>): Observable<T | ObservedValueOf<O>> {
     const operator = new CatchOperator(selector);
-    const caught = lift(source, operator);
+    const caught = lift(source, operator) as Observable<T>;
     operator.caught = caught;
     return caught;
   };


### PR DESCRIPTION
**Description:**
The cast was removed in https://github.com/ReactiveX/rxjs/pull/5572 but it is needed in Google for this to compile.
