### PR TITLE
refactor(skipLast): rename skipLast's parameter to `count`

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -260,7 +260,7 @@ export declare function single<T>(predicate?: (value: T, index: number, source: 
 
 export declare function skip<T>(count: number): MonoTypeOperatorFunction<T>;
 
-export declare function skipLast<T>(skipCount: number): MonoTypeOperatorFunction<T>;
+export declare function skipLast<T>(count: number): MonoTypeOperatorFunction<T>;
 
 export declare function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T>;
 

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -36,32 +36,32 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @throws {ArgumentOutOfRangeError} When using `skipLast(i)`, it throws
  * ArgumentOutOrRangeError if `i < 0`.
  *
- * @param {number} skipCount Number of elements to skip from the end of the source Observable.
+ * @param {number} count Number of elements to skip from the end of the source Observable.
  * @returns {Observable<T>} An Observable that skips the last count values
  * emitted by the source Observable.
  * @name skipLast
  */
-export function skipLast<T>(skipCount: number): MonoTypeOperatorFunction<T> {
-  // For skipCounts less than or equal to zero, we are just mirroring the source.
-  return skipCount <= 0
+export function skipLast<T>(count: number): MonoTypeOperatorFunction<T> {
+  // For count less than or equal to zero, we are just mirroring the source.
+  return count <= 0
     ? identity
     : operate((source, subscriber) => {
         // A ring buffer to hold the values while we wait to see
         // if we can emit it or it's part of the "skipped" last values.
         // Note that it is the _same size_ as the skip count.
-        let ring: T[] = new Array(skipCount);
-        let count = 0;
+        let ring: T[] = new Array(count);
+        let counter = 0;
         source.subscribe(
           new OperatorSubscriber(
             subscriber,
             (value) => {
               // Move us to the next slot in the ring buffer.
-              const currentCount = count++;
-              if (currentCount < skipCount) {
+              const currentCount = counter++;
+              if (currentCount < count) {
                 // Fill the ring first
                 ring[currentCount] = value;
               } else {
-                const index = currentCount % skipCount;
+                const index = currentCount % count;
                 // Pull the oldest value out and emit it,
                 // then stuff the new value in it's place.
                 const oldValue = ring[index];


### PR DESCRIPTION
I renamed `skipLast`'s parameter from `skipCount` to `count` for two reasons:
- the docs in the first sentence is still referring to this parameter named as `count`;
- to have to same name as the other operators (e.g.`skip`, `take` or `takeLast`).