### PR TITLE
fix(delayWhen): only deprecates when subscriptionDelay presents

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -72,7 +72,8 @@ export declare function defaultIfEmpty<T, R = T>(defaultValue?: R): OperatorFunc
 export declare function delay<T>(due: number | Date, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 
 export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<never>, subscriptionDelay?: Observable<any>): MonoTypeOperatorFunction<T>;
-export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>, subscriptionDelay?: Observable<any>): MonoTypeOperatorFunction<T>;
+export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>, subscriptionDelay: Observable<any>): MonoTypeOperatorFunction<T>;
+export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>): MonoTypeOperatorFunction<T>;
 
 export declare function dematerialize<N extends ObservableNotification<any>>(): OperatorFunction<N, ValueFromNotification<N>>;
 

--- a/spec-dtslint/operators/delayWhen-spec.ts
+++ b/spec-dtslint/operators/delayWhen-spec.ts
@@ -27,3 +27,8 @@ it('should enforce types of delayWhenDurationSelector', () => {
 it('should enforce types of subscriptiondelayWhen', () => {
   const o = of(1, 2, 3).pipe(delayWhen(() => of('a', 'b', 'c'), 'a')); // $ExpectError
 });
+
+it('should deprecates', () => {
+  of(1, 2, 3).pipe(delayWhen(() => NEVER)); // $ExpectDeprecation
+  of(1, 2, 3).pipe(delayWhen(() => of('a', 'b', 'c'), of(0))); // $ExpectDeprecation
+});

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -16,7 +16,10 @@ export function delayWhen<T>(
 /** @deprecated In future versions, `subscriptionDelay` will no longer be supported. */
 export function delayWhen<T>(
   delayDurationSelector: (value: T, index: number) => Observable<any>,
-  subscriptionDelay?: Observable<any>
+  subscriptionDelay: Observable<any>
+): MonoTypeOperatorFunction<T>;
+export function delayWhen<T>(
+  delayDurationSelector: (value: T, index: number) => Observable<any>
 ): MonoTypeOperatorFunction<T>;
 /* tslint:disable:max-line-length */
 


### PR DESCRIPTION
Noticed this after **vscode** starts [showing][vsc] the deprecation from jsdoc, not sure how to test this change tho.




[vsc]: https://code.visualstudio.com/updates/v1_49#_deprecated-tag-support-for-javascript-and-typescript