### PR TITLE
Issue/5739 smaller operator creation

### DIFF
--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -438,8 +438,7 @@ describe('publishReplay operator', () => {
     const source = cold('--1-2---3-4---|');
     const published = source.pipe(publishReplay(1, Infinity, selector));
 
-    // The exception is thrown outside Rx chain (not as an error notification).
-    expect(() => published.subscribe()).to.throw(error);
+    expectObservable(published).toBe('#', undefined, "It's broken");
   });
 
   it('should emit an error when the selector returns an Observable that emits an error', () => {

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -1,10 +1,8 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { isScheduler } from '../util/isScheduler';
 import { OperatorFunction, SchedulerLike } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { arrRemove } from '../util/arrRemove';
 import { asyncScheduler } from '../scheduler/async';
@@ -85,93 +83,91 @@ export function bufferTime<T>(bufferTimeSpan: number, ...otherArgs: any[]): Oper
   const bufferCreationInterval = (otherArgs[0] as number) ?? null;
   const maxBufferSize = (otherArgs[1] as number) || Infinity;
 
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T[]>, source: Observable<T>) {
-      const subscriber = this;
-      // The active buffers, their related subscriptions, and removal functions.
-      let bufferRecords: { buffer: T[]; subs: Subscription }[] | null = [];
-      // If true, it means that every time we emit a buffer, we want to start a new buffer
-      // this is only really used for when *just* the buffer time span is passed.
-      let restartOnEmit = false;
+  return operate((source, subscriber) => {
+    // The active buffers, their related subscriptions, and removal functions.
+    let bufferRecords: { buffer: T[]; subs: Subscription }[] | null = [];
+    // If true, it means that every time we emit a buffer, we want to start a new buffer
+    // this is only really used for when *just* the buffer time span is passed.
+    let restartOnEmit = false;
 
-      /**
-       * Does the work of emitting the buffer from the record, ensuring that the
-       * record is removed before the emission so reentrant code (from some custom scheduling, perhaps)
-       * does not alter the buffer. Also checks to see if a new buffer needs to be started
-       * after the emit.
-       */
-      const emit = (record: { buffer: T[]; subs: Subscription }) => {
-        const { buffer, subs } = record;
-        subs.unsubscribe();
-        arrRemove(bufferRecords, record);
-        subscriber.next(buffer);
-        restartOnEmit && startBuffer();
-      };
+    /**
+     * Does the work of emitting the buffer from the record, ensuring that the
+     * record is removed before the emission so reentrant code (from some custom scheduling, perhaps)
+     * does not alter the buffer. Also checks to see if a new buffer needs to be started
+     * after the emit.
+     */
+    const emit = (record: { buffer: T[]; subs: Subscription }) => {
+      const { buffer, subs } = record;
+      subs.unsubscribe();
+      arrRemove(bufferRecords, record);
+      subscriber.next(buffer);
+      restartOnEmit && startBuffer();
+    };
 
-      /**
-       * Called every time we start a new buffer. This does
-       * the work of scheduling a job at the requested bufferTimeSpan
-       * that will emit the buffer (if it's not unsubscribed before then).
-       */
-      const startBuffer = () => {
-        if (bufferRecords) {
-          const subs = new Subscription();
-          subscriber.add(subs);
-          const buffer: T[] = [];
-          const record = {
-            buffer,
-            subs,
-          };
-          bufferRecords.push(record);
-          subs.add(scheduler.schedule(() => emit(record), bufferTimeSpan));
+    /**
+     * Called every time we start a new buffer. This does
+     * the work of scheduling a job at the requested bufferTimeSpan
+     * that will emit the buffer (if it's not unsubscribed before then).
+     */
+    const startBuffer = () => {
+      if (bufferRecords) {
+        const subs = new Subscription();
+        subscriber.add(subs);
+        const buffer: T[] = [];
+        const record = {
+          buffer,
+          subs,
+        };
+        bufferRecords.push(record);
+        subs.add(scheduler.schedule(() => emit(record), bufferTimeSpan));
+      }
+    };
+
+    bufferCreationInterval !== null && bufferCreationInterval >= 0
+      ? // The user passed both a bufferTimeSpan (required), and a creation interval
+        // That means we need to start new buffers on the interval, and those buffers need
+        // to wait the required time span before emitting.
+        subscriber.add(
+          scheduler.schedule(function () {
+            startBuffer();
+            !this.closed && subscriber.add(this.schedule(null, bufferCreationInterval));
+          }, bufferCreationInterval)
+        )
+      : (restartOnEmit = true);
+
+    startBuffer();
+
+    const bufferTimeSubscriber = new OperatorSubscriber(
+      subscriber,
+      (value: T) => {
+        // Copy the records, so if we need to remove one we
+        // don't mutate the array. It's hard, but not impossible to
+        // set up a buffer time that could mutate the array and
+        // cause issues here.
+        const recordsCopy = bufferRecords!.slice();
+        for (const record of recordsCopy) {
+          // Loop over all buffers and
+          const { buffer } = record;
+          buffer.push(value);
+          // If the buffer is over the max size, we need to emit it.
+          maxBufferSize <= buffer.length && emit(record);
         }
-      };
+      },
+      undefined,
+      () => {
+        // The source completed, emit all of the active
+        // buffers we have before we complete.
+        while (bufferRecords?.length) {
+          subscriber.next(bufferRecords.shift()!.buffer);
+        }
+        bufferTimeSubscriber?.unsubscribe();
+        subscriber.complete();
+        subscriber.unsubscribe();
+      },
+      // Clean up
+      () => (bufferRecords = null)
+    );
 
-      bufferCreationInterval !== null && bufferCreationInterval >= 0
-        ? // The user passed both a bufferTimeSpan (required), and a creation interval
-          // That means we need to start new buffers on the interval, and those buffers need
-          // to wait the required time span before emitting.
-          subscriber.add(
-            scheduler.schedule(function () {
-              startBuffer();
-              !this.closed && subscriber.add(this.schedule(null, bufferCreationInterval));
-            }, bufferCreationInterval)
-          )
-        : (restartOnEmit = true);
-
-      startBuffer();
-
-      const bufferTimeSubscriber = new OperatorSubscriber(
-        subscriber,
-        (value: T) => {
-          // Copy the records, so if we need to remove one we
-          // don't mutate the array. It's hard, but not impossible to
-          // set up a buffer time that could mutate the array and
-          // cause issues here.
-          const recordsCopy = bufferRecords!.slice();
-          for (const record of recordsCopy) {
-            // Loop over all buffers and
-            const { buffer } = record;
-            buffer.push(value);
-            // If the buffer is over the max size, we need to emit it.
-            maxBufferSize <= buffer.length && emit(record);
-          }
-        },
-        undefined,
-        () => {
-          // The source completed, emit all of the active
-          // buffers we have before we complete.
-          while (bufferRecords?.length) {
-            subscriber.next(bufferRecords.shift()!.buffer);
-          }
-          bufferTimeSubscriber?.unsubscribe();
-          subscriber.complete();
-          subscriber.unsubscribe();
-        },
-        // Clean up
-        () => (bufferRecords = null)
-      );
-
-      source.subscribe(bufferTimeSubscriber);
-    });
+    source.subscribe(bufferTimeSubscriber);
+  });
 }

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -56,7 +56,7 @@ export function bufferToggle<T, O>(
   openings: SubscribableOrPromise<O>,
   closingSelector: (value: O) => SubscribableOrPromise<any>
 ): OperatorFunction<T, T[]> {
-  return operate((liftedSource, subscriber) => {
+  return operate((source, subscriber) => {
     const buffers: T[][] = [];
 
     // Subscribe to the openings notifier first
@@ -87,7 +87,7 @@ export function bufferToggle<T, O>(
       )
     );
 
-    liftedSource.subscribe(
+    source.subscribe(
       new OperatorSubscriber(
         subscriber,
         (value) => {

--- a/src/internal/operators/concatWith.ts
+++ b/src/internal/operators/concatWith.ts
@@ -1,13 +1,14 @@
-import { Observable } from '../Observable';
+/** @prettier */
 import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray, MonoTypeOperatorFunction, SchedulerLike } from '../types';
-import { lift } from '../util/lift';
-import { Subscriber } from '../Subscriber';
+import { operate } from '../util/lift';
 import { concatAll } from './concatAll';
 import { fromArray } from '../observable/fromArray';
 import { isScheduler } from '../util/isScheduler';
 
 export function concatWith<T>(): OperatorFunction<T, T>;
-export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T>;
+export function concatWith<T, A extends ObservableInput<any>[]>(
+  ...otherSources: A
+): OperatorFunction<T, ObservedValueUnionFromArray<A> | T>;
 
 /**
  * Emits all of the values from the source observable, then, once it completes, subscribes
@@ -47,7 +48,9 @@ export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources:
  *
  * @param otherSources Other observable sources to subscribe to, in sequence, after the original source is complete.
  */
-export function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T> {
+export function concatWith<T, A extends ObservableInput<any>[]>(
+  ...otherSources: A
+): OperatorFunction<T, ObservedValueUnionFromArray<A> | T> {
   return concat(...otherSources);
 }
 
@@ -56,18 +59,39 @@ export function concat<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T
 /** @deprecated remove in v8. Use {@link concatWith} */
 export function concat<T, T2>(v2: ObservableInput<T2>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2>;
 /** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3>;
+export function concat<T, T2, T3>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T | T2 | T3>;
 /** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4>;
+export function concat<T, T2, T3, T4>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T | T2 | T3 | T4>;
 /** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
+export function concat<T, T2, T3, T4, T5>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
 /** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
+export function concat<T, T2, T3, T4, T5, T6>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  v6: ObservableInput<T6>,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
 /** @deprecated remove in v8. Use {@link concatWith} */
 export function concat<T>(...observables: Array<ObservableInput<T> | SchedulerLike>): MonoTypeOperatorFunction<T>;
 /** @deprecated remove in v8. Use {@link concatWith} */
 export function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike>): OperatorFunction<T, R>;
-
 
 /**
  * @deprecated remove in v8. Use {@link concatWith}
@@ -79,10 +103,7 @@ export function concat<T, R>(...args: any[]): OperatorFunction<T, R> {
     scheduler = args.pop() as SchedulerLike;
   }
 
-  return (source: Observable<T>) => lift(
-    source,
-    function (this: Subscriber<any>, source: Observable<T>) {
-      concatAll()(fromArray([source, ...args], scheduler)).subscribe(this);
-    }
-  );
+  return operate((source, subscriber) => {
+    concatAll()(fromArray([source, ...args], scheduler)).subscribe(subscriber as any);
+  });
 }

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -67,7 +67,7 @@ export function count<T>(predicate?: (value: T, index: number, source: Observabl
     let index = 0;
     let count = 0;
 
-    return source.subscribe(
+    source.subscribe(
       new OperatorSubscriber(
         subscriber,
         (value) => (!predicate || predicate(value, index++, source)) && count++,

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -1,8 +1,7 @@
-/** @pretter */
+/** @prettier */
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
-import { Subscriber } from '../Subscriber';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 /**
  * Counts the number of emissions on the source and emits that number when the
@@ -64,15 +63,20 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 
 export function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number> {
-  return (source: Observable<T>) => lift(source, function (this: Subscriber<number>, source: Observable<T>) {
-    const subscriber = this;
+  return operate((source, subscriber) => {
     let index = 0;
     let count = 0;
-    return source.subscribe(new OperatorSubscriber(subscriber, (value) =>
-      (!predicate || predicate(value, index++, source)) && count++
-    , undefined, () => {
-      subscriber.next(count);
-      subscriber.complete();
-    }))
+
+    return source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => (!predicate || predicate(value, index++, source)) && count++,
+        undefined,
+        () => {
+          subscriber.next(count);
+          subscriber.complete();
+        }
+      )
+    );
   });
 }

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /* tslint:disable:max-line-length */
@@ -45,25 +43,23 @@ export function defaultIfEmpty<T, R = T>(defaultValue?: R): OperatorFunction<T, 
  * @name defaultIfEmpty
  */
 export function defaultIfEmpty<T, R>(defaultValue: R | null = null): OperatorFunction<T, T | R> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T | R>, source: Observable<T>) {
-      const subscriber = this;
-      let hasValue = false;
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => {
-            hasValue = true;
-            subscriber.next(value);
-          },
-          undefined,
-          () => {
-            if (!hasValue) {
-              subscriber.next(defaultValue!);
-            }
-            subscriber.complete();
+  return operate((source, subscriber) => {
+    let hasValue = false;
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          hasValue = true;
+          subscriber.next(value);
+        },
+        undefined,
+        () => {
+          if (!hasValue) {
+            subscriber.next(defaultValue!);
           }
-        )
-      );
-    });
+          subscriber.complete();
+        }
+      )
+    );
+  });
 }

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -1,10 +1,8 @@
 /** @prettier */
 import { asyncScheduler } from '../scheduler/async';
 import { isValidDate } from '../util/isDate';
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -57,81 +55,79 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 export function delay<T>(delay: number | Date, scheduler: SchedulerLike = asyncScheduler): MonoTypeOperatorFunction<T> {
   // TODO: Properly handle negative delays and dates in the past.
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      const isAbsoluteDelay = isValidDate(delay);
-      // If the source is complete
-      let isComplete = false;
-      // The number of active delays in progress.
-      let active = 0;
-      // For absolute time delay, we collect the values in this array and emit
-      // them when the delay fires.
-      let absoluteTimeValues: T[] | null = isAbsoluteDelay ? [] : null;
+  return operate((source, subscriber) => {
+    const isAbsoluteDelay = isValidDate(delay);
+    // If the source is complete
+    let isComplete = false;
+    // The number of active delays in progress.
+    let active = 0;
+    // For absolute time delay, we collect the values in this array and emit
+    // them when the delay fires.
+    let absoluteTimeValues: T[] | null = isAbsoluteDelay ? [] : null;
 
-      /**
-       * Used to check to see if we should complete the resulting
-       * subscription after delays finish or when the source completes.
-       * We don't want to complete when the source completes if we
-       * have delays in flight.
-       */
-      const checkComplete = () => isComplete && !active && !absoluteTimeValues?.length && subscriber.complete();
+    /**
+     * Used to check to see if we should complete the resulting
+     * subscription after delays finish or when the source completes.
+     * We don't want to complete when the source completes if we
+     * have delays in flight.
+     */
+    const checkComplete = () => isComplete && !active && !absoluteTimeValues?.length && subscriber.complete();
 
-      if (isAbsoluteDelay) {
-        // A date was passed. We only do one delay, so let's get it
-        // scheduled right away.
-        active++;
-        subscriber.add(
-          scheduler.schedule(() => {
-            active--;
-            if (absoluteTimeValues) {
-              const values = absoluteTimeValues;
-              absoluteTimeValues = null;
-              for (const value of values) {
-                subscriber.next(value);
-              }
+    if (isAbsoluteDelay) {
+      // A date was passed. We only do one delay, so let's get it
+      // scheduled right away.
+      active++;
+      subscriber.add(
+        scheduler.schedule(() => {
+          active--;
+          if (absoluteTimeValues) {
+            const values = absoluteTimeValues;
+            absoluteTimeValues = null;
+            for (const value of values) {
+              subscriber.next(value);
             }
-            checkComplete();
-          }, +delay - scheduler.now())
-        );
-      }
-
-      // Subscribe to the source
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => {
-            if (isAbsoluteDelay) {
-              // If we're dealing with an absolute time (via Date) delay, then before
-              // the delay fires, the `absoluteTimeValues` array will be present, and
-              // we want to add them to that. Otherwise, if it's `null`, that is because
-              // the delay has already fired.
-              absoluteTimeValues ? absoluteTimeValues.push(value) : subscriber.next(value);
-            } else {
-              active++;
-              subscriber.add(
-                scheduler.schedule(() => {
-                  active--;
-                  subscriber.next(value);
-                  checkComplete();
-                }, delay as number)
-              );
-            }
-          },
-          // Allow errors to pass through.
-          undefined,
-          () => {
-            isComplete = true;
-            checkComplete();
           }
-        )
+          checkComplete();
+        }, +delay - scheduler.now())
       );
+    }
 
-      // Additional teardown. The other teardown is set up
-      // implicitly by subscribing with Subscribers.
-      return () => {
-        // Release the buffered values.
-        absoluteTimeValues = null!;
-      };
-    });
+    // Subscribe to the source
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          if (isAbsoluteDelay) {
+            // If we're dealing with an absolute time (via Date) delay, then before
+            // the delay fires, the `absoluteTimeValues` array will be present, and
+            // we want to add them to that. Otherwise, if it's `null`, that is because
+            // the delay has already fired.
+            absoluteTimeValues ? absoluteTimeValues.push(value) : subscriber.next(value);
+          } else {
+            active++;
+            subscriber.add(
+              scheduler.schedule(() => {
+                active--;
+                subscriber.next(value);
+                checkComplete();
+              }, delay as number)
+            );
+          }
+        },
+        // Allow errors to pass through.
+        undefined,
+        () => {
+          isComplete = true;
+          checkComplete();
+        }
+      )
+    );
+
+    // Additional teardown. The other teardown is set up
+    // implicitly by subscribing with Subscribers.
+    return () => {
+      // Release the buffered values.
+      absoluteTimeValues = null!;
+    };
+  });
 }

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -1,8 +1,7 @@
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
+/** @prettier */
 import { observeNotification } from '../Notification';
 import { OperatorFunction, ObservableNotification, ValueFromNotification } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -53,10 +52,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * embedded in Notification objects emitted by the source Observable.
  */
 export function dematerialize<N extends ObservableNotification<any>>(): OperatorFunction<N, ValueFromNotification<N>> {
-  return (source: Observable<N>) => {
-    return lift(source, function (this: Subscriber<ValueFromNotification<N>>, source: Observable<N>) {
-      const subscriber = this;
-      return source.subscribe(new OperatorSubscriber(subscriber, (notification) => observeNotification(notification, subscriber)))
-    });
-  };
+  return operate((source, subscriber) =>
+    source.subscribe(new OperatorSubscriber(subscriber, (notification) => observeNotification(notification, subscriber)))
+  );
 }

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -52,7 +52,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * embedded in Notification objects emitted by the source Observable.
  */
 export function dematerialize<N extends ObservableNotification<any>>(): OperatorFunction<N, ValueFromNotification<N>> {
-  return operate((source, subscriber) =>
-    source.subscribe(new OperatorSubscriber(subscriber, (notification) => observeNotification(notification, subscriber)))
-  );
+  return operate((source, subscriber) => {
+    source.subscribe(new OperatorSubscriber(subscriber, (notification) => observeNotification(notification, subscriber)));
+  });
 }

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -1,8 +1,7 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -34,25 +33,23 @@ export function every<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,
   thisArg?: any
 ): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<boolean>, source: Observable<T>) {
-      const subscriber = this;
-      let index = 0;
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => {
-            if (!predicate.call(thisArg, value, index, source)) {
-              subscriber.next(false);
-              subscriber.complete();
-            }
-          },
-          undefined,
-          () => {
-            subscriber.next(true);
+  return operate((source, subscriber) => {
+    let index = 0;
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          if (!predicate.call(thisArg, value, index, source)) {
+            subscriber.next(false);
             subscriber.complete();
           }
-        )
-      );
-    });
+        },
+        undefined,
+        () => {
+          subscriber.next(true);
+          subscriber.complete();
+        }
+      )
+    );
+  });
 }

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -58,15 +58,11 @@ export function filter<T>(predicate: (value: T, index: number) => boolean, thisA
 
     // Subscribe to the source, all errors and completions are
     // forwarded to the consumer.
-    return source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
-        // Call the predicate with the appropriate `this` context,
-        // if the predicate returns `true`, then send the value
-        // to the consumer.
-        if (predicate.call(thisArg, value, index++)) {
-          subscriber.next(value);
-        }
-      })
+    source.subscribe(
+      // Call the predicate with the appropriate `this` context,
+      // if the predicate returns `true`, then send the value
+      // to the consumer.
+      new OperatorSubscriber(subscriber, (value) => predicate.call(thisArg, value, index++) && subscriber.next(value))
     );
   });
 }

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { OperatorFunction, MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /* tslint:disable:max-line-length */
@@ -54,23 +52,21 @@ export function filter<T>(predicate: (value: T, index: number) => boolean, thisA
  * in the `predicate` function.
  */
 export function filter<T>(predicate: (value: T, index: number) => boolean, thisArg?: any): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      // An index passed to our predicate function on each call.
-      let index = 0;
+  return operate((source, subscriber) => {
+    // An index passed to our predicate function on each call.
+    let index = 0;
 
-      // Subscribe to the source, all errors and completions are
-      // forwarded to the consumer.
-      return source.subscribe(
-        new OperatorSubscriber(subscriber, (value) => {
-          // Call the predicate with the appropriate `this` context,
-          // if the predicate returns `true`, then send the value
-          // to the consumer.
-          if (predicate.call(thisArg, value, index++)) {
-            subscriber.next(value);
-          }
-        })
-      );
-    });
+    // Subscribe to the source, all errors and completions are
+    // forwarded to the consumer.
+    return source.subscribe(
+      new OperatorSubscriber(subscriber, (value) => {
+        // Call the predicate with the appropriate `this` context,
+        // if the predicate returns `true`, then send the value
+        // to the consumer.
+        if (predicate.call(thisArg, value, index++)) {
+          subscriber.next(value);
+        }
+      })
+    );
+  });
 }

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -1,7 +1,5 @@
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 
 /**
  * Returns an Observable that mirrors the source Observable, but will call a specified function when
@@ -59,8 +57,8 @@ import { lift } from '../util/lift';
  * @name finally
  */
 export function finalize<T>(callback: () => void): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-    source.subscribe(this);
