### PR TITLE
fix(repeat): Ensure teardown happens between repeated synchronous obs…

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -622,7 +622,7 @@ export declare class VirtualAction<T> extends AsyncAction<T> {
     protected recycleAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     protected requestAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     schedule(state?: T, delay?: number): Subscription;
-    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 1 | 0 | -1;
+    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 1 | -1 | 0;
 }
 
 export declare class VirtualTimeScheduler extends AsyncScheduler {

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -622,7 +622,7 @@ export declare class VirtualAction<T> extends AsyncAction<T> {
     protected recycleAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     protected requestAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     schedule(state?: T, delay?: number): Subscription;
-    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 1 | -1 | 0;
+    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 1 | 0 | -1;
 }
 
 export declare class VirtualTimeScheduler extends AsyncScheduler {

--- a/spec/operators/repeat-spec.ts
+++ b/spec/operators/repeat-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { repeat, mergeMap, map, multicast, refCount } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { of, Subject } from 'rxjs';
+import { of, Subject, Observable } from 'rxjs';
 
 declare const rxTestScheduler: TestScheduler;
 
@@ -96,19 +96,54 @@ describe('repeat operator', () => {
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
-  it('should consider negative count as repeat indefinitely', () => {
+  it('should consider negative count as no repeat, and return EMPTY', () => {
     const e1 =  cold('--a--b--|                                    ');
-    const subs =    ['^       !                                    ',
-                   '        ^       !                            ',
-                   '                ^       !                    ',
-                   '                        ^       !            ',
-                   '                                ^       !    ',
-                   '                                        ^   !'];
     const unsub =    '                                            !';
-    const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
+    const expected = '|';
 
     expectObservable(e1.pipe(repeat(-1)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+    expectSubscriptions(e1.subscriptions).toBe([]);
+  });
+
+  it('should always teardown before starting the next cycle', async () => {
+    const results: any[] = [];
+    const source = new Observable<number>(subscriber => {
+      Promise.resolve().then(() => {
+        subscriber.next(1)
+        Promise.resolve().then(() => {
+          subscriber.next(2);
+          Promise.resolve().then(() => {
+            subscriber.complete();
+          });
+        });
+      });
+      return () => {
+        results.push('teardown');
+      }
+    });
+
+    await source.pipe(repeat(3)).forEach(value => results.push(value));
+  
+    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'teardown'])
+  });
+
+  it('should always teardown before starting the next cycle, even when synchronous', () => {
+    const results: any[] = [];
+    const source = new Observable<number>(subscriber => {
+      subscriber.next(1);
+      subscriber.next(2);
+      subscriber.complete();
+      return () => {
+        results.push('teardown');
+      }
+    });
+    const subscription = source.pipe(repeat(3)).subscribe({
+      next: value => results.push(value),
+      complete: () => results.push('complete')
+    });
+
+    expect(subscription.closed).to.be.true;
+    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'complete', 'teardown'])
   });
 
   it('should not complete when source never completes', () => {

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -67,7 +67,8 @@ export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) =>
     count <= 0
       ? EMPTY
-      : new Observable<T>((subscriber) => {
+      : lift(source, function (this: Subscriber<T>, source: Observable<T>) {
+          const subscriber = this;
           let soFar = 0;
           const subscription = new Subscription();
           let innerSub: Subscription | null;

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -72,7 +72,7 @@ export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
           let soFar = 0;
           const subscription = new Subscription();
           let innerSub: Subscription | null;
-          const subscribeNext = () => {
+          const subscribeForRepeat = () => {
             let syncUnsub = false;
             innerSub = source.subscribe({
               next: (value) => subscriber.next(value),
@@ -80,9 +80,9 @@ export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
               complete: () => {
                 if (++soFar < count) {
                   if (innerSub) {
-                    subscription.remove(innerSub);
                     innerSub.unsubscribe();
-                    subscribeNext();
+                    innerSub = null;
+                    subscribeForRepeat();
                   } else {
                     syncUnsub = true;
                   }
@@ -94,12 +94,12 @@ export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
             if (syncUnsub) {
               innerSub.unsubscribe();
               innerSub = null;
-              subscribeNext();
+              subscribeForRepeat();
             } else {
               subscription.add(innerSub);
             }
           };
-          subscribeNext();
+          subscribeForRepeat();
           return subscription;
         });
 }

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -1,9 +1,11 @@
-import { Operator } from '../Operator';
-import { Subscriber } from '../Subscriber';
+/** @prettier */
 import { Observable } from '../Observable';
+import { Subscription } from '../Subscription';
 import { EMPTY } from '../observable/empty';
-import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { SimpleOuterSubscriber } from '../innerSubscribe';
 import { lift } from '../util/lift';
+import { Subscriber } from '../Subscriber';
+import { MonoTypeOperatorFunction } from '../types';
 
 /**
  * Returns an Observable that will resubscribe to the source stream when the source stream completes, at most count times.
@@ -60,47 +62,43 @@ import { lift } from '../util/lift';
  * , at most count times.
  * @name repeat
  */
-export function repeat<T>(count: number = -1): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => {
-    if (count === 0) {
-      return EMPTY;
-    } else if (count < 0) {
-      return lift(source, new RepeatOperator(-1, source));
-    } else {
-      return lift(source, new RepeatOperator(count - 1, source));
-    }
-  };
-}
 
-class RepeatOperator<T> implements Operator<T, T> {
-  constructor(private count: number,
-              private source: Observable<T>) {
-  }
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source.subscribe(new RepeatSubscriber(subscriber, this.count, this.source));
-  }
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
-class RepeatSubscriber<T> extends Subscriber<T> {
-  constructor(destination: Subscriber<any>,
-              private count: number,
-              private source: Observable<T>) {
-    super(destination);
-  }
-  complete() {
-    if (!this.isStopped) {
-      const { source, count } = this;
-      if (count === 0) {
-        return super.complete();
-      } else if (count > -1) {
-        this.count = count - 1;
-      }
-      source.subscribe(this._unsubscribeAndRecycle());
-    }
-  }
+export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
+  return (source: Observable<T>) =>
+    count <= 0
+      ? EMPTY
+      : new Observable<T>((subscriber) => {
+          let soFar = 0;
+          const subscription = new Subscription();
+          let innerSub: Subscription | null;
+          const subscribeNext = () => {
+            let syncUnsub = false;
+            innerSub = source.subscribe({
+              next: (value) => subscriber.next(value),
+              error: (err) => subscriber.error(err),
+              complete: () => {
+                if (++soFar < count) {
+                  if (innerSub) {
+                    subscription.remove(innerSub);
+                    innerSub.unsubscribe();
+                    subscribeNext();
+                  } else {
+                    syncUnsub = true;
+                  }
+                } else {
+                  subscriber.complete();
+                }
+              },
+            });
+            if (syncUnsub) {
+              innerSub.unsubscribe();
+              innerSub = null;
+              subscribeNext();
+            } else {
+              subscription.add(innerSub);
+            }
+          };
+          subscribeNext();
+          return subscription;
+        });
 }


### PR DESCRIPTION
…ervables

- Simplifies repeat code
- Removes reliance on unsubscribeAndRecycle
- Gets rid of strange, undocumented behavior where numbers less than zero were treated like positive infinity
- Fixes an issue where `finalize` would be called N times after the completion of the resulting observable if the source was synchronous.
- Fixes an issue where N unsubscriptions would always occur after the total completion.

BREAKING CHANGE: Removed an undocumented behavior where passing a negative count argument to `repeat` would result in an observable that repeats forever.

