### PR TITLE
Negative tests for skip, skipLast, take and takeLast

### DIFF
--- a/spec/operators/skip-spec.ts
+++ b/spec/operators/skip-spec.ts
@@ -56,6 +56,17 @@ describe('skip', () => {
     });
   });
 
+  it('should not skip if count is negative value', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--a--b--c--d--e--|');
+      const subs = '       ^----------------!';
+      const expected = '   --a--b--c--d--e--|';
+
+      expectObservable(source.pipe(skip(-42))).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
+  });
+
   it('should allow unsubscribing explicitly and early', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const source = hot('--a--b--c--d--e--|');

--- a/spec/operators/skipLast-spec.ts
+++ b/spec/operators/skipLast-spec.ts
@@ -67,6 +67,17 @@ describe('skipLast operator', () => {
     });
   });
 
+  it('should not skip any values if provided with negative value', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const e1subs = '  ^-------------------!';
+      const expected = '--a-----b----c---d--|';
+
+      expectObservable(e1.pipe(skipLast(-42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
   it('should work with empty', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
       const e1 = cold(' |');

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { take, mergeMap } from 'rxjs/operators';
-import { range, ArgumentOutOfRangeError, of, Observable, Subject } from 'rxjs';
+import { of, Observable, Subject } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
@@ -52,6 +52,17 @@ describe('take', () => {
       const expected = '   |';
 
       expectObservable(e1.pipe(take(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
+  it('should be empty if provided with negative value', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const expected = '|';
+      const e1subs: string[] = []; // Don't subscribe at all
+
+      expectObservable(e1.pipe(take(-42))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });

--- a/spec/operators/takeLast-spec.ts
+++ b/spec/operators/takeLast-spec.ts
@@ -1,6 +1,5 @@
-import { expect } from 'chai';
 import { takeLast, mergeMap } from 'rxjs/operators';
-import { range, ArgumentOutOfRangeError, of } from 'rxjs';
+import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
@@ -57,11 +56,24 @@ describe('takeLast operator', () => {
   });
 
   it('should not take any values', () => {
-    rxTest.run(({ cold, expectObservable }) => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
       const e1 = cold(' --a-----b----c---d--|');
       const expected = '|';
+      const e1subs: string[] = [];
 
       expectObservable(e1.pipe(takeLast(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
+  it('should not take any values if provided with negative value', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a-----b----c---d--|');
+      const expected = '|';
+      const e1subs: string[] = [];
+
+      expectObservable(e1.pipe(takeLast(-42))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 


### PR DESCRIPTION
Adding tests for `skip`, `skipLast`, `take` and `takeLast` when provided with negative `count` values.