### PR TITLE
Update skip and skipLast tests to run mode

### DIFF
--- a/spec/operators/skip-spec.ts
+++ b/spec/operators/skip-spec.ts
@@ -1,151 +1,188 @@
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { skip, mergeMap, take } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
+import { observableMatcher } from '../helpers/observableMatcher';
 import { of, Observable } from 'rxjs';
 
 /** @test {skip} */
-describe('skip operator', () => {
-  it('should skip values before a total', () => {
-    const source = hot('--a--b--c--d--e--|');
-    const subs =       '^                !';
-    const expected =   '-----------d--e--|';
+describe('skip', () => {
+  let testScheduler: TestScheduler;
 
-    expectObservable(source.pipe(skip(3))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should skip values before a total', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--e--|');
+      const subs = '      ^----------------!';
+      const expected = '  -----------d--e--|';
+
+      expectObservable(source.pipe(skip(3))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should skip all values without error if total is more than actual number of values', () => {
-    const source = hot('--a--b--c--d--e--|');
-    const subs =       '^                !';
-    const expected =   '-----------------|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--e--|');
+      const subs = '      ^----------------!';
+      const expected = '  -----------------|';
 
-    expectObservable(source.pipe(skip(6))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(source.pipe(skip(6))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should skip all values without error if total is same as actual number of values', () => {
-    const source = hot('--a--b--c--d--e--|');
-    const subs =       '^                !';
-    const expected =   '-----------------|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--e--|');
+      const subs = '      ^----------------!';
+      const expected = '  -----------------|';
 
-    expectObservable(source.pipe(skip(5))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(source.pipe(skip(5))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should not skip if count is zero', () => {
-    const source = hot('--a--b--c--d--e--|');
-    const subs =       '^                !';
-    const expected =   '--a--b--c--d--e--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--e--|');
+      const subs = '      ^----------------!';
+      const expected = '  --a--b--c--d--e--|';
 
-    expectObservable(source.pipe(skip(0))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(source.pipe(skip(0))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const source = hot('--a--b--c--d--e--|');
-    const unsub =      '          !       ';
-    const subs =       '^         !       ';
-    const expected =   '--------c--       ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--e--|');
+      const unsub = '     ----------!       ';
+      const subs = '      ^---------!       ';
+      const expected = '  --------c--       ';
 
-    expectObservable(source.pipe(skip(2)), unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(source.pipe(skip(2)), unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const source = hot('--a--b--c--d--e--|');
-    const subs =       '^         !       ';
-    const expected =   '--------c--       ';
-    const unsub =      '          !       ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--e--|');
+      const subs = '      ^---------!       ';
+      const expected = '  --------c--       ';
+      const unsub = '     ----------!       ';
 
-    const result = source.pipe(
-      mergeMap((x: string) => of(x)),
-      skip(2),
-      mergeMap((x: string) => of(x))
-    );
+      const result = source.pipe(
+        mergeMap((x: string) => of(x)),
+        skip(2),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should raise error if skip count is more than actual number of emits and source raises error', () => {
-    const source = hot('--a--b--c--d--#');
-    const subs =       '^             !';
-    const expected =   '--------------#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--#');
+      const subs = '      ^-------------!';
+      const expected = '  --------------#';
 
-    expectObservable(source.pipe(skip(6))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(source.pipe(skip(6))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should raise error if skip count is same as emits of source and source raises error', () => {
-    const source = hot('--a--b--c--d--#');
-    const subs =       '^             !';
-    const expected =   '--------------#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--#');
+      const subs = '      ^-------------!';
+      const expected = '  --------------#';
 
-    expectObservable(source.pipe(skip(4))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(source.pipe(skip(4))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should skip values before a total and raises error if source raises error', () => {
-    const source = hot('--a--b--c--d--#');
-    const subs =       '^             !';
-    const expected =   '-----------d--#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b--c--d--#');
+      const subs = '      ^-------------!';
+      const expected = '  -----------d--#';
 
-    expectObservable(source.pipe(skip(3))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(source.pipe(skip(3))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should complete regardless of skip count if source is empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |');
+      const e1subs = '  (^!)';
+      const expected = '|';
 
-    expectObservable(e1.pipe(skip(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skip(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not complete if source never completes without emit', () => {
-    const e1 =   hot('-');
-    const e1subs =   '^';
-    const expected = '-';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    expectObservable(e1.pipe(skip(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skip(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should skip values before total and never completes if source emits and does not complete', () => {
-    const e1 =   hot('--a--b--c-');
-    const e1subs =   '^         ';
-    const expected = '-----b--c-';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--c-');
+      const e1subs = '  ^         ';
+      const expected = '-----b--c-';
 
-    expectObservable(e1.pipe(skip(1))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skip(1))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should skip all values and never completes if total is more than numbers of value and source does not complete', () => {
-    const e1 =   hot('--a--b--c-');
-    const e1subs =   '^         ';
-    const expected = '----------';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--c-');
+      const e1subs = '  ^         ';
+      const expected = '----------';
 
-    expectObservable(e1.pipe(skip(6))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skip(6))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should skip all values and never completes if total is same asnumbers of value and source does not complete', () => {
-    const e1 =   hot('--a--b--c-');
-    const e1subs =   '^         ';
-    const expected = '----------';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--c-');
+      const e1subs = '  ^         ';
+      const expected = '----------';
 
-    expectObservable(e1.pipe(skip(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skip(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raise error if source throws', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #');
+      const e1subs = '  (^!)';
+      const expected = '#';
 
-    expectObservable(e1.pipe(skip(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skip(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {

--- a/spec/operators/skipLast-spec.ts
+++ b/spec/operators/skipLast-spec.ts
@@ -1,151 +1,188 @@
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { skipLast, mergeMap, take } from 'rxjs/operators';
-import { range, ArgumentOutOfRangeError, of, Observable } from 'rxjs';
+import { of, Observable } from 'rxjs';
+import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
+import { observableMatcher } from '../helpers/observableMatcher';
 
-/** @test {takeLast} */
+/** @test {skipLast} */
 describe('skipLast operator', () => {
-  it('should skip two values of an observable with many values', () => {
-    const e1 =  cold('--a-----b----c---d--|');
-    const e1subs =   '^                   !';
-    const expected = '-------------a---b--|';
+  let testScheduler: TestScheduler;
 
-    expectObservable(e1.pipe(skipLast(2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should skip two values of an observable with many values', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const e1subs = '  ^-------------------!';
+      const expected = '-------------a---b--|';
+
+      expectObservable(e1.pipe(skipLast(2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should skip last three values', () => {
-    const e1 =  cold('--a-----b----c---d--|');
-    const e1subs =   '^                   !';
-    const expected = '-----------------a--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const e1subs = '  ^-------------------!';
+      const expected = '-----------------a--|';
 
-    expectObservable(e1.pipe(skipLast(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
-  it('should skip all values when trying to take larger then source', () => {
-    const e1 =  cold('--a-----b----c---d--|');
-    const e1subs =   '^                   !';
-    const expected = '--------------------|';
+  it('should skip all elements when trying to skip larger then source', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const e1subs = '  ^-------------------!';
+      const expected = '--------------------|';
 
-    expectObservable(e1.pipe(skipLast(5))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(5))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
-  it('should skip all element when try to take exact', () => {
-    const e1 =  cold('--a-----b----c---d--|');
-    const e1subs =   '^                   !';
-    const expected = '--------------------|';
+  it('should skip all elements when trying to skip exact', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const e1subs = '  ^-------------------!';
+      const expected = '--------------------|';
 
-    expectObservable(e1.pipe(skipLast(4))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(4))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not skip any values', () => {
-    const e1 =  cold('--a-----b----c---d--|');
-    const e1subs =   '^                   !';
-    const expected = '--a-----b----c---d--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const e1subs = '  ^-------------------!';
+      const expected = '--a-----b----c---d--|';
 
-    expectObservable(e1.pipe(skipLast(0))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |');
+      const e1subs = '  (^!)';
+      const expected = '|';
 
-    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should go on forever on never', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should skip one value from an observable with one value', () => {
-    const e1 =   hot('---(a|)');
-    const e1subs =   '^  !   ';
-    const expected = '---|   ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---(a|)');
+      const e1subs = '  ^--!   ';
+      const expected = '---|   ';
 
-    expectObservable(e1.pipe(skipLast(1))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(1))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should skip one value from an observable with many values', () => {
-    const e1 = hot('--a--^--b----c---d--|');
-    const e1subs =      '^              !';
-    const expected =    '--------b---c--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b----c---d--|');
+      const e1subs = '     ^--------------!';
+      const expected = '   --------b---c--|';
 
-    expectObservable(e1.pipe(skipLast(1))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(1))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with empty and early emission', () => {
-    const e1 = hot('--a--^----|');
-    const e1subs =      '^    !';
-    const expected =    '-----|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^----|');
+      const e1subs = '     ^----!';
+      const expected = '   -----|';
 
-    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should propagate error from the source observable', () => {
-    const e1 = hot('---^---#', undefined, 'too bad');
-    const e1subs =    '^   !';
-    const expected =  '----#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^---#', undefined, 'too bad');
+      const e1subs = '   ^---!';
+      const expected = ' ----#';
 
-    expectObservable(e1.pipe(skipLast(42))).toBe(expected, null, 'too bad');
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(42))).toBe(expected, null, 'too bad');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should propagate error from an observable with values', () => {
-    const e1 = hot('---^--a--b--#');
-    const e1subs =    '^        !';
-    const expected =  '---------#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^--a--b--#');
+      const e1subs = '   ^--------!';
+      const expected = ' ---------#';
 
-    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 = hot('---^--a--b-----c--d--e--|');
-    const unsub =     '         !            ';
-    const e1subs =    '^        !            ';
-    const expected =  '----------            ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^--a--b-----c--d--e--|');
+      const unsub = '    ---------!            ';
+      const e1subs = '   ^--------!            ';
+      const expected = ' ----------            ';
 
-    expectObservable(e1.pipe(skipLast(42)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(42)), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with throw', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #');
+      const e1subs = '  (^!)';
+      const expected = '#';
 
-    expectObservable(e1.pipe(skipLast(42))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(skipLast(42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
-    const e1 = hot('---^--a--b-----c--d--e--|');
-    const unsub =     '         !            ';
-    const e1subs =    '^        !            ';
-    const expected =  '----------            ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^--a--b-----c--d--e--|');
+      const unsub = '    ---------!            ';
+      const e1subs = '   ^--------!            ';
+      const expected = ' ----------            ';
 
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      skipLast(42),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        skipLast(42),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {


### PR DESCRIPTION
~`take`, `takeLast` and `skipLast` are not throwing errors anymore when provided with negative values, so I updated docs and added tests for such cases. Also, I changed `skip` and `skipLast` tests to use `TestScheduler` in run mode.~

[Updated](https://github.com/ReactiveX/rxjs/pull/5796#issuecomment-705690602).