### PR TITLE
refactor: Improve memory pressure

### DIFF
--- a/src/internal/innerSubscribe.ts
+++ b/src/internal/innerSubscribe.ts
@@ -1,0 +1,114 @@
+/** @prettier */
+import { Subscription } from './Subscription';
+import { Subscriber } from './Subscriber';
+import { Observable } from './Observable';
+import { subscribeTo } from './util/subscribeTo';
+
+interface SimpleOuterSubscriberLike<T> {
+  /**
+   * A handler for inner next notifications from the inner subscription
+   * @param innerValue the value nexted by the inner producer
+   */
+  notifyNext(innerValue: T): void;
+  /**
+   * A handler for inner error notifications from the inner subscription
+   * @param err the error from the inner producer
+   */
+  notifyError(err: any): void;
+  /**
+   * A handler for inner complete notifications from the inner subscription.
+   */
+  notifyComplete(): void;
+}
+
+export class SimpleInnerSubscriber<T> extends Subscriber<T> {
+  constructor(private parent: SimpleOuterSubscriberLike<any>) {
+    super();
+  }
+
+  protected _next(value: T): void {
+    this.parent.notifyNext(value);
+  }
+
+  protected _error(error: any): void {
+    this.parent.notifyError(error);
+    this.unsubscribe();
+  }
+
+  protected _complete(): void {
+    this.parent.notifyComplete();
+    this.unsubscribe();
+  }
+}
+
+export class ComplexInnerSubscriber<T, R> extends Subscriber<R> {
+  constructor(private parent: ComplexOuterSubscriber<T, R>, public outerValue: T, public outerIndex: number) {
+    super();
+  }
+
+  protected _next(value: R): void {
+    this.parent.notifyNext(this.outerValue, value, this.outerIndex, this);
+  }
+
+  protected _error(error: any): void {
+    this.parent.notifyError(error);
+    this.unsubscribe();
+  }
+
+  protected _complete(): void {
+    this.parent.notifyComplete(this);
+    this.unsubscribe();
+  }
+}
+
+export class SimpleOuterSubscriber<T, R> extends Subscriber<T> implements SimpleOuterSubscriberLike<R> {
+  notifyNext(innerValue: R): void {
+    this.destination.next(innerValue);
+  }
+
+  notifyError(err: any): void {
+    this.destination.error(err);
+  }
+
+  notifyComplete(): void {
+    this.destination.complete();
+  }
+}
+
+/**
+ * DO NOT USE (formerly "OuterSubscriber")
+ * TODO: We want to refactor this and remove it. It is retaining values it shouldn't for long
+ * periods of time.
+ */
+export class ComplexOuterSubscriber<T, R> extends Subscriber<T> {
+  /**
+   * @param _outerValue Used by: bufferToggle, delayWhen, windowToggle
+   * @param innerValue Used by: subclass default, combineLatest, race, bufferToggle, windowToggle, withLatestFrom
+   * @param _outerIndex Used by: combineLatest, race, withLatestFrom
+   * @param _innerSub Used by: delayWhen
+   */
+  notifyNext(_outerValue: T, innerValue: R, _outerIndex: number, _innerSub: ComplexInnerSubscriber<T, R>): void {
+    this.destination.next(innerValue);
+  }
+
+  notifyError(error: any): void {
+    this.destination.error(error);
+  }
+
+  /**
+   * @param _innerSub Used by: race, bufferToggle, delayWhen, windowToggle, windowWhen
+   */
+  notifyComplete(_innerSub: ComplexInnerSubscriber<T, R>): void {
+    this.destination.complete();
+  }
+}
+
+export function innerSubscribe(result: any, innerSubscriber: Subscriber<any>): Subscription | undefined {
+  if (innerSubscriber.closed) {
+    return undefined;
+  }
+  if (result instanceof Observable) {
+    return result.subscribe(innerSubscriber);
+  }
+  return subscribeTo(result)(innerSubscriber) as Subscription;
+}

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -102,24 +102,23 @@ export class RaceSubscriber<T> extends OuterSubscriber<T, T> {
     const len = observables.length;
 
     if (len === 0) {
-      this.destination.complete();
+      this.destination.complete!();
     } else {
       for (let i = 0; i < len && !this.hasFirst; i++) {
-        let observable = observables[i];
-        let subscription = subscribeToResult(this, observable, observable as any, i);
+        const observable = observables[i];
+        const subscription = subscribeToResult(this, observable, undefined, i)!;
 
         if (this.subscriptions) {
           this.subscriptions.push(subscription);
         }
         this.add(subscription);
       }
-      this.observables = null;
+      this.observables = null!;
     }
   }
 
