### PR TITLE
chore: add triple-slash ref to asynciterable

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,4 +1,8 @@
 /** @prettier */
+
+// https://github.com/microsoft/TypeScript/issues/40462#issuecomment-689879308
+/// <reference lib="esnext.asynciterable" />
+
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a triple-slash `lib` reference to `esnext.asynciterable` as per the TypeScript recommendation/suggestion linked to in the accompanying comment.

I've tested this locally and it resolves the issue with `unknown` being inferred in situations in which the `tsconfig.json` does not specify a sufficiently-up-to-date `lib`.

We could add `lib` references for any other types we depend upon - like `Promise` - but I figured we ought to keep this minimal and address only the problems that we've seen so far to minimize and unintended consequences.

**Related issue (if exists):** #5708