### PR TITLE
Use `unknown` instead of `any` to catch more mistakes

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -175,8 +175,8 @@ export declare function mergeMap<T, O extends ObservableInput<any>>(project: (va
 export declare function mergeMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined, concurrent?: number): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function mergeMap<T, R, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
 
-export declare function mergeMapTo<O extends ObservableInput<any>>(innerObservable: O, concurrent?: number): OperatorFunction<any, ObservedValueOf<O>>;
-export declare function mergeMapTo<T, R, O extends ObservableInput<any>>(innerObservable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
+export declare function mergeMapTo<O extends ObservableInput<unknown>>(innerObservable: O, concurrent?: number): OperatorFunction<any, ObservedValueOf<O>>;
+export declare function mergeMapTo<T, R, O extends ObservableInput<unknown>>(innerObservable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
 
 export declare function mergeScan<T, R>(accumulator: (acc: R, value: T, index: number) => ObservableInput<R>, seed: R, concurrent?: number): OperatorFunction<T, R>;
 

--- a/spec-dtslint/operators/mergeMapTo-spec.ts
+++ b/spec-dtslint/operators/mergeMapTo-spec.ts
@@ -54,6 +54,11 @@ it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(mergeMapTo()); // $ExpectError
 });
 
+it('should enforce types of the observable parameter', () => {
+  const fn = () => {}
+  const o = of(1, 2, 3).pipe(mergeMapTo(fn)); // $ExpectError
+});
+
 it('should enforce the return type', () => {
   const o = of(1, 2, 3).pipe(mergeMapTo(p => p)); // $ExpectError
   const p = of(1, 2, 3).pipe(mergeMapTo(4)); // $ExpectError

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -4,9 +4,9 @@ import { ObservableInput } from '../types';
 import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
-export function mergeMapTo<O extends ObservableInput<any>>(innerObservable: O, concurrent?: number): OperatorFunction<any, ObservedValueOf<O>>;
+export function mergeMapTo<O extends ObservableInput<unknown>>(innerObservable: O, concurrent?: number): OperatorFunction<any, ObservedValueOf<O>>;
 /** @deprecated */
-export function mergeMapTo<T, R, O extends ObservableInput<any>>(innerObservable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
+export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(innerObservable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -47,7 +47,7 @@ export function mergeMapTo<T, R, O extends ObservableInput<any>>(innerObservable
  * @return {Observable} An Observable that emits items from the given
  * `innerObservable`
  */
-export function mergeMapTo<T, R, O extends ObservableInput<any>>(
+export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,
   resultSelector?: ((outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R) | number,
   concurrent: number = Infinity


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

I recently shipped a bug to production which TS should have caught. It looked something like this: https://stackblitz.com/edit/rxjs-jlgx8q?devtoolsheight=60

```ts
import { of } from "rxjs";
import { mergeMapTo } from "rxjs/operators";

const source = of(10);

const fn = () => {};
// Expected type error, but got none.
source.pipe(mergeMapTo(fn)).subscribe();
```

The reason TS doesn't catch this is because:

- `mergeMapTo` uses `ObservableInput<any>`
- `ObservableInput<any>` uses `ArrayLike<any>`
- TS has a "bug" whereby `ArrayLike<any>` is assignable to a function https://github.com/microsoft/TypeScript/issues/18757

We can workaround this by replacing `ObservableInput<any>` with `ObservableInput<unknown>`, as @cartant suggested on Twitter: https://twitter.com/ncjamieson/status/1318501262162239489.

I had a quick go at replacing all usages across the codebase, but I ended up with a lot of failing type tests. Perhaps we will only be able to switch to `unknown` in certain places like this. WDYT?

**Related issue (if exists):**
