### PR TITLE
Fix Issue 4532 subscribe no longer takes subscribable, forkJoin has N-arguments typings.

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -237,25 +237,14 @@ export declare type FactoryOrValue<T> = T | (() => T);
 
 export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
-export declare function forkJoin<T>(v1: SubscribableOrPromise<T>): Observable<[T]>;
-export declare function forkJoin<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>): Observable<[T, T2]>;
-export declare function forkJoin<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<[T, T2, T3]>;
-export declare function forkJoin<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<[T, T2, T3, T4]>;
-export declare function forkJoin<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<[T, T2, T3, T4, T5]>;
-export declare function forkJoin<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<[T, T2, T3, T4, T5, T6]>;
-export declare function forkJoin<A>(sources: [ObservableInput<A>]): Observable<[A]>;
-export declare function forkJoin<A, B>(sources: [ObservableInput<A>, ObservableInput<B>]): Observable<[A, B]>;
-export declare function forkJoin<A, B, C>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>]): Observable<[A, B, C]>;
-export declare function forkJoin<A, B, C, D>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>]): Observable<[A, B, C, D]>;
-export declare function forkJoin<A, B, C, D, E>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>]): Observable<[A, B, C, D, E]>;
-export declare function forkJoin<A, B, C, D, E, F>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>, ObservableInput<F>]): Observable<[A, B, C, D, E, F]>;
-export declare function forkJoin<A extends ObservableInput<any>[]>(sources: A): Observable<ObservedValueUnionFromArray<A>[]>;
+export declare function forkJoin(sources: []): Observable<never>;
+export declare function forkJoin<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
+export declare function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin(sourcesObject: {}): Observable<never>;
 export declare function forkJoin<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
 export declare function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
