### PR TITLE
Refactor: combineLatest and forkJoin types for n-args

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -102,6 +102,13 @@ export declare function bindNodeCallback<A1, A2, A3, A4, A5, R1>(callbackFunc: (
 export declare function bindNodeCallback<A1, A2, A3, A4, A5>(callbackFunc: (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5, callback: (err: any) => any) => any, scheduler?: SchedulerLike): (arg1: A1, arg2: A2, arg3: A3, arg4: A4, arg5: A5) => Observable<void>;
 export declare function bindNodeCallback(callbackFunc: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any[]>;
 
+export declare function combineLatest(sources: []): Observable<never>;
+export declare function combineLatest<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+export declare function combineLatest<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
+export declare function combineLatest(sourcesObject: {}): Observable<never>;
+export declare function combineLatest<T>(sourcesObject: T): Observable<{
+    [K in keyof T]: ObservedValueOf<T[K]>;
+}>;
 export declare function combineLatest<O1 extends ObservableInput<any>, R>(sources: [O1], resultSelector: (v1: ObservedValueOf<O1>) => R, scheduler?: SchedulerLike): Observable<R>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, R>(sources: [O1, O2], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>) => R, scheduler?: SchedulerLike): Observable<R>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, R>(sources: [O1, O2, O3], resultSelector: (v1: ObservedValueOf<O1>, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>) => R, scheduler?: SchedulerLike): Observable<R>;
@@ -129,21 +136,6 @@ export declare function combineLatest<O1 extends ObservableInput<any>, O2 extend
     ObservedValueOf<O6>
 ]>;
 export declare function combineLatest<O extends ObservableInput<any>>(sources: O[], scheduler: SchedulerLike): Observable<ObservedValueOf<O>[]>;
-export declare function combineLatest<O1 extends ObservableInput<any>>(sources: [O1]): Observable<[ObservedValueOf<O1>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(sources: [O1, O2]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(sources: [O1, O2, O3]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(sources: [O1, O2, O3, O4]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(sources: [O1, O2, O3, O4, O5, O6]): Observable<[
-    ObservedValueOf<O1>,
-    ObservedValueOf<O2>,
-    ObservedValueOf<O3>,
-    ObservedValueOf<O4>,
-    ObservedValueOf<O5>,
-    ObservedValueOf<O6>
-]>;
-export declare function combineLatest<O extends ObservableInput<any>>(sources: O[]): Observable<ObservedValueOf<O>[]>;
-export declare function combineLatest<O extends readonly ObservableInput<any>[]>(sources: O): Observable<ObservedValueTupleFromArray<O>>;
 export declare function combineLatest<O1 extends ObservableInput<any>>(v1: O1, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(v1: O1, v2: O2, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
 export declare function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
@@ -163,10 +155,6 @@ export declare function combineLatest<O extends ObservableInput<any>, R>(array: 
 export declare function combineLatest<O extends ObservableInput<any>>(...observables: Array<O | SchedulerLike>): Observable<any[]>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>): Observable<R>;
 export declare function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
-export declare function combineLatest(sourcesObject: {}): Observable<never>;
-export declare function combineLatest<T>(sourcesObject: T): Observable<{
-    [K in keyof T]: ObservedValueOf<T[K]>;
-}>;
 
 export interface CompleteNotification {
     kind: 'C';
@@ -238,7 +226,7 @@ export declare type FactoryOrValue<T> = T | (() => T);
 export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
 export declare function forkJoin(sources: []): Observable<never>;
-export declare function forkJoin<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
+export declare function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin(sourcesObject: {}): Observable<never>;
 export declare function forkJoin<T>(sourcesObject: T): Observable<{

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -27,7 +27,7 @@ it('should accept 6 params', () => {
 });
 
 it('should result in Observable<unknown> for 7 or more params', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, f$, g$); // $ExpectType Observable<unknown>
+  const o = combineLatest(a$, b$, c$, d$, e$, f$, g$); // $ExpectType Observable<[A, B, C, D, E, F, G]>
 });
 
 it('should accept union types', () => {
@@ -89,15 +89,15 @@ it('should accept 6 params', () => {
 });
 
 it('should have basic support for 7 or more params', () => {
-  const o = combineLatest([a$, b$, c$, d$, e$, f$, g$]); // $ExpectType Observable<(A | B | C | D | E | F | G)[]>
+  const o = combineLatest([a$, b$, c$, d$, e$, f$, g$]); // $ExpectType Observable<[A, B, C, D, E, F, G]>
 });
 
 it('should have full support for 7 or more params with readonly tuples', () => {
-  const o = combineLatest([a$, b$, c$, d$, e$, f$, g$] as const); // $ExpectType Observable<readonly [A, B, C, D, E, F, G]>
+  const o = combineLatest([a$, b$, c$, d$, e$, f$, g$] as const); // $ExpectType Observable<[A, B, C, D, E, F, G]>
 });
 
 it('should handle an array of Observables', () => {
-  const o = combineLatest([a$, a$, a$, a$, a$, a$, a$, a$, a$, a$, a$]); // $ExpectType Observable<A[]>
+  const o = combineLatest([a$, a$, a$, a$, a$, a$, a$, a$, a$, a$, a$]); // $ExpectType Observable<[A, A, A, A, A, A, A, A, A, A, A]>
 });
 
 it('should accept 1 param and a result selector', () => {

--- a/spec-dtslint/observables/forkJoin-spec.ts
+++ b/spec-dtslint/observables/forkJoin-spec.ts
@@ -1,3 +1,4 @@
+import { a$, b$, c$ } from 'helpers';
 import { of, forkJoin } from 'rxjs';
 
 describe('deprecated rest args', () => {
@@ -69,10 +70,13 @@ describe('forkJoin({})', () => {
 });
 
 describe('forkJoin([])', () => {
-  // TODO(benlesh): Uncomment for TS 3.0
-  // it('should properly type empty arrays', () => {
-  //   const res = forkJoin([]); // $ExpectType Observable<never>
-  // });
+  it('should properly type empty arrays', () => {
+    const res = forkJoin([]); // $ExpectType Observable<never>
+  });
+
+    it('should properly type readonly arrays', () => {
+    const res = forkJoin([a$, b$, c$] as const); // $ExpectType Observable<[A, B, C]>
+  });
 
   it('should infer correctly for array of 1 observable', () => {
     const res = forkJoin([of(1, 2, 3)]); // $ExpectType Observable<[number]>

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValueTupleFromArray } from '../types';
+import { ObservableInput, SchedulerLike, ObservedValueOf, ObservableInputTuple } from '../types';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { Subscriber } from '../Subscriber';
 import { from } from './from';
@@ -9,7 +9,17 @@ import { Subscription } from '../Subscription';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { popResultSelector, popScheduler } from '../util/args';
 
-/* tslint:disable:max-line-length */
+// combineLatest([a, b, c])
+export function combineLatest(sources: []): Observable<never>;
+export function combineLatest<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+
+// combineLatest(a, b, c)
+/** @deprecated Use the version that takes an array of Observables instead */
+export function combineLatest<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
+
+// combineLatest({a, b, c})
+export function combineLatest(sourcesObject: {}): Observable<never>;
+export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 // If called with a single array, it "auto-spreads" the array, with result selector
 /** @deprecated resultSelector no longer supported, pipe to map instead */
@@ -227,45 +237,6 @@ export function combineLatest<
 /** @deprecated The scheduler argument is deprecated, use scheduled and combineAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function combineLatest<O extends ObservableInput<any>>(sources: O[], scheduler: SchedulerLike): Observable<ObservedValueOf<O>[]>;
 
-// Best case
-export function combineLatest<O1 extends ObservableInput<any>>(sources: [O1]): Observable<[ObservedValueOf<O1>]>;
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(
-  sources: [O1, O2]
-): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>]>;
-export function combineLatest<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(
-  sources: [O1, O2, O3]
-): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
-export function combineLatest<
-  O1 extends ObservableInput<any>,
-  O2 extends ObservableInput<any>,
-  O3 extends ObservableInput<any>,
-  O4 extends ObservableInput<any>
->(sources: [O1, O2, O3, O4]): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
-export function combineLatest<
-  O1 extends ObservableInput<any>,
-  O2 extends ObservableInput<any>,
-  O3 extends ObservableInput<any>,
-  O4 extends ObservableInput<any>,
-  O5 extends ObservableInput<any>
->(
-  sources: [O1, O2, O3, O4, O5]
-): Observable<[ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export function combineLatest<
-  O1 extends ObservableInput<any>,
-  O2 extends ObservableInput<any>,
-  O3 extends ObservableInput<any>,
-  O4 extends ObservableInput<any>,
-  O5 extends ObservableInput<any>,
-  O6 extends ObservableInput<any>
->(
-  sources: [O1, O2, O3, O4, O5, O6]
-): Observable<
-  [ObservedValueOf<O1>, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]
->;
-export function combineLatest<O extends ObservableInput<any>>(sources: O[]): Observable<ObservedValueOf<O>[]>;
-export function combineLatest<O extends readonly ObservableInput<any>[]>(sources: O): Observable<ObservedValueTupleFromArray<O>>;
-
-// Standard calls
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
 export function combineLatest<O1 extends ObservableInput<any>>(v1: O1, scheduler?: SchedulerLike): Observable<[ObservedValueOf<O1>]>;
 /** @deprecated Pass arguments in a single array instead `combineLatest([a, b, c])` */
@@ -356,12 +327,6 @@ export function combineLatest<O extends ObservableInput<any>, R>(
 export function combineLatest<R>(
   ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>
 ): Observable<R>;
-
-// combineLatest({})
-export function combineLatest(sourcesObject: {}): Observable<never>;
-export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
-
-/* tslint:enable:max-line-length */
 
 /**
  * Combines multiple Observables to create an Observable whose values are

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -8,7 +8,7 @@ import { popResultSelector } from '../util/args';
 
 // forkJoin([a, b, c])
 export function forkJoin(sources: []): Observable<never>;
-export function forkJoin<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
+export function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 
 // forkJoin(a, b, c)
 /** @deprecated Use the version that takes an array of Observables instead */
@@ -19,7 +19,8 @@ export function forkJoin(sourcesObject: {}): Observable<never>;
 export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 // forkJoin(a, b, c, resultSelector)
-/** @deprecated resultSelector is deprecated, pipe to map instead */	
+/** @deprecated resultSelector is deprecated, pipe to map instead */
+
 export function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
 
 /**


### PR DESCRIPTION
- Resolves an issue where `forkJoin([a, b, c] as const)` didn't infer properly.
- Updates `combineLatest` with new approach for n-args.