### PR TITLE
refactor: `bindCallback` and `bindNodeCallback` are based on the same…

### DIFF
--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -256,30 +256,30 @@ describe('bindCallback', () => {
     expect(results2).to.deep.equal([42, 'done']);
   });
 
-  it('should not even call the callbackFn if immediately unsubscribed', () => {
-      let calls = 0;
-      function callback(datum: number, cb: Function) {
-        calls++;
-        cb(datum);
-      }
-      const boundCallback = bindCallback(callback, rxTestScheduler);
-      const results1: Array<number|string> = [];
+  it('should not even call the callbackFn if scheduled and immediately unsubscribed', () => {
+    let calls = 0;
+    function callback(datum: number, cb: Function) {
+      calls++;
+      cb(datum);
+    }
+    const boundCallback = bindCallback(callback, rxTestScheduler);
+    const results1: Array<number|string> = [];
 
-      const source = boundCallback(42);
+    const source = boundCallback(42);
 
-      const subscription = source.subscribe((x: any) => {
-        results1.push(x);
-      }, null, () => {
-        results1.push('done');
-      });
-
-      subscription.unsubscribe();
-
-      rxTestScheduler.flush();
-
-      expect(calls).to.equal(0);
+    const subscription = source.subscribe((x: any) => {
+      results1.push(x);
+    }, null, () => {
+      results1.push('done');
     });
+
+    subscription.unsubscribe();
+
+    rxTestScheduler.flush();
+
+    expect(calls).to.equal(0);
   });
+});
 
   it('should emit post-callback errors', () => {
     function badFunction(callback: (answer: number) => void): void {

--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -315,5 +315,29 @@ describe('bindNodeCallback', () => {
     expect(result1).to.equal('test');
     expect(result2).to.equal('test');
     expect(calls).to.equal(1);
-  })
+  });
+
+  it('should not even call the callbackFn if scheduled and immediately unsubscribed', () => {
+    let calls = 0;
+    function callback(datum: number, cb: Function) {
+      calls++;
+      cb(null, datum);
+    }
+    const boundCallback = bindNodeCallback(callback, rxTestScheduler);
+    const results1: Array<number|string> = [];
+
+    const source = boundCallback(42);
+
+    const subscription = source.subscribe((x: any) => {
+      results1.push(x);
+    }, null, () => {
+      results1.push('done');
+    });
+
+    subscription.unsubscribe();
+
+    rxTestScheduler.flush();
+
+    expect(calls).to.equal(0);
+  });
 });

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -1,7 +1,6 @@
 import { SchedulerLike } from '../types';
 import { Observable } from '../Observable';
-import { isScheduler } from '../util/isScheduler';
-import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
+import { bindCallbackInternals } from './bindCallbackInternals';
 
 // tslint:disable:max-line-length
 /** @deprecated resultSelector is no longer supported, use a mapping function. */
@@ -177,103 +176,5 @@ export function bindCallback(
   resultSelector?: any,
   scheduler?: SchedulerLike
 ): (...args: any[]) => Observable<unknown> {
-  if (resultSelector) {
-    if (isScheduler(resultSelector)) {
-      scheduler = resultSelector;
-    } else {
-      // Deprecated path (Returning Observable<R>)
-      // TODO: Fix these internal typings.
-      return (...args: any[]) => (bindCallback(callbackFunc, scheduler) as any)(...args).pipe(
-        mapOneOrManyArgs(resultSelector),
-      );
-    }
-  }
-
-  
-  return function (this: any, ...args: any[]) {
-    let results: any;
-    let hasResults = false;
-    let hasError = false;
-    let error: any;
-    return new Observable((subscriber) => {
-      if (!scheduler) {
-        let isCurrentlyAsync = false;
-        let hasCompletedSynchronously = false;
-        if (hasResults) {
-          subscriber.next(results);
-          subscriber.complete();
-        } else if (hasError) {
-          subscriber.error(error);
-        } else {
-          const handler = (...innerArgs: any[]) => {
-            hasResults = true;
-            results = innerArgs.length <= 1 ? innerArgs[0] : innerArgs;
-            subscriber.next(results);
-            if (isCurrentlyAsync) {
-              subscriber.complete();
-            } else {
-              hasCompletedSynchronously = true;
-            }
-          };
-
-          try {
-            callbackFunc.apply(this, [...args, handler]);
-          } catch (err) {
-            hasError = true;
-            error = err;
-            subscriber.error(err);
-          }
-          isCurrentlyAsync = true;
-
-          if (hasCompletedSynchronously && !hasError) {
-            subscriber.complete();
-          }
-        }
-        return;
-      } else {
-        const scheduleNext = (value: any[]) => {
-          hasResults = true;
-          results = value.length <= 1 ? value[0] : value;
-          subscriber.add(
-            scheduler!.schedule(() => {
-              subscriber.next(results);
-              subscriber.add(
-                scheduler!.schedule(() => {
-                  subscriber.complete();
-                })
-              );
-            })
-          );
-        };
-
-        const scheduleError = (err: any) => {
-          hasError = true;
-          error = err;
-          subscriber.add(
-            scheduler!.schedule(() => {
-              subscriber.error(error);
-            })
-          );
-        };
-
-        return scheduler.schedule(() => {
-          if (hasResults) {
-            scheduleNext(results);
-          } else if (hasError) {
-            scheduleError(error);
-          } else {
-            try {
-              callbackFunc.apply(this, [
-                ...args,
-                (...innerArgs: any[]) => scheduleNext(innerArgs)
-              ]);
-            } catch (err) {
-              scheduleError(err);
-              return;
-            }
-          }
-        });
-      }
-    });
-  };
+  return bindCallbackInternals(false, callbackFunc, resultSelector, scheduler);
 }

