### PR TITLE
refactor(config): just a POJO

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -190,7 +190,6 @@ export declare function concat<A extends ObservableInput<any>[]>(...observables:
 
 export declare const config: {
     onUnhandledError: ((err: any) => void) | null;
-    quietBadConfig: boolean;
     Promise: PromiseConstructorLike;
     useDeprecatedSynchronousErrorHandling: boolean;
     useDeprecatedNextContext: boolean;

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -306,7 +306,7 @@ export declare function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFu
 
 export declare function throttle<T>(durationSelector: (value: T) => SubscribableOrPromise<any>, config?: ThrottleConfig): MonoTypeOperatorFunction<T>;
 
-export declare function throttleTime<T>(duration: number, scheduler?: SchedulerLike, config?: ThrottleConfig): MonoTypeOperatorFunction<T>;
+export declare function throttleTime<T>(duration: number, scheduler?: SchedulerLike, { leading, trailing }?: ThrottleConfig): MonoTypeOperatorFunction<T>;
 
 export declare function throwIfEmpty<T>(errorFactory?: (() => any)): MonoTypeOperatorFunction<T>;
 

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -585,34 +585,8 @@ describe('Observable', () => {
       });
     });
 
-    describe('config.useDeprecatedSynchronousErrorHandling', () => {
-      it('should log when it is set and unset', () => {
-        const _log = console.log;
-        const logCalledWith: any[][] = [];
-        console.log = (...args: any[]) => {
-          logCalledWith.push(args);
-        };
-
-        const _warn = console.warn;
-        const warnCalledWith: any[][] = [];
-        console.warn = (...args: any[]) => {
-          warnCalledWith.push(args);
-        };
-
-        config.useDeprecatedSynchronousErrorHandling = true;
-        expect(warnCalledWith.length).to.equal(1);
-
-        config.useDeprecatedSynchronousErrorHandling = false;
-        expect(logCalledWith.length).to.equal(1);
-
-        console.log = _log;
-        console.warn = _warn;
-      });
-    });
-
     describe('if config.useDeprecatedSynchronousErrorHandling === true', () => {
       beforeEach(() => {
-        config.quietBadConfig = true;
         config.useDeprecatedSynchronousErrorHandling = true;
       });
 
@@ -636,7 +610,6 @@ describe('Observable', () => {
 
       afterEach(() => {
         config.useDeprecatedSynchronousErrorHandling = false;
-        config.quietBadConfig = false;
       });
     });
   });

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -192,13 +192,11 @@ describe('Subscriber', () => {
 
   describe('deprecated next context mode', () => {
     beforeEach(() => {
-      config.quietBadConfig = true;
       config.useDeprecatedNextContext = true;
     });
 
     afterEach(() => {
       config.useDeprecatedNextContext = false;
-      config.quietBadConfig = false;
     });
 
     it('should allow changing the context of `this` in a POJO subscriber', () => {

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,6 +1,4 @@
 /** @prettier */
-let _enable_super_gross_mode_that_will_cause_bad_things = false;
-let _enable_deoptimized_subscriber_creation = false;
 
 /**
  * The global configuration object for RxJS, used to configure things
@@ -17,12 +15,6 @@ export const config = {
    * behavior of the library.
    */
   onUnhandledError: null as ((err: any) => void) | null,
-
-  /**
-   * If true, console logs for deprecation warnings will not be emitted.
-   * @deprecated this will be removed in v8 when all deprecated settings are removed.
-   */
-  quietBadConfig: false,
 
   /**
    * The promise constructor used by default for methods such as
@@ -46,26 +38,7 @@ export const config = {
    * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
    * behaviors described above.
    */
-  set useDeprecatedSynchronousErrorHandling(value: boolean) {
-    if (!this.quietBadConfig) {
-      if (value) {
-        const error = new Error();
-        console.warn('DEPRECATED! RxJS was set to use deprecated synchronous error handling behavior by code at: \n' + error.stack);
-      } else if (_enable_super_gross_mode_that_will_cause_bad_things) {
-        console.log('RxJS: Back to a better error behavior. Thank you. <3');
-      }
-    }
-    _enable_super_gross_mode_that_will_cause_bad_things = value;
-  },
-
-  /**
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
-   * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
-   * behaviors described above.
-   */
-  get useDeprecatedSynchronousErrorHandling() {
-    return _enable_super_gross_mode_that_will_cause_bad_things;
-  },
+  useDeprecatedSynchronousErrorHandling: false,
 
   /**
    * If true, enables an as-of-yet undocumented feature from v5: The ability to access
@@ -81,28 +54,5 @@ export const config = {
    * you will have access to a subscription or a signal or token that will allow you to do things like
    * unsubscribe and test closed status.
    */
-  set useDeprecatedNextContext(value: boolean) {
-    if (!this.quietBadConfig) {
-      if (value) {
-        const error = new Error();
-        console.warn(
-          'DEPRECATED! RxJS was set to use deprecated next context. This will result in deoptimizations when creating any new subscription. \n' +
-            error.stack
-        );
-      } else if (_enable_deoptimized_subscriber_creation) {
-        console.log('RxJS: back to more optimized subscription creation. Thank you. <3');
-      }
-    }
-    _enable_deoptimized_subscriber_creation = value;
-  },
-
-  /**
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
-   * context of next functions provided as part of an observer to Subscribe. Instead,
-   * you will have access to a subscription or a signal or token that will allow you to do things like
-   * unsubscribe and test closed status.
-   */
-  get useDeprecatedNextContext(): boolean {
-    return _enable_deoptimized_subscriber_creation;
-  },
+  useDeprecatedNextContext: false,
 };


### PR DESCRIPTION
- Removes fancy code that would emit console warnings and other log messages
- Removes configuration that would disable the console warnings
- Size impact down to < 100 KB (from > 700 KB). I was unable to even get a measurement on it from source-map-explorer.

NOTE: Now that deprecations show up so prominently in IDEs like VS Code, I don't think we really need to be emitting anything to console, if we even should have to begin with.
