### PR TITLE
refactor(Observable): simplify subscription and subscriber code

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -532,7 +532,7 @@ export declare type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<ne
 
 export declare class Subscriber<T> extends Subscription implements Observer<T> {
     protected destination: Observer<any> | Subscriber<any>;
-    protected isStopped: boolean; syncErrorThrowable: boolean; syncErrorThrown: boolean; syncErrorValue: any;
+    protected isStopped: boolean;
     constructor(destinationOrNext?: PartialObserver<any> | ((value: T) => void) | null, error?: ((e?: any) => void) | null, complete?: (() => void) | null);
     protected _complete(): void;
     protected _error(err: any): void;

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -620,7 +620,7 @@ describe('Observable', () => {
         expect(() => throwError(new Error('thrown error')).subscribe()).to.throw(Error, 'thrown error');
       });
 
-      it('should rethrow if sink has syncErrorThrowable = false', () => {
+      it('should rethrow if next handler throws', () => {
         const observable = new Observable((observer) => {
           observer.next(1);
         });


### PR DESCRIPTION
- Gets rid of weirdness with syncErrorThrowable, et al
- General code golf in a few spots.