### PR TITLE
chore(fromEvent): use more accurate jQuery types in dtslint test

### DIFF
--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -14,10 +14,13 @@ declare const nodeCompatibleSource: {
   removeListener: (eventName: string, handler: (...args: any[]) => void) => void;
 };
 
-declare const jQueryStyleSource: {
-  on: (eventName: string, handler: Function) => void;
-  off: (eventName: string, handler: Function) => void;
+// Use handler types like those in @types/jquery. See:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/847731ba1d7fa6db6b911c0e43aa0afe596e7723/types/jquery/misc.d.ts#L6395
+interface JQueryStyleSource<TContext, T> {
+  on: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
+  off: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
 };
+declare const jQueryStyleSource: JQueryStyleSource<any, any>;
 
 it('should support an event target source', () => {
   const a = fromEvent(eventTargetSource, "click"); // $ExpectType Observable<Event>
@@ -33,7 +36,8 @@ it('should support a node-compatible source', () => {
   const b = fromEvent<B>(nodeCompatibleSource, "something"); // $ExpectType Observable<B>
 });
 
-it('should support a jQuery-style source', () => {
-  const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<unknown>
-  const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>
-});
+// TODO: uncomment when the fromEvent jQuery types are fixed
+// it('should support a jQuery-style source', () => {
+//   const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<unknown>
+//   const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>
+// });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR tweaks the types used for the jQuery source in the dtslint tests to better represent what's in `@types/jquery`. When the changes in #5584 are made, the jQuery dtslint test - which fail with the more accurate types - can be uncommented.

**Related issue (if exists):** #5584