-    this.add(callback);
+  return operate((source, subscriber) => {
+    source.subscribe(subscriber);
+    subscriber.add(callback);
   });
 }

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -2,7 +2,7 @@
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 export function find<T, S extends T>(
@@ -55,7 +55,7 @@ export function find<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,
   thisArg?: any
 ): OperatorFunction<T, T | undefined> {
-  return (source: Observable<T>) => lift(source, createFind(predicate, thisArg, 'value'));
+  return operate(createFind(predicate, thisArg, 'value'));
 }
 
 export function createFind<T>(
@@ -64,8 +64,7 @@ export function createFind<T>(
   emit: 'value' | 'index'
 ) {
   const findIndex = emit === 'index';
-  return function (this: Subscriber<any>, source: Observable<T>) {
-    const subscriber = this;
+  return (source: Observable<T>, subscriber: Subscriber<any>) => {
     let index = 0;
     source.subscribe(
       new OperatorSubscriber(

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { createFind } from './find';
 /**
  * Emits only the index of the first value emitted by the source Observable that
@@ -46,5 +46,5 @@ export function findIndex<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,
   thisArg?: any
 ): OperatorFunction<T, number> {
-  return (source: Observable<T>) => lift(source, createFind(predicate, thisArg, 'index'));
+  return operate(createFind(predicate, thisArg, 'index'));
 }

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 
@@ -39,9 +37,7 @@ import { noop } from '../util/noop';
  * @name ignoreElements
  */
 export function ignoreElements(): OperatorFunction<any, never> {
-  return (source: Observable<any>) =>
-    lift(source, function (this: Subscriber<never>, source: Observable<any>) {
-      const subscriber = this;
-      source.subscribe(new OperatorSubscriber(subscriber, noop));
-    });
+  return operate((source, subscriber) => {
+    source.subscribe(new OperatorSubscriber(subscriber, noop));
+  });
 }

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -70,22 +68,20 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 
 export function isEmpty<T>(): OperatorFunction<T, boolean> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<boolean>, source: Observable<any>) {
-      const subscriber = this;
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          () => {
-            subscriber.next(false);
-            subscriber.complete();
-          },
-          undefined,
-          () => {
-            subscriber.next(true);
-            subscriber.complete();
-          }
-        )
-      );
-    });
+  return operate((source, subscriber) => {
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        () => {
+          subscriber.next(false);
+          subscriber.complete();
+        },
+        undefined,
+        () => {
+          subscriber.next(true);
+          subscriber.complete();
+        }
+      )
+    );
+  });
 }

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -44,19 +42,17 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name map
  */
 export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): OperatorFunction<T, R> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<R>, source: Observable<T>) {
-      const subscriber = this;
-      // The index of the value from the source. Used with projection.
-      let index = 0;
-      // Subscribe to the source, all errors and completions are sent along
-      // to the consumer.
-      source.subscribe(
-        new OperatorSubscriber(subscriber, (value: T) => {
-          // Call the projection function with the appropriate this context,
-          // and send the resulting value to the consumer.
-          subscriber.next(project.call(thisArg, value, index++));
-        })
-      );
-    });
+  return operate((source, subscriber) => {
+    // The index of the value from the source. Used with projection.
+    let index = 0;
+    // Subscribe to the source, all errors and completions are sent along
+    // to the consumer.
+    source.subscribe(
+      new OperatorSubscriber(subscriber, (value: T) => {
+        // Call the projection function with the appropriate this context,
+        // and send the resulting value to the consumer.
+        subscriber.next(project.call(thisArg, value, index++));
+      })
+    );
+  });
 }

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 export function mapTo<R>(value: R): OperatorFunction<any, R>;
@@ -41,16 +39,14 @@ export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
  * @name mapTo
  */
 export function mapTo<R>(value: R): OperatorFunction<any, R> {
-  return (source: Observable<any>) =>
-    lift(source, function (this: Subscriber<R>, source: Observable<any>) {
-      const subscriber = this;
-      // Subscribe to the source. All errors and completions are forwarded to the consumer
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          // On every value from the source, send the `mapTo` value to the consumer.
-          () => subscriber.next(value)
-        )
-      );
-    });
+  return operate((source, subscriber) => {
+    // Subscribe to the source. All errors and completions are forwarded to the consumer
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        // On every value from the source, send the `mapTo` value to the consumer.
+        () => subscriber.next(value)
+      )
+    );
+  });
 }

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -1,9 +1,7 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { Notification } from '../Notification';
 import { OperatorFunction, ObservableNotification } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -61,24 +59,22 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * will not be available on the emitted values at that time.
  */
 export function materialize<T>(): OperatorFunction<T, Notification<T> & ObservableNotification<T>> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<Notification<T>>, source: Observable<T>) {
-      const subscriber = this;
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => {
-            subscriber.next(Notification.createNext(value));
-          },
-          (err) => {
-            subscriber.next(Notification.createError(err));
-            subscriber.complete();
-          },
-          () => {
-            subscriber.next(Notification.createComplete());
-            subscriber.complete();
-          }
-        )
-      );
-    });
+  return operate((source, subscriber) => {
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          subscriber.next(Notification.createNext(value));
+        },
+        (err) => {
+          subscriber.next(Notification.createError(err));
+          subscriber.complete();
+        },
+        () => {
+          subscriber.next(Notification.createComplete());
+          subscriber.complete();
+        }
+      )
+    );
+  });
 }

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -1,11 +1,10 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
 import { from } from '../observable/from';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /* tslint:disable:max-line-length */
