### PR TITLE
fix: handle synchronous reentrant during subscribing the inner sub

### DIFF
--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -1,5 +1,5 @@
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { concat, defer, Observable, of } from 'rxjs';
+import { concat, defer, Observable, of, BehaviorSubject } from 'rxjs';
 import { exhaustMap, mergeMap, takeWhile, map, take } from 'rxjs/operators';
 import { expect } from 'chai';
 import { asInteropObservable } from '../helpers/interop-helper';
@@ -450,5 +450,20 @@ describe('exhaustMap', () => {
     ).subscribe(() => { /* noop */ });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
+  });
+
+  it('should ignore subsequent synchronous reentrances during subscribing the inner sub', () => {
+    const e = new BehaviorSubject(1);
+    const results: Array<number> = [];
+
+    e.pipe(
+      take(3),
+      exhaustMap(value => new Observable<number>(subscriber => {
+        e.next(value+1);
+        subscriber.next(value);
+      })),
+    ).subscribe(value => results.push(value));
+
+    expect(results).to.deep.equal([1]);
   });
 });

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { switchMap, mergeMap, map, takeWhile, take } from 'rxjs/operators';
-import { concat, defer, of, Observable } from 'rxjs';
+import { concat, defer, of, Observable, BehaviorSubject } from 'rxjs';
 import { asInteropObservable } from '../helpers/interop-helper';
 
 /** @test {switchMap} */
@@ -459,5 +459,20 @@ describe('switchMap', () => {
     ).subscribe(() => { /* noop */ });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
+  });
+
+  it('should unsubscribe previous inner sub when getting synchronously reentrance during subscribing the inner sub', () => {
+    const e = new BehaviorSubject(1);
+    const results: Array<number> = [];
+
+    e.pipe(
+      take(3),
+      switchMap(value => new Observable<number>(subscriber => {
+        e.next(value+1);
+        subscriber.next(value);
+      })),
+    ).subscribe(value => results.push(value));
+
+    expect(results).to.deep.equal([3]);
   });
 });

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -113,7 +113,8 @@ class ExhaustMapSubscriber<T, R> extends SimpleOuterSubscriber<T, R> {
       const innerSubscriber = new SimpleInnerSubscriber(this);
       const destination = this.destination;
       destination.add(innerSubscriber);
-      this.innerSubscription = innerSubscribe(result, innerSubscriber);
+      this.innerSubscription = innerSubscriber;
+      innerSubscribe(result, innerSubscriber);
     }
   }
 

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -129,7 +129,8 @@ class SwitchMapSubscriber<T, R> extends SimpleOuterSubscriber<T, R> {
     }
     const innerSubscriber = new SimpleInnerSubscriber(this);
     this.destination.add(innerSubscriber);
-    this.innerSubscription = innerSubscribe(result, innerSubscriber);
+    this.innerSubscription = innerSubscriber;
+    innerSubscribe(result, innerSubscriber);
   }
 
   protected _complete(): void {


### PR DESCRIPTION
**Description:**

Some operators create inner subscriptions on `next()`. But during subscribing to the inner sub, some side effects may trigger another `next()` on this operator synchronously, i.e. synchronous reentrant, leading to a new inner subscription to be created. However the previous inner subscription is not yet set on the operator, which would cause unexpected behavior for some operators. It's clear to us that `switchMap` and `exhaustMap` behaves unexpectedly under this setting, because their correct behaviors are defined by the order of messages being received.

This PR is trying to address these unexpected behaviors so that:

- `switchMap` should unsubscribe previous inner sub when getting synchronously reentrance during subscribing the inner sub
- `exhaustMap` should ignore subsequent synchronous reentrances during subscribing the inner sub

**Related issue (if exists):**

It's yet to be determined if other operators' behaviors under this setting should be considered unexpected.
