### PR TITLE
Refactor isArray usage

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -121,14 +121,28 @@ export declare function combineLatest<O1 extends ObservableInput<any>, O2 extend
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(sources: [O1, O2, O3], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(sources: [O1, O2, O3, O4], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
+export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6], scheduler: SchedulerLike): Observable<[
+    ObservedValueOf<O1>,
+    ObservedValueOf<O2>,
+    ObservedValueOf<O3>,
+    ObservedValueOf<O4>,
+    ObservedValueOf<O5>,
+    ObservedValueOf<O6>
+]>;
 export declare function combineLatest<O extends ObservableInput<any>>(sources: O[], scheduler: SchedulerLike): Observable<ObservedValueOf<O>[]>;
 export declare function combineLatest<O1 extends ObservableInput<any>>(sources: [O1]): Observable<[ObservedValueOf<O1>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(sources: [O1, O2]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(sources: [O1, O2, O3]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(sources: [O1, O2, O3, O4]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
+export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6]): Observable<[
+    ObservedValueOf<O1>,
+    ObservedValueOf<O2>,
+    ObservedValueOf<O3>,
+    ObservedValueOf<O4>,
+    ObservedValueOf<O5>,
+    ObservedValueOf<O6>
+]>;
 export declare function combineLatest<O extends ObservableInput<any>>(sources: O[]): Observable<ObservedValueOf<O>[]>;
 export declare function combineLatest<O extends readonly ObservableInput<any>[]>(sources: O): Observable<ObservedValueTupleFromArray<O>>;
 export declare function combineLatest<O1 extends ObservableInput<any>>(v1: O1, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>]>;
@@ -136,7 +150,14 @@ export declare function combineLatest<O1 extends ObservableInput<any>, O2 extend
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
+export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler?: SchedulerLike): Observable<[
+    ObservedValueOf<O1>,
+    ObservedValueOf<O2>,
+    ObservedValueOf<O3>,
+    ObservedValueOf<O4>,
+    ObservedValueOf<O5>,
+    ObservedValueOf<O6>
+]>;
 export declare function combineLatest<O extends ObservableInput<any>>(...observables: O[]): Observable<any[]>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(array: O[], resultSelector: (...values: ObservedValueOf<O>[]) => R, scheduler?: SchedulerLike): Observable<R>;

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -1,7 +1,7 @@
 import { SchedulerLike } from '../types';
 import { Observable } from '../Observable';
-import { map } from '../operators/map';
 import { isScheduler } from '../util/isScheduler';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 
 // tslint:disable:max-line-length
 /** @deprecated resultSelector is no longer supported, use a mapping function. */
@@ -172,18 +172,19 @@ export function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike):
  * Observable that delivers the same values the callback would deliver.
  * @name bindCallback
  */
