### PR TITLE
fix(timeout): allow synchronous observable as source

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -694,14 +694,11 @@ describe('webSocket', () => {
   });
 
   describe('node constructor', () => {
-
     it('should send and receive messages', () => {
       let messageReceived = false;
       const subject = webSocket<string>(<any>{
         url: 'ws://mysocket',
-        WebSocketCtor: (url: string, protocol: string): MockWebSocket => {
-          return new MockWebSocket(url, protocol);
-        }
+        WebSocketCtor: MockWebSocket
       });
 
       subject.next('ping');

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -179,6 +179,12 @@ describe('timeout operator', () => {
     });
   });
 
+  it('should work with synchronous observable', () => {
+    expect(() => {
+      of(1).pipe(timeout(10)).subscribe();
+    }).to.not.throw();
+  });
+
   describe('config', () => {
     it('should timeout after a specified timeout period', () => {
       rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions, time }) => {
@@ -418,7 +424,7 @@ describe('timeout operator', () => {
         const expected = '     -----x-y-z-|  ';
 
         const result = source.pipe(timeout({
-          each: t, 
+          each: t,
           with: () => inner,
         }));
 
@@ -439,7 +445,7 @@ describe('timeout operator', () => {
 
         // The the current frame is zero.
         const result = source.pipe(timeout({
-          first: new Date(t), 
+          first: new Date(t),
           with: () => inner,
         }));
 
@@ -459,7 +465,7 @@ describe('timeout operator', () => {
         const expected = '    ---a---b----x-y-|  ';
 
         const result = source.pipe(timeout({
-          each: t, 
+          each: t,
           with: () => inner, }));
 
         expectObservable(result).toBe(expected);

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -363,7 +363,7 @@ export function timeout<T, R, M>(config: number | Date | TimeoutConfig<T, R, M>,
           subscriber,
           (value) => {
             // clear the timer so we can emit and start another one.
-            timerSubscription.unsubscribe();
+              timerSubscription?.unsubscribe();
             seen++;
             // Emit
             subscriber.next((lastValue = value));
@@ -373,6 +373,9 @@ export function timeout<T, R, M>(config: number | Date | TimeoutConfig<T, R, M>,
           undefined,
           undefined,
           () => {
+              if (!timerSubscription?.closed) {
+                timerSubscription?.unsubscribe();
+              }
             // Be sure not to hold the last value in memory after unsubscription
             // it could be quite large.
             lastValue = null;

--- a/wallaby.js
+++ b/wallaby.js
@@ -4,7 +4,7 @@ module.exports = function (wallaby) {
       'tsconfig.base.json',
       'tsconfig.json',
       'src/**/*.ts',
-      { pattern: 'spec/helpers/*.ts', instrument: false, load: true }
+      { pattern: 'spec/helpers/!(*-spec).ts', instrument: false, load: true }
     ],
 
     tests: ['spec/**/*-spec.ts'],
@@ -19,6 +19,13 @@ module.exports = function (wallaby) {
     },
 
     workers: { initial: 2, regular: 1 },
+
+    compilers: {
+      '**/*.ts?(x)': wallaby.compilers.typeScript({
+        module: 'commonjs',
+        target: 'esnext'
+      })
+    },
 
     setup: function (w) {
       if (!global._tsconfigPathsRegistered) {


### PR DESCRIPTION
- closes #5746

let synchronous subscription do not try to unsubscribe from not yet assigned timer subscription.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
