### PR TITLE
refactor(skip): skip is just filtering by index

### DIFF
--- a/src/internal/operators/skip.ts
+++ b/src/internal/operators/skip.ts
@@ -1,22 +1,21 @@
 /** @prettier */
 import { MonoTypeOperatorFunction } from '../types';
-import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { filter } from './filter';
 
 /**
  * Returns an Observable that skips the first `count` items emitted by the source Observable.
  *
  * ![](skip.png)
- * 
- * Skips the values until the sent notifications are equal or less than provided skip count. It raises 
+ *
+ * Skips the values until the sent notifications are equal or less than provided skip count. It raises
  * an error if skip count is equal or more than the actual number of emits and source raises an error.
- * 
+ *
  * ## Example
  * Skip the values before the emission
  * ```ts
  * import { interval } from 'rxjs';
  * import { skip } from 'rxjs/operators';
- * 
+ *
  * //emit every half second
  * const source = interval(500);
  * //skip the first 10 emitted values
@@ -24,7 +23,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * //output: 10...11...12...13........
  * const subscribe = example.subscribe(val => console.log(val));
  * ```
- * 
+ *
  * @see {@link last}
  * @see {@link skipWhile}
  * @see {@link skipUntil}
@@ -35,8 +34,5 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name skip
  */
 export function skip<T>(count: number): MonoTypeOperatorFunction<T> {
-  return operate((source, subscriber) => {
-    let seen = 0;
-    source.subscribe(new OperatorSubscriber(subscriber, (value) => (count === seen ? subscriber.next(value) : seen++)));
-  });
+  return filter((_, index) => count <= index);
 }


### PR DESCRIPTION
basically `filter((_, index) => count <= index)`