### PR TITLE
fix(retry): Ensure teardown happens before resubscription with synchr…

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -537,7 +537,6 @@ export declare class Subscriber<T> extends Subscription implements Observer<T> {
     protected _complete(): void;
     protected _error(err: any): void;
     protected _next(value: T): void;
-    _unsubscribeAndRecycle(): Subscriber<T>;
     complete(): void;
     error(err?: any): void;
     next(value?: T): void;

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -144,17 +144,6 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     this.destination.complete();
     this.unsubscribe();
   }
-
-  /** @deprecated This is an internal implementation detail, do not use. */
-  _unsubscribeAndRecycle(): Subscriber<T> {
-    const {  _parentOrParents } = this;
-    this._parentOrParents = null!;
-    this.unsubscribe();
-    this.closed = false;
-    this.isStopped = false;
-    this._parentOrParents = _parentOrParents;
-    return this;
-  }
 }
 
 /**


### PR DESCRIPTION
…onous observables

Related: #5620

- Resolves an issue where all teardowns would not execute until the result observable was complete if the source was synchronous

BREAKING CHANGE: Removed an undocumented behavior where passing a negative count argument to `retry` would result in an observable that repeats forever.
