### PR TITLE
Refactor `timer` and `interval`

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -598,7 +598,9 @@ export interface TimeoutError<T = unknown, M = unknown> extends Error {
 
 export declare const TimeoutError: TimeoutErrorCtor;
 
-export declare function timer(dueTime?: number | Date, periodOrScheduler?: number | SchedulerLike, scheduler?: SchedulerLike): Observable<number>;
+export declare function timer(due: number | Date, scheduler?: SchedulerLike): Observable<0>;
+export declare function timer(startDue: number | Date, intervalDuration: number, scheduler?: SchedulerLike): Observable<number>;
+export declare function timer(dueTime: number | Date, unused: undefined, scheduler?: SchedulerLike): Observable<0>;
 
 export interface Timestamp<T> {
     timestamp: number;

--- a/spec-dtslint/observables/timer-spec.ts
+++ b/spec-dtslint/observables/timer-spec.ts
@@ -1,11 +1,11 @@
 import { timer, animationFrameScheduler } from 'rxjs';
 
 it('should infer correctly with 1 parameter of number type', () => {
-  const a = timer(1); // $ExpectType Observable<number>
+  const a = timer(1); // $ExpectType Observable<0>
 });
 
 it('should infer correctly with 1 parameter of date type', () => {
-  const a = timer((new Date())); // $ExpectType Observable<number>
+  const a = timer((new Date())); // $ExpectType Observable<0>
 });
 
 it('should not support string parameter', () => {
@@ -17,7 +17,7 @@ it('should infer correctly with 2 parameters', () => {
 });
 
 it('should support scheduler as second parameter', () => {
-  const a = timer(1, animationFrameScheduler); // $ExpectType Observable<number>
+  const a = timer(1, animationFrameScheduler); // $ExpectType Observable<0>
 });
 
 it('should support scheduler as third parameter', () => {

--- a/src/internal/observable/interval.ts
+++ b/src/internal/observable/interval.ts
@@ -1,10 +1,8 @@
 /** @prettier */
 import { Observable } from '../Observable';
 import { asyncScheduler } from '../scheduler/async';
-import { SchedulerAction, SchedulerLike } from '../types';
-import { isNumeric } from '../util/isNumeric';
-import { Subscriber } from '../Subscriber';
-import { isScheduler } from '../util/isScheduler';
+import { SchedulerLike } from '../types';
+import { timer } from './timer';
 
 /**
  * Creates an Observable that emits sequential numbers every specified
@@ -55,27 +53,10 @@ import { isScheduler } from '../util/isScheduler';
  * @owner Observable
  */
 export function interval(period = 0, scheduler: SchedulerLike = asyncScheduler): Observable<number> {
-  if (!isNumeric(period) || period < 0) {
+  if (period < 0) {
+    // We cannot schedule an interval in the past.
     period = 0;
   }
 
-  if (!isScheduler(scheduler)) {
-    scheduler = asyncScheduler;
-  }
-
-  return new Observable<number>((subscriber) => {
-    subscriber.add(scheduler.schedule(dispatch as any, period, { subscriber, counter: 0, period }));
-  });
-}
-
-function dispatch(this: SchedulerAction<IntervalState>, state: IntervalState) {
-  const { subscriber, counter, period } = state;
-  subscriber.next(counter);
-  this.schedule({ subscriber, counter: counter + 1, period }, period);
-}
-
-interface IntervalState {
-  subscriber: Subscriber<number>;
-  counter: number;
-  period: number;
+  return timer(period, period, scheduler);
 }


### PR DESCRIPTION
- `timer` now a smaller implementation.
- Improved types for `timer`.
- Improved docs for `timer`.
-`interval` now based off of timer, as the implementations were barely different, and no real efficiency was gained by `interval` having its own impl.