@@ -93,102 +92,100 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(
   } else if (typeof resultSelector === 'number') {
     concurrent = resultSelector;
   }
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<ObservedValueOf<O>>, source: Observable<T>) {
-      const subscriber = this;
-      // Whether or not the outer subscription is complete
-      let isComplete = false;
-      // The number of active inner subscriptions
-      let active = 0;
-      // The index of the value from source (used for projection)
-      let index = 0;
-      // The buffered values from the source (used for concurrency)
-      let buffer: T[] = [];
+  return operate((source, subscriber) => {
+    // Whether or not the outer subscription is complete
+    let isComplete = false;
+    // The number of active inner subscriptions
+    let active = 0;
+    // The index of the value from source (used for projection)
+    let index = 0;
+    // The buffered values from the source (used for concurrency)
+    let buffer: T[] = [];
 
-      /**
-       * Called to check to see if we can complete, and completes the result if
-       * nothing is active.
-       */
-      const checkComplete = () => isComplete && !active && subscriber.complete();
+    /**
+     * Called to check to see if we can complete, and completes the result if
+     * nothing is active.
+     */
+    const checkComplete = () => isComplete && !active && subscriber.complete();
 
-      /**
-       * Attempts to start an inner subscription from a buffered value,
-       * so long as we don't have more active inner subscriptions than
-       * the concurrency limit allows.
-       */
-      const tryInnerSub = () => {
-        while (active < concurrent && buffer.length > 0) {
-          doInnerSub(buffer.shift()!);
-        }
-      };
+    /**
+     * Attempts to start an inner subscription from a buffered value,
+     * so long as we don't have more active inner subscriptions than
+     * the concurrency limit allows.
+     */
+    const tryInnerSub = () => {
+      while (active < concurrent && buffer.length > 0) {
+        doInnerSub(buffer.shift()!);
+      }
+    };
 
-      /**
-       * Creates an inner observable and subscribes to it with the
-       * given outer value.
-       * @param value the value to process
-       */
-      const doInnerSub = (value: T) => {
-        // Subscribe to the inner source
-        active++;
-        subscriber.add(
-          from(project(value, index++)).subscribe(
-            new OperatorSubscriber(
-              subscriber,
-              // INNER SOURCE NEXT
-              // We got a value from the inner source, emit it from the result.
-              (innerValue) => subscriber.next(innerValue),
-              // Errors are sent to the consumer.
-              undefined,
-              () => {
-                // INNER SOURCE COMPLETE
-                // Decrement the active count to ensure that the next time
-                // we try to call `doInnerSub`, the number is accurate.
-                active--;
-                // If we have more values in the buffer, try to process those
-                // Note that this call will increment `active` ahead of the
-                // next conditional, if there were any more inner subscriptions
-                // to start.
-                buffer.length && tryInnerSub();
-                // Check to see if we can complete, and complete if so.
-                checkComplete();
-              }
-            )
+    /**
+     * Creates an inner observable and subscribes to it with the
+     * given outer value.
+     * @param value the value to process
+     */
+    const doInnerSub = (value: T) => {
+      // Subscribe to the inner source
+      active++;
+      subscriber.add(
+        from(project(value, index++)).subscribe(
+          new OperatorSubscriber(
+            subscriber,
+            // INNER SOURCE NEXT
+            // We got a value from the inner source, emit it from the result.
+            (innerValue) => subscriber.next(innerValue),
+            // Errors are sent to the consumer.
+            undefined,
+            () => {
+              // INNER SOURCE COMPLETE
+              // Decrement the active count to ensure that the next time
+              // we try to call `doInnerSub`, the number is accurate.
+              active--;
+              // If we have more values in the buffer, try to process those
+              // Note that this call will increment `active` ahead of the
+              // next conditional, if there were any more inner subscriptions
+              // to start.
+              buffer.length && tryInnerSub();
+              // Check to see if we can complete, and complete if so.
+              checkComplete();
+            }
           )
-        );
-      };
-
-      let outerSubs: Subscription;
-      outerSubs = source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          // OUTER SOURCE NEXT
-          // If we are under our concurrency limit, start the inner subscription with the value
-          // right away. Otherwise, push it onto the buffer and wait.
-          (value) => (active < concurrent ? doInnerSub(value) : buffer.push(value)),
-          // Let errors pass through.
-          undefined,
-          () => {
-            // OUTER SOURCE COMPLETE
-            // We don't necessarily stop here. If have any pending inner subscriptions
-            // we need to wait for those to be done first. That includes buffered inners
-            // that we haven't even subscribed to yet.
-            isComplete = true;
-            // If nothing is active, and nothing in the buffer, with no hope of getting any more
-            // we can complete the result
-            checkComplete();
-            // Be sure to teardown the outer subscription ASAP, in any case.
-            outerSubs?.unsubscribe();
-          }
         )
       );
+    };
 
-      // Additional teardown. Called when the destination is torn down.
-      // Other teardown is registered implicitly above during subscription.
-      return () => {
-        // Release buffered values
-        buffer = null!;
-      };
-    });
+    let outerSubs: Subscription;
+    outerSubs = source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        // OUTER SOURCE NEXT
+        // If we are under our concurrency limit, start the inner subscription with the value
+        // right away. Otherwise, push it onto the buffer and wait.
+        (value) => (active < concurrent ? doInnerSub(value) : buffer.push(value)),
+        // Let errors pass through.
+        undefined,
+        () => {
+          // OUTER SOURCE COMPLETE
+          // We don't necessarily stop here. If have any pending inner subscriptions
+          // we need to wait for those to be done first. That includes buffered inners
+          // that we haven't even subscribed to yet.
+          isComplete = true;
+          // If nothing is active, and nothing in the buffer, with no hope of getting any more
+          // we can complete the result
+          checkComplete();
+          // Be sure to teardown the outer subscription ASAP, in any case.
+          outerSubs?.unsubscribe();
+        }
+      )
+    );
+
+    // Additional teardown. Called when the destination is torn down.
+    // Other teardown is registered implicitly above during subscription.
+    return () => {
+      // Release buffered values
+      buffer = null!;
+    };
+  });
 }
 
 /**

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { from } from '../observable/from';
 
@@ -49,97 +47,95 @@ export function mergeScan<T, R>(
   seed: R,
   concurrent = Infinity
 ): OperatorFunction<T, R> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<R>, source: Observable<T>) {
-      const subscriber = this;
-      // Buffered values, in the event of going over our concurrency limit
-      let buffer: T[] = [];
-      // The number of active inner subscriptions.
-      let active = 0;
-      // Whether or not we have gotten any accumulated state. This is used to
-      // decide whether or not to emit in the event of an empty result.
-      let hasState = false;
-      // The accumulated state.
-      let state = seed;
-      // An index to pass to our accumulator function
-      let index = 0;
-      // Whether or not the outer source has completed.
-      let isComplete = false;
+  return operate((source, subscriber) => {
+    // Buffered values, in the event of going over our concurrency limit
+    let buffer: T[] = [];
+    // The number of active inner subscriptions.
+    let active = 0;
+    // Whether or not we have gotten any accumulated state. This is used to
+    // decide whether or not to emit in the event of an empty result.
+    let hasState = false;
+    // The accumulated state.
+    let state = seed;
+    // An index to pass to our accumulator function
+    let index = 0;
+    // Whether or not the outer source has completed.
+    let isComplete = false;
 
-      /**
-       * Checks to see if we can complete our result or not.
-       */
-      const checkComplete = () => {
-        // If the outer has completed, and nothing is left in the buffer,
-        // and we don't have any active inner subscriptions, then we can
-        // Emit the state and complete.
-        if (isComplete && !buffer.length && !active) {
-          // TODO: This seems like it might result in a double emission, perhaps bad behavior?
-          // maybe we should change this in an upcoming major?
-          !hasState && subscriber.next(state);
-          subscriber.complete();
-        }
-      };
+    /**
+     * Checks to see if we can complete our result or not.
+     */
+    const checkComplete = () => {
+      // If the outer has completed, and nothing is left in the buffer,
+      // and we don't have any active inner subscriptions, then we can
+      // Emit the state and complete.
+      if (isComplete && !buffer.length && !active) {
+        // TODO: This seems like it might result in a double emission, perhaps bad behavior?
+        // maybe we should change this in an upcoming major?
+        !hasState && subscriber.next(state);
+        subscriber.complete();
+      }
+    };
 
