### PR TITLE
Unify approaches to reduce, scan, combineAll and zipAll

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -61,7 +61,7 @@ export declare function concatMapTo<T, R, O extends ObservableInput<any>>(observ
 export declare function concatWith<T>(): OperatorFunction<T, T>;
 export declare function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T>;
 
-export declare function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number>;
+export declare function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number>;
 
 export declare function debounce<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T>;
 

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -1,7 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueOf } from '../types';
-import { Subscription } from '../Subscription';
 import { from } from './from';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { EMPTY } from './empty';

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -199,6 +199,11 @@ export function zip<O extends ObservableInput<any>, R>(
         // Keyed by the same index with which the sources were passed in.
         let completed = sources.map(() => false);
 
+        // When everything is done, release the arrays above.
+        subscriber.add(() => {
+          buffers = completed = null!;
+        });
+
         // Loop over our sources and subscribe to each one. The index `i` is
         // especially important here, because we use it in closures below to
         // access the related buffers and completion properties
@@ -233,14 +238,15 @@ export function zip<O extends ObservableInput<any>, R>(
                 // can complete the result, because we can't possibly have any more
                 // values from this to zip together with the oterh values.
                 !buffers[i].length && subscriber.complete();
-              },
-              () => {
-                // Free up memory
-                buffers = completed = null!;
               }
             )
           );
         }
+
+        // When everything is done, release the arrays above.
+        return () => {
+          buffers = completed = null!;
+        };
       })
     : EMPTY;
 }

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -1,10 +1,7 @@
+/** @prettier */
 import { combineLatest } from '../observable/combineLatest';
-import { Observable } from '../Observable';
 import { OperatorFunction, ObservableInput } from '../types';
-import { toArray } from './toArray';
-import { concatMap } from './concatMap';
-import { identity } from '../util/identity';
-import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
+import { joinAllInternals } from './joinAllInternals';
 
 export function combineAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export function combineAll<T>(): OperatorFunction<any, T[]>;
@@ -55,10 +52,6 @@ export function combineAll<R>(project: (...values: Array<any>) => R): OperatorFu
  * @param project optional function to map the most recent values from each inner Observable into a new result.
  * Takes each of the most recent values from each collected inner Observable as arguments, in order.
  */
-export function combineAll<T, R>(project?: (...values: Array<any>) => R): OperatorFunction<ObservableInput<T>, R|T[]> {
-  return (source: Observable<ObservableInput<T>>) => source.pipe(
-    toArray(),
-    concatMap((sources) => combineLatest(sources)),
-    project ? mapOneOrManyArgs(project) : identity as any
-  );
+export function combineAll<R>(project?: (...values: Array<any>) => R) {
+  return joinAllInternals(combineLatest, project);
 }

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
-import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { reduce } from './reduce';
 /**
  * Counts the number of emissions on the source and emits that number when the
  * source completes.
@@ -51,32 +49,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link min}
  * @see {@link reduce}
  *
- * @param {function(value: T, i: number, source: Observable<T>): boolean} [predicate] A
- * boolean function to select what values are to be counted. It is provided with
- * arguments of:
- * - `value`: the value from the source Observable.
- * - `index`: the (zero-based) "index" of the value from the source Observable.
- * - `source`: the source Observable instance itself.
- * @return {Observable} An Observable of one number that represents the count as
- * described above.
- * @name count
+ * @param predicate A function that is used to analyze the value and the index and
+ * determine whether or not to increment the count. Return `true` to increment the count,
+ * and return `false` to keep the count the same.
+ * If the predicate is not provided, every value will be counted.
  */
 
-export function count<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number> {
-  return operate((source, subscriber) => {
-    let index = 0;
-    let count = 0;
-
-    source.subscribe(
-      new OperatorSubscriber(
-        subscriber,
-        (value) => (!predicate || predicate(value, index++, source)) && count++,
-        undefined,
-        () => {
-          subscriber.next(count);
-          subscriber.complete();
-        }
-      )
-    );
-  });
+export function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number> {
+  return reduce((count, value, i) => (!predicate || predicate(value, i) ? count + 1 : count), 0);
 }

--- a/src/internal/operators/joinAllInternals.ts
+++ b/src/internal/operators/joinAllInternals.ts
@@ -1,0 +1,30 @@
+/** @prettier */
+import { Observable } from '../Observable';
+import { ObservableInput, OperatorFunction } from '../types';
+import { identity } from '../util/identity';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
+import { pipe } from '../util/pipe';
+import { mergeMap } from './mergeMap';
+import { toArray } from './toArray';
+
+/**
+ * Collects all of the inner sources from source observable. Then, once the
+ * source completes, joins the values using the given static.
+ *
+ * This is used for {@link combineAll} and {@link zipAll} which both have the
+ * same behavior of collecting all inner observables, then operating on them.
+ *
+ * @param joinFn The type of static join to apply to the sources collected
+ * @param project The projection function to apply to the values, if any
+ */
+export function joinAllInternals<T, R>(joinFn: (sources: ObservableInput<T>[]) => Observable<T>, project?: (...args: any[]) => R) {
+  return pipe(
+    // Collect all inner sources into an array, and emit them when the
+    // source completes.
+    toArray() as OperatorFunction<ObservableInput<T>, ObservableInput<T>[]>,
+    // Run the join function on the collected array of inner sources.
+    mergeMap((sources) => joinFn(sources)),
+    // If a projection function was supplied, apply it to each result.
+    project ? mapOneOrManyArgs(project) : (identity as any)
+  );
+}

--- a/src/internal/operators/scanInternals.ts
+++ b/src/internal/operators/scanInternals.ts
@@ -1,0 +1,64 @@
+/** @prettier */
+import { Observable } from '../Observable';
+import { Subscriber } from '../Subscriber';
+import { OperatorSubscriber } from './OperatorSubscriber';
+
+/**
+ * A basic scan operation. This is used for `scan` and `reduce`.
+ * @param accumulator The accumulator to use
+ * @param seed The seed value for the state to accumulate
+ * @param hasSeed Whether or not a seed was provided
+ * @param emitOnNext Whether or not to emit the state on next
+ * @param emitBeforeComplete Whether or not to emit the before completion
+ */
+
+export function scanInternals<V, A, S>(
+  accumulator: (acc: V | A | S, value: V, index: number) => A,
+  seed: S,
+  hasSeed: boolean,
+  emitOnNext: boolean,
+  emitBeforeComplete?: undefined | true
+) {
+  return (source: Observable<V>, subscriber: Subscriber<any>) => {
+    // Whether or not we have state yet. This will only be
+    // false before the first value arrives if we didn't get
+    // a seed value.
+    let hasState = hasSeed;
+    // The state that we're tracking, starting with the seed,
+    // if there is one, and then updated by the return value
+    // from the accumulator on each emission.
+    let state: any = seed;
+    // An index to pass to the accumulator function.
+    let index = 0;
+
+    // Subscribe to our source. All errors and completions are passed through.
+    source.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          // Always increment the index.
+          const i = index++;
+          // Set the state
+          state = hasState
+            ? // We already have state, so we can get the new state from the accumulator
+              accumulator(state, value, i)
+            : // We didn't have state yet, a seed value was not provided, so
+
+              // we set the state to the first value, and mark that we have state now
+              ((hasState = true), value);
+
+          // Maybe send it to the consumer.
+          emitOnNext && subscriber.next(state);
+        },
+        undefined,
+        // If an onComplete was given, call it, otherwise
+        // just pass through the complete notification to the consumer.
+        emitBeforeComplete &&
+          (() => {
+            hasState && subscriber.next(state);
+            subscriber.complete();
+          })
+      )
+    );
+  };
+}

