### PR TITLE
test(mergeAll): add test with multiple types

### DIFF
--- a/spec-dtslint/operators/mergeAll-spec.ts
+++ b/spec-dtslint/operators/mergeAll-spec.ts
@@ -1,10 +1,15 @@
 import { of } from 'rxjs';
 import { mergeAll } from 'rxjs/operators';
+import { a$, b$ } from '../helpers';
 
-it('should infer correctly', () => {
-  const o = of(of(1, 2, 3)).pipe(mergeAll()); // $ExpectType Observable<number>
+it('should infer correctly with sources of same type', () => {
+  const o = of(a$, a$).pipe(mergeAll()); // $ExpectType Observable<A>
+});
+
+it('should infer correctly with sources of different types', () => {
+  const o = of(a$, b$).pipe(mergeAll()); // $ExpectType Observable<A | B>
 });
 
 it('should enforce types', () => {
-  const o = of(1, 2, 3).pipe(mergeAll()); // $ExpectError
+  const o = a$.pipe(mergeAll()); // $ExpectError
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a dtslint test for `mergeAll` in which the observables within the higher-order observable have different types. It also changes the tests to use the predefined helper sources.

Added because I noticed a type issue in v6 and when I checked the v7 types, they were fine, but the test was missing.

**Related issue (if exists):** None