-      const doInnerSub = (value: T) => {
-        active++;
-        from(accumulator(state!, value, index++)).subscribe(
-          new OperatorSubscriber(
-            subscriber,
-            (innerValue) => {
-              hasState = true;
-              // Intentially terse. Set the state, then emit it.
-              subscriber.next((state = innerValue));
-            },
-            // Errors are passed to the destination.
-            undefined,
-
-            // TODO: Much of this code is duplicated from mergeMap. Perhaps
-            // look into a way to unify this.
-
-            () => {
-              // INNER SOURCE COMPLETE
-              // Decrement the active count to ensure that the next time
-              // we try to call `doInnerSub`, the number is accurate.
-              active--;
-              // If we have more values in the buffer, try to process those
-              // Note that this call will increment `active` ahead of the
-              // next conditional, if there were any more inner subscriptions
-              // to start.
-              buffer.length && tryInnerSub();
-              // Check to see if we can complete, and complete if so.
-              checkComplete();
-            }
-          )
-        );
-      };
-
-      const tryInnerSub = () => {
-        while (buffer.length && active < concurrent) {
-          doInnerSub(buffer.shift()!);
-        }
-      };
-
-      source.subscribe(
+    const doInnerSub = (value: T) => {
+      active++;
+      from(accumulator(state!, value, index++)).subscribe(
         new OperatorSubscriber(
           subscriber,
-          // If we're under our concurrency limit, just start the inner subscription, otherwise buffer and wait.
-          (value) => (active < concurrent ? doInnerSub(value) : buffer.push(value)),
-          // Errors are passed through
+          (innerValue) => {
+            hasState = true;
+            // Intentially terse. Set the state, then emit it.
+            subscriber.next((state = innerValue));
+          },
+          // Errors are passed to the destination.
           undefined,
+
+          // TODO: Much of this code is duplicated from mergeMap. Perhaps
+          // look into a way to unify this.
+
           () => {
-            // Outer completed, make a note of it, and check to see if we can complete everything.
-            isComplete = true;
+            // INNER SOURCE COMPLETE
+            // Decrement the active count to ensure that the next time
+            // we try to call `doInnerSub`, the number is accurate.
+            active--;
+            // If we have more values in the buffer, try to process those
+            // Note that this call will increment `active` ahead of the
+            // next conditional, if there were any more inner subscriptions
+            // to start.
+            buffer.length && tryInnerSub();
+            // Check to see if we can complete, and complete if so.
             checkComplete();
           }
         )
       );
+    };
 
-      // Additional teardown (for when the destination is torn down).
-      // Other teardown is added implicitly via subscription above.
-      return () => {
-        // Ensure buffered values are released.
-        buffer = null!;
-      };
-    });
+    const tryInnerSub = () => {
+      while (buffer.length && active < concurrent) {
+        doInnerSub(buffer.shift()!);
+      }
+    };
+
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        // If we're under our concurrency limit, just start the inner subscription, otherwise buffer and wait.
+        (value) => (active < concurrent ? doInnerSub(value) : buffer.push(value)),
+        // Errors are passed through
+        undefined,
+        () => {
+          // Outer completed, make a note of it, and check to see if we can complete everything.
+          isComplete = true;
+          checkComplete();
+        }
+      )
+    );
+
+    // Additional teardown (for when the destination is torn down).
+    // Other teardown is added implicitly via subscription above.
+    return () => {
+      // Ensure buffered values are released.
+      buffer = null!;
+    };
+  });
 }

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike, ObservedValueUnionFromArray } from '../types';
-import { lift } from '../util/lift';
-import { Subscriber } from '../Subscriber';
+import { operate } from '../util/lift';
 import { isScheduler } from '../util/isScheduler';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { fromArray } from '../observable/fromArray';
@@ -136,10 +134,9 @@ export function merge<T, R>(...args: Array<ObservableInput<any> | SchedulerLike 
 
   args = argsOrArgArray(args);
 
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<any>, source: Observable<T>) {
-      mergeAll(concurrent)(fromArray([source, ...(args as ObservableInput<T>[])], scheduler)).subscribe(this);
-    });
+  return operate((source, subscriber) => {
+    mergeAll(concurrent)(fromArray([source, ...(args as ObservableInput<T>[])], scheduler)).subscribe(subscriber as any);
+  });
 }
 
 export function mergeWith<T>(): OperatorFunction<T, T>;

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -58,16 +56,14 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * but with provided scheduler.
  */
 export function observeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => subscriber.add(scheduler.schedule(() => subscriber.next(value), delay)),
-          (err) => subscriber.add(scheduler.schedule(() => subscriber.error(err), delay)),
-          () => subscriber.add(scheduler.schedule(() => subscriber.complete(), delay))
-        )
-      );
-    });
+  return operate((source, subscriber) => {
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => subscriber.add(scheduler.schedule(() => subscriber.next(value), delay)),
+        (err) => subscriber.add(scheduler.schedule(() => subscriber.error(err), delay)),
+        () => subscriber.add(scheduler.schedule(() => subscriber.complete(), delay))
+      )
+    );
+  });
 }

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -1,10 +1,11 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf, ObservedValueUnionFromArray, MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { from } from '../observable/from';
 import { argsOrArgArray } from '../util/argsOrArgArray';
+import { OperatorSubscriber } from './OperatorSubscriber';
+import { noop } from '../util/noop';
 
 export function onErrorResumeNext<T>(): MonoTypeOperatorFunction<T>;
 export function onErrorResumeNext<T, O extends ObservableInput<any>>(arrayOfSources: O[]): OperatorFunction<T, T | ObservedValueOf<O>>;
@@ -100,7 +101,7 @@ export function onErrorResumeNext<T>(...nextSources: ObservableInput<any>[]): Op
           // The `closed` property of upstream Subscribers synchronously, that
           // would result in situation were we could not stop a synchronous firehose
           // with something like `take(3)`.
-          const innerSub = new OnErrorResumeNextSubscriber(subscriber);
+          const innerSub = new OperatorSubscriber(subscriber, undefined, noop, noop);
           subscriber.add(nextSource.subscribe(innerSub));
           innerSub.add(subscribeNext);
         } else {
@@ -110,17 +111,5 @@ export function onErrorResumeNext<T>(...nextSources: ObservableInput<any>[]): Op
     };
 
     subscribeNext();
-
-    return subscriber;
   });
-}
-
-class OnErrorResumeNextSubscriber extends Subscriber<any> {
-  _error() {
-    this.unsubscribe();
-  }
-
-  _complete() {
-    this.unsubscribe();
-  }
 }

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -2,7 +2,7 @@
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf, ObservedValueUnionFromArray, MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { from } from '../observable/from';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 
@@ -83,38 +83,36 @@ export function onErrorResumeNext<T, A extends ObservableInput<any>[]>(
 export function onErrorResumeNext<T>(...nextSources: ObservableInput<any>[]): OperatorFunction<T, unknown> {
   nextSources = argsOrArgArray(nextSources);
 
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<any>, source: Observable<T>) {
-      const subscriber = this;
-      const remaining = [source, ...nextSources];
-      const subscribeNext = () => {
-        if (!subscriber.closed) {
-          if (remaining.length > 0) {
-            let nextSource: Observable<any>;
-            try {
-              nextSource = from(remaining.shift()!);
-            } catch (err) {
-              subscribeNext();
-              return;
-            }
-
-            // Here we have to use one of our Subscribers, or it does not wire up
-            // The `closed` property of upstream Subscribers synchronously, that
-            // would result in situation were we could not stop a synchronous firehose
-            // with something like `take(3)`.
-            const innerSub = new OnErrorResumeNextSubscriber(subscriber);
-            subscriber.add(nextSource.subscribe(innerSub));
-            innerSub.add(subscribeNext);
-          } else {
-            subscriber.complete();
+  return operate((source, subscriber) => {
+    const remaining = [source, ...nextSources];
+    const subscribeNext = () => {
+      if (!subscriber.closed) {
+        if (remaining.length > 0) {
+          let nextSource: Observable<any>;
+          try {
+            nextSource = from(remaining.shift()!);
+          } catch (err) {
+            subscribeNext();
+            return;
           }
+
+          // Here we have to use one of our Subscribers, or it does not wire up
+          // The `closed` property of upstream Subscribers synchronously, that
+          // would result in situation were we could not stop a synchronous firehose
+          // with something like `take(3)`.
+          const innerSub = new OnErrorResumeNextSubscriber(subscriber);
+          subscriber.add(nextSource.subscribe(innerSub));
+          innerSub.add(subscribeNext);
+        } else {
+          subscriber.complete();
         }
-      };
+      }
+    };
 
-      subscribeNext();
+    subscribeNext();
 
-      return subscriber;
-    });
+    return subscriber;
+  });
 }
 
 class OnErrorResumeNextSubscriber extends Subscriber<any> {

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -48,18 +46,16 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name pairwise
  */
 export function pairwise<T>(): OperatorFunction<T, [T, T]> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<[T, T]>, source: Observable<T>) {
-      const subscriber = this;
-      let prev: T;
-      let hasPrev = false;
-      source.subscribe(
-        new OperatorSubscriber(subscriber, (value) => {
-          const p = prev;
-          prev = value;
-          hasPrev && subscriber.next([p, value]);
-          hasPrev = true;
-        })
-      );
-    });
+  return operate((source, subscriber) => {
+    let prev: T;
+    let hasPrev = false;
+    source.subscribe(
+      new OperatorSubscriber(subscriber, (value) => {
+        const p = prev;
+        prev = value;
+        hasPrev && subscriber.next([p, value]);
+        hasPrev = true;
+      })
+    );
+  });
 }

