### PR TITLE
fix(audit, auditTime): audit and auditTime emit last value after source completes

### DIFF
--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -120,17 +120,17 @@ describe('audit operator', () => {
 
   it('should handle a busy producer emitting a regular repeating sequence', () => {
     testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  abcdefabcdefabcdefabcdefa|');
-      const e1subs = '  ^------------------------!';
-      const e2 = cold(' -----|                    ');
+      const e1 = hot('  abcdefabcdefabcdefabcdefa|    ');
+      const e1subs = '  ^------------------------!    ';
+      const e2 = cold(' -----|                        ');
       const e2subs = [
-        '               ^----!                    ',
-        '               ------^----!              ',
-        '               ------------^----!        ',
-        '               ------------------^----!  ',
-        '               ------------------------^!'
+        '               ^----!                        ',
+        '               ------^----!                  ',
+        '               ------------^----!            ',
+        '               ------------------^----!      ',
+        '               ------------------------^----!'
       ];
-      const expected = '-----f-----f-----f-----f-|';
+      const expected = '-----f-----f-----f-----f-----(a|)';
 
       const result = e1.pipe(audit(() => e2));
 
@@ -168,13 +168,13 @@ describe('audit operator', () => {
     });
   });
 
-  it('should emit no values if duration is a never', () => {
+  it('should emit no values and never complete if duration is a never', () => {
     testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ----abcdefabcdefabcdefabcdefa|');
       const e1subs = '  ^----------------------------!';
       const e2 = cold(' -');
-      const e2subs = '  ----^------------------------!';
-      const expected = '-----------------------------|';
+      const e2subs = '  ----^-------------------------';
+      const expected = '------------------------------';
 
       const result = e1.pipe(audit(() => e2));
 
@@ -232,23 +232,23 @@ describe('audit operator', () => {
 
   it('should audit using durations of varying lengths', () => {
     testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  abcdefabcdabcdefghabca|');
-      const e1subs = '  ^---------------------!';
+      const e1 = hot('  abcdefabcdabcdefghabca|     ');
+      const e1subs = '  ^---------------------!     ';
       const e2 = [
-        cold('          -----|                 '),
-        cold('              ---|               '),
-        cold('                  -------|       '),
-        cold('                        --|      '),
-        cold('                           ----| ')
+        cold('          -----|                      '),
+        cold('              ---|                    '),
+        cold('                  -------|            '),
+        cold('                        --|           '),
+        cold('                           ----|      ')
       ];
       const e2subs =  [
-        '               ^----!                  ',
-        '               ------^--!              ',
-        '               ----------^------!      ',
-        '               ------------------^-!   ',
-        '               ---------------------^! '
+        '               ^----!                      ',
+        '               ------^--!                  ',
+        '               ----------^------!          ',
+        '               ------------------^-!       ',
+        '               ---------------------^---!  '
       ];
-      const expected = '-----f---d-------h--c-| ';
+      const expected = '-----f---d-------h--c----(a|)';
 
       let i = 0;
       const result = e1.pipe(audit(() => e2[i++]));
@@ -391,12 +391,10 @@ describe('audit operator', () => {
 
   it('should audit by promise resolves', (done: MochaDone) => {
     const e1 = interval(10).pipe(take(5));
-    const expected = [0, 1, 2, 3];
+    const expected = [0, 1, 2, 3, 4, 5];
 
     e1.pipe(
-      audit(() => {
-        return new Promise((resolve: any) => { resolve(42); });
-      })
+      audit(() => Promise.resolve(42))
     ).subscribe(
       (x: number) => {
         expect(x).to.equal(expected.shift()); },
@@ -404,7 +402,7 @@ describe('audit operator', () => {
         done(new Error('should not be called'));
       },
       () => {
-        expect(expected.length).to.equal(0);
+        expect(expected.length).to.equal(1);
         done();
       }
     );
@@ -454,5 +452,24 @@ describe('audit operator', () => {
     ).subscribe(() => { /* noop */ });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
+  });
+
+  it('should emit last value after duration completes if source completes first', () =>  {
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 =   hot('-a--------xy|  ');
+      const e1subs = '  ^-----------!  ';
+      const e2 =  cold(' ----|         ');
+      const e2subs =  [
+        '               -^---!         ',
+        '               ----------^---!'
+      ];
+      const expected = '-----a--------(y|)';
+
+      const result = e1.pipe(audit(() =>  e2));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 });

--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -391,7 +391,7 @@ describe('audit operator', () => {
 
   it('should audit by promise resolves', (done: MochaDone) => {
     const e1 = interval(10).pipe(take(5));
-    const expected = [0, 1, 2, 3, 4, 5];
+    const expected = [0, 1, 2, 3, 4];
 
     e1.pipe(
       audit(() => Promise.resolve(42))
@@ -402,7 +402,7 @@ describe('audit operator', () => {
         done(new Error('should not be called'));
       },
       () => {
-        expect(expected.length).to.equal(1);
+        expect(expected.length).to.equal(0);
         done();
       }
     );

--- a/spec/operators/auditTime-spec.ts
+++ b/spec/operators/auditTime-spec.ts
@@ -58,8 +58,8 @@ describe('auditTime operator', () => {
 
   it('should handle a busy producer emitting a regular repeating sequence', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  abcdefabcdefabcdefabcdefa    |');
-      const subs = '    ^------------------------    !';
+      const e1 = hot('  abcdefabcdefabcdefabcdefa|');
+      const subs = '    ^------------------------!';
       const expected = '-----f-----f-----f-----f-----(a|)';
 
       expectObservable(e1.pipe(auditTime(5, testScheduler))).toBe(expected);

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -56,6 +56,7 @@ export function audit<T>(durationSelector: (value: T) => SubscribableOrPromise<a
     let hasValue = false;
     let lastValue: T | null = null;
     let durationSubscriber: Subscriber<any> | null = null;
+    let isComplete = false;
 
     const endDuration = () => {
       durationSubscriber?.unsubscribe();
@@ -66,18 +67,27 @@ export function audit<T>(durationSelector: (value: T) => SubscribableOrPromise<a
         lastValue = null;
         subscriber.next(value);
       }
+      isComplete && subscriber.complete();
     };
 
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
-        hasValue = true;
-        lastValue = value;
-        if (!durationSubscriber) {
-          innerFrom(durationSelector(value)).subscribe(
-            (durationSubscriber = new OperatorSubscriber(subscriber, endDuration, undefined, endDuration))
-          );
+      new OperatorSubscriber(
+        subscriber,
+        (value) => {
+          hasValue = true;
+          lastValue = value;
+          if (!durationSubscriber) {
+            innerFrom(durationSelector(value)).subscribe(
+              (durationSubscriber = new OperatorSubscriber(subscriber, endDuration, undefined, endDuration))
+            );
+          }
+        },
+        undefined,
+        () => {
+          isComplete = true;
+          (!hasValue || !durationSubscriber || durationSubscriber.closed) && subscriber.complete();
         }
-      })
+      )
     );
   });
 }


### PR DESCRIPTION
**Description:**
Adjust audit operator to emit the last value when source completes

**Related issue (if exists):**
#5730