--- a/src/internal/observable/bindCallbackInternals.ts
+++ b/src/internal/observable/bindCallbackInternals.ts
@@ -1,0 +1,121 @@
+/** @prettier */
+import { SchedulerLike } from '../types';
+import { isScheduler } from '../util/isScheduler';
+import { Observable } from '../Observable';
+import { subscribeOn } from '../operators/subscribeOn';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
+import { observeOn } from '../operators/observeOn';
+import { AsyncSubject } from '../AsyncSubject';
+
+export function bindCallbackInternals(
+  isNodeStyle: boolean,
+  callbackFunc: any,
+  resultSelector?: any,
+  scheduler?: SchedulerLike
+): (...args: any[]) => Observable<unknown> {
+  if (resultSelector) {
+    if (isScheduler(resultSelector)) {
+      scheduler = resultSelector;
+    } else {
+      // DEPRECATED PATH
+      // The user provided a result selector.
+      return function (this: any, ...args: any[]) {
+        return (bindCallbackInternals(isNodeStyle, callbackFunc, scheduler) as any)
+          .apply(this, args)
+          .pipe(mapOneOrManyArgs(resultSelector as any));
+      };
+    }
+  }
+
+  // If a scheduler was passed, use our `subscribeOn` and `observeOn` operators
+  // to compose that behavior for the user.
+  if (scheduler) {
+    return function (this: any, ...args: any[]) {
+      return (bindCallbackInternals(isNodeStyle, callbackFunc) as any)
+        .apply(this, args)
+        .pipe(subscribeOn(scheduler!), observeOn(scheduler!));
+    };
+  }
+
+  // We're using AsyncSubject, because it emits when it completes,
+  // and it will play the value to all late-arriving subscribers.
+  const subject = new AsyncSubject<any>();
+
+  return function (this: any, ...args: any[]): Observable<any> {
+    // If this is true, then we haven't called our function yet.
+    let uninitialized = true;
+    return new Observable((subscriber) => {
+      // Add our subscriber to the subject.
+      const subs = subject.subscribe(subscriber);
+
+      if (uninitialized) {
+        uninitialized = false;
+        // We're going to execute the bound function
+        // This bit is to signal that we are hitting the callback asychronously.
+        // Because we don't have any anti-"Zalgo" gaurantees with whatever
+        // function we are handed, we use this bit to figure out whether or not
+        // we are getting hit in a callback synchronously during our call.
+        let isAsync = false;
+
+        // This is used to signal that the callback completed synchronously.
+        let isComplete = false;
+
+        // Call our function that has a callback. If at any time during this
+        // call, an error is thrown, it will be caught by the Observable
+        // subscription process and sent to the consumer.
+        callbackFunc.apply(
+          // Pass the appropriate `this` context.
+          this,
+          [
+            // Pass the arguments.
+            ...args,
+            // And our callback handler.
+            (...results: any[]) => {
+              if (isNodeStyle) {
+                // If this is a node callback, shift the first value off of the
+                // results and check it, as it is the error argument. By shifting,
+                // we leave only the argument(s) we want to pass to the consumer.
+                const err = results.shift();
+                if (err != null) {
+                  subject.error(err);
+                  // If we've errored, we can stop processing this function
+                  // as there's nothing else to do. Just return to escape.
+                  return;
+                }
+              }
+              // If we have one argument, notify the consumer
+              // of it as a single value, otherwise, if there's more than one, pass
+              // them as an array. Note that if there are no arguments, `undefined`
+              // will be emitted.
+              subject.next(1 < results.length ? results : results[0]);
+              // Flip this flag, so we know we can complete it in the synchronous
+              // case below.
+              isComplete = true;
+              // If we're not asynchronous, we need to defer the `complete` call
+              // until after the call to the function is over. This is because an
+              // error could be thrown in the function after it calls our callback,
+              // and if that is the case, if we complete here, we are unable to notify
+              // the consumer than an error occured.
+              if (isAsync) {
+                subject.complete();
+              }
+            },
+          ]
+        );
+        // If we flipped `isComplete` during the call, we resolved synchronously,
+        // notify complete, because we skipped it in the callback to wait
+        // to make sure there were no errors during the call.
+        if (isComplete) {
+          subject.complete();
+        }
+
+        // We're no longer synchronous. If the callback is called at this point
+        // we can notify complete on the spot.
+        isAsync = true;
+      }
+
+      // Return the subscription fron adding our subscriber to the subject.
+      return subs;
+    });
+  };
+}


### PR DESCRIPTION
… code

- Add `bindCallbackInternals`, a base implementation for both creation methods
- Add a missing test to `bindNodeCallback` to catch an issue where the initial call to the provided function was not scheduled.
- Updates comments

This work effectively just copies and pastes the work from #5780 into a new function called `bindCallbackInternals`, and alters it a bit to account for the differences in the call patterns. Then it adds the use of `subscribeOn` to the scheduled code path, because `bindCallback` had a test that caught something that the tests for `bindNodeCallback` did not. Also adds that test for `bindNodeCallback`.