### PR TITLE
fix(onErrorResumeNext): observables always finalized before moving to next source

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -435,13 +435,9 @@ export declare function of<T, U>(value1: T, value2: U): Observable<T | U>;
 export declare function of<T, U, V>(value1: T, value2: U, value3: V): Observable<T | U | V>;
 export declare function of<A extends Array<any>>(...args: A): Observable<ValueFromArray<A>>;
 
-export declare function onErrorResumeNext<R>(v: ObservableInput<R>): Observable<R>;
-export declare function onErrorResumeNext<T2, T3, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<R>;
-export declare function onErrorResumeNext<T2, T3, T4, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<R>;
-export declare function onErrorResumeNext<T2, T3, T4, T5, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<R>;
-export declare function onErrorResumeNext<T2, T3, T4, T5, T6, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<R>;
-export declare function onErrorResumeNext<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
-export declare function onErrorResumeNext<R>(array: ObservableInput<any>[]): Observable<R>;
+export declare function onErrorResumeNext(): Observable<never>;
+export declare function onErrorResumeNext<O extends ObservableInput<any>>(arrayOfSources: O[]): Observable<ObservedValueOf<O>>;
+export declare function onErrorResumeNext<A extends ObservableInput<any>[]>(...sources: A): Observable<ObservedValueUnionFromArray<A>>;
 
 export interface Operator<T, R> {
     call(subscriber: Subscriber<R>, source: any): TeardownLogic;

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -191,15 +191,9 @@ export declare function multicast<T, O extends ObservableInput<any>>(SubjectFact
 
 export declare function observeOn<T>(scheduler: SchedulerLike, delay?: number): MonoTypeOperatorFunction<T>;
 
-export declare function onErrorResumeNext<T>(): OperatorFunction<T, T>;
-export declare function onErrorResumeNext<T, T2>(v: ObservableInput<T2>): OperatorFunction<T, T | T2>;
-export declare function onErrorResumeNext<T, T2, T3>(v: ObservableInput<T2>, v2: ObservableInput<T3>): OperatorFunction<T, T | T2 | T3>;
-export declare function onErrorResumeNext<T, T2, T3, T4>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>): OperatorFunction<T, T | T2 | T3 | T4>;
-export declare function onErrorResumeNext<T, T2, T3, T4, T5>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>, v4: ObservableInput<T5>): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-export declare function onErrorResumeNext<T, T2, T3, T4, T5, T6>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>, v4: ObservableInput<T5>, v5: ObservableInput<T6>): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-export declare function onErrorResumeNext<T, T2, T3, T4, T5, T6, T7>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>, v4: ObservableInput<T5>, v5: ObservableInput<T6>, v6: ObservableInput<T7>): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6 | T7>;
-export declare function onErrorResumeNext<T, R>(...observables: Array<ObservableInput<any>>): OperatorFunction<T, T | R>;
-export declare function onErrorResumeNext<T, R>(array: ObservableInput<any>[]): OperatorFunction<T, T | R>;
+export declare function onErrorResumeNext<T>(): MonoTypeOperatorFunction<T>;
+export declare function onErrorResumeNext<T, O extends ObservableInput<any>>(arrayOfSources: O[]): OperatorFunction<T, T | ObservedValueOf<O>>;
+export declare function onErrorResumeNext<T, A extends ObservableInput<any>[]>(...sources: A): OperatorFunction<T, T | ObservedValueUnionFromArray<A>>;
 
 export declare function pairwise<T>(): OperatorFunction<T, [T, T]>;
 

