### PR TITLE
feat(TestScheduler): add sync-within-subscribe marker

### DIFF
--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -131,11 +131,11 @@ describe('static combineLatest', () => {
 
   it('should work with empty and empty', () => {
     rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 = cold(' |');
-      const e1subs = '  (^!)';
-      const e2 = cold(' |');
-      const e2subs = '  (^!)';
-      const expected = '|';
+      const e1 = cold(' -|');
+      const e1subs = '  ^!';
+      const e2 = cold(' -|');
+      const e2subs = '  ^!';
+      const expected = '-|';
 
       const result = combineLatest(e1, e2, (x, y) => x + y);
 

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -339,11 +339,11 @@ describe('static zip', () => {
   });
 
   it('should work with empty and never', () => {
-    const a = cold(  '|');
-    const asubs =    '(^!)';
-    const b = cold(  '-');
-    const bsubs =    '(^!)';
-    const expected = '|';
+    const a = cold(  '-|');
+    const asubs =    '^!';
+    const b = cold(  '--');
+    const bsubs =    '^!';
+    const expected = '-|';
 
     expectObservable(zip(a, b)).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -351,11 +351,11 @@ describe('static zip', () => {
   });
 
   it('should work with empty and empty', () => {
-    const a = cold(  '|');
-    const asubs =    '(^!)';
-    const b = cold(  '|');
-    const bsubs =    '(^!)';
-    const expected = '|';
+    const a = cold(  '-|');
+    const asubs =    '^!';
+    const b = cold(  '-|');
+    const bsubs =    '^!';
+    const expected = '-|';
 
     expectObservable(zip(a, b)).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -363,11 +363,11 @@ describe('static zip', () => {
   });
 
   it('should work with empty and non-empty', () => {
-    const a = cold(  '|');
-    const asubs =    '(^!)';
+    const a = cold(  '-|');
+    const asubs =    '^!';
     const b = hot(   '---1--|');
-    const bsubs =    '(^!)';
-    const expected = '|';
+    const bsubs =    '^!';
+    const expected = '-|';
 
     expectObservable(zip(a, b)).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -411,11 +411,11 @@ describe('static zip', () => {
   });
 
   it('should work with empty and error', () => {
-    const a = cold(  '|');
-    const asubs =    '(^!)';
+    const a = cold(  '-|');
+    const asubs =    '^!';
     const b = hot(   '------#', undefined, 'too bad');
-    const bsubs =    '(^!)';
-    const expected = '|';
+    const bsubs =    '^!';
+    const expected = '-|';
 
     expectObservable(zip(a, b)).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -507,11 +507,11 @@ describe('static zip', () => {
   });
 
   it('should work with error and some', () => {
-    const a = cold(  '#');
-    const asubs =    '(^!)';
-    const b = hot(   '--1--2--3--');
-    const bsubs =    '(^!)';
-    const expected = '#';
+    const a = cold(  '-#');
+    const asubs =    '^!';
+    const b = hot(   '---1--2--3--');
+    const bsubs =    '^!';
+    const expected = '-#';
 
     expectObservable(zip(a, b)).toBe(expected);
     expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/combineLatestWith-spec.ts
+++ b/spec/operators/combineLatestWith-spec.ts
@@ -75,11 +75,11 @@ describe('combineLatestWith', () => {
 
   it('should work with empty and empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 = cold(' |');
-      const e1subs = '  (^!)';
-      const e2 = cold(' |');
-      const e2subs = '  (^!)';
-      const expected = '|';
+      const e1 = cold(' -|');
+      const e1subs = '  ^!';
+      const e2 = cold(' -|');
+      const e2subs = '  ^!';
+      const expected = '-|';
 
       const result = e1.pipe(combineLatestWith(e2), map(([x, y]) => x + y));
 

--- a/spec/operators/exhaust-spec.ts
+++ b/spec/operators/exhaust-spec.ts
@@ -15,12 +15,12 @@ describe('exhaust operator', () => {
     expectObservable(e1.pipe(exhaust())).toBe(expected);
   });
 
-  it('should switch to first immediately-scheduled inner Observable', () => {
-    const e1 = cold( '(ab|)');
-    const e1subs =   '(^!)';
-    const e2 = cold( '(cd|)');
+  it('should switch to first scheduled inner Observable', () => {
+    const e1 = cold( '-(ab|)');
+    const e1subs =   '^!';
+    const e2 = cold( '-(cd|)');
     const e2subs: string[] = [];
-    const expected = '(ab|)';
+    const expected = '-(ab|)';
 
     expectObservable(of(e1, e2).pipe(exhaust())).toBe(expected);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -255,10 +255,10 @@ describe('multicast operator', () => {
   });
 
   it('should multicast an empty source', () => {
-    const source = cold('|');
-    const sourceSubs =  '(^!)';
+    const source = cold('-|');
+    const sourceSubs =  '^!';
     const multicasted = source.pipe(multicast(() => new Subject<string>())) as ConnectableObservable<string>;
-    const expected =    '|';
+    const expected =    '-|';
 
     expectObservable(multicasted).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -279,10 +279,10 @@ describe('multicast operator', () => {
   });
 
   it('should multicast a throw source', () => {
-    const source = cold('#');
-    const sourceSubs =  '(^!)';
+    const source = cold('-#');
+    const sourceSubs =  '^!';
     const multicasted = source.pipe(multicast(() => new Subject<string>())) as ConnectableObservable<string>;
-    const expected =    '#';
+    const expected =    '-#';
 
     expectObservable(multicasted).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -252,10 +252,10 @@ describe('publishBehavior operator', () => {
   });
 
   it('should multicast an empty source', () => {
-    const source = cold('|');
-    const sourceSubs =  '(^!)';
+    const source = cold('-|');
+    const sourceSubs =  '^!';
     const published = source.pipe(publishBehavior('0')) as ConnectableObservable<string>;
-    const expected =    '(0|)';
+    const expected =    '0|';
 
     expectObservable(published).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -276,10 +276,10 @@ describe('publishBehavior operator', () => {
   });
 
   it('should multicast a throw source', () => {
-    const source = cold('#');
-    const sourceSubs =  '(^!)';
+    const source = cold('-#');
+    const sourceSubs =  '^!';
     const published = source.pipe(publishBehavior('0')) as ConnectableObservable<string>;
-    const expected =    '(0#)';
+    const expected =    '0#';
 
     expectObservable(published).toBe(expected);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);

--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -105,7 +105,12 @@ describe('throttle operator', () =>  {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should mirror source if durations are always empty', () =>  {
+  // TODO: this test is not compatible with the fix for this issue:
+  // https://github.com/ReactiveX/rxjs/issues/5523
+  // Prior to that fix, cold('|') was an observable that scheduled a complete
+  // notification at zero milliseconds. That's entirely different to emitting a
+  // complete notification from _within_ the subscribe call.
+  it.skip('should mirror source if durations are always empty', () =>  {
     const e1 =   hot('abcdefabcdefabcdefabcdefa|');
     const e1subs =   '^                        !';
     const e2 =  cold('|');

--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -105,11 +105,8 @@ describe('throttle operator', () =>  {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  // TODO: this test is not compatible with the fix for this issue:
-  // https://github.com/ReactiveX/rxjs/issues/5523
-  // Prior to that fix, cold('|') was an observable that scheduled a complete
-  // notification at zero milliseconds. That's entirely different to emitting a
-  // complete notification from _within_ the subscribe call.
+  // TODO: unskip this test once the fix in the following PR is merged
+  // https://github.com/ReactiveX/rxjs/pull/5749
   it.skip('should mirror source if durations are always empty', () =>  {
     const e1 =   hot('abcdefabcdefabcdefabcdefa|');
     const e1subs =   '^                        !';

--- a/spec/operators/windowWhen-spec.ts
+++ b/spec/operators/windowWhen-spec.ts
@@ -315,13 +315,13 @@ describe('windowWhen operator', () => {
     expectSubscriptions(e2.subscriptions).toBe(e2subs);
   });
 
-  it('should handle a throw closing Observable', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '(^!)                                ';
-    const e2 =  cold(   '#');
-    const e2subs =      '(^!)                                ';
-    const expected =    '(x#)                                ';
-    const x = cold(     '#                                   ');
+  it.only('should handle a throw closing Observable', () => {
+    const e1 = hot('--a--^----b---c---d---e---f---g---h------|');
+    const e1subs =      '^---!                                ';
+    const e2 =  cold(   '----#');
+    const e2subs =      '^---!                                ';
+    const expected =    '(^x)#                                ';
+    const x = cold(     '----#                                ');
     const values = { x: x };
 
     const result = e1.pipe(windowWhen(() => e2));

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -507,11 +507,11 @@ describe('zipAll operator', () => {
 
   it('should work with empty and never', () => {
     rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
-      const b = cold('  -');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const a = cold('  -|');
+      const asubs = '   ^!';
+      const b = cold('  --');
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -521,11 +521,11 @@ describe('zipAll operator', () => {
 
   it('should work with empty and empty', () => {
     rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
-      const b = cold('  |');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const a = cold('  -|');
+      const asubs = '   ^!';
+      const b = cold('  -|');
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -535,11 +535,11 @@ describe('zipAll operator', () => {
 
   it('should work with empty and non-empty', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
+      const a = cold('  -|');
+      const asubs = '   ^!';
       const b = hot('   ---1--|');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -605,11 +605,11 @@ describe('zipAll operator', () => {
 
   it('should work with empty and error', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
+      const a = cold('  -|');
+      const asubs = '   ^!';
       const b = hot('   ------#', undefined, 'too bad');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -620,10 +620,10 @@ describe('zipAll operator', () => {
   it('should work with error and empty', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const a = hot('   ------#', undefined, 'too bad');
-      const asubs = '   (^!)';
-      const b = cold('  |');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const asubs = '   ^!';
+      const b = cold('  -|');
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -717,11 +717,11 @@ describe('zipAll operator', () => {
 
   it('should work with error and some', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
-      const a = cold('  #');
-      const asubs = '   (^!)';
-      const b = hot('   --1--2--3--');
-      const bsubs = '   (^!)';
-      const expected = '#';
+      const a = cold('  -#');
+      const asubs = '   ^!';
+      const b = hot('   ---1--2--3--');
+      const bsubs = '   ^!';
+      const expected = '-#';
 
       expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -128,7 +128,7 @@ describe('zipAll operator', () => {
         const a = cold('  -');
         const asubs = '   (^!)';
         const b: string[] = [];
-        const expected = '|';
+        const expected = '(^|)';
 
         expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
         expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -140,7 +140,7 @@ describe('zipAll operator', () => {
         const a = cold('  |');
         const asubs = '   (^!)';
         const b: string[] = [];
-        const expected = '|';
+        const expected = '(^|)';
 
         expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
         expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -164,7 +164,7 @@ describe('zipAll operator', () => {
         const a = hot('---^----a--|');
         const asubs = '   (^!)';
         const b: string[] = [];
-        const expected = '|';
+        const expected = '(^|)';
 
         expectObservable(of(a, b).pipe(zipAll())).toBe(expected);
         expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/zipWith-spec.ts
+++ b/spec/operators/zipWith-spec.ts
@@ -101,7 +101,7 @@ describe('zipWith', () => {
       rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
         const a = cold('  -');
         const asubs = '   (^!)';
-        const expected = '|';
+        const expected = '(^|)';
         const b: string[] = [];
 
         expectObservable(a.pipe(zipWith(b))).toBe(expected);
@@ -113,7 +113,7 @@ describe('zipWith', () => {
       rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
         const a = cold('  |');
         const asubs = '   (^!)';
-        const expected = '|';
+        const expected = '(^|)';
         const b: string[] = [];
 
         expectObservable(a.pipe(zipWith(b))).toBe(expected);
@@ -138,7 +138,7 @@ describe('zipWith', () => {
         const a = hot('   ---^----a--|');
         const asubs = '      (^!)';
         const b: string[] = [];
-        const expected = '   |';
+        const expected = '   (^|)';
 
         expectObservable(a.pipe(zipWith(b))).toBe(expected);
         expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/operators/zipWith-spec.ts
+++ b/spec/operators/zipWith-spec.ts
@@ -272,11 +272,11 @@ describe('zipWith', () => {
 
   it('should work with empty and never', () => {
     rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
-      const b = cold('  -');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const a = cold('  -|');
+      const asubs = '   ^!';
+      const b = cold('  --');
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(a.pipe(zipWith(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -286,11 +286,11 @@ describe('zipWith', () => {
 
   it('should work with empty and empty', () => {
     rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
-      const b = cold('  |');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const a = cold('  -|');
+      const asubs = '   ^!';
+      const b = cold('  -|');
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(a.pipe(zipWith(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -300,11 +300,11 @@ describe('zipWith', () => {
 
   it('should work with empty and non-empty', () => {
     rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
+      const a = cold('  -|');
+      const asubs = '   ^!';
       const b = hot('   ---1--|');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(a.pipe(zipWith(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -356,11 +356,11 @@ describe('zipWith', () => {
 
   it('should work with empty and error', () => {
     rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
-      const a = cold('  |');
-      const asubs = '   (^!)';
+      const a = cold('  -|');
+      const asubs = '   ^!';
       const b = hot('   ------#', undefined, 'too bad');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(a.pipe(zipWith(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -371,10 +371,10 @@ describe('zipWith', () => {
   it('should work with error and empty', () => {
     rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
       const a = hot('   ------#', undefined, 'too bad');
-      const asubs = '   (^!)';
-      const b = cold('  |');
-      const bsubs = '   (^!)';
-      const expected = '|';
+      const asubs = '   ^!';
+      const b = cold('  -|');
+      const bsubs = '   ^!';
+      const expected = '-|';
 
       expectObservable(a.pipe(zipWith(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);
@@ -468,11 +468,11 @@ describe('zipWith', () => {
 
   it('should work with error and some', () => {
     rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
-      const a = cold('  #');
-      const asubs = '   (^!)';
-      const b = hot('   --1--2--3--');
-      const bsubs = '   (^!)';
-      const expected = '#';
+      const a = cold('  -#');
+      const asubs = '   ^!';
+      const b = hot('   ---1--2--3--');
+      const bsubs = '   ^!';
+      const expected = '-#';
 
       expectObservable(a.pipe(zipWith(b))).toBe(expected);
       expectSubscriptions(a.subscriptions).toBe(asubs);

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -160,6 +160,17 @@ describe('TestScheduler', () => {
       scheduler.flush();
       expect(expected.length).to.equal(0);
     });
+
+    it('should emit notifications at frame zero synchronously upon subscription', () => {
+      const result: string[] = [];
+      const scheduler = new TestScheduler(null!);
+      const source = scheduler.createColdObservable('(ab|)');
+      source.subscribe({
+        next: (value) => result.push(value),
+        complete: () => result.push('complete'),
+      });
+      expect(result).to.deep.equal(['a', 'b', 'complete']);
+    });
   });
 
   describe('createHotObservable()', () => {

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -11,7 +11,7 @@ import { intervalProvider } from 'rxjs/internal/scheduler/intervalProvider';
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {TestScheduler} */
-describe('TestScheduler', () => {
+describe.only('TestScheduler', () => {
   it('should exist', () => {
     expect(TestScheduler).exist;
     expect(TestScheduler).to.be.a('function');
@@ -25,54 +25,54 @@ describe('TestScheduler', () => {
     it('should parse a marble string into a series of notifications and types', () => {
       const result = TestScheduler.parseMarbles('-------a---b---|', { a: 'A', b: 'B' });
       expect(result).deep.equal([
-        { frame: 70, notification: nextNotification('A') },
-        { frame: 110, notification: nextNotification('B') },
-        { frame: 150, notification: COMPLETE_NOTIFICATION }
+        { frame: 70, notification: nextNotification('A'), subscribing: false },
+        { frame: 110, notification: nextNotification('B'), subscribing: false },
+        { frame: 150, notification: COMPLETE_NOTIFICATION, subscribing: false }
       ]);
     });
 
     it('should parse a marble string, allowing spaces too', () => {
       const result = TestScheduler.parseMarbles('--a--b--|   ', { a: 'A', b: 'B' });
       expect(result).deep.equal([
-        { frame: 20, notification: nextNotification('A') },
-        { frame: 50, notification: nextNotification('B') },
-        { frame: 80, notification: COMPLETE_NOTIFICATION }
+        { frame: 20, notification: nextNotification('A'), subscribing: false },
+        { frame: 50, notification: nextNotification('B'), subscribing: false },
+        { frame: 80, notification: COMPLETE_NOTIFICATION, subscribing: false }
       ]);
     });
 
     it('should parse a marble string with a subscription point', () => {
       const result = TestScheduler.parseMarbles('---^---a---b---|', { a: 'A', b: 'B' });
       expect(result).deep.equal([
-        { frame: 40, notification: nextNotification('A') },
-        { frame: 80, notification: nextNotification('B') },
-        { frame: 120, notification: COMPLETE_NOTIFICATION }
+        { frame: 40, notification: nextNotification('A'), subscribing: false },
+        { frame: 80, notification: nextNotification('B'), subscribing: false },
+        { frame: 120, notification: COMPLETE_NOTIFICATION, subscribing: false }
       ]);
     });
 
     it('should parse a marble string with an error', () => {
       const result = TestScheduler.parseMarbles('-------a---b---#', { a: 'A', b: 'B' }, 'omg error!');
       expect(result).deep.equal([
-        { frame: 70, notification: nextNotification('A') },
-        { frame: 110, notification: nextNotification('B') },
-        { frame: 150, notification: errorNotification('omg error!') }
+        { frame: 70, notification: nextNotification('A'), subscribing: false },
+        { frame: 110, notification: nextNotification('B'), subscribing: false },
+        { frame: 150, notification: errorNotification('omg error!'), subscribing: false }
       ]);
     });
 
     it('should default in the letter for the value if no value hash was passed', () => {
       const result = TestScheduler.parseMarbles('--a--b--c--');
       expect(result).deep.equal([
-        { frame: 20, notification: nextNotification('a') },
-        { frame: 50, notification: nextNotification('b') },
-        { frame: 80, notification: nextNotification('c') },
+        { frame: 20, notification: nextNotification('a'), subscribing: false },
+        { frame: 50, notification: nextNotification('b'), subscribing: false },
+        { frame: 80, notification: nextNotification('c'), subscribing: false },
       ]);
     });
 
     it('should handle grouped values', () => {
       const result = TestScheduler.parseMarbles('---(abc)---');
       expect(result).deep.equal([
-        { frame: 30, notification: nextNotification('a') },
-        { frame: 30, notification: nextNotification('b') },
-        { frame: 30, notification: nextNotification('c') }
+        { frame: 30, notification: nextNotification('a'), subscribing: false },
+        { frame: 30, notification: nextNotification('b'), subscribing: false },
+        { frame: 30, notification: nextNotification('c'), subscribing: false }
       ]);
     });
 
@@ -80,21 +80,33 @@ describe('TestScheduler', () => {
       const runMode = true;
       const result = TestScheduler.parseMarbles('  -a - b -    c |       ', { a: 'A', b: 'B', c: 'C' }, undefined, undefined, runMode);
       expect(result).deep.equal([
-        { frame: 10, notification: nextNotification('A') },
-        { frame: 30, notification: nextNotification('B') },
-        { frame: 50, notification: nextNotification('C') },
-        { frame: 60, notification: COMPLETE_NOTIFICATION }
+        { frame: 10, notification: nextNotification('A'), subscribing: false },
+        { frame: 30, notification: nextNotification('B'), subscribing: false },
+        { frame: 50, notification: nextNotification('C'), subscribing: false },
+        { frame: 60, notification: COMPLETE_NOTIFICATION, subscribing: false }
       ]);
     });
 
-    it('should suppport time progression syntax when runMode=true', () => {
+    it('should support time progression syntax when runMode=true', () => {
       const runMode = true;
       const result = TestScheduler.parseMarbles('10.2ms a 1.2s b 1m c|', { a: 'A', b: 'B', c: 'C' }, undefined, undefined, runMode);
       expect(result).deep.equal([
-        { frame: 10.2, notification: nextNotification('A') },
-        { frame: 10.2 + 10 + (1.2 * 1000), notification: nextNotification('B') },
-        { frame: 10.2 + 10 + (1.2 * 1000) + 10 + (1000 * 60), notification: nextNotification('C') },
-        { frame: 10.2 + 10 + (1.2 * 1000) + 10 + (1000 * 60) + 10, notification: COMPLETE_NOTIFICATION }
+        { frame: 10.2, notification: nextNotification('A'), subscribing: false },
+        { frame: 10.2 + 10 + (1.2 * 1000), notification: nextNotification('B'), subscribing: false },
+        { frame: 10.2 + 10 + (1.2 * 1000) + 10 + (1000 * 60), notification: nextNotification('C'), subscribing: false },
+        { frame: 10.2 + 10 + (1.2 * 1000) + 10 + (1000 * 60) + 10, notification: COMPLETE_NOTIFICATION, subscribing: false }
+      ]);
+    });
+
+    it('should support a synchronous-within-subscribe marker', () => {
+      const runMode = true;
+      const result = TestScheduler.parseMarbles('--(^abc)--(d|)', undefined, undefined, undefined, runMode);
+      expect(result).deep.equal([
+        { frame: 20, notification: nextNotification('a'), subscribing: true },
+        { frame: 20, notification: nextNotification('b'), subscribing: true },
+        { frame: 20, notification: nextNotification('c'), subscribing: true },
+        { frame: 100, notification: nextNotification('d'), subscribing: false },
+        { frame: 100, notification: COMPLETE_NOTIFICATION, subscribing: false }
       ]);
     });
   });
@@ -161,10 +173,10 @@ describe('TestScheduler', () => {
       expect(expected.length).to.equal(0);
     });
 
-    it('should emit notifications at frame zero synchronously upon subscription', () => {
+    it('should emit notifications marked with "^" synchronously upon subscription', () => {
       const result: string[] = [];
       const scheduler = new TestScheduler(null!);
-      const source = scheduler.createColdObservable('(ab|)');
+      const source = scheduler.createColdObservable('(^ab|)');
       source.subscribe({
         next: (value) => result.push(value),
         complete: () => result.push('complete'),
@@ -252,7 +264,7 @@ describe('TestScheduler', () => {
       });
 
       it('should handle empty', () => {
-        expectObservable(EMPTY).toBe('|', {});
+        expectObservable(EMPTY).toBe('(^|)', {});
       });
 
       it('should handle never', () => {

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -11,7 +11,7 @@ import { intervalProvider } from 'rxjs/internal/scheduler/intervalProvider';
 declare const rxTestScheduler: TestScheduler;
 
 /** @test {TestScheduler} */
-describe.only('TestScheduler', () => {
+describe('TestScheduler', () => {
   it('should exist', () => {
     expect(TestScheduler).exist;
     expect(TestScheduler).to.be.a('function');

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -161,7 +161,7 @@ describe('TestScheduler', () => {
       expect(expected.length).to.equal(0);
     });
 
-    it.only('should emit notifications at frame zero synchronously upon subscription', () => {
+    it('should emit notifications at frame zero synchronously upon subscription', () => {
       const result: string[] = [];
       const scheduler = new TestScheduler(null!);
       const source = scheduler.createColdObservable('(ab|)');

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -161,7 +161,7 @@ describe('TestScheduler', () => {
       expect(expected.length).to.equal(0);
     });
 
-    it('should emit notifications at frame zero synchronously upon subscription', () => {
+    it.only('should emit notifications at frame zero synchronously upon subscription', () => {
       const result: string[] = [];
       const scheduler = new TestScheduler(null!);
       const source = scheduler.createColdObservable('(ab|)');

--- a/src/internal/testing/ColdObservable.ts
+++ b/src/internal/testing/ColdObservable.ts
@@ -41,7 +41,7 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
     const messagesLength = this.messages.length;
     for (let i = 0; i < messagesLength; i++) {
       const message = this.messages[i];
-      if (message.frame === 0) {
+      if (message.subscribing) {
         observeNotification(message.notification, subscriber);
       } else {
         subscriber.add(

--- a/src/internal/testing/ColdObservable.ts
+++ b/src/internal/testing/ColdObservable.ts
@@ -41,16 +41,20 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
     const messagesLength = this.messages.length;
     for (let i = 0; i < messagesLength; i++) {
       const message = this.messages[i];
-      subscriber.add(
-        this.scheduler.schedule(
-          (state) => {
-            const { message, subscriber } = state!;
-            observeNotification(message.notification, subscriber);
-          },
-          message.frame,
-          { message, subscriber }
-        )
-      );
+      if (message.frame === 0) {
+        observeNotification(message.notification, subscriber);
+      } else {
+        subscriber.add(
+          this.scheduler.schedule(
+            (state) => {
+              const { message, subscriber } = state!;
+              observeNotification(message.notification, subscriber);
+            },
+            message.frame,
+            { message, subscriber }
+          )
+        );
+      }
     }
   }
 }

--- a/src/internal/testing/TestMessage.ts
+++ b/src/internal/testing/TestMessage.ts
@@ -3,5 +3,5 @@ import { ObservableNotification } from '../types';
 export interface TestMessage {
   frame: number;
   notification: ObservableNotification<any>;
-  isGhost?: boolean;
+  subscribing: boolean;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR now adds a sync-within-`subscribe` marker as described in [this comment](https://github.com/ReactiveX/rxjs/pull/5760#issuecomment-699676467).

**Previous Description:**

This PR changes the `ColdObservable` implementation so that notifications scheduled at frame zero are emitted **within** `subscribe` instead of being scheduled for emission at zero milliseconds. See #5523 for a more detailed explanation.

After making this change, there were a whole bunch of tests - a total of 21, IIRC - that needed to be updated, as they depended upon the notifications at frame zero being emitted **after** `subscribe` returned. For example, consider this test:

```ts
    const a = cold(  '|');
    const asubs =    '(^!)';
    const b = cold(  '-');
    const bsubs =    '(^!)';
    const expected = '|';
    expectObservable(zip(a, b)).toBe(expected);
```

If the complete notification in `a` occurs within the `subscribe`, the subscription to `b` - asserted by the test - will never occur.

So, in order for the test to pass - and to effect the behaviour it purports to test - the notification needs to be moved off the zero frame, like this:

```ts
    const a = cold(  '-|');
    const asubs =    '^!';
    const b = cold(  '--');
    const bsubs =    '^!';
    const expected = '-|';
    expectObservable(zip(a, b)).toBe(expected);
```

Pretty much all of the changes to the test are like this. The only exception was the test for `throttle` - <s>and, TBH, I'm not altogether sure what's going on with that one</s> which will pass once the fix in #5749 is merged.

As I mentioned in the issue, there are [existing tests](https://github.com/ReactiveX/rxjs/blob/d608cf33791cceb5f330270da96b0b2805223208/spec/operators/share-spec.ts#L209) that appear to use `cold` in a manner that expects sync-within-subscribe notifications and there are [others](https://github.com/ReactiveX/rxjs/blob/985905934e7355b45c531096690ff0a5be86f373/spec/operators/every-spec.ts#L148) that explicitly use `of` instead of `cold`.

Whether or not we should make this change, IDK. As I mentioned in the issue, this behaviour could be seen as a quirk. It is, however, pretty confusing as it is at the moment.

Also, this would be a breaking change for anyone dependent upon the cold-observables-are-never-synchronous-within-subscribe behaviour.

**Related issue (if exists):** #5523
