### PR TITLE
fix(multicast,share,refCount,shareReplay): enable synchronous firehose

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -198,6 +198,7 @@ export declare class ConnectableObservable<T> extends Observable<T> {
     protected _connection: Subscription | null;
     protected _refCount: number;
     protected _subject: Subject<T> | null;
+    protected _waiting: boolean;
     source: Observable<T>;
     protected subjectFactory: () => Subject<T>;
     constructor(source: Observable<T>, subjectFactory: () => Subject<T>);
@@ -205,6 +206,7 @@ export declare class ConnectableObservable<T> extends Observable<T> {
     protected _teardown(): void;
     connect(): Subscription;
     protected getSubject(): Subject<T>;
+    prepare(): Subscription;
     refCount(): Observable<T>;
 }
 

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -701,7 +701,6 @@ describe('multicast operator', () => {
     });
   });
 
-  // TODO: fix firehose unsubscription
   // AFAICT, it's not possible for multicast observables to support ASAP
   // unsubscription from synchronous firehose sources. The problem is that the
   // chaining of the closed 'signal' is broken by the subject. For example,
@@ -718,7 +717,7 @@ describe('multicast operator', () => {
   // That breaks the chaining of closed - i.e. even if the unsubscribe is
   // called on the subject, closing it, the SafeSubscriber's closed property
   // won't reflect that.
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
+  it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
     const synchronousObservable = new Observable<number>(subscriber => {
       // This will check to see if the subscriber was closed on each loop

--- a/spec/operators/refCount-spec.ts
+++ b/spec/operators/refCount-spec.ts
@@ -115,8 +115,7 @@ describe('refCount', () => {
     expect(arr[1]).to.equal('the number two');
   });
 
-  // TODO: fix firehose unsubscription
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
+  it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
     const synchronousObservable = new Observable<number>(subscriber => {
       // This will check to see if the subscriber was closed on each loop

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -309,8 +309,7 @@ describe('share operator', () => {
     expectObservable(e1.pipe(share())).toBe(expected);
   });
 
-  // TODO: fix firehose unsubscription
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
+  it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
     const synchronousObservable = new Observable<number>(subscriber => {
       // This will check to see if the subscriber was closed on each loop

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -299,8 +299,7 @@ describe('shareReplay operator', () => {
     expectObservable(result).toBe(expected);
   });
 
-  // TODO: fix firehose unsubscription
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
+  it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
     const synchronousObservable = new Observable<number>(subscriber => {
       // This will check to see if the subscriber was closed on each loop
@@ -312,7 +311,7 @@ describe('shareReplay operator', () => {
     });
 
     synchronousObservable.pipe(
-      shareReplay(),
+      shareReplay({ refCount: true }),
       take(3),
     ).subscribe(() => { /* noop */ });
 

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -5,6 +5,7 @@ import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { OperatorFunction, UnaryFunction, ObservedValueOf, ObservableInput } from '../types';
 import { hasLift, operate } from '../util/lift';
 import { isFunction } from '../util/isFunction';
+import { SafeSubscriber } from '../Subscriber';
 
 /* tslint:disable:max-line-length */
 export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
@@ -50,7 +51,10 @@ export function multicast<T, R>(
       // that to the resulting subscription. The act of subscribing with `this`,
       // the primary destination subscriber, will automatically add the subscription
       // to the result.
-      selector(subject).subscribe(subscriber).add(source.subscribe(subject));
+      const subscription = selector(subject).subscribe(subscriber);
+      const subjectSubscriber = new SafeSubscriber(subject);
+      subscription.add(subjectSubscriber);
+      source.subscribe(subjectSubscriber);
     });
   }
 


### PR DESCRIPTION
- use known subscriber when possible instead of returned subscription
- remove unused unsubscribe from refCount Operator
- add teardown logic before calling subscribe when possible
- enable remaining synchronous firehose tests

fixes #5658
