### PR TITLE
refactor(combineLatest): remove stankyLift, make smaller

### DIFF
--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -39,16 +39,17 @@ describe('static combineLatest', () => {
       [3, 8],
     ];
 
+    const actual: [number, number][] = [];
     //type definition need to be updated
     combineLatest(a, b, queueScheduler).subscribe(
       (vals) => {
-        expect(vals).to.deep.equal(r.shift());
+        actual.push(vals);
       },
       () => {
         done(new Error('should not be called'));
       },
       () => {
-        expect(r.length).to.equal(0);
+        expect(actual).to.deep.equal(r);
         done();
       }
     );

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -3,8 +3,8 @@ import { Observable } from '../Observable';
 import { OperatorFunction, ObservableInput } from '../types';
 import { toArray } from './toArray';
 import { concatMap } from './concatMap';
-import { map } from './map';
 import { identity } from '../util/identity';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 
 export function combineAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export function combineAll<T>(): OperatorFunction<any, T[]>;
@@ -49,17 +49,16 @@ export function combineAll<R>(project: (...values: Array<any>) => R): OperatorFu
  * ```
  *
  * @see {@link combineLatest}
+ * @see {@link combineLatestWith}
  * @see {@link mergeAll}
  *
- * @param {function(...values: Array<any>)} An optional function to map the most recent values from each inner Observable into a new result.
+ * @param project optional function to map the most recent values from each inner Observable into a new result.
  * Takes each of the most recent values from each collected inner Observable as arguments, in order.
- * @return {Observable<T>}
- * @name combineAll
  */
 export function combineAll<T, R>(project?: (...values: Array<any>) => R): OperatorFunction<ObservableInput<T>, R|T[]> {
   return (source: Observable<ObservableInput<T>>) => source.pipe(
     toArray(),
     concatMap((sources) => combineLatest(sources)),
-    project ? map((args) => args.length === 1 ? project(args) : project(...args)) : identity as any
+    project ? mapOneOrManyArgs(project) : identity as any
   );
 }


### PR DESCRIPTION
- Refactors one test to make it easier to debug
- Removes the use of `stankyLift` for `combineLatestWith`.
- Builds `combineAll` from `toArray` and `combineLatest`. I think this has the added benefit if making it more obvious what the operator does for those that read the source.
- Refactors implementation of static `combineLatest` to be smaller.

I'm hopeful that this refactor will serve as the basis for refactoring other operators with similar issues.


combineLatest static judged by including a build of this PR into a new angular app, built in prod mode and looked at in `source-map-explorer`:

Before: 1.21KB

![PR-5711-before](https://user-images.githubusercontent.com/1540597/92765923-6462ee00-f35b-11ea-8a81-621d240c86d9.png)

After: 698B

![PR-5711-after](https://user-images.githubusercontent.com/1540597/92765926-662cb180-f35b-11ea-90a4-fb53916acf9f.png)