-export declare function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
 
 export declare function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
 export declare function from<O extends ObservableInput<any>>(input: O, scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
@@ -281,7 +270,7 @@ export declare type Head<X extends any[]> = ((...args: X) => any) extends (arg: 
 
 export declare function identity<T>(x: T): T;
 
-export declare function iif<T = never, F = never>(condition: () => boolean, trueResult?: SubscribableOrPromise<T>, falseResult?: SubscribableOrPromise<F>): Observable<T | F>;
+export declare function iif<T = never, F = never>(condition: () => boolean, trueResult?: ObservableInput<T>, falseResult?: ObservableInput<F>): Observable<T | F>;
 
 export interface InteropObservable<T> {
     [Symbol.observable]: () => Subscribable<T>;
@@ -414,7 +403,11 @@ export declare class Observable<T> implements Subscribable<T> {
     static create: (...args: any[]) => any;
 }
 
-export declare type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Iterable<T> | AsyncIterableIterator<T>;
+export declare type ObservableInput<T> = Observable<T> | InteropObservable<T> | AsyncIterable<T> | PromiseLike<T> | ArrayLike<T> | Iterable<T>;
+
+export declare type ObservableInputTuple<T> = {
+    [K in keyof T]: ObservableInput<T[K]>;
+};
 
 export declare type ObservableLike<T> = InteropObservable<T>;
 
@@ -424,9 +417,9 @@ export declare type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T 
 
 export declare type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
 
-export declare type ObservedValueTupleFromArray<X> = X extends readonly ObservableInput<any>[] ? {
+export declare type ObservedValueTupleFromArray<X> = {
     [K in keyof X]: ObservedValueOf<X[K]>;
-} : never;
+};
 
 export declare type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -1,4 +1,4 @@
-export declare function audit<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T>;
+export declare function audit<T>(durationSelector: (value: T) => ObservableInput<any>): MonoTypeOperatorFunction<T>;
 
 export declare function auditTime<T>(duration: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 
@@ -10,7 +10,7 @@ export declare function bufferTime<T>(bufferTimeSpan: number, scheduler?: Schedu
 export declare function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
 export declare function bufferTime<T>(bufferTimeSpan: number, bufferCreationInterval: number | null | undefined, maxBufferSize: number, scheduler?: SchedulerLike): OperatorFunction<T, T[]>;
 
-export declare function bufferToggle<T, O>(openings: SubscribableOrPromise<O>, closingSelector: (value: O) => SubscribableOrPromise<any>): OperatorFunction<T, T[]>;
+export declare function bufferToggle<T, O>(openings: ObservableInput<O>, closingSelector: (value: O) => ObservableInput<any>): OperatorFunction<T, T[]>;
 
 export declare function bufferWhen<T>(closingSelector: () => ObservableInput<any>): OperatorFunction<T, T[]>;
 
@@ -63,7 +63,7 @@ export declare function concatWith<T, A extends ObservableInput<any>[]>(...other
 
 export declare function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number>;
 
-export declare function debounce<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T>;
+export declare function debounce<T>(durationSelector: (value: T) => ObservableInput<any>): MonoTypeOperatorFunction<T>;
 
 export declare function debounceTime<T>(dueTime: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 
@@ -169,7 +169,7 @@ export declare function merge<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3
 export declare function merge<T>(...observables: Array<ObservableInput<T> | SchedulerLike | number>): MonoTypeOperatorFunction<T>;
 export declare function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number>): OperatorFunction<T, R>;
 
-export declare function mergeAll<T>(concurrent?: number): OperatorFunction<ObservableInput<T>, T>;
+export declare function mergeAll<O extends ObservableInput<any>>(concurrent?: number): OperatorFunction<O, ObservedValueOf<O>>;
 
 export declare function mergeMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, concurrent?: number): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function mergeMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined, concurrent?: number): OperatorFunction<T, ObservedValueOf<O>>;
@@ -278,8 +278,7 @@ export declare function startWith<T, A extends any[] = T[]>(...values: A): Opera
 
 export declare function subscribeOn<T>(scheduler: SchedulerLike, delay?: number): MonoTypeOperatorFunction<T>;
 
-export declare function switchAll<T>(): OperatorFunction<ObservableInput<T>, T>;
-export declare function switchAll<R>(): OperatorFunction<any, R>;
+export declare function switchAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>>;
 
 export declare function switchMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function switchMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;
@@ -307,7 +306,7 @@ export declare function tap<T>(next: (value: T) => void, error: null | undefined
 export declare function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
 
-export declare function throttle<T>(durationSelector: (value: T) => SubscribableOrPromise<any>, { leading, trailing }?: ThrottleConfig): MonoTypeOperatorFunction<T>;
+export declare function throttle<T>(durationSelector: (value: T) => ObservableInput<any>, { leading, trailing }?: ThrottleConfig): MonoTypeOperatorFunction<T>;
 
 export declare function throttleTime<T>(duration: number, scheduler?: SchedulerLike, config?: import("./throttle").ThrottleConfig): MonoTypeOperatorFunction<T>;
 

--- a/spec-dtslint/observables/forkJoin-spec.ts
+++ b/spec-dtslint/observables/forkJoin-spec.ts
@@ -55,7 +55,7 @@ it('should infer of type any for more than 6 parameters', () => {
   const e = of(1, 2, 3);
   const f = of(1, 2, 3);
   const g = of(1, 2, 3);
-  const res = forkJoin(a, b, c, d, e, f, g); // $ExpectType Observable<any>
+  const res = forkJoin(a, b, c, d, e, f, g); // $ExpectType Observable<[number, string, number, number, number, number, number]>
 });
 
 describe('forkJoin({})', () => {
@@ -99,6 +99,6 @@ describe('forkJoin([])', () => {
   });
 
   it('should force user cast for array of 6+ observables', () => {
-    const res = forkJoin([of(1, 2, 3), of('a', 'b', 'c'), of(1, 2, 3), of(1, 2, 3), of(1, 2, 3), of(1, 2, 3), of(1, 2, 3)]); // $ExpectType Observable<(string | number)[]>
+    const res = forkJoin([of(1, 2, 3), of('a', 'b', 'c'), of(1, 2, 3), of(1, 2, 3), of(1, 2, 3), of(1, 2, 3), of(1, 2, 3)]); // $ExpectType Observable<[number, string, number, number, number, number, number]>
   });
 });

--- a/spec-dtslint/operators/bufferToggle-spec.ts
+++ b/spec-dtslint/operators/bufferToggle-spec.ts
@@ -23,7 +23,8 @@ it('should enforce types', () => {
 });
 
 it('should enforce type of openings', () => {
-  const o = of(1, 2, 3).pipe(bufferToggle('a', () => of('a', 'b', 'c'))); // $ExpectError
+  const o = of(1, 2, 3).pipe(bufferToggle('a', () => of('a', 'b', 'c'))); // $ExpectType Observable<number[]>
+  const o2 = of(1, 2, 3).pipe(bufferToggle('a', (x: number) => of('a', 'b', 'c'))); // $ExpectError
 });
 
 it('should enforce type of closingSelector', () => {

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf, ObservedValueTupleFromArray, ObservableInputTuple } from '../types';
+import { ObservableInput, ObservedValueOf, ObservableInputTuple } from '../types';
 import { map } from '../operators/map';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { innerFrom } from './from';

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -6,13 +6,21 @@ import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { innerFrom } from './from';
 import { popResultSelector } from '../util/args';
 
+// forkJoin([a, b, c])
 export function forkJoin(sources: []): Observable<never>;
 export function forkJoin<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
+
+// forkJoin(a, b, c)
 /** @deprecated Use the version that takes an array of Observables instead */
 export function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-// forkJoin({})
+
+// forkJoin({a, b, c})
 export function forkJoin(sourcesObject: {}): Observable<never>;
 export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+
+// forkJoin(a, b, c, resultSelector)
+/** @deprecated resultSelector is deprecated, pipe to map instead */	
+export function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
 
 /**
  * Accepts an `Array` of {@link ObservableInput} or a dictionary `Object` of {@link ObservableInput} and returns

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,68 +1,18 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf } from '../types';
+import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf, ObservedValueTupleFromArray, ObservableInputTuple } from '../types';
 import { map } from '../operators/map';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { innerFrom } from './from';
 import { popResultSelector } from '../util/args';
 
-// forkJoin(a$, b$, c$)
+export function forkJoin(sources: []): Observable<never>;
+export function forkJoin<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
 /** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T>(v1: ObservableInput<T>): Observable<[T]>;
-/** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>): Observable<[T, T2]>;
-/** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<[T, T2, T3]>;
-/** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2, T3, T4>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>
-): Observable<[T, T2, T3, T4]>;
-/** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2, T3, T4, T5>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>
-): Observable<[T, T2, T3, T4, T5]>;
-/** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T, T2, T3, T4, T5, T6>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>
-): Observable<[T, T2, T3, T4, T5, T6]>;
-
-// forkJoin([a$, b$, c$]);
-// TODO(benlesh): Uncomment for TS 3.0
-// export function forkJoin(sources: []): Observable<never>;
-export function forkJoin<A>(sources: [ObservableInput<A>]): Observable<[A]>;
-export function forkJoin<A, B>(sources: [ObservableInput<A>, ObservableInput<B>]): Observable<[A, B]>;
-export function forkJoin<A, B, C>(sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>]): Observable<[A, B, C]>;
-export function forkJoin<A, B, C, D>(
-  sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>]
-): Observable<[A, B, C, D]>;
-export function forkJoin<A, B, C, D, E>(
-  sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>]
-): Observable<[A, B, C, D, E]>;
-export function forkJoin<A, B, C, D, E, F>(
-  sources: [ObservableInput<A>, ObservableInput<B>, ObservableInput<C>, ObservableInput<D>, ObservableInput<E>, ObservableInput<F>]
-): Observable<[A, B, C, D, E, F]>;
-export function forkJoin<A extends ObservableInput<any>[]>(sources: A): Observable<ObservedValueUnionFromArray<A>[]>;
-
+export function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 // forkJoin({})
 export function forkJoin(sourcesObject: {}): Observable<never>;
 export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
-
-/** @deprecated resultSelector is deprecated, pipe to map instead */
-export function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
-/** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T>(...sources: ObservableInput<T>[]): Observable<T[]>;
 
 /**
  * Accepts an `Array` of {@link ObservableInput} or a dictionary `Object` of {@link ObservableInput} and returns

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf, SubscribableOrPromise } from '../types';
+import { ObservableInput, ObservedValueUnionFromArray, ObservedValueOf } from '../types';
 import { map } from '../operators/map';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { innerFrom } from './from';
@@ -8,7 +8,7 @@ import { popResultSelector } from '../util/args';
 
 // forkJoin(a$, b$, c$)
 /** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<T>(v1: SubscribableOrPromise<T>): Observable<[T]>;
+export function forkJoin<T>(v1: ObservableInput<T>): Observable<[T]>;
 /** @deprecated Use the version that takes an array of Observables instead */
 export function forkJoin<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>): Observable<[T, T2]>;
 /** @deprecated Use the version that takes an array of Observables instead */

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -123,7 +123,7 @@ export function from<T>(input: ObservableInput<T>, scheduler?: SchedulerLike): O
 // TODO: Use this throughout the library, rather than the `from` above, to avoid
 // the unnecessary scheduling check and reduce bundled sizes of operators that use `from`.
 // TODO: Eventually, this just becomes `from`, as we don't have the deprecated scheduled path anymore.
-export function innerFrom<T>(input: ObservableInput<T>) {
+export function innerFrom<T>(input: ObservableInput<T>): Observable<T> {
   if (input instanceof Observable) {
     return input;
   }

--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { defer } from './defer';
 import { EMPTY } from './empty';
-import { SubscribableOrPromise } from '../types';
+import { ObservableInput } from '../types';
 
 /**
  * Decides at subscription time which Observable will actually be subscribed.
@@ -90,8 +90,8 @@ import { SubscribableOrPromise } from '../types';
  */
 export function iif<T = never, F = never>(
   condition: () => boolean,
-  trueResult: SubscribableOrPromise<T> = EMPTY,
-  falseResult: SubscribableOrPromise<F> = EMPTY
+  trueResult: ObservableInput<T> = EMPTY,
+  falseResult: ObservableInput<F> = EMPTY
 ): Observable<T|F> {
   return defer(() => condition() ? trueResult : falseResult);
 }

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Subscriber } from '../Subscriber';
-import { MonoTypeOperatorFunction, SubscribableOrPromise } from '../types';
+import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/from';
@@ -44,13 +44,13 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link sample}
  * @see {@link throttle}
  *
- * @param {function(value: T): SubscribableOrPromise} durationSelector A function
+ * @param durationSelector A function
  * that receives a value from the source Observable, for computing the silencing
  * duration, returned as an Observable or a Promise.
- * @return {Observable<T>} An Observable that performs rate-limiting of
+ * @return An Observable that performs rate-limiting of
  * emissions from the source Observable.
  */
-export function audit<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T> {
+export function audit<T>(durationSelector: (value: T) => ObservableInput<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
     let hasValue = false;
     let lastValue: T | null = null;

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Subscription } from '../Subscription';
-import { OperatorFunction, SubscribableOrPromise } from '../types';
+import { OperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/from';
 import { OperatorSubscriber } from './OperatorSubscriber';
@@ -43,17 +43,17 @@ import { arrRemove } from '../util/arrRemove';
  * @see {@link bufferWhen}
  * @see {@link windowToggle}
  *
- * @param {SubscribableOrPromise<O>} openings A Subscribable or Promise of notifications to start new
+ * @param openings A Subscribable or Promise of notifications to start new
  * buffers.
- * @param {function(value: O): SubscribableOrPromise} closingSelector A function that takes
+ * @param closingSelector A function that takes
  * the value emitted by the `openings` observable and returns a Subscribable or Promise,
  * which, when it emits, signals that the associated buffer should be emitted
  * and cleared.
- * @return {Observable<T[]>} An observable of arrays of buffered values.
+ * @return An observable of arrays of buffered values.
  */
 export function bufferToggle<T, O>(
-  openings: SubscribableOrPromise<O>,
-  closingSelector: (value: O) => SubscribableOrPromise<any>
+  openings: ObservableInput<O>,
+  closingSelector: (value: O) => ObservableInput<any>
 ): OperatorFunction<T, T[]> {
   return operate((source, subscriber) => {
     const buffers: T[][] = [];

--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -1,6 +1,6 @@
 
 import { mergeAll } from './mergeAll';
-import { OperatorFunction, ObservableInput } from '../types';
+import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
 
 export function concatAll<T>(): OperatorFunction<ObservableInput<T>, T>;
 export function concatAll<R>(): OperatorFunction<any, R>;
@@ -61,6 +61,6 @@ export function concatAll<R>(): OperatorFunction<any, R>;
  * @return {Observable} An Observable emitting values from all the inner
  * Observables concatenated.
  */
-export function concatAll<T>(): OperatorFunction<ObservableInput<T>, T> {
-  return mergeAll<T>(1);
+export function concatAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>> {
+  return mergeAll(1);
 }

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Subscriber } from '../Subscriber';
-import { MonoTypeOperatorFunction, SubscribableOrPromise } from '../types';
+import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
@@ -56,14 +56,14 @@ import { innerFrom } from '../observable/from';
  * @see {@link throttle}
  * @see {@link throttleTime}
  *
- * @param {function(value: T): SubscribableOrPromise} durationSelector A function
+ * @param durationSelector A function
  * that receives a value from the source Observable, for computing the timeout
  * duration for each source value, returned as an Observable or a Promise.
- * @return {Observable} An Observable that delays the emissions of the source
+ * @return An Observable that delays the emissions of the source
  * Observable by the specified duration Observable returned by
  * `durationSelector`, and may drop some values if they occur too frequently.
  */
-export function debounce<T>(durationSelector: (value: T) => SubscribableOrPromise<any>): MonoTypeOperatorFunction<T> {
+export function debounce<T>(durationSelector: (value: T) => ObservableInput<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
     let hasValue = false;
     let lastValue: T | null = null;

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -1,6 +1,6 @@
 import { mergeMap } from './mergeMap';
 import { identity } from '../util/identity';
-import { OperatorFunction, ObservableInput } from '../types';
+import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
 
 /**
  * Converts a higher-order Observable into a first-order Observable which
@@ -58,6 +58,6 @@ import { OperatorFunction, ObservableInput } from '../types';
  * @return {Observable} An Observable that emits values coming from all the
  * inner Observables emitted by the source Observable.
  */
-export function mergeAll<T>(concurrent: number = Infinity): OperatorFunction<ObservableInput<T>, T> {
+export function mergeAll<O extends ObservableInput<any>>(concurrent: number = Infinity): OperatorFunction<O, ObservedValueOf<O>> {
   return mergeMap(identity, concurrent);
 }

--- a/src/internal/operators/switchAll.ts
+++ b/src/internal/operators/switchAll.ts
@@ -1,9 +1,8 @@
-import {OperatorFunction, ObservableInput} from '../types';
+import {OperatorFunction, ObservableInput, ObservedValueOf} from '../types';
 import { switchMap } from './switchMap';
 import { identity } from '../util/identity';
 
-export function switchAll<T>(): OperatorFunction<ObservableInput<T>, T>;
-export function switchAll<R>(): OperatorFunction<any, R>;
+export function switchAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { Subscription } from '../Subscription';
 
-import { MonoTypeOperatorFunction, SubscribableOrPromise } from '../types';
+import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/from';
@@ -52,16 +52,16 @@ export const defaultThrottleConfig: ThrottleConfig = {
  * @see {@link sample}
  * @see {@link throttleTime}
  *
- * @param {function(value: T): SubscribableOrPromise} durationSelector A function
+ * @param durationSelector A function
  * that receives a value from the source Observable, for computing the silencing
  * duration for each source value, returned as an Observable or a Promise.
- * @param {Object} config a configuration object to define `leading` and `trailing` behavior. Defaults
+ * @param config a configuration object to define `leading` and `trailing` behavior. Defaults
  * to `{ leading: true, trailing: false }`.
- * @return {Observable<T>} An Observable that performs the throttle operation to
+ * @return An Observable that performs the throttle operation to
  * limit the rate of emissions from the source.
  */
 export function throttle<T>(
-  durationSelector: (value: T) => SubscribableOrPromise<any>,
+  durationSelector: (value: T) => ObservableInput<any>,
   { leading, trailing }: ThrottleConfig = defaultThrottleConfig
 ): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -213,8 +213,11 @@ export type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
  * `[Observable<string>, Observable<number>]` you would get back a type
  * of `[string, number]`.
  */
-export type ObservedValueTupleFromArray<X> = X extends readonly ObservableInput<any>[] ? { [K in keyof X]: ObservedValueOf<X[K]> } : never;
+export type ObservedValueTupleFromArray<X> = { [K in keyof X]: ObservedValueOf<X[K]> };
 
+export type ObservableInputTuple<T> = {
+  [K in keyof T]: ObservableInput<T[K]>
+}
 /**
  * Constructs a new tuple with the specified type at the head.
  * If you declare `Cons<A, [B, C]>` you will get back `[A, B, C]`.

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -215,9 +215,15 @@ export type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
  */
 export type ObservedValueTupleFromArray<X> = { [K in keyof X]: ObservedValueOf<X[K]> };
 
+/**
+ * Used to infer types from arguments to functions like {@link forkJoin}.
+ * So that you can have `forkJoin([Observable<A>, PromiseLike<B>]): Observable<[A, B]>` 
+ * et al.
+ */
 export type ObservableInputTuple<T> = {
   [K in keyof T]: ObservableInput<T[K]>
 }
+
 /**
  * Constructs a new tuple with the specified type at the head.
  * If you declare `Cons<A, [B, C]>` you will get back `[A, B, C]`.

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -65,6 +65,7 @@ export interface SubscriptionLike extends Unsubscribable {
   readonly closed: boolean;
 }
 
+/** @deprecated To be removed in v8. Do not use. Most likely you want to use `ObservableInput` */
 export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | PromiseLike<T> | InteropObservable<T>;
 
 /** OBSERVABLE INTERFACES */
@@ -80,11 +81,17 @@ export interface Subscribable<T> {
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Unsubscribable;
 }
 
-export type ObservableInput<T> = SubscribableOrPromise<T> | ArrayLike<T> | Iterable<T> | AsyncIterableIterator<T>;
+/**
+ * Valid types that can be converted to observables.
+ */
+export type ObservableInput<T> = Observable<T> | InteropObservable<T> | AsyncIterable<T> | PromiseLike<T> | ArrayLike<T> | Iterable<T>;
 
 /** @deprecated use {@link InteropObservable } */
 export type ObservableLike<T> = InteropObservable<T>;
 
+/**
+ * An object that implements the `Symbol.observable` interface.
+ */
 export interface InteropObservable<T> {
   [Symbol.observable]: () => Subscribable<T>;
 }

--- a/src/internal/util/argsArgArrayOrObject.ts
+++ b/src/internal/util/argsArgArrayOrObject.ts
@@ -18,7 +18,7 @@ export function argsArgArrayOrObject<T, O extends Record<string, T>>(args: T[] |
     if (isPOJO(first)) {
       const keys = getKeys(first);
       return {
-        args: keys.map((key) => (first as O)[key]),
+        args: keys.map((key) => first[key]),
         keys,
       };
     }


### PR DESCRIPTION
Refactors to remove bad usage of `Subscribable` and updates the `InputObservable` type.

In the process I ended up needing to fix `mergeAll`, `concatAll` and `forkJoin`.

`bufferToggle` also had one bad dtslint test.

Related, I filed this in TS trying to figure this out: https://github.com/microsoft/TypeScript/issues/41091