--- a/spec-dtslint/observables/onErrorResumeNext-spec.ts
+++ b/spec-dtslint/observables/onErrorResumeNext-spec.ts
@@ -1,0 +1,31 @@
+/** @prettier */
+import { onErrorResumeNext } from 'rxjs';
+import { a$, b$, c$, d$, e$, f$, g$, h$, i$, j$ } from '../helpers';
+
+it('should infer correctly', () => {
+  const o1 = onErrorResumeNext(); // $ExpectType Observable<never>
+  const o2 = onErrorResumeNext(a$); // $ExpectType Observable<A>
+  const o3 = onErrorResumeNext(a$, b$); // $ExpectType Observable<A | B>
+  const o4 = onErrorResumeNext(a$, b$, c$); // $ExpectType Observable<A | B | C>
+  const o5 = onErrorResumeNext(a$, b$, c$, d$); // $ExpectType Observable<A | B | C | D>
+  const o6 = onErrorResumeNext(a$, b$, c$, d$, e$); // $ExpectType Observable<A | B | C | D | E>
+  const o7 = onErrorResumeNext(a$, b$, c$, d$, e$, f$); // $ExpectType Observable<A | B | C | D | E | F>
+  const o8 = onErrorResumeNext(a$, b$, c$, d$, e$, f$, g$); // $ExpectType Observable<A | B | C | D | E | F | G>
+  const o9 = onErrorResumeNext(a$, b$, c$, d$, e$, f$, g$, h$); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+  const o10 = onErrorResumeNext(a$, b$, c$, d$, e$, f$, g$, h$, i$); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+  const o11 = onErrorResumeNext(a$, b$, c$, d$, e$, f$, g$, h$, i$, j$); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+});
+
+it('should handle non-observable inputs appropriately', () => {
+  const o1 = onErrorResumeNext({ lol: 'test' }); // $ExpectError
+  const o2 = onErrorResumeNext(a$, { haha: 'no' }); // $ExpectError
+});
+
+it('should handle observable inputs okay', () => {
+  const o1 = onErrorResumeNext([1, 2, 3, 'test'], Promise.resolve(true)); // $ExpectType Observable<string | number | boolean>
+  const o2 = onErrorResumeNext( // $ExpecType Observable<string>
+    (function* () {
+      return 'test';
+    })()
+  );
+});

--- a/spec-dtslint/operators/onErrorResumeNext-spec.ts
+++ b/spec-dtslint/operators/onErrorResumeNext-spec.ts
@@ -43,14 +43,9 @@ it('should accept six inputs', () => {
 });
 
 it('should accept seven and more inputs', () => {
-  const o = of('apple', 'banana', 'peach').pipe(onErrorResumeNext(of(1), of(2), of('3'), of('4'), of(5), of('6'), of(7))); // $ExpectType Observable<unknown>
-  const p = of('apple', 'banana', 'peach').pipe(onErrorResumeNext<string, string | number>(of(1), of(2), of('3'), of('4'), of(5), of('6'), of(7))); // $ExpectType Observable<string | number>
+  const o = of('apple', 'banana', 'peach').pipe(onErrorResumeNext(of(1), of(2), of('3'), of('4'), of(5), of('6'), of(7))); // $ExpectType Observable<string | number>
 });
 
 it('should enforce types', () => {
   const o = of('apple', 'banana', 'peach').pipe(onErrorResumeNext(5)); // $ExpectError
-});
-
-it('should enforce source types', () => {
-  const p = of('apple', 'banana', 'peach').pipe(onErrorResumeNext<number, number>(of(5))); // $ExpectError
 });

--- a/spec/observables/onErrorResumeNext-spec.ts
+++ b/spec/observables/onErrorResumeNext-spec.ts
@@ -1,6 +1,8 @@
 
