### PR TITLE
chore: update lint-staged config

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,12 +13,10 @@
     }
   },
   "lint-staged": {
-    "src/**/*.ts": [
-      "prettier --write"
-    ],
     "*.js": "eslint --cache --fix",
-    "*.ts": [
-      "tslint --fix"
+    "(src|spec)/**/*.ts": [
+      "tslint --fix",
+      "prettier --write"
     ],
     "*.{js,css,md}": "prettier --write"
   },


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR tweaks the `lint-staged` configuration so that `api_guardian` files are not run through `tslint` and so that `prettier` is applied after `tslint` takes the opportunity to 'fix' things. ATM, committing updates to `api_guardian` files necessitates the use of `--no-verify` and it's a minor annoyance.

**Related issue (if exists):** None