### PR TITLE
fix(firstValueFrom): stop listening after first

### DIFF
--- a/spec/firstValueFrom-spec.ts
+++ b/spec/firstValueFrom-spec.ts
@@ -42,7 +42,7 @@ describe('firstValueFrom', () => {
     expect(finalized).to.be.true;
   });
 
-  it('should stop listening to a synchronous observable when unsubscribed', async () => {
+  it('should stop listening to a synchronous observable when resolved', async () => {
     const sideEffects: number[] = [];
     const synchronousObservable = new Observable<number>(subscriber => {
       // This will check to see if the subscriber was closed on each loop

--- a/spec/firstValueFrom-spec.ts
+++ b/spec/firstValueFrom-spec.ts
@@ -1,4 +1,4 @@
-import { interval, firstValueFrom, EMPTY, EmptyError, throwError, of } from 'rxjs';
+import { interval, firstValueFrom, EMPTY, EmptyError, throwError, of, Observable } from 'rxjs';
 import { expect } from 'chai';
 import { finalize } from 'rxjs/operators';
 
@@ -40,5 +40,20 @@ describe('firstValueFrom', () => {
     const result = await firstValueFrom(source);
     expect(result).to.equal('apples');
     expect(finalized).to.be.true;
+  });
+
+  it('should stop listening to a synchronous observable when unsubscribed', async () => {
+    const sideEffects: number[] = [];
+    const synchronousObservable = new Observable<number>(subscriber => {
+      // This will check to see if the subscriber was closed on each loop
+      // when the unsubscribe hits (from the `take`), it should be closed
+      for (let i = 0; !subscriber.closed && i < 10; i++) {
+        sideEffects.push(i);
+        subscriber.next(i);
+      }
+    });
+
+    const result = await firstValueFrom(synchronousObservable);
+    expect(sideEffects).to.deep.equal([0]);
   });
 });

--- a/src/internal/firstValueFrom.ts
+++ b/src/internal/firstValueFrom.ts
@@ -1,6 +1,6 @@
 import { Observable } from './Observable';
 import { EmptyError } from './util/EmptyError';
-import { Subscription } from './Subscription';
+import { SafeSubscriber } from './Subscriber';
 
 /**
  * Converts an observable to a promise by subscribing to the observable,
@@ -44,18 +44,16 @@ import { Subscription } from './Subscription';
  */
 export function firstValueFrom<T>(source: Observable<T>) {
   return new Promise<T>((resolve, reject) => {
-    const subs = new Subscription();
-    subs.add(
-      source.subscribe({
-        next: value => {
-          resolve(value);
-          subs.unsubscribe();
-        },
-        error: reject,
-        complete: () => {
-          reject(new EmptyError());
-        },
-      })
-    );
+    const subscriber = new SafeSubscriber<T>({
+      next: value => {
+        resolve(value);
+        subscriber.unsubscribe();
+      },
+      error: reject,
+      complete: () => {
+        reject(new EmptyError());
+      },
+    });
+    source.subscribe(subscriber);
   });
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing firehose test for `firstValueFrom` and fixes the problem by using a subscriber instead of a subscription - so that the `closed` 'signal' is chained to the source observable.

**Related issue (if exists):** #5811
