### PR TITLE
TestScheduler's createTime bug fix

### DIFF
--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -131,8 +131,9 @@ describe('find operator', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^    !';
     const expected =   '-------(b|)';
+    const t =               '--|';
 
-    const duration = rxTestScheduler.createTime('--|');
+    const duration = rxTestScheduler.createTime(t);
 
     expectObservable(source.pipe(
       find((value: string) => value === 'b'),

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -131,7 +131,7 @@ describe('find operator', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^    !';
     const expected =   '-------(b|)';
-    const t =               '--|';
+    const t =               '  |';
 
     const duration = rxTestScheduler.createTime(t);
 

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -131,7 +131,7 @@ describe('find operator', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^    !';
     const expected =   '-------(b|)';
-    const t =               '  |';
+    const t =               '--|';
 
     const duration = rxTestScheduler.createTime(t);
 

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -131,8 +131,9 @@ describe('findIndex operator', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^    !';
     const expected =   '-------(x|)';
+    const t =               '--|';
 
-    const duration = rxTestScheduler.createTime('--|');
+    const duration = rxTestScheduler.createTime(t);
 
     expectObservable(source.pipe(
       findIndex((value: string) => value === 'b'),

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -131,7 +131,7 @@ describe('findIndex operator', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^    !';
     const expected =   '-------(x|)';
-    const t =               '--|';
+    const t =               '  |';
 
     const duration = rxTestScheduler.createTime(t);
 

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -131,7 +131,7 @@ describe('findIndex operator', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^    !';
     const expected =   '-------(x|)';
-    const t =               '  |';
+    const t =               '--|';
 
     const duration = rxTestScheduler.createTime(t);
 

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -106,8 +106,9 @@ describe('Observable.prototype.first', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^ !';
     const expected =   '----(a|)';
+    const t =            '--|';
 
-    const duration = rxTestScheduler.createTime('--|');
+    const duration = rxTestScheduler.createTime(t);
 
     expectObservable(source.pipe(
       first(),

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -106,7 +106,7 @@ describe('Observable.prototype.first', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^ !';
     const expected =   '----(a|)';
-    const t =            '  |';
+    const t =            '--|';
 
     const duration = rxTestScheduler.createTime(t);
 

--- a/spec/operators/first-spec.ts
+++ b/spec/operators/first-spec.ts
@@ -106,7 +106,7 @@ describe('Observable.prototype.first', () => {
     const source = hot('--a--b---c-|');
     const subs =       '^ !';
     const expected =   '----(a|)';
-    const t =            '--|';
+    const t =            '  |';
 
     const duration = rxTestScheduler.createTime(t);
 

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -73,7 +73,7 @@ export class TestScheduler extends VirtualTimeScheduler {
   }
 
   createTime(marbles: string): number {
-    const indexOf = marbles.trim().indexOf('|');
+    const indexOf = this.runMode ? marbles.trim().indexOf('|') : marbles.indexOf('|');
     if (indexOf === -1) {
       throw new Error('marble diagram for time should have a completion marker "|"');
     }
@@ -494,7 +494,7 @@ export class TestScheduler extends VirtualTimeScheduler {
     const run = () => {
       // Whenever a scheduled run is executed, it must run a single immediate
       // or interval action - with immediate actions being prioritized over
-      // interval actions. 
+      // interval actions.
       const now = this.now();
       const scheduledRecords = Array.from(scheduleLookup.values());
       const scheduledRecordsDue = scheduledRecords.filter(({ due }) => due <= now);


### PR DESCRIPTION
Hi everyone,

I found about `TestScheduler`'s `time` helper function couple of [days ago](5819) and I wanted to know when it was added and how to use it. And I think I have found a bug.

Since `time` is an alias for  `TestScheduler`'s `createTime`, I don't know what implications will this fix have, since I'm not sure how much people were using `createTime` function. It was added many years ago and I think this bug was introduced with [this PR](5060).

What's the problem? `createTime` trims marbles passed to it and I think that this trimming should happen only if the scheduler is in run mode because when in run mode, we're also ignoring spaces. For example, much like

```ts
const subs = '^   !';
```
advances time the same way this does (when not in run mode)
```ts
const subs = '^---!';
```

time progression syntax should behave the same when used with `createTime`:

```ts
const t = '  |';
```
```ts
const t = '--|';
```

But, this is not the case. The first time progression syntax gets trimmed and spaces do not progress time causing tests to fail. And I proved this by creating two commits and editing the only three tests we have that use `createTime` function (all of them are not using run mode). In the first commit, I just extracted time progression marbles aligning them with the rest of other marbles. In the second commit, I replaced minuses (`--`) with spaces (`  `) causing those three tests to fail. The last commit adds a fix by checking if the scheduler is using run mode.

@cartant, can you please review this since you were reviewing PR that introduced marbles trimming in `createTime`.

If everything looks good and if this PR gets approved, I will add some more unit tests for `createTime`.