### PR TITLE
fix(ReplaySubject): don't buffer next if stopped

### DIFF
--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -1,5 +1,4 @@
 import { expect } from 'chai';
-import { values } from 'lodash';
 import { ReplaySubject, Subject, of } from 'rxjs';
 import { mergeMapTo, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -1,4 +1,5 @@
 import { expect } from 'chai';
+import { values } from 'lodash';
 import { ReplaySubject, Subject, of } from 'rxjs';
 import { mergeMapTo, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
@@ -350,5 +351,33 @@ describe('ReplaySubject', () => {
     );
 
     expect(results).to.deep.equal([3, 4, 5, 'done']);
+  });
+
+  it('should not buffer nexted values after complete', () => {
+    const results: (number | string)[] = [];
+    const subject = new ReplaySubject<number>();
+    subject.next(1);
+    subject.next(2);
+    subject.complete();
+    subject.next(3);
+    subject.subscribe({
+      next: value => results.push(value),
+      complete: () => results.push('C'),
+    });
+    expect(results).to.deep.equal([1, 2, 'C']);
+  });
+
+  it('should not buffer nexted values after error', () => {
+    const results: (number | string)[] = [];
+    const subject = new ReplaySubject<number>();
+    subject.next(1);
+    subject.next(2);
+    subject.error(new Error('Boom!'));
+    subject.next(3);
+    subject.subscribe({
+      next: value => results.push(value),
+      error: () => results.push('E'),
+    });
+    expect(results).to.deep.equal([1, 2, 'E']);
   });
 });

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -65,21 +65,23 @@ export class ReplaySubject<T> extends Subject<T> {
   }
 
   private nextInfiniteTimeWindow(value: T): void {
-    const _events = this._events;
-    _events.push(value);
-    // Since this method is invoked in every next() call than the buffer
-    // can overgrow the max size only by one item
-    if (_events.length > this._bufferSize) {
-      _events.shift();
+    if (!this.isStopped) {
+      const _events = this._events;
+      _events.push(value);
+      // Since this method is invoked in every next() call than the buffer
+      // can overgrow the max size only by one item
+      if (_events.length > this._bufferSize) {
+        _events.shift();
+      }
     }
-
     super.next(value);
   }
 
   private nextTimeWindow(value: T): void {
-    this._events.push({ time: this._getNow(), value });
-    this._trimBufferThenGetEvents();
-
+    if (!this.isStopped) {
+      this._events.push({ time: this._getNow(), value });
+      this._trimBufferThenGetEvents();
+    }
     super.next(value);
   }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes a bug in `ReplaySubject` - demonstrated in failing tests - in which nexted values were buffered **after** the subject was stopped (by a `complete` or `error` call).

**Related issue (if exists):** None