-import { onErrorResumeNext } from 'rxjs';
+import { onErrorResumeNext, of } from 'rxjs';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { finalize } from 'rxjs/operators';
+import { expect } from 'chai';
 
 describe('onErrorResumeNext', () => {
   it('should continue with observables', () => {
@@ -46,5 +48,51 @@ describe('onErrorResumeNext', () => {
 
     expectObservable(onErrorResumeNext(source)).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(subs);
+  });
+
+  
+  it('should skip invalid sources and move on', () => {
+    const results: any[] = [];
+
+    onErrorResumeNext(
+      of(1),
+      [2, 3, 4],
+      { notValid: 'LOL' } as any,
+      of(5, 6),
+    )
+    .subscribe({
+      next: value => results.push(value),
+      complete: () => results.push('complete')
+    });
+
+    expect(results).to.deep.equal([1, 2, 3, 4, 5, 6, 'complete']);
+  });
+
+  it('should call finalize after each sync observable', () => {
+    let results: any[] = []
+    
+    onErrorResumeNext(
+      of(1).pipe(
+        finalize(() => results.push('finalize 1'))
+      ),
+      of(2).pipe(
+        finalize(() => results.push('finalize 2'))
+      ), of(3).pipe(
+        finalize(() => results.push('finalize 3'))
+      ), of(4).pipe(
+        finalize(() => results.push('finalize 4'))
+      )
+    ).subscribe({
+      next: value => results.push(value),
+      complete: () => results.push('complete')
+    });
+
+    expect(results).to.deep.equal([
+      1, 'finalize 1',
+      2, 'finalize 2',
+      3, 'finalize 3',
+      4, 'finalize 4',
+      'complete'
+    ]);
   });
 });

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -222,4 +222,16 @@ describe('finalize operator', () => {
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });
+  
+  it('should finalize in the proper order', () => {
+    const results: any[] = [];
+    of(1).pipe(
+      finalize(() => results.push(1)),
+      finalize(() => results.push(2)),
+      finalize(() => results.push(3)),
+      finalize(() => results.push(4)),
+    ).subscribe();
+
+    expect(results).to.deep.equal([1, 2, 3, 4]);
+  });
 });