-export function bindCallback<T>(
-  callbackFunc: Function,
-  resultSelector?: Function|SchedulerLike,
+export function bindCallback<T, R>(
+  callbackFunc: any,
+  resultSelector?: any,
   scheduler?: SchedulerLike
-): (...args: any[]) => Observable<T> {
+): (...args: any[]) => Observable<T | R> {
   if (resultSelector) {
     if (isScheduler(resultSelector)) {
       scheduler = resultSelector;
     } else {
-      // DEPRECATED PATH
-      return (...args: any[]) => bindCallback(callbackFunc, scheduler)(...args).pipe(
-        map((args) => Array.isArray(args) ? resultSelector(...args) : resultSelector(args)),
+      // Deprecated path (Returning Observable<R>)
+      // TODO: Fix these internal typings.
+      return (...args: any[]) => (bindCallback(callbackFunc, scheduler) as any)(...args).pipe(
+        mapOneOrManyArgs(resultSelector),
       );
     }
   }

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -1,7 +1,6 @@
 import { SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { map } from '../operators/map';
-import { isArray } from '../util/isArray';
 import { isScheduler } from '../util/isScheduler';
 
 // tslint:disable:max-line-length
@@ -184,7 +183,7 @@ export function bindCallback<T>(
     } else {
       // DEPRECATED PATH
       return (...args: any[]) => bindCallback(callbackFunc, scheduler)(...args).pipe(
-        map((args) => isArray(args) ? resultSelector(...args) : resultSelector(args)),
+        map((args) => Array.isArray(args) ? resultSelector(...args) : resultSelector(args)),
       );
     }
   }

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -172,11 +172,11 @@ export function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike):
  * Observable that delivers the same values the callback would deliver.
  * @name bindCallback
  */
-export function bindCallback<T, R>(
+export function bindCallback(
   callbackFunc: any,
   resultSelector?: any,
   scheduler?: SchedulerLike
-): (...args: any[]) => Observable<T | R> {
+): (...args: any[]) => Observable<unknown> {
   if (resultSelector) {
     if (isScheduler(resultSelector)) {
       scheduler = resultSelector;
@@ -190,12 +190,12 @@ export function bindCallback<T, R>(
   }
 
   
-  return function (this: any, ...args: any[]): Observable<T> {
+  return function (this: any, ...args: any[]) {
     let results: any;
     let hasResults = false;
     let hasError = false;
     let error: any;
-    return new Observable<T>((subscriber) => {
+    return new Observable((subscriber) => {
       if (!scheduler) {
         let isCurrentlyAsync = false;
         let hasCompletedSynchronously = false;

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -3,7 +3,6 @@ import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { map } from '../operators/map';
 import { isScheduler } from '../util/isScheduler';
-import { isArray } from '../util/isArray';
 
 /* tslint:disable:max-line-length */
 /** @deprecated resultSelector is deprecated, pipe to map instead */
@@ -269,7 +268,7 @@ export function bindNodeCallback<T>(
         bindNodeCallback(
           callbackFunc,
           scheduler
-        )(...args).pipe(map((args) => (isArray(args) ? resultSelector(...args) : resultSelector(args))));
+        )(...args).pipe(map((args) => (Array.isArray(args) ? resultSelector(...args) : resultSelector(args))));
     }
   }
 

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -1,8 +1,8 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
-import { map } from '../operators/map';
 import { isScheduler } from '../util/isScheduler';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 
 /* tslint:disable:max-line-length */
 /** @deprecated resultSelector is deprecated, pipe to map instead */
@@ -264,11 +264,7 @@ export function bindNodeCallback<T>(
       scheduler = resultSelector;
     } else {
       // DEPRECATED PATH
-      return (...args: any[]) =>
-        bindNodeCallback(
-          callbackFunc,
-          scheduler
-        )(...args).pipe(map((args) => (Array.isArray(args) ? resultSelector(...args) : resultSelector(args))));
+      return (...args: any[]) => bindNodeCallback(callbackFunc, scheduler)(...args).pipe(mapOneOrManyArgs(resultSelector as any));
     }
   }
 

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -1,7 +1,6 @@
 import { Observable } from '../Observable';
 import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValueTupleFromArray } from '../types';
 import { isScheduler  } from '../util/isScheduler';
-import { isArray  } from '../util/isArray';
 import { Subscriber } from '../Subscriber';
 import { ComplexOuterSubscriber, ComplexInnerSubscriber, innerSubscribe } from '../innerSubscribe';
 import { Operator } from '../Operator';
@@ -253,7 +252,7 @@ export function combineLatest<O extends ObservableInput<any>, R>(
 
   if (observables.length === 1) {
     const first = observables[0] as any;
-    if (isArray(first)) {
+    if (Array.isArray(first)) {
       // if the first and only other argument besides the resultSelector is an array
       // assume it's been called with `combineLatest([obs1, obs2, obs3], resultSelector)`
       observables = first;

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -1,12 +1,13 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValueTupleFromArray } from '../types';
-import { isScheduler  } from '../util/isScheduler';
+import { isScheduler } from '../util/isScheduler';
 import { Subscriber } from '../Subscriber';
 import { ComplexOuterSubscriber, ComplexInnerSubscriber, innerSubscribe } from '../innerSubscribe';
 import { Operator } from '../Operator';
-import { isObject } from '../util/isObject';
 import { fromArray } from './fromArray';
 import { lift } from '../util/lift';
+import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 
 const NONE = {};
 
@@ -14,57 +15,255 @@ const NONE = {};
 
 // If called with a single array, it "auto-spreads" the array, with result selector
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, R>(sources: [O1], resultSelector: (v1: ObservedValueOf<O1>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O1 extends ObservableInput<any>, R>(
+  sources: [O1],
+  resultSelector: (v1: ObservedValueOf<O1>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, R>(sources: [O1, O2], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, R>(
+  sources: [O1, O2],
+  resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, R>(sources: [O1, O2, O3], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, R>(
+  sources: [O1, O2, O3],
+  resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, R>(sources: [O1, O2, O3, O4], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  R
+>(
+  sources: [O1, O2, O3, O4],
+  resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, R>(sources: [O1, O2, O3, O4, O5], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>, v5: ObservedValueOf<O5>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>,
+  R
+>(
+  sources: [O1, O2, O3, O4, O5],
+  resultSelector: (
+    v1: ObservedValueOf<O1>,
+    v2: ObservedValueOf<O2>,
+    v3: ObservedValueOf<O3>,
+    v4: ObservedValueOf<O4>,
+    v5: ObservedValueOf<O5>
+  ) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>, R>(sources: [O1, O2, O3, O4, O5, O6], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>, v5: ObservedValueOf<O5>, v6: ObservedValueOf<O6>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>,
+  O6 extends ObservableInput<any>,
+  R
+>(
+  sources: [O1, O2, O3, O4, O5, O6],
+  resultSelector: (
+    v1: ObservedValueOf<O1>,
+    v2: ObservedValueOf<O2>,
+    v3: ObservedValueOf<O3>,
+    v4: ObservedValueOf<O4>,
+    v5: ObservedValueOf<O5>,
+    v6: ObservedValueOf<O6>
+  ) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O extends ObservableInput<any>, R>(sources: O[], resultSelector: (...args: ObservedValueOf<O>[]) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O extends ObservableInput<any>, R>(
+  sources: O[],
+  resultSelector: (...args: ObservedValueOf<O>[]) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 
 // standard call, but with a result selector
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, R>(v1: O1, resultSelector: (v1: ObservedValueOf<O1>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O1 extends ObservableInput<any>, R>(
+  v1: O1,
+  resultSelector: (v1: ObservedValueOf<O1>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, R>(v1: O1, v2: O2, resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, R>(
+  v1: O1,
+  v2: O2,
+  resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, R>(v1: O1, v2: O2, v3: O3, resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, R>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, R>(v1: O1, v2: O2, v3: O3, v4: O4, resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  R
+>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  v4: O4,
+  resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, R>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>, v5: ObservedValueOf<O5>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>,
+  R
+>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  v4: O4,
+  v5: O5,
+  resultSelector: (
+    v1: ObservedValueOf<O1>,
+    v2: ObservedValueOf<O2>,
+    v3: ObservedValueOf<O3>,
+    v4: ObservedValueOf<O4>,
+    v5: ObservedValueOf<O5>
+  ) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>, R>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>, v5: ObservedValueOf<O5>, v6: ObservedValueOf<O6>) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>,
+  O6 extends ObservableInput<any>,
+  R
+>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  v4: O4,
+  v5: O5,
+  v6: O6,
+  resultSelector: (
+    v1: ObservedValueOf<O1>,
+    v2: ObservedValueOf<O2>,
+    v3: ObservedValueOf<O3>,
+    v4: ObservedValueOf<O4>,
+    v5: ObservedValueOf<O5>,
+    v6: ObservedValueOf<O6>
+  ) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 
 // With a scheduler (deprecated)
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
 export function combineLatest<O1 extends ObservableInput<any>>(sources: [O1], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>]>;
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(sources: [O1, O2], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(
+  sources: [O1, O2],
+  scheduler: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(sources: [O1, O2, O3], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(
+  sources: [O1, O2, O3],
+  scheduler: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(sources: [O1, O2, O3, O4], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>
+>(
+  sources: [O1, O2, O3, O4],
+  scheduler: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>
+>(
+  sources: [O1, O2, O3, O4, O5],
+  scheduler: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6], scheduler: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>,
+  O6 extends ObservableInput<any>
+>(
+  sources: [O1, O2, O3, O4, O5, O6],
+  scheduler: SchedulerLike
+): Observable<
+  [ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]
+>;
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
 export function combineLatest<O extends ObservableInput<any>>(sources: O[], scheduler: SchedulerLike): Observable<ObservedValueOf<O>[]>;
 
 // Best case
 export function combineLatest<O1 extends ObservableInput<any>>(sources: [O1]): Observable<[ObservedValueOf<O1>]>;
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(sources: [O1, O2]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(sources: [O1, O2, O3]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(sources: [O1, O2, O3, O4]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(
+  sources: [O1, O2]
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(
+  sources: [O1, O2, O3]
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>
+>(sources: [O1, O2, O3, O4]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>
+>(
+  sources: [O1, O2, O3, O4, O5]
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>,
+  O6 extends ObservableInput<any>
+>(
+  sources: [O1, O2, O3, O4, O5, O6]
+): Observable<
+  [ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]
+>;
 export function combineLatest<O extends ObservableInput<any>>(sources: O[]): Observable<ObservedValueOf<O>[]>;
 export function combineLatest<O extends readonly ObservableInput<any>[]>(sources: O): Observable<ObservedValueTupleFromArray<O>>;
 
@@ -72,33 +271,93 @@ export function combineLatest<O extends readonly ObservableInput<any>[]>(sources
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
 export function combineLatest<O1 extends ObservableInput<any>>(v1: O1, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>]>;
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(v1: O1, v2: O2, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(
+  v1: O1,
+  v2: O2,
+  scheduler?: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
+export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  scheduler?: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>
+>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  v4: O4,
+  scheduler?: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>
+>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  v4: O4,
+  v5: O5,
+  scheduler?: SchedulerLike
+): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
+export function combineLatest<
+  O1 extends ObservableInput<any>,
+  O2 extends ObservableInput<any>,
+  O3 extends ObservableInput<any>,
+  O4 extends ObservableInput<any>,
+  O5 extends ObservableInput<any>,
+  O6 extends ObservableInput<any>
+>(
+  v1: O1,
+  v2: O2,
+  v3: O3,
+  v4: O4,
+  v5: O5,
+  v6: O6,
+  scheduler?: SchedulerLike
+): Observable<
+  [ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]
+>;
 
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
 export function combineLatest<O extends ObservableInput<any>>(...observables: O[]): Observable<any[]>;
 
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
-export function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): Observable<R>;
+export function combineLatest<O extends ObservableInput<any>, R>(
+  ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>
+): Observable<R>;
 
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O extends ObservableInput<any>, R>(array: O[], resultSelector: (...values: ObservedValueOf<O>[]) => R, scheduler?: SchedulerLike): Observable<R>;
+export function combineLatest<O extends ObservableInput<any>, R>(
+  array: O[],
+  resultSelector: (...values: ObservedValueOf<O>[]) => R,
+  scheduler?: SchedulerLike
+): Observable<R>;
 
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
 export function combineLatest<O extends ObservableInput<any>>(...observables: Array<O | SchedulerLike>): Observable<any[]>;
 
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
-export function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>): Observable<R>;
+export function combineLatest<O extends ObservableInput<any>, R>(
+  ...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>
+): Observable<R>;
 
 /** @deprecated Passing a scheduler here is deprecated, use {@link subscribeOn} and/or {@link observeOn} instead */
-export function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
+export function combineLatest<R>(
+  ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>
+): Observable<R>;
 
 // combineLatest({})
 export function combineLatest(sourcesObject: {}): Observable<never>;
@@ -166,7 +425,7 @@ export function combineLatest<T, K extends keyof T>(sourcesObject: T): Observabl
  * ```
  * ### Combine a dictionary of Observables
  * ```ts
-* import { combineLatest, of } from 'rxjs';
+ * import { combineLatest, of } from 'rxjs';
  * import { delay, startWith } from 'rxjs/operators';
  *
  * const observables = {
@@ -236,41 +495,26 @@ export function combineLatest<T, K extends keyof T>(sourcesObject: T): Observabl
  * each input Observable.
  */
 export function combineLatest<O extends ObservableInput<any>, R>(
-  ...observables: (O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike)[]
+  ...args: (O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike)[]
 ): Observable<R> {
-  let resultSelector: ((...values: Array<any>) => R) | undefined =  undefined;
+  let resultSelector: ((...values: Array<any>) => R) | undefined = undefined;
   let scheduler: SchedulerLike | undefined = undefined;
-  let keys: Array<string> | undefined = undefined;
 
-  if (isScheduler(observables[observables.length - 1])) {
-    scheduler = observables.pop() as SchedulerLike;
+  if (isScheduler(args[args.length - 1])) {
+    scheduler = args.pop() as SchedulerLike;
   }
 
-  if (typeof observables[observables.length - 1] === 'function') {
-    resultSelector = observables.pop() as (...values: Array<any>) => R;
+  if (typeof args[args.length - 1] === 'function') {
+    resultSelector = args.pop() as (...values: Array<any>) => R;
   }
 
-  if (observables.length === 1) {
-    const first = observables[0] as any;
-    if (Array.isArray(first)) {
-      // if the first and only other argument besides the resultSelector is an array
-      // assume it's been called with `combineLatest([obs1, obs2, obs3], resultSelector)`
-      observables = first;
-    }
-    // if the first and only argument is an object, assume it's been called with
-    // `combineLatest({})`
-    if (isObject(first) && Object.getPrototypeOf(first) === Object.prototype) {
-      keys = Object.keys(first);
-      observables = keys.map(key => first[key]);
-    }
-  }
+  const { args: observables, keys } = argsArgArrayOrObject(args);
 
-  return lift(fromArray(observables, scheduler), new CombineLatestOperator<ObservedValueOf<O>, R>(resultSelector, keys));
+  return lift(fromArray(observables, scheduler), new CombineLatestOperator(resultSelector, keys));
 }
 
 export class CombineLatestOperator<T, R> implements Operator<T, R> {
-  constructor(private resultSelector?: (...values: Array<any>) => R, private keys?: Array<string>) {
-  }
+  constructor(private resultSelector: ((...values: Array<any>) => R) | undefined, private keys: Array<string> | null) {}
 
   call(subscriber: Subscriber<R>, source: any): any {
     return source.subscribe(new CombineLatestSubscriber(subscriber, this.resultSelector, this.keys));
@@ -288,7 +532,11 @@ export class CombineLatestSubscriber<T, R> extends ComplexOuterSubscriber<T, R> 
   private observables: any[] = [];
   private toRespond: number | undefined;
 
-  constructor(destination: Subscriber<R>, private resultSelector?: (...values: Array<any>) => R, private keys?: Array<string>) {
+  constructor(
+    destination: Subscriber<R>,
+    private resultSelector: ((...values: Array<any>) => R) | undefined,
+    private keys: Array<string> | null
+  ) {
     super(destination);
   }
 
@@ -318,22 +566,19 @@ export class CombineLatestSubscriber<T, R> extends ComplexOuterSubscriber<T, R> 
     }
   }
 
-  notifyNext(_outerValue: T, innerValue: R,
-             outerIndex: number): void {
+  notifyNext(_outerValue: T, innerValue: R, outerIndex: number): void {
     const values = this.values;
     const oldVal = values[outerIndex];
-    const toRespond = !this.toRespond
-      ? 0
-      : oldVal === NONE ? --this.toRespond : this.toRespond;
+    const toRespond = !this.toRespond ? 0 : oldVal === NONE ? --this.toRespond : this.toRespond;
     values[outerIndex] = innerValue;
 
     if (toRespond === 0) {
       if (this.resultSelector) {
         this._tryResultSelector(values);
       } else {
-        this.destination.next(this.keys ?
-          this.keys.reduce((result, key, i) => ((result as any)[key] = values[i], result), {}) :
-          values.slice());
+        this.destination.next(
+          this.keys ? this.keys.reduce((result, key, i) => (((result as any)[key] = values[i]), result), {}) : values.slice()
+        );
       }
     }
   }

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf, SubscribableOrPromise } from '../types';
 import { map } from '../operators/map';
-import { isObject } from '../util/isObject';
+import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { from } from './from';
 
 /* tslint:disable:max-line-length */
@@ -130,7 +130,7 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * @see {@link combineLatest}
  * @see {@link zip}
  *
- * @param {...ObservableInput} sources Any number of Observables provided either as an array or as an arguments
+ * @param {...ObservableInput} args Any number of Observables provided either as an array or as an arguments
  * passed directly to the operator.
  * @param {function} [project] Function that takes values emitted by input Observables and returns value
  * that will appear in resulting Observable instead of default array.
@@ -138,29 +138,23 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * or value from project function.
  */
 export function forkJoin(
-  ...sources: any[]
+  ...args: any[]
 ): Observable<any> {
-  if (sources.length === 1) {
-    const first = sources[0];
-    if (Array.isArray(first)) {
-      return forkJoinInternal(first, null);
-    }
-    if (isObject(first) && Object.getPrototypeOf(first) === Object.prototype) {
-      const keys = Object.keys(first);
-      return forkJoinInternal(keys.map(key => first[key]), keys);
-    }
+  let resultSelector: ((...args: any[]) => any) | undefined;
+  if (typeof args[args.length - 1] === 'function') {
+    resultSelector = args.pop();
   }
 
-  // DEPRECATED PATHS BELOW HERE
-  if (typeof sources[sources.length - 1] === 'function') {
-    const resultSelector = sources.pop() as Function;
-    sources = (sources.length === 1 && Array.isArray(sources[0])) ? sources[0] : sources;
-    return forkJoinInternal(sources, null).pipe(
-      map((args: any[]) => resultSelector(...args))
+  const { args: sources, keys } = argsArgArrayOrObject(args);
+
+  if (resultSelector) {
+    // deprecated path.
+    return forkJoinInternal(sources, keys).pipe(
+      map((values: any[]) => resultSelector!(...values))
     );
   }
 
-  return forkJoinInternal(sources, null);
+  return forkJoinInternal(sources, keys);
 }
 
 function forkJoinInternal(sources: ObservableInput<any>[], keys: string[] | null): Observable<any> {

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,6 +1,5 @@
 import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf, SubscribableOrPromise } from '../types';
-import { isArray } from '../util/isArray';
 import { map } from '../operators/map';
 import { isObject } from '../util/isObject';
 import { from } from './from';
@@ -143,7 +142,7 @@ export function forkJoin(
 ): Observable<any> {
   if (sources.length === 1) {
     const first = sources[0];
-    if (isArray(first)) {
+    if (Array.isArray(first)) {
       return forkJoinInternal(first, null);
     }
     if (isObject(first) && Object.getPrototypeOf(first) === Object.prototype) {
@@ -155,7 +154,7 @@ export function forkJoin(
   // DEPRECATED PATHS BELOW HERE
   if (typeof sources[sources.length - 1] === 'function') {
     const resultSelector = sources.pop() as Function;
-    sources = (sources.length === 1 && isArray(sources[0])) ? sources[0] : sources;
+    sources = (sources.length === 1 && Array.isArray(sources[0])) ? sources[0] : sources;
     return forkJoinInternal(sources, null).pipe(
       map((args: any[]) => resultSelector(...args))
     );

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { isFunction } from '../util/isFunction';
 import { Subscriber } from '../Subscriber';
-import { map } from '../operators/map';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 
 export interface NodeStyleEventEmitter {
   addListener: (eventName: string | symbol, handler: NodeEventHandler) => this;
@@ -186,7 +186,7 @@ export function fromEvent<T>(
   if (resultSelector) {
     // DEPRECATED PATH
     return fromEvent<T>(target, eventName, options as EventListenerOptions | undefined).pipe(
-      map(args => Array.isArray(args) ? resultSelector!(...args) : resultSelector!(args))
+      mapOneOrManyArgs(resultSelector)
     );
   }
 

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -1,5 +1,4 @@
 import { Observable } from '../Observable';
-import { isArray } from '../util/isArray';
 import { isFunction } from '../util/isFunction';
 import { Subscriber } from '../Subscriber';
 import { map } from '../operators/map';
@@ -187,7 +186,7 @@ export function fromEvent<T>(
   if (resultSelector) {
     // DEPRECATED PATH
     return fromEvent<T>(target, eventName, options as EventListenerOptions | undefined).pipe(
-      map(args => isArray(args) ? resultSelector!(...args) : resultSelector!(args))
+      map(args => Array.isArray(args) ? resultSelector!(...args) : resultSelector!(args))
     );
   }
 

--- a/src/internal/observable/fromEventPattern.ts
+++ b/src/internal/observable/fromEventPattern.ts
@@ -1,5 +1,4 @@
 import { Observable } from '../Observable';
-import { isArray } from '../util/isArray';
 import { isFunction } from '../util/isFunction';
 import { NodeEventHandler } from './fromEvent';
 import { map } from '../operators/map';
@@ -145,7 +144,7 @@ export function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => a
   if (resultSelector) {
     // DEPRECATED PATH
     return fromEventPattern<T>(addHandler, removeHandler).pipe(
-      map(args => isArray(args) ? resultSelector(...args) : resultSelector(args))
+      map(args => Array.isArray(args) ? resultSelector(...args) : resultSelector(args))
     );
   }
 

--- a/src/internal/observable/fromEventPattern.ts
+++ b/src/internal/observable/fromEventPattern.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { isFunction } from '../util/isFunction';
 import { NodeEventHandler } from './fromEvent';
-import { map } from '../operators/map';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 
 /* tslint:disable:max-line-length */
 export function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any, removeHandler?: (handler: NodeEventHandler, signal?: any) => void): Observable<T>;
@@ -144,7 +144,7 @@ export function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => a
   if (resultSelector) {
     // DEPRECATED PATH
     return fromEventPattern<T>(addHandler, removeHandler).pipe(
-      map(args => Array.isArray(args) ? resultSelector(...args) : resultSelector(args))
+      mapOneOrManyArgs(resultSelector)
     );
   }
 

--- a/src/internal/observable/onErrorResumeNext.ts
+++ b/src/internal/observable/onErrorResumeNext.ts
@@ -3,6 +3,7 @@ import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf } from '../types';
 import { EMPTY } from './empty';
 import { onErrorResumeNext as onErrorResumeNextWith } from '../operators/onErrorResumeNext';
+import { argsOrArgArray } from '../util/argsOrArgArray';
 
 /* tslint:disable:max-line-length */
 export function onErrorResumeNext(): Observable<never>;
@@ -71,8 +72,5 @@ export function onErrorResumeNext<A extends ObservableInput<any>[]>(...sources: 
  * ignoring all errors, such that any error causes it to move on to the next source.
  */
 export function onErrorResumeNext(...sources: ObservableInput<any>[]): Observable<any> {
-  if (sources.length === 1 && Array.isArray(sources)) {
-    sources = sources[0] as any;
-  }
-  return onErrorResumeNextWith(sources)(EMPTY);
+  return onErrorResumeNextWith(argsOrArgArray(sources))(EMPTY);
 }

--- a/src/internal/observable/onErrorResumeNext.ts
+++ b/src/internal/observable/onErrorResumeNext.ts
@@ -3,7 +3,6 @@ import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf } from '../types';
 import { EMPTY } from './empty';
 import { onErrorResumeNext as onErrorResumeNextWith } from '../operators/onErrorResumeNext';
-import { isArray } from '../util/isArray';
 
 /* tslint:disable:max-line-length */
 export function onErrorResumeNext(): Observable<never>;
@@ -72,7 +71,7 @@ export function onErrorResumeNext<A extends ObservableInput<any>[]>(...sources: 
  * ignoring all errors, such that any error causes it to move on to the next source.
  */
 export function onErrorResumeNext(...sources: ObservableInput<any>[]): Observable<any> {
-  if (sources.length === 1 && isArray(sources)) {
+  if (sources.length === 1 && Array.isArray(sources)) {
     sources = sources[0] as any;
   }
   return onErrorResumeNextWith(sources)(EMPTY);

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -1,12 +1,11 @@
 import { Observable } from '../Observable';
 import { from } from './from';
-import { fromArray } from './fromArray';
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
-import { TeardownLogic, ObservableInput, ObservedValueUnionFromArray } from '../types';
+import { ObservableInput, ObservedValueUnionFromArray } from '../types';
 import { ComplexOuterSubscriber, innerSubscribe, ComplexInnerSubscriber } from '../innerSubscribe';
 import { lift } from '../util/lift';
+import { argsOrArgArray } from "../util/argsOrArgArray";
 
 export function race<A extends ObservableInput<any>[]>(observables: A): Observable<ObservedValueUnionFromArray<A>>;
 export function race<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
@@ -55,21 +54,11 @@ export function race<A extends ObservableInput<any>[]>(...observables: A): Obser
 export function race<T>(...observables: (ObservableInput<T> | ObservableInput<T>[])[]): Observable<any> {
   // if the only argument is an array, it was most likely called with
   // `race([obs1, obs2, ...])`
-  if (observables.length === 1) {
-    if (Array.isArray(observables[0])) {
-      observables = observables[0] as ObservableInput<T>[];
-    } else {
-      return from(observables[0] as ObservableInput<T>);
-    }
-  }
+  observables = argsOrArgArray(observables);
 
-  return lift(fromArray(observables, undefined), new RaceOperator<T>());
-}
-
-export class RaceOperator<T> implements Operator<T, T> {
-  call(subscriber: Subscriber<T>, source: any): TeardownLogic {
-    return source.subscribe(new RaceSubscriber(subscriber));
-  }
+  return observables.length === 1 ? from(observables[0]) : lift(from(observables), function (this: Subscriber<T>, source: Observable<any>) {
+    return source.subscribe(new RaceSubscriber(this));
+  });
 }
 
 /**

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -1,5 +1,4 @@
 import { Observable } from '../Observable';
-import { isArray } from '../util/isArray';
 import { from } from './from';
 import { fromArray } from './fromArray';
 import { Operator } from '../Operator';
@@ -57,7 +56,7 @@ export function race<T>(...observables: (ObservableInput<T> | ObservableInput<T>
   // if the only argument is an array, it was most likely called with
   // `race([obs1, obs2, ...])`
   if (observables.length === 1) {
-    if (isArray(observables[0])) {
+    if (Array.isArray(observables[0])) {
       observables = observables[0] as ObservableInput<T>[];
     } else {
       return from(observables[0] as ObservableInput<T>);

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -54,5 +54,5 @@ export function combineAll<R>(project: (...values: Array<any>) => R): OperatorFu
  * @name combineAll
  */
 export function combineAll<T, R>(project?: (...values: Array<any>) => R): OperatorFunction<T, R> {
-  return (source: Observable<T>) => lift(source, new CombineLatestOperator(project));
+  return (source: Observable<T>) => lift(source, new CombineLatestOperator(project, null));
 }

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -1,8 +1,10 @@
+/** @prettier */
 import { CombineLatestOperator } from '../observable/combineLatest';
 import { from } from '../observable/from';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
 import { stankyLift } from '../util/lift';
+import { argsOrArgArray } from '../util/argsOrArgArray';
 
 /* tslint:disable:max-line-length */
 /** @deprecated use {@link combineLatestWith} */
@@ -10,53 +12,81 @@ export function combineLatest<T, R>(project: (v1: T) => R): OperatorFunction<T, 
 /** @deprecated use {@link combineLatestWith} */
 export function combineLatest<T, T2, R>(v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R): OperatorFunction<T, R>;
+export function combineLatest<T, T2, T3, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  project: (v1: T, v2: T2, v3: T3) => R
+): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R): OperatorFunction<T, R>;
+export function combineLatest<T, T2, T3, T4, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  project: (v1: T, v2: T2, v3: T3, v4: T4) => R
+): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R): OperatorFunction<T, R>;
+export function combineLatest<T, T2, T3, T4, T5, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R
+): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5, T6, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R): OperatorFunction<T, R> ;
+export function combineLatest<T, T2, T3, T4, T5, T6, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  v6: ObservableInput<T6>,
+  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R
+): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
 export function combineLatest<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
 /** @deprecated use {@link combineLatestWith} */
 export function combineLatest<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, [T, T2, T3, T4]>;
+export function combineLatest<T, T2, T3, T4>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>
+): OperatorFunction<T, [T, T2, T3, T4]>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, [T, T2, T3, T4, T5]>;
+export function combineLatest<T, T2, T3, T4, T5>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>
+): OperatorFunction<T, [T, T2, T3, T4, T5]>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]> ;
+export function combineLatest<T, T2, T3, T4, T5, T6>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  v6: ObservableInput<T6>
+): OperatorFunction<T, [T, T2, T3, T4, T5, T6]>;
 /** @deprecated use {@link combineLatestWith} */
 export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
 export function combineLatest<T, R>(array: ObservableInput<T>[]): OperatorFunction<T, Array<T>>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, TOther, R>(array: ObservableInput<TOther>[], project: (v1: T, ...values: Array<TOther>) => R): OperatorFunction<T, R>;
+export function combineLatest<T, TOther, R>(
+  array: ObservableInput<TOther>[],
+  project: (v1: T, ...values: Array<TOther>) => R
+): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**
  * @deprecated Deprecated, use {@link combineLatestWith} or static {@link combineLatest}
  */
-export function combineLatest<T, R>(...observables: Array<ObservableInput<any> |
-                                                    Array<ObservableInput<any>> |
-                                                    ((...values: Array<any>) => R)>): OperatorFunction<T, R> {
+export function combineLatest<T, R>(...args: (ObservableInput<any> | ((...values: any[]) => R))[]): OperatorFunction<T, R> {
   let project: ((...values: Array<any>) => R) | undefined = undefined;
-  if (typeof observables[observables.length - 1] === 'function') {
-    project = <(...values: Array<any>) => R>observables.pop();
+  if (typeof args[args.length - 1] === 'function') {
+    project = args.pop() as (...values: any[]) => R;
   }
 
-  // if the first and only other argument besides the resultSelector is an array
-  // assume it's been called with `combineLatest([obs1, obs2, obs3], project)`
-  if (observables.length === 1 && Array.isArray(observables[0])) {
-    observables = (<any>observables[0]).slice();
-  }
-
-  return (source: Observable<T>) => stankyLift(
-    source,
-    from([source, ...observables]),
-    new CombineLatestOperator(project)
-  );
+  return (source: Observable<T>) => stankyLift(source, from([source, ...argsOrArgArray(args)]), new CombineLatestOperator(project, null));
 }
 
 /**

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -1,10 +1,8 @@
-
-import { isArray } from '../util/isArray';
 import { CombineLatestOperator } from '../observable/combineLatest';
 import { from } from '../observable/from';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
-import { lift, stankyLift } from '../util/lift';
+import { stankyLift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated use {@link combineLatestWith} */
@@ -50,7 +48,7 @@ export function combineLatest<T, R>(...observables: Array<ObservableInput<any> |
 
   // if the first and only other argument besides the resultSelector is an array
   // assume it's been called with `combineLatest([obs1, obs2, obs3], project)`
-  if (observables.length === 1 && isArray(observables[0])) {
+  if (observables.length === 1 && Array.isArray(observables[0])) {
     observables = (<any>observables[0]).slice();
   }
 

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -1,7 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { isArray } from '../util/isArray';
 import { ObservableInput, OperatorFunction, ObservedValueOf, ObservedValueUnionFromArray, MonoTypeOperatorFunction } from '../types';
 import { lift } from '../util/lift';
 import { from } from '../observable/from';
@@ -83,7 +82,7 @@ export function onErrorResumeNext<T, A extends ObservableInput<any>[]>(
 export function onErrorResumeNext<T>(...nextSources: ObservableInput<any>[]): OperatorFunction<T, unknown> {
   // If there is only one argument, and it is an array, we'll treat it like it is
   // and array of arguments.
-  if (nextSources.length === 1 && isArray(nextSources[0])) {
+  if (nextSources.length === 1 && Array.isArray(nextSources[0])) {
     nextSources = nextSources[0];
   }
 

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -4,6 +4,7 @@ import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf, ObservedValueUnionFromArray, MonoTypeOperatorFunction } from '../types';
 import { lift } from '../util/lift';
 import { from } from '../observable/from';
+import { argsOrArgArray } from '../util/argsOrArgArray';
 
 export function onErrorResumeNext<T>(): MonoTypeOperatorFunction<T>;
 export function onErrorResumeNext<T, O extends ObservableInput<any>>(arrayOfSources: O[]): OperatorFunction<T, T | ObservedValueOf<O>>;
@@ -80,11 +81,7 @@ export function onErrorResumeNext<T, A extends ObservableInput<any>[]>(
  */
 
 export function onErrorResumeNext<T>(...nextSources: ObservableInput<any>[]): OperatorFunction<T, unknown> {
-  // If there is only one argument, and it is an array, we'll treat it like it is
-  // and array of arguments.
-  if (nextSources.length === 1 && Array.isArray(nextSources[0])) {
-    nextSources = nextSources[0];
-  }
+  nextSources = argsOrArgArray(nextSources);
 
   return (source: Observable<T>) =>
     lift(source, function (this: Subscriber<any>, source: Observable<T>) {

--- a/src/internal/operators/raceWith.ts
+++ b/src/internal/operators/raceWith.ts
@@ -1,9 +1,7 @@
 import { Observable } from '../Observable';
-import { isArray } from '../util/isArray';
 import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, ObservedValueUnionFromArray } from '../types';
-import { race as raceStatic, RaceOperator } from '../observable/race';
-import { fromArray } from '../observable/fromArray';
-import { lift, stankyLift } from '../util/lift';
+import { race as raceStatic } from '../observable/race';
+import { stankyLift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link raceWith} */
@@ -26,7 +24,7 @@ export function race<T, R>(...observables: Array<Observable<any> | Array<Observa
 export function race<T, R>(...observables: ObservableInput<R>[]): OperatorFunction<T, (T|R)[]> {
   // if the only argument is an array, it was most likely called with
   // `pair([obs1, obs2, ...])`
-  if (observables.length === 1 && isArray(observables[0])) {
+  if (observables.length === 1 && Array.isArray(observables[0])) {
     observables = observables[0];
   }
 

--- a/src/internal/operators/raceWith.ts
+++ b/src/internal/operators/raceWith.ts
@@ -2,6 +2,7 @@ import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, ObservedValueUnionFromArray } from '../types';
 import { race as raceStatic } from '../observable/race';
 import { stankyLift } from '../util/lift';
+import { argsOrArgArray } from "../util/argsOrArgArray";
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link raceWith} */
@@ -21,14 +22,8 @@ export function race<T, R>(...observables: Array<Observable<any> | Array<Observa
  * @return {Observable} An Observable that mirrors the output of the first Observable to emit an item.
  * @deprecated Deprecated use {@link raceWith}
  */
-export function race<T, R>(...observables: ObservableInput<R>[]): OperatorFunction<T, (T|R)[]> {
-  // if the only argument is an array, it was most likely called with
-  // `pair([obs1, obs2, ...])`
-  if (observables.length === 1 && Array.isArray(observables[0])) {
-    observables = observables[0];
-  }
-
-  return raceWith(...observables) as any;
+export function race<T, R>(...args: any[]): OperatorFunction<T, R> {
+  return raceWith(...argsOrArgArray(args)) as OperatorFunction<T, R>;
 }
 
 /**

--- a/src/internal/operators/raceWith.ts
+++ b/src/internal/operators/raceWith.ts
@@ -22,8 +22,8 @@ export function race<T, R>(...observables: Array<Observable<any> | Array<Observa
  * @return {Observable} An Observable that mirrors the output of the first Observable to emit an item.
  * @deprecated Deprecated use {@link raceWith}
  */
-export function race<T, R>(...args: any[]): OperatorFunction<T, R> {
-  return raceWith(...argsOrArgArray(args)) as OperatorFunction<T, R>;
+export function race<T, R>(...args: any[]): OperatorFunction<T, unknown> {
+  return raceWith(...argsOrArgArray(args));
 }
 
 /**

--- a/src/internal/util/argsArgArrayOrObject.ts
+++ b/src/internal/util/argsArgArrayOrObject.ts
@@ -1,0 +1,32 @@
+/** @prettier */
+
+const { isArray } = Array;
+const { getPrototypeOf, prototype: objectProto, keys: getKeys } = Object;
+
+/**
+ * Used in functions where either a list of arguments, a single array of arguments, or a
+ * dictionary of arguments can be returned. Returns an object with an `args` property with
+ * the arguments in an array, if it is a dictionary, it will also return the `keys` in another
+ * property.
+ */
+export function argsArgArrayOrObject<T, O extends { [key: string]: T }>(args: T[] | [O] | [T[]]): { args: T[]; keys: string[] | null } {
+  if (args.length === 1) {
+    const first = args[0];
+    if (isArray(first)) {
+      return { args: first, keys: null };
+    }
+    if (isPOJO(first)) {
+      const keys = getKeys(first);
+      return {
+        args: keys.map((key) => (first as O)[key]),
+        keys,
+      };
+    }
+  }
+
+  return { args: args as T[], keys: null };
+}
+
+function isPOJO(obj: any): obj is Object {
+  return obj && typeof obj === 'object' && getPrototypeOf(obj) === objectProto;
+}

--- a/src/internal/util/argsArgArrayOrObject.ts
+++ b/src/internal/util/argsArgArrayOrObject.ts
@@ -9,7 +9,7 @@ const { getPrototypeOf, prototype: objectProto, keys: getKeys } = Object;
  * the arguments in an array, if it is a dictionary, it will also return the `keys` in another
  * property.
  */
-export function argsArgArrayOrObject<T, O extends { [key: string]: T }>(args: T[] | [O] | [T[]]): { args: T[]; keys: string[] | null } {
+export function argsArgArrayOrObject<T, O extends Record<string, T>>(args: T[] | [O] | [T[]]): { args: T[]; keys: string[] | null } {
   if (args.length === 1) {
     const first = args[0];
     if (isArray(first)) {

--- a/src/internal/util/argsOrArgArray.ts
+++ b/src/internal/util/argsOrArgArray.ts
@@ -1,0 +1,11 @@
+/** @prettier */
+
+const { isArray } = Array;
+
+/**
+ * Used in operators and functions that accept either a list of arguments, or an array of arguments
+ * as a single argument.
+ */
+export function argsOrArgArray<T>(args: (T | T[])[]): T[] {
+  return args.length === 1 && isArray(args[0]) ? args[0] : (args as T[]);
+}

--- a/src/internal/util/isArray.ts
+++ b/src/internal/util/isArray.ts
@@ -1,1 +1,0 @@
-export const isArray = (() => Array.isArray || (<T>(x: any): x is T[] => x && typeof x.length === 'number'))();

--- a/src/internal/util/isNumeric.ts
+++ b/src/internal/util/isNumeric.ts
@@ -1,9 +1,7 @@
-import { isArray } from './isArray';
-
 export function isNumeric(val: any): val is number | string {
   // parseFloat NaNs numeric-cast false positives (null|true|false|"")
   // ...but misinterprets leading-number strings, particularly hex literals ("0x...")
   // subtraction forces infinities to NaN
   // adding 1 corrects loss of precision from parseFloat (#15100)
-  return !isArray(val) && (val - parseFloat(val) + 1) >= 0;
+  return !Array.isArray(val) && (val - parseFloat(val) + 1) >= 0;
 }

--- a/src/internal/util/mapOneOrManyArgs.ts
+++ b/src/internal/util/mapOneOrManyArgs.ts
@@ -1,0 +1,16 @@
+import { OperatorFunction } from "../types";
+import { map } from "../operators/map";
+
+const { isArray } = Array;
+
+function callOrApply<T, R>(fn: ((...values: T[]) => R), args: T|T[]): R {
+    return isArray(args) ? fn(...args) : fn(args);
+}
+
+/**
+ * Used in several -- mostly deprecated -- situations where we need to 
+ * apply a list of arguments or a single argument to a result selector.
+ */
+export function mapOneOrManyArgs<T, R>(fn: ((...values: T[]) => R)): OperatorFunction<T|T[], R> {
+    return map(args => callOrApply(fn, args))
+}


### PR DESCRIPTION
- Gets rid of legacy `isArray` implementation.
- Centralizes the common tasks involving arrays of arguments that `isArray` was being used for into a few useful utilities.
- Additional LOC caused by formatting with prettier, not actual code addition. Should be less code when bundled.