### PR TITLE
refactor: use `innerFrom` for internal calls

### DIFF
--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -1,6 +1,7 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { ObservedValueOf, ObservableInput } from '../types';
-import { from } from './from'; // lol
+import { innerFrom } from './from';
 
 /**
  * Creates an Observable that, on subscribe, calls an Observable factory to
@@ -52,7 +53,7 @@ import { from } from './from'; // lol
  * @owner Observable
  */
 export function defer<R extends ObservableInput<any>>(observableFactory: () => R): Observable<ObservedValueOf<R>> {
-  return new Observable<ObservedValueOf<R>>(subscriber => {
+  return new Observable<ObservedValueOf<R>>((subscriber) => {
     let input: R;
     try {
       input = observableFactory();
@@ -60,7 +61,7 @@ export function defer<R extends ObservableInput<any>>(observableFactory: () => R
       subscriber.error(err);
       return undefined;
     }
-    const source = from(input);
+    const source = innerFrom(input);
     return source.subscribe(subscriber);
   });
 }

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,11 +1,10 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf, SubscribableOrPromise } from '../types';
 import { map } from '../operators/map';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
-import { from } from './from';
+import { innerFrom } from './from';
 import { popResultSelector } from '../util/args';
-
-/* tslint:disable:max-line-length */
 
 // forkJoin(a$, b$, c$)
 /** @deprecated Use the version that takes an array of Observables instead */
@@ -15,11 +14,29 @@ export function forkJoin<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>)
 /** @deprecated Use the version that takes an array of Observables instead */
 export function forkJoin<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<[T, T2, T3]>;
 /** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<[T, T2, T3, T4]>;
+export function forkJoin<T, T2, T3, T4>(
+  v1: ObservableInput<T>,
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>
+): Observable<[T, T2, T3, T4]>;
 /** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<[T, T2, T3, T4, T5]>;
+export function forkJoin<T, T2, T3, T4, T5>(
+  v1: ObservableInput<T>,
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>
+): Observable<[T, T2, T3, T4, T5]>;
 /** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<[T, T2, T3, T4, T5, T6]>;
+export function forkJoin<T, T2, T3, T4, T5, T6>(
+  v1: ObservableInput<T>,
+  v2: ObservableInput<T2>,
+  v3: ObservableInput<T3>,
+  v4: ObservableInput<T4>,
+  v5: ObservableInput<T5>,
+  v6: ObservableInput<T6>
+): Observable<[T, T2, T3, T4, T5, T6]>;
 
 // forkJoin([a$, b$, c$]);
 // TODO(benlesh): Uncomment for TS 3.0
@@ -27,9 +44,15 @@ export function forkJoin<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: Obse
 export function forkJoin<A>(sources: [ObservableInput<A>]): Observable<[A]>;
 export function forkJoin<A, B>(sources: [ObservableInput<A>, ObservableInput<B>]): Observable<[A, B]>;
 export function forkJoin<A, B, C>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>]): Observable<[A, B, C]>;
-export function forkJoin<A, B, C, D>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>]): Observable<[A, B, C, D]>;
-export function forkJoin<A, B, C, D, E>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>]): Observable<[A, B, C, D, E]>;
-export function forkJoin<A, B, C, D, E, F>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>, ObservableInput<F>]): Observable<[A, B, C, D, E, F]>;
+export function forkJoin<A, B, C, D>(
+  sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>]
+): Observable<[A, B, C, D]>;
+export function forkJoin<A, B, C, D, E>(
+  sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>]
+): Observable<[A, B, C, D, E]>;
+export function forkJoin<A, B, C, D, E, F>(
+  sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>, ObservableInput<F>]
+): Observable<[A, B, C, D, E, F]>;
 export function forkJoin<A extends ObservableInput<any>[]>(sources: A): Observable<ObservedValueUnionFromArray<A>[]>;
 
 // forkJoin({})
@@ -37,10 +60,9 @@ export function forkJoin(sourcesObject: {}): Observable<never>;
 export function forkJoin<T, K extends keyof T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /** @deprecated resultSelector is deprecated, pipe to map instead */
-export function forkJoin(...args: Array<ObservableInput<any>|Function>): Observable<any>;
+export function forkJoin(...args: Array<ObservableInput<any> | Function>): Observable<any>;
 /** @deprecated Use the version that takes an array of Observables instead */
 export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
-/* tslint:enable:max-line-length */
 
 /**
  * Accepts an `Array` of {@link ObservableInput} or a dictionary `Object` of {@link ObservableInput} and returns
@@ -138,25 +160,21 @@ export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
  * @return {Observable} Observable emitting either an array of last values emitted by passed Observables
  * or value from project function.
  */
-export function forkJoin(
-  ...args: any[]
-): Observable<any> {
+export function forkJoin(...args: any[]): Observable<any> {
   const resultSelector = popResultSelector(args);
 
   const { args: sources, keys } = argsArgArrayOrObject(args);
 
   if (resultSelector) {
     // deprecated path.
-    return forkJoinInternal(sources, keys).pipe(
-      map((values: any[]) => resultSelector!(...values))
-    );
+    return forkJoinInternal(sources, keys).pipe(map((values: any[]) => resultSelector!(...values)));
   }
 
   return forkJoinInternal(sources, keys);
 }
 
 function forkJoinInternal(sources: ObservableInput<any>[], keys: string[] | null): Observable<any> {
-  return new Observable(subscriber => {
+  return new Observable((subscriber) => {
     const len = sources.length;
     if (len === 0) {
       subscriber.complete();
@@ -166,29 +184,29 @@ function forkJoinInternal(sources: ObservableInput<any>[], keys: string[] | null
     let completed = 0;
     let emitted = 0;
     for (let i = 0; i < len; i++) {
-      const source = from(sources[i]);
+      const source = innerFrom(sources[i]);
       let hasValue = false;
-      subscriber.add(source.subscribe({
-        next: value => {
-          if (!hasValue) {
-            hasValue = true;
-            emitted++;
-          }
-          values[i] = value;
-        },
-        error: err => subscriber.error(err),
-        complete: () => {
-          completed++;
-          if (completed === len || !hasValue) {
-            if (emitted === len) {
-              subscriber.next(keys ?
-                keys.reduce((result, key, i) => ((result as any)[key] = values[i], result), {}) :
-                values);
+      subscriber.add(
+        source.subscribe({
+          next: (value) => {
+            if (!hasValue) {
+              hasValue = true;
+              emitted++;
             }
-            subscriber.complete();
-          }
-        }
-      }));
+            values[i] = value;
+          },
+          error: (err) => subscriber.error(err),
+          complete: () => {
+            completed++;
+            if (completed === len || !hasValue) {
+              if (emitted === len) {
+                subscriber.next(keys ? keys.reduce((result, key, i) => (((result as any)[key] = values[i]), result), {}) : values);
+              }
+              subscriber.complete();
+            }
+          },
+        })
+      );
     }
   });
 }

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -4,7 +4,7 @@ import { ObservableInput, SchedulerLike } from '../types';
 import { mergeAll } from '../operators/mergeAll';
 import { internalFromArray } from './fromArray';
 import { argsOrArgArray } from '../util/argsOrArgArray';
-import { from } from './from';
+import { innerFrom } from './from';
 import { EMPTY } from './empty';
 import { popNumber, popScheduler } from '../util/args';
 
@@ -237,7 +237,7 @@ export function merge(...args: (ObservableInput<any> | SchedulerLike | number)[]
       EMPTY
     : args.length === 1
     ? // One source? Just return it.
-      from(args[0] as ObservableInput<any>)
+      innerFrom(args[0] as ObservableInput<any>)
     : // Merge all sources
       mergeAll(concurrent)(internalFromArray(args as ObservableInput<any>[], scheduler));
 }

--- a/src/internal/observable/partition.ts
+++ b/src/internal/observable/partition.ts
@@ -2,7 +2,7 @@ import { not } from '../util/not';
 import { filter } from '../operators/filter';
 import { ObservableInput } from '../types';
 import { Observable } from '../Observable';
-import { from } from './from';
+import {  innerFrom } from './from';
 
 /**
  * Splits the source Observable into two, one with values that satisfy a
@@ -61,7 +61,7 @@ export function partition<T>(
   thisArg?: any
 ): [Observable<T>, Observable<T>] {
   return [
-    filter(predicate, thisArg)(from(source)),
-    filter(not(predicate, thisArg))(from(source))
+    filter(predicate, thisArg)(innerFrom(source)),
+    filter(not(predicate, thisArg))(innerFrom(source))
   ] as [Observable<T>, Observable<T>];
 }

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { from } from './from';
+import { innerFrom } from './from';
 import { Subscription } from '../Subscription';
 import { ObservableInput, ObservedValueUnionFromArray } from '../types';
 import { argsOrArgArray } from '../util/argsOrArgArray';
@@ -54,7 +54,7 @@ export function race<A extends ObservableInput<any>[]>(...observables: A): Obser
 export function race<T>(...sources: (ObservableInput<T> | ObservableInput<T>[])[]): Observable<any> {
   sources = argsOrArgArray(sources);
   // If only one source was passed, just return it. Otherwise return the race.
-  return sources.length === 1 ? from(sources[0]) : new Observable<T>(raceInit(sources as ObservableInput<T>[]));
+  return sources.length === 1 ? innerFrom(sources[0] as ObservableInput<T>) : new Observable<T>(raceInit(sources as ObservableInput<T>[]));
 }
 
 /**
@@ -72,7 +72,7 @@ export function raceInit<T>(sources: ObservableInput<T>[]) {
     // stop before it subscribes to any more.
     for (let i = 0; subscriptions && !subscriber.closed && i < sources.length; i++) {
       subscriptions.push(
-        from(sources[i] as ObservableInput<T>).subscribe(
+        innerFrom(sources[i] as ObservableInput<T>).subscribe(
           new OperatorSubscriber(subscriber, (value) => {
             if (subscriptions) {
               // We're still racing, but we won! So unsubscribe

--- a/src/internal/observable/using.ts
+++ b/src/internal/observable/using.ts
@@ -1,6 +1,7 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { Unsubscribable, ObservableInput } from '../types';
-import { from } from './from'; // from from from! LAWL
+import { innerFrom } from './from';
 import { EMPTY } from './empty';
 
 /**
@@ -31,9 +32,11 @@ import { EMPTY } from './empty';
  * @return {Observable<T>} An Observable that behaves the same as Observable returned by `observableFactory`, but
  * which - when completed, errored or unsubscribed - will also call `unsubscribe` on created resource object.
  */
-export function using<T>(resourceFactory: () => Unsubscribable | void,
-                         observableFactory: (resource: Unsubscribable | void) => ObservableInput<T> | void): Observable<T> {
-  return new Observable<T>(subscriber => {
+export function using<T>(
+  resourceFactory: () => Unsubscribable | void,
+  observableFactory: (resource: Unsubscribable | void) => ObservableInput<T> | void
+): Observable<T> {
+  return new Observable<T>((subscriber) => {
     let resource: Unsubscribable | void;
 
     try {
@@ -51,7 +54,7 @@ export function using<T>(resourceFactory: () => Unsubscribable | void,
       return undefined;
     }
 
-    const source = result ? from(result) : EMPTY;
+    const source = result ? innerFrom(result) : EMPTY;
     const subscription = source.subscribe(subscriber);
     return () => {
       subscription.unsubscribe();

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueOf } from '../types';
-import { from } from './from';
+import { innerFrom } from './from';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { EMPTY } from './empty';
 import { OperatorSubscriber } from '../operators/OperatorSubscriber';
@@ -205,7 +205,7 @@ export function zip<O extends ObservableInput<any>, R>(
         // especially important here, because we use it in closures below to
         // access the related buffers and completion properties
         for (let i = 0; !subscriber.closed && i < sources.length; i++) {
-          from(sources[i]).subscribe(
+          innerFrom(sources[i]).subscribe(
             new OperatorSubscriber(
               subscriber,
               (value) => {

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -3,7 +3,7 @@ import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction, SubscribableOrPromise } from '../types';
 
 import { operate } from '../util/lift';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -73,7 +73,7 @@ export function audit<T>(durationSelector: (value: T) => SubscribableOrPromise<a
         hasValue = true;
         lastValue = value;
         if (!durationSubscriber) {
-          from(durationSelector(value)).subscribe(
+          innerFrom(durationSelector(value)).subscribe(
             (durationSubscriber = new OperatorSubscriber(subscriber, endDuration, undefined, endDuration))
           );
         }

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -2,7 +2,7 @@
 import { Subscription } from '../Subscription';
 import { OperatorFunction, SubscribableOrPromise } from '../types';
 import { operate } from '../util/lift';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 import { arrRemove } from '../util/arrRemove';
@@ -60,7 +60,7 @@ export function bufferToggle<T, O>(
     const buffers: T[][] = [];
 
     // Subscribe to the openings notifier first
-    from(openings).subscribe(
+    innerFrom(openings).subscribe(
       new OperatorSubscriber(
         subscriber,
         (openValue) => {
@@ -80,7 +80,9 @@ export function bufferToggle<T, O>(
           };
 
           // The line below will add the subscription to the parent subscriber *and* the closing subscription.
-          closingSubscription.add(from(closingSelector(openValue)).subscribe(new OperatorSubscriber(subscriber, emit, undefined, emit)));
+          closingSubscription.add(
+            innerFrom(closingSelector(openValue)).subscribe(new OperatorSubscriber(subscriber, emit, undefined, emit))
+          );
         },
         undefined,
         noop

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -4,7 +4,7 @@ import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 
 /**
  * Buffers the source Observable values, using a factory function of closing
@@ -61,7 +61,7 @@ export function bufferWhen<T>(closingSelector: () => ObservableInput<any>): Oper
 
       let closingNotifier: Observable<any>;
       try {
-        closingNotifier = from(closingSelector());
+        closingNotifier = innerFrom(closingSelector());
       } catch (err) {
         subscriber.error(err);
         return;

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { Subscription } from '../Subscription';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { operate } from '../util/lift';
 
@@ -115,7 +115,7 @@ export function catchError<T, O extends ObservableInput<any>>(
 
     innerSub = source.subscribe(
       new OperatorSubscriber(subscriber, undefined, (err) => {
-        handledResult = from(selector(err, catchError(selector)(source)));
+        handledResult = innerFrom(selector(err, catchError(selector)(source)));
         if (innerSub) {
           innerSub.unsubscribe();
           innerSub = null;

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -4,7 +4,7 @@ import { MonoTypeOperatorFunction, SubscribableOrPromise } from '../types';
 
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 
 /**
  * Emits a notification from the source Observable only after a particular time span
@@ -100,7 +100,7 @@ export function debounce<T>(durationSelector: (value: T) => SubscribableOrPromis
           // and we're going to emit the value.
           durationSubscriber = new OperatorSubscriber(subscriber, emit, undefined, emit);
           // Subscribe to the duration.
-          from(durationSelector(value)).subscribe(durationSubscriber);
+          innerFrom(durationSelector(value)).subscribe(durationSubscriber);
         },
         undefined,
         () => {

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -2,7 +2,7 @@
 import { Subscription } from '../Subscription';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 export function exhaust<T>(): OperatorFunction<ObservableInput<T>, T>;
@@ -60,7 +60,7 @@ export function exhaust<T>(): OperatorFunction<any, T> {
         subscriber,
         (inner) => {
           if (!innerSub) {
-            innerSub = from(inner).subscribe(
+            innerSub = innerFrom(inner).subscribe(
               new OperatorSubscriber(subscriber, undefined, undefined, () => {
                 innerSub = null;
                 isComplete && subscriber.complete();

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
@@ -74,7 +74,7 @@ export function exhaustMap<T, R, O extends ObservableInput<any>>(
   if (resultSelector) {
     // DEPRECATED PATH
     return (source: Observable<T>) =>
-      source.pipe(exhaustMap((a, i) => from(project(a, i)).pipe(map((b: any, ii: any) => resultSelector(a, b, i, ii)))));
+      source.pipe(exhaustMap((a, i) => innerFrom(project(a, i)).pipe(map((b: any, ii: any) => resultSelector(a, b, i, ii)))));
   }
   return operate((source, subscriber) => {
     let index = 0;
@@ -89,7 +89,7 @@ export function exhaustMap<T, R, O extends ObservableInput<any>>(
               innerSub = null;
               isComplete && subscriber.complete();
             });
-            from(project(outerValue, index++)).subscribe(innerSub);
+            innerFrom(project(outerValue, index++)).subscribe(innerSub);
           }
         },
         undefined,

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -2,7 +2,7 @@
 import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 
 /* tslint:disable:max-line-length */
 export function expand<T, R>(
@@ -100,7 +100,7 @@ export function expand<T, R>(
       // keep a larger allocation (the observable) in memory, the tradeoff is it
       // keeps the size down.
       // TODO: Correct the types here. `project` could be R or T.
-      const inner = from(project(value as any, index++));
+      const inner = innerFrom(project(value as any, index++));
       active++;
       const doSub = () => {
         inner.subscribe(

--- a/src/internal/operators/mergeInternals.ts
+++ b/src/internal/operators/mergeInternals.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { Subscriber } from '../Subscriber';
 import { ObservableInput } from '../types';
 import { OperatorSubscriber } from './OperatorSubscriber';
@@ -48,7 +48,7 @@ export function mergeInternals<T, R>(
 
   const doInnerSub = (value: T) => {
     active++;
-    from(project(value, index++)).subscribe(
+    innerFrom(project(value, index++)).subscribe(
       new OperatorSubscriber(
         subscriber,
         (innerValue) => {

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -2,7 +2,7 @@
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { operate } from '../util/lift';
 import { mergeInternals } from './mergeInternals';
 import { isFunction } from '../util/isFunction';
@@ -88,7 +88,7 @@ export function mergeMap<T, R, O extends ObservableInput<any>>(
   if (isFunction(resultSelector)) {
     // DEPRECATED PATH
     return (source: Observable<T>) =>
-      source.pipe(mergeMap((a, i) => from(project(a, i)).pipe(map((b: any, ii: number) => resultSelector(a, b, i, ii))), concurrent));
+      source.pipe(mergeMap((a, i) => innerFrom(project(a, i)).pipe(map((b: any, ii: number) => resultSelector(a, b, i, ii))), concurrent));
   } else if (typeof resultSelector === 'number') {
     concurrent = resultSelector;
   }

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -2,7 +2,7 @@
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueOf, ObservedValueUnionFromArray, MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
@@ -91,7 +91,7 @@ export function onErrorResumeNext<T>(...nextSources: ObservableInput<any>[]): Op
         if (remaining.length > 0) {
           let nextSource: Observable<any>;
           try {
-            nextSource = from(remaining.shift()!);
+            nextSource = innerFrom(remaining.shift()!);
           } catch (err) {
             subscribeNext();
             return;

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -27,7 +27,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * import { from, fromEvent } from 'rxjs';
  * import { sequenceEqual, bufferCount, mergeMap, map } from 'rxjs/operators';
  *
- * const codes = from([
+ * const codes = innerFrom([
  *   'ArrowUp',
  *   'ArrowUp',
  *   'ArrowDown',
@@ -45,7 +45,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * const matches = keys.pipe(
  *   bufferCount(11, 1),
  *   mergeMap(
- *     last11 => from(last11).pipe(sequenceEqual(codes)),
+ *     last11 => innerFrom(last11).pipe(sequenceEqual(codes)),
  *   ),
  * );
  * matches.subscribe(matched => console.log('Successful cheat at Contra? ', matched));

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { noop } from '../util/noop';
 
 /**
@@ -58,7 +58,7 @@ export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunctio
       noop
     );
 
-    from(notifier).subscribe(skipSubscriber);
+    innerFrom(notifier).subscribe(skipSubscriber);
 
     source.subscribe(new OperatorSubscriber(subscriber, (value) => taking && subscriber.next(value)));
   });

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
@@ -105,7 +105,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
           let innerIndex = 0;
           let outerIndex = index++;
           // Start the next inner subscription
-          from(project(value, outerIndex)).subscribe(
+          innerFrom(project(value, outerIndex)).subscribe(
             (innerSubscriber = new OperatorSubscriber(
               subscriber,
               // When we get a new inner value, next it through. Note that this is

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -2,7 +2,7 @@
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { noop } from '../util/noop';
 
 /**
@@ -46,7 +46,7 @@ import { noop } from '../util/noop';
  */
 export function takeUntil<T>(notifier: ObservableInput<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
-    from(notifier).subscribe(new OperatorSubscriber(subscriber, () => subscriber.complete(), undefined, noop));
+    innerFrom(notifier).subscribe(new OperatorSubscriber(subscriber, () => subscriber.complete(), undefined, noop));
     !subscriber.closed && source.subscribe(subscriber);
   });
 }

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -4,7 +4,7 @@ import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction, SubscribableOrPromise } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 
 export interface ThrottleConfig {
   leading?: boolean;
@@ -81,7 +81,9 @@ export function throttle<T>(
     };
 
     const throttle = (value: T) =>
-      (throttled = from(durationSelector(value)).subscribe(new OperatorSubscriber(subscriber, throttlingDone, undefined, throttlingDone)));
+      (throttled = innerFrom(durationSelector(value)).subscribe(
+        new OperatorSubscriber(subscriber, throttlingDone, undefined, throttlingDone)
+      ));
 
     const send = () => {
       if (hasValue) {

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -5,7 +5,7 @@ import { isValidDate } from '../util/isDate';
 import { Subscription } from '../Subscription';
 import { operate } from '../util/lift';
 import { Observable } from '../Observable';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { createErrorClass } from '../util/createErrorClass';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
@@ -340,7 +340,7 @@ export function timeout<T, R, M>(config: number | Date | TimeoutConfig<T, R, M>,
         (timerSubscription = scheduler!.schedule(() => {
           let withObservable: Observable<R>;
           try {
-            withObservable = from(
+            withObservable = innerFrom(
               _with!({
                 meta,
                 lastValue,
@@ -363,7 +363,7 @@ export function timeout<T, R, M>(config: number | Date | TimeoutConfig<T, R, M>,
           subscriber,
           (value) => {
             // clear the timer so we can emit and start another one.
-              timerSubscription?.unsubscribe();
+            timerSubscription?.unsubscribe();
             seen++;
             // Emit
             subscriber.next((lastValue = value));
@@ -373,9 +373,9 @@ export function timeout<T, R, M>(config: number | Date | TimeoutConfig<T, R, M>,
           undefined,
           undefined,
           () => {
-              if (!timerSubscription?.closed) {
-                timerSubscription?.unsubscribe();
-              }
+            if (!timerSubscription?.closed) {
+              timerSubscription?.unsubscribe();
+            }
             // Be sure not to hold the last value in memory after unsubscription
             // it could be quite large.
             lastValue = null;

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -4,7 +4,7 @@ import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 import { arrRemove } from '../util/arrRemove';
@@ -72,7 +72,7 @@ export function windowToggle<T, O>(
 
     let openNotifier: Observable<O>;
     try {
-      openNotifier = from(openings);
+      openNotifier = innerFrom(openings);
     } catch (err) {
       subscriber.error(err);
       return;
@@ -92,7 +92,7 @@ export function windowToggle<T, O>(
 
           let closingNotifier: Observable<any>;
           try {
-            closingNotifier = from(closingSelector(openValue));
+            closingNotifier = innerFrom(closingSelector(openValue));
           } catch (err) {
             handleError(err);
             return;

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -5,7 +5,7 @@ import { Subject } from '../Subject';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 
 /**
  * Branch out the source Observable values as a nested Observable using a
@@ -86,7 +86,7 @@ export function windowWhen<T>(closingSelector: () => ObservableInput<any>): Oper
       // Get our closing notifier.
       let closingNotifier: Observable<any>;
       try {
-        closingNotifier = from(closingSelector());
+        closingNotifier = innerFrom(closingSelector());
       } catch (err) {
         handleError(err);
         return;

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
-import { from } from '../observable/from';
+import { innerFrom } from '../observable/from';
 import { identity } from '../util/identity';
 import { noop } from '../util/noop';
 import { popResultSelector } from '../util/args';
@@ -177,7 +177,7 @@ export function withLatestFrom<T, R>(...inputs: any[]): OperatorFunction<T, R | 
       const input = inputs[i];
       let otherSource: Observable<any>;
       try {
-        otherSource = from(input);
+        otherSource = innerFrom(input);
       } catch (err) {
         subscriber.error(err);
         return;


### PR DESCRIPTION
Uses `innerFrom` throughout the library where we know we don't need to pass a scheduler.

This is done to reduce bundle size. If we used `from` internally, but didn't need scheduling for that call, we were just using it to convert to an observable (the 95% case), we would end up including `scheduled` in the bundle when we didn't need to, because the deprecated path of `from` calls `scheduled`.


### Other Thoughts

Perhaps it should be called `internalFrom` since  "inner" often has other connotations in our library? Happy to change that in this PR.
