### PR TITLE
perf(SafeSubscriber): avoid using `Object.create`

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -167,8 +167,10 @@ export declare function concat<O1 extends ObservableInput<any>, O2 extends Obser
 export declare function concat<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
 
 export declare const config: {
+    quietBadConfig: boolean;
     Promise: PromiseConstructorLike;
     useDeprecatedSynchronousErrorHandling: boolean;
+    useDeprecatedNextContext: boolean;
 };
 
 export declare class ConnectableObservable<T> extends Observable<T> {

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,10 +1,18 @@
+/** @prettier */
 let _enable_super_gross_mode_that_will_cause_bad_things = false;
+let _enable_deoptimized_subscriber_creation = false;
 
 /**
  * The global configuration object for RxJS, used to configure things
  * like what Promise contructor should used to create Promises
  */
 export const config = {
+  /**
+   * If true, console logs for deprecation warnings will not be emitted.
+   * @deprecated this will be removed in v8 when all deprecated settings are removed.
+   */
+  quietBadConfig: false,
+
   /**
    * The promise constructor used by default for methods such as
    * {@link toPromise} and {@link forEach}
@@ -28,11 +36,13 @@ export const config = {
    * behaviors described above.
    */
   set useDeprecatedSynchronousErrorHandling(value: boolean) {
-    if (value) {
-      const error = new Error();
-      console.warn('DEPRECATED! RxJS was set to use deprecated synchronous error handling behavior by code at: \n' + error.stack);
-    } else if (_enable_super_gross_mode_that_will_cause_bad_things) {
-      console.log('RxJS: Back to a better error behavior. Thank you. <3');
+    if (!this.quietBadConfig) {
+      if (value) {
+        const error = new Error();
+        console.warn('DEPRECATED! RxJS was set to use deprecated synchronous error handling behavior by code at: \n' + error.stack);
+      } else if (_enable_super_gross_mode_that_will_cause_bad_things) {
+        console.log('RxJS: Back to a better error behavior. Thank you. <3');
+      }
     }
     _enable_super_gross_mode_that_will_cause_bad_things = value;
   },
@@ -44,5 +54,44 @@ export const config = {
    */
   get useDeprecatedSynchronousErrorHandling() {
     return _enable_super_gross_mode_that_will_cause_bad_things;
+  },
+
+  /**
+   * If true, enables an as-of-yet undocumented feature from v5: The ability to access
+   * `unsubscribe()` via `this` context in `next` functions created in observers passed
+   * to `subscribe`.
+   *
+   * This is being removed because the performance was severely problematic, and it could also cause
+   * issues when types other than POJOs are passed to subscribe as subscribers, as they will likely have
+   * their `this` context overwritten.
+   *
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
+   * context of next functions provided as part of an observer to Subscribe. Instead,
+   * you will have access to a subscription or a signal or token that will allow you to do things like
+   * unsubscribe and test closed status.
+   */
+  set useDeprecatedNextContext(value: boolean) {
+    if (!this.quietBadConfig) {
+      if (value) {
+        const error = new Error();
+        console.warn(
+          'DEPRECATED! RxJS was set to use deprecated next context. This will result in deoptimizations when creating any new subscription. \n' +
+            error.stack
+        );
+      } else if (_enable_deoptimized_subscriber_creation) {
+        console.log('RxJS: back to more optimized subscription creation. Thank you. <3');
+      }
+    }
+    _enable_deoptimized_subscriber_creation = value;
+  },
+
+  /**
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
+   * context of next functions provided as part of an observer to Subscribe. Instead,
+   * you will have access to a subscription or a signal or token that will allow you to do things like
+   * unsubscribe and test closed status.
+   */
+  get useDeprecatedNextContext(): boolean {
+    return _enable_deoptimized_subscriber_creation;
   },
 };


### PR DESCRIPTION
In profiling sessions, the `SafeSubscriber` constructor was showing as hot
function for code that creates and tear downs Observables very frequently.
The usage of `Object.create` attributes to the slowness; avoiding using it
completely removes any overhead of `SafeSubscriber`.

The `Object.create` result was used to call anonymous subscribers in their
own context, i.e. the `this` pointer in `next`/`error`/`complete` is the
anonymous object itself. This commit implements an alternative to achieve
the same effect; binding the subscriber functions to the observer object.


# Timings
The below timings are with NodeJS 14.8.0 in a full Angular CLI build of https://github.com/JoostK/ng9-aot-build-times/tree/extra.

**Before**:
<img width="480" alt="Before" src="https://user-images.githubusercontent.com/123679/90319282-ed426180-df36-11ea-8d85-8c0dd7de7b4f.png">

**After**:
<img width="440" alt="After" src="https://user-images.githubusercontent.com/123679/90319279-eb789e00-df36-11ea-921e-d822fe917c63.png">
