### PR TITLE
Refactor some scheduled jobs with try/catch

### DIFF
--- a/src/internal/scheduled/scheduleArray.ts
+++ b/src/internal/scheduled/scheduleArray.ts
@@ -1,21 +1,28 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
-import { Subscription } from '../Subscription';
 
 export function scheduleArray<T>(input: ArrayLike<T>, scheduler: SchedulerLike) {
-  return new Observable<T>(subscriber => {
-    const sub = new Subscription();
+  return new Observable<T>((subscriber) => {
+    // The current array index.
     let i = 0;
-    sub.add(scheduler.schedule(function () {
+    // Start iterating over the array like on a schedule.
+    return scheduler.schedule(function () {
       if (i === input.length) {
+        // If we have hit the end of the array like in the
+        // previous job, we can complete.
         subscriber.complete();
-        return;
+      } else {
+        // Otherwise let's next the value at the current index,
+        // then increment our index.
+        subscriber.next(input[i++]);
+        // If the last emission didn't cause us to close the subscriber
+        // (via take or some side effect), reschedule the job and we'll
+        // make another pass.
+        if (!subscriber.closed) {
+          this.schedule();
+        }
       }
-      subscriber.next(input[i++]);
-      if (!subscriber.closed) {
-        sub.add(this.schedule());
-      }
-    }));
-    return sub;
+    });
   });
 }

--- a/src/internal/scheduled/scheduleIterable.ts
+++ b/src/internal/scheduled/scheduleIterable.ts
@@ -12,7 +12,7 @@ import { caughtSchedule } from '../util/caughtSchedule';
  */
 export function scheduleIterable<T>(input: Iterable<T>, scheduler: SchedulerLike) {
   return new Observable<T>((subscriber) => {
-    let iterator: Iterator<T>;
+    let iterator: Iterator<T, T>;
 
     // Schedule the initial creation of the iterator from
     // the iterable. This is so the code in the iterable is
@@ -24,10 +24,8 @@ export function scheduleIterable<T>(input: Iterable<T>, scheduler: SchedulerLike
 
         // Schedule the first iteration and emission.
         caughtSchedule(subscriber, scheduler, function () {
-          let value: T;
-          let done: boolean | undefined;
           // Pull the value out of the iterator
-          ({ value, done } = iterator.next());
+          const { value, done } = iterator.next();
           if (done) {
             // If it is "done" we just complete. This mimics the
             // behavior of JavaScript's `for..of` consumption of

--- a/src/internal/scheduled/scheduleIterable.ts
+++ b/src/internal/scheduled/scheduleIterable.ts
@@ -24,26 +24,22 @@ export function scheduleIterable<T>(input: Iterable<T>, scheduler: SchedulerLike
 
         // Schedule the first iteration and emission.
         caughtSchedule(subscriber, scheduler, function () {
-          // Check to make sure teardown was not triggered
-          // by the consumer since the last iteration.
-          if (!subscriber.closed) {
-            let value: T;
-            let done: boolean | undefined;
-            // Pull the value out of the iterator
-            ({ value, done } = iterator.next());
-            if (done) {
-              // If it is "done" we just complete. This mimics the
-              // behavior of JavaScript's `for..of` consumption of
-              // iterables, which will not emit the value from an iterator
-              // result of `{ done: true: value: 'here' }`.
-              subscriber.complete();
-            } else {
-              // The iterable is not done, emit the value.
-              subscriber.next(value);
-              // Reschedule. This will cause this function to be
-              // called again on the same scheduled delay.
-              this.schedule();
-            }
+          let value: T;
+          let done: boolean | undefined;
+          // Pull the value out of the iterator
+          ({ value, done } = iterator.next());
+          if (done) {
+            // If it is "done" we just complete. This mimics the
+            // behavior of JavaScript's `for..of` consumption of
+            // iterables, which will not emit the value from an iterator
+            // result of `{ done: true: value: 'here' }`.
+            subscriber.complete();
+          } else {
+            // The iterable is not done, emit the value.
+            subscriber.next(value);
+            // Reschedule. This will cause this function to be
+            // called again on the same scheduled delay.
+            this.schedule();
           }
         });
       })

--- a/src/internal/scheduled/schedulePromise.ts
+++ b/src/internal/scheduled/schedulePromise.ts
@@ -1,21 +1,23 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
-import { Subscription } from '../Subscription';
 
 export function schedulePromise<T>(input: PromiseLike<T>, scheduler: SchedulerLike) {
-  return new Observable<T>(subscriber => {
-    const sub = new Subscription();
-    sub.add(scheduler.schedule(() => input.then(
-      value => {
-        sub.add(scheduler.schedule(() => {
-          subscriber.next(value);
-          sub.add(scheduler.schedule(() => subscriber.complete()));
-        }));
-      },
-      err => {
-        sub.add(scheduler.schedule(() => subscriber.error(err)));
-      }
-    )));
-    return sub;
+  return new Observable<T>((subscriber) => {
+    return scheduler.schedule(() =>
+      input.then(
+        (value) => {
+          subscriber.add(
+            scheduler.schedule(() => {
+              subscriber.next(value);
+              subscriber.add(scheduler.schedule(() => subscriber.complete()));
+            })
+          );
+        },
+        (err) => {
+          subscriber.add(scheduler.schedule(() => subscriber.error(err)));
+        }
+      )
+    );
   });
 }

--- a/src/internal/util/caughtSchedule.ts
+++ b/src/internal/util/caughtSchedule.ts
@@ -1,0 +1,22 @@
+/** @prettier */
+
+import { Subscriber } from '../Subscriber';
+import { Subscription } from '../Subscription';
+import { SchedulerAction, SchedulerLike } from '../types';
+
+export function caughtSchedule(
+  subscriber: Subscriber<any>,
+  scheduler: SchedulerLike,
+  execute: (this: SchedulerAction<any>) => void,
+  delay = 0
+): Subscription {
+  const subscription = scheduler.schedule(function () {
+    try {
+      execute.call(this);
+    } catch (err) {
+      subscriber.error(err);
+    }
+  }, delay);
+  subscriber.add(subscription);
+  return subscription;
+}


### PR DESCRIPTION
Unifies a few areas where we are scheduling work that requires a try/catch that sends to `subscriber`.

Some other minor clean up of schedule-related calls.