### PR TITLE
refactor(tap): slight size reduction

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "changelog": "npx conventional-changelog-cli -p angular -i CHANGELOG.md -s",
     "commitmsg": "validate-commit-msg",
     "build:spec:browser": "echo \"Browser test is not working currently\" && exit -1 && webpack --config spec/support/webpack.mocha.config.js",
-    "lint_spec": "tslint -c tslint.json -p spec/tsconfig.json \"spec/**/*.ts\"",
+    "lint_spec": "tslint -c spec/tslint.json -p spec/tsconfig.json \"spec/**/*.ts\"",
     "lint_src": "tslint -c tslint.json -p src/tsconfig.base.json \"src/**/*.ts\"",
     "lint": "npm-run-all --parallel lint_*",
     "dtslint": "tsc -b ./src/tsconfig.types.json && tslint -c spec-dtslint/tslint.json -p spec-dtslint/tsconfig.json \"spec-dtslint/**/*.ts\"",

--- a/spec/tslint.json
+++ b/spec/tslint.json
@@ -1,0 +1,44 @@
+{
+    "extends": ["tslint:latest", "tslint-no-unused-expression-chai", "tslint-config-prettier"],
+    "rulesDirectory": ["../node_modules/tslint-etc/dist/rules", "../node_modules/tslint-no-toplevel-property-access/rules"],
+    // This is really just a list of what is wrong in our codebase,
+    // We should remove all of these over time.
+    "rules": {
+      "ordered-imports": [false],
+      "interface-name": [false],
+      "variable-name": [false], // Ben cries
+      "member-access": [false],
+      "ban-types": [false],
+      "array-type": [false],
+      "no-angle-bracket-type-assertion": [false],
+      "no-shadowed-variable": [false],
+      "no-empty-interface": [false],
+      "interface-over-type-literal": [false],
+      "member-ordering": [false],
+      "only-arrow-functions": [false],
+      "callable-types": [false],
+      "prefer-const": [false],
+      "object-literal-sort-keys": [false],
+      "no-this-assignment": [false],
+      "one-variable-per-declaration": [false],
+      "no-conditional-assignment": [false],
+      "no-unnecessary-initializer": [false],
+      "max-classes-per-file": [true, 10],
+      "unified-signatures": [false],
+      "jsdoc-format": [false],
+      "no-console": [false],
+      "prefer-for-of": [false],
+      "comment-format": [false],
+      "object-literal-shorthand": [false],
+      "prefer-conditional-expression": [false],
+      "triple-equals": [false], // OH MY GOD!!!!! AHHH!!!!
+      "no-object-literal-type-assertion": [false],
+      "ban-comma-operator": [false],
+      "no-submodule-imports": [false],
+      "no-implicit-dependencies": [true, "dev", ["rxjs", "chai"]],
+      "radix": [false],
+      "no-string-literal": [false],
+      "no-string-throw": [false],
+      "arrow-return-shorthand": [false]
+    }
+  }

--- a/tslint.json
+++ b/tslint.json
@@ -1,9 +1,10 @@
 {
-  "extends": ["tslint:latest", "tslint-no-unused-expression-chai", "tslint-config-prettier"],
+  "extends": ["tslint:latest", "tslint-config-prettier"],
   "rulesDirectory": ["node_modules/tslint-etc/dist/rules", "node_modules/tslint-no-toplevel-property-access/rules"],
   // This is really just a list of what is wrong in our codebase,
   // We should remove all of these over time.
   "rules": {
+    "no-unused-expression": [true, "allow-fast-null-checks"],
     "ordered-imports": [false],
     "interface-name": [false],
     "variable-name": [false], // Ben cries


### PR DESCRIPTION
- Also ensures that unsubscribe is called in error and complete callbacks by calling `super._error` etc.
- Rewrites docs and adds more examples (LOC will look like more, probably)

Before: 913B

![tap-before](https://user-images.githubusercontent.com/1540597/92873775-0111a400-f3cd-11ea-8a0c-b3aba6f02d40.png)


After: 549B (60% of original size)

![tap-after](https://user-images.githubusercontent.com/1540597/92931374-f5dc6980-f408-11ea-85db-cae85d33caf3.png)

