### PR TITLE
Reworking Multicasting: share, connect, and makeConnectable

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -118,6 +118,8 @@ export declare const config: {
     useDeprecatedNextContext: boolean;
 };
 
+export declare function connectable<T>(source: ObservableInput<T>, connector?: Subject<T>): ConnectableObservableLike<T>;
+
 export declare class ConnectableObservable<T> extends Observable<T> {
     protected _connection: Subscription | null;
     protected _refCount: number;
@@ -330,7 +332,6 @@ export declare type ObservedValueTupleFromArray<X> = {
 export declare type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
 
 export interface Observer<T> {
-    closed?: boolean;
     complete: () => void;
     error: (err: any) => void;
     next: (value: T) => void;
@@ -438,12 +439,10 @@ export declare class Subject<T> extends Observable<T> implements SubscriptionLik
     static create: (...args: any[]) => any;
 }
 
+export declare type SubjectLike<T> = Observer<T> & Subscribable<T>;
+
 export interface Subscribable<T> {
-    subscribe(observer?: PartialObserver<T>): Unsubscribable;
-    subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable;
-    subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Unsubscribable;
-    subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Unsubscribable;
-    subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
+    subscribe(observer: Observer<T>): Unsubscribable;
 }
 
 export declare type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | PromiseLike<T> | InteropObservable<T>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -300,7 +300,7 @@ export declare class Observable<T> implements Subscribable<T> {
     pipe<A, B, C, D, E, F, G, H>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>): Observable<H>;
     pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): Observable<I>;
     pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>, ...operations: OperatorFunction<any, any>[]): Observable<unknown>;
-    subscribe(observer?: PartialObserver<T>): Subscription;
+    subscribe(observer?: Partial<Observer<T>>): Subscription;
     subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
     subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
     subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
@@ -439,10 +439,11 @@ export declare class Subject<T> extends Observable<T> implements SubscriptionLik
     static create: (...args: any[]) => any;
 }
 