--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { onErrorResumeNext, takeWhile } from 'rxjs/operators';
-import { concat, defer, throwError, of } from 'rxjs';
+import { onErrorResumeNext, take, finalize } from 'rxjs/operators';
+import { concat, throwError, of, Observable } from 'rxjs';
 import { asInteropObservable } from '../helpers/interop-helper';
 
 describe('onErrorResumeNext operator', () => {
@@ -105,27 +105,21 @@ describe('onErrorResumeNext operator', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = concat(
-      defer(() => {
-        sideEffects.push(1);
-        return of(1);
-      }),
-      defer(() => {
-        sideEffects.push(2);
-        return of(2);
-      }),
-      defer(() => {
-        sideEffects.push(3);
-        return of(3);
-      })
-    );
+    const synchronousObservable = new Observable(subscriber => {
+      // This will check to see if the subscriber was closed on each loop
+      // when the unsubscribe hits (from the `take`), it should be closed
+      for (let i = 0; !subscriber.closed && i < 10; i++) {
+        sideEffects.push(i);
+        subscriber.next(i);
+      }
+    });
 
     throwError(new Error('Some error')).pipe(
       onErrorResumeNext(synchronousObservable),
-      takeWhile((x) => x != 2) // unsubscribe at the second side-effect
+      take(3),
     ).subscribe(() => { /* noop */ });
 
-    expect(sideEffects).to.deep.equal([1, 2]);
+    expect(sideEffects).to.deep.equal([0, 1, 2]);
   });
 
   it('should unsubscribe from an interop observble upon explicit unsubscription', () => {
@@ -152,11 +146,55 @@ describe('onErrorResumeNext operator', () => {
     source.pipe(onErrorResumeNext(Promise.resolve(2)))
       .subscribe(x => {
         expect(expected.shift()).to.equal(x);
-      }, (err: any) => {
+      }, () => {
         done(new Error('should not be called'));
       }, () => {
         expect(expected).to.be.empty;
         done();
       });
+  });
+
+  it('should skip invalid sources and move on', () => {
+    const results: any[] = [];
+
+    of(1).pipe(
+      onErrorResumeNext(
+        [2, 3, 4],
+        { notValid: 'LOL' } as any,
+        of(5, 6),
+      )
+    )
+    .subscribe({
+      next: value => results.push(value),
+      complete: () => results.push('complete')
+    });
+
+    expect(results).to.deep.equal([1, 2, 3, 4, 5, 6, 'complete']);
+  });
+
+  it('should call finalize after each sync observable', () => {
+    let results: any[] = []
+
+    of(1).pipe(
+      finalize(() => results.push('finalize 1')),
+      onErrorResumeNext(of(2).pipe(
+        finalize(() => results.push('finalize 2'))
+      ), of(3).pipe(
+        finalize(() => results.push('finalize 3'))
+      ), of(4).pipe(
+        finalize(() => results.push('finalize 4'))
+      ))
+    ).subscribe({
+      next: value => results.push(value),
+      complete: () => results.push('complete')
+    });
+
+    expect(results).to.deep.equal([
+      1, 'finalize 1',
+      2, 'finalize 2',
+      3, 'finalize 3',
+      4, 'finalize 4',
+      'complete'
+    ]);
   });
 });

--- a/src/internal/observable/onErrorResumeNext.ts
+++ b/src/internal/observable/onErrorResumeNext.ts
@@ -1,18 +1,15 @@
+/** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInput } from '../types';
-import { from } from './from';
-import { isArray } from '../util/isArray';
+import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf } from '../types';
 import { EMPTY } from './empty';
+import { onErrorResumeNext as onErrorResumeNextWith } from '../operators/onErrorResumeNext';
+import { isArray } from 'util';
 
 /* tslint:disable:max-line-length */
-export function onErrorResumeNext<R>(v: ObservableInput<R>): Observable<R>;
-export function onErrorResumeNext<T2, T3, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<R>;
-export function onErrorResumeNext<T2, T3, T4, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<R>;
-export function onErrorResumeNext<T2, T3, T4, T5, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<R>;
-export function onErrorResumeNext<T2, T3, T4, T5, T6, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<R>;
+export function onErrorResumeNext(): Observable<never>;
+export function onErrorResumeNext<O extends ObservableInput<any>>(arrayOfSources: O[]): Observable<ObservedValueOf<O>>;
+export function onErrorResumeNext<A extends ObservableInput<any>[]>(...sources: A): Observable<ObservedValueUnionFromArray<A>>;
 
-export function onErrorResumeNext<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
-export function onErrorResumeNext<R>(array: ObservableInput<any>[]): Observable<R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -74,29 +71,9 @@ export function onErrorResumeNext<R>(array: ObservableInput<any>[]): Observable<
  * @return {Observable} An Observable that concatenates all sources, one after the other,
  * ignoring all errors, such that any error causes it to move on to the next source.
  */
-export function onErrorResumeNext<T, R>(...sources: Array<ObservableInput<any> |
-                                                              Array<ObservableInput<any>> |
-                                                              ((...values: Array<any>) => R)>): Observable<R> {
-
-  if (sources.length === 0) {
-    return EMPTY;
+export function onErrorResumeNext(...sources: ObservableInput<any>[]): Observable<any> {
+  if (sources.length === 1 && isArray(sources)) {
+    sources = sources[0] as any;
   }
-
-  const [ first, ...remainder ] = sources;
-
-  if (sources.length === 1 && isArray(first)) {
-    return onErrorResumeNext(...first);
-  }
-
-  return new Observable(subscriber => {
-    const subNext = () => subscriber.add(
-      onErrorResumeNext(...remainder).subscribe(subscriber)
-    );
-
-    return from(first).subscribe({
-      next(value) { subscriber.next(value); },
-      error: subNext,
-      complete: subNext,
-    });
-  });
+  return onErrorResumeNextWith(sources)(EMPTY);
 }

--- a/src/internal/observable/onErrorResumeNext.ts
+++ b/src/internal/observable/onErrorResumeNext.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf } from '../types';
 import { EMPTY } from './empty';
 import { onErrorResumeNext as onErrorResumeNextWith } from '../operators/onErrorResumeNext';
-import { isArray } from 'util';
+import { isArray } from '../util/isArray';
 
 /* tslint:disable:max-line-length */
 export function onErrorResumeNext(): Observable<never>;

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -1,23 +1,16 @@
+/** @prettier */
 import { Observable } from '../Observable';
-import { from } from '../observable/from';
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { isArray } from '../util/isArray';
-import { ObservableInput, OperatorFunction } from '../types';
+import { ObservableInput, OperatorFunction, ObservedValueOf, ObservedValueUnionFromArray, MonoTypeOperatorFunction } from '../types';
 import { lift } from '../util/lift';
-import { SimpleOuterSubscriber, SimpleInnerSubscriber, innerSubscribe } from '../innerSubscribe';
+import { from } from '../observable/from';
 
-/* tslint:disable:max-line-length */
-export function onErrorResumeNext<T>(): OperatorFunction<T, T>;
-export function onErrorResumeNext<T, T2>(v: ObservableInput<T2>): OperatorFunction<T, T | T2>;
-export function onErrorResumeNext<T, T2, T3>(v: ObservableInput<T2>, v2: ObservableInput<T3>): OperatorFunction<T, T | T2 | T3>;
-export function onErrorResumeNext<T, T2, T3, T4>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>): OperatorFunction<T, T | T2 | T3 | T4>;
-export function onErrorResumeNext<T, T2, T3, T4, T5>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>, v4: ObservableInput<T5>): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-export function onErrorResumeNext<T, T2, T3, T4, T5, T6>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>, v4: ObservableInput<T5>, v5: ObservableInput<T6>): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-export function onErrorResumeNext<T, T2, T3, T4, T5, T6, T7>(v: ObservableInput<T2>, v2: ObservableInput<T3>, v3: ObservableInput<T4>, v4: ObservableInput<T5>, v5: ObservableInput<T6>, v6: ObservableInput<T7>): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6 | T7>;
-export function onErrorResumeNext<T, R>(...observables: Array<ObservableInput<any>>): OperatorFunction<T, T | R>;
-export function onErrorResumeNext<T, R>(array: ObservableInput<any>[]): OperatorFunction<T, T | R>;
-/* tslint:enable:max-line-length */
+export function onErrorResumeNext<T>(): MonoTypeOperatorFunction<T>;
+export function onErrorResumeNext<T, O extends ObservableInput<any>>(arrayOfSources: O[]): OperatorFunction<T, T | ObservedValueOf<O>>;
+export function onErrorResumeNext<T, A extends ObservableInput<any>[]>(
+  ...sources: A
+): OperatorFunction<T, T | ObservedValueUnionFromArray<A>>;
 
 /**
  * When any of the provided Observable emits an complete or error notification, it immediately subscribes to the next one
@@ -87,81 +80,53 @@ export function onErrorResumeNext<T, R>(array: ObservableInput<any>[]): Operator
  * @name onErrorResumeNext
  */
 
