### PR TITLE
chore(fromEvent): add dtslint tests

### DIFF
--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -1,0 +1,39 @@
+import { fromEvent } from 'rxjs';
+import { B } from "../helpers";
+
+declare const eventTargetSource: HTMLDocument;
+
+interface NodeStyleSource {
+  addListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
+  removeListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
+};
+declare const nodeStyleSource : NodeStyleSource;
+
+declare const nodeCompatibleSource: {
+  addListener: (eventName: string, handler: (...args: any[]) => void) => void;
+  removeListener: (eventName: string, handler: (...args: any[]) => void) => void;
+};
+
+declare const jQueryStyleSource: {
+  on: (eventName: string, handler: Function) => void;
+  off: (eventName: string, handler: Function) => void;
+};
+
+it('should support an event target source', () => {
+  const a = fromEvent(eventTargetSource, "click"); // $ExpectType Observable<Event>
+});
+
+it('should support a node-style source', () => {
+  const a = fromEvent(nodeStyleSource, "something"); // $ExpectType Observable<unknown>
+  const b = fromEvent<B>(nodeStyleSource, "something"); // $ExpectType Observable<B>
+});
+
+it('should support a node-compatible source', () => {
+  const a = fromEvent(nodeCompatibleSource, "something"); // $ExpectType Observable<unknown>
+  const b = fromEvent<B>(nodeCompatibleSource, "something"); // $ExpectType Observable<B>
+});
+
+it('should support a jQuery-style source', () => {
+  const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<unknown>
+  const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Adds dtslint tests for `fromEvent` to make things a little easier for contributors - see #5584.

**Related issue (if exists):** #5584