-export declare type SubjectLike<T> = Observer<T> & Subscribable<T>;
+export interface SubjectLike<T> extends Observer<T>, Subscribable<T> {
+}
 
 export interface Subscribable<T> {
-    subscribe(observer: Observer<T>): Unsubscribable;
+    subscribe(observer: Partial<Observer<T>>): Unsubscribable;
 }
 
 export declare type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | PromiseLike<T> | InteropObservable<T>;

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -60,10 +60,7 @@ export declare function concatMapTo<T, R, O extends ObservableInput<any>>(observ
 
 export declare function concatWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
-export declare function connect<T, R>({ connector, setup, }: {
-    connector?: () => SubjectLike<T>;
-    setup: (shared: Observable<T>) => ObservableInput<R>;
-}): OperatorFunction<T, R>;
+export declare function connect<T, R>(selector: (shared: Observable<T>) => ObservableInput<R>, config?: ConnectConfig<T>): OperatorFunction<T, R>;
 
 export declare function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number>;
 
@@ -253,7 +250,7 @@ export declare function scan<V, A, S>(accumulator: (acc: A | S, value: V, index:
 export declare function sequenceEqual<T>(compareTo: Observable<T>, comparator?: (a: T, b: T) => boolean): OperatorFunction<T, boolean>;
 
 export declare function share<T>(): MonoTypeOperatorFunction<T>;
-export declare function share<T, R = T>(options: ShareOptions<T, R>): OperatorFunction<T, R>;
+export declare function share<T>(options: ShareConfig<T>): MonoTypeOperatorFunction<T>;
 
 export declare function shareReplay<T>(config: ShareReplayConfig): MonoTypeOperatorFunction<T>;
 export declare function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -217,7 +217,7 @@ export declare function publishBehavior<T>(initialValue: T): UnaryFunction<Obser
 export declare function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 
 export declare function publishReplay<T>(bufferSize?: number, windowTime?: number, timestampProvider?: TimestampProvider): MonoTypeOperatorFunction<T>;
-export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize: number | undefined, windowTime: number | undefined, selector: OperatorFunction<T, ObservedValueOf<O>>, timestampProvider?: TimestampProvider): OperatorFunction<T, ObservedValueOf<O>>;
+export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize: number | undefined, windowTime: number | undefined, selector: (shared: Observable<T>) => O, timestampProvider?: TimestampProvider): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize: number | undefined, windowTime: number | undefined, selector: undefined, timestampProvider: TimestampProvider): OperatorFunction<T, ObservedValueOf<O>>;
 
 export declare function race<T>(observables: Array<Observable<T>>): MonoTypeOperatorFunction<T>;

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -60,6 +60,11 @@ export declare function concatMapTo<T, R, O extends ObservableInput<any>>(observ
 
 export declare function concatWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
+export declare function connect<T, R>({ connector, setup, }: {
+    connector?: () => SubjectLike<T>;
+    setup: (shared: Observable<T>) => ObservableInput<R>;
+}): OperatorFunction<T, R>;
+
 export declare function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number>;
 
 export declare function debounce<T>(durationSelector: (value: T) => ObservableInput<any>): MonoTypeOperatorFunction<T>;
@@ -182,9 +187,9 @@ export declare function mergeWith<T, A extends readonly unknown[]>(...otherSourc
 export declare function min<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T>;
 
 export declare function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
-export declare function multicast<T, O extends ObservableInput<any>>(subject: Subject<T>, selector: (shared: Observable<T>) => O): UnaryFunction<Observable<T>, ConnectableObservable<ObservedValueOf<O>>>;
-export declare function multicast<T>(subjectFactory: (this: Observable<T>) => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
-export declare function multicast<T, O extends ObservableInput<any>>(SubjectFactory: (this: Observable<T>) => Subject<T>, selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
+export declare function multicast<T, O extends ObservableInput<any>>(subject: Subject<T>, selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
+export declare function multicast<T>(subjectFactory: () => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
+export declare function multicast<T, O extends ObservableInput<any>>(subjectFactory: () => Subject<T>, selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
 
 export declare function observeOn<T>(scheduler: SchedulerLike, delay?: number): MonoTypeOperatorFunction<T>;
 
@@ -206,14 +211,14 @@ export declare function pluck<T>(...properties: string[]): OperatorFunction<T, u
 
 export declare function publish<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export declare function publish<T, O extends ObservableInput<any>>(selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
-export declare function publish<T>(selector: MonoTypeOperatorFunction<T>): MonoTypeOperatorFunction<T>;
 
-export declare function publishBehavior<T>(value: T): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
+export declare function publishBehavior<T>(initialValue: T): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 
 export declare function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 
-export declare function publishReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize?: number, windowTime?: number, selector?: (shared: Observable<T>) => O, scheduler?: SchedulerLike): OperatorFunction<T, ObservedValueOf<O>>;
+export declare function publishReplay<T>(bufferSize?: number, windowTime?: number, timestampProvider?: TimestampProvider): MonoTypeOperatorFunction<T>;
+export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize: number | undefined, windowTime: number | undefined, selector: OperatorFunction<T, ObservedValueOf<O>>, timestampProvider?: TimestampProvider): OperatorFunction<T, ObservedValueOf<O>>;
+export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize: number | undefined, windowTime: number | undefined, selector: undefined, timestampProvider: TimestampProvider): OperatorFunction<T, ObservedValueOf<O>>;
 
 export declare function race<T>(observables: Array<Observable<T>>): MonoTypeOperatorFunction<T>;
 export declare function race<T, R>(observables: Array<Observable<T>>): OperatorFunction<T, R>;
@@ -248,6 +253,7 @@ export declare function scan<V, A, S>(accumulator: (acc: A | S, value: V, index:
 export declare function sequenceEqual<T>(compareTo: Observable<T>, comparator?: (a: T, b: T) => boolean): OperatorFunction<T, boolean>;
 
 export declare function share<T>(): MonoTypeOperatorFunction<T>;
+export declare function share<T, R = T>(options: ShareOptions<T, R>): OperatorFunction<T, R>;
 
 export declare function shareReplay<T>(config: ShareReplayConfig): MonoTypeOperatorFunction<T>;
 export declare function shareReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;

--- a/api_guard/dist/types/testing/index.d.ts
+++ b/api_guard/dist/types/testing/index.d.ts
@@ -20,12 +20,13 @@ export declare class TestScheduler extends VirtualTimeScheduler {
         [marble: string]: T;
     }, error?: any): HotObservable<T>;
     createTime(marbles: string): number;
-    expectObservable(observable: Observable<any>, subscriptionMarbles?: string | null): ({
-        toBe: observableToBeFn;
-    });
-    expectSubscriptions(actualSubscriptionLogs: SubscriptionLog[]): ({
+    expectObservable<T>(observable: Observable<T>, subscriptionMarbles?: string | null): {
+        toBe(marbles: string, values?: any, errorValue?: any): void;
+        toEqual: (other: Observable<T>) => void;
+    };
+    expectSubscriptions(actualSubscriptionLogs: SubscriptionLog[]): {
         toBe: subscriptionLogsToBeFn;
-    });
+    };
     flush(): void;
     run<T>(callback: (helpers: RunHelpers) => T): T;
     static frameTimeFactor: number;

--- a/spec/deprecation-equivalents/multicasting-deprecations-spec.ts
+++ b/spec/deprecation-equivalents/multicasting-deprecations-spec.ts
@@ -1,0 +1,148 @@
+/** @prettier */
+import { Observable, ConnectableObservable, connectable, of, AsyncSubject, BehaviorSubject, ReplaySubject, Subject, merge } from 'rxjs';
+import { connect, share, multicast, publish, publishReplay, publishBehavior, publishLast, refCount, repeat, retry } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+describe('multicasting equivalent tests', () => {
+  let rxTest: TestScheduler;
+
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
+  testEquivalents(
+    'multicast(() => new Subject()), refCount() and share()',
+    (source) =>
+      source.pipe(
+        multicast(() => new Subject<string>()),
+        refCount()
+      ),
+    (source) => source.pipe(share())
+  );
+
+  testEquivalents(
+    'multicast(new Subject()), refCount() and share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })',
+    (source) => source.pipe(multicast(new Subject()), refCount()),
+    (source) => source.pipe(share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))
+  );
+
+  testEquivalents(
+    'publish(), refCount() and share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })',
+    (source) => source.pipe(publish(), refCount()),
+    (source) => source.pipe(share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))
+  );
+
+  testEquivalents(
+    'publishLast(), refCount() and share({ connector: () => new AsyncSubject(), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })',
+    (source) => source.pipe(publishLast(), refCount()),
+    (source) =>
+      source.pipe(share({ connector: () => new AsyncSubject(), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))
+  );
+
+  testEquivalents(
+    'publishBehavior("X"), refCount() and share({ connector: () => new BehaviorSubject("X"), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })',
+    (source) => source.pipe(publishBehavior('X'), refCount()),
+    (source) =>
+      source.pipe(
+        share({ connector: () => new BehaviorSubject('X'), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })
+      )
+  );
+
+  testEquivalents(
+    'publishReplay(3, 10), refCount() and share({ connector: () => new ReplaySubject(3, 10), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })',
+    (source) => source.pipe(publishReplay(3, 10), refCount()),
+    (source) =>
+      source.pipe(
+        share({ connector: () => new ReplaySubject(3, 10), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })
+      )
+  );
+
+  const fn = (source: Observable<any>) => merge(source, source);
+
+  testEquivalents(
+    'publish(fn) and connect({ setup: fn })',
+    (source) => source.pipe(publish(fn)),
+    (source) =>
+      source.pipe(
+        connect({
+          setup: fn,
+        })
+      )
+  );
+
+  testEquivalents(
+    'publishReplay(3, 10, fn) and `subject = new ReplaySubject(3, 10), connect({ connector: () => subject , setup: fn })`',
+    (source) => source.pipe(publishReplay(3, 10, fn)),
+    (source) => {
+      const subject = new ReplaySubject(3, 10);
+      return source.pipe(connect({ connector: () => subject, setup: fn }));
+    }
+  );
+
+  /**
+   * Used to test a variety of scenarios with multicast operators that should be equivalent.
+   * @param name The name to add to the test output
+   * @param oldExpression The old expression we're saying matches the updated expression
+   * @param updatedExpression The updated expression we're telling people to use instead.
+   */
+  function testEquivalents(
+    name: string,
+    oldExpression: (source: Observable<string>) => Observable<string>,
+    updatedExpression: (source: Observable<string>) => Observable<string>
+  ) {
+    it(`should be equivalent for ${name} for async sources`, () => {
+      rxTest.run(({ cold, expectObservable }) => {
+        const source = cold('----a---b---c----d---e----|');
+        const old = oldExpression(source);
+        const updated = updatedExpression(source);
+        expectObservable(updated).toEqual(old);
+      });
+    });
+
+    it(`should be equivalent for ${name} for async sources that repeat`, () => {
+      rxTest.run(({ cold, expectObservable }) => {
+        const source = cold('----a---b---c----d---e----|');
+        const old = oldExpression(source).pipe(repeat(3));
+        const updated = updatedExpression(source).pipe(repeat(3));
+        expectObservable(updated).toEqual(old);
+      });
+    });
+
+    it(`should be equivalent for ${name} for async sources that retry`, () => {
+      rxTest.run(({ cold, expectObservable }) => {
+        const source = cold('----a---b---c----d---e----#');
+        const old = oldExpression(source).pipe(retry(3));
+        const updated = updatedExpression(source).pipe(retry(3));
+        expectObservable(updated).toEqual(old);
+      });
+    });
+
+    it(`should be equivalent for ${name} for async sources`, () => {
+      rxTest.run(({ expectObservable }) => {
+        const source = of('a', 'b', 'c');
+        const old = oldExpression(source);
+        const updated = updatedExpression(source);
+        expectObservable(updated).toEqual(old);
+      });
+    });
+
+    it(`should be equivalent for ${name} for async sources that repeat`, () => {
+      rxTest.run(({ expectObservable }) => {
+        const source = of('a', 'b', 'c');
+        const old = oldExpression(source).pipe(repeat(3));
+        const updated = updatedExpression(source).pipe(repeat(3));
+        expectObservable(updated).toEqual(old);
+      });
+    });
+
+    it(`should be equivalent for ${name} for async sources that retry`, () => {
+      rxTest.run(({ expectObservable }) => {
+        const source = of('a', 'b', 'c');
+        const old = oldExpression(source).pipe(retry(3));
+        const updated = updatedExpression(source).pipe(retry(3));
+        expectObservable(updated).toEqual(old);
+      });
+    });
+  }
+});

--- a/spec/deprecation-equivalents/multicasting-deprecations-spec.ts
+++ b/spec/deprecation-equivalents/multicasting-deprecations-spec.ts
@@ -63,12 +63,7 @@ describe('multicasting equivalent tests', () => {
   testEquivalents(
     'publish(fn) and connect({ setup: fn })',
     (source) => source.pipe(publish(fn)),
-    (source) =>
-      source.pipe(
-        connect({
-          setup: fn,
-        })
-      )
+    (source) => source.pipe(connect(fn))
   );
 
   testEquivalents(
@@ -76,7 +71,7 @@ describe('multicasting equivalent tests', () => {
     (source) => source.pipe(publishReplay(3, 10, fn)),
     (source) => {
       const subject = new ReplaySubject(3, 10);
-      return source.pipe(connect({ connector: () => subject, setup: fn }));
+      return source.pipe(connect(fn, { connector: () => subject }));
     }
   );
 

--- a/spec/operators/connect-spec.ts
+++ b/spec/operators/connect-spec.ts
@@ -11,37 +11,33 @@ describe('connect', () => {
     rxTest = new TestScheduler(observableMatcher);
   });
 
-  it('should connect a source through a setup function', () => {
+  it('should connect a source through a selector function', () => {
     rxTest.run(({ cold, time, expectObservable }) => {
       const source = cold('---a----b-----c---|');
       const d = time('        ---|');
       const expected = '   ---a--a-b--b--c--c|';
 
-      const result = source.pipe(
-        connect({
-          setup: (shared) => {
-            return merge(shared.pipe(delay(d)), shared);
-          },
-        })
-      );
+      const result = source.pipe(connect((shared) => merge(shared.pipe(delay(d)), shared)));
 
       expectObservable(result).toBe(expected);
     });
   });
 
-  it('should connect a source through a setup function and use the provided connector', () => {
+  it('should connect a source through a selector function and use the provided connector', () => {
     rxTest.run(({ cold, time, expectObservable }) => {
       const source = cold('--------a---------b---------c-----|');
       const d = time('             ---|');
       const expected = '   S--S----a--a------b--b------c--c--|';
 
       const result = source.pipe(
-        connect({
-          connector: () => new BehaviorSubject('S'),
-          setup: (shared) => {
+        connect(
+          (shared) => {
             return merge(shared.pipe(delay(d)), shared);
           },
-        })
+          {
+            connector: () => new BehaviorSubject('S'),
+          }
+        )
       );
 
       expectObservable(result).toBe(expected);

--- a/spec/operators/connect-spec.ts
+++ b/spec/operators/connect-spec.ts
@@ -1,0 +1,50 @@
+/** @prettier */
+import { BehaviorSubject, merge } from 'rxjs';
+import { connect, delay } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+describe('connect', () => {
+  let rxTest: TestScheduler;
+
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
+  it('should connect a source through a setup function', () => {
+    rxTest.run(({ cold, time, expectObservable }) => {
+      const source = cold('---a----b-----c---|');
+      const d = time('        ---|');
+      const expected = '   ---a--a-b--b--c--c|';
+
+      const result = source.pipe(
+        connect({
+          setup: (shared) => {
+            return merge(shared.pipe(delay(d)), shared);
+          },
+        })
+      );
+
+      expectObservable(result).toBe(expected);
+    });
+  });
+
+  it('should connect a source through a setup function and use the provided connector', () => {
+    rxTest.run(({ cold, time, expectObservable }) => {
+      const source = cold('--------a---------b---------c-----|');
+      const d = time('             ---|');
+      const expected = '   S--S----a--a------b--b------c--c--|';
+
+      const result = source.pipe(
+        connect({
+          connector: () => new BehaviorSubject('S'),
+          setup: (shared) => {
+            return merge(shared.pipe(delay(d)), shared);
+          },
+        })
+      );
+
+      expectObservable(result).toBe(expected);
+    });
+  });
+});

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -430,7 +430,7 @@ describe('publishReplay operator', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
-  it('should emit an error when the selector throws an exception', () => {
+  it('should EMIT an error when the selector throws an exception', () => {
     const error = "It's broken";
     const selector = () => {
       throw error;

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -1,331 +1,466 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { share, retry, mergeMapTo, mergeMap, tap, repeat, take } from 'rxjs/operators';
-import { Observable, EMPTY, NEVER, of } from 'rxjs';
+import { share, retry, mergeMapTo, mergeMap, tap, repeat, take, takeUntil, takeWhile, materialize } from 'rxjs/operators';
+import { Observable, EMPTY, NEVER, of, Subject, Observer, from } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+import sinon = require('sinon');
 
 /** @test {share} */
-describe('share operator', () => {
-  it('should mirror a simple source Observable', () => {
-    const source = cold('--1-2---3-4--5-|');
-    const sourceSubs =  '^              !';
-    const expected =    '--1-2---3-4--5-|';
+describe('share', () => {
+  describe('share()', () => {
+    it('should mirror a simple source Observable', () => {
+      const source = cold('--1-2---3-4--5-|');
+      const sourceSubs =  '^              !';
+      const expected =    '--1-2---3-4--5-|';
 
-    const shared = source.pipe(share());
+      const shared = source.pipe(share());
 
-    expectObservable(shared).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should share a single subscription', () => {
-    let subscriptionCount = 0;
-    const obs = new Observable<never>(observer => {
-      subscriptionCount++;
+      expectObservable(shared).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
     });
 
-    const source = obs.pipe(share());
+    it('should share a single subscription', () => {
+      let subscriptionCount = 0;
+      const obs = new Observable<never>(observer => {
+        subscriptionCount++;
+      });
 
-    expect(subscriptionCount).to.equal(0);
+      const source = obs.pipe(share());
 
-    source.subscribe();
-    source.subscribe();
+      expect(subscriptionCount).to.equal(0);
 
-    expect(subscriptionCount).to.equal(1);
-  });
+      source.subscribe();
+      source.subscribe();
 
-  it('should not change the output of the observable when error', () => {
-    const e1 = hot('---a--^--b--c--d--e--#');
-    const e1subs =       '^              !';
-    const expected =     '---b--c--d--e--#';
-
-    expectObservable(e1.pipe(share())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should not change the output of the observable when successful with cold observable', () => {
-    const e1 =  cold('---a--b--c--d--e--|');
-    const e1subs =   '^                 !';
-    const expected = '---a--b--c--d--e--|';
-
-    expectObservable(e1.pipe(share())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should not change the output of the observable when error with cold observable', () => {
-    const e1 =  cold('---a--b--c--d--e--#');
-    const e1subs =   '^                 !';
-    const expected = '---a--b--c--d--e--#';
-
-    expectObservable(e1.pipe(share())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should retry just fine', () => {
-    const e1 =  cold('---a--b--c--d--e--#');
-    const e1subs =  ['^                 !                  ',
-                   '                  ^                 !'];
-    const expected = '---a--b--c--d--e-----a--b--c--d--e--#';
-
-    expectObservable(e1.pipe(share(), retry(1))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-  });
-
-  it('should share the same values to multiple observers', () => {
-    const source =     cold('-1-2-3----4-|');
-    const sourceSubs =      '^           !';
-    const shared = source.pipe(share());
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
-    const expected1   =     '-1-2-3----4-|';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
-    const expected2   =     '    -3----4-|';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
-    const expected3   =     '        --4-|';
-
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should share an error from the source to multiple observers', () => {
-    const source =     cold('-1-2-3----4-#');
-    const sourceSubs =      '^           !';
-    const shared = source.pipe(share());
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
-    const expected1   =     '-1-2-3----4-#';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
-    const expected2   =     '    -3----4-#';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
-    const expected3   =     '        --4-#';
-
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should share the same values to multiple observers, ' +
-  'but is unsubscribed explicitly and early', () => {
-    const source =     cold('-1-2-3----4-|');
-    const sourceSubs =      '^        !   ';
-    const shared = source.pipe(share());
-    const unsub =           '         !   ';
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
-    const expected1   =     '-1-2-3----   ';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
-    const expected2   =     '    -3----   ';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
-    const expected3   =     '        --   ';
-
-    expectObservable(subscriber1, unsub).toBe(expected1);
-    expectObservable(subscriber2, unsub).toBe(expected2);
-    expectObservable(subscriber3, unsub).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should share an empty source', () => {
-    const source = cold('|');
-    const sourceSubs =  '(^!)';
-    const shared = source.pipe(share());
-    const expected =    '|';
-
-    expectObservable(shared).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should share a never source', () => {
-    const source = cold('-');
-    const sourceSubs =  '^';
-    const shared = source.pipe(share());
-    const expected =    '-';
-
-    expectObservable(shared).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should share a throw source', () => {
-    const source = cold('#');
-    const sourceSubs =  '(^!)';
-    const shared = source.pipe(share());
-    const expected =    '#';
-
-    expectObservable(shared).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should connect when first subscriber subscribes', () => {
-    const source = cold(       '-1-2-3----4-|');
-    const sourceSubs =      '   ^           !';
-    const shared = source.pipe(share());
-    const subscriber1 = hot('   a|           ').pipe(mergeMapTo(shared));
-    const expected1 =       '   -1-2-3----4-|';
-    const subscriber2 = hot('       b|       ').pipe(mergeMapTo(shared));
-    const expected2 =       '       -3----4-|';
-    const subscriber3 = hot('           c|   ').pipe(mergeMapTo(shared));
-    const expected3 =       '           --4-|';
-
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should disconnect when last subscriber unsubscribes', () => {
-    const source =     cold(   '-1-2-3----4-|');
-    const sourceSubs =      '   ^        !   ';
-    const shared = source.pipe(share());
-    const subscriber1 = hot('   a|           ').pipe(mergeMapTo(shared));
-    const unsub1 =          '          !     ';
-    const expected1   =     '   -1-2-3--     ';
-    const subscriber2 = hot('       b|       ').pipe(mergeMapTo(shared));
-    const unsub2 =          '            !   ';
-    const expected2   =     '       -3----   ';
-
-    expectObservable(subscriber1, unsub1).toBe(expected1);
-    expectObservable(subscriber2, unsub2).toBe(expected2);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should not break unsubscription chain when last subscriber unsubscribes', () => {
-    const source =     cold(   '-1-2-3----4-|');
-    const sourceSubs =      '   ^        !   ';
-    const shared = source.pipe(
-      mergeMap((x: string) => of(x)),
-      share(),
-      mergeMap((x: string) => of(x))
-    );
-    const subscriber1 = hot('   a|           ').pipe(mergeMapTo(shared));
-    const unsub1 =          '          !     ';
-    const expected1   =     '   -1-2-3--     ';
-    const subscriber2 = hot('       b|       ').pipe(mergeMapTo(shared));
-    const unsub2 =          '            !   ';
-    const expected2   =     '       -3----   ';
-
-    expectObservable(subscriber1, unsub1).toBe(expected1);
-    expectObservable(subscriber2, unsub2).toBe(expected2);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should be retryable when cold source is synchronous', () => {
-    const source = cold('(123#)');
-    const shared = source.pipe(share());
-    const subscribe1 =  's         ';
-    const expected1 =   '(123123#) ';
-    const subscribe2 =  ' s        ';
-    const expected2 =   ' (123123#)';
-    const sourceSubs = ['(^!)',
-                      '(^!)',
-                      ' (^!)',
-                      ' (^!)'];
-
-    expectObservable(hot(subscribe1).pipe(tap(() => {
-      expectObservable(shared.pipe(retry(1))).toBe(expected1);
-    }))).toBe(subscribe1);
-
-    expectObservable(hot(subscribe2).pipe(tap(() => {
-      expectObservable(shared.pipe(retry(1))).toBe(expected2);
-    }))).toBe(subscribe2);
-
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should be repeatable when cold source is synchronous', () => {
-    const source = cold('(123|)');
-    const shared = source.pipe(share());
-    const subscribe1 =  's         ';
-    const expected1 =   '(123123|) ';
-    const subscribe2 =  ' s        ';
-    const expected2 =   ' (123123|)';
-    const sourceSubs = ['(^!)',
-                      '(^!)',
-                      ' (^!)',
-                      ' (^!)'];
-
-    expectObservable(hot(subscribe1).pipe(tap(() => {
-      expectObservable(shared.pipe(repeat(2))).toBe(expected1);
-    }))).toBe(subscribe1);
-
-    expectObservable(hot(subscribe2).pipe(tap(() => {
-      expectObservable(shared.pipe(repeat(2))).toBe(expected2);
-    }))).toBe(subscribe2);
-
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should be retryable', () => {
-    const source =     cold('-1-2-3----4-#                        ');
-    const sourceSubs =     ['^           !                        ',
-                          '            ^           !            ',
-                          '                        ^           !'];
-    const shared = source.pipe(share());
-    const subscribe1 =      's                                    ';
-    const expected1 =       '-1-2-3----4--1-2-3----4--1-2-3----4-#';
-    const subscribe2 =      '    s                                ';
-    const expected2 =       '    -3----4--1-2-3----4--1-2-3----4-#';
-
-    expectObservable(hot(subscribe1).pipe(tap(() => {
-      expectObservable(shared.pipe(retry(2))).toBe(expected1);
-    }))).toBe(subscribe1);
-
-    expectObservable(hot(subscribe2).pipe(tap(() => {
-      expectObservable(shared.pipe(retry(2))).toBe(expected2);
-    }))).toBe(subscribe2);
-
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should be repeatable', () => {
-    const source =     cold('-1-2-3----4-|                        ');
-    const sourceSubs =     ['^           !                        ',
-                          '            ^           !            ',
-                          '                        ^           !'];
-    const shared = source.pipe(share());
-    const subscribe1 =      's                                    ';
-    const expected1 =       '-1-2-3----4--1-2-3----4--1-2-3----4-|';
-    const subscribe2 =      '    s                                ';
-    const expected2 =       '    -3----4--1-2-3----4--1-2-3----4-|';
-
-    expectObservable(hot(subscribe1).pipe(tap(() => {
-      expectObservable(shared.pipe(repeat(3))).toBe(expected1);
-    }))).toBe(subscribe1);
-
-    expectObservable(hot(subscribe2).pipe(tap(() => {
-      expectObservable(shared.pipe(repeat(3))).toBe(expected2);
-    }))).toBe(subscribe2);
-
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-  });
-
-  it('should not change the output of the observable when never', () => {
-    const e1 = NEVER;
-    const expected = '-';
-
-    expectObservable(e1.pipe(share())).toBe(expected);
-  });
-
-  it('should not change the output of the observable when empty', () => {
-    const e1 = EMPTY;
-    const expected = '|';
-
-    expectObservable(e1.pipe(share())).toBe(expected);
-  });
-
-  // TODO: fix firehose unsubscription
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
-    const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
-      // This will check to see if the subscriber was closed on each loop
-      // when the unsubscribe hits (from the `take`), it should be closed
-      for (let i = 0; !subscriber.closed && i < 10; i++) {
-        sideEffects.push(i);
-        subscriber.next(i);
-      }
+      expect(subscriptionCount).to.equal(1);
     });
 
-    synchronousObservable.pipe(
-      share(),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    it('should not change the output of the observable when error', () => {
+      const e1 = hot('---a--^--b--c--d--e--#');
+      const e1subs =       '^              !';
+      const expected =     '---b--c--d--e--#';
 
-    expect(sideEffects).to.deep.equal([0, 1, 2]);
+      expectObservable(e1.pipe(share())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+
+    it('should not change the output of the observable when successful with cold observable', () => {
+      const e1 =  cold('---a--b--c--d--e--|');
+      const e1subs =   '^                 !';
+      const expected = '---a--b--c--d--e--|';
+
+      expectObservable(e1.pipe(share())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+
+    it('should not change the output of the observable when error with cold observable', () => {
+      const e1 =  cold('---a--b--c--d--e--#');
+      const e1subs =   '^                 !';
+      const expected = '---a--b--c--d--e--#';
+
+      expectObservable(e1.pipe(share())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+
+    it('should retry just fine', () => {
+      const e1 =  cold('---a--b--c--d--e--#');
+      const e1subs =  ['^                 !                  ',
+                    '                  ^                 !'];
+      const expected = '---a--b--c--d--e-----a--b--c--d--e--#';
+
+      expectObservable(e1.pipe(share(), retry(1))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+
+    it('should share the same values to multiple observers', () => {
+      const source =     cold('-1-2-3----4-|');
+      const sourceSubs =      '^           !';
+      const shared = source.pipe(share());
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
+      const expected1   =     '-1-2-3----4-|';
+      const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
+      const expected2   =     '    -3----4-|';
+      const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
+      const expected3   =     '        --4-|';
+
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should share an error from the source to multiple observers', () => {
+      const source =     cold('-1-2-3----4-#');
+      const sourceSubs =      '^           !';
+      const shared = source.pipe(share());
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
+      const expected1   =     '-1-2-3----4-#';
+      const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
+      const expected2   =     '    -3----4-#';
+      const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
+      const expected3   =     '        --4-#';
+
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should share the same values to multiple observers, ' +
+    'but is unsubscribed explicitly and early', () => {
+      const source =     cold('-1-2-3----4-|');
+      const sourceSubs =      '^        !   ';
+      const shared = source.pipe(share());
+      const unsub =           '         !   ';
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(shared));
+      const expected1   =     '-1-2-3----   ';
+      const subscriber2 = hot('    b|       ').pipe(mergeMapTo(shared));
+      const expected2   =     '    -3----   ';
+      const subscriber3 = hot('        c|   ').pipe(mergeMapTo(shared));
+      const expected3   =     '        --   ';
+
+      expectObservable(subscriber1, unsub).toBe(expected1);
+      expectObservable(subscriber2, unsub).toBe(expected2);
+      expectObservable(subscriber3, unsub).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should share an empty source', () => {
+      const source = cold('|');
+      const sourceSubs =  '(^!)';
+      const shared = source.pipe(share());
+      const expected =    '|';
+
+      expectObservable(shared).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should share a never source', () => {
+      const source = cold('-');
+      const sourceSubs =  '^';
+      const shared = source.pipe(share());
+      const expected =    '-';
+
+      expectObservable(shared).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should share a throw source', () => {
+      const source = cold('#');
+      const sourceSubs =  '(^!)';
+      const shared = source.pipe(share());
+      const expected =    '#';
+
+      expectObservable(shared).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should connect when first subscriber subscribes', () => {
+      const source = cold(       '-1-2-3----4-|');
+      const sourceSubs =      '   ^           !';
+      const shared = source.pipe(share());
+      const subscriber1 = hot('   a|           ').pipe(mergeMapTo(shared));
+      const expected1 =       '   -1-2-3----4-|';
+      const subscriber2 = hot('       b|       ').pipe(mergeMapTo(shared));
+      const expected2 =       '       -3----4-|';
+      const subscriber3 = hot('           c|   ').pipe(mergeMapTo(shared));
+      const expected3 =       '           --4-|';
+
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should disconnect when last subscriber unsubscribes', () => {
+      const source =     cold(   '-1-2-3----4-|');
+      const sourceSubs =      '   ^        !   ';
+      const shared = source.pipe(share());
+      const subscriber1 = hot('   a|           ').pipe(mergeMapTo(shared));
+      const unsub1 =          '          !     ';
+      const expected1   =     '   -1-2-3--     ';
+      const subscriber2 = hot('       b|       ').pipe(mergeMapTo(shared));
+      const unsub2 =          '            !   ';
+      const expected2   =     '       -3----   ';
+
+      expectObservable(subscriber1, unsub1).toBe(expected1);
+      expectObservable(subscriber2, unsub2).toBe(expected2);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should not break unsubscription chain when last subscriber unsubscribes', () => {
+      const source =     cold(   '-1-2-3----4-|');
+      const sourceSubs =      '   ^        !   ';
+      const shared = source.pipe(
+        mergeMap((x: string) => of(x)),
+        share(),
+        mergeMap((x: string) => of(x))
+      );
+      const subscriber1 = hot('   a|           ').pipe(mergeMapTo(shared));
+      const unsub1 =          '          !     ';
+      const expected1   =     '   -1-2-3--     ';
+      const subscriber2 = hot('       b|       ').pipe(mergeMapTo(shared));
+      const unsub2 =          '            !   ';
+      const expected2   =     '       -3----   ';
+
+      expectObservable(subscriber1, unsub1).toBe(expected1);
+      expectObservable(subscriber2, unsub2).toBe(expected2);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should be retryable when cold source is synchronous', () => {
+      const source = cold('(123#)');
+      const shared = source.pipe(share());
+      const subscribe1 =  's         ';
+      const expected1 =   '(123123#) ';
+      const subscribe2 =  ' s        ';
+      const expected2 =   ' (123123#)';
+      const sourceSubs = ['(^!)',
+                        '(^!)',
+                        ' (^!)',
+                        ' (^!)'];
+
+      expectObservable(hot(subscribe1).pipe(tap(() => {
+        expectObservable(shared.pipe(retry(1))).toBe(expected1);
+      }))).toBe(subscribe1);
+
+      expectObservable(hot(subscribe2).pipe(tap(() => {
+        expectObservable(shared.pipe(retry(1))).toBe(expected2);
+      }))).toBe(subscribe2);
+
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should be repeatable when cold source is synchronous', () => {
+      const source = cold('(123|)');
+      const shared = source.pipe(share());
+      const subscribe1 =  's         ';
+      const expected1 =   '(123123|) ';
+      const subscribe2 =  ' s        ';
+      const expected2 =   ' (123123|)';
+      const sourceSubs = ['(^!)',
+                        '(^!)',
+                        ' (^!)',
+                        ' (^!)'];
+
+      expectObservable(hot(subscribe1).pipe(tap(() => {
+        expectObservable(shared.pipe(repeat(2))).toBe(expected1);
+      }))).toBe(subscribe1);
+
+      expectObservable(hot(subscribe2).pipe(tap(() => {
+        expectObservable(shared.pipe(repeat(2))).toBe(expected2);
+      }))).toBe(subscribe2);
+
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should be retryable', () => {
+      const source =     cold('-1-2-3----4-#                        ');
+      const sourceSubs =     ['^           !                        ',
+                            '            ^           !            ',
+                            '                        ^           !'];
+      const shared = source.pipe(share());
+      const subscribe1 =      's                                    ';
+      const expected1 =       '-1-2-3----4--1-2-3----4--1-2-3----4-#';
+      const subscribe2 =      '    s                                ';
+      const expected2 =       '    -3----4--1-2-3----4--1-2-3----4-#';
+
+      expectObservable(hot(subscribe1).pipe(tap(() => {
+        expectObservable(shared.pipe(retry(2))).toBe(expected1);
+      }))).toBe(subscribe1);
+
+      expectObservable(hot(subscribe2).pipe(tap(() => {
+        expectObservable(shared.pipe(retry(2))).toBe(expected2);
+      }))).toBe(subscribe2);
+
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should be repeatable', () => {
+      const source =     cold('-1-2-3----4-|                        ');
+      const sourceSubs =     ['^           !                        ',
+                              '            ^           !            ',
+                              '                        ^           !'];
+      const shared = source.pipe(share());
+      const subscribe1 =      's                                    ';
+      const expected1 =       '-1-2-3----4--1-2-3----4--1-2-3----4-|';
+      const subscribe2 =      '    s                                ';
+      const expected2 =       '    -3----4--1-2-3----4--1-2-3----4-|';
+
+      expectObservable(hot(subscribe1).pipe(tap(() => {
+        expectObservable(shared.pipe(repeat(3))).toBe(expected1);
+      }))).toBe(subscribe1);
+
+      expectObservable(hot(subscribe2).pipe(tap(() => {
+        expectObservable(shared.pipe(repeat(3))).toBe(expected2);
+      }))).toBe(subscribe2);
+
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+
+    it('should not change the output of the observable when never', () => {
+      const e1 = NEVER;
+      const expected = '-';
+
+      expectObservable(e1.pipe(share())).toBe(expected);
+    });
+
+    it('should not change the output of the observable when empty', () => {
+      const e1 = EMPTY;
+      const expected = '|';
+
+      expectObservable(e1.pipe(share())).toBe(expected);
+    });
+
+    // TODO: fix firehose unsubscription
+    it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
+      const sideEffects: number[] = [];
+      const synchronousObservable = new Observable<number>(subscriber => {
+        // This will check to see if the subscriber was closed on each loop
+        // when the unsubscribe hits (from the `take`), it should be closed
+        for (let i = 0; !subscriber.closed && i < 10; i++) {
+          sideEffects.push(i);
+          subscriber.next(i);
+        }
+      });
+
+      synchronousObservable.pipe(
+        share(),
+        take(3),
+      ).subscribe(() => { /* noop */ });
+
+      expect(sideEffects).to.deep.equal([0, 1, 2]);
+    });
+  });
+
+  describe('share(config)', () => {
+    let rxTest: TestScheduler;
+    
+    beforeEach(() => {
+      rxTest = new TestScheduler(observableMatcher);
+    });
+
+    it('should not reset on error if configured to do so', () => {
+      rxTest.run(({ hot, expectObservable, expectSubscriptions }) => {
+        const source = hot('---a---b---c---d---e---f----#');
+        const expected = '  ---a---b---c---d---e---f----#';
+        const sourceSubs = [
+          '                 ^----------!',
+          '                 -----------^-----------!',
+          '                 -----------------------^----!'
+        ];
+        const result = source.pipe(
+          // takes a, b, c... then repeat causes it to take d, e, f
+          take(3),
+          share({
+            resetOnError: false
+          }),
+          repeat()
+        );
+
+        expectObservable(result).toBe(expected);
+        expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      });
+    });
+
+    it('should not reset on complete if configured to do so', () => {
+      rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const source = cold('---a---b---c---#');
+        const expected = '   ---a---b---c------a---b---c------a---b---|';
+        const sourceSubs = [
+          '                  ^--------------!',
+          '                  ---------------^--------------!',
+          '                  ------------------------------^----------!'
+        ];
+
+        // Used to trigger the source to complete at a given moment.
+        const triggerComplete = new Subject<void>();
+
+        // just used to count how many values have made it through the share.
+        let count = 0;
+
+        const result = source.pipe(
+          takeUntil(triggerComplete),
+          share({
+            resetOnComplete: false
+          }),
+          // Retry on any error.
+          retry(),
+          tap(() => {
+            if (++count === 9) {
+              // If we see the ninth value, complete the source this time.
+              triggerComplete.next();
+            }
+          })
+        );
+
+        expectObservable(result).toBe(expected);
+        expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      });
+    });
+
+    it('should not reset on refCount 0 if configured to do so', () => {
+      rxTest.run(({ hot, expectObservable, expectSubscriptions }) => {
+        const source = hot('  ---v---v---v---E--v---v---v---C---v----v------v---');
+        const expected = '    ---v---v---v------v---v---v-------v----v----';
+        const subscription = '^-------------------------------------------!';
+        const sourceSubs = [
+          '                   ^--------------!',
+          '                   ---------------^--------------!',
+          // Note this last subscription never ends, because refCount hitting zero isn't going to reset.
+          '                   ------------------------------^--------------'
+        ];
+
+        const result = source.pipe(
+          tap(value => {
+            if (value === 'E') {
+              throw new Error('E');
+            }
+          }),
+          takeWhile(value => value !== 'C'),
+          share({
+            resetOnRefCountZero: false
+          }),
+          retry(),
+          repeat(),
+        );
+
+        expectObservable(result, subscription).toBe(expected);
+        expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      });
+    });
+
+    it('should use the connector function provided', () => {
+      const connector = sinon.spy(() => new Subject());
+
+      rxTest.run(({ hot, expectObservable }) => {
+        const source = hot('  ---v---v---v---E--v---v---v---C---v----v--------v----v---');
+        const subs1 = '       ^-------------------------------------------!';
+        const expResult1 = '  ---v---v---v------v---v---v-------v----v-----';
+        const subs2 = '       ----------------------------------------------^---------!';
+        const expResult2 = '  ------------------------------------------------v----v---';
+
+        
+        const result = source.pipe(
+          tap(value => {
+            if (value === 'E') {
+              throw new Error('E');
+            }
+          }),
+          takeWhile(value => value !== 'C'),
+          share({
+            connector
+          }),
+          retry(),
+          repeat(),
+        );
+
+        expectObservable(result, subs1).toBe(expResult1);
+        expectObservable(result, subs2).toBe(expResult2);
+      });
+      
+      expect(connector).to.have.callCount(4);
+    })
   });
 });

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -387,13 +387,16 @@ describe('TestScheduler', () => {
         expect(expectObservable).to.be.a('function');
         expect(expectSubscriptions).to.be.a('function');
 
-        const obs1 = cold('-a-c-e|');
+      const obs1 = cold('-a-c-e|');
         const obs2 = hot(' ^-b-d-f|');
         const output = merge(obs1, obs2);
         const expected = ' -abcdef|';
 
         expectObservable(output).toBe(expected);
         expectObservable(output).toEqual(cold(expected));
+        // There are two subscriptions to each of these, because we merged
+        // them together, then we subscribed to the merged result once
+        // to check `toBe` and another time to check `toEqual`.
         expectSubscriptions(obs1.subscriptions).toBe(['^-----!', '^-----!']);
         expectSubscriptions(obs2.subscriptions).toBe(['^------!', '^------!']);
       });

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -393,8 +393,9 @@ describe('TestScheduler', () => {
         const expected = ' -abcdef|';
 
         expectObservable(output).toBe(expected);
-        expectSubscriptions(obs1.subscriptions).toBe('^-----!');
-        expectSubscriptions(obs2.subscriptions).toBe('^------!');
+        expectObservable(output).toEqual(cold(expected));
+        expectSubscriptions(obs1.subscriptions).toBe(['^-----!', '^-----!']);
+        expectSubscriptions(obs2.subscriptions).toBe(['^------!', '^------!']);
       });
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -51,6 +51,7 @@ export { bindCallback } from './internal/observable/bindCallback';
 export { bindNodeCallback } from './internal/observable/bindNodeCallback';
 export { combineLatest } from './internal/observable/combineLatest';
 export { concat } from './internal/observable/concat';
+export { connectable } from './internal/observable/connectable';
 export { defer } from './internal/observable/defer';
 export { empty } from './internal/observable/empty';
 export { forkJoin } from './internal/observable/forkJoin';

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -4,7 +4,7 @@
 import { Operator } from './Operator';
 import { SafeSubscriber, Subscriber } from './Subscriber';
 import { isSubscription, Subscription } from './Subscription';
-import { TeardownLogic, OperatorFunction, PartialObserver, Subscribable, Observer } from './types';
+import { TeardownLogic, OperatorFunction, Subscribable, Observer } from './types';
 import { observable as Symbol_observable } from './symbol/observable';
 import { pipeFromArray } from './util/pipe';
 import { config } from './config';
@@ -68,7 +68,7 @@ export class Observable<T> implements Subscribable<T> {
     return observable;
   }
 
-  subscribe(observer?: PartialObserver<T>): Subscription;
+  subscribe(observer?: Partial<Observer<T>>): Subscription;
   /** @deprecated Use an observer instead of a complete callback */
   subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
   /** @deprecated Use an observer instead of an error callback */
@@ -202,7 +202,7 @@ export class Observable<T> implements Subscribable<T> {
    * @method subscribe
    */
   subscribe(
-    observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
+    observerOrNext?: Partial<Observer<T>> | ((value: T) => void) | null,
     error?: ((error: any) => void) | null,
     complete?: (() => void) | null
   ): Subscription {

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -204,7 +204,7 @@ function handleStoppedNotification(notification: ObservableNotification<any>, su
  * pass any arguments to `subscribe`. Comes with the default error handling
  * behavior.
  */
-export const EMPTY_OBSERVER: Readonly<Observer<any>> = {
+export const EMPTY_OBSERVER: Readonly<Observer<any>> & { closed: true } = {
   closed: true,
   next: noop,
   error: defaultErrorHandler,

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { isFunction } from './util/isFunction';
-import { Observer, PartialObserver, ObservableNotification } from './types';
+import { Observer, ObservableNotification } from './types';
 import { isSubscription, Subscription } from './Subscription';
 import { config } from './config';
 import { reportUnhandledError } from './util/reportUnhandledError';
@@ -126,7 +126,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
 
 export class SafeSubscriber<T> extends Subscriber<T> {
   constructor(
-    observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
+    observerOrNext?: Partial<Observer<T>> | ((value: T) => void) | null,
     error?: ((e?: any) => void) | null,
     complete?: (() => void) | null
   ) {

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -8,12 +8,25 @@ import { OperatorSubscriber } from '../operators/OperatorSubscriber';
 
 /**
  * @class ConnectableObservable<T>
+ * @deprecated To be removed in version 8. Please use {@link connectable} to create a connectable observable.
+ * If you are using the `refCount` method of `ConnectableObservable` you can use the updated {@link share} operator
+ * instead, which is now highly configurable.
  */
 export class ConnectableObservable<T> extends Observable<T> {
   protected _subject: Subject<T> | null = null;
   protected _refCount: number = 0;
   protected _connection: Subscription | null = null;
 
+  /**
+   * @param source The source observable
+   * @param subjectFactory The factory that creates the subject used internally.
+   * @deprecated To be removed in version 8. Please use {@link connectable} to create a connectable observable.
+   * If you are using the `refCount` method of `ConnectableObservable` you can use the {@link share} operator
+   * instead, which is now highly configurable. `new ConnectableObservable(source, fn)` is equivalent
+   * to `connectable(source, fn)`. With the exception of when the `refCount()` method is needed, in which
+   * case, the new {@link share} operator should be used: `new ConnectableObservable(source, fn).refCount()`
+   * is equivalent to `source.pipe(share({ connector: fn }))`.
+   */
   constructor(public source: Observable<T>, protected subjectFactory: () => Subject<T>) {
     super();
   }
@@ -68,6 +81,10 @@ export class ConnectableObservable<T> extends Observable<T> {
     return connection;
   }
 
+  /**
+   * @deprecated The {@link ConnectableObservable} class is scheduled for removal in version 8.
+   * Please use the {@link share} operator, which is now highly configurable.
+   */
   refCount(): Observable<T> {
     return higherOrderRefCount()(this) as Observable<T>;
   }

--- a/src/internal/observable/connectable.ts
+++ b/src/internal/observable/connectable.ts
@@ -6,7 +6,11 @@ import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
 import { defer } from './defer';
 
-export type ConnectableObservableLike<T> = Observable<T> & {
+/**
+ * An observable with a `connect` method that is used to create a subscription
+ * to an underlying source, connecting it with all consumers via a multicast.
+ */
+export interface ConnectableObservableLike<T> extends Observable<T> {
   /**
    * (Idempotent) Calling this method will connect the underlying source observable to all subscribed consumers
    * through an underlying {@link Subject}.
@@ -14,7 +18,7 @@ export type ConnectableObservableLike<T> = Observable<T> & {
    * severing notifications to all consumers.
    */
   connect(): Subscription;
-};
+}
 
 /**
  * Creates an observable that multicasts once `connect()` is called on it.

--- a/src/internal/observable/connectable.ts
+++ b/src/internal/observable/connectable.ts
@@ -1,0 +1,47 @@
+/** @prettier */
+
+import { ObservableInput } from '../types';
+import { Subject } from '../Subject';
+import { Subscription } from '../Subscription';
+import { Observable } from '../Observable';
+import { defer } from './defer';
+
+export type ConnectableObservableLike<T> = Observable<T> & {
+  /**
+   * (Idempotent) Calling this method will connect the underlying source observable to all subscribed consumers
+   * through an underlying {@link Subject}.
+   * @returns A subscription, that when unsubscribed, will "disconnect" the source from the connector subject,
+   * severing notifications to all consumers.
+   */
+  connect(): Subscription;
+};
+
+/**
+ * Creates an observable that multicasts once `connect()` is called on it.
+ *
+ * @param source The observable source to make connectable.
+ * @param connector The subject to used to multicast the source observable to all subscribers.
+ * Defaults to a new {@link Subject}.
+ * @returns A "connectable" observable, that has a `connect()` method, that you must call to
+ * connect the source to all consumers through the subject provided as the connector.
+ */
+export function connectable<T>(source: ObservableInput<T>, connector: Subject<T> = new Subject<T>()): ConnectableObservableLike<T> {
+  // The subscription representing the connection.
+  let connection: Subscription | null = null;
+
+  const result: any = new Observable<T>((subscriber) => {
+    return connector.subscribe(subscriber);
+  });
+
+  // Define the `connect` function. This is what users must call
+  // in order to "connect" the source to the subject that is
+  // multicasting it.
+  result.connect = () => {
+    if (!connection) {
+      connection = defer(() => source).subscribe(connector);
+    }
+    return connection;
+  };
+
+  return result;
+}

--- a/src/internal/observable/fromSubscribable.ts
+++ b/src/internal/observable/fromSubscribable.ts
@@ -1,0 +1,18 @@
+/** @prettier */
+import { Observable } from '../Observable';
+import { Subscriber } from '../Subscriber';
+import { Subscribable } from '../types';
+
+/**
+ * Used to convert a subscribable to an observable.
+ *
+ * Currently, this is only used within internals.
+ *
+ * TODO: Discuss ObservableInput supporting "Subscribable".
+ * https://github.com/ReactiveX/rxjs/issues/5909
+ *
+ * @param subscribable A subscribable
+ */
+export function fromSubscribable<T>(subscribable: Subscribable<T>) {
+  return new Observable((subscriber: Subscriber<T>) => subscribable.subscribe(subscriber));
+}

--- a/src/internal/operators/connect.ts
+++ b/src/internal/operators/connect.ts
@@ -1,0 +1,111 @@
+/** @prettier */
+import { OperatorFunction, ObservableInput, SubjectLike } from '../types';
+import { Observable } from '../Observable';
+import { Subject } from '../Subject';
+import { from } from '../observable/from';
+import { operate } from '../util/lift';
+import { fromSubscribable } from '../observable/fromSubscribable';
+
+/**
+ * The default connector function used for `connect`.
+ * A factory function that will create a {@link Subject}.
+ */
+function defaultConnector<T>() {
+  return new Subject<T>();
+}
+
+/**
+ * Creates an observable by multicasting the source within a function that
+ * allows the developer to define the usage of the multicast prior to connection.
+ *
+ * This is particularly useful if the observable source you wish to multicast could
+ * be synchronous or asynchronous. This sets it apart from {@link share}, which, in the
+ * case of totally synchronous sources will fail to share a single subscription with
+ * multiple consumers, as by the time the subscription to the result of {@link share}
+ * has returned, if the source is synchronous its internal reference count will jump from
+ * 0 to 1 back to 0 and reset.
+ *
+ * To use `connect`, you provide a `setup` function via configuration that will give you
+ * a multicast observable that is not yet connected. You then use that multicast observable
+ * to create a resulting observable that, when subscribed, will set up your multicast. This is
+ * generally, but not always, accomplished with {@link merge}.
+ *
+ * Note that using a {@link takeUntil} inside of `connect`'s `setup` _might_ mean you were looking
+ * to use the {@link takeWhile} operator instead.
+ *
+ * When you subscribe to the result of `connect`, the `setup` function will be called. After
+ * the `setup` function returns, the observable it returns will be subscribed to, _then_ the
+ * multicast will be connected to the source.
+ *
+ * ### Example
+ *
+ * Sharing a totally synchronous observable
+ *
+ * ```ts
+ * import { defer, of } from 'rxjs';
+ * import { tap, connect } from 'rxjs/operators';
+ *
+ * const source$ = defer(() => {
+ *  console.log('subscription started');
+ *  return of(1, 2, 3, 4, 5).pipe(
+ *    tap(n => console.log(`source emitted ${n}`))
+ *  );
+ * });
+ *
+ * source$.pipe(
+ *  connect({
+ *    // Notice in here we're merging three subscriptions to `shared$`.
+ *    setup: (shared$) => merge(
+ *      shared$.pipe(map(n => `all ${n}`)),
+ *      shared$.pipe(filter(n => n % 2 === 0), map(n => `even ${n}`)),
+ *      shared$.pipe(filter(n => n % 2 === 1), map(n => `odd ${n}`)),
+ *    )
+ *  })
+ * )
+ * .subscribe(console.log);
+ *
+ * // Expected output: (notice only one subscription)
+ * "subscription started"
+ * "source emitted 1"
+ * "all 1"
+ * "odd 1"
+ * "source emitted 2"
+ * "all 2"
+ * "even 2"
+ * "source emitted 3"
+ * "all 3"
+ * "odd 3"
+ * "source emitted 4"
+ * "all 4"
+ * "even 4"
+ * "source emitted 5"
+ * "all 5"
+ * "odd 5"
+ * ```
+ *
+ * @param param0 The configuration object for `connect`.
+ */
+export function connect<T, R>({
+  connector = defaultConnector,
+  setup,
+}: {
+  /**
+   * A factory function used to create the Subject through which the source
+   * is multicast. By default this creates a {@link Subject}.
+   */
+  connector?: () => SubjectLike<T>;
+  /**
+   * A function used to set up the multicast. Gives you a multicast observable
+   * that is not yet connected. With that, you're expected to create and return
+   * and Observable, that when subscribed to, will utilize the multicast observable.
+   * After this function is executed -- and its return value subscribed to -- the
+   * the operator will subscribe to the source, and the connection will be made.
+   */
+  setup: (shared: Observable<T>) => ObservableInput<R>;
+}): OperatorFunction<T, R> {
+  return operate((source, subscriber) => {
+    const subject = connector();
+    from(setup(fromSubscribable(subject))).subscribe(subscriber);
+    subscriber.add(source.subscribe(subject));
+  });
+}

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -58,9 +58,9 @@ export function multicast<T>(subjectFactory: () => Subject<T>): UnaryFunction<Ob
  * {@link connect} operator.
  *
  * @param subjectFactory A factory that creates the subject used to multicast.
- * @param selector A setup function to setup the multicast
+ * @param selector A function to setup the multicast and select the output.
  * @deprecated To be removed in version 8. Please use the new {@link connect} operator.
- * `multicast(fn1, fn2)` is equivalent to `connect({ connector: fn1, setup: fn2 })`.
+ * `multicast(subjectFactor, selector)` is equivalent to `connect(selector, { connector: subjectFactory })`.
  */
 export function multicast<T, O extends ObservableInput<any>>(
   subjectFactory: () => Subject<T>,
@@ -77,9 +77,8 @@ export function multicast<T, R>(
     // If a selector function is provided, then we're a "normal" operator that isn't
     // going to return a ConnectableObservable. We can use `connect` to do what we
     // need to do.
-    return connect({
+    return connect(selector, {
       connector: subjectFactory,
-      setup: selector,
     });
   }
 

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -28,7 +28,7 @@ export function publish<T>(): UnaryFunction<Observable<T>, ConnectableObservable
  * @param selector A function used to setup multicasting prior to automatic connection.
  *
  * @deprecated To be removed in version 8. Use the new {@link connect} operator.
- * If you're using `publish(fn)`, it is equivalent to `connect({ setup: fn })`.
+ * If you're using `publish(fn)`, it is equivalent to `connect(fn)`.
  */
 export function publish<T, O extends ObservableInput<any>>(selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
 
@@ -79,10 +79,5 @@ export function publish<T, O extends ObservableInput<any>>(selector: (shared: Ob
  * @return A ConnectableObservable that upon connection causes the source Observable to emit items to its Observers.
  */
 export function publish<T, R>(selector?: OperatorFunction<T, R>): MonoTypeOperatorFunction<T> | OperatorFunction<T, R> {
-  return selector
-    ? connect({
-        connector: () => new Subject<T>(),
-        setup: selector,
-      })
-    : multicast(new Subject<T>());
+  return selector ? connect(selector) : multicast(new Subject<T>());
 }

--- a/src/internal/operators/publishBehavior.ts
+++ b/src/internal/operators/publishBehavior.ts
@@ -1,13 +1,22 @@
 import { Observable } from '../Observable';
 import { BehaviorSubject } from '../BehaviorSubject';
-import { multicast } from './multicast';
 import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { UnaryFunction } from '../types';
 
 /**
- * @param value
+ * Creates a {@link ConnectableObservable} that utilizes a {@link BehaviorSubject}.
+ * 
+ * @param initialValue The initial value passed to the {@link BehaviorSubject}.
  * @return {ConnectableObservable<T>}
+ * @deprecated to be removed in version 8. If you want to get a connectable observable that uses a 
+ * {@link BehaviorSubject} under the hood, please use {@link connectable}. `source.pipe(publishBehavior(initValue))` 
+ * is equivalent to: `connectable(source, () => new BehaviorSubject(initValue))`.
+ * If you're using {@link refCount} after the call to `publishBehavior`, use the {@link share} operator, which is now
+ * highly configurable. `source.pipe(publishBehavior(initValue), refCount())` is equivalent to:
+ * `source.pipe(share({ connector: () => new BehaviorSubject(initValue), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false  }))`.
  */
-export function publishBehavior<T>(value: T):  UnaryFunction<Observable<T>, ConnectableObservable<T>> {
-  return (source: Observable<T>) => multicast(new BehaviorSubject<T>(value))(source) as ConnectableObservable<T>;
+export function publishBehavior<T>(initialValue: T):  UnaryFunction<Observable<T>, ConnectableObservable<T>> {
+  const subject = new BehaviorSubject<T>(initialValue);
+  // Note that this has *never* supported the selector function.
+  return (source) => new ConnectableObservable(source, () => subject);
 }

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -1,6 +1,5 @@
 import { Observable } from '../Observable';
 import { AsyncSubject } from '../AsyncSubject';
-import { multicast } from './multicast';
 import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { UnaryFunction } from '../types';
 
@@ -51,14 +50,17 @@ import { UnaryFunction } from '../types';
  * //    "Sub. B Complete"
  * ```
  *
- * @see {@link ConnectableObservable}
- * @see {@link publish}
- * @see {@link publishReplay}
- * @see {@link publishBehavior}
- *
- * @return {ConnectableObservable} An observable sequence that contains the elements of a
+ * @return A connectable observable sequence that contains the elements of a
  * sequence produced by multicasting the source sequence.
+ * @deprecated To be removed in version 8. If you're trying to create a connectable observable
+ * with an {@link AsyncSubject} under the hood, please use the new {@link connectable} creation function.
+ * `source.pipe(publishLast())` is equivalent to `connectable(source, () => new AsyncSubject())`.
+ * If you're using {@link refCount} on the result of `publishLast`, you can use the updated {@link share}
+ * operator, which is now highly configurable. `source.pipe(publishLast(), refCount())`
+ * is equivalent to `source.pipe(share({ connector: () => new AsyncSubject(), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))`.
  */
 export function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>> {
-  return (source: Observable<T>) => multicast(new AsyncSubject<T>())(source);
+  const subject = new AsyncSubject<T>();
+  // Note that this has *never* supported a selector function like `publish` and `publishReplay`.
+  return (source) => new ConnectableObservable(source, () => subject);
 }

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -2,32 +2,88 @@
 import { Observable } from '../Observable';
 import { ReplaySubject } from '../ReplaySubject';
 import { multicast } from './multicast';
-import { ConnectableObservable } from '../observable/ConnectableObservable';
-import { UnaryFunction, MonoTypeOperatorFunction, OperatorFunction, SchedulerLike, ObservableInput, ObservedValueOf } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, TimestampProvider, ObservableInput, ObservedValueOf } from '../types';
 import { isFunction } from '../util/isFunction';
 
-/* tslint:disable:max-line-length */
-export function publishReplay<T>(bufferSize?: number, windowTime?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export function publishReplay<T, O extends ObservableInput<any>>(
+/**
+ * Creates a {@link ConnectableObservable} that uses a {@link ReplaySubject}
+ * internally.
+ *
+ * @param bufferSize The buffer size for the underlying {@link ReplaySubject}.
+ * @param windowTime The window time for the underlying {@link ReplaySubject}.
+ * @param timestampProvider The timestamp provider for the underlying {@link ReplaySubject}.
+ * @deprecated To be removed in version 8. Use the new {@link connectable} create method to create
+ * a connectable observable. `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
+ * `connectable(source, () => new ReplaySubject(size, time, scheduler))`.
+ * If you're using this with {@link refCount}, then use the new {@link share} operator,
+ * which is now highly configurable. `publishReplay(size, time, scheduler), refCount()`
+ * is equivalent to `share({ connector: () => new ReplaySubject(size, time, scheduler) })`.
+ */
+export function publishReplay<T>(
   bufferSize?: number,
   windowTime?: number,
-  selector?: (shared: Observable<T>) => O,
-  scheduler?: SchedulerLike
+  timestampProvider?: TimestampProvider
+): MonoTypeOperatorFunction<T>;
+
+/**
+ * Creates an observable, that when subscribed to, will create a {@link ReplaySubject},
+ * and pass an observable from it (using {@link asObservable}) to the `selector`
+ * function, which then returns an observable that is subscribed to before "connecting"
+ * the source to the internal `ReplaySubject`.
+ *
+ * Since this is deprecated, for additional details see the documentation for {@link connect}.
+ *
+ * @param bufferSize The buffer size for the underlying {@link ReplaySubject}.
+ * @param windowTime The window time for the underlying {@link ReplaySubject}.
+ * @param selector A function used to setup the multicast.
+ * @param timestampProvider The timestamp provider for the underlying {@link ReplaySubject}.
+ * @deprecated To be removed in version 8. Use the new {@link connect} operator.
+ * `source.pipe(publishReplay(size, window, fn, scheduler))` is equivalent to
+ * `const subject = new ReplaySubject(size, window, scheduler), connect({ connector: () => subject, setup: fn })`.
+ */
+export function publishReplay<T, O extends ObservableInput<any>>(
+  bufferSize: number | undefined,
+  windowTime: number | undefined,
+  selector: OperatorFunction<T, ObservedValueOf<O>>,
+  timestampProvider?: TimestampProvider
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/* tslint:enable:max-line-length */
+
+/**
+ * Creates a {@link ConnectableObservable} that uses a {@link ReplaySubject}
+ * internally.
+ *
+ * @param bufferSize The buffer size for the underlying {@link ReplaySubject}.
+ * @param windowTime The window time for the underlying {@link ReplaySubject}.
+ * @param selector Passing `undefined` here determines that this operator will return a {@link ConnectableObservable}.
+ * @param timestampProvider The timestamp provider for the underlying {@link ReplaySubject}.
+ * @deprecated To be removed in version 8. Use the new {@link connectable} create method to create
+ * a connectable observable. `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
+ * `connectable(source, () => new ReplaySubject(size, time, scheduler))`.
+ * If you're using this with {@link refCount}, then use the new {@link share} operator,
+ * which is now highly configurable. `publishReplay(size, time, scheduler), refCount()`
+ * is equivalent to `share({ connector: () => new ReplaySubject(size, time, scheduler) })`.
+ */
+export function publishReplay<T, O extends ObservableInput<any>>(
+  bufferSize: number | undefined,
+  windowTime: number | undefined,
+  selector: undefined,
+  timestampProvider: TimestampProvider
+): OperatorFunction<T, ObservedValueOf<O>>;
 
 export function publishReplay<T, R>(
   bufferSize?: number,
   windowTime?: number,
-  selectorOrScheduler?: SchedulerLike | OperatorFunction<T, R>,
-  scheduler?: SchedulerLike
-): UnaryFunction<Observable<T>, ConnectableObservable<R>> {
+  selectorOrScheduler?: TimestampProvider | OperatorFunction<T, R>,
+  timestampProvider?: TimestampProvider
+) {
   if (selectorOrScheduler && !isFunction(selectorOrScheduler)) {
-    scheduler = selectorOrScheduler;
+    timestampProvider = selectorOrScheduler;
   }
 
   const selector = isFunction(selectorOrScheduler) ? selectorOrScheduler : undefined;
-  const subject = new ReplaySubject<T>(bufferSize, windowTime, scheduler);
+  const subject = new ReplaySubject<T>(bufferSize, windowTime, timestampProvider);
 
-  return (source: Observable<T>) => multicast(() => subject, selector!)(source) as ConnectableObservable<R>;
+  // Note, we're passing `selector!` here, because at runtime, `undefined` is an acceptable argument
+  // but it makes our TypeScript signature for `multicast` unhappy (as it should, because it's gross).
+  return (source: Observable<T>) => multicast(subject, selector!)(source);
 }

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -39,7 +39,7 @@ export function publishReplay<T>(
  * @param timestampProvider The timestamp provider for the underlying {@link ReplaySubject}.
  * @deprecated To be removed in version 8. Use the new {@link connect} operator.
  * `source.pipe(publishReplay(size, window, fn, scheduler))` is equivalent to
- * `const subject = new ReplaySubject(size, window, scheduler), connect({ connector: () => subject, setup: fn })`.
+ * `const subject = new ReplaySubject(size, window, scheduler), source.pipe(connect(fn, { connector: () => subject }))`.
  */
 export function publishReplay<T, O extends ObservableInput<any>>(
   bufferSize: number | undefined,

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -44,7 +44,7 @@ export function publishReplay<T>(
 export function publishReplay<T, O extends ObservableInput<any>>(
   bufferSize: number | undefined,
   windowTime: number | undefined,
-  selector: OperatorFunction<T, ObservedValueOf<O>>,
+  selector: (shared: Observable<T>) => O,
   timestampProvider?: TimestampProvider
 ): OperatorFunction<T, ObservedValueOf<O>>;
 

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -1,5 +1,5 @@
-import { ConnectableObservable } from '../observable/ConnectableObservable';
 /** @prettier */
+import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
@@ -15,7 +15,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * refCount has only a single subscription independently of the number of subscribers to the target
  * observable.
  *
- * Note that using the {@link share} operator is exactly the same as using the `multicast(() => new Subject())` operator 
+ * Note that using the {@link share} operator is exactly the same as using the `multicast(() => new Subject())` operator
  * (making the observable hot) and the *refCount* operator in a sequence.
  *
  * ![](refCount.png)
@@ -54,9 +54,11 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * // Nothing happens until you call .connect() on the observable.
  * ```
  *
- * @see {@link ConnectableObservable}
- * @see {@link share}
- * @see {@link publish}
+ * @deprecated to be removed in version 8. Use the updated {@link share} operator,
+ * which now is highly configurable. How `share` is used will depend on the connectable
+ * observable you created just prior to the `refCount` operator. For examples on how
+ * to replace this, see documentation in {@link multicast}, {@link publish}, {@link publishReplay},
+ * {@link publishBehavior}, {@link publishLast} or {@link ConnectableObservable}.
  */
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -7,7 +7,7 @@ import { Subscription } from '../Subscription';
 import { from } from '../observable/from';
 import { operate } from '../util/lift';
 
-interface ShareOptions<T, R> {
+export interface ShareConfig<T> {
   /**
    * The factory used to create the subject that will connect the source observable to
    * multicast consumers.
@@ -43,7 +43,7 @@ interface ShareOptions<T, R> {
 
 export function share<T>(): MonoTypeOperatorFunction<T>;
 
-export function share<T, R = T>(options: ShareOptions<T, R>): OperatorFunction<T, R>;
+export function share<T>(options: ShareConfig<T>): MonoTypeOperatorFunction<T>;
 
 /**
  * Returns a new Observable that multicasts (shares) the original Observable. As long as there is at least one
@@ -87,7 +87,7 @@ export function share<T, R = T>(options: ShareOptions<T, R>): OperatorFunction<T
  * // ... and so on
  * ```
  */
-export function share<T, R>(options?: ShareOptions<T, R>): OperatorFunction<T, T | R> {
+export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
   options = options || {};
   const { connector = () => new Subject<T>(), resetOnComplete = true, resetOnError = true, resetOnRefCountZero = true } = options;
 

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { ColdObservable } from './ColdObservable';
 import { HotObservable } from './HotObservable';
@@ -114,42 +115,44 @@ export class TestScheduler extends VirtualTimeScheduler {
     return subject;
   }
 
-  private materializeInnerObservable(observable: Observable<any>,
-                                     outerFrame: number): TestMessage[] {
+  private materializeInnerObservable(observable: Observable<any>, outerFrame: number): TestMessage[] {
     const messages: TestMessage[] = [];
-    observable.subscribe((value) => {
-      messages.push({ frame: this.frame - outerFrame, notification: nextNotification(value) });
-    }, (error) => {
-      messages.push({ frame: this.frame - outerFrame, notification: errorNotification(error) });
-    }, () => {
-      messages.push({ frame: this.frame - outerFrame, notification: COMPLETE_NOTIFICATION });
-    });
+    observable.subscribe(
+      (value) => {
+        messages.push({ frame: this.frame - outerFrame, notification: nextNotification(value) });
+      },
+      (error) => {
+        messages.push({ frame: this.frame - outerFrame, notification: errorNotification(error) });
+      },
+      () => {
+        messages.push({ frame: this.frame - outerFrame, notification: COMPLETE_NOTIFICATION });
+      }
+    );
     return messages;
   }
 
-  expectObservable(observable: Observable<any>,
-                   subscriptionMarbles: string | null = null): ({ toBe: observableToBeFn }) {
+  expectObservable<T>(observable: Observable<T>, subscriptionMarbles: string | null = null) {
     const actual: TestMessage[] = [];
     const flushTest: FlushableTest = { actual, ready: false };
     const subscriptionParsed = TestScheduler.parseMarblesAsSubscriptions(subscriptionMarbles, this.runMode);
-    const subscriptionFrame = subscriptionParsed.subscribedFrame === Infinity ?
-      0 : subscriptionParsed.subscribedFrame;
+    const subscriptionFrame = subscriptionParsed.subscribedFrame === Infinity ? 0 : subscriptionParsed.subscribedFrame;
     const unsubscriptionFrame = subscriptionParsed.unsubscribedFrame;
     let subscription: Subscription;
 
     this.schedule(() => {
-      subscription = observable.subscribe(x => {
-        let value = x;
-        // Support Observable-of-Observables
-        if (x instanceof Observable) {
-          value = this.materializeInnerObservable(value, this.frame);
+      subscription = observable.subscribe(
+        (x) => {
+          // Support Observable-of-Observables
+          const value = x instanceof Observable ? this.materializeInnerObservable(x, this.frame) : x;
+          actual.push({ frame: this.frame, notification: nextNotification(value) });
+        },
+        (error) => {
+          actual.push({ frame: this.frame, notification: errorNotification(error) });
+        },
+        () => {
+          actual.push({ frame: this.frame, notification: COMPLETE_NOTIFICATION });
         }
-        actual.push({ frame: this.frame, notification: nextNotification(value) });
-      }, (error) => {
-        actual.push({ frame: this.frame, notification: errorNotification(error) });
-      }, () => {
-        actual.push({ frame: this.frame, notification: COMPLETE_NOTIFICATION });
-      });
+      );
     }, subscriptionFrame);
 
     if (unsubscriptionFrame !== Infinity) {
@@ -163,22 +166,41 @@ export class TestScheduler extends VirtualTimeScheduler {
       toBe(marbles: string, values?: any, errorValue?: any) {
         flushTest.ready = true;
         flushTest.expected = TestScheduler.parseMarbles(marbles, values, errorValue, true, runMode);
-      }
+      },
+      toEqual: (other: Observable<T>) => {
+        flushTest.ready = true;
+        flushTest.expected = [];
+        this.schedule(() => {
+          subscription = other.subscribe(
+            (x) => {
+              // Support Observable-of-Observables
+              const value = x instanceof Observable ? this.materializeInnerObservable(x, this.frame) : x;
+              flushTest.expected!.push({ frame: this.frame, notification: nextNotification(value) });
+            },
+            (error) => {
+              flushTest.expected!.push({ frame: this.frame, notification: errorNotification(error) });
+            },
+            () => {
+              flushTest.expected!.push({ frame: this.frame, notification: COMPLETE_NOTIFICATION });
+            }
+          );
+        }, subscriptionFrame);
+      },
     };
   }
 
-  expectSubscriptions(actualSubscriptionLogs: SubscriptionLog[]): ({ toBe: subscriptionLogsToBeFn }) {
+  expectSubscriptions(actualSubscriptionLogs: SubscriptionLog[]): { toBe: subscriptionLogsToBeFn } {
     const flushTest: FlushableTest = { actual: actualSubscriptionLogs, ready: false };
     this.flushTests.push(flushTest);
     const { runMode } = this;
     return {
       toBe(marblesOrMarblesArray: string | string[]) {
-        const marblesArray: string[] = (typeof marblesOrMarblesArray === 'string') ? [marblesOrMarblesArray] : marblesOrMarblesArray;
+        const marblesArray: string[] = typeof marblesOrMarblesArray === 'string' ? [marblesOrMarblesArray] : marblesOrMarblesArray;
         flushTest.ready = true;
-        flushTest.expected = marblesArray.map(marbles =>
-          TestScheduler.parseMarblesAsSubscriptions(marbles, runMode)
-        ).filter(marbles => marbles.subscribedFrame !== Infinity);
-      }
+        flushTest.expected = marblesArray
+          .map((marbles) => TestScheduler.parseMarblesAsSubscriptions(marbles, runMode))
+          .filter((marbles) => marbles.subscribedFrame !== Infinity);
+      },
     };
   }
 
@@ -190,7 +212,7 @@ export class TestScheduler extends VirtualTimeScheduler {
 
     super.flush();
 
-    this.flushTests = this.flushTests.filter(test => {
+    this.flushTests = this.flushTests.filter((test) => {
       if (test.ready) {
         this.assertDeepEqual(test.actual, test.expected);
         return false;
@@ -236,16 +258,14 @@ export class TestScheduler extends VirtualTimeScheduler {
           break;
         case '^':
           if (subscriptionFrame !== Infinity) {
-            throw new Error('found a second subscription point \'^\' in a ' +
-              'subscription marble diagram. There can only be one.');
+            throw new Error("found a second subscription point '^' in a " + 'subscription marble diagram. There can only be one.');
           }
           subscriptionFrame = groupStart > -1 ? groupStart : frame;
           advanceFrameBy(1);
           break;
         case '!':
           if (unsubscriptionFrame !== Infinity) {
-            throw new Error('found a second unsubscription point \'!\' in a ' +
-              'subscription marble diagram. There can only be one.');
+            throw new Error("found a second unsubscription point '!' in a " + 'subscription marble diagram. There can only be one.');
           }
           unsubscriptionFrame = groupStart > -1 ? groupStart : frame;
           break;
@@ -283,8 +303,7 @@ export class TestScheduler extends VirtualTimeScheduler {
             }
           }
 
-          throw new Error('there can only be \'^\' and \'!\' markers in a ' +
-            'subscription marble diagram. Found instead \'' + c + '\'.');
+          throw new Error("there can only be '^' and '!' markers in a " + "subscription marble diagram. Found instead '" + c + "'.");
       }
 
       frame = nextFrame;
@@ -298,28 +317,30 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   /** @nocollapse */
-  static parseMarbles(marbles: string,
-                      values?: any,
-                      errorValue?: any,
-                      materializeInnerObservables: boolean = false,
-                      runMode = false): TestMessage[] {
+  static parseMarbles(
+    marbles: string,
+    values?: any,
+    errorValue?: any,
+    materializeInnerObservables: boolean = false,
+    runMode = false
+  ): TestMessage[] {
     if (marbles.indexOf('!') !== -1) {
-      throw new Error('conventional marble diagrams cannot have the ' +
-        'unsubscription marker "!"');
+      throw new Error('conventional marble diagrams cannot have the ' + 'unsubscription marker "!"');
     }
     const len = marbles.length;
     const testMessages: TestMessage[] = [];
     const subIndex = runMode ? marbles.replace(/^[ ]+/, '').indexOf('^') : marbles.indexOf('^');
-    let frame = subIndex === -1 ? 0 : (subIndex * -this.frameTimeFactor);
-    const getValue = typeof values !== 'object' ?
-      (x: any) => x :
-      (x: any) => {
-        // Support Observable-of-Observables
-        if (materializeInnerObservables && values[x] instanceof ColdObservable) {
-          return values[x].messages;
-        }
-        return values[x];
-      };
+    let frame = subIndex === -1 ? 0 : subIndex * -this.frameTimeFactor;
+    const getValue =
+      typeof values !== 'object'
+        ? (x: any) => x
+        : (x: any) => {
+            // Support Observable-of-Observables
+            if (materializeInnerObservables && values[x] instanceof ColdObservable) {
+              return values[x].messages;
+            }
+            return values[x];
+          };
     let groupStart = -1;
 
     for (let i = 0; i < len; i++) {
@@ -427,7 +448,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     const delegate = {
       requestAnimationFrame(callback: FrameRequestCallback) {
         if (!map) {
-          throw new Error("animate() was not called within run()");
+          throw new Error('animate() was not called within run()');
         }
         const handle = ++lastHandle;
         map.set(handle, callback);
@@ -435,10 +456,10 @@ export class TestScheduler extends VirtualTimeScheduler {
       },
       cancelAnimationFrame(handle: number) {
         if (!map) {
-          throw new Error("animate() was not called within run()");
+          throw new Error('animate() was not called within run()');
         }
         map.delete(handle);
-      }
+      },
     };
 
     const animate = (marbles: string) => {
@@ -446,7 +467,7 @@ export class TestScheduler extends VirtualTimeScheduler {
         throw new Error('animate() must not be called more than once within run()');
       }
       if (/[|#]/.test(marbles)) {
-        throw new Error('animate() must not complete or error')
+        throw new Error('animate() must not complete or error');
       }
       map = new Map<number, FrameRequestCallback>();
       const messages = TestScheduler.parseMarbles(marbles, undefined, undefined, undefined, true);
@@ -483,14 +504,17 @@ export class TestScheduler extends VirtualTimeScheduler {
     // animate run helper.
 
     let lastHandle = 0;
-    const scheduleLookup = new Map<number, {
-      due: number;
-      duration: number;
-      handle: number;
-      handler: () => void;
-      subscription: Subscription;
-      type: 'immediate' | 'interval' | 'timeout';
-    }>();
+    const scheduleLookup = new Map<
+      number,
+      {
+        due: number;
+        duration: number;
+        handle: number;
+        handler: () => void;
+        subscription: Subscription;
+        type: 'immediate' | 'interval' | 'timeout';
+      }
+    >();
 
     const run = () => {
       // Whenever a scheduled run is executed, it must run a single immediate
@@ -559,7 +583,7 @@ export class TestScheduler extends VirtualTimeScheduler {
           value.subscription.unsubscribe();
           scheduleLookup.delete(handle);
         }
-      }
+      },
     };
 
     const interval = {
@@ -581,7 +605,7 @@ export class TestScheduler extends VirtualTimeScheduler {
           value.subscription.unsubscribe();
           scheduleLookup.delete(handle);
         }
-      }
+      },
     };
 
     const timeout = {
@@ -603,7 +627,7 @@ export class TestScheduler extends VirtualTimeScheduler {
           value.subscription.unsubscribe();
           scheduleLookup.delete(handle);
         }
-      }
+      },
     };
 
     return { immediate, interval, timeout };

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -87,14 +87,7 @@ export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | P
 /** OBSERVABLE INTERFACES */
 
 export interface Subscribable<T> {
-  subscribe(observer?: PartialObserver<T>): Unsubscribable;
-  /** @deprecated Use an observer instead of a complete callback */
-  subscribe(next: null | undefined, error: null | undefined, complete: () => void): Unsubscribable;
-  /** @deprecated Use an observer instead of an error callback */
-  subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Unsubscribable;
-  /** @deprecated Use an observer instead of a complete callback */
-  subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Unsubscribable;
-  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
+  subscribe(observer: Observer<T>): Unsubscribable;
 }
 
 /**
@@ -174,11 +167,12 @@ export interface CompletionObserver<T> {
 export type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
 export interface Observer<T> {
-  closed?: boolean;
   next: (value: T) => void;
   error: (err: any) => void;
   complete: () => void;
 }
+
+export type SubjectLike<T> = Observer<T> & Subscribable<T>;
 
 /** SCHEDULER INTERFACES */
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -87,7 +87,7 @@ export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | P
 /** OBSERVABLE INTERFACES */
 
 export interface Subscribable<T> {
-  subscribe(observer: Observer<T>): Unsubscribable;
+  subscribe(observer: Partial<Observer<T>>): Unsubscribable;
 }
 
 /**
@@ -172,7 +172,7 @@ export interface Observer<T> {
   complete: () => void;
 }
 
-export type SubjectLike<T> = Observer<T> & Subscribable<T>;
+export interface SubjectLike<T> extends Observer<T>, Subscribable<T> {}
 
 /** SCHEDULER INTERFACES */
 

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -14,6 +14,7 @@ export { concatAll } from '../internal/operators/concatAll';
 export { concatMap } from '../internal/operators/concatMap';
 export { concatMapTo } from '../internal/operators/concatMapTo';
 export { concat, concatWith } from '../internal/operators/concatWith';
+export { connect } from '../internal/operators/connect';
 export { count } from '../internal/operators/count';
 export { debounce } from '../internal/operators/debounce';
 export { debounceTime } from '../internal/operators/debounceTime';


### PR DESCRIPTION
I'd like to do this instead of what I was doing over at #5432 ..

## Overview

1. Make `share` configurable, such that it can be used to create things like `shareReplay` or people can configure the behavior however they like. If they want a `shareBehavior` or `shareLast`, they can easily make it work however they like.
2. Add a new`connect` operator that does the "selector" version of `multicast`, `publish`, et al. (this also fixes a broken error behavior in `publishReplay`). 
3. Add a new `makeConnectable` function that creates a `ConnectableObservableLike` (instead of `ConnectableObservable`).

## What this sets us up for:

### We'd have
- `share` (NOTE: I'll leave `shareReplay` as just a wrapper around this, as seen in this PR)
- `connect`
- `connectable`

### Instead of
- `share`
- `multicast`
- `publish`
- `publishLast`
- `publishReplay`
- `publishBehavior`
- `refCount`
- `shareReplay`
- `ConnectableObservable`


All "operators" at that point would actually only return `Observable` and never `ConnectableObservable`, nor would any require `ConnectableObservable` as a source (such as with `refCount`).

## TODO:

- [ ] Additional documentation
- [ ] Additional tests
- [ ] Add deprecation details to deprecated operators and paths

## Other thoughts

It's possible that a better API for `makeConnectable` might be to return a tuple with a `connect` function. Like so:

```ts
const [ result$, connect ] = makeConnectable(source);
result$.subscribe(console.log);
connect();

// instead of
const result$ = makeConnectable(source);
result$.subscribe(console.log);
result$.connect();
```

## How this "replaces" certain things

Well, the I find the prevalence of `publishReplay(1), refCount()` _very_ disturbing. For one thing, I doubt many folks using this are aware of what this does completely. It's not retryable, it's not replayable, etc.

```ts
a$.pipe(publishReplay(1), refCount())

// is

a$.pipe(
  share({
    connector: () => new ReplaySubject(1),
    resetOnError: false,
    resetOnComplete: false,
    resetOnUnsubscribe: false
  });
)
```

"But Ben, that's more code!"... yes, and it's explicit code that tells you _exactly_ what you're doing there. That's not retryable, it's not repeatable... it will never reset internally. It also allows the author more control without having to know implementation details of `publishReplay`. Needing to know implementation details of our multicasting operators has been a sore point of this library, IMO.

**NO WORRIES**: `a$.pipe(share())` will work _exactly_ as it does now. (Notice those tests didn't change)