-export function onErrorResumeNext<T, R>(...nextSources: Array<ObservableInput<any> |
-                                                       Array<ObservableInput<any>>>): OperatorFunction<T, R> {
+export function onErrorResumeNext<T, R>(...nextSources: ObservableInput<any>[]): OperatorFunction<T, R> {
+  // If there is only one argument, and it is an array, we'll treat it like it is
+  // and array of arguments.
   if (nextSources.length === 1 && isArray(nextSources[0])) {
-    nextSources = <Array<Observable<any>>>nextSources[0];
+    nextSources = nextSources[0];
   }
 
-  return (source: Observable<T>) => lift(source, new OnErrorResumeNextOperator<T, R>(nextSources));
+  return (source: Observable<T>) =>
+    lift(source, function (this: Subscriber<any>, source: Observable<T>) {
+      const subscriber = this;
+      const remaining = [source, ...nextSources];
+      const subscribeNext = () => {
+        if (!subscriber.closed) {
+          if (remaining.length > 0) {
+            let nextSource: Observable<any>;
+            try {
+              nextSource = from(remaining.shift()!);
+            } catch (err) {
+              subscribeNext();
+              return;
+            }
+
+            // Here we have to use one of our Subscribers, or it does not wire up
+            // The `closed` property of upstream Subscribers synchronously, that
+            // would result in situation were we could not stop a synchronous firehose
+            // with something like `take(3)`.
+            const innerSub = new OnErrorResumeNextSubscriber(subscriber);
+            subscriber.add(nextSource.subscribe(innerSub));
+            innerSub.add(subscribeNext);
+          } else {
+            subscriber.complete();
+          }
+        }
+      };
+
+      subscribeNext();
+
+      return subscriber;
+    });
 }
 
-/* tslint:disable:max-line-length */
-export function onErrorResumeNextStatic<R>(v: ObservableInput<R>): Observable<R>;
-export function onErrorResumeNextStatic<T2, T3, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<R>;
-export function onErrorResumeNextStatic<T2, T3, T4, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<R>;
-export function onErrorResumeNextStatic<T2, T3, T4, T5, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<R>;
-export function onErrorResumeNextStatic<T2, T3, T4, T5, T6, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<R>;
-
-export function onErrorResumeNextStatic<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
-export function onErrorResumeNextStatic<R>(array: ObservableInput<any>[]): Observable<R>;
-/* tslint:enable:max-line-length */
-
-export function onErrorResumeNextStatic<T, R>(...nextSources: Array<ObservableInput<any> |
-  Array<ObservableInput<any>> |
-  ((...values: Array<any>) => R)>): Observable<R> {
-  let source: ObservableInput<any> | null = null;
-
-  if (nextSources.length === 1 && isArray(nextSources[0])) {
-    nextSources = <Array<ObservableInput<any>>>nextSources[0];
-  }
-  source = nextSources.shift()!;
-
-  return lift(from(source), new OnErrorResumeNextOperator<T, R>(nextSources));
-}
-
-class OnErrorResumeNextOperator<T, R> implements Operator<T, R> {
-  constructor(private nextSources: Array<ObservableInput<any>>) {
-  }
-
-  call(subscriber: Subscriber<R>, source: any): any {
-    return source.subscribe(new OnErrorResumeNextSubscriber(subscriber, this.nextSources));
-  }
-}
-
-class OnErrorResumeNextSubscriber<T, R> extends SimpleOuterSubscriber<T, R> {
-  constructor(protected destination: Subscriber<T>,
-              private nextSources: Array<ObservableInput<any>>) {
-    super(destination);
-  }
-
-  notifyError(): void {
-    this.subscribeToNextSource();
-  }
-
-  notifyComplete(): void {
-    this.subscribeToNextSource();
-  }
-
-  protected _error(err: any): void {
-    this.subscribeToNextSource();
+class OnErrorResumeNextSubscriber extends Subscriber<any> {
+  _error() {
     this.unsubscribe();
   }
 
-  protected _complete(): void {
-    this.subscribeToNextSource();
+  _complete() {
     this.unsubscribe();
-  }
-
-  private subscribeToNextSource(): void {
-    const next = this.nextSources.shift();
-    if (!!next) {
-      const innerSubscriber = new SimpleInnerSubscriber(this);
-      const destination = this.destination;
-      destination.add(innerSubscriber);
-      innerSubscribe(next, innerSubscriber);
-    } else {
-      this.destination.complete();
-    }
   }
 }

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -80,7 +80,7 @@ export function onErrorResumeNext<T, A extends ObservableInput<any>[]>(
  * @name onErrorResumeNext
  */
 
-export function onErrorResumeNext<T, R>(...nextSources: ObservableInput<any>[]): OperatorFunction<T, R> {
+export function onErrorResumeNext<T>(...nextSources: ObservableInput<any>[]): OperatorFunction<T, unknown> {
   // If there is only one argument, and it is an array, we'll treat it like it is
   // and array of arguments.
   if (nextSources.length === 1 && isArray(nextSources[0])) {


### PR DESCRIPTION
- Fixes an issue where finalize would be called after all sources were complete
- Removes superfluous onErrorResumeNext implementation
- Ensures that invalid sources handed to onErrorResumeNext do not cause an error, and instead resume to the next source
- Updates types to infer N arguments
- Removes invalid type signature that allowed a function for no reason
- Adds dtslint tests for static creation function
- Adds finalize test to ensure order of finalize calls (as a sanity check)
