### PR TITLE
feat(fromEvent): support lazy event targets

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -392,4 +392,28 @@ describe('fromEvent', () => {
     }).to.not.throw(TypeError);
   });
 
+  it('should allow to subscribe to lazy targets', () => {
+    let onHandler;
+    let offHandler;
+
+    const event$ = fromEvent(() => target as any, 'click')
+    const target = {
+      addEventListener: (a: string, b: EventListener) => {
+        onHandler = b;
+      },
+      removeEventListener: (a: string, b: EventListener) => {
+        offHandler = b;
+      }
+    };
+
+    const subscription = event$
+      .subscribe(() => {
+        //noop
+       });
+
+    subscription.unsubscribe();
+
+    expect(typeof onHandler).to.equal('function');
+    expect(offHandler).to.equal(onHandler);
+  })
 });

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -30,7 +30,7 @@ export interface HasEventTargetAddRemove<E> {
 
 export type EventTargetLike<T> = HasEventTargetAddRemove<T> | NodeStyleEventEmitter | NodeCompatibleEventEmitter | JQueryStyleEventEmitter;
 
-export type FromEventTarget<T> = EventTargetLike<T> | ArrayLike<EventTargetLike<T>>;
+export type FromEventTarget<T> = EventTargetLike<T> | ArrayLike<EventTargetLike<T>> | (() => EventTargetLike<T>) | (() => ArrayLike<EventTargetLike<T>>);
 
 export interface EventListenerOptions {
   capture?: boolean;
@@ -62,7 +62,9 @@ export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, opti
  * ![](fromEvent.png)
  *
  * `fromEvent` accepts as a first argument event target, which is an object with methods
- * for registering event handler functions. As a second argument it takes string that indicates
+ * for registering event handler functions. Alternatively a function returning an event target
+ * can be provided, to account for event targets not existing yet when creating an observable
+ * but will exist when subscribing to it. As a second argument it takes string that indicates
  * type of event we want to listen for. `fromEvent` supports selected types of event targets,
  * which are described in detail below. If your event target does not match any of the ones listed,
  * you should use {@link fromEventPattern}, which can be used on arbitrary APIs.
@@ -198,7 +200,8 @@ export function fromEvent<T>(
         subscriber.next(e);
       }
     }
-    setupSubscription(target, eventName, handler, subscriber, options as EventListenerOptions);
+    const eventTarget = isFunction(target) ? target() : target
+    setupSubscription(eventTarget, eventName, handler, subscriber, options as EventListenerOptions);
   });
 }
 


### PR DESCRIPTION
**Description:**

Hello 👋, first thanks for this great library that I've been using for some time now!

Like other observables, `fromEvent` will lazily consume resources when an observer will subscribe to it. However in the case of DOM elements, its current API requires the target to exist when creating an observable, despite a target only been required at subscription time. With this PR I propose to support event target getters, so that event targets can be retrieved lazily at the time of subscription.

```ts
const clickEvents$ = fromEvent(() => document.getElementById('id'), 'click')
```

Or even in React:

```ts
const ref = useRef()
const clickEvents$ = useMemo(
  () => fromEvent(() => ref.current, 'click'),
  []
)
```

Note that it is possible to achieve with `fromEventPattern`, but it is more verbose.
