### PR TITLE
refactor(VirtualTimeScheduler): remove sortActions from public API

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -623,7 +623,6 @@ export declare class VirtualAction<T> extends AsyncAction<T> {
     protected recycleAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     protected requestAsyncId(scheduler: VirtualTimeScheduler, id?: any, delay?: number): any;
     schedule(state?: T, delay?: number): Subscription;
-    static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>): 1 | 0 | -1;
 }
 
 export declare class VirtualTimeScheduler extends AsyncScheduler {

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -111,7 +111,7 @@ export class VirtualAction<T> extends AsyncAction<T> {
     }
   }
 
-  public static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>) {
+  private static sortActions<T>(a: VirtualAction<T>, b: VirtualAction<T>) {
     if (a.delay === b.delay) {
       if (a.index === b.index) {
         return 0;


### PR DESCRIPTION
BREAKING CHANGE: The static `sortActions` method on `VirtualTimeScheduler` is no longer publicly exposed by our TS types.
