### PR TITLE
fix(catchError): ensure proper handling of async return for synchrono…

### DIFF
--- a/spec/operators/catch-spec.ts
+++ b/spec/operators/catch-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { concat, defer, Observable, of, throwError, EMPTY, from } from 'rxjs';
-import { catchError, map, mergeMap, takeWhile } from 'rxjs/operators';
+import { catchError, map, mergeMap, takeWhile, delay } from 'rxjs/operators';
 import * as sinon from 'sinon';
 import { createObservableInputs } from '../helpers/test-helper';
 import { TestScheduler } from 'rxjs/testing';
@@ -431,8 +431,8 @@ describe('catchError operator', () => {
   // TODO(v8): see https://github.com/ReactiveX/rxjs/issues/5115
   // The re-implementation in version 8 should fix the problem in the
   // referenced issue. Closed subscribers should remain closed.
-  /*
-  it('issue #5115', (done: MochaDone) => {
+  
+  it('Properly handle async handled result if source is synchronous', (done: MochaDone) => {
     const source = new Observable<string>(observer => {
       observer.error(new Error('kaboom!'));
       observer.complete();
@@ -456,5 +456,5 @@ describe('catchError operator', () => {
       }
     );
   });
-  */
+
 });


### PR DESCRIPTION
…us source error handling

- Refactors catchError to be simpler and to get rid of _unsubscribeAndRecycle usage as well as some other overly clever bits.

fixes #5115


Also part of my evil plot to get rid of `_unsubscribeAndRecycle` as mentioned here #5626 