-  notifyNext(outerValue: T, innerValue: T,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, T>): void {
+  notifyNext(_outerValue: T, innerValue: T,
+             outerIndex: number): void {
     if (!this.hasFirst) {
       this.hasFirst = true;
 
@@ -132,9 +131,9 @@ export class RaceSubscriber<T> extends OuterSubscriber<T, T> {
         }
       }
 
-      this.subscriptions = null;
+      this.subscriptions = null!;
     }
 
-    this.destination.next(innerValue);
+    this.destination.next!(innerValue);
   }
 }

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -1,10 +1,8 @@
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
-import { OuterSubscriber } from '../OuterSubscriber';
-import { InnerSubscriber } from '../InnerSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
 import { OperatorFunction } from '../types';
+import { SimpleOuterSubscriber, innerSubscribe, SimpleInnerSubscriber } from '../innerSubscribe';
 
 /**
  * Buffers the source Observable values until `closingNotifier` emits.
@@ -67,23 +65,21 @@ class BufferOperator<T> implements Operator<T, T[]> {
  * @ignore
  * @extends {Ignored}
  */
-class BufferSubscriber<T> extends OuterSubscriber<T, any> {
+class BufferSubscriber<T> extends SimpleOuterSubscriber<T, any> {
   private buffer: T[] = [];
 
   constructor(destination: Subscriber<T[]>, closingNotifier: Observable<any>) {
     super(destination);
-    this.add(subscribeToResult(this, closingNotifier));
+    this.add(innerSubscribe(closingNotifier, new SimpleInnerSubscriber(this)));
   }
 
   protected _next(value: T) {
     this.buffer.push(value);
   }
 
-  notifyNext(outerValue: T, innerValue: any,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, any>): void {
+  notifyNext(): void {
     const buffer = this.buffer;
     this.buffer = [];
-    this.destination.next(buffer);
+    this.destination.next!(buffer);
   }
 }

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -87,7 +87,7 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
   private contexts: Array<BufferContext<T>> = [];
 
   constructor(destination: Subscriber<T[]>,
-              private openings: SubscribableOrPromise<O>,
+              openings: SubscribableOrPromise<O>,
               private closingSelector: (value: O) => SubscribableOrPromise<any> | void) {
     super(destination);
     this.add(subscribeToResult(this, openings));
@@ -104,31 +104,29 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
   protected _error(err: any): void {
     const contexts = this.contexts;
     while (contexts.length > 0) {
-      const context = contexts.shift();
+      const context = contexts.shift()!;
       context.subscription.unsubscribe();
-      context.buffer = null;
-      context.subscription = null;
+      context.buffer = null!;
+      context.subscription = null!;
     }
-    this.contexts = null;
+    this.contexts = null!;
     super._error(err);
   }
 
   protected _complete(): void {
     const contexts = this.contexts;
     while (contexts.length > 0) {
-      const context = contexts.shift();
-      this.destination.next(context.buffer);
+      const context = contexts.shift()!;
+      this.destination.next!(context.buffer);
       context.subscription.unsubscribe();
-      context.buffer = null;
-      context.subscription = null;
+      context.buffer = null!;
+      context.subscription = null!;
     }
-    this.contexts = null;
+    this.contexts = null!;
     super._complete();
   }
 
-  notifyNext(outerValue: any, innerValue: O,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, O>): void {
+  notifyNext(outerValue: any, innerValue: O): void {
     outerValue ? this.closeBuffer(outerValue) : this.openBuffer(innerValue);
   }
 
@@ -153,7 +151,7 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
 
     if (contexts && context) {
       const { buffer, subscription } = context;
-      this.destination.next(buffer);
+      this.destination.next!(buffer);
       contexts.splice(contexts.indexOf(context), 1);
       this.remove(subscription);
       subscription.unsubscribe();
@@ -168,12 +166,12 @@ class BufferToggleSubscriber<T, O> extends OuterSubscriber<T, O> {
     const context = { buffer, subscription };
     contexts.push(context);
 
-    const innerSubscription = subscribeToResult(this, closingNotifier, <any>context);
+    const innerSubscription = subscribeToResult(this, closingNotifier, context as any);
 
     if (!innerSubscription || innerSubscription.closed) {
       this.closeBuffer(context);
     } else {
-      (<any> innerSubscription).context = context;
+      (innerSubscription as any).context = context;
 
       this.add(innerSubscription);
       subscription.add(innerSubscription);

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -2,10 +2,8 @@ import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 
-import { OuterSubscriber } from '../OuterSubscriber';
-import { InnerSubscriber } from '../InnerSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
+import { SimpleOuterSubscriber, SimpleInnerSubscriber, innerSubscribe } from '../innerSubscribe';
 
 /* tslint:disable:max-line-length */
 export function catchError<T, O extends ObservableInput<any>>(selector: (err: any, caught: Observable<T>) => O): OperatorFunction<T, T | ObservedValueOf<O>>;
@@ -113,7 +111,7 @@ class CatchOperator<T, R> implements Operator<T, T | R> {
  * @ignore
  * @extends {Ignored}
  */
-class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
+class CatchSubscriber<T, R> extends SimpleOuterSubscriber<T, T | R> {
   constructor(destination: Subscriber<any>,
               private selector: (err: any, caught: Observable<T>) => ObservableInput<T | R>,
               private caught: Observable<T>) {
@@ -135,9 +133,9 @@ class CatchSubscriber<T, R> extends OuterSubscriber<T, T | R> {
         return;
       }
       this._unsubscribeAndRecycle();
-      const innerSubscriber = new InnerSubscriber(this, undefined, undefined);
+      const innerSubscriber = new SimpleInnerSubscriber(this);
       this.add(innerSubscriber);
-      const innerSubscription = subscribeToResult(this, result, undefined, undefined, innerSubscriber);
+      const innerSubscription = innerSubscribe(result, innerSubscriber);
       // The returned subscription will usually be the subscriber that was
       // passed. However, interop subscribers will be wrapped and for
       // unsubscriptions to chain correctly, the wrapper needs to be added, too.

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -107,10 +107,10 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
     super(destination);
   }
 
-  notifyNext(outerValue: T, innerValue: any,
-             outerIndex: number, innerIndex: number,
+  notifyNext(outerValue: T, _innerValue: any,
+             _outerIndex: number, _innerIndex: number,
              innerSub: InnerSubscriber<T, R>): void {
-    this.destination.next(outerValue);
+    this.destination.next!(outerValue);
     this.removeSubscription(innerSub);
     this.tryComplete();
   }
@@ -122,7 +122,7 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
   notifyComplete(innerSub: InnerSubscriber<T, R>): void {
     const value = this.removeSubscription(innerSub);
     if (value) {
-      this.destination.next(value);
+      this.destination.next!(value);
     }
     this.tryComplete();
   }
@@ -135,7 +135,7 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
         this.tryDelay(delayNotifier, value);
       }
     } catch (err) {
-      this.destination.error(err);
+      this.destination.error!(err);
     }
   }
 
@@ -168,7 +168,7 @@ class DelayWhenSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private tryComplete(): void {
     if (this.completed && this.delayNotifierSubscriptions.length === 0) {
-      this.destination.complete();
+      this.destination.complete!();
     }
   }
 }

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -1,10 +1,3 @@
-import { Operator } from '../Operator';
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
-import { Subscription } from '../Subscription';
-import { OuterSubscriber } from '../OuterSubscriber';
-import { InnerSubscriber } from '../InnerSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
 import { ObservableInput, OperatorFunction } from '../types';
 import { switchMap } from './switchMap';
 

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -3,9 +3,8 @@ import { Subscriber } from '../Subscriber';
 import { async } from '../scheduler/async';
 import { Observable } from '../Observable';
 import { isDate } from '../util/isDate';
-import { OuterSubscriber } from '../OuterSubscriber';
-import { subscribeToResult } from '../util/subscribeToResult';
-import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
+import { ObservableInput, OperatorFunction, SchedulerAction, SchedulerLike, TeardownLogic } from '../types';
+import { SimpleOuterSubscriber, innerSubscribe, SimpleInnerSubscriber } from '../innerSubscribe';
 
 /* tslint:disable:max-line-length */
 export function timeoutWith<T, R>(due: number | Date, withObservable: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;
@@ -93,9 +92,9 @@ class TimeoutWithOperator<T> implements Operator<T, T> {
  * @ignore
  * @extends {Ignored}
  */
-class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
+class TimeoutWithSubscriber<T, R> extends SimpleOuterSubscriber<T, R> {
 
-  private action: SchedulerAction<TimeoutWithSubscriber<T, R>> = null;
+  private action?: SchedulerAction<TimeoutWithSubscriber<T, R>>;
 
   constructor(destination: Subscriber<T>,
               private absoluteTimeout: boolean,
@@ -108,8 +107,8 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   private static dispatchTimeout<T, R>(subscriber: TimeoutWithSubscriber<T, R>): void {
     const { withObservable } = subscriber;
-    (<any> subscriber)._unsubscribeAndRecycle();
-    subscriber.add(subscribeToResult(subscriber, withObservable));
+    subscriber._unsubscribeAndRecycle();
+    subscriber.add(innerSubscribe(withObservable, new SimpleInnerSubscriber(subscriber)));
   }
 
   private scheduleTimeout(): void {
@@ -123,7 +122,7 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
       this.action = (<SchedulerAction<TimeoutWithSubscriber<T, R>>> action.schedule(this, this.waitFor));
     } else {
       this.add(this.action = (<SchedulerAction<TimeoutWithSubscriber<T, R>>> this.scheduler.schedule<TimeoutWithSubscriber<T, R>>(
-        TimeoutWithSubscriber.dispatchTimeout, this.waitFor, this
+        TimeoutWithSubscriber.dispatchTimeout as any, this.waitFor, this
       )));
     }
   }
@@ -137,8 +136,8 @@ class TimeoutWithSubscriber<T, R> extends OuterSubscriber<T, R> {
 
   /** @deprecated This is an internal implementation detail, do not use. */
   _unsubscribe() {
-    this.action = null;
-    this.scheduler = null;
-    this.withObservable = null;
+    this.action = undefined;
+    this.scheduler = null!;
+    this.withObservable = null!;
   }
 }

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -74,8 +74,8 @@ class WindowOperator<T> implements Operator<T, Observable<T>> {
  * @extends {Ignored}
  */
 class WindowSubscriber<T> extends OuterSubscriber<T, any> {
-  private window: Subject<T>;
-  private closingNotification: Subscription;
+  private window?: Subject<T>;
+  private closingNotification?: Subscription;
 
   constructor(protected destination: Subscriber<Observable<T>>,
               private closingSelector: () => Observable<any>) {
@@ -83,13 +83,13 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     this.openWindow();
   }
 
-  notifyNext(outerValue: T, innerValue: any,
-             outerIndex: number, innerIndex: number,
+  notifyNext(_outerValue: T, _innerValue: any,
+             _outerIndex: number, _innerIndex: number,
              innerSub: InnerSubscriber<T, any>): void {
     this.openWindow(innerSub);
   }
 
-  notifyError(error: any, innerSub: InnerSubscriber<T, any>): void {
+  notifyError(error: any): void {
     this._error(error);
   }
 
@@ -98,17 +98,17 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
   }
 
   protected _next(value: T): void {
-    this.window.next(value);
+    this.window!.next(value);
   }
 
   protected _error(err: any): void {
-    this.window.error(err);
+    this.window!.error(err);
     this.destination.error(err);
     this.unsubscribeClosingNotification();
   }
 
   protected _complete(): void {
-    this.window.complete();
+    this.window!.complete();
     this.destination.complete();
     this.unsubscribeClosingNotification();
   }
@@ -119,7 +119,7 @@ class WindowSubscriber<T> extends OuterSubscriber<T, any> {
     }
   }
 
-  private openWindow(innerSub: InnerSubscriber<T, any> = null): void {
+  private openWindow(innerSub: InnerSubscriber<T, any> | null = null): void {
     if (innerSub) {
       this.remove(innerSub);
       innerSub.unsubscribe();

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -111,13 +111,12 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
 
     for (let i = 0; i < len; i++) {
       let observable = observables[i];
-      this.add(subscribeToResult<T, R>(this, observable, <any>observable, i));
+      this.add(subscribeToResult<T, R>(this, observable, undefined, i));
     }
   }
 
-  notifyNext(outerValue: T, innerValue: R,
-             outerIndex: number, innerIndex: number,
-             innerSub: InnerSubscriber<T, R>): void {
+  notifyNext(_outerValue: T, innerValue: R,
+             outerIndex: number): void {
     this.values[outerIndex] = innerValue;
     const toRespond = this.toRespond;
     if (toRespond.length > 0) {
@@ -138,7 +137,7 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
       if (this.project) {
         this._tryProject(args);
       } else {
-        this.destination.next(args);
+        this.destination.next!(args);
       }
     }
   }
@@ -146,11 +145,11 @@ class WithLatestFromSubscriber<T, R> extends OuterSubscriber<T, R> {
   private _tryProject(args: any[]) {
     let result: any;
     try {
-      result = this.project.apply(this, args);
+      result = this.project!.apply(this, args);
     } catch (err) {
-      this.destination.error(err);
+      this.destination.error!(err);
       return;
     }
-    this.destination.next(result);
+    this.destination.next!(result);
   }
 }


### PR DESCRIPTION
this is the duplicate of #5610, it is refactoring to ensure outer values are not retained when they do not have to be. It needs to be done in a separate PR because the branches diverge just enough to require it. This PR also has some mild, internal type fixes.
