### PR TITLE
Yet another ajax refactor

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -3,7 +3,7 @@ export declare const ajax: AjaxCreationMethod;
 export interface AjaxError extends Error {
     request: AjaxRequest;
     response: any;
-    responseType: string;
+    responseType: XMLHttpRequestResponseType;
     status: number;
     xhr: XMLHttpRequest;
 }
@@ -19,7 +19,7 @@ export interface AjaxRequest {
     headers?: object;
     method?: string;
     password?: string;
-    progressSubscriber?: Subscriber<any>;
+    progressSubscriber?: PartialObserver<ProgressEvent>;
     responseType?: string;
     timeout?: number;
     url?: string;

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -788,6 +788,29 @@ describe('ajax', () => {
       expect(complete).to.be.true;
     });
     
+    it('should allow partial progressSubscriber ', function() {
+      const spy = sinon.spy();
+      const progressSubscriber: any = {
+        next: spy,
+      };
+
+      ajax({
+        url: '/flibbertyJibbet',
+        progressSubscriber
+      })
+        .subscribe();
+
+      const request = MockXMLHttpRequest.mostRecent;
+
+      request.respondWith({
+        'status': 200,
+        'contentType': 'application/json',
+        'responseText': JSON.stringify({})
+      }, 3);
+
+      expect(spy).to.be.calledThrice;
+    });
+
     it('should emit progress event when progressSubscriber is specified', function() {
       const spy = sinon.spy();
       const progressSubscriber = (<any>{
@@ -974,6 +997,7 @@ describe('ajax', () => {
 });
 
 class MockXMLHttpRequest {
+  public static readonly DONE = 4;
   private static requests: Array<MockXMLHttpRequest> = [];
   private static recentRequest: MockXMLHttpRequest;
 

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -303,7 +303,7 @@ describe('ajax', () => {
     expect(complete).to.be.true;
   });
 
-  it('should fail if fails to parse error response', () => {
+  it('should not fail if fails to parse error response', () => {
     let error: any;
     const obj = {
       url: '/flibbertyJibbet',
@@ -326,11 +326,11 @@ describe('ajax', () => {
       'status': 404,
       'contentType': '',
       'responseType': '',
-      'responseText': 'Wee! I am text, but should be valid JSON!'
+      'responseText': 'This is not what we expected is it? But that is okay'
     });
 
-    expect(error instanceof SyntaxError).to.be.true;
-    expect(error.message).to.equal('Unexpected token W in JSON at position 0');
+    expect(error instanceof AjaxError).to.be.true;
+    expect(error.response).to.equal('This is not what we expected is it? But that is okay');
   });
 
   it('should succeed no settings', () => {

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -226,10 +226,10 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
   next(e: Event): void {
     this.done = true;
-    const { xhr, request, destination } = this;
-    let result;
+    const destination = this.destination as Subscriber<any>;
+    let result: AjaxResponse;
     try {
-      result = new AjaxResponse(e, xhr, request);
+      result = new AjaxResponse(e, this.xhr, this.request);
     } catch (err) {
       return destination.error(err);
     }

--- a/src/internal/observable/dom/AjaxObservable.ts
+++ b/src/internal/observable/dom/AjaxObservable.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { Observable } from '../../Observable';
 import { Subscriber } from '../../Subscriber';
 import { TeardownLogic } from '../../types';
@@ -89,7 +90,7 @@ export function ajaxPatch(url: string, body?: any, headers?: Object): Observable
   return new AjaxObservable<AjaxResponse>({ method: 'PATCH', url, body, headers });
 }
 
-const mapResponse = map((x: AjaxResponse, index: number) => x.response);
+const mapResponse = map((x: AjaxResponse) => x.response);
 
 export function ajaxGetJSON<T>(url: string, headers?: Object): Observable<T> {
   return mapResponse(
@@ -97,7 +98,7 @@ export function ajaxGetJSON<T>(url: string, headers?: Object): Observable<T> {
       method: 'GET',
       url,
       responseType: 'json',
-      headers
+      headers,
     })
   );
 }
@@ -115,7 +116,7 @@ export class AjaxObservable<T> extends Observable<T> {
    * ## Example
    * ```ts
    * import { ajax } from 'rxjs/ajax';
- *
+   *
    * const source1 = ajax('/products');
    * const source2 = ajax({ url: 'products', method: 'GET' });
    * ```
@@ -138,7 +139,7 @@ export class AjaxObservable<T> extends Observable<T> {
    * @name ajax
    * @owner Observable
    * @nocollapse
-  */
+   */
   static create: AjaxCreationMethod = (() => {
     const create: any = (urlOrRequest: string | AjaxRequest) => {
       return new AjaxObservable(urlOrRequest);
@@ -161,7 +162,7 @@ export class AjaxObservable<T> extends Observable<T> {
 
     const request: AjaxRequest = {
       async: true,
-      createXHR: function(this: AjaxRequest) {
+      createXHR: function (this: AjaxRequest) {
         return this.crossDomain ? getCORSRequest() : getXMLHttpRequest();
       },
       crossDomain: true,
@@ -169,7 +170,7 @@ export class AjaxObservable<T> extends Observable<T> {
       headers: {},
       method: 'GET',
       responseType: 'json',
-      timeout: 0
+      timeout: 0,
     };
 
     if (typeof urlOrRequest === 'string') {
@@ -204,7 +205,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
   constructor(destination: Subscriber<T>, public request: AjaxRequest) {
     super(destination);
 
-    const headers = request.headers = request.headers || {};
+    const headers = (request.headers = request.headers || {});
 
     // force CORS if requested
     if (!request.crossDomain && !this.getHeader(headers, 'X-Requested-With')) {
@@ -213,7 +214,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
     // ensure content type is set
     let contentTypeHeader = this.getHeader(headers, 'Content-Type');
-    if (!contentTypeHeader && typeof request.body !== 'undefined' && !(isFormData(request.body))) {
+    if (!contentTypeHeader && typeof request.body !== 'undefined' && !isFormData(request.body)) {
       (headers as any)['Content-Type'] = 'application/x-www-form-urlencoded; charset=UTF-8';
     }
 
@@ -238,10 +239,10 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
   private send(): void {
     const {
       request,
-      request: { user, method, url, async, password, headers, body }
+      request: { user, method, url, async, password, headers, body },
     } = this;
     try {
-      const xhr = this.xhr = request.createXHR!();
+      const xhr = (this.xhr = request.createXHR!());
 
       // set up the events before open XHR
       // https://developer.mozilla.org/en/docs/Web/API/XMLHttpRequest/Using_XMLHttpRequest
@@ -295,7 +296,9 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
 
     switch (contentType) {
       case 'application/x-www-form-urlencoded':
-        return Object.keys(body).map(key => `${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`).join('&');
+        return Object.keys(body)
+          .map((key) => `${encodeURIComponent(key)}=${encodeURIComponent(body[key])}`)
+          .join('&');
       case 'application/json':
         return JSON.stringify(body);
       default:
@@ -325,7 +328,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
     const progressSubscriber = request.progressSubscriber;
 
     function xhrTimeout(this: XMLHttpRequest, e: ProgressEvent): void {
-      const {subscriber, progressSubscriber, request } = (<any>xhrTimeout);
+      const { subscriber, progressSubscriber, request } = <any>xhrTimeout;
       if (progressSubscriber) {
         progressSubscriber.error(e);
       }
@@ -344,8 +347,8 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
     if (xhr.upload && 'withCredentials' in xhr) {
       if (progressSubscriber) {
         let xhrProgress: (e: ProgressEvent) => void;
-        xhrProgress = function(e: ProgressEvent) {
-          const { progressSubscriber } = (<any>xhrProgress);
+        xhrProgress = function (e: ProgressEvent) {
+          const { progressSubscriber } = <any>xhrProgress;
           progressSubscriber.next(e);
         };
         if (typeof XDomainRequest === 'function') {
@@ -356,8 +359,8 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
         (<any>xhrProgress).progressSubscriber = progressSubscriber;
       }
       let xhrError: (e: any) => void;
-      xhrError = function(this: XMLHttpRequest, e: ErrorEvent) {
-        const { progressSubscriber, subscriber, request } = (<any>xhrError);
+      xhrError = function (this: XMLHttpRequest, e: ErrorEvent) {
+        const { progressSubscriber, subscriber, request } = <any>xhrError;
         if (progressSubscriber) {
           progressSubscriber.error(e);
         }
@@ -375,7 +378,7 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
       (<any>xhrError).progressSubscriber = progressSubscriber;
     }
 
-    function xhrReadyStateChange(this: XMLHttpRequest, e: Event) {
+    function xhrReadyStateChange(this: XMLHttpRequest) {
       return;
     }
     xhr.onreadystatechange = xhrReadyStateChange;
@@ -384,12 +387,11 @@ export class AjaxSubscriber<T> extends Subscriber<Event> {
     (<any>xhrReadyStateChange).request = request;
 
     function xhrLoad(this: XMLHttpRequest, e: Event) {
-      const { subscriber, progressSubscriber, request } = (<any>xhrLoad);
+      const { subscriber, progressSubscriber, request } = <any>xhrLoad;
       if (this.readyState === 4) {
         // normalize IE9 bug (http://bugs.jquery.com/ticket/1450)
         let status: number = this.status === 1223 ? 204 : this.status;
-        let response: any = (this.responseType === 'text' ?  (
-          this.response || this.responseText) : this.response);
+        let response: any = this.responseType === 'text' ? this.response || this.responseText : this.response;
 
         // fix status code when it is 0 (0 status is undocumented).
         // Occurs when accessing file resources or on Android 4.1 stock browser
@@ -489,7 +491,7 @@ export interface AjaxError extends Error {
 }
 
 export interface AjaxErrorCtor {
-  new(message: string, xhr: XMLHttpRequest, request: AjaxRequest): AjaxError;
+  new (message: string, xhr: XMLHttpRequest, request: AjaxRequest): AjaxError;
 }
 
 const AjaxErrorImpl = (() => {
@@ -524,22 +526,21 @@ function parseJson(xhr: XMLHttpRequest) {
 function parseXhrResponse(responseType: string, xhr: XMLHttpRequest) {
   switch (responseType) {
     case 'json':
-        return parseJson(xhr);
-      case 'xml':
-        return xhr.responseXML;
-      case 'text':
-      default:
-          // HACK(benlesh): TypeScript shennanigans
-          // tslint:disable-next-line:no-any XMLHttpRequest is defined to always have 'response' inferring xhr as never for the else sub-expression.
-          return  ('response' in (xhr as any)) ? xhr.response : xhr.responseText;
+      return parseJson(xhr);
+    case 'xml':
+      return xhr.responseXML;
+    case 'text':
+    default:
+      // HACK(benlesh): TypeScript shennanigans
+      // tslint:disable-next-line:no-any XMLHttpRequest is defined to always have 'response' inferring xhr as never for the else sub-expression.
+      return 'response' in (xhr as any) ? xhr.response : xhr.responseText;
   }
 }
 
-export interface AjaxTimeoutError extends AjaxError {
-}
+export interface AjaxTimeoutError extends AjaxError {}
 
 export interface AjaxTimeoutErrorCtor {
-  new(xhr: XMLHttpRequest, request: AjaxRequest): AjaxTimeoutError;
+  new (xhr: XMLHttpRequest, request: AjaxRequest): AjaxTimeoutError;
 }
 
 const AjaxTimeoutErrorImpl = (() => {

--- a/src/internal/observable/dom/ajax.ts
+++ b/src/internal/observable/dom/ajax.ts
@@ -63,7 +63,7 @@ export interface AjaxCreationMethod {
    * @param url The URL to get the resource from
    * @param headers Optional headers. Case-Insensitive.
    */
-  get(url: string, headers?: Object): Observable<AjaxResponse>;
+  get(url: string, headers?: Record<string, string>): Observable<AjaxResponse>;
 
   /**
    * Performs an HTTP POST using the
@@ -79,7 +79,7 @@ export interface AjaxCreationMethod {
    * @param body The content to send. The body is automatically serialized.
    * @param headers Optional headers. Case-Insensitive.
    */
-  post(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
+  post(url: string, body?: any, headers?: Record<string, string>): Observable<AjaxResponse>;
 
   /**
    * Performs an HTTP PUT using the
@@ -95,7 +95,7 @@ export interface AjaxCreationMethod {
    * @param body The content to send. The body is automatically serialized.
    * @param headers Optional headers. Case-Insensitive.
    */
-  put(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
+  put(url: string, body?: any, headers?: Record<string, string>): Observable<AjaxResponse>;
 
   /**
    * Performs an HTTP PATCH using the
@@ -111,7 +111,7 @@ export interface AjaxCreationMethod {
    * @param body The content to send. The body is automatically serialized.
    * @param headers Optional headers. Case-Insensitive.
    */
-  patch(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
+  patch(url: string, body?: any, headers?: Record<string, string>): Observable<AjaxResponse>;
 
   /**
    * Performs an HTTP DELETE using the
@@ -121,7 +121,7 @@ export interface AjaxCreationMethod {
    * @param url The URL to get the resource from
    * @param headers Optional headers. Case-Insensitive.
    */
-  delete(url: string, headers?: Object): Observable<AjaxResponse>;
+  delete(url: string, headers?: Record<string, string>): Observable<AjaxResponse>;
 
   /**
    * Performs an HTTP GET using the
@@ -132,32 +132,32 @@ export interface AjaxCreationMethod {
    * @param url The URL to get the resource from
    * @param headers Optional headers. Case-Insensitive.
    */
-  getJSON<T>(url: string, headers?: Object): Observable<T>;
+  getJSON<T>(url: string, headers?: Record<string, string>): Observable<T>;
 }
 
-function ajaxGet(url: string, headers?: object) {
+function ajaxGet(url: string, headers?: Record<string, string>) {
   return ajax({ method: 'GET', url, headers });
 }
 
-function ajaxPost(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
+function ajaxPost(url: string, body?: any, headers?: Record<string, string>): Observable<AjaxResponse> {
   return ajax({ method: 'POST', url, body, headers });
 }
 
-function ajaxDelete(url: string, headers?: Object): Observable<AjaxResponse> {
+function ajaxDelete(url: string, headers?: Record<string, string>): Observable<AjaxResponse> {
   return ajax({ method: 'DELETE', url, headers });
 }
 
-function ajaxPut(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
+function ajaxPut(url: string, body?: any, headers?: Record<string, string>): Observable<AjaxResponse> {
   return ajax({ method: 'PUT', url, body, headers });
 }
 
-function ajaxPatch(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
+function ajaxPatch(url: string, body?: any, headers?: Record<string, string>): Observable<AjaxResponse> {
   return ajax({ method: 'PATCH', url, body, headers });
 }
 
 const mapResponse = map((x: AjaxResponse) => x.response);
 
-function ajaxGetJSON<T>(url: string, headers?: Object): Observable<T> {
+function ajaxGetJSON<T>(url: string, headers?: Record<string, string>): Observable<T> {
   return mapResponse(
     ajax({
       method: 'GET',
@@ -249,8 +249,8 @@ function ajaxGetJSON<T>(url: string, headers?: Object): Observable<T> {
  * ```
  */
 export const ajax: AjaxCreationMethod = (() => {
-  const create: any = (urlOrRequest: string | AjaxRequest) => {
-    return new AjaxObservable(urlOrRequest);
+  const create = <T>(urlOrRequest: string | AjaxRequest) => {
+    return new AjaxObservable<T>(urlOrRequest);
   };
 
   create.get = ajaxGet;
@@ -260,5 +260,5 @@ export const ajax: AjaxCreationMethod = (() => {
   create.patch = ajaxPatch;
   create.getJSON = ajaxGetJSON;
 
-  return <AjaxCreationMethod>create;
+  return create;
 })();

--- a/src/internal/observable/dom/ajax.ts
+++ b/src/internal/observable/dom/ajax.ts
@@ -1,4 +1,173 @@
-import {  AjaxObservable, AjaxCreationMethod  } from './AjaxObservable';
+/** @prettier */
+import { AjaxObservable, AjaxRequest, AjaxResponse } from './AjaxObservable';
+
+import { map } from '../../operators/map';
+import { Observable } from '../../Observable';
+
+export interface AjaxCreationMethod {
+  /**
+   * Perform an HTTP GET using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope. Defaults to a `responseType` of `"json"`.
+   *
+   * ### Example
+   * ```ts
+   * import { ajax } from 'rxjs/ajax';
+   * import { map, catchError } from 'rxjs/operators';
+   * import { of } from 'rxjs';
+   *
+   * const obs$ = ajax(`https://api.github.com/users?per_page=5`).pipe(
+   *   map(userResponse => console.log('users: ', userResponse)),
+   *   catchError(error => {
+   *     console.log('error: ', error);
+   *     return of(error);
+   *   })
+   * );
+   * ```
+   */
+  (url: string): Observable<AjaxResponse>;
+
+  /**
+   * Creates an observable that will perform an AJAX request using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope by default.
+   *
+   * This is the most configurable option, and the basis for all other AJAX calls in the library.
+   *
+   * ### Example
+   * ```ts
+   * import { ajax } from 'rxjs/ajax';
+   * import { map, catchError } from 'rxjs/operators';
+   * import { of } from 'rxjs';
+   *
+   * const obs$ = ajax({
+   *    method: 'GET',
+   *    url: `https://api.github.com/users?per_page=5`,
+   *    responseType: 'json',
+   * }).pipe(
+   *   map(userResponse => console.log('users: ', userResponse)),
+   *   catchError(error => {
+   *     console.log('error: ', error);
+   *     return of(error);
+   *   })
+   * );
+   * ```
+   */
+  (config: AjaxRequest): Observable<AjaxResponse>;
+
+  /**
+   * Performs an HTTP GET using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope by default, and a `responseType` of `"json"`.
+   *
+   * @param url The URL to get the resource from
+   * @param headers Optional headers. Case-Insensitive.
+   */
+  get(url: string, headers?: Object): Observable<AjaxResponse>;
+
+  /**
+   * Performs an HTTP POST using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope by default, and a `responseType` of `"json"`.
+   *
+   * Before sending the value passed to the `body` argument, it is automatically serialized
+   * based on the specified `responseType`. By default, a JavaScript object will be serialized
+   * to JSON. A `responseType` of `application/x-www-form-urlencoded` will flatten any provided
+   * dictionary object to a url-encoded string.
+   *
+   * @param url The URL to get the resource from
+   * @param body The content to send. The body is automatically serialized.
+   * @param headers Optional headers. Case-Insensitive.
+   */
+  post(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
+
+  /**
+   * Performs an HTTP PUT using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope by default, and a `responseType` of `"json"`.
+   *
+   * Before sending the value passed to the `body` argument, it is automatically serialized
+   * based on the specified `responseType`. By default, a JavaScript object will be serialized
+   * to JSON. A `responseType` of `application/x-www-form-urlencoded` will flatten any provided
+   * dictionary object to a url-encoded string.
+   *
+   * @param url The URL to get the resource from
+   * @param body The content to send. The body is automatically serialized.
+   * @param headers Optional headers. Case-Insensitive.
+   */
+  put(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
+
+  /**
+   * Performs an HTTP PATCH using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope by default, and a `responseType` of `"json"`.
+   *
+   * Before sending the value passed to the `body` argument, it is automatically serialized
+   * based on the specified `responseType`. By default, a JavaScript object will be serialized
+   * to JSON. A `responseType` of `application/x-www-form-urlencoded` will flatten any provided
+   * dictionary object to a url-encoded string.
+   *
+   * @param url The URL to get the resource from
+   * @param body The content to send. The body is automatically serialized.
+   * @param headers Optional headers. Case-Insensitive.
+   */
+  patch(url: string, body?: any, headers?: Object): Observable<AjaxResponse>;
+
+  /**
+   * Performs an HTTP DELETE using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope by default, and a `responseType` of `"json"`.
+   *
+   * @param url The URL to get the resource from
+   * @param headers Optional headers. Case-Insensitive.
+   */
+  delete(url: string, headers?: Object): Observable<AjaxResponse>;
+
+  /**
+   * Performs an HTTP GET using the
+   * [XMLHttpRequest](https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest) in
+   * global scope by default, and returns the hydrated JavaScript object from the
+   * response.
+   *
+   * @param url The URL to get the resource from
+   * @param headers Optional headers. Case-Insensitive.
+   */
+  getJSON<T>(url: string, headers?: Object): Observable<T>;
+}
+
+function ajaxGet(url: string, headers?: object) {
+  return ajax({ method: 'GET', url, headers });
+}
+
+function ajaxPost(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
+  return ajax({ method: 'POST', url, body, headers });
+}
+
+function ajaxDelete(url: string, headers?: Object): Observable<AjaxResponse> {
+  return ajax({ method: 'DELETE', url, headers });
+}
+
+function ajaxPut(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
+  return ajax({ method: 'PUT', url, body, headers });
+}
+
+function ajaxPatch(url: string, body?: any, headers?: Object): Observable<AjaxResponse> {
+  return ajax({ method: 'PATCH', url, body, headers });
+}
+
+const mapResponse = map((x: AjaxResponse) => x.response);
+
+function ajaxGetJSON<T>(url: string, headers?: Object): Observable<T> {
+  return mapResponse(
+    ajax({
+      method: 'GET',
+      url,
+      responseType: 'json',
+      headers,
+    })
+  );
+}
+
 /**
  * There is an ajax operator on the Rx object.
  *
@@ -19,7 +188,6 @@ import {  AjaxObservable, AjaxCreationMethod  } from './AjaxObservable';
  *     return of(error);
  *   })
  * );
- *
  * ```
  *
  * ## Using ajax.getJSON() to fetch data from API.
@@ -80,4 +248,17 @@ import {  AjaxObservable, AjaxCreationMethod  } from './AjaxObservable';
  *
  * ```
  */
-export const ajax: AjaxCreationMethod = (() => AjaxObservable.create)();
+export const ajax: AjaxCreationMethod = (() => {
+  const create: any = (urlOrRequest: string | AjaxRequest) => {
+    return new AjaxObservable(urlOrRequest);
+  };
+
+  create.get = ajaxGet;
+  create.post = ajaxPost;
+  create.delete = ajaxDelete;
+  create.put = ajaxPut;
+  create.patch = ajaxPatch;
+  create.getJSON = ajaxGetJSON;
+
+  return <AjaxCreationMethod>create;
+})();


### PR DESCRIPTION
Refactors the existing AJAX implementation. (Unrelated to OJ's rewrite)

- Gets it inline, browser-support wise, with contemporaries like Axios, et al.
- Removes old optimizations from several years ago that were no longer relevant.
- Adds documentation for the various functions, at least at some level.
- Removes funky code paths that were CLEARLY never hit or we'd have had complaints about them. For example [people probably are not using this against IE9 and under based off of the existance of this line here](https://github.com/ReactiveX/rxjs/blob/edd67313814bfc32e8a5129d8049e4d4678cd35d/src/internal/observable/dom/AjaxObservable.ts#L378-L384). Which means that all of the ActiveXObject and IE9 and under support was useless. Also, in that case, checks for `XDomainRequest` were no longer relevant, and those code paths can be removed.

Fixes:
- Fixes issue where an imcomplete observer implementation handed to `progressSubscriber` would result in a runtime error.
- Fixes types to be more appropriate. Observable<ProgressEvent>, for example. Or using the proper types for `responseType`.
- Properly checks for `"document"` response type instead of `"xml"` which isn't a thing.

BREAKING:

- Drops support for IE 10 and under. (IE11 is supported)
- Drops support for Android 4 browsers (< 0.04% of browser usage, according to some numbers I found)