### PR TITLE
WIP: Draft (concept of smaller operators still)

### DIFF
--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -20,16 +20,17 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
    */
   constructor(
     destination: Subscriber<any>,
-    onNext?: (value: T) => void,
+    onNext?: (value: T, index: number, destination: Subscriber<any>) => void,
     onError?: (err: any) => void,
-    onComplete?: () => void,
+    onComplete?: (destination: Subscriber<any>) => void,
     private onUnsubscribe?: () => void
   ) {
     super(destination);
     if (onNext) {
+      let index = 0;
       this._next = function (value: T) {
         try {
-          onNext(value);
+          onNext(value, index++, destination);
         } catch (err) {
           this.destination.error(err);
         }
@@ -50,7 +51,7 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
     if (onComplete) {
       this._complete = function () {
         try {
-          onComplete();
+          onComplete(destination);
         } catch (err) {
           // Send any errors that occur down stream.
           this.destination.error(err);

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -1,8 +1,6 @@
 /** @prettier */
-import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
-import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createBasicSyncOperator } from './createBasicSyncOperator';
 
 /**
  * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
@@ -29,27 +27,17 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @return {Observable} An Observable of booleans that determines if all items of the source Observable meet the condition specified.
  * @name every
  */
-export function every<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
-): OperatorFunction<T, boolean> {
-  return operate((source, subscriber) => {
-    let index = 0;
-    source.subscribe(
-      new OperatorSubscriber(
-        subscriber,
-        (value) => {
-          if (!predicate.call(thisArg, value, index++, source)) {
-            subscriber.next(false);
-            subscriber.complete();
-          }
-        },
-        undefined,
-        () => {
-          subscriber.next(true);
-          subscriber.complete();
-        }
-      )
-    );
-  });
+export function every<T>(predicate: (value: T, index: number) => boolean, thisArg?: any): OperatorFunction<T, boolean> {
+  return createBasicSyncOperator(
+    (value, index, subscriber) => {
+      if (!predicate.call(thisArg, value, index++)) {
+        subscriber.next(false);
+        subscriber.complete();
+      }
+    },
+    (subscriber) => {
+      subscriber.next(true);
+      subscriber.complete();
+    }
+  );
 }

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -1,7 +1,6 @@
 /** @prettier */
 import { OperatorFunction, MonoTypeOperatorFunction } from '../types';
-import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createBasicSyncOperator } from './createBasicSyncOperator';
 
 /* tslint:disable:max-line-length */
 export function filter<T, S extends T>(predicate: (value: T, index: number) => value is S, thisArg?: any): OperatorFunction<T, S>;
@@ -52,17 +51,5 @@ export function filter<T>(predicate: (value: T, index: number) => boolean, thisA
  * in the `predicate` function.
  */
 export function filter<T>(predicate: (value: T, index: number) => boolean, thisArg?: any): MonoTypeOperatorFunction<T> {
-  return operate((source, subscriber) => {
-    // An index passed to our predicate function on each call.
-    let index = 0;
-
-    // Subscribe to the source, all errors and completions are
-    // forwarded to the consumer.
-    source.subscribe(
-      // Call the predicate with the appropriate `this` context,
-      // if the predicate returns `true`, then send the value
-      // to the consumer.
-      new OperatorSubscriber(subscriber, (value) => predicate.call(thisArg, value, index++) && subscriber.next(value))
-    );
-  });
+  return createBasicSyncOperator((value, index, subscriber) => predicate.call(thisArg, value, index++) && subscriber.next(value));
 }

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -34,7 +34,7 @@ import { createFind } from './find';
  * @see {@link first}
  * @see {@link take}
  *
- * @param {function(value: T, index: number, source: Observable<T>): boolean} predicate
+ * @param  predicate
  * A function called with each item to test for condition matching.
  * @param {any} [thisArg] An optional argument to determine the value of `this`
  * in the `predicate` function.
@@ -42,9 +42,6 @@ import { createFind } from './find';
  * matches the condition.
  * @name find
  */
-export function findIndex<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
-): OperatorFunction<T, number> {
-  return operate(createFind(predicate, thisArg, 'index'));
+export function findIndex<T>(predicate: (value: T, index: number) => boolean, thisArg?: any): OperatorFunction<T, number> {
+  return createFind(predicate, thisArg, 'index');
 }

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -13,11 +13,11 @@ export function first<T, D = T>(
   defaultValue?: D
 ): OperatorFunction<T, T | D>;
 export function first<T, S extends T>(
-  predicate: (value: T, index: number, source: Observable<T>) => value is S,
+  predicate: (value: T, index: number) => value is S,
   defaultValue?: S
 ): OperatorFunction<T, S>;
 export function first<T, D = T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
+  predicate: (value: T, index: number) => boolean,
   defaultValue?: D
 ): OperatorFunction<T, T | D>;
 /* tslint:enable:max-line-length */
@@ -68,8 +68,7 @@ export function first<T, D = T>(
  * callback if the Observable completes before any `next` notification was sent.
  * This is how `first()` is different from {@link take}(1) which completes instead.
  *
- * @param {function(value: T, index: number, source: Observable<T>): boolean} [predicate]
- * An optional function called with each item to test for condition matching.
+ * @param predicate An optional function called with each item to test for condition matching.
  * @param {R} [defaultValue] The default value emitted in case no valid value
  * was found on the source.
  * @return {Observable<T|R>} An Observable of the first item that matches the
@@ -77,12 +76,12 @@ export function first<T, D = T>(
  * @name first
  */
 export function first<T, D>(
-  predicate?: ((value: T, index: number, source: Observable<T>) => boolean) | null,
+  predicate?: ((value: T, index: number) => boolean) | null,
   defaultValue?: D
 ): OperatorFunction<T, T | D> {
   const hasDefaultValue = arguments.length >= 2;
   return (source: Observable<T>) => source.pipe(
-    predicate ? filter((v, i) => predicate(v, i, source)) : identity,
+    predicate ? filter(predicate) : identity,
     take(1),
     hasDefaultValue ? defaultIfEmpty<T, D>(defaultValue) : throwIfEmpty(() => new EmptyError()),
   );

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -1,8 +1,7 @@
 /** @prettier */
 import { OperatorFunction } from '../types';
-import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
+import { createBasicSyncOperator } from './createBasicSyncOperator';
 
 /**
  * Ignores all items emitted by the source Observable and only passes calls of `complete` or `error`.
@@ -37,7 +36,5 @@ import { noop } from '../util/noop';
  * @name ignoreElements
  */
 export function ignoreElements(): OperatorFunction<any, never> {
-  return operate((source, subscriber) => {
-    source.subscribe(new OperatorSubscriber(subscriber, noop));
-  });
+  return createBasicSyncOperator(noop);
 }

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -1,6 +1,7 @@
 /** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
+import { createBasicSyncOperator } from './createBasicSyncOperator';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -68,20 +69,14 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 
 export function isEmpty<T>(): OperatorFunction<T, boolean> {
-  return operate((source, subscriber) => {
-    source.subscribe(
-      new OperatorSubscriber(
-        subscriber,
-        () => {
-          subscriber.next(false);
-          subscriber.complete();
-        },
-        undefined,
-        () => {
-          subscriber.next(true);
-          subscriber.complete();
-        }
-      )
-    );
-  });
+  return createBasicSyncOperator(
+    (_value, _index, subscriber) => {
+      subscriber.next(false);
+      subscriber.complete();
+    },
+    (subscriber) => {
+      subscriber.next(true);
+      subscriber.complete();
+    }
+  );
 }

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -1,7 +1,6 @@
 /** @prettier */
 import { OperatorFunction } from '../types';
-import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createBasicSyncOperator } from './createBasicSyncOperator';
 
 /**
  * Applies a given `project` function to each value emitted by the source
@@ -42,17 +41,9 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @name map
  */
 export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): OperatorFunction<T, R> {
-  return operate((source, subscriber) => {
-    // The index of the value from the source. Used with projection.
-    let index = 0;
-    // Subscribe to the source, all errors and completions are sent along
-    // to the consumer.
-    source.subscribe(
-      new OperatorSubscriber(subscriber, (value: T) => {
-        // Call the projection function with the appropriate this context,
-        // and send the resulting value to the consumer.
-        subscriber.next(project.call(thisArg, value, index++));
-      })
-    );
+  return createBasicSyncOperator((value, index, subscriber) => {
+    // Call the projection function with the appropriate this context,
+    // and send the resulting value to the consumer.
+    subscriber.next(project.call(thisArg, value, index++));
   });
 }

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -1,6 +1,7 @@
 /** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
+import { createBasicSyncOperator } from './createBasicSyncOperator';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 export function mapTo<R>(value: R): OperatorFunction<any, R>;
@@ -39,14 +40,8 @@ export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
  * @name mapTo
  */
 export function mapTo<R>(value: R): OperatorFunction<any, R> {
-  return operate((source, subscriber) => {
-    // Subscribe to the source. All errors and completions are forwarded to the consumer
-    source.subscribe(
-      new OperatorSubscriber(
-        subscriber,
-        // On every value from the source, send the `mapTo` value to the consumer.
-        () => subscriber.next(value)
-      )
-    );
-  });
+  return createBasicSyncOperator(
+    // On every value from the source, send the `mapTo` value to the consumer.
+    (_v, _index, subscriber) => subscriber.next(value)
+  );
 }


### PR DESCRIPTION
- Removes crazy `source` arguments from predicates and other callbacks, as they really don't make sense.
- Adds common `index++` logic to `OperatorSubscriber`.

Rough idea in place.