### PR TITLE
Add cast to configOrCount to fix types in Google

### DIFF
--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -65,7 +65,7 @@ export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTy
     config = configOrCount;
   } else {
     config = {
-      count: configOrCount
+      count: configOrCount as number
     };
   }
   const { count, resetOnSuccess = false } = config;


### PR DESCRIPTION
**Description:**
Without this case I kept the following compilation error: 

```
Type 'number | RetryConfig' is not assignable to type 'number'.
  Type 'RetryConfig' is not assignable to type 'number'.

85     config = {count: configOrCount};
                 ~~~~~

  third_party/javascript/rxjs/src/internal/operators/retry.ts:27:3
    27   count: number;
         ~~~~~
    The expected type comes from property 'count' which is declared here on type 'RetryConfig'

```


**Related issue (if exists):**
