### PR TITLE
fix: use != and == to compare null/undefined delays

### DIFF
--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -32,7 +32,7 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     // If delay exists and is greater than 0, or if the delay is null (the
     // action wasn't rescheduled) but was originally scheduled as an async
     // action, then recycle as an async action.
-    if ((delay !== null && delay > 0) || (delay === null && this.delay > 0)) {
+    if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
     // If the scheduler queue is empty, cancel the requested animation frame and

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -33,7 +33,7 @@ export class AsapAction<T> extends AsyncAction<T> {
     // If delay exists and is greater than 0, or if the delay is null (the
     // action wasn't rescheduled) but was originally scheduled as an async
     // action, then recycle as an async action.
-    if ((delay !== null && delay > 0) || (delay === null && this.delay > 0)) {
+    if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
     // If the scheduler queue is empty, cancel the requested microtask and

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -76,7 +76,7 @@ export class AsyncAction<T> extends Action<T> {
 
   protected recycleAsyncId(scheduler: AsyncScheduler, id: any, delay: number | null = 0): any {
     // If this action is rescheduled with the same delay time, don't clear the interval id.
-    if (delay !== null && this.delay === delay && this.pending === false) {
+    if (delay != null && this.delay === delay && this.pending === false) {
       return id;
     }
     // Otherwise, if the action's delay time is different from the current delay,

--- a/src/internal/scheduler/QueueAction.ts
+++ b/src/internal/scheduler/QueueAction.ts
@@ -35,7 +35,7 @@ export class QueueAction<T> extends AsyncAction<T> {
     // If delay exists and is greater than 0, or if the delay is null (the
     // action wasn't rescheduled) but was originally scheduled as an async
     // action, then recycle as an async action.
-    if ((delay !== null && delay > 0) || (delay === null && this.delay > 0)) {
+    if ((delay !== undefined && delay > 0) || (delay === undefined && this.delay > 0)) {
       return super.requestAsyncId(scheduler, id, delay);
     }
     // Otherwise flush the scheduler starting with this action.

--- a/src/internal/scheduler/QueueAction.ts
+++ b/src/internal/scheduler/QueueAction.ts
@@ -35,7 +35,8 @@ export class QueueAction<T> extends AsyncAction<T> {
     // If delay exists and is greater than 0, or if the delay is null (the
     // action wasn't rescheduled) but was originally scheduled as an async
     // action, then recycle as an async action.
-    if ((delay !== undefined && delay > 0) || (delay === undefined && this.delay > 0)) {
+
+    if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.requestAsyncId(scheduler, id, delay);
     }
     // Otherwise flush the scheduler starting with this action.


### PR DESCRIPTION
The type checking shows that parameter `delay` will never be null.