### PR TITLE
fix(withlatestfrom): allow synchronous source

### DIFF
--- a/spec/operators/withLatestFrom-spec.ts
+++ b/spec/operators/withLatestFrom-spec.ts
@@ -260,4 +260,16 @@ describe('withLatestFrom operator', () => {
         expect(x).to.deep.equal([1, 4, 6]);
       });
   });
+
+  it('should work with synchronous observables', () => {
+    const result: Array<Array<number>> = [];
+    of(1, 2, 3).pipe(withLatestFrom(of(4, 5))).subscribe((x) => {
+      result.push(x);
+    });
+
+    expect(result.length).to.equal(3);
+    expect(result[0]).to.deep.equal([1,5]);
+    expect(result[1]).to.deep.equal([2,5]);
+    expect(result[2]).to.deep.equal([3,5]);
+  })
 });

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -159,17 +159,6 @@ export function withLatestFrom<T, R>(...inputs: any[]): OperatorFunction<T, R | 
     // we are ready to start emitting values.
     let ready = false;
 
-    // Source subscription
-    source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
-        if (ready) {
-          // We have at least one value from the other sources. Go ahead and emit.
-          const values = [value, ...otherValues];
-          subscriber.next(project ? project(...values) : values);
-        }
-      })
-    );
-
     // Other sources. Note that here we are not checking `subscriber.closed`,
     // this causes all inputs to be subscribed to, even if nothing can be emitted
     // from them. This is an important distinction because subscription constitutes
@@ -197,5 +186,16 @@ export function withLatestFrom<T, R>(...inputs: any[]): OperatorFunction<T, R | 
         )
       );
     }
+
+    // Source subscription
+    source.subscribe(
+      new OperatorSubscriber(subscriber, (value) => {
+        if (ready) {
+          // We have at least one value from the other sources. Go ahead and emit.
+          const values = [value, ...otherValues];
+          subscriber.next(project ? project(...values) : values);
+        }
+      })
+    );
   });
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Attempt to fix #5827 by adjusting subscription order, let source does not complete even before subscribe into other sources.

**Related issue (if exists):**
