### PR TITLE
docs(canonical-link): add a canonical url for rxjs.dev

### DIFF
--- a/docs_app/src/app/app.component.ts
+++ b/docs_app/src/app/app.component.ts
@@ -23,6 +23,8 @@ import { TocService } from 'app/shared/toc.service';
 
 import { BehaviorSubject, combineLatest, Observable } from 'rxjs';
 import { first, map } from 'rxjs/operators';
+import { Inject } from '@angular/core';
+import { DOCUMENT } from '@angular/common';
 
 const sideNavView = 'SideNav';
 
@@ -114,7 +116,8 @@ export class AppComponent implements OnInit {
     private navigationService: NavigationService,
     private scrollService: ScrollService,
     private searchService: SearchService,
-    private tocService: TocService
+    private tocService: TocService,
+    @Inject(DOCUMENT) private dom
   ) {}
 
   ngOnInit() {
@@ -233,7 +236,15 @@ export class AppComponent implements OnInit {
       // (Apparently, this happens with a slight delay.)
       setTimeout(() => (this.isStarting = false), 100);
     }
-
+    console.log('ondoc rednered');
+    const head = this.dom.getElementsByTagName('head')[0];
+    let element: HTMLLinkElement = this.dom.querySelector(`link[rel='canonical']`) || null
+    if (element === null) {
+      element = this.dom.createElement('link') as HTMLLinkElement;
+      head.appendChild(element);
+    }
+    element.setAttribute('rel', 'canonical')
+    element.setAttribute('href', `https://rxjs.dev/${this.currentPath}`)
     this.isTransitioning = false;
   }
 


### PR DESCRIPTION
This pr should help fixing the SEO problem, that always the rxjs-dev-firebase... whatever url is shown in google etc.
This should be merged into 6.x and master