### PR TITLE
refactor(bufferTime): reduce the size of the implementation

### DIFF
--- a/spec/operators/bufferTime-spec.ts
+++ b/spec/operators/bufferTime-spec.ts
@@ -53,6 +53,9 @@ describe('bufferTime operator', () => {
       const e1 = hot('  ---a---b---c---d---e---f---g-----|   ');
       const subs = '    ^--------------------------------!   ';
       const t = time('  ----------|                          ');
+      //                       ----------|
+      //                               ----------|
+      //                                       ----------|
       const expected = '-------w-------x-------y---------(z|)';
       const values = {
         w: ['a', 'b'],
@@ -73,6 +76,7 @@ describe('bufferTime operator', () => {
       const e1 = hot('  ---a---b---c---d---e---f---g-----|   ');
       const subs = '    ^--------------------------------!   ';
       const t = time('  ----------|                          ');
+      //                          ---------|---------|---------|
       const expected = '----------w--------x---------y---(z|)';
       const values = {
         w: ['a', 'b'],
@@ -110,8 +114,7 @@ describe('bufferTime operator', () => {
     });
   });
 
-  it('should emit buffers that have been created at intervals and close after the specified delay ' +
-  'or when the buffer is full', () => {
+  it('should emit buffers that have been created at intervals and close after the specified delay or when the buffer is full', () => {
     testScheduler.run(({ hot, time, expectObservable }) => {
       const e1 = hot('  ---a---b---c----d----e----f----g----h----i----(k|)');
       //                --------------------*--------------------*----  start interval
@@ -297,18 +300,17 @@ describe('bufferTime operator', () => {
     });
   });
 
-  it('should emit buffers that have been created at intervals and close after ' +
-  'the specified delay with errors', () => {
+  it('should emit buffers that have been created at intervals and close after the specified delay with errors', () => {
     testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  ---a---b---c----d----e----f----g----h----i--#');
-      //                --------------------*--------------------*----  start interval
-      //                ---------------------|                          timespans
-      //                                    ---------------------|
-      //                                                         -----|
-      const e1subs = '  ^-------------------------------------------!';
-      const t = time('  ---------------------|                       ');
+      const e1 = hot('       ---a---b---c----d----e----f----g----h----i--#');
+      //                     --------------------|-------------------|-------------------| interval
+      //                     ---------------------|
+      //                                         ---------------------|
+      //                                                             ---------------------| timespan
+      const e1subs = '       ^-------------------------------------------!';
+      const t = time('       ---------------------|                       ');
       const interval = time('                --------------------|   ');
-      const expected = '---------------------x-------------------y--#';
+      const expected = '     ---------------------x-------------------y--#';
       const values = {
         x: ['a', 'b', 'c', 'd', 'e'],
         y: ['e', 'f', 'g', 'h', 'i']

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { Operator } from '../Operator';
 import { async } from '../scheduler/async';
 import { Observable } from '../Observable';
@@ -9,8 +10,17 @@ import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 export function bufferTime<T>(bufferTimeSpan: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
-export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
-export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, maxBufferSize: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
+export function bufferTime<T>(
+  bufferTimeSpan: number,
+  bufferCreationInterval: number | null | undefined,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T[]>;
+export function bufferTime<T>(
+  bufferTimeSpan: number,
+  bufferCreationInterval: number | null | undefined,
+  maxBufferSize: number,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T[]>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -69,189 +79,128 @@ export function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: nu
  * @return {Observable<T[]>} An observable of arrays of buffered values.
  * @name bufferTime
  */
-export function bufferTime<T>(bufferTimeSpan: number): OperatorFunction<T, T[]> {
-  let length: number = arguments.length;
-
+export function bufferTime<T>(bufferTimeSpan: number, ...otherArgs: any[]): OperatorFunction<T, T[]> {
   let scheduler: SchedulerLike = async;
-  if (isScheduler(arguments[arguments.length - 1])) {
-    scheduler = arguments[arguments.length - 1];
-    length--;
+
+  if (isScheduler(otherArgs[otherArgs.length - 1])) {
+    scheduler = otherArgs.pop() as SchedulerLike;
   }
 
-  let bufferCreationInterval: number | null = null;
-  if (length >= 2) {
-    bufferCreationInterval = arguments[1];
-  }
-
-  let maxBufferSize: number = Infinity;
-  if (length >= 3) {
-    maxBufferSize = arguments[2];
-  }
+  const bufferCreationInterval = (otherArgs[0] as number) || null;
+  const maxBufferSize = (otherArgs[1] as number) || Infinity;
 
   return function bufferTimeOperatorFunction(source: Observable<T>) {
-    return lift(source, new BufferTimeOperator<T>(bufferTimeSpan, bufferCreationInterval, maxBufferSize, scheduler));
+    return lift(source, function (this: Subscriber<T[]>, source: Observable<T>) {
+      const subscriber = this;
+      // The active buffers, their related subscriptions, and removal functions.
+      let bufferRecords: { buffer: T[]; subs: Subscription; remove: () => void }[] = [];
+      // If true, it means that every time we emit a buffer, we want to start a new buffer
+      // this is only really used for when *just* the buffer time span is passed.
+      let restartOnEmit = false;
+
+      /**
+       * Does the work of emitting the buffer from the record, ensuring that the
+       * record is removed before the emission so reentrant code (from some custom scheduling, perhaps)
+       * does not alter the buffer. Also checks to see if a new buffer needs to be started
+       * after the emit.
+       */
+      const emit = (record: { buffer: T[]; subs: Subscription; remove: () => void }) => {
+        record.remove();
+        subscriber.next(record.buffer);
+        if (restartOnEmit) {
+          startBuffer();
+        }
+      };
+
+      /**
+       * Called every time we start a new buffer. This does
+       * the work of scheduling a job at the requested bufferTimeSpan
+       * that will emit the buffer (if it's not unsubscribed before then).
+       */
+      const startBuffer = () => {
+        const subs = new Subscription();
+        subscriber.add(subs);
+        const buffer: T[] = [];
+        const record = {
+          buffer,
+          subs,
+          remove() {
+            this.subs.unsubscribe();
+            if (bufferRecords) {
+              const index = bufferRecords.indexOf(this);
+              if (0 <= index) {
+                bufferRecords.splice(index, 1);
+              }
+            }
+          },
+        };
+        bufferRecords.push(record);
+        subs.add(
+          scheduler.schedule(() => {
+            emit(record);
+          }, bufferTimeSpan)
+        );
+      };
+
+      if (bufferCreationInterval !== null && bufferCreationInterval >= 0) {
+        // The user passed both a bufferTimeSpan (required), and a creation interval
+        // That means we need to start new buffers on the interval, and those buffers need
+        // to wait the required time span before emitting.
+        subscriber.add(
+          scheduler.schedule(function () {
+            startBuffer();
+            subscriber.add(this.schedule(null, bufferCreationInterval));
+          }, bufferCreationInterval)
+        );
+        startBuffer();
+      } else {
+        restartOnEmit = true;
+        startBuffer();
+      }
+
+      source.subscribe(
+        new BufferTimeSubscriber(
+          subscriber,
+          (value) => {
+            // Copy the records, so if we need to remove one we
+            // don't mutate the array. It's hard, but not impossible to
+            // set up a buffer time that could mutate the array and
+            // cause issues here.
+            const recordsCopy = bufferRecords.slice();
+            for (let i = 0; i < recordsCopy.length; i++) {
+              // Loop over all buffers and
+              const record = recordsCopy[i];
+              const { buffer } = record;
+              buffer.push(value);
+              // If the buffer is over the max size, we need to emit it.
+              if (maxBufferSize <= buffer.length) {
+                emit(record);
+              }
+            }
+          },
+          () => {
+            // The source completed, emit all of the active
+            // buffers we have before we complete.
+            for (const record of bufferRecords) {
+              record.remove();
+              subscriber.next(record.buffer);
+            }
+            // Free up memory.
+            bufferRecords = null!;
+          }
+        )
+      );
+    });
   };
 }
 
-class BufferTimeOperator<T> implements Operator<T, T[]> {
-  constructor(private bufferTimeSpan: number,
-              private bufferCreationInterval: number | null,
-              private maxBufferSize: number,
-              private scheduler: SchedulerLike) {
-  }
-
-  call(subscriber: Subscriber<T[]>, source: any): any {
-    return source.subscribe(new BufferTimeSubscriber(
-      subscriber, this.bufferTimeSpan, this.bufferCreationInterval, this.maxBufferSize, this.scheduler
-    ));
-  }
-}
-
-class Context<T> {
-  buffer: T[] = [];
-  closeAction: Subscription | undefined;
-}
-
-interface DispatchCreateArg<T> {
-  bufferTimeSpan: number;
-  bufferCreationInterval: number | null;
-  subscriber: BufferTimeSubscriber<T>;
-  scheduler: SchedulerLike;
-}
-
-interface DispatchCloseArg<T> {
-  subscriber: BufferTimeSubscriber<T>;
-  context: Context<T>;
-}
-
-/**
- * We need this JSDoc comment for affecting ESDoc.
- * @ignore
- * @extends {Ignored}
- */
 class BufferTimeSubscriber<T> extends Subscriber<T> {
-  private contexts: Array<Context<T>> = [];
-  private timespanOnly: boolean;
-
-  constructor(destination: Subscriber<T[]>,
-              private bufferTimeSpan: number,
-              private bufferCreationInterval: number | null,
-              private maxBufferSize: number,
-              private scheduler: SchedulerLike) {
+  constructor(destination: Subscriber<T[]>, protected _next: (value: T) => void, protected onBeforeComplete: () => void) {
     super(destination);
-
-    const context = this.openContext();
-    this.timespanOnly = bufferCreationInterval == null || bufferCreationInterval < 0;
-    if (this.timespanOnly) {
-      const timeSpanOnlyState = { subscriber: this, context, bufferTimeSpan };
-      this.add(context.closeAction = scheduler.schedule(dispatchBufferTimeSpanOnly, bufferTimeSpan, timeSpanOnlyState));
-    } else {
-      const closeState = { subscriber: this, context };
-      const creationState: DispatchCreateArg<T> = { bufferTimeSpan, bufferCreationInterval, subscriber: this, scheduler };
-      this.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(dispatchBufferClose as any, bufferTimeSpan, closeState));
-      this.add(scheduler.schedule<DispatchCreateArg<T>>(dispatchBufferCreation as any, bufferCreationInterval!, creationState));
-    }
   }
 
-  protected _next(value: T) {
-    const contexts = this.contexts;
-    const len = contexts.length;
-    let filledBufferContext: Context<T> | undefined;
-    for (let i = 0; i < len; i++) {
-      const context = contexts[i];
-      const buffer = context.buffer;
-      buffer.push(value);
-      if (buffer.length == this.maxBufferSize) {
-        filledBufferContext = context;
-      }
-    }
-
-    if (filledBufferContext) {
-      this.onBufferFull(filledBufferContext);
-    }
-  }
-
-  protected _error(err: any) {
-    this.contexts.length = 0;
-    super._error(err);
-  }
-
-  protected _complete() {
-    const { contexts, destination } = this;
-    while (contexts.length > 0) {
-      const context = contexts.shift()!;
-      destination.next(context.buffer);
-    }
+  _complete() {
+    this.onBeforeComplete();
     super._complete();
   }
-
-  unsubscribe() {
-    if (!this.closed) {
-      this.contexts = null!;
-      super.unsubscribe();
-    }
-  }
-
-  protected onBufferFull(context: Context<T>) {
-    this.closeContext(context);
-    const closeAction = context.closeAction;
-    closeAction!.unsubscribe();
-    this.remove(closeAction!);
-
-    if (!this.closed && this.timespanOnly) {
-      context = this.openContext();
-      const bufferTimeSpan = this.bufferTimeSpan;
-      const timeSpanOnlyState = { subscriber: this, context, bufferTimeSpan };
-      this.add(context.closeAction = this.scheduler.schedule(dispatchBufferTimeSpanOnly, bufferTimeSpan, timeSpanOnlyState));
-    }
-  }
-
-  openContext(): Context<T> {
-    const context: Context<T> = new Context<T>();
-    this.contexts.push(context);
-    return context;
-  }
-
-  closeContext(context: Context<T>) {
-    this.destination.next(context.buffer);
-    const contexts = this.contexts;
-
-    const spliceIndex = contexts ? contexts.indexOf(context) : -1;
-    if (spliceIndex >= 0) {
-      contexts.splice(contexts.indexOf(context), 1);
-    }
-  }
-}
-
-function dispatchBufferTimeSpanOnly(this: SchedulerAction<any>, state: any) {
-  const subscriber: BufferTimeSubscriber<any> = state.subscriber;
-
-  const prevContext = state.context;
-  if (prevContext) {
-    subscriber.closeContext(prevContext);
-  }
-
-  if (!subscriber.closed) {
-    state.context = subscriber.openContext();
-    state.context.closeAction = this.schedule(state, state.bufferTimeSpan);
-  }
-}
-
-function dispatchBufferCreation<T>(this: SchedulerAction<DispatchCreateArg<T>>, state: DispatchCreateArg<T>) {
-  const { bufferCreationInterval, bufferTimeSpan, subscriber, scheduler } = state;
-  const context = subscriber.openContext();
-  const action = <SchedulerAction<DispatchCreateArg<T>>>this;
-  if (!subscriber.closed) {
-    subscriber.add(context.closeAction = scheduler.schedule<DispatchCloseArg<T>>(
-      dispatchBufferClose as any,
-      bufferTimeSpan,
-      { subscriber, context }
-    ));
-    action.schedule(state, bufferCreationInterval!);
-  }
-}
-
-function dispatchBufferClose<T>(arg: DispatchCloseArg<T>) {
-  const { subscriber, context } = arg;
-  subscriber.closeContext(context);
 }


### PR DESCRIPTION
- Complete rewrite of `bufferTime`
- Adds some comments
- Formats a couple of tests for readability during debugging.


Before: 2.24KB

![bufferTime-before](https://user-images.githubusercontent.com/1540597/92795558-14ddeb80-f376-11ea-8e5a-60b3af467356.png)


After: 823B

![bufferTime-after](https://user-images.githubusercontent.com/1540597/92795568-17d8dc00-f376-11ea-8b23-4cfa93729fbb.png)