--- a/src/internal/operators/raceWith.ts
+++ b/src/internal/operators/raceWith.ts
@@ -1,9 +1,9 @@
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, ObservedValueUnionFromArray } from '../types';
 import { raceInit } from '../observable/race';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { argsOrArgArray } from "../util/argsOrArgArray";
-import { Subscriber } from '../Subscriber';
+import { identity } from '../util/identity';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link raceWith} */
@@ -58,7 +58,7 @@ export function race<T>(...args: any[]): OperatorFunction<T, unknown> {
 export function raceWith<T, A extends ObservableInput<any>[]>(
   ...otherSources: A
 ): OperatorFunction<T, T | ObservedValueUnionFromArray<A>> {
-  return (source: Observable<T>) => (!otherSources.length) ? source : lift(source, function(this: Subscriber<any>, source: Observable<T>) {
-    return raceInit([source, ...otherSources])(this);
+  return !otherSources.length ? identity : operate((source, subscriber) => {
+    raceInit([source, ...otherSources])(subscriber);
   });
 }

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -106,12 +106,10 @@ export function refCount<T>(): MonoTypeOperatorFunction<T> {
       subscriber.unsubscribe();
     });
 
-    const subscription = source.subscribe(refCounter);
+    source.subscribe(refCounter);
 
     if (!refCounter.closed) {
       connection = (source as ConnectableObservable<T>).connect();
     }
-
-    return subscription;
   });
 }

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -2,8 +2,7 @@
 import { Observable } from '../Observable';
 import { Subscription } from '../Subscription';
 import { EMPTY } from '../observable/empty';
-import { lift } from '../util/lift';
-import { Subscriber } from '../Subscriber';
+import { operate } from '../util/lift';
 import { MonoTypeOperatorFunction } from '../types';
 
 /**
@@ -63,42 +62,40 @@ import { MonoTypeOperatorFunction } from '../types';
  */
 
 export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    count <= 0
-      ? EMPTY
-      : lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-          const subscriber = this;
-          let soFar = 0;
-          const subscription = new Subscription();
-          let innerSub: Subscription | null;
-          const subscribeForRepeat = () => {
-            let syncUnsub = false;
-            innerSub = source.subscribe({
-              next: (value) => subscriber.next(value),
-              error: (err) => subscriber.error(err),
-              complete: () => {
-                if (++soFar < count) {
-                  if (innerSub) {
-                    innerSub.unsubscribe();
-                    innerSub = null;
-                    subscribeForRepeat();
-                  } else {
-                    syncUnsub = true;
-                  }
+  return count <= 0
+    ? () => EMPTY
+    : operate((source, subscriber) => {
+        let soFar = 0;
+        const subscription = new Subscription();
+        let innerSub: Subscription | null;
+        const subscribeForRepeat = () => {
+          let syncUnsub = false;
+          innerSub = source.subscribe({
+            next: (value) => subscriber.next(value),
+            error: (err) => subscriber.error(err),
+            complete: () => {
+              if (++soFar < count) {
+                if (innerSub) {
+                  innerSub.unsubscribe();
+                  innerSub = null;
+                  subscribeForRepeat();
                 } else {
-                  subscriber.complete();
+                  syncUnsub = true;
                 }
-              },
-            });
-            if (syncUnsub) {
-              innerSub.unsubscribe();
-              innerSub = null;
-              subscribeForRepeat();
-            } else {
-              subscription.add(innerSub);
-            }
-          };
-          subscribeForRepeat();
-          return subscription;
-        });
+              } else {
+                subscriber.complete();
+              }
+            },
+          });
+          if (syncUnsub) {
+            innerSub.unsubscribe();
+            innerSub = null;
+            subscribeForRepeat();
+          } else {
+            subscription.add(innerSub);
+          }
+        };
+        subscribeForRepeat();
+        return subscription;
+      });
 }

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -1,5 +1,4 @@
 /** @prettier */
-import { Observable } from '../Observable';
 import { Subscription } from '../Subscription';
 import { EMPTY } from '../observable/empty';
 import { operate } from '../util/lift';

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -1,11 +1,10 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
 
 import { MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -38,87 +37,85 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name repeatWhen
  */
 export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      let innerSub: Subscription | null;
-      let syncResub = false;
-      let completions$: Subject<void>;
-      let isNotifierComplete = false;
-      let isMainComplete = false;
+  return operate((source, subscriber) => {
+    let innerSub: Subscription | null;
+    let syncResub = false;
+    let completions$: Subject<void>;
+    let isNotifierComplete = false;
+    let isMainComplete = false;
 
-      /**
-       * Checks to see if we can complete the result, completes it, and returns `true` if it was completed.
-       */
-      const checkComplete = () => isMainComplete && isNotifierComplete && (subscriber.complete(), true);
-      /**
-       * Gets the subject to send errors through. If it doesn't exist,
-       * we know we need to setup the notifier.
-       */
-      const getCompletionSubject = () => {
-        if (!completions$) {
-          completions$ = new Subject();
+    /**
+     * Checks to see if we can complete the result, completes it, and returns `true` if it was completed.
+     */
+    const checkComplete = () => isMainComplete && isNotifierComplete && (subscriber.complete(), true);
+    /**
+     * Gets the subject to send errors through. If it doesn't exist,
+     * we know we need to setup the notifier.
+     */
+    const getCompletionSubject = () => {
+      if (!completions$) {
+        completions$ = new Subject();
 
-          // If the call to `notifier` throws, it will be caught by the OperatorSubscriber
-          // In the main subscription -- in `subscribeForRepeatWhen`.
-          notifier(completions$).subscribe(
-            new OperatorSubscriber(
-              subscriber,
-              () => {
-                if (innerSub) {
-                  subscribeForRepeatWhen();
-                } else {
-                  // If we don't have an innerSub yet, that's because the inner subscription
-                  // call hasn't even returned yet. We've arrived here synchronously.
-                  // So we flag that we want to resub, such that we can ensure teardown
-                  // happens before we resubscribe.
-                  syncResub = true;
-                }
-              },
-              undefined,
-              () => {
-                isNotifierComplete = true;
-                checkComplete();
+        // If the call to `notifier` throws, it will be caught by the OperatorSubscriber
+        // In the main subscription -- in `subscribeForRepeatWhen`.
+        notifier(completions$).subscribe(
+          new OperatorSubscriber(
+            subscriber,
+            () => {
+              if (innerSub) {
+                subscribeForRepeatWhen();
+              } else {
+                // If we don't have an innerSub yet, that's because the inner subscription
+                // call hasn't even returned yet. We've arrived here synchronously.
+                // So we flag that we want to resub, such that we can ensure teardown
+                // happens before we resubscribe.
+                syncResub = true;
               }
-            )
-          );
-        }
-        return completions$;
-      };
-
-      const subscribeForRepeatWhen = () => {
-        isMainComplete = false;
-
-        innerSub = source.subscribe(
-          new OperatorSubscriber(subscriber, undefined, undefined, () => {
-            isMainComplete = true;
-            // Check to see if we are complete, and complete if so.
-            // If we are not complete. Get the subject. This calls the `notifier` function.
-            // If that function fails, it will throw and `.next()` will not be reached on this
-            // line. The thrown error is caught by the _complete handler in this
-            // `OperatorSubscriber` and handled appropriately.
-            !checkComplete() && getCompletionSubject().next();
-          })
+            },
+            undefined,
+            () => {
+              isNotifierComplete = true;
+              checkComplete();
+            }
+          )
         );
+      }
+      return completions$;
+    };
 
-        if (syncResub) {
-          // Ensure that the inner subscription is torn down before
-          // moving on to the next subscription in the synchronous case.
-          // If we don't do this here, all inner subscriptions will not be
-          // torn down until the entire observable is done.
-          innerSub.unsubscribe();
-          // It is important to null this out. Not only to free up memory, but
-          // to make sure code above knows we are in a subscribing state to
-          // handle synchronous resubscription.
-          innerSub = null;
-          // We may need to do this multiple times, so reset the flags.
-          syncResub = false;
-          // Resubscribe
-          subscribeForRepeatWhen();
-        }
-      };
+    const subscribeForRepeatWhen = () => {
+      isMainComplete = false;
 
-      // Start the subscription
-      subscribeForRepeatWhen();
-    });
+      innerSub = source.subscribe(
+        new OperatorSubscriber(subscriber, undefined, undefined, () => {
+          isMainComplete = true;
+          // Check to see if we are complete, and complete if so.
+          // If we are not complete. Get the subject. This calls the `notifier` function.
+          // If that function fails, it will throw and `.next()` will not be reached on this
+          // line. The thrown error is caught by the _complete handler in this
+          // `OperatorSubscriber` and handled appropriately.
+          !checkComplete() && getCompletionSubject().next();
+        })
+      );
+
+      if (syncResub) {
+        // Ensure that the inner subscription is torn down before
+        // moving on to the next subscription in the synchronous case.
+        // If we don't do this here, all inner subscriptions will not be
+        // torn down until the entire observable is done.
+        innerSub.unsubscribe();
+        // It is important to null this out. Not only to free up memory, but
+        // to make sure code above knows we are in a subscribing state to
+        // handle synchronous resubscription.
+        innerSub = null;
+        // We may need to do this multiple times, so reset the flags.
+        syncResub = false;
+        // Resubscribe
+        subscribeForRepeatWhen();
+      }
+    };
+
+    // Start the subscription
+    subscribeForRepeatWhen();
+  });
 }

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -1,11 +1,10 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
 
 import { MonoTypeOperatorFunction } from '../types';
-import { wrappedLift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -61,50 +60,49 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name retryWhen
  */
 export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    wrappedLift(source, (subscriber: Subscriber<T>, source: Observable<T>) => {
-      let innerSub: Subscription | null;
-      let syncResub = false;
-      let errors$: Subject<any>;
+  return operate((source, subscriber) => {
+    let innerSub: Subscription | null;
+    let syncResub = false;
+    let errors$: Subject<any>;
 
-      const subscribeForRetryWhen = () => {
-        innerSub = source.subscribe(
-          new OperatorSubscriber(subscriber, undefined, (err) => {
-            if (!errors$) {
-              errors$ = new Subject();
-              notifier(errors$).subscribe(
-                new OperatorSubscriber(subscriber, () =>
-                  // If we have an innerSub, this was an asynchronous call, kick off the retry.
-                  // Otherwise, if we don't have an innerSub yet, that's because the inner subscription
-                  // call hasn't even returned yet. We've arrived here synchronously.
-                  // So we flag that we want to resub, such that we can ensure teardown
-                  // happens before we resubscribe.
-                  innerSub ? subscribeForRetryWhen() : (syncResub = true)
-                )
-              );
-            }
-            if (errors$) {
-              // We have set up the notifier without error.
-              errors$.next(err);
-            }
-          })
-        );
+    const subscribeForRetryWhen = () => {
+      innerSub = source.subscribe(
+        new OperatorSubscriber(subscriber, undefined, (err) => {
+          if (!errors$) {
+            errors$ = new Subject();
+            notifier(errors$).subscribe(
+              new OperatorSubscriber(subscriber, () =>
+                // If we have an innerSub, this was an asynchronous call, kick off the retry.
+                // Otherwise, if we don't have an innerSub yet, that's because the inner subscription
+                // call hasn't even returned yet. We've arrived here synchronously.
+                // So we flag that we want to resub, such that we can ensure teardown
+                // happens before we resubscribe.
+                innerSub ? subscribeForRetryWhen() : (syncResub = true)
+              )
+            );
+          }
+          if (errors$) {
+            // We have set up the notifier without error.
+            errors$.next(err);
+          }
+        })
+      );
 
-        if (syncResub) {
-          // Ensure that the inner subscription is torn down before
-          // moving on to the next subscription in the synchronous case.
-          // If we don't do this here, all inner subscriptions will not be
-          // torn down until the entire observable is done.
-          innerSub.unsubscribe();
-          innerSub = null;
-          // We may need to do this multiple times, so reset the flag.
-          syncResub = false;
-          // Resubscribe
-          subscribeForRetryWhen();
-        }
-      };
+      if (syncResub) {
+        // Ensure that the inner subscription is torn down before
+        // moving on to the next subscription in the synchronous case.
+        // If we don't do this here, all inner subscriptions will not be
+        // torn down until the entire observable is done.
+        innerSub.unsubscribe();
+        innerSub = null;
+        // We may need to do this multiple times, so reset the flag.
+        syncResub = false;
+        // Resubscribe
+        subscribeForRetryWhen();
+      }
+    };
 
-      // Start the subscription
-      subscribeForRetryWhen();
-    });
+    // Start the subscription
+    subscribeForRetryWhen();
+  });
 }

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -1,11 +1,10 @@
 import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { EmptyError } from '../util/EmptyError';
 
 import { MonoTypeOperatorFunction } from '../types';
 import { SequenceError } from '../util/SequenceError';
 import { NotFoundError } from '../util/NotFoundError';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -91,8 +90,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function single<T>(
   predicate?: (value: T, index: number, source: Observable<T>) => boolean
 ): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-    const subscriber = this;
