### PR TITLE
chore(interval): remove pointless teardown return

### DIFF
--- a/src/internal/observable/interval.ts
+++ b/src/internal/observable/interval.ts
@@ -66,7 +66,6 @@ export function interval(period = 0,
     subscriber.add(
       scheduler.schedule(dispatch as any, period, { subscriber, counter: 0, period })
     );
-    return subscriber;
   });
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes the returning of the `subscriber` within the `interval` observable. Any returned teardown would be added to the sink - which is the subscriber itself.

**Related issue (if exists):** None
