### PR TITLE
fix: use empty object type in combineLatest/forkJoin sigs

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -43,7 +43,9 @@ export declare function bindNodeCallback<A extends readonly unknown[], R extends
 export declare function combineLatest(sources: []): Observable<never>;
 export declare function combineLatest<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 export declare function combineLatest<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-export declare function combineLatest(sourcesObject: {}): Observable<never>;
+export declare function combineLatest(sourcesObject: {
+    [K in any]: never;
+}): Observable<never>;
 export declare function combineLatest<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
@@ -93,12 +95,6 @@ export declare function combineLatest<O extends ObservableInput<any>, R>(array: 
 export declare function combineLatest<O extends ObservableInput<any>>(...observables: Array<O | SchedulerLike>): Observable<any[]>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>): Observable<R>;
 export declare function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
-export declare function combineLatest(sourcesObject: {
-    [K in any]: never;
-}): Observable<never>;
-export declare function combineLatest<T>(sourcesObject: T): Observable<{
-    [K in keyof T]: ObservedValueOf<T[K]>;
-}>;
 
 export interface CompleteNotification {
     kind: 'C';

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -93,6 +93,12 @@ export declare function combineLatest<O extends ObservableInput<any>, R>(array: 
 export declare function combineLatest<O extends ObservableInput<any>>(...observables: Array<O | SchedulerLike>): Observable<any[]>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>): Observable<R>;
 export declare function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
+export declare function combineLatest(sourcesObject: {
+    [K in any]: never;
+}): Observable<never>;
+export declare function combineLatest<T>(sourcesObject: T): Observable<{
+    [K in keyof T]: ObservedValueOf<T[K]>;
+}>;
 
 export interface CompleteNotification {
     kind: 'C';
@@ -166,7 +172,9 @@ export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 export declare function forkJoin(sources: []): Observable<never>;
 export declare function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-export declare function forkJoin(sourcesObject: {}): Observable<never>;
+export declare function forkJoin(sourcesObject: {
+    [K in any]: never;
+}): Observable<never>;
 export declare function forkJoin<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -136,4 +136,9 @@ describe('combineLatest({})', () => {
   it('should work for the simple case', () => {
     const res = combineLatest({ foo: a$, bar: b$, baz: c$ }); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
   });
+
+  it('should not reply upon the excess-properties behavior', () => {
+    const obj = { foo: a$, bar: b$, baz: c$ };
+    const res = combineLatest(obj); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
+  });
 });

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -137,7 +137,7 @@ describe('combineLatest({})', () => {
     const res = combineLatest({ foo: a$, bar: b$, baz: c$ }); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
   });
 
-  it('should not reply upon the excess-properties behavior', () => {
+  it('should not reply upon the excess-properties behavior to identify empty objects', () => {
     const obj = { foo: a$, bar: b$, baz: c$ };
     const res = combineLatest(obj); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
   });

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -137,7 +137,7 @@ describe('combineLatest({})', () => {
     const res = combineLatest({ foo: a$, bar: b$, baz: c$ }); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
   });
 
-  it('should not reply upon the excess-properties behavior to identify empty objects', () => {
+  it('should not rely upon the excess-properties behavior to identify empty objects', () => {
     const obj = { foo: a$, bar: b$, baz: c$ };
     const res = combineLatest(obj); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
   });

--- a/spec-dtslint/observables/forkJoin-spec.ts
+++ b/spec-dtslint/observables/forkJoin-spec.ts
@@ -67,6 +67,11 @@ describe('forkJoin({})', () => {
   it('should work for the simple case', () => {
     const res = forkJoin({ foo: of(1), bar: of('two'), baz: of(false) }); // $ExpectType Observable<{ foo: number; bar: string; baz: boolean; }>
   });
+
+  it('should not rely upon the excess-properties behavior', () => {
+    const obj = { foo: of(1), bar: of('two'), baz: of(false) };
+    const res = forkJoin(obj); // $ExpectType Observable<{ foo: number; bar: string; baz: boolean; }>
+  });
 });
 
 describe('forkJoin([])', () => {

--- a/spec-dtslint/observables/forkJoin-spec.ts
+++ b/spec-dtslint/observables/forkJoin-spec.ts
@@ -68,7 +68,7 @@ describe('forkJoin({})', () => {
     const res = forkJoin({ foo: of(1), bar: of('two'), baz: of(false) }); // $ExpectType Observable<{ foo: number; bar: string; baz: boolean; }>
   });
 
-  it('should not rely upon the excess-properties behavior', () => {
+  it('should not rely upon the excess-properties behavior to identify empty objects', () => {
     const obj = { foo: of(1), bar: of('two'), baz: of(false) };
     const res = forkJoin(obj); // $ExpectType Observable<{ foo: number; bar: string; baz: boolean; }>
   });

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -18,7 +18,7 @@ export function combineLatest<A extends readonly unknown[]>(sources: readonly [.
 export function combineLatest<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 
 // combineLatest({a, b, c})
-export function combineLatest(sourcesObject: {}): Observable<never>;
+export function combineLatest(sourcesObject: { [K in any]: never }): Observable<never>;
 export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 // If called with a single array, it "auto-spreads" the array, with result selector
@@ -327,10 +327,6 @@ export function combineLatest<O extends ObservableInput<any>, R>(
 export function combineLatest<R>(
   ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>
 ): Observable<R>;
-
-// combineLatest({})
-export function combineLatest(sourcesObject: { [K in any]: never }): Observable<never>;
-export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /**
  * Combines multiple Observables to create an Observable whose values are

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -332,8 +332,6 @@ export function combineLatest<R>(
 export function combineLatest(sourcesObject: { [K in any]: never }): Observable<never>;
 export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
-/* tslint:enable:max-line-length */
-
 /**
  * Combines multiple Observables to create an Observable whose values are
  * calculated from the latest values of each of its input Observables.

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -328,6 +328,12 @@ export function combineLatest<R>(
   ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>
 ): Observable<R>;
 
+// combineLatest({})
+export function combineLatest(sourcesObject: { [K in any]: never }): Observable<never>;
+export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+
+/* tslint:enable:max-line-length */
+
 /**
  * Combines multiple Observables to create an Observable whose values are
  * calculated from the latest values of each of its input Observables.

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -15,7 +15,7 @@ export function forkJoin<A extends readonly unknown[]>(sources: readonly [...Obs
 export function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 
 // forkJoin({a, b, c})
-export function forkJoin(sourcesObject: {}): Observable<never>;
+export function forkJoin(sourcesObject: { [K in any]: never }): Observable<never>;
 export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 // forkJoin(a, b, c, resultSelector)

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -20,7 +20,6 @@ export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: Obse
 
 // forkJoin(a, b, c, resultSelector)
 /** @deprecated resultSelector is deprecated, pipe to map instead */
-
 export function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds failing tests to show that the current signatures for `combineLatest` and `forkJoin` depend upon the excess-properties behaviour that TypeScript applies to object literals and fixes the problem by using a proper empty-object type in the function signatures.

See [this comment](https://github.com/ReactiveX/rxjs/pull/5830#discussion_r505902405).

**Related issue (if exists):** None