+  return operate((source, subscriber) => {
     let hasValue = false;
     let singleValue: T;
     let seenValue = false;

--- a/src/internal/operators/skip.ts
+++ b/src/internal/operators/skip.ts
@@ -15,10 +15,6 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function skip<T>(count: number): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
     let seen = 0;
-    return source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
-        count === seen ? subscriber.next(value) : seen++;
-      })
-    );
+    source.subscribe(new OperatorSubscriber(subscriber, (value) => (count === seen ? subscriber.next(value) : seen++)));
   });
 }

--- a/src/internal/operators/skip.ts
+++ b/src/internal/operators/skip.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -15,14 +13,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name skip
  */
 export function skip<T>(count: number): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      let seen = 0;
-      return source.subscribe(
-        new OperatorSubscriber(subscriber, (value) => {
-          count === seen ? subscriber.next(value) : seen++;
-        })
-      );
-    });
+  return operate((source, subscriber) => {
+    let seen = 0;
+    return source.subscribe(
+      new OperatorSubscriber(subscriber, (value) => {
+        count === seen ? subscriber.next(value) : seen++;
+      })
+    );
+  });
 }

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -1,7 +1,7 @@
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
+/** @prettier */
 import { MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { identity } from '../util/identity';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -43,30 +43,38 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 export function skipLast<T>(skipCount: number): MonoTypeOperatorFunction<T> {
   // For skipCounts less than or equal to zero, we are just mirroring the source.
-  return (source: Observable<T>) => skipCount <= 0 ? source : lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-    const subscriber = this;
-    // A ring buffer to hold the values while we wait to see
-    // if we can emit it or it's part of the "skipped" last values.
-    // Note that it is the _same size_ as the skip count.
-    let ring: T[] = new Array(skipCount);
-    let count = 0;
-    source.subscribe(new OperatorSubscriber(subscriber, value => {
-      // Move us to the next slot in the ring buffer.
-      const currentCount = count++;
-      if (currentCount < skipCount) {
-        // Fill the ring first
-        ring[currentCount] = value;
-      } else {
-        const index = currentCount % skipCount;
-        // Pull the oldest value out and emit it,
-        // then stuff the new value in it's place.
-        const oldValue = ring[index];
-        ring[index] = value;
-        subscriber.next(oldValue);
-      }
-    }, undefined, undefined, () =>
-      // Free up memory
-      ring = null!
-    ))
-  });
+  return skipCount <= 0
+    ? identity
+    : operate((source, subscriber) => {
+        // A ring buffer to hold the values while we wait to see
+        // if we can emit it or it's part of the "skipped" last values.
+        // Note that it is the _same size_ as the skip count.
+        let ring: T[] = new Array(skipCount);
+        let count = 0;
+        source.subscribe(
+          new OperatorSubscriber(
+            subscriber,
+            (value) => {
+              // Move us to the next slot in the ring buffer.
+              const currentCount = count++;
+              if (currentCount < skipCount) {
+                // Fill the ring first
+                ring[currentCount] = value;
+              } else {
+                const index = currentCount % skipCount;
+                // Pull the oldest value out and emit it,
+                // then stuff the new value in it's place.
+                const oldValue = ring[index];
+                ring[index] = value;
+                subscriber.next(oldValue);
+              }
+            },
+            undefined,
+            undefined,
+            () =>
+              // Free up memory
+              (ring = null!)
+          )
+        );
+      });
 }

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
-import { wrappedLift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { from } from '../observable/from';
 import { noop } from '../util/noop';
@@ -45,22 +45,21 @@ import { noop } from '../util/noop';
  * @name skipUntil
  */
 export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    wrappedLift(source, (subscriber, liftedSource) => {
-      let taking = false;
+  return operate((source, subscriber) => {
+    let taking = false;
 
-      const skipSubscriber = new OperatorSubscriber(
-        subscriber,
-        () => {
-          skipSubscriber?.unsubscribe();
-          taking = true;
-        },
-        undefined,
-        noop
-      );
+    const skipSubscriber = new OperatorSubscriber(
+      subscriber,
+      () => {
+        skipSubscriber?.unsubscribe();
+        taking = true;
+      },
+      undefined,
+      noop
+    );
 
-      from(notifier).subscribe(skipSubscriber);
+    from(notifier).subscribe(skipSubscriber);
 
-      liftedSource.subscribe(new OperatorSubscriber(subscriber, (value) => taking && subscriber.next(value)));
-    });
+    source.subscribe(new OperatorSubscriber(subscriber, (value) => taking && subscriber.next(value)));
+  });
 }

--- a/src/internal/operators/skipWhile.ts
+++ b/src/internal/operators/skipWhile.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -17,13 +15,11 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name skipWhile
  */
 export function skipWhile<T>(predicate: (value: T, index: number) => boolean): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      let taking = false;
-      let index = 0;
-      source.subscribe(
-        new OperatorSubscriber(subscriber, (value) => (taking || (taking = !predicate(value, index++))) && subscriber.next(value))
-      );
-    });
+  return operate((source, subscriber) => {
+    let taking = false;
+    let index = 0;
+    source.subscribe(
+      new OperatorSubscriber(subscriber, (value) => (taking || (taking = !predicate(value, index++))) && subscriber.next(value))
+    );
+  });
 }

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
-import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 
 /**
  * Asynchronously subscribes Observers to this Observable on the specified {@link SchedulerLike}.
@@ -64,9 +62,7 @@ import { lift } from '../util/lift';
  * @return The source Observable modified so that its subscriptions happen on the specified {@link SchedulerLike}.
  */
 export function subscribeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      subscriber.add(scheduler.schedule(() => source.subscribe(subscriber), delay));
