### PR TITLE
refactor(expand): use mergeInternals

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -105,7 +105,7 @@ export declare function exhaustMap<T, O extends ObservableInput<any>>(project: (
 export declare function exhaustMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
 export declare function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: SchedulerLike): OperatorFunction<T, R>;
-export declare function expand<T>(project: (value: T, index: number) => ObservableInput<T>, concurrent?: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export declare function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent: number | undefined, scheduler: SchedulerLike): OperatorFunction<T, R>;
 
 export declare function filter<T, S extends T>(predicate: (value: T, index: number) => value is S, thisArg?: any): OperatorFunction<T, S>;
 export declare function filter<T>(predicate: BooleanConstructor): OperatorFunction<T | null | undefined, NonNullable<T>>;


### PR DESCRIPTION
- Adds a small amount of complexity to `mergeInternals` to support `expand`.
- `expand` now based off of the same internals as `mergeMap` and `mergeScan`.
- `deprecates` the scheduler argument to `expand` with an explanation.

NOTE: While I'm not fond of the number of arguments to `mergeInternals`, it's an _internal_ API, and given that it's not public, I'd like to refrain from creating named parameters via a configuration object just to make our internal code more readable, especially when this is relatively hot code. Instead, I've opted to make sure everything is well commented.