--- a/src/internal/operators/toArray.ts
+++ b/src/internal/operators/toArray.ts
@@ -1,13 +1,8 @@
 import { reduce } from './reduce';
 import { OperatorFunction } from '../types';
+import { operate } from '../util/lift';
 
-function toArrayReducer<T>(arr: T[], item: T, index: number): T[] {
-  if (index === 0) {
-    return [item];
-  }
-  arr.push(item);
-  return arr;
-}
+const arrReducer = (arr: any[], value: any) => (arr.push(value), arr);
 
 /**
  * Collects all source emissions and emits them as an array when the source completes.
@@ -40,5 +35,10 @@ function toArrayReducer<T>(arr: T[], item: T, index: number): T[] {
 * @name toArray
 */
 export function toArray<T>(): OperatorFunction<T, T[]> {
-  return reduce(toArrayReducer, [] as T[]);
+  // Because arrays are mutable, and we're mutating the array in this
+  // reducer process, we have to escapulate the creation of the initial
+  // array within this `operate` function.
+  return operate((source, subscriber) => {
+    reduce(arrReducer, [] as T[])(source).subscribe(subscriber)
+  });
 }

--- a/src/internal/operators/zipAll.ts
+++ b/src/internal/operators/zipAll.ts
@@ -1,29 +1,21 @@
 /** @prettier */
 import { OperatorFunction, ObservableInput } from '../types';
-import { operate } from '../util/lift';
 import { zip } from '../observable/zip';
+import { joinAllInternals } from './joinAllInternals';
 
+/**
+ * Collects all observable inner sources from the source, once the source completes,
+ * it will subscribe to all inner sources, combining their values by index and emitting
+ * them.
+ *
+ * {@see zipWith}
+ * {@see zip}
+ */
 export function zipAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export function zipAll<T>(): OperatorFunction<any, T[]>;
 export function zipAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
 export function zipAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 
-export function zipAll<T, R>(project?: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, any> {
-  return operate((source, subscriber) => {
-    const sources: ObservableInput<T>[] = [];
-    subscriber.add(
-      source.subscribe({
-        next: (source) => sources.push(source),
-        error: (err) => subscriber.error(err),
-        complete: () => {
-          if (sources.length > 0) {
-            const args = project ? [...sources, project] : sources;
-            subscriber.add(zip(...args).subscribe(subscriber));
-          } else {
-            subscriber.complete();
-          }
-        },
-      })
-    );
-  });
+export function zipAll<T, R>(project?: (...values: T[]) => R) {
+  return joinAllInternals(zip, project);
 }


### PR DESCRIPTION
- refactor: `combineAll` and `zipAll` use shared logic

- fix(zip): zip now accepts an array of arguments like its counterparts
  - `forkJoin` and `combineLatest` both allow an array of arguments to be passed to it like so: `forkJoin([a$, b$, c$])`. Now `zip` does the same: `zip([a$, b$, c$])`
  
  BREAKING CHANGE: Zipping a single array will now have a different result. This is an extreme corner-case, because it is very unlikely that anyone would want to zip an array with nothing at all.

- refactor(toArray): reduce complexity a little.

  There was a situation where the `toArray` implementation was relying on a quirk of `reduce` and a trick with the `index` in order to ensure that two subscriptions to the same `toArray`-ed observable would not mutate the same underlying array.

  This change gets around that problem in a more straight-forward manner, if at the cost of a few bytes.

- refactor(count): Base off of `reduce`.

  BREAKING CHANGE: No longer passes `source` observable as a third argument to the predicate. That feature was rarely used, and of limited value. The workaround is to simply close over the source inside of the function if you need to access it in there.


- refactor: Unify code that runs `scan` and `reduce`, make reduce a little smaller and more efficient
  - Creates `scanInternals`, which is a shared operator setup between both operators.
    