-    });
+  return operate((source, subscriber) => {
+    subscriber.add(scheduler.schedule(() => source.subscribe(subscriber), delay));
+  });
 }

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -53,7 +53,7 @@ export function take<T>(count: number): MonoTypeOperatorFunction<T> {
     ? () => EMPTY
     : operate((source, subscriber) => {
         let seen = 0;
-        return source.subscribe(
+        source.subscribe(
           new OperatorSubscriber(subscriber, (value) => {
             if (++seen <= count) {
               subscriber.next(value);

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -1,9 +1,6 @@
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
-
-
+/** @prettier */
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { from } from '../observable/from';
 import { noop } from '../util/noop';
@@ -48,8 +45,7 @@ import { noop } from '../util/noop';
  * @name takeUntil
  */
 export function takeUntil<T>(notifier: ObservableInput<any>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-    const subscriber = this;
+  return operate((source, subscriber) => {
     from(notifier).subscribe(new OperatorSubscriber(subscriber, () => subscriber.complete(), undefined, noop));
     !subscriber.closed && source.subscribe(subscriber);
   });

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -53,7 +53,7 @@ export function takeWhile<T>(predicate: (value: T, index: number) => boolean, in
 export function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive = false): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
     let index = 0;
-    return source.subscribe(
+    source.subscribe(
       new OperatorSubscriber(subscriber, (value) => {
         const result = predicate(value, index++);
         (result || inclusive) && subscriber.next(value);

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { OperatorFunction, MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 export function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S): OperatorFunction<T, S>;
@@ -53,16 +51,14 @@ export function takeWhile<T>(predicate: (value: T, index: number) => boolean, in
  * @name takeWhile
  */
 export function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive = false): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      let index = 0;
-      return source.subscribe(
-        new OperatorSubscriber(subscriber, (value) => {
-          const result = predicate(value, index++);
-          (result || inclusive) && subscriber.next(value);
-          !result && subscriber.complete();
-        })
-      );
-    });
+  return operate((source, subscriber) => {
+    let index = 0;
+    return source.subscribe(
+      new OperatorSubscriber(subscriber, (value) => {
+        const result = predicate(value, index++);
+        (result || inclusive) && subscriber.next(value);
+        !result && subscriber.complete();
+      })
+    );
+  });
 }

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -149,7 +149,8 @@ export function tap<T>(
       onError = error ? wrap(error.bind(nextOrObserver)) : noop;
       onComplete = complete ? wrap(complete.bind(nextOrObserver)) : noop;
     }
-    return source.subscribe(new TapSubscriber(subscriber, onNext, onError, onComplete));
+
+    source.subscribe(new TapSubscriber(subscriber, onNext, onError, onComplete));
   });
 }
 

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -1,11 +1,9 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { asyncScheduler } from '../scheduler/async';
-import { Observable } from '../Observable';
 import { ThrottleConfig, defaultThrottleConfig } from './throttle';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -90,99 +88,97 @@ export function throttleTime<T>(
   scheduler: SchedulerLike = asyncScheduler,
   { leading = false, trailing = false }: ThrottleConfig = defaultThrottleConfig
 ): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      // Whether or not we have received a trailing value
-      let hasTrailingValue = false;
-      // The trailing value we have received
-      let trailingValue: T | null = null;
-      // The subscription for the scheduled throttle job.
-      // If this is null, no throttle is currently scheduled.
-      let throttleSubs: Subscription | null = null;
-      // Whether or not the source has completed.
-      let isComplete = false;
+  return operate((source, subscriber) => {
+    // Whether or not we have received a trailing value
+    let hasTrailingValue = false;
+    // The trailing value we have received
+    let trailingValue: T | null = null;
+    // The subscription for the scheduled throttle job.
+    // If this is null, no throttle is currently scheduled.
+    let throttleSubs: Subscription | null = null;
+    // Whether or not the source has completed.
+    let isComplete = false;
 
-      /**
-       * Executed when the throttled time completes.
-       */
-      const throttleJob = () => {
-        // Clear the throttle subs, we check this to see if there's
-        // A throttle scheduled already.
-        throttleSubs = null;
-        if (trailing && hasTrailingValue) {
-          // If we have the trailing behavior, and we have a trailing value
-          // then emit the trailing value. Emitting will start another throttle
-          // peroid.
-          hasTrailingValue = false;
-          emit(trailingValue!);
-          trailingValue = null;
-        }
-        if (isComplete) {
-          subscriber.complete();
-        }
-      };
+    /**
+     * Executed when the throttled time completes.
+     */
+    const throttleJob = () => {
+      // Clear the throttle subs, we check this to see if there's
+      // A throttle scheduled already.
+      throttleSubs = null;
+      if (trailing && hasTrailingValue) {
+        // If we have the trailing behavior, and we have a trailing value
+        // then emit the trailing value. Emitting will start another throttle
+        // peroid.
+        hasTrailingValue = false;
+        emit(trailingValue!);
+        trailingValue = null;
+      }
+      if (isComplete) {
+        subscriber.complete();
+      }
+    };
 
-      /**
-       * Does the work of scheduling the throttle job.
-       */
-      const startThrottle = () => subscriber.add((throttleSubs = scheduler.schedule(throttleJob, duration)));
+    /**
+     * Does the work of scheduling the throttle job.
+     */
+    const startThrottle = () => subscriber.add((throttleSubs = scheduler.schedule(throttleJob, duration)));
 
-      /**
-       * Sets the trailing value if we have that behavior.
-       */
-      const setTrailing = (value: T) => {
-        if (trailing) {
-          hasTrailingValue = true;
-          trailingValue = value;
-        }
-      };
+    /**
+     * Sets the trailing value if we have that behavior.
+     */
+    const setTrailing = (value: T) => {
+      if (trailing) {
+        hasTrailingValue = true;
+        trailingValue = value;
+      }
+    };
 
-      /**
-       * Emits the value, and if the source is not complete,
-       * it will schedule another throttle period.
-       */
-      const emit = (value: T) => {
-        subscriber.next(value);
-        !isComplete && startThrottle();
-      };
+    /**
+     * Emits the value, and if the source is not complete,
+     * it will schedule another throttle period.
+     */
+    const emit = (value: T) => {
+      subscriber.next(value);
+      !isComplete && startThrottle();
+    };
 
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => {
-            // We got a new value
-            if (throttleSubs) {
-              // We're already throttled, set the trailing value if we have to.
-              setTrailing(value);
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          // We got a new value
+          if (throttleSubs) {
+            // We're already throttled, set the trailing value if we have to.
+            setTrailing(value);
+          } else {
+            // We are not throttled yet.
+            if (leading) {
+              // If we have the leading behavior, emit right away and start
+              // a new throttle period.
+              emit(value);
             } else {
-              // We are not throttled yet.
-              if (leading) {
-                // If we have the leading behavior, emit right away and start
-                // a new throttle period.
-                emit(value);
-              } else {
-                // If we do not have the leading behavior,
-                // set the trailing value and start a new throttle peroid.
-                // If they don't have the leading behavior, we'll just assume
-                // they have the trailing behavior here. We need to record the value
-                // So it comes out after the throttle period. If they don't have
-                // either behavior that is just weird. Not adding extra code for that.
-                setTrailing(value);
-                startThrottle();
-              }
+              // If we do not have the leading behavior,
+              // set the trailing value and start a new throttle peroid.
+              // If they don't have the leading behavior, we'll just assume
+              // they have the trailing behavior here. We need to record the value
+              // So it comes out after the throttle period. If they don't have
+              // either behavior that is just weird. Not adding extra code for that.
+              setTrailing(value);
+              startThrottle();
             }
-          },
-          undefined,
-          () => {
-            // The source completed
-            isComplete = true;
-            // If we're trailing, and we're in a throttle period and have a trailing value,
-            // wait for the throttle period to end before we actually complete.
-            // Otherwise, returning `true` here completes the result right away.
-            (!trailing || !throttleSubs || !hasTrailingValue) && subscriber.complete();
           }
-        )
-      );
-    });
+        },
+        undefined,
+        () => {
+          // The source completed
+          isComplete = true;
+          // If we're trailing, and we're in a throttle period and have a trailing value,
+          // wait for the throttle period to end before we actually complete.
+          // Otherwise, returning `true` here completes the result right away.
+          (!trailing || !throttleSubs || !hasTrailingValue) && subscriber.complete();
+        }
+      )
+    );
+  });
 }

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -1,9 +1,7 @@
 /** @prettier */
 import { EmptyError } from '../util/EmptyError';
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -37,22 +35,20 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * value.
  */
 export function throwIfEmpty<T>(errorFactory: () => any = defaultErrorFactory): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<T>, source: Observable<T>) {
-      const subscriber = this;
-      let hasValue = false;
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => {
-            hasValue = true;
-            subscriber.next(value);
-          },
-          undefined,
-          () => (hasValue ? subscriber.complete() : subscriber.error(errorFactory()))
-        )
-      );
-    });
+  return operate((source, subscriber) => {
+    let hasValue = false;
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          hasValue = true;
+          subscriber.next(value);
+        },
+        undefined,
+        () => (hasValue ? subscriber.complete() : subscriber.error(errorFactory()))
+      )
+    );
+  });
 }
 
 function defaultErrorFactory() {

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -1,9 +1,8 @@
 /** @prettier */
-import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -71,64 +70,62 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function windowCount<T>(windowSize: number, startWindowEvery: number = 0): OperatorFunction<T, Observable<T>> {
   const startEvery = startWindowEvery > 0 ? startWindowEvery : windowSize;
 
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<Observable<T>>, source: Observable<T>) {
-      const subscriber = this;
-      let windows = [new Subject<T>()];
-      let starts: number[] = [];
-      let count = 0;
+  return operate((source, subscriber) => {
+    let windows = [new Subject<T>()];
+    let starts: number[] = [];
+    let count = 0;
 
-      // Open the first window.
-      subscriber.next(windows[0].asObservable());
+    // Open the first window.
+    subscriber.next(windows[0].asObservable());
 
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value: T) => {
-            // Emit the value through all current windows.
-            // We don't need to create a new window yet, we
-            // do that as soon as we close one.
-            for (const window of windows) {
-              window.next(value);
-            }
-            // Here we're using the size of the window array to figure
-            // out if the oldest window has emitted enough values. We can do this
-            // because the size of the window array is a function of the values
-            // seen by the subscription. If it's time to close it, we complete
-            // it and remove it.
-            const c = count - windowSize + 1;
-            if (c >= 0 && c % startEvery === 0) {
-              windows.shift()!.complete();
-            }
-
-            // Look to see if the next count tells us it's time to open a new window.
-            // TODO: We need to figure out if this really makes sense. We're technically
-            // emitting windows *before* we have a value to emit them for. It's probably
-            // more expected that we should be emitting the window when the start
-            // count is reached -- not before.
-            if (++count % startEvery === 0) {
-              const window = new Subject<T>();
-              windows.push(window);
-              subscriber.next(window.asObservable());
-            }
-          },
-          (err) => {
-            while (windows.length > 0) {
-              windows.shift()!.error(err);
-            }
-            subscriber.error(err);
-          },
-          () => {
-            while (windows.length > 0) {
-              windows.shift()!.complete();
-            }
-            subscriber.complete();
-          },
-          () => {
-            starts = null!;
-            windows = null!;
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value: T) => {
+          // Emit the value through all current windows.
+          // We don't need to create a new window yet, we
+          // do that as soon as we close one.
+          for (const window of windows) {
+            window.next(value);
           }
-        )
-      );
-    });
+          // Here we're using the size of the window array to figure
+          // out if the oldest window has emitted enough values. We can do this
+          // because the size of the window array is a function of the values
+          // seen by the subscription. If it's time to close it, we complete
+          // it and remove it.
+          const c = count - windowSize + 1;
+          if (c >= 0 && c % startEvery === 0) {
+            windows.shift()!.complete();
+          }
+
+          // Look to see if the next count tells us it's time to open a new window.
+          // TODO: We need to figure out if this really makes sense. We're technically
+          // emitting windows *before* we have a value to emit them for. It's probably
+          // more expected that we should be emitting the window when the start
+          // count is reached -- not before.
+          if (++count % startEvery === 0) {
+            const window = new Subject<T>();
+            windows.push(window);
+            subscriber.next(window.asObservable());
+          }
+        },
+        (err) => {
+          while (windows.length > 0) {
+            windows.shift()!.error(err);
+          }
+          subscriber.error(err);
+        },
+        () => {
+          while (windows.length > 0) {
+            windows.shift()!.complete();
+          }
+          subscriber.complete();
+        },
+        () => {
+          starts = null!;
+          windows = null!;
+        }
+      )
+    );
+  });
 }

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -3,7 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { ObservableInput, OperatorFunction } from '../types';
-import { lift } from '../util/lift';
+import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { from } from '../observable/from';
 
@@ -52,76 +52,74 @@ import { from } from '../observable/from';
  * @name windowWhen
  */
 export function windowWhen<T>(closingSelector: () => ObservableInput<any>): OperatorFunction<T, Observable<T>> {
-  return (source: Observable<T>) =>
-    lift(source, function (this: Subscriber<Observable<T>>, source: Observable<T>) {
-      const subscriber = this;
-      let window: Subject<T> | null;
-      let closingSubscriber: Subscriber<any> | undefined;
+  return operate((source, subscriber) => {
+    let window: Subject<T> | null;
+    let closingSubscriber: Subscriber<any> | undefined;
 
-      /**
-       * When we get an error, we have to notify both the
-       * destiation subscriber and the window.
-       */
-      const handleError = (err: any) => {
-        window!.error(err);
-        subscriber.error(err);
-      };
+    /**
+     * When we get an error, we have to notify both the
+     * destiation subscriber and the window.
+     */
+    const handleError = (err: any) => {
+      window!.error(err);
+      subscriber.error(err);
+    };
 
-      /**
-       * Called every time we need to open a window.
-       * Recursive, as it will start the closing notifier, which
-       * inevitably *should* call openWindow -- but may not if
-       * it is a "never" observable.
-       */
-      const openWindow = () => {
-        // We need to clean up our closing subscription,
-        // we only cared about the first next or complete notification.
-        closingSubscriber?.unsubscribe();
+    /**
+     * Called every time we need to open a window.
+     * Recursive, as it will start the closing notifier, which
+     * inevitably *should* call openWindow -- but may not if
+     * it is a "never" observable.
+     */
+    const openWindow = () => {
+      // We need to clean up our closing subscription,
+      // we only cared about the first next or complete notification.
+      closingSubscriber?.unsubscribe();
 
-        // Close our window before starting a new one.
-        window?.complete();
+      // Close our window before starting a new one.
+      window?.complete();
 
-        // Start the new window.
-        window = new Subject<T>();
-        subscriber.next(window.asObservable());
+      // Start the new window.
+      window = new Subject<T>();
+      subscriber.next(window.asObservable());
 
-        // Get our closing notifier.
-        let closingNotifier: Observable<any>;
-        try {
-          closingNotifier = from(closingSelector());
-        } catch (err) {
-          handleError(err);
-          return;
+      // Get our closing notifier.
+      let closingNotifier: Observable<any>;
+      try {
+        closingNotifier = from(closingSelector());
+      } catch (err) {
+        handleError(err);
+        return;
+      }
+
+      // Subscribe to the closing notifier, be sure
+      // to capture the subscriber (aka Subscription)
+      // so we can clean it up when we close the window
+      // and open a new one.
+      closingNotifier.subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openWindow, handleError, openWindow)));
+    };
+
+    // Start the first window.
+    openWindow();
+
+    // Subscribe to the source
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => window!.next(value),
+        handleError,
+        () => {
+          // The source completed, close the window and complete.
+          window!.complete();
+          subscriber.complete();
+        },
+        () => {
+          // Be sure to clean up our closing subscription
+          // when this tears down.
+          closingSubscriber?.unsubscribe();
+          window = null!;
         }
-
-        // Subscribe to the closing notifier, be sure
-        // to capture the subscriber (aka Subscription)
-        // so we can clean it up when we close the window
-        // and open a new one.
-        closingNotifier.subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openWindow, handleError, openWindow)));
-      };
-
-      // Start the first window.
-      openWindow();
-
-      // Subscribe to the source
-      source.subscribe(
-        new OperatorSubscriber(
-          subscriber,
-          (value) => window!.next(value),
-          handleError,
-          () => {
-            // The source completed, close the window and complete.
-            window!.complete();
-            subscriber.complete();
-          },
-          () => {
-            // Be sure to clean up our closing subscription
-            // when this tears down.
-            closingSubscriber?.unsubscribe();
-            window = null!;
-          }
-        )
-      );
-    });
+      )
+    );
+  });
 }

