### PR TITLE
refactor(pairs): Based off of `from` and `Object.entries`

### DIFF
--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -1,7 +1,7 @@
+/** @prettier */
 import { Observable } from '../Observable';
-import { SchedulerAction, SchedulerLike } from '../types';
-import { Subscriber } from '../Subscriber';
-import { Subscription } from '../Subscription';
+import { SchedulerLike } from '../types';
+import { from } from './from';
 
 /**
  * Convert an object into an Observable of `[key, value]` pairs.
@@ -43,51 +43,19 @@ import { Subscription } from '../Subscription';
  * // "Complete!"
  * ```
  *
+ * ### Object.entries required
+ *
+ * In IE, you will need to polyfill `Object.entries` in order to use this.
+ * [MDN has a polyfill here](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/entries)
+ *
  * @param {Object} obj The object to inspect and turn into an
  * Observable sequence.
  * @param {Scheduler} [scheduler] An optional IScheduler to schedule
  * when resulting Observable will emit values.
  * @returns {(Observable<Array<string|T>>)} An observable sequence of
  * [key, value] pairs from the object.
+ * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
  */
 export function pairs<T>(obj: Object, scheduler?: SchedulerLike): Observable<[string, T]> {
-  if (!scheduler) {
-    return new Observable<[string, T]>(subscriber => {
-      const keys = Object.keys(obj);
-      for (let i = 0; i < keys.length && !subscriber.closed; i++) {
-        const key = keys[i];
-        if (obj.hasOwnProperty(key)) {
-          subscriber.next([key, (obj as any)[key]]);
-        }
-      }
-      subscriber.complete();
-    });
-  } else {
-    return new Observable<[string, T]>(subscriber => {
-      const keys = Object.keys(obj);
-      const subscription = new Subscription();
-      subscription.add(
-        scheduler.schedule<{ keys: string[], index: number, subscriber: Subscriber<[string, T]>, subscription: Subscription, obj: Object }>(
-          dispatch as any,
-          0,
-          { keys, index: 0, subscriber, subscription, obj }
-        ));
-      return subscription;
-    });
-  }
-}
-
-/** @internal */
-export function dispatch<T>(this: SchedulerAction<any>,
-                            state: { keys: string[], index: number, subscriber: Subscriber<[string, T]>, subscription: Subscription, obj: Object }) {
-  const { keys, index, subscriber, subscription, obj } = state;
-  if (!subscriber.closed) {
-    if (index < keys.length) {
-      const key = keys[index];
-      subscriber.next([key, (obj as any)[key]]);
-      subscription.add(this.schedule({ keys, index: index + 1, subscriber, subscription, obj }));
-    } else {
-      subscriber.complete();
-    }
-  }
+  return from(Object.entries(obj), scheduler as any);
 }


### PR DESCRIPTION
BREAKING CHANGE: `pairs` will no longer function in IE without a polyfill for `Object.entries`. `pairs` itself is also deprecated in favor of users just using `from(Object.entries(obj))`.
