### PR TITLE
fix(iif): No longer allow accidental undefined arguments

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -270,7 +270,9 @@ export declare type Head<X extends any[]> = ((...args: X) => any) extends (arg: 
 
 export declare function identity<T>(x: T): T;
 
-export declare function iif<T = never, F = never>(condition: () => boolean, trueResult?: ObservableInput<T>, falseResult?: ObservableInput<F>): Observable<T | F>;
+export declare function iif<T>(condition: () => true, trueResult: ObservableInput<T>, falseResult: ObservableInput<any>): Observable<T>;
+export declare function iif<F>(condition: () => false, trueResult: ObservableInput<any>, falseResult: ObservableInput<F>): Observable<F>;
+export declare function iif<T, F>(condition: () => boolean, trueResult: ObservableInput<T>, falseResult: ObservableInput<F>): Observable<T | F>;
 
 export interface InteropObservable<T> {
     [Symbol.observable]: () => Subscribable<T>;

--- a/spec-dtslint/observables/iif-spec.ts
+++ b/spec-dtslint/observables/iif-spec.ts
@@ -1,17 +1,25 @@
-import { iif, of } from 'rxjs';
+import { a$, b$ } from 'helpers';
+import { iif, EMPTY } from 'rxjs';
 
-it('should accept function as first parameter', () => {
-  const a = iif(() => false); // $ExpectType Observable<never>
+const randomBoolean = () => Math.random() > 0.5;
+
+it('should error for insufficient parameters', () => {
+  const r0 = iif(randomBoolean); // $ExpectError
+  const r1 = iif(randomBoolean, a$); // $ExpectError
+  const r2 = iif(randomBoolean, undefined, b$); // $ExpectError
 });
 
-it('should infer correctly with 2 parameters', () => {
-  const a = iif(() => false, of(1)); // $ExpectType Observable<number>
+it('should error for incorrect parameters', () => {
+  const r0 = iif(() => 132, a$, b$); // $ExpectError
+  const r1 = iif(randomBoolean, {}, b$); // $ExpectError
+  const r2 = iif(randomBoolean, a$, {}); // $ExpectError
 });
 
-it('should infer correctly with 3 parameters', () => {
-  const a = iif(() => false, of(1), of(2)); // $ExpectType Observable<number>
-});
-
-it('should infer correctly with 3 parameters of different types', () => {
-  const a = iif(() => false, of(1), of('a')); // $ExpectType Observable<string | number>
+it('should infer correctly', () => {
+  const r0 = iif(() => false, a$, b$); // $ExpectType Observable<B>
+  const r1 = iif(() => true, a$, b$); // $ExpectType Observable<A>
+  const r2 = iif(randomBoolean, a$, b$); // $ExpectType Observable<A | B>
+  const r3 = iif(() => false, a$, EMPTY); // $ExpectType Observable<never>
+  const r4 = iif(() => true, EMPTY, b$); // $ExpectType Observable<never>
+  const r5 = iif(randomBoolean, EMPTY, EMPTY); // $ExpectType Observable<never>
 });

--- a/spec/observables/if-spec.ts
+++ b/spec/observables/if-spec.ts
@@ -4,7 +4,7 @@ import { expectObservable } from '../helpers/marble-testing';
 
 describe('iif', () => {
   it('should subscribe to thenSource when the conditional returns true', () => {
-    const e1 = iif(() => true, of('a'));
+    const e1 = iif(() => true, of('a'), of());
     const expected = '(a|)';
 
     expectObservable(e1).toBe(expected);
@@ -18,16 +18,16 @@ describe('iif', () => {
   });
 
   it('should complete without an elseSource when the conditional returns false', () => {
-    const e1 = iif(() => false, of('a'));
+    const e1 = iif(() => false, of('a'), of());
     const expected = '|';
 
     expectObservable(e1).toBe(expected);
   });
 
   it('should raise error when conditional throws', () => {
-    const e1 = iif(<any>(() => {
+    const e1 = iif(((): boolean => {
       throw 'error';
-    }), of('a'));
+    }), of('a'), of());
 
     const expected = '#';
 
@@ -36,7 +36,7 @@ describe('iif', () => {
 
   it('should accept resolved promise as thenSource', (done: MochaDone) => {
     const expected = 42;
-    const e1 = iif(() => true, new Promise((resolve: any) => { resolve(expected); }));
+    const e1 = iif(() => true, new Promise((resolve: any) => { resolve(expected); }), of());
 
     e1.subscribe(x => {
       expect(x).to.equal(expected);
@@ -80,7 +80,7 @@ describe('iif', () => {
 
   it('should accept rejected promise as thenSource', (done: MochaDone) => {
     const expected = 42;
-    const e1 = iif(() => true, new Promise((resolve: any, reject: any) => { reject(expected); }));
+    const e1 = iif(() => true, new Promise((resolve: any, reject: any) => { reject(expected); }), of());
 
     e1.subscribe(x => {
       done(new Error('should not be called'));

--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -1,32 +1,30 @@
+/** @prettier */
 import { Observable } from '../Observable';
 import { defer } from './defer';
-import { EMPTY } from './empty';
 import { ObservableInput } from '../types';
 
+export function iif<T>(condition: () => true, trueResult: ObservableInput<T>, falseResult: ObservableInput<any>): Observable<T>;
+
+export function iif<F>(condition: () => false, trueResult: ObservableInput<any>, falseResult: ObservableInput<F>): Observable<F>;
+
+export function iif<T, F>(condition: () => boolean, trueResult: ObservableInput<T>, falseResult: ObservableInput<F>): Observable<T | F>;
+
 /**
- * Decides at subscription time which Observable will actually be subscribed.
+ * Checks a boolean at subscription time, and chooses between one of two observable sources
  *
- * <span class="informal">`If` statement for Observables.</span>
+ * `iif` excepts a function that returns a boolean (the `condition` function), and two sources,
+ * the `trueResult` and the `falseResult`, and returns an Observable.
  *
- * `iif` accepts a condition function and two Observables. When
- * an Observable returned by the operator is subscribed, condition function will be called.
- * Based on what boolean it returns at that moment, consumer will subscribe either to
- * the first Observable (if condition was true) or to the second (if condition was false). Condition
- * function may also not return anything - in that case condition will be evaluated as false and
- * second Observable will be subscribed.
+ * At the moment of subscription, the `condition` function is called. If the result is `true`, the
+ * subscription will be to the source passed as the `trueResult`, otherwise, the subscription will be
+ * to the source passed as the `falseResult`.
  *
- * Note that Observables for both cases (true and false) are optional. If condition points to an Observable that
- * was left undefined, resulting stream will simply complete immediately. That allows you to, rather
- * than controlling which Observable will be subscribed, decide at runtime if consumer should have access
- * to given Observable or not.
- *
- * If you have more complex logic that requires decision between more than two Observables, {@link defer}
- * will probably be a better choice. Actually `iif` can be easily implemented with {@link defer}
- * and exists only for convenience and readability reasons.
- *
+ * If you need to check more than two options to choose between more than one observable, have a look at the {@link defer} creation method.
  *
  * ## Examples
+ *
  * ### Change at runtime which Observable will be subscribed
+ *
  * ```ts
  * import { iif, of } from 'rxjs';
  *
@@ -52,6 +50,7 @@ import { ObservableInput } from '../types';
  * ```
  *
  * ### Control an access to an Observable
+ *
  * ```ts
  * let accessGranted;
  * const observableIfYouHaveAccess = iif(
@@ -83,15 +82,11 @@ import { ObservableInput } from '../types';
  *
  * @see {@link defer}
  *
- * @param {function(): boolean} condition Condition which Observable should be chosen.
- * @param {Observable} [trueObservable] An Observable that will be subscribed if condition is true.
- * @param {Observable} [falseObservable] An Observable that will be subscribed if condition is false.
- * @return {Observable} Either first or second Observable, depending on condition.
+ * @param condition Condition which Observable should be chosen.
+ * @param trueResult An Observable that will be subscribed if condition is true.
+ * @param falseResult An Observable that will be subscribed if condition is false.
+ * @return An observable that proxies to `trueResult` or `falseResult`, depending on the result of the `condition` function.
  */
-export function iif<T = never, F = never>(
-  condition: () => boolean,
-  trueResult: ObservableInput<T> = EMPTY,
-  falseResult: ObservableInput<F> = EMPTY
-): Observable<T|F> {
-  return defer(() => condition() ? trueResult : falseResult);
+export function iif<T, F>(condition: () => boolean, trueResult: ObservableInput<T>, falseResult: ObservableInput<F>): Observable<T | F> {
+  return defer(() => (condition() ? trueResult : falseResult));
 }


### PR DESCRIPTION
- Updates types
- Ensures that result arguments must be passed
- Ensures narrower type when conditional result is known to be `true`, or known to be `false`.

BREAKING CHANGE: `iif` will no longer allow result arguments that are `undefined`. This was a bad call pattern that was likely an error in most cases. If for some reason you are relying on this behavior, simply substitute `EMPTY` in place of the `undefined` argument. This ensures that the behavior was intentional and desired, rather than the result of an accidental `undefined` argument.
