### PR TITLE
chore: bump TypeScript to 4.0.1-rc

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs",
-  "version": "7.0.0-beta.3",
+  "version": "7.0.0-beta.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -8185,9 +8185,9 @@
       }
     },
     "typescript": {
-      "version": "3.9.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.9.2.tgz",
-      "integrity": "sha512-q2ktq4n/uLuNNShyayit+DTobV2ApPEo/6so68JaD5ojvc/6GClBipedB9zNWYxRSAlZXAe405Rlijzl6qDiSw==",
+      "version": "4.0.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.1-rc.tgz",
+      "integrity": "sha512-TCkspT3dSKOykbzS3/WSK7pqU2h1d/lEO6i45Afm5Y3XNAEAo8YXTG3kHOQk/wFq/5uPyO1+X8rb/Q+g7UsxJw==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
     "tslint-no-toplevel-property-access": "0.0.2",
     "tslint-no-unused-expression-chai": "0.0.3",
     "typedoc": "^0.17.8",
-    "typescript": "~3.9.2",
+    "typescript": "~4.0.1-rc",
     "validate-commit-msg": "2.14.0",
     "webpack": "^4.31.0"
   },

--- a/spec-dtslint/types-spec.ts
+++ b/spec-dtslint/types-spec.ts
@@ -68,7 +68,7 @@ describe('Cons', () => {
 
   it('should support rest tuples', () => {
     let explicit: Cons<A, B[]>;
-    let inferred = explicit!; // $ExpectType [A, ...B[]]
+    let inferred = explicit!; // $ExpectType [arg: A, ...rest: B[]]
   });
 });
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR bumps TypeScript to `4.0.1-rc`. Almost no changes were needed:

* `npm run lint` effects no failures.
* `npm run test` sees all tests pass with no compile errors.
* `npm run build:package` builds with no compile errors.
* `npm run dtslint` effected a single failure that was due to named tuple elements being a thing in TS4. (It seems the file with this change had CRLF line endings. They're now LF, hence the large diff. The change is on line 71.)
* And I guess we'll soon find out what happens in CI ... It seems CI is happy 🎉

IMO, we might as well bump this now. Given that it will allow us to remove so many overloads, I think we should be choosing TS4 as the minimum supported version for v7.

Note that this change will affect the Google merge, as [they're using TypeScript 3.8.2](https://github.com/ReactiveX/rxjs/pull/5609#issuecomment-670680772). 😬

**Related issue (if exists):** None