### PR TITLE
Fix tslint rules (plus a fix for `every`)

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -34,7 +34,7 @@ export declare class BehaviorSubject<T> extends Subject<T> {
     next(value: T): void;
 }
 
-export declare function bindCallback(callbackFunc: Function, resultSelector: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
+export declare function bindCallback(callbackFunc: (...args: any[]) => any, resultSelector: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
 export declare function bindCallback<R1, R2, R3, R4>(callbackFunc: (callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): () => Observable<any[]>;
 export declare function bindCallback<R1, R2, R3>(callbackFunc: (callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2, R3]>;
 export declare function bindCallback<R1, R2>(callbackFunc: (callback: (res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2]>;
@@ -67,9 +67,9 @@ export declare function bindCallback<A1, A2, A3, A4, A5, R1>(callbackFunc: (arg1
 export declare function bindCallback<A1, A2, A3, A4, A5>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: () => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<void>;
 export declare function bindCallback<A, R>(callbackFunc: (...args: Array<A | ((result: R) => any)>) => any, scheduler?: SchedulerLike): (...args: A[]) => Observable<R>;
 export declare function bindCallback<A, R>(callbackFunc: (...args: Array<A | ((...results: R[]) => any)>) => any, scheduler?: SchedulerLike): (...args: A[]) => Observable<R[]>;
-export declare function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
+export declare function bindCallback(callbackFunc: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
 
-export declare function bindNodeCallback(callbackFunc: Function, resultSelector: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
+export declare function bindNodeCallback(callbackFunc: (...args: any[]) => any, resultSelector: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
 export declare function bindNodeCallback<R1, R2, R3, R4>(callbackFunc: (callback: (err: any, res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
 export declare function bindNodeCallback<R1, R2, R3>(callbackFunc: (callback: (err: any, res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2, R3]>;
 export declare function bindNodeCallback<R1, R2>(callbackFunc: (callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2]>;
@@ -100,7 +100,7 @@ export declare function bindNodeCallback<A1, A2, A3, A4, A5, R1, R2, R3>(callbac
 export declare function bindNodeCallback<A1, A2, A3, A4, A5, R1, R2>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, res1: R1, res2: R2) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<[R1, R2]>;
 export declare function bindNodeCallback<A1, A2, A3, A4, A5, R1>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any, res1: R1) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<R1>;
 export declare function bindNodeCallback<A1, A2, A3, A4, A5>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<void>;
-export declare function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export declare function bindNodeCallback(callbackFunc: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
 
 export declare function combineLatest<O1 extends ObservableInput<any>, R>(sources: [O1], resultSelector: (v1: ObservedValueOf<O1>) => R, scheduler?: SchedulerLike): Observable<R>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, R>(sources: [O1, O2], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>) => R, scheduler?: SchedulerLike): Observable<R>;
@@ -164,7 +164,7 @@ export declare function combineLatest<O extends ObservableInput<any>>(...observa
 export declare function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>): Observable<R>;
 export declare function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
 export declare function combineLatest(sourcesObject: {}): Observable<never>;
-export declare function combineLatest<T, K extends keyof T>(sourcesObject: T): Observable<{
+export declare function combineLatest<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
 
@@ -208,7 +208,7 @@ export declare class ConnectableObservable<T> extends Observable<T> {
     refCount(): Observable<T>;
 }
 
-export declare type Cons<X, Y extends any[]> = ((arg: X, ...rest: Y) => any) extends ((...args: infer U) => any) ? U : never;
+export declare type Cons<X, Y extends any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
 
 export declare function defer<R extends ObservableInput<any>>(observableFactory: () => R): Observable<ObservedValueOf<R>>;
 
@@ -251,10 +251,10 @@ export declare function forkJoin<A, B, C, D, E>(sources: [ObservableInput<A>, Ob
 export declare function forkJoin<A, B, C, D, E, F>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>, ObservableInput<F>]): Observable<[A, B, C, D, E, F]>;
 export declare function forkJoin<A extends ObservableInput<any>[]>(sources: A): Observable<ObservedValueUnionFromArray<A>[]>;
 export declare function forkJoin(sourcesObject: {}): Observable<never>;
-export declare function forkJoin<T, K extends keyof T>(sourcesObject: T): Observable<{
+export declare function forkJoin<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
-export declare function forkJoin(...args: Array<ObservableInput<any> | Function>): Observable<any>;
+export declare function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
 export declare function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
 
 export declare function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
@@ -277,15 +277,15 @@ export interface GroupedObservable<K, T> extends Observable<T> {
     readonly key: K;
 }
 
-export declare type Head<X extends any[]> = ((...args: X) => any) extends ((arg: infer U, ...rest: any[]) => any) ? U : never;
+export declare type Head<X extends any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
 
 export declare function identity<T>(x: T): T;
 
 export declare function iif<T = never, F = never>(condition: () => boolean, trueResult?: SubscribableOrPromise<T>, falseResult?: SubscribableOrPromise<F>): Observable<T | F>;
 
-export declare type InteropObservable<T> = {
+export interface InteropObservable<T> {
     [Symbol.observable]: () => Subscribable<T>;
-};
+}
 
 export declare function interval(period?: number, scheduler?: SchedulerLike): Observable<number>;
 
@@ -408,10 +408,10 @@ export declare class Observable<T> implements Subscribable<T> {
     subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
     subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
     subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
-    toPromise<T>(this: Observable<T>): Promise<T | undefined>;
-    toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T | undefined>;
-    toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;
-    static create: Function;
+    toPromise(): Promise<T | undefined>;
+    toPromise(PromiseCtor: typeof Promise): Promise<T | undefined>;
+    toPromise(PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;
+    static create: (...args: any[]) => any;
 }
 
 export declare type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Iterable<T> | AsyncIterableIterator<T>;
@@ -465,7 +465,9 @@ export interface Operator<T, R> {
 export interface OperatorFunction<T, R> extends UnaryFunction<Observable<T>, Observable<R>> {
 }
 
-export declare function pairs<T>(obj: Object, scheduler?: SchedulerLike): Observable<[string, T]>;
+export declare function pairs<T>(obj: {
+    [s: string]: T;
+} | ArrayLike<T>, scheduler?: SchedulerLike): Observable<[string, T]>;
 
 export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
@@ -503,7 +505,7 @@ export declare function scheduled<T>(input: ObservableInput<T>, scheduler: Sched
 
 export declare class Scheduler implements SchedulerLike {
     now: () => number;
-    constructor(SchedulerAction: typeof Action, now?: () => number);
+    constructor(schedulerActionCtor: typeof Action, now?: () => number);
     schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay?: number, state?: T): Subscription;
     static now: () => number;
 }
@@ -539,7 +541,7 @@ export declare class Subject<T> extends Observable<T> implements SubscriptionLik
     lift<R>(operator: Operator<T, R>): Observable<R>;
     next(value: T): void;
     unsubscribe(): void;
-    static create: Function;
+    static create: (...args: any[]) => any;
 }
 
 export interface Subscribable<T> {
@@ -580,7 +582,7 @@ export interface SubscriptionLike extends Unsubscribable {
     unsubscribe(): void;
 }
 
-export declare type Tail<X extends any[]> = ((...args: X) => any) extends ((arg: any, ...rest: infer U) => any) ? U : never;
+export declare type Tail<X extends any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
 
 export declare type TeardownLogic = Subscription | Unsubscribable | (() => void) | void;
 
@@ -632,9 +634,9 @@ export declare type ValueFromArray<A> = A extends Array<infer T> ? T : never;
 
 export declare type ValueFromNotification<T> = T extends {
     kind: 'N' | 'E' | 'C';
-} ? (T extends NextNotification<any> ? (T extends {
+} ? T extends NextNotification<any> ? T extends {
     value: infer V;
-} ? V : undefined) : never) : never;
+} ? V : undefined : never : never;
 
 export declare class VirtualAction<T> extends AsyncAction<T> {
     protected active: boolean;
@@ -652,7 +654,7 @@ export declare class VirtualTimeScheduler extends AsyncScheduler {
     frame: number;
     index: number;
     maxFrames: number;
-    constructor(SchedulerAction?: typeof AsyncAction, maxFrames?: number);
+    constructor(schedulerActionCtor?: typeof AsyncAction, maxFrames?: number);
     flush(): void;
     static frameTimeFactor: number;
 }

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -465,9 +465,7 @@ export interface Operator<T, R> {
 export interface OperatorFunction<T, R> extends UnaryFunction<Observable<T>, Observable<R>> {
 }
 
-export declare function pairs<T>(obj: {
-    [s: string]: T;
-} | ArrayLike<T>, scheduler?: SchedulerLike): Observable<[string, T]>;
+export declare function pairs<T>(obj: Record<string, T> | ArrayLike<T>, scheduler?: SchedulerLike): Observable<[string, T]>;
 
 export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -69,7 +69,7 @@ export declare function debounceTime<T>(dueTime: number, scheduler?: SchedulerLi
 
 export declare function defaultIfEmpty<T, R = T>(defaultValue?: R): OperatorFunction<T, T | R>;
 
-export declare function delay<T>(delay: number | Date, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export declare function delay<T>(due: number | Date, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 
 export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<never>, subscriptionDelay?: Observable<any>): MonoTypeOperatorFunction<T>;
 export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>, subscriptionDelay?: Observable<any>): MonoTypeOperatorFunction<T>;

--- a/spec-dtslint/observables/bindCallback-spec.ts
+++ b/spec-dtslint/observables/bindCallback-spec.ts
@@ -260,12 +260,3 @@ describe('callbackFunc and 5 args' , () => {
     const o = bindCallback(fa5cb4) // $ExpectType (arg1: E, arg2: F, arg3: G, arg4: A, arg5: B) => Observable<any[]>
   });
 });
-
-describe('callbackFunc: Function type', () => {
-  const fn: Function = () => {};
-
-  it('should accept Function', () => {
-    const o = bindCallback(fn); // $ExpectType (...args: any[]) => Observable<any>
-  });
-
-});

--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -1,5 +1,6 @@
 import { fromEvent } from 'rxjs';
-import { B } from "../helpers";
+import { JQueryStyleEventEmitter } from '../../src/internal/observable/fromEvent';
+import { A, B } from "../helpers";
 
 declare const eventTargetSource: HTMLDocument;
 
@@ -14,13 +15,7 @@ declare const nodeCompatibleSource: {
   removeListener: (eventName: string, handler: (...args: any[]) => void) => void;
 };
 
-// Use handler types like those in @types/jquery. See:
-// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/847731ba1d7fa6db6b911c0e43aa0afe596e7723/types/jquery/misc.d.ts#L6395
-interface JQueryStyleSource<TContext, T> {
-  on: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
-  off: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
-};
-declare const jQueryStyleSource: JQueryStyleSource<any, any>;
+
 
 it('should support an event target source', () => {
   const a = fromEvent(eventTargetSource, "click"); // $ExpectType Observable<Event>
@@ -36,8 +31,8 @@ it('should support a node-compatible source', () => {
   const b = fromEvent<B>(nodeCompatibleSource, "something"); // $ExpectType Observable<B>
 });
 
-// TODO: uncomment when the fromEvent jQuery types are fixed
-// it('should support a jQuery-style source', () => {
-//   const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<unknown>
-//   const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>
-// });
+declare const jQueryStyleSource: JQueryStyleEventEmitter<A, B>;
+it('should support a jQuery-style source', () => {
+  const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<B>
+  const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>
+});

--- a/spec/operators/every-spec.ts
+++ b/spec/operators/every-spec.ts
@@ -32,6 +32,18 @@ describe('every operator', () => {
 
   });
 
+  it('should increment index on each call to the predicate', () => {
+    const indices: number[] = [];
+    of(1, 2, 3, 4).pipe(
+      every((_, i) => {
+        indices.push(i);
+        return true;
+      })
+    ).subscribe();
+
+    expect(indices).to.deep.equal([0, 1, 2, 3]);
+  });
+
   it('should accept thisArg with array observables', () => {
     const thisArg = {};
 

--- a/spec/util/createErrorClass-spec.ts
+++ b/spec/util/createErrorClass-spec.ts
@@ -18,7 +18,6 @@ describe('createErrorClass', () => {
     const err = new MySpecialError(123, 'Test');
     expect(err).to.be.an.instanceOf(Error);
     expect(err).to.be.an.instanceOf(MySpecialError);
-    expect(err.name).to.equal('MySpecialError');
     expect(err.constructor).to.equal(MySpecialError);
     expect(err.stack).to.be.a('string');
     expect(err.message).to.equal('Super special error!');

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -435,11 +435,11 @@ export class Observable<T> implements Subscribable<T> {
 
   /* tslint:disable:max-line-length */
   /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
-  toPromise<T>(this: Observable<T>): Promise<T | undefined>;
+  toPromise(): Promise<T | undefined>;
   /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
-  toPromise<T>(this: Observable<T>, PromiseCtor: typeof Promise): Promise<T | undefined>;
+  toPromise(PromiseCtor: typeof Promise): Promise<T | undefined>;
   /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
-  toPromise<T>(this: Observable<T>, PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;
+  toPromise(PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;
   /* tslint:enable:max-line-length */
 
   /**

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -49,7 +49,7 @@ export class Observable<T> implements Subscribable<T> {
    * @nocollapse
    * @deprecated use new Observable() instead
    */
-  static create: Function = <T>(subscribe?: (subscriber: Subscriber<T>) => TeardownLogic) => {
+  static create: (...args: any[]) => any = <T>(subscribe?: (subscriber: Subscriber<T>) => TeardownLogic) => {
     return new Observable<T>(subscribe);
   };
 

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -26,7 +26,7 @@ export class Scheduler implements SchedulerLike {
 
   public static now: () => number = dateTimestampProvider.now;
 
-  constructor(private SchedulerAction: typeof Action,
+  constructor(private schedulerActionCtor: typeof Action,
               now: () => number = Scheduler.now) {
     this.now = now;
   }
@@ -59,6 +59,6 @@ export class Scheduler implements SchedulerLike {
    * the scheduled work.
    */
   public schedule<T>(work: (this: SchedulerAction<T>, state?: T) => void, delay: number = 0, state?: T): Subscription {
-    return new this.SchedulerAction<T>(this, work).schedule(state, delay);
+    return new this.schedulerActionCtor<T>(this, work).schedule(state, delay);
   }
 }

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -31,7 +31,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
    * @nocollapse
    * @deprecated Recommended you do not use, will be removed at some point in the future. Plans for replacement still under discussion.
    */
-  static create: Function = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
+  static create: (...args: any[]) => any = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
   };
 

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -18,10 +18,11 @@ import { arrRemove } from './util/arrRemove';
  */
 export class Subscription implements SubscriptionLike {
   /** @nocollapse */
-  public static EMPTY: Subscription = (function (empty: any) {
+  public static EMPTY = (() => {
+    const empty = new Subscription();
     empty.closed = true;
     return empty;
-  })(new Subscription());
+  })();
 
   /**
    * A flag to indicate whether this Subscription has already been unsubscribed.

--- a/src/internal/ajax/errors.ts
+++ b/src/internal/ajax/errors.ts
@@ -56,7 +56,7 @@ export interface AjaxErrorCtor {
  */
 export const AjaxError: AjaxErrorCtor = createErrorClass(
   (_super) =>
-    function AjaxError(this: any, message: string, xhr: XMLHttpRequest, request: AjaxRequest) {
+    function AjaxErrorImpl(this: any, message: string, xhr: XMLHttpRequest, request: AjaxRequest) {
       this.message = message;
       this.name = 'AjaxError';
       this.xhr = xhr;
@@ -85,16 +85,6 @@ export interface AjaxTimeoutErrorCtor {
   new (xhr: XMLHttpRequest, request: AjaxRequest): AjaxTimeoutError;
 }
 
-const AjaxTimeoutErrorImpl = (() => {
-  function AjaxTimeoutErrorImpl(this: any, xhr: XMLHttpRequest, request: AjaxRequest) {
-    AjaxError.call(this, 'ajax timeout', xhr, request);
-    this.name = 'AjaxTimeoutError';
-    return this;
-  }
-  AjaxTimeoutErrorImpl.prototype = Object.create(AjaxError.prototype);
-  return AjaxTimeoutErrorImpl;
-})();
-
 /**
  * Thrown when an AJAX request timesout. Not to be confused with {@link TimeoutError}.
  *
@@ -105,4 +95,12 @@ const AjaxTimeoutErrorImpl = (() => {
  * @class AjaxTimeoutError
  * @see ajax
  */
-export const AjaxTimeoutError: AjaxTimeoutErrorCtor = AjaxTimeoutErrorImpl as any;
+export const AjaxTimeoutError: AjaxTimeoutErrorCtor = (() => {
+  function AjaxTimeoutErrorImpl(this: any, xhr: XMLHttpRequest, request: AjaxRequest) {
+    AjaxError.call(this, 'ajax timeout', xhr, request);
+    this.name = 'AjaxTimeoutError';
+    return this;
+  }
+  AjaxTimeoutErrorImpl.prototype = Object.create(AjaxError.prototype);
+  return AjaxTimeoutErrorImpl;
+})() as any;

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -4,7 +4,7 @@ import { bindCallbackInternals } from './bindCallbackInternals';
 
 // tslint:disable:max-line-length
 /** @deprecated resultSelector is no longer supported, use a mapping function. */
-export function bindCallback(callbackFunc: Function, resultSelector: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
+export function bindCallback(callbackFunc: (...args: any[]) => any, resultSelector: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
 
 export function bindCallback<R1, R2, R3, R4>(callbackFunc: (callback: (res1: R1, res2: R2, res3: R3, res4: R4, ...args: any[]) => any) => any, scheduler?: SchedulerLike): () => Observable<any[]>;
 export function bindCallback<R1, R2, R3>(callbackFunc: (callback: (res1: R1, res2: R2, res3: R3) => any) => any, scheduler?: SchedulerLike): () => Observable<[R1, R2, R3]>;
@@ -45,7 +45,7 @@ export function bindCallback<A1, A2, A3, A4, A5>(callbackFunc: (arg1: A1, arg2: 
 export function bindCallback<A, R>(callbackFunc: (...args: Array<A | ((result: R) => any)>) => any, scheduler?: SchedulerLike): (...args: A[]) => Observable<R>;
 export function bindCallback<A, R>(callbackFunc: (...args: Array<A | ((...results: R[]) => any)>) => any, scheduler?: SchedulerLike): (...args: A[]) => Observable<R[]>;
 
-export function bindCallback(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
+export function bindCallback(callbackFunc: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
 
 // tslint:enable:max-line-length
 

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -5,8 +5,8 @@ import { bindCallbackInternals } from './bindCallbackInternals';
 
 /** @deprecated resultSelector is deprecated, pipe to map instead */
 export function bindNodeCallback(
-  callbackFunc: Function,
-  resultSelector: Function,
+  callbackFunc: (...args: any[]) => any,
+  resultSelector: (...args: any[]) => any,
   scheduler?: SchedulerLike
 ): (...args: any[]) => Observable<any>;
 
@@ -146,7 +146,7 @@ export function bindNodeCallback<A1, A2, A3, A4, A5>(
   scheduler?: SchedulerLike
 ): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<void>;
 
-export function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
+export function bindNodeCallback(callbackFunc: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
 /**
  * Converts a Node.js-style callback API to a function that returns an
  * Observable.
@@ -253,8 +253,8 @@ export function bindNodeCallback(callbackFunc: Function, scheduler?: SchedulerLi
  * @name bindNodeCallback
  */
 export function bindNodeCallback(
-  callbackFunc: Function,
-  resultSelector?: Function | SchedulerLike,
+  callbackFunc: (...args: any[]) => any,
+  resultSelector?: ((...args: any[]) => any) | SchedulerLike,
   scheduler?: SchedulerLike
 ): (...args: any[]) => Observable<any> {
   return bindCallbackInternals(true, callbackFunc, resultSelector, scheduler);

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -359,7 +359,7 @@ export function combineLatest<R>(
 
 // combineLatest({})
 export function combineLatest(sourcesObject: {}): Observable<never>;
-export function combineLatest<T, K extends keyof T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /* tslint:enable:max-line-length */
 
@@ -504,10 +504,10 @@ export function combineLatest<O extends ObservableInput<any>, R>(...args: any[])
       scheduler,
       keys
         ? // A handler for scrubbing the array of args into a dictionary.
-          (args: any[]) => {
+          (values: any[]) => {
             const value: any = {};
-            for (let i = 0; i < args.length; i++) {
-              value[keys![i]] = args[i];
+            for (let i = 0; i < values.length; i++) {
+              value[keys![i]] = values[i];
             }
             return value;
           }

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -545,7 +545,7 @@ class CombineLatestSubscriber<T> extends Subscriber<T> {
 
 export function combineLatestInit(
   observables: ObservableInput<any>[],
-  scheduler: SchedulerLike | undefined = undefined,
+  scheduler: SchedulerLike | undefined,
   valueTransform: (values: any[]) => any = identity
 ) {
   return (subscriber: Subscriber<any>) => {

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -545,7 +545,7 @@ class CombineLatestSubscriber<T> extends Subscriber<T> {
 
 export function combineLatestInit(
   observables: ObservableInput<any>[],
-  scheduler: SchedulerLike | undefined,
+  scheduler?: SchedulerLike | undefined,
   valueTransform: (values: any[]) => any = identity
 ) {
   return (subscriber: Subscriber<any>) => {

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -545,7 +545,7 @@ class CombineLatestSubscriber<T> extends Subscriber<T> {
 
 export function combineLatestInit(
   observables: ObservableInput<any>[],
-  scheduler?: SchedulerLike | undefined,
+  scheduler?: SchedulerLike,
   valueTransform: (values: any[]) => any = identity
 ) {
   return (subscriber: Subscriber<any>) => {

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -278,7 +278,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
       }
     });
 
-    socket.onopen = (e: Event) => {
+    socket.onopen = (evt: Event) => {
       const { _socket } = this;
       if (!_socket) {
         socket!.close();
@@ -287,7 +287,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
       }
       const { openObserver } = this._config;
       if (openObserver) {
-        openObserver.next(e);
+        openObserver.next(evt);
       }
 
       const queue = this.destination;
@@ -303,13 +303,13 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
             }
           }
         },
-        (e) => {
+        (err) => {
           const { closingObserver } = this._config;
           if (closingObserver) {
             closingObserver.next(undefined);
           }
-          if (e && e.code) {
-            socket!.close(e.code, e.reason);
+          if (err && err.code) {
+            socket!.close(err.code, err.reason);
           } else {
             observer.error(new TypeError(WEBSOCKETSUBJECT_INVALID_ERROR_OBJECT));
           }

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -189,7 +189,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
   }
 
   lift<R>(operator: Operator<T, R>): WebSocketSubject<R> {
-    const sock = new WebSocketSubject<R>(this._config as WebSocketSubjectConfig<any>, <any> this.destination);
+    const sock = new WebSocketSubject<R>(this._config as WebSocketSubjectConfig<any>, this.destination as any);
     sock.operator = operator;
     sock.source = this;
     return sock;
@@ -326,7 +326,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
       ) as Subscriber<any>;
 
       if (queue && queue instanceof ReplaySubject) {
-        subscription.add((<ReplaySubject<T>>queue).subscribe(this.destination));
+        subscription.add((queue as ReplaySubject<T>).subscribe(this.destination));
       }
     };
 

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -172,7 +172,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
       if (typeof urlConfigOrSource === 'string') {
         config.url = urlConfigOrSource;
       } else {
-        for (let key in urlConfigOrSource) {
+        for (const key in urlConfigOrSource) {
           if (urlConfigOrSource.hasOwnProperty(key)) {
             (config as any)[key] = (urlConfigOrSource as any)[key];
           }

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -60,7 +60,7 @@ export function forkJoin(sourcesObject: {}): Observable<never>;
 export function forkJoin<T, K extends keyof T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /** @deprecated resultSelector is deprecated, pipe to map instead */
-export function forkJoin(...args: Array<ObservableInput<any> | Function>): Observable<any>;
+export function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
 /** @deprecated Use the version that takes an array of Observables instead */
 export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
 

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -57,7 +57,7 @@ export function forkJoin<A extends ObservableInput<any>[]>(sources: A): Observab
 
 // forkJoin({})
 export function forkJoin(sourcesObject: {}): Observable<never>;
-export function forkJoin<T, K extends keyof T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /** @deprecated resultSelector is deprecated, pipe to map instead */
 export function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
@@ -183,8 +183,8 @@ function forkJoinInternal(sources: ObservableInput<any>[], keys: string[] | null
     const values = new Array(len);
     let completed = 0;
     let emitted = 0;
-    for (let i = 0; i < len; i++) {
-      const source = innerFrom(sources[i]);
+    for (let sourceIndex = 0; sourceIndex < len; sourceIndex++) {
+      const source = innerFrom(sources[sourceIndex]);
       let hasValue = false;
       subscriber.add(
         source.subscribe({
@@ -193,7 +193,7 @@ function forkJoinInternal(sources: ObservableInput<any>[], keys: string[] | null
               hasValue = true;
               emitted++;
             }
-            values[i] = value;
+            values[sourceIndex] = value;
           },
           error: (err) => subscriber.error(err),
           complete: () => {

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -21,9 +21,11 @@ export interface NodeCompatibleEventEmitter {
   removeListener: (eventName: string, handler: NodeEventHandler) => void | {};
 }
 
-export interface JQueryStyleEventEmitter {
-  on: (eventName: string, handler: (event: any) => any) => void;
-  off: (eventName: string, handler: (event: any) => any) => void;
+// Use handler types like those in @types/jquery. See:
+// https://github.com/DefinitelyTyped/DefinitelyTyped/blob/847731ba1d7fa6db6b911c0e43aa0afe596e7723/types/jquery/misc.d.ts#L6395
+export interface JQueryStyleEventEmitter<TContext, T> {
+  on: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
+  off: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
 }
 
 export interface HasEventTargetAddRemove<E> {
@@ -31,7 +33,11 @@ export interface HasEventTargetAddRemove<E> {
   removeEventListener(type: string, listener?: ((evt: E) => void) | null, options?: EventListenerOptions | boolean): void;
 }
 
-export type EventTargetLike<T> = HasEventTargetAddRemove<T> | NodeStyleEventEmitter | NodeCompatibleEventEmitter | JQueryStyleEventEmitter;
+export type EventTargetLike<T> =
+  | HasEventTargetAddRemove<T>
+  | NodeStyleEventEmitter
+  | NodeCompatibleEventEmitter
+  | JQueryStyleEventEmitter<any, T>;
 
 export type FromEventTarget<T> = EventTargetLike<T> | ArrayLike<EventTargetLike<T>>;
 
@@ -228,7 +234,7 @@ function isNodeStyleEventEmitter(sourceObj: any): sourceObj is NodeStyleEventEmi
   return isFunction(sourceObj.addListener) && isFunction(sourceObj.removeListener);
 }
 
-function isJQueryStyleEventEmitter(sourceObj: any): sourceObj is JQueryStyleEventEmitter {
+function isJQueryStyleEventEmitter(sourceObj: any): sourceObj is JQueryStyleEventEmitter<any, any> {
   return isFunction(sourceObj.on) && isFunction(sourceObj.off);
 }
 

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -22,8 +22,8 @@ export interface NodeCompatibleEventEmitter {
 }
 
 export interface JQueryStyleEventEmitter {
-  on: (eventName: string, handler: Function) => void;
-  off: (eventName: string, handler: Function) => void;
+  on: (eventName: string, handler: (event: any) => any) => void;
+  off: (eventName: string, handler: (event: any) => any) => void;
 }
 
 export interface HasEventTargetAddRemove<E> {

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -214,7 +214,7 @@ export function fromEvent<T>(
     }
 
     if (isArrayLike(target)) {
-      return (mergeMap((target: any) => fromEvent(target, eventName, options as any))(internalFromArray(target)) as Observable<
+      return (mergeMap((subTarget: any) => fromEvent(subTarget, eventName, options as any))(internalFromArray(target)) as Observable<
         T
       >).subscribe(subscriber);
     }

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -344,7 +344,7 @@ export function generate<T, S>(
 
   // TODO: Remove this as we move away from deprecated signatures
   // and move towards a configuration object argument.
-  if (arguments.length == 1) {
+  if (arguments.length === 1) {
     // If we only have one argument, we can assume it is a configuration object.
     // Note that folks not using TypeScript may trip over this.
     ({

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -56,6 +56,6 @@ import { from } from './from';
  * [key, value] pairs from the object.
  * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
  */
-export function pairs<T>(obj: { [s: string]: T } | ArrayLike<T>, scheduler?: SchedulerLike): Observable<[string, T]> {
+export function pairs<T>(obj: Record<string, T> | ArrayLike<T>, scheduler?: SchedulerLike): Observable<[string, T]> {
   return from(Object.entries(obj), scheduler as any);
 }

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -56,6 +56,6 @@ import { from } from './from';
  * [key, value] pairs from the object.
  * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
  */
-export function pairs<T>(obj: Object, scheduler?: SchedulerLike): Observable<[string, T]> {
+export function pairs<T>(obj: { [s: string]: T } | ArrayLike<T>, scheduler?: SchedulerLike): Observable<[string, T]> {
   return from(Object.entries(obj), scheduler as any);
 }

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -204,12 +204,12 @@ export function zip<O extends ObservableInput<any>, R>(
         // Loop over our sources and subscribe to each one. The index `i` is
         // especially important here, because we use it in closures below to
         // access the related buffers and completion properties
-        for (let i = 0; !subscriber.closed && i < sources.length; i++) {
-          innerFrom(sources[i]).subscribe(
+        for (let sourceIndex = 0; !subscriber.closed && sourceIndex < sources.length; sourceIndex++) {
+          innerFrom(sources[sourceIndex]).subscribe(
             new OperatorSubscriber(
               subscriber,
               (value) => {
-                buffers[i].push(value);
+                buffers[sourceIndex].push(value);
                 // if every buffer has at least one value in it, then we
                 // can shift out the oldest value from each buffer and emit
                 // them as an array.
@@ -230,11 +230,11 @@ export function zip<O extends ObservableInput<any>, R>(
               () => {
                 // This source completed. Mark it as complete so we can check it later
                 // if we have to.
-                completed[i] = true;
+                completed[sourceIndex] = true;
                 // But, if this complete source has nothing in its buffer, then we
                 // can complete the result, because we can't possibly have any more
                 // values from this to zip together with the oterh values.
-                !buffers[i].length && subscriber.complete();
+                !buffers[sourceIndex].length && subscriber.complete();
               }
             )
           );

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -214,7 +214,7 @@ export function zip<O extends ObservableInput<any>, R>(
                 // can shift out the oldest value from each buffer and emit
                 // them as an array.
                 if (buffers.every((buffer) => buffer.length)) {
-                  let result: any = buffers.map((buffer) => buffer.shift()!);
+                  const result: any = buffers.map((buffer) => buffer.shift()!);
                   // Emit the array. If theres' a result selector, use that.
                   subscriber.next(resultSelector ? resultSelector(...result) : result);
                   // If any one of the sources is both complete and has an empty buffer

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -45,24 +45,24 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
   return operate((source, subscriber) => {
-    let buffer: T[] = [];
+    let currentBuffer: T[] = [];
 
     // Subscribe to our source.
-    source.subscribe(new OperatorSubscriber(subscriber, (value) => buffer.push(value)));
+    source.subscribe(new OperatorSubscriber(subscriber, (value) => currentBuffer.push(value)));
 
     // Subscribe to the closing notifier.
     closingNotifier.subscribe(
       new OperatorSubscriber(subscriber, () => {
         // Start a new buffer and emit the previous one.
-        const b = buffer;
-        buffer = [];
+        const b = currentBuffer;
+        currentBuffer = [];
         subscriber.next(b);
       })
     );
 
     return () => {
       // Ensure buffered values are released on teardown.
-      buffer = null!;
+      currentBuffer = null!;
     };
   });
 }

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -56,5 +56,5 @@ import { reduce } from './reduce';
  */
 
 export function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number> {
-  return reduce((count, value, i) => (!predicate || predicate(value, i) ? count + 1 : count), 0);
+  return reduce((total, value, i) => (!predicate || predicate(value, i) ? total + 1 : total), 0);
 }

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -45,14 +45,14 @@ import { timer } from '../observable/timer';
  * @see {@link debounceTime}
  * @see {@link delayWhen}
  *
- * @param {number|Date} delay The delay duration in milliseconds (a `number`) or
+ * @param {number|Date} due The delay duration in milliseconds (a `number`) or
  * a `Date` until which the emission of the source items is delayed.
  * @param {SchedulerLike} [scheduler=async] The {@link SchedulerLike} to use for
  * managing the timers that handle the time-shift for each item.
  * @return {Observable} An Observable that delays the emissions of the source
  * Observable by the specified timeout or Date.
  */
-export function delay<T>(delay: number | Date, scheduler: SchedulerLike = asyncScheduler): MonoTypeOperatorFunction<T> {
-  const duration = timer(delay, scheduler);
+export function delay<T>(due: number | Date, scheduler: SchedulerLike = asyncScheduler): MonoTypeOperatorFunction<T> {
+  const duration = timer(due, scheduler);
   return delayWhen(() => duration);
 }

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -39,7 +39,7 @@ export function every<T>(
       new OperatorSubscriber(
         subscriber,
         (value) => {
-          if (!predicate.call(thisArg, value, index, source)) {
+          if (!predicate.call(thisArg, value, index++, source)) {
             subscriber.next(false);
             subscriber.complete();
           }

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -217,7 +217,7 @@ export function groupBy<T, K, R>(
      * @param key The key of the group
      * @param groupSubject The subject that fuels the group
      */
-    function createGroupedObservable<K, T>(key: K, groupSubject: Subject<any>) {
+    function createGroupedObservable(key: K, groupSubject: Subject<any>) {
       const result: any = new Observable<T>((groupSubscriber) => {
         groupBySourceSubscriber.activeGroups++;
         const innerSub = groupSubject.subscribe(groupSubscriber);

--- a/src/internal/operators/mergeInternals.ts
+++ b/src/internal/operators/mergeInternals.ts
@@ -96,11 +96,11 @@ export function mergeInternals<T, R>(
           // next conditional, if there were any more inner subscriptions
           // to start.
           while (buffer.length && active < concurrent) {
-            const value = buffer.shift()!;
+            const bufferedValue = buffer.shift()!;
             // Particularly for `expand`, we need to check to see if a scheduler was provided
             // for when we want to start our inner subscription. Otherwise, we just start
             // are next inner subscription.
-            innerSubScheduler ? subscriber.add(innerSubScheduler.schedule(() => doInnerSub(value))) : doInnerSub(value);
+            innerSubScheduler ? subscriber.add(innerSubScheduler.schedule(() => doInnerSub(bufferedValue))) : doInnerSub(bufferedValue);
           }
           // Check to see if we can complete, and complete if so.
           checkComplete();

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -95,7 +95,7 @@ export function refCount<T>(): MonoTypeOperatorFunction<T> {
       //      to the shared connection Subscription
       ///
 
-      const sharedConnection = (<any>source)._connection;
+      const sharedConnection = (source as any)._connection;
       const conn = connection;
       connection = null;
 

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -103,7 +103,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
           // Cancel the previous inner subscription if there was one
           innerSubscriber?.unsubscribe();
           let innerIndex = 0;
-          let outerIndex = index++;
+          const outerIndex = index++;
           // Start the next inner subscription
           innerFrom(project(value, outerIndex)).subscribe(
             (innerSubscriber = new OperatorSubscriber(

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -80,7 +80,7 @@ export function throttle<T>(
       }
     };
 
-    const throttle = (value: T) =>
+    const startThrottle = (value: T) =>
       (throttled = innerFrom(durationSelector(value)).subscribe(
         new OperatorSubscriber(subscriber, throttlingDone, undefined, throttlingDone)
       ));
@@ -88,7 +88,7 @@ export function throttle<T>(
     const send = () => {
       if (hasValue) {
         subscriber.next(sendValue!);
-        !isComplete && throttle(sendValue!);
+        !isComplete && startThrottle(sendValue!);
       }
       hasValue = false;
       sendValue = null;
@@ -105,7 +105,7 @@ export function throttle<T>(
         (value) => {
           hasValue = true;
           sendValue = value;
-          !(throttled && !throttled.closed) && (leading ? send() : throttle(value));
+          !(throttled && !throttled.closed) && (leading ? send() : startThrottle(value));
         },
         undefined,
         () => {

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -88,7 +88,7 @@ export interface TimeoutErrorCtor {
  */
 export const TimeoutError: TimeoutErrorCtor = createErrorClass(
   (_super) =>
-    function TimeoutError(this: any, info: TimeoutInfo<any> | null = null) {
+    function TimeoutErrorImpl(this: any, info: TimeoutInfo<any> | null = null) {
       _super(this);
       this.message = 'Timeout has occurred';
       this.name = 'TimeoutError';

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -87,7 +87,7 @@ export function timeoutWith<T, R>(
   scheduler?: SchedulerLike
 ): OperatorFunction<T, T | R> {
   let first: number | Date | undefined;
-  let each: number | undefined = undefined;
+  let each: number | undefined;
   let _with: () => ObservableInput<R>;
   scheduler = scheduler ?? async;
 

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -56,11 +56,11 @@ export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T
     /**
      * Subscribes to one of our two observables in this operator in the same way,
      * only allowing for different behaviors with the next handler.
-     * @param source The observable to subscribe to.
+     * @param sourceOrNotifier The observable to subscribe to.
      * @param next The next handler to use with the subscription
      */
-    const windowSubscribe = (source: Observable<any>, next: (value: any) => void) =>
-      source.subscribe(
+    const windowSubscribe = (sourceOrNotifier: Observable<any>, next: (value: any) => void) =>
+      sourceOrNotifier.subscribe(
         new OperatorSubscriber(
           subscriber,
           next,

--- a/src/internal/scheduler/AnimationFrameScheduler.ts
+++ b/src/internal/scheduler/AnimationFrameScheduler.ts
@@ -9,9 +9,9 @@ export class AnimationFrameScheduler extends AsyncScheduler {
 
     const {actions} = this;
     let error: any;
-    let index: number = -1;
+    let index = -1;
     action = action || actions.shift()!;
-    let count: number = actions.length;
+    const count = actions.length;
 
     do {
       if (error = action.execute(action.state, action.delay)) {

--- a/src/internal/scheduler/AsapScheduler.ts
+++ b/src/internal/scheduler/AsapScheduler.ts
@@ -9,9 +9,9 @@ export class AsapScheduler extends AsyncScheduler {
 
     const {actions} = this;
     let error: any;
-    let index: number = -1;
+    let index = -1;
     action = action || actions.shift()!;
-    let count: number = actions.length;
+    const count = actions.length;
 
     do {
       if (error = action.execute(action.state, action.delay)) {

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -117,7 +117,7 @@ export class AsyncAction<T> extends Action<T> {
 
   protected _execute(state: T, _delay: number): any {
     let errored: boolean = false;
-    let errorValue: any = undefined;
+    let errorValue: any;
     try {
       this.work(state);
     } catch (e) {

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -42,7 +42,8 @@ export class VirtualTimeScheduler extends AsyncScheduler {
   public flush(): void {
 
     const {actions, maxFrames} = this;
-    let error: any, action: AsyncAction<any> | undefined;
+    let error: any;
+    let action: AsyncAction<any> | undefined;
 
     while ((action = actions[0]) && action.delay <= maxFrames) {
       actions.shift();

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -26,12 +26,12 @@ export class VirtualTimeScheduler extends AsyncScheduler {
    * This creates an instance of a `VirtualTimeScheduler`. Experts only. The signature of
    * this constructor is likely to change in the long run.
    *
-   * @param SchedulerAction The type of Action to initialize when initializing actions during scheduling.
+   * @param schedulerActionCtor The type of Action to initialize when initializing actions during scheduling.
    * @param maxFrames The maximum number of frames to process before stopping. Used to prevent endless flush cycles.
    */
-  constructor(SchedulerAction: typeof AsyncAction = VirtualAction as any,
+  constructor(schedulerActionCtor: typeof AsyncAction = VirtualAction as any,
               public maxFrames: number = Infinity) {
-    super(SchedulerAction, () => this.frame);
+    super(schedulerActionCtor, () => this.frame);
   }
 
   /**

--- a/src/internal/scheduler/animationFrameProvider.ts
+++ b/src/internal/scheduler/animationFrameProvider.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { Subscription } from '../Subscription';
 
-type AnimationFrameProvider = {
+interface AnimationFrameProvider {
   schedule(callback: FrameRequestCallback): Subscription;
   requestAnimationFrame: typeof requestAnimationFrame;
   cancelAnimationFrame: typeof cancelAnimationFrame;
@@ -11,7 +11,7 @@ type AnimationFrameProvider = {
         cancelAnimationFrame: typeof cancelAnimationFrame;
       }
     | undefined;
-};
+}
 
 export const animationFrameProvider: AnimationFrameProvider = {
   // When accessing the delegate, use the variable rather than `this` so that

--- a/src/internal/scheduler/immediateProvider.ts
+++ b/src/internal/scheduler/immediateProvider.ts
@@ -5,7 +5,7 @@ const { setImmediate, clearImmediate } = Immediate;
 type SetImmediateFunction = (handler: () => void, ...args: any[]) => number;
 type ClearImmediateFunction = (handle: number) => void;
 
-type ImmediateProvider = {
+interface ImmediateProvider {
   setImmediate: SetImmediateFunction;
   clearImmediate: ClearImmediateFunction;
   delegate:
@@ -14,7 +14,7 @@ type ImmediateProvider = {
         clearImmediate: ClearImmediateFunction;
       }
     | undefined;
-};
+}
 
 export const immediateProvider: ImmediateProvider = {
   // When accessing the delegate, use the variable rather than `this` so that

--- a/src/internal/scheduler/intervalProvider.ts
+++ b/src/internal/scheduler/intervalProvider.ts
@@ -2,7 +2,7 @@
 type SetIntervalFunction = (handler: () => void, timeout?: number, ...args: any[]) => number;
 type ClearIntervalFunction = (handle: number) => void;
 
-type IntervalProvider = {
+interface IntervalProvider {
   setInterval: SetIntervalFunction;
   clearInterval: ClearIntervalFunction;
   delegate:
@@ -11,7 +11,7 @@ type IntervalProvider = {
         clearInterval: ClearIntervalFunction;
       }
     | undefined;
-};
+}
 
 export const intervalProvider: IntervalProvider = {
   // When accessing the delegate, use the variable rather than `this` so that

--- a/src/internal/testing/ColdObservable.ts
+++ b/src/internal/testing/ColdObservable.ts
@@ -44,8 +44,8 @@ export class ColdObservable<T> extends Observable<T> implements SubscriptionLogg
       subscriber.add(
         this.scheduler.schedule(
           (state) => {
-            const { message, subscriber } = state!;
-            observeNotification(message.notification, subscriber);
+            const { message: { notification }, subscriber: destination } = state!;
+            observeNotification(notification, destination);
           },
           message.frame,
           { message, subscriber }

--- a/src/internal/testing/HotObservable.ts
+++ b/src/internal/testing/HotObservable.ts
@@ -44,13 +44,13 @@ export class HotObservable<T> extends Subject<T> implements SubscriptionLoggable
     const subject = this;
     const messagesLength = subject.messages.length;
     /* tslint:disable:no-var-keyword */
-    for (var i = 0; i < messagesLength; i++) {
+    for (let i = 0; i < messagesLength; i++) {
       (() => {
-        var message = subject.messages[i];
+        const { notification, frame } = subject.messages[i];
         /* tslint:enable */
         subject.scheduler.schedule(() => {
-          observeNotification(message.notification, subject);
-        }, message.frame);
+          observeNotification(notification, subject);
+        }, frame);
       })();
     }
   }

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -482,7 +482,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     // animate run helper.
 
     let lastHandle = 0;
-    let map = new Map<number, {
+    const map = new Map<number, {
       due: number;
       duration: number;
       handle: number;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,9 +1,12 @@
+/** @prettier */
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
 
 /** OPERATOR INTERFACES */
 
-export interface UnaryFunction<T, R> { (source: T): R; }
+export interface UnaryFunction<T, R> {
+  (source: T): R;
+}
 
 export interface OperatorFunction<T, R> extends UnaryFunction<Observable<T>, Observable<R>> {}
 
@@ -78,7 +81,9 @@ export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Itera
 /** @deprecated use {@link InteropObservable } */
 export type ObservableLike<T> = InteropObservable<T>;
 
-export type InteropObservable<T> = { [Symbol.observable]: () => Subscribable<T>; };
+export interface InteropObservable<T> {
+  [Symbol.observable]: () => Subscribable<T>;
+}
 
 /** NOTIFICATIONS */
 
@@ -186,10 +191,7 @@ export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
  * If you pass in `[Observable<string>, Observable<number>]` you would
  * get back a type of `string | number`.
  */
-export type ObservedValueUnionFromArray<X> =
-  X extends Array<ObservableInput<infer T>>
-    ? T
-    : never;
+export type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
 
 /** @deprecated use {@link ObservedValueUnionFromArray} */
 export type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
@@ -200,37 +202,25 @@ export type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
  * `[Observable<string>, Observable<number>]` you would get back a type
  * of `[string, number]`.
  */
-export type ObservedValueTupleFromArray<X> =
-  X extends readonly ObservableInput<any>[]
-    ? { [K in keyof X]: ObservedValueOf<X[K]> }
-    : never;
+export type ObservedValueTupleFromArray<X> = X extends readonly ObservableInput<any>[] ? { [K in keyof X]: ObservedValueOf<X[K]> } : never;
 
 /**
  * Constructs a new tuple with the specified type at the head.
  * If you declare `Cons<A, [B, C]>` you will get back `[A, B, C]`.
  */
-export type Cons<X, Y extends any[]> =
-  ((arg: X, ...rest: Y) => any) extends ((...args: infer U) => any)
-    ? U
-    : never;
+export type Cons<X, Y extends any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
 
 /**
  * Extracts the head of a tuple.
  * If you declare `Head<[A, B, C]>` you will get back `A`.
  */
-export type Head<X extends any[]> =
-  ((...args: X) => any) extends ((arg: infer U, ...rest: any[]) => any)
-    ? U
-    : never;
+export type Head<X extends any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
 
 /**
  * Extracts the tail of a tuple.
  * If you declare `Tail<[A, B, C]>` you will get back `[B, C]`.
  */
-export type Tail<X extends any[]> =
-((...args: X) => any) extends ((arg: any, ...rest: infer U) => any)
-  ? U
-  : never;
+export type Tail<X extends any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
 
 /**
  * Extracts the generic value from an Array type.
@@ -242,8 +232,10 @@ export type ValueFromArray<A> = A extends Array<infer T> ? T : never;
 /**
  * Gets the value type from an {@link ObservableNotification}, if possible.
  */
-export type ValueFromNotification<T> = T extends { kind: 'N'|'E'|'C' } ?
-  (T extends NextNotification<any> ?
-    (T extends { value: infer V } ? V : undefined )
-  : never)
+export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
+  ? T extends NextNotification<any>
+    ? T extends { value: infer V }
+      ? V
+      : undefined
+    : never
   : never;

--- a/src/internal/util/ArgumentOutOfRangeError.ts
+++ b/src/internal/util/ArgumentOutOfRangeError.ts
@@ -19,8 +19,9 @@ export interface ArgumentOutOfRangeErrorCtor {
  */
 export const ArgumentOutOfRangeError: ArgumentOutOfRangeErrorCtor = createErrorClass(
   (_super) =>
-    function ArgumentOutOfRangeError(this: any) {
+    function ArgumentOutOfRangeErrorImpl(this: any) {
       _super(this);
+      this.name = 'ArgumentOutOfRangeError';
       this.message = 'argument out of range';
     }
 );

--- a/src/internal/util/EmptyError.ts
+++ b/src/internal/util/EmptyError.ts
@@ -17,7 +17,8 @@ export interface EmptyErrorCtor {
  *
  * @class EmptyError
  */
-export const EmptyError: EmptyErrorCtor = createErrorClass((_super) => function EmptyError(this: any) {
+export const EmptyError: EmptyErrorCtor = createErrorClass((_super) => function EmptyErrorImpl(this: any) {
   _super(this);
+  this.name = 'EmptyError';
   this.message = 'no elements in sequence';
 });

--- a/src/internal/util/NotFoundError.ts
+++ b/src/internal/util/NotFoundError.ts
@@ -17,8 +17,9 @@ export interface NotFoundErrorCtor {
  */
 export const NotFoundError: NotFoundErrorCtor = createErrorClass(
   (_super) =>
-    function NotFoundError(this: any, message: string) {
+    function NotFoundErrorImpl(this: any, message: string) {
       _super(this);
+      this.name = 'NotFoundError';
       this.message = message;
     }
 );

--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -18,8 +18,9 @@ export interface ObjectUnsubscribedErrorCtor {
  */
 export const ObjectUnsubscribedError: ObjectUnsubscribedErrorCtor = createErrorClass(
   (_super) =>
-    function ObjectUnsubscribedError(this: any) {
+    function ObjectUnsubscribedErrorImpl(this: any) {
       _super(this);
+      this.name = 'ObjectUnsubscribedError';
       this.message = 'object unsubscribed';
     }
 );

--- a/src/internal/util/SequenceError.ts
+++ b/src/internal/util/SequenceError.ts
@@ -17,8 +17,9 @@ export interface SequenceErrorCtor {
  */
 export const SequenceError: SequenceErrorCtor = createErrorClass(
   (_super) =>
-    function SequenceError(this: any, message: string) {
+    function SequenceErrorImpl(this: any, message: string) {
       _super(this);
+      this.name = 'SequenceError';
       this.message = message;
     }
 );

--- a/src/internal/util/UnsubscriptionError.ts
+++ b/src/internal/util/UnsubscriptionError.ts
@@ -15,7 +15,7 @@ export interface UnsubscriptionErrorCtor {
  */
 export const UnsubscriptionError: UnsubscriptionErrorCtor = createErrorClass(
   (_super) =>
-    function UnsubscriptionError(this: any, errors: (Error | string)[]) {
+    function UnsubscriptionErrorImpl(this: any, errors: (Error | string)[]) {
       _super(this);
       this.message = errors
         ? `${errors.length} errors occurred during unsubscription:

--- a/src/internal/util/argsArgArrayOrObject.ts
+++ b/src/internal/util/argsArgArrayOrObject.ts
@@ -27,6 +27,6 @@ export function argsArgArrayOrObject<T, O extends Record<string, T>>(args: T[] |
   return { args: args as T[], keys: null };
 }
 
-function isPOJO(obj: any): obj is {} {
+function isPOJO(obj: any): obj is object {
   return obj && typeof obj === 'object' && getPrototypeOf(obj) === objectProto;
 }

--- a/src/internal/util/argsArgArrayOrObject.ts
+++ b/src/internal/util/argsArgArrayOrObject.ts
@@ -27,6 +27,6 @@ export function argsArgArrayOrObject<T, O extends Record<string, T>>(args: T[] |
   return { args: args as T[], keys: null };
 }
 
-function isPOJO(obj: any): obj is Object {
+function isPOJO(obj: any): obj is {} {
   return obj && typeof obj === 'object' && getPrototypeOf(obj) === objectProto;
 }

--- a/src/internal/util/createErrorClass.ts
+++ b/src/internal/util/createErrorClass.ts
@@ -7,13 +7,11 @@
  * as well as other built-in types: https://github.com/Microsoft/TypeScript/issues/12123
  *
  * @param createImpl A factory function to create the actual constructor implementation. The returned
- * function should be a named function that calls `_super` internally. The name of the function
- * will be the name of the error.
+ * function should be a named function that calls `_super` internally.
  */
 export function createErrorClass<T>(createImpl: (_super: any) => any): T {
   const _super = (instance: any) => {
     Error.call(instance);
-    instance.name = instance.constructor.name;
     instance.stack = new Error().stack;
   };
 

--- a/src/internal/util/isFunction.ts
+++ b/src/internal/util/isFunction.ts
@@ -4,6 +4,6 @@
  * Returns true if the object is a function.
  * @param value The value to check
  */
-export function isFunction(value: any): value is Function {
+export function isFunction(value: any): value is (...args: any[]) => any {
   return typeof value === 'function';
 }

--- a/src/internal/util/isObject.ts
+++ b/src/internal/util/isObject.ts
@@ -1,3 +1,0 @@
-export function isObject(x: any): x is Object {
-  return x !== null && typeof x === 'object';
-}

--- a/src/internal/util/throwUnobservableError.ts
+++ b/src/internal/util/throwUnobservableError.ts
@@ -1,5 +1,4 @@
 /** @prettier */
-import { isObject } from './isObject';
 
 /**
  * Creates the TypeError to throw if an invalid object is passed to `from` or `scheduled`.
@@ -9,7 +8,7 @@ export function createInvalidObservableTypeError(input: any) {
   // TODO: We should create error codes that can be looked up, so this can be less verbose.
   return new TypeError(
     `You provided ${
-      isObject(input) ? 'an invalid object' : `'${input}'`
+      input !== null && typeof input === 'object' ? 'an invalid object' : `'${input}'`
     } where a stream was expected. You can provide an Observable, Promise, Array, AsyncIterable, or Iterable.`
   );
 }

--- a/tslint.json
+++ b/tslint.json
@@ -12,7 +12,6 @@
     "member-access": [false],
     "array-type": [false],
     "no-empty-interface": [false],
-    "interface-over-type-literal": [false],
     "member-ordering": [false],
     "only-arrow-functions": [false],
     "callable-types": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -13,7 +13,6 @@
     "array-type": [false],
     "no-empty-interface": [false],
     "member-ordering": [false],
-    "only-arrow-functions": [false],
     "callable-types": [false],
     "object-literal-sort-keys": [false],
     "no-this-assignment": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -19,6 +19,8 @@
     "no-this-assignment": [false],
     "no-conditional-assignment": [false],
     "max-classes-per-file": [false, 1000],
+    // TODO: unified signatures not be disabled, but it will
+    // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
     "no-console": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,6 @@
     "unified-signatures": [false],
     "jsdoc-format": [false],
     "ban-comma-operator": [false],
-    "radix": [false],
     "no-string-literal": [false],
     "no-string-throw": [false],
     "arrow-return-shorthand": [false]

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,6 @@
     // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
-    "no-object-literal-type-assertion": [false],
     "ban-comma-operator": [false],
     "no-submodule-imports": [false],
     "no-implicit-dependencies": [true, "dev", ["rxjs", "chai"]],

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,6 @@
     // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
-    "prefer-conditional-expression": [false],
     "no-object-literal-type-assertion": [false],
     "ban-comma-operator": [false],
     "no-submodule-imports": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -22,7 +22,6 @@
     "no-this-assignment": [false],
     "one-variable-per-declaration": [false],
     "no-conditional-assignment": [false],
-    "no-unnecessary-initializer": [false],
     "max-classes-per-file": [true, 10],
     "unified-signatures": [false],
     "jsdoc-format": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -22,7 +22,7 @@
     "no-this-assignment": [false],
     "one-variable-per-declaration": [false],
     "no-conditional-assignment": [false],
-    "max-classes-per-file": [true, 10],
+    "max-classes-per-file": [false, 1000],
     "unified-signatures": [false],
     "jsdoc-format": [false],
     "no-console": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,6 @@
     "unified-signatures": [false],
     "jsdoc-format": [false],
     "ban-comma-operator": [false],
-    "no-implicit-dependencies": [true, "dev", ["rxjs", "chai"]],
     "radix": [false],
     "no-string-literal": [false],
     "no-string-throw": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,6 @@
     // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
-    "comment-format": [false],
     "object-literal-shorthand": [false],
     "prefer-conditional-expression": [false],
     "no-object-literal-type-assertion": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,6 @@
     // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
-    "ban-comma-operator": [false],
-    "arrow-return-shorthand": [false]
+    "ban-comma-operator": [false]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,6 @@
     // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
-    "prefer-for-of": [false],
     "comment-format": [false],
     "object-literal-shorthand": [false],
     "prefer-conditional-expression": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,6 @@
     "unified-signatures": [false],
     "jsdoc-format": [false],
     "ban-comma-operator": [false],
-    "no-submodule-imports": [false],
     "no-implicit-dependencies": [true, "dev", ["rxjs", "chai"]],
     "radix": [false],
     "no-string-literal": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,6 @@
     "unified-signatures": [false],
     "jsdoc-format": [false],
     "ban-comma-operator": [false],
-    "no-string-literal": [false],
     "no-string-throw": [false],
     "arrow-return-shorthand": [false]
   }

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,6 @@
     // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
-    "no-console": [false],
     "prefer-for-of": [false],
     "comment-format": [false],
     "object-literal-shorthand": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -23,7 +23,6 @@
     // be a lot of work to verify the fixes don't mess something up.
     "unified-signatures": [false],
     "jsdoc-format": [false],
-    "object-literal-shorthand": [false],
     "prefer-conditional-expression": [false],
     "no-object-literal-type-assertion": [false],
     "ban-comma-operator": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -24,7 +24,6 @@
     "unified-signatures": [false],
     "jsdoc-format": [false],
     "ban-comma-operator": [false],
-    "no-string-throw": [false],
     "arrow-return-shorthand": [false]
   }
 }

--- a/tslint.json
+++ b/tslint.json
@@ -33,7 +33,6 @@
     "comment-format": [false],
     "object-literal-shorthand": [false],
     "prefer-conditional-expression": [false],
-    "triple-equals": [false], // OH MY GOD!!!!! AHHH!!!!
     "no-object-literal-type-assertion": [false],
     "ban-comma-operator": [false],
     "no-submodule-imports": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -8,10 +8,9 @@
     "no-unused-expression": [true, "allow-fast-null-checks"],
     "ordered-imports": [false],
     "interface-name": [false],
-    "variable-name": [false], // Ben cries
+    "variable-name": [false],
     "member-access": [false],
     "array-type": [false],
-    "no-angle-bracket-type-assertion": [false],
     "no-shadowed-variable": [false],
     "no-empty-interface": [false],
     "interface-over-type-literal": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -18,7 +18,6 @@
     "member-ordering": [false],
     "only-arrow-functions": [false],
     "callable-types": [false],
-    "prefer-const": [false],
     "object-literal-sort-keys": [false],
     "no-this-assignment": [false],
     "one-variable-per-declaration": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -11,7 +11,6 @@
     "variable-name": [false],
     "member-access": [false],
     "array-type": [false],
-    "no-shadowed-variable": [false],
     "no-empty-interface": [false],
     "interface-over-type-literal": [false],
     "member-ordering": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -10,7 +10,6 @@
     "interface-name": [false],
     "variable-name": [false], // Ben cries
     "member-access": [false],
-    "ban-types": [false],
     "array-type": [false],
     "no-angle-bracket-type-assertion": [false],
     "no-shadowed-variable": [false],

--- a/tslint.json
+++ b/tslint.json
@@ -17,7 +17,6 @@
     "callable-types": [false],
     "object-literal-sort-keys": [false],
     "no-this-assignment": [false],
-    "one-variable-per-declaration": [false],
     "no-conditional-assignment": [false],
     "max-classes-per-file": [false, 1000],
     "unified-signatures": [false],


### PR DESCRIPTION
- Removes every tslint override that (IMO) was bad except one
- Adds a `TODO` for the `unified-signatures` override, because I felt addressing that would be a minefield of type changes.
- fixes an issue with `every` that was uncovered by the removal of the `prefer-const` override, where we were not incrementing the index being passed to the predicate. Adds a test for that one.


Consequently, this change also removes all usage of `Function`, which I know @cartant hated passionately.

Other thoughts:

- We should move to `eslint` soon.
- Many of the linting issues were actually fixed during the refactor.
- I couldn't get tslint to set up `Array` usage in a way that _I personally_ agreed with, so that is still on
- the `variable-names` bit is still on because it conflicts with the unused variables override of prefixing with an underscore.

**Note that commits labelled as `chore` were mostly non-changes. Just deleting a rule or an irrelevant bit of code or test.**
