### PR TITLE
docs(partition): add an overload for better typing

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -321,10 +321,10 @@ export declare function pairs(n: number | bigint | boolean | ((...args: any[]) =
 
 export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
+export declare function partition<T, U extends T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => value is U, thisArg: A): [Observable<U>, Observable<T>];
+export declare function partition<T, U extends T>(source: ObservableInput<T>, predicate: (value: T, index: number) => value is U): [Observable<U>, Observable<T>];
 export declare function partition<T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => boolean, thisArg: A): [Observable<T>, Observable<T>];
 export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
-export declare function partition<T, U extends T>(source: ObservableInput<T>, predicate: (value: T, index: number) => value is U, thisArg?: any): [Observable<U>, Observable<T>];
-export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean, thisArg?: any): [Observable<T>, Observable<T>];
 
 export declare function pipe(): typeof identity;
 export declare function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -323,6 +323,8 @@ export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | Co
 
 export declare function partition<T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => boolean, thisArg: A): [Observable<T>, Observable<T>];
 export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
+export declare function partition<T, U extends T>(source: ObservableInput<T>, predicate: (value: T, index: number) => value is U, thisArg?: any): [Observable<U>, Observable<T>];
+export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean, thisArg?: any): [Observable<T>, Observable<T>];
 
 export declare function pipe(): typeof identity;
 export declare function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;

--- a/spec-dtslint/observables/partition-spec.ts
+++ b/spec-dtslint/observables/partition-spec.ts
@@ -5,8 +5,8 @@ it('should infer correctly', () => {
   const p = partition(of('a', 'b', 'c'), () => true); // $ExpectType [Observable<string>, Observable<string>]
 });
 
-it('should accept a thisArg parameter', () => {
-  const o = partition(of('a', 'b', 'c'), () => true, 5); // $ExpectType [Observable<string>, Observable<string>]
+it('should support a user-defined type guard', () => {
+  const o = partition(of(1, 2, 3), (value: number): value is 1 => value === 1); // $ExpectType [Observable<1>, Observable<number>]
 });
 
 it('should enforce predicate', () => {
@@ -19,9 +19,17 @@ it('should enforce predicate types', () => {
   const q = partition(of('a', 'b', 'c'), (value, index: string) => true); // $ExpectError
 });
 
-it('should support this', () => {
+it('should support this with type guard', () => {
   const thisArg = { limit: 2 };
-  const a = partition(of(1, 2, 3), function (val) {
+  const a = partition(of(1, 2, 3), function (val): val is 1 { // $ExpectType [Observable<1>, Observable<number>]
+    const limit = this.limit; // $ExpectType number
+    return val < limit;
+  }, thisArg);
+});
+
+it('should support this with predicate', () => {
+  const thisArg = { limit: 2 };
+  const a = partition(of(1, 2, 3), function (val) { // $ExpectType [Observable<number>, Observable<number>]
     const limit = this.limit; // $ExpectType number
     return val < limit;
   }, thisArg);

--- a/src/internal/observable/partition.ts
+++ b/src/internal/observable/partition.ts
@@ -11,6 +11,17 @@ export function partition<T, A>(
 ): [Observable<T>, Observable<T>];
 export function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
 
+export function partition<T, U extends T>(
+  source: ObservableInput<T>,
+  predicate: (value: T, index: number) => value is U,
+  thisArg?: any
+): [Observable<U>, Observable<T>];
+export function partition<T>(
+  source: ObservableInput<T>,
+  predicate: (value: T, index: number) => boolean,
+  thisArg?: any
+): [Observable<T>, Observable<T>];
+
 /**
  * Splits the source Observable into two, one with values that satisfy a
  * predicate, and another with values that don't satisfy the predicate.

--- a/src/internal/observable/partition.ts
+++ b/src/internal/observable/partition.ts
@@ -4,23 +4,22 @@ import { ObservableInput } from '../types';
 import { Observable } from '../Observable';
 import { innerFrom } from './from';
 
+export function partition<T, U extends T, A>(
+  source: ObservableInput<T>,
+  predicate: (this: A, value: T, index: number) => value is U,
+  thisArg: A
+): [Observable<U>, Observable<T>];
+export function partition<T, U extends T>(
+  source: ObservableInput<T>,
+  predicate: (value: T, index: number) => value is U
+): [Observable<U>, Observable<T>];
+
 export function partition<T, A>(
   source: ObservableInput<T>,
   predicate: (this: A, value: T, index: number) => boolean,
   thisArg: A
 ): [Observable<T>, Observable<T>];
 export function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
-
-export function partition<T, U extends T>(
-  source: ObservableInput<T>,
-  predicate: (value: T, index: number) => value is U,
-  thisArg?: any
-): [Observable<U>, Observable<T>];
-export function partition<T>(
-  source: ObservableInput<T>,
-  predicate: (value: T, index: number) => boolean,
-  thisArg?: any
-): [Observable<T>, Observable<T>];
 
 /**
  * Splits the source Observable into two, one with values that satisfy a


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Just adds a new overload to `partition` to give more useful types, similar to the one for `filter`. I found myself wanting this feature, and It seemed easy enough to implement.