--- a/src/internal/operators/zipAll.ts
+++ b/src/internal/operators/zipAll.ts
@@ -1,7 +1,6 @@
-import { Observable } from '../Observable';
+/** @prettier */
 import { OperatorFunction, ObservableInput } from '../types';
-import { lift } from '../util/lift';
-import { Subscriber } from '../Subscriber';
+import { operate } from '../util/lift';
 import { zip } from '../observable/zip';
 
 export function zipAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
@@ -9,25 +8,22 @@ export function zipAll<T>(): OperatorFunction<any, T[]>;
 export function zipAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
 export function zipAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 
-export function zipAll<T, R>(project?: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R> {
-  return (source: Observable<ObservableInput<T>>) => lift(source, function zipAllOperator(this: Subscriber<R|T[]>, source: Observable<ObservableInput<T>>) {
-    const subscriber = this;
+export function zipAll<T, R>(project?: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, any> {
+  return operate((source, subscriber) => {
     const sources: ObservableInput<T>[] = [];
     subscriber.add(
       source.subscribe({
-        next: source => sources.push(source),
-        error: err => subscriber.error(err),
+        next: (source) => sources.push(source),
+        error: (err) => subscriber.error(err),
         complete: () => {
           if (sources.length > 0) {
             const args = project ? [...sources, project] : sources;
-            subscriber.add(
-              zip(...args).subscribe(subscriber)
-            )
+            subscriber.add(zip(...args).subscribe(subscriber));
           } else {
             subscriber.complete();
           }
-        }
+        },
       })
-    )
+    );
   });
 }

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -1,8 +1,7 @@
+/** @prettier */
 import { zip as zipStatic } from '../observable/zip';
-import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
-import { lift } from '../util/lift';
-import { Subscriber } from '../Subscriber'
+import { operate } from '../util/lift';
 
 /* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link zipWith} */
@@ -10,39 +9,76 @@ export function zip<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
 export function zip<T, T2, R>(v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R): OperatorFunction<T, R>;
+export function zip<T, T2, T3, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  project: (v1: T, v2: T2, v3: T3) => R
+): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R): OperatorFunction<T, R>;
+export function zip<T, T2, T3, T4, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  project: (v1: T, v2: T2, v3: T3, v4: T4) => R
+): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R): OperatorFunction<T, R>;
+export function zip<T, T2, T3, T4, T5, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R
+): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5, T6, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R): OperatorFunction<T, R> ;
+export function zip<T, T2, T3, T4, T5, T6, R>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  v6: ObservableInput<T6>,
+  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R
+): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
 export function zip<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
 /** @deprecated Deprecated use {@link zipWith} */
 export function zip<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, [T, T2, T3, T4]>;
+export function zip<T, T2, T3, T4>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>
+): OperatorFunction<T, [T, T2, T3, T4]>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, [T, T2, T3, T4, T5]>;
+export function zip<T, T2, T3, T4, T5>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>
+): OperatorFunction<T, [T, T2, T3, T4, T5]>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]> ;
+export function zip<T, T2, T3, T4, T5, T6>(
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  v6: ObservableInput<T6>
+): OperatorFunction<T, [T, T2, T3, T4, T5, T6]>;
 /** @deprecated Deprecated use {@link zipWith} */
 export function zip<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
 export function zip<T, R>(array: Array<ObservableInput<T>>): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, TOther, R>(array: Array<ObservableInput<TOther>>, project: (v1: T, ...values: Array<TOther>) => R): OperatorFunction<T, R>;
+export function zip<T, TOther, R>(
+  array: Array<ObservableInput<TOther>>,
+  project: (v1: T, ...values: Array<TOther>) => R
+): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**
  * @deprecated Deprecated. Use {@link zipWith}.
  */
-export function zip<T, R>(...sources: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, R> {
-  return (source: Observable<T>) => lift(source, function (this: Subscriber<any>, source: Observable<T>) {
-    const args = [source, ...sources];
-    return zipStatic(...args).subscribe(this);
-  })
+export function zip<T, R>(...sources: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, any> {
+  return operate((source, subscriber) => zipStatic(source, ...sources).subscribe(subscriber));
 }
 
 /**

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -78,7 +78,9 @@ export function zip<T, TOther, R>(
  * @deprecated Deprecated. Use {@link zipWith}.
  */
 export function zip<T, R>(...sources: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, any> {
-  return operate((source, subscriber) => zipStatic(source, ...sources).subscribe(subscriber));
+  return operate((source, subscriber) => {
+    zipStatic(source, ...sources).subscribe(subscriber);
+  });
 }
 
 /**

--- a/src/internal/util/lift.ts
+++ b/src/internal/util/lift.ts
@@ -2,7 +2,7 @@
 import { Observable } from '../Observable';
 import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { TeardownLogic } from '../types';
+import { OperatorFunction, TeardownLogic } from '../types';
 
 /**
  * A utility to lift observables. Will also error if an observable is passed that does not
@@ -46,4 +46,19 @@ export function wrappedLift<T, R>(
 
 export function hasLift(source: any): source is { lift: InstanceType<typeof Observable>['lift'] } {
   return source && typeof source.lift === 'function';
+}
+
+export function operate<T, R>(init: (liftedSource: Observable<T>, subscriber: Subscriber<R>) => TeardownLogic): OperatorFunction<T, R> {
+  return (source: Observable<T>) => {
+    if (hasLift(source)) {
+      return source.lift(function (this: Subscriber<R>, liftedSource: Observable<T>) {
+        try {
+          return init(liftedSource, this);
+        } catch (err) {
+          this.error(err);
+        }
+      });
+    }
+    throw new TypeError('Unable to lift unknown Observable type');
+  };
 }

--- a/src/internal/util/lift.ts
+++ b/src/internal/util/lift.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { OperatorFunction, TeardownLogic } from '../types';
+import { OperatorFunction } from '../types';
 
 /**
  * Used to determine if an object is an Observable with a lift function.
@@ -14,7 +14,9 @@ export function hasLift(source: any): source is { lift: InstanceType<typeof Obse
  * Creates an `OperatorFunction`. Used to define operators throughout the library in a concise way.
  * @param init The logic to connect the liftedSource to the subscriber at the moment of subscription.
  */
-export function operate<T, R>(init: (liftedSource: Observable<T>, subscriber: Subscriber<R>) => TeardownLogic): OperatorFunction<T, R> {
+export function operate<T, R>(
+  init: (liftedSource: Observable<T>, subscriber: Subscriber<R>) => (() => void) | void
+): OperatorFunction<T, R> {
   return (source: Observable<T>) => {
     if (hasLift(source)) {
       return source.lift(function (this: Subscriber<R>, liftedSource: Observable<T>) {

--- a/src/internal/util/lift.ts
+++ b/src/internal/util/lift.ts
@@ -1,53 +1,19 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction, TeardownLogic } from '../types';
 
 /**
- * A utility to lift observables. Will also error if an observable is passed that does not
- * have the lift mechanism.
- *
- * We _must_ do this for version 7, because it is what allows subclassed observables to compose through
- * the operators that use this. That will be going away in v8.
- *
- * See https://github.com/ReactiveX/rxjs/issues/5571
- * and https://github.com/ReactiveX/rxjs/issues/5431
- *
- * @param source The source observable to lift
- * @param operator The operator to lift it with. Note that the operator possibly being undefined here
- * is related to issues around the "stanky" lifting of static creation functions as operators, see below.
+ * Used to determine if an object is an Observable with a lift function.
  */
-export function lift<T, R>(source: Observable<T>, operator?: Operator<T, R>): Observable<R> {
-  if (hasLift(source)) {
-    return source.lift(operator);
-  }
-  throw new TypeError('Unable to lift unknown Observable type');
-}
-
-/**
- * A lightweight wrapper to deal with sitations where there may be try/catching at the
- * time of the subscription (and not just via notifications).
- * @param source The source observable to lift
- * @param wrappedOperator The lightweight operator function to wrap.
- */
-export function wrappedLift<T, R>(
-  source: Observable<T>,
-  wrappedOperator: (subscriber: Subscriber<R>, liftedSource: Observable<T>) => TeardownLogic
-): Observable<R> {
-  return lift(source, function (this: Subscriber<R>, liftedSource: Observable<T>) {
-    try {
-      wrappedOperator(this, liftedSource);
-    } catch (err) {
-      this.error(err);
-    }
-  });
-}
-
 export function hasLift(source: any): source is { lift: InstanceType<typeof Observable>['lift'] } {
   return source && typeof source.lift === 'function';
 }
 
+/**
+ * Creates an `OperatorFunction`. Used to define operators throughout the library in a concise way.
+ * @param init The logic to connect the liftedSource to the subscriber at the moment of subscription.
+ */
 export function operate<T, R>(init: (liftedSource: Observable<T>, subscriber: Subscriber<R>) => TeardownLogic): OperatorFunction<T, R> {
   return (source: Observable<T>) => {
     if (hasLift(source)) {

--- a/src/internal/util/lift.ts
+++ b/src/internal/util/lift.ts
@@ -7,7 +7,7 @@ import { OperatorFunction, TeardownLogic } from '../types';
  * Used to determine if an object is an Observable with a lift function.
  */
 export function hasLift(source: any): source is { lift: InstanceType<typeof Observable>['lift'] } {
-  return source && typeof source.lift === 'function';
+  return typeof source?.lift === 'function';
 }
 
 /**


### PR DESCRIPTION
- Adds new `operate` function for creating operators
- Replaces all `lift` and `wrappedLift` helpers.
- Fixes an issue with `publishReplay` et al, where an error thrown in the selector function was being thrown externally instead of send to the subscriber via an error notification.

Further size reduction.

~~57K -> 55K~~
57K -> 54K approximately

![image](https://user-images.githubusercontent.com/1540597/94034440-a6425a00-fd87-11ea-86a9-f1f52d863b77.png)
