### PR TITLE
refactor(Subscription): minor size reduction

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -560,7 +560,7 @@ export interface SubscriptionLike extends Unsubscribable {
 
 export declare type Tail<X extends any[]> = ((...args: X) => any) extends ((arg: any, ...rest: infer U) => any) ? U : never;
 
-export declare type TeardownLogic = Subscription | Unsubscribable | Function | void;
+export declare type TeardownLogic = Subscription | Unsubscribable | (() => void) | void;
 
 export declare function throwError(errorFactory: () => any): Observable<never>;
 export declare function throwError(error: any): Observable<never>;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -51,7 +51,7 @@ export interface Unsubscribable {
   unsubscribe(): void;
 }
 
-export type TeardownLogic = Subscription | Unsubscribable | Function | void;
+export type TeardownLogic = Subscription | Unsubscribable | (() => void) | void;
 
 export interface SubscriptionLike extends Unsubscribable {
   unsubscribe(): void;


### PR DESCRIPTION
- Reduces the size of subscription a little
- Moves back to a single property for single/many parents scenarios
- Updates the type of `Teardown` to not be so loose.  does not may any sense there.
