### PR TITLE
chore: add no-unused-declaration lint rule (for imports)

### DIFF
--- a/src/internal/AsyncSubject.ts
+++ b/src/internal/AsyncSubject.ts
@@ -1,7 +1,6 @@
 /** @prettier */
 import { Subject } from './Subject';
 import { Subscriber } from './Subscriber';
-import { Subscription } from './Subscription';
 
 /**
  * A variant of Subject that only emits a value when it completes. It will emit

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -4,10 +4,8 @@ import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValueTupleFrom
 import { isScheduler } from '../util/isScheduler';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { Subscriber } from '../Subscriber';
-import { isObject } from '../util/isObject';
 import { from } from './from';
 import { identity } from '../util/identity';
-import { map } from '../operators/map';
 import { Subscription } from '../Subscription';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -1,6 +1,5 @@
 import { Observable } from '../Observable';
 import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValueUnionFromArray } from '../types';
-import { of } from './of';
 import { concatAll } from '../operators/concatAll';
 import { isScheduler } from '../util/isScheduler';
 import { fromArray } from './fromArray';

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -1,7 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
-import { Subscriber } from '../Subscriber';
 
 /**
  * Creates an observable that will create an error instance and push it to the consumer as an error

--- a/src/internal/operators/concatWith.ts
+++ b/src/internal/operators/concatWith.ts
@@ -1,4 +1,3 @@
-import { concat as concatStatic } from '../observable/concat';
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray, MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { lift } from '../util/lift';

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -1,6 +1,5 @@
 /** @prettier */
 import { Subject } from '../Subject';
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { ConnectableObservable } from '../observable/ConnectableObservable';

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -5,7 +5,7 @@ import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
 
 import { MonoTypeOperatorFunction } from '../types';
-import { lift, wrappedLift } from '../util/lift';
+import { wrappedLift } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -1,9 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
 import { asyncScheduler } from '../scheduler/async';
-import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike } from '../types';
-import { lift } from '../util/lift';
+import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { sample } from './sample';
 import { interval } from '../observable/interval';
 

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -1,10 +1,8 @@
 /** @prettier */
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { EMPTY } from '../observable/empty';
 import { Observable } from '../Observable';
-import { MonoTypeOperatorFunction, TeardownLogic } from '../types';
+import { MonoTypeOperatorFunction } from '../types';
 import { lift } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -1,10 +1,8 @@
 /** @prettier */
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
-import { MonoTypeOperatorFunction, PartialObserver, TeardownLogic } from '../types';
+import { MonoTypeOperatorFunction, PartialObserver } from '../types';
 import { noop } from '../util/noop';
-import { isFunction } from '../util/isFunction';
 import { lift } from '../util/lift';
 
 /* tslint:disable:max-line-length */

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -1,9 +1,8 @@
 /** @prettier */
 import { EmptyError } from '../util/EmptyError';
 import { Observable } from '../Observable';
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
-import { TeardownLogic, MonoTypeOperatorFunction } from '../types';
+import { MonoTypeOperatorFunction } from '../types';
 import { lift } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -1,5 +1,4 @@
 /** @prettier */
-import { Operator } from '../Operator';
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -5,7 +5,6 @@ import { TestMessage } from './TestMessage';
 import { SubscriptionLog } from './SubscriptionLog';
 import { Subscription } from '../Subscription';
 import { VirtualTimeScheduler, VirtualAction } from '../scheduler/VirtualTimeScheduler';
-import { AsyncScheduler } from '../scheduler/AsyncScheduler';
 import { ObservableNotification } from '../types';
 import { COMPLETE_NOTIFICATION, errorNotification, nextNotification } from '../Notification';
 import { dateTimestampProvider } from '../scheduler/dateTimestampProvider';

--- a/tslint.json
+++ b/tslint.json
@@ -4,6 +4,7 @@
   // This is really just a list of what is wrong in our codebase,
   // We should remove all of these over time.
   "rules": {
+    "no-unused-declaration": [true, { "declarations": false, "imports": true }],
     "no-unused-expression": [true, "allow-fast-null-checks"],
     "ordered-imports": [false],
     "interface-name": [false],


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds the `tslint-etc` `no-unused-declaration` rule and configures it to effect failures only for unused imports - not for variable declarations, etc.

The PR also removes a bunch of unused imports.

**Related issue (if exists):** None
