### PR TITLE
refactor(merge): Create better typings

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -358,7 +358,7 @@ export declare function of<T, U>(value1: T, value2: U): Observable<T | U>;
 export declare function of<T, U, V>(value1: T, value2: U, value3: V): Observable<T | U | V>;
 export declare function of<A extends Array<any>>(...args: A): Observable<ValueFromArray<A>>;
 
-export declare type OneOrMoreUnknownObservableInputs = readonly [ObservableInput<unknown>, ...unknown[]];
+export declare type OneOrMoreUnknownObservableInputs = readonly [ObservableInput<unknown>, ...ObservableInput<unknown>[]];
 
 export declare function onErrorResumeNext(): Observable<never>;
 export declare function onErrorResumeNext<O extends ObservableInput<any>>(arrayOfSources: O[]): Observable<ObservedValueOf<O>>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -113,6 +113,8 @@ export declare function concat<O1 extends ObservableInput<any>, O2 extends Obser
 export declare function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4> | ObservedValueOf<O5> | ObservedValueOf<O6>>;
 export declare function concat<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
 
+export declare type Concat<T extends readonly unknown[], E extends readonly unknown[]> = readonly [...T, ...E];
+
 export declare const config: {
     onUnhandledError: ((err: any) => void) | null;
     Promise: PromiseConstructorLike;
@@ -210,34 +212,14 @@ export declare function isObservable<T>(obj: any): obj is Observable<T>;
 
 export declare function lastValueFrom<T>(source: Observable<T>): Promise<T>;
 
-export declare function merge<T>(v1: ObservableInput<T>, scheduler: SchedulerLike): Observable<T>;
-export declare function merge<T>(v1: ObservableInput<T>, concurrent: number, scheduler: SchedulerLike): Observable<T>;
-export declare function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler: SchedulerLike): Observable<T | T2>;
-export declare function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent: number, scheduler: SchedulerLike): Observable<T | T2>;
-export declare function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler: SchedulerLike): Observable<T | T2 | T3>;
-export declare function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent: number, scheduler: SchedulerLike): Observable<T | T2 | T3>;
-export declare function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4>;
-export declare function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent: number, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4>;
-export declare function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
-export declare function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent: number, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
-export declare function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export declare function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent: number, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export declare function merge<T>(v1: ObservableInput<T>): Observable<T>;
-export declare function merge<T>(v1: ObservableInput<T>, concurrent: number): Observable<T>;
-export declare function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>): Observable<T | T2>;
-export declare function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent: number): Observable<T | T2>;
-export declare function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<T | T2 | T3>;
-export declare function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent: number): Observable<T | T2 | T3>;
-export declare function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): Observable<T | T2 | T3 | T4>;
-export declare function merge<T, T2, T3, T4>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent: number): Observable<T | T2 | T3 | T4>;
-export declare function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): Observable<T | T2 | T3 | T4 | T5>;
-export declare function merge<T, T2, T3, T4, T5>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent: number): Observable<T | T2 | T3 | T4 | T5>;
-export declare function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export declare function merge<T, T2, T3, T4, T5, T6>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent: number): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export declare function merge<T>(...observables: (ObservableInput<T> | number)[]): Observable<T>;
-export declare function merge<T>(...observables: (ObservableInput<T> | SchedulerLike | number)[]): Observable<T>;
-export declare function merge<T, R>(...observables: (ObservableInput<any> | number)[]): Observable<R>;
-export declare function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLike | number)[]): Observable<R>;
+export declare function merge<O extends ObservableInput<unknown>>(sources: O[], concurrent: number, scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
+export declare function merge<O extends ObservableInput<unknown>>(sources: O[], scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
+export declare function merge<O extends ObservableInput<unknown>>(sources: O[], concurrent: number): Observable<ObservedValueOf<O>>;
+export declare function merge<O extends ObservableInput<unknown>>(sources: O[]): Observable<ObservedValueOf<O>>;
+export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...sources: Sources): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...sources: Concat<Sources, [number]>): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: Concat<Sources, [SchedulerLike]>): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: Concat<Sources, [number, SchedulerLike]>): Observable<ObservedValueUnionFromArray<Sources>>;
 
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {
 }
@@ -349,7 +331,7 @@ export declare type ObservedValueTupleFromArray<X> = {
     [K in keyof X]: ObservedValueOf<X[K]>;
 };
 
-export declare type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
+export declare type ObservedValueUnionFromArray<X> = X extends readonly ObservableInput<infer T>[] ? T : never;
 
 export interface Observer<T> {
     closed?: boolean;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -113,8 +113,6 @@ export declare function concat<O1 extends ObservableInput<any>, O2 extends Obser
 export declare function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4> | ObservedValueOf<O5> | ObservedValueOf<O6>>;
 export declare function concat<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
 
-export declare type Concat<T extends readonly unknown[], E extends readonly unknown[]> = readonly [...T, ...E];
-
 export declare const config: {
     onUnhandledError: ((err: any) => void) | null;
     Promise: PromiseConstructorLike;
@@ -217,9 +215,9 @@ export declare function merge<O extends ObservableInput<unknown>>(sources: O[], 
 export declare function merge<O extends ObservableInput<unknown>>(sources: O[], concurrent: number): Observable<ObservedValueOf<O>>;
 export declare function merge<O extends ObservableInput<unknown>>(sources: O[]): Observable<ObservedValueOf<O>>;
 export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...sources: Sources): Observable<ObservedValueUnionFromArray<Sources>>;
-export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...sources: Concat<Sources, [number]>): Observable<ObservedValueUnionFromArray<Sources>>;
-export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: Concat<Sources, [SchedulerLike]>): Observable<ObservedValueUnionFromArray<Sources>>;
-export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: Concat<Sources, [number, SchedulerLike]>): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...sources: [...Sources, number]): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: [...Sources, SchedulerLike]): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: [...Sources, number, SchedulerLike]): Observable<ObservedValueUnionFromArray<Sources>>;
 
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {
 }

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -214,10 +214,13 @@ export declare function merge<O extends ObservableInput<unknown>>(sources: O[], 
 export declare function merge<O extends ObservableInput<unknown>>(sources: O[], scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
 export declare function merge<O extends ObservableInput<unknown>>(sources: O[], concurrent: number): Observable<ObservedValueOf<O>>;
 export declare function merge<O extends ObservableInput<unknown>>(sources: O[]): Observable<ObservedValueOf<O>>;
+export declare function merge<T>(source: ObservableInput<T>, concurrency: number, scheduler: SchedulerLike): Observable<T>;
+export declare function merge<T>(source: ObservableInput<T>, concurrency: number): Observable<T>;
+export declare function merge<T>(source: ObservableInput<T>, scheduler: SchedulerLike): Observable<T>;
 export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...sources: Sources): Observable<ObservedValueUnionFromArray<Sources>>;
-export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...sources: [...Sources, number]): Observable<ObservedValueUnionFromArray<Sources>>;
-export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: [...Sources, SchedulerLike]): Observable<ObservedValueUnionFromArray<Sources>>;
-export declare function merge<Sources extends readonly ObservableInput<unknown>[]>(...args: [...Sources, number, SchedulerLike]): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends OneOrMoreUnknownObservableInputs>(...args: [...Sources, number, SchedulerLike]): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends OneOrMoreUnknownObservableInputs>(...args: [...Sources, SchedulerLike]): Observable<ObservedValueUnionFromArray<Sources>>;
+export declare function merge<Sources extends OneOrMoreUnknownObservableInputs>(...sources: [...Sources, number]): Observable<ObservedValueUnionFromArray<Sources>>;
 
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {
 }
@@ -354,6 +357,8 @@ export declare function of<T>(value: T): Observable<T>;
 export declare function of<T, U>(value1: T, value2: U): Observable<T | U>;
 export declare function of<T, U, V>(value1: T, value2: U, value3: V): Observable<T | U | V>;
 export declare function of<A extends Array<any>>(...args: A): Observable<ValueFromArray<A>>;
+
+export declare type OneOrMoreUnknownObservableInputs = readonly [ObservableInput<unknown>, ...unknown[]];
 
 export declare function onErrorResumeNext(): Observable<never>;
 export declare function onErrorResumeNext<O extends ObservableInput<any>>(arrayOfSources: O[]): Observable<ObservedValueOf<O>>;

--- a/spec-dtslint/observables/merge-spec.ts
+++ b/spec-dtslint/observables/merge-spec.ts
@@ -1,0 +1,115 @@
+import { a$, b$, c$, d$, e$, f$, g$, h$, i$, j$ } from 'helpers';
+import { asapScheduler, merge } from 'rxjs';
+
+describe('it should infer the result properly', () => {
+  const o1 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$, j$); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+  const o2 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+  const o3 = merge(a$, b$, c$, d$, e$, f$, g$, h$); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+  const o4 = merge(a$, b$, c$, d$, e$, f$, g$); // $ExpectType Observable<A | B | C | D | E | F | G>
+  const o5 = merge(a$, b$, c$, d$, e$, f$); // $ExpectType Observable<A | B | C | D | E | F>
+  const o6 = merge(a$, b$, c$, d$, e$); // $ExpectType Observable<A | B | C | D | E>
+  const o7 = merge(a$, b$, c$, d$); // $ExpectType Observable<A | B | C | D>
+  const o8 = merge(a$, b$, c$); // $ExpectType Observable<A | B | C>
+  const o9 = merge(a$, b$); // $ExpectType Observable<A | B>
+  const o10 = merge(a$); // $ExpectType Observable<A>
+});
+
+describe('it should infer the result properly with concurrency', () => {
+  const o1 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$, j$, 3); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+  const o2 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$, 3); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+  const o3 = merge(a$, b$, c$, d$, e$, f$, g$, h$, 3); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+  const o4 = merge(a$, b$, c$, d$, e$, f$, g$, 3); // $ExpectType Observable<A | B | C | D | E | F | G>
+  const o5 = merge(a$, b$, c$, d$, e$, f$, 3); // $ExpectType Observable<A | B | C | D | E | F>
+  const o6 = merge(a$, b$, c$, d$, e$, 3); // $ExpectType Observable<A | B | C | D | E>
+  const o7 = merge(a$, b$, c$, d$, 3); // $ExpectType Observable<A | B | C | D>
+  const o8 = merge(a$, b$, c$, 3); // $ExpectType Observable<A | B | C>
+  const o9 = merge(a$, b$, 3); // $ExpectType Observable<A | B>
+  const o10 = merge(a$, 3); // $ExpectType Observable<A>
+});
+
+describe('it should infer the result properly with concurrency and scheduler', () => {
+  const o1 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$, j$, 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+  const o2 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$, 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+  const o3 = merge(a$, b$, c$, d$, e$, f$, g$, h$, 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+  const o4 = merge(a$, b$, c$, d$, e$, f$, g$, 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G>
+  const o5 = merge(a$, b$, c$, d$, e$, f$, 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F>
+  const o6 = merge(a$, b$, c$, d$, e$, 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E>
+  const o7 = merge(a$, b$, c$, d$, 3, asapScheduler); // $ExpectType Observable<A | B | C | D>
+  const o8 = merge(a$, b$, c$, 3, asapScheduler); // $ExpectType Observable<A | B | C>
+  const o9 = merge(a$, b$, 3, asapScheduler); // $ExpectType Observable<A | B>
+  const o10 = merge(a$, 3, asapScheduler); // $ExpectType Observable<A>
+});
+
+describe('it should infer the result properly with scheduler', () => {
+  const o1 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$, j$, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+  const o2 = merge(a$, b$, c$, d$, e$, f$, g$, h$, i$, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+  const o3 = merge(a$, b$, c$, d$, e$, f$, g$, h$, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+  const o4 = merge(a$, b$, c$, d$, e$, f$, g$, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G>
+  const o5 = merge(a$, b$, c$, d$, e$, f$, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F>
+  const o6 = merge(a$, b$, c$, d$, e$, asapScheduler); // $ExpectType Observable<A | B | C | D | E>
+  const o7 = merge(a$, b$, c$, d$, asapScheduler); // $ExpectType Observable<A | B | C | D>
+  const o8 = merge(a$, b$, c$, asapScheduler); // $ExpectType Observable<A | B | C>
+  const o9 = merge(a$, b$, asapScheduler); // $ExpectType Observable<A | B>
+  const o10 = merge(a$, asapScheduler); // $ExpectType Observable<A>
+});
+
+describe('single array', () => {
+  describe('it should infer the result properly', () => {
+    const o1 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$, j$]); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+    const o2 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$]); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+    const o3 = merge([a$, b$, c$, d$, e$, f$, g$, h$]); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+    const o4 = merge([a$, b$, c$, d$, e$, f$, g$]); // $ExpectType Observable<A | B | C | D | E | F | G>
+    const o5 = merge([a$, b$, c$, d$, e$, f$]); // $ExpectType Observable<A | B | C | D | E | F>
+    const o6 = merge([a$, b$, c$, d$, e$]); // $ExpectType Observable<A | B | C | D | E>
+    const o7 = merge([a$, b$, c$, d$]); // $ExpectType Observable<A | B | C | D>
+    const o8 = merge([a$, b$, c$]); // $ExpectType Observable<A | B | C>
+    const o9 = merge([a$, b$]); // $ExpectType Observable<A | B>
+    const o10 = merge([a$]); // $ExpectType Observable<A>
+  });
+
+  describe('it should infer the result properly with concurrency', () => {
+    const o1 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$, j$], 3); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+    const o2 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$], 3); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+    const o3 = merge([a$, b$, c$, d$, e$, f$, g$, h$], 3); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+    const o4 = merge([a$, b$, c$, d$, e$, f$, g$], 3); // $ExpectType Observable<A | B | C | D | E | F | G>
+    const o5 = merge([a$, b$, c$, d$, e$, f$], 3); // $ExpectType Observable<A | B | C | D | E | F>
+    const o6 = merge([a$, b$, c$, d$, e$], 3); // $ExpectType Observable<A | B | C | D | E>
+    const o7 = merge([a$, b$, c$, d$], 3); // $ExpectType Observable<A | B | C | D>
+    const o8 = merge([a$, b$, c$], 3); // $ExpectType Observable<A | B | C>
+    const o9 = merge([a$, b$], 3); // $ExpectType Observable<A | B>
+    const o10 = merge([a$], 3); // $ExpectType Observable<A>
+  });
+
+  describe('it should infer the result properly with concurrency and scheduler', () => {
+    const o1 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$, j$], 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+    const o2 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$], 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+    const o3 = merge([a$, b$, c$, d$, e$, f$, g$, h$], 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+    const o4 = merge([a$, b$, c$, d$, e$, f$, g$], 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G>
+    const o5 = merge([a$, b$, c$, d$, e$, f$], 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E | F>
+    const o6 = merge([a$, b$, c$, d$, e$], 3, asapScheduler); // $ExpectType Observable<A | B | C | D | E>
+    const o7 = merge([a$, b$, c$, d$], 3, asapScheduler); // $ExpectType Observable<A | B | C | D>
+    const o8 = merge([a$, b$, c$], 3, asapScheduler); // $ExpectType Observable<A | B | C>
+    const o9 = merge([a$, b$], 3, asapScheduler); // $ExpectType Observable<A | B>
+    const o10 = merge([a$], 3, asapScheduler); // $ExpectType Observable<A>
+  });
+
+    describe('it should infer the result properly with scheduler only', () => {
+    const o1 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$, j$],asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I | J>
+    const o2 = merge([a$, b$, c$, d$, e$, f$, g$, h$, i$],asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H | I>
+    const o3 = merge([a$, b$, c$, d$, e$, f$, g$, h$],asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G | H>
+    const o4 = merge([a$, b$, c$, d$, e$, f$, g$],asapScheduler); // $ExpectType Observable<A | B | C | D | E | F | G>
+    const o5 = merge([a$, b$, c$, d$, e$, f$],asapScheduler); // $ExpectType Observable<A | B | C | D | E | F>
+    const o6 = merge([a$, b$, c$, d$, e$],asapScheduler); // $ExpectType Observable<A | B | C | D | E>
+    const o7 = merge([a$, b$, c$, d$],asapScheduler); // $ExpectType Observable<A | B | C | D>
+    const o8 = merge([a$, b$, c$],asapScheduler); // $ExpectType Observable<A | B | C>
+    const o9 = merge([a$, b$],asapScheduler); // $ExpectType Observable<A | B>
+    const o10 = merge([a$],asapScheduler); // $ExpectType Observable<A>
+  });
+})
+
+describe('the unhappy path', () => {
+  // These here are unfortunate. We'll need to figure out something for this.
+  const o1 = merge(1, 2, 3, 4, 5); // $ExpectType Observable<unknown>
+  const o3 = merge(a$, 2, b$); // $ExpectType Observable<unknown>
+  const o2 = merge(a$, asapScheduler, b$); // $ExpectType Observable<unknown>
+});

--- a/spec-dtslint/observables/merge-spec.ts
+++ b/spec-dtslint/observables/merge-spec.ts
@@ -112,4 +112,6 @@ describe('the unhappy path', () => {
   const o2 = merge(a$, asapScheduler, b$); // $ExpectError
   const o3 = merge(a$, 2, b$); // $ExpectError
   const o4 = merge(a$, 2, asapScheduler, b$); // $ExpectError
+  const o5 = merge(a$, 1, 2, 3, 4, 5); // $ExpectError
+  const o6 = merge(a$, 1, 2, 3, 4, 5, asapScheduler); // $ExpectError
 });

--- a/spec-dtslint/observables/merge-spec.ts
+++ b/spec-dtslint/observables/merge-spec.ts
@@ -108,8 +108,8 @@ describe('single array', () => {
 })
 
 describe('the unhappy path', () => {
-  // These here are unfortunate. We'll need to figure out something for this.
-  const o1 = merge(1, 2, 3, 4, 5); // $ExpectType Observable<unknown>
-  const o3 = merge(a$, 2, b$); // $ExpectType Observable<unknown>
-  const o2 = merge(a$, asapScheduler, b$); // $ExpectType Observable<unknown>
+  const o1 = merge(1, 2, 3, 4, 5); // $ExpectError
+  const o2 = merge(a$, asapScheduler, b$); // $ExpectError
+  const o3 = merge(a$, 2, b$); // $ExpectError
+  const o4 = merge(a$, 2, asapScheduler, b$); // $ExpectError
 });

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInput, SchedulerLike } from '../types';
+import { Concat, ObservableInput, ObservedValueOf, ObservedValueUnionFromArray, SchedulerLike } from '../types';
 import { mergeAll } from '../operators/mergeAll';
 import { internalFromArray } from './fromArray';
 import { argsOrArgArray } from '../util/argsOrArgArray';
@@ -8,156 +8,38 @@ import { innerFrom } from './from';
 import { EMPTY } from './empty';
 import { popNumber, popScheduler } from '../util/args';
 
-/* tslint:disable:max-line-length */
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T>(v1: ObservableInput<T>, scheduler: SchedulerLike): Observable<T>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T>(v1: ObservableInput<T>, concurrent: number, scheduler: SchedulerLike): Observable<T>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, scheduler: SchedulerLike): Observable<T | T2>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
+/** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
+export function merge<O extends ObservableInput<unknown>>(
+  sources: O[],
   concurrent: number,
   scheduler: SchedulerLike
-): Observable<T | T2>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  concurrent: number,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3, T4>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3, T4>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  concurrent: number,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3, T4, T5>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3, T4, T5>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  concurrent: number,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3, T4, T5, T6>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5 | T6>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function merge<T, T2, T3, T4, T5, T6>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  concurrent: number,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5 | T6>;
+): Observable<ObservedValueOf<O>>;
 
-export function merge<T>(v1: ObservableInput<T>): Observable<T>;
-export function merge<T>(v1: ObservableInput<T>, concurrent: number): Observable<T>;
-export function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>): Observable<T | T2>;
-export function merge<T, T2>(v1: ObservableInput<T>, v2: ObservableInput<T2>, concurrent: number): Observable<T | T2>;
-export function merge<T, T2, T3>(v1: ObservableInput<T>, v2: ObservableInput<T2>, v3: ObservableInput<T3>): Observable<T | T2 | T3>;
-export function merge<T, T2, T3>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  concurrent: number
-): Observable<T | T2 | T3>;
-export function merge<T, T2, T3, T4>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>
-): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  concurrent: number
-): Observable<T | T2 | T3 | T4>;
-export function merge<T, T2, T3, T4, T5>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>
-): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  concurrent: number
-): Observable<T | T2 | T3 | T4 | T5>;
-export function merge<T, T2, T3, T4, T5, T6>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>
-): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T, T2, T3, T4, T5, T6>(
-  v1: ObservableInput<T>,
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  concurrent: number
-): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export function merge<T>(...observables: (ObservableInput<T> | number)[]): Observable<T>;
 /** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
-export function merge<T>(...observables: (ObservableInput<T> | SchedulerLike | number)[]): Observable<T>;
-export function merge<T, R>(...observables: (ObservableInput<any> | number)[]): Observable<R>;
+export function merge<O extends ObservableInput<unknown>>(sources: O[], scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
+
+export function merge<O extends ObservableInput<unknown>>(sources: O[], concurrent: number): Observable<ObservedValueOf<O>>;
+
+export function merge<O extends ObservableInput<unknown>>(sources: O[]): Observable<ObservedValueOf<O>>;
+
+export function merge<Sources extends readonly ObservableInput<unknown>[]>(
+  ...sources: Sources
+): Observable<ObservedValueUnionFromArray<Sources>>;
+
+export function merge<Sources extends readonly ObservableInput<unknown>[]>(
+  ...sources: Concat<Sources, [number]>
+): Observable<ObservedValueUnionFromArray<Sources>>;
+
 /** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
-export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLike | number)[]): Observable<R>;
-/* tslint:enable:max-line-length */
+export function merge<Sources extends readonly ObservableInput<unknown>[]>(
+  ...args: Concat<Sources, [SchedulerLike]>
+): Observable<ObservedValueUnionFromArray<Sources>>;
+
+/** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
+export function merge<Sources extends readonly ObservableInput<unknown>[]>(
+  ...args: Concat<Sources, [number, SchedulerLike]>
+): Observable<ObservedValueUnionFromArray<Sources>>;
+
 /**
  * Creates an output Observable which concurrently emits all values from every
  * given input Observable.
@@ -225,7 +107,7 @@ export function merge<T, R>(...observables: (ObservableInput<any> | SchedulerLik
  * @return {Observable} an Observable that emits items that are the result of
  * every input Observable.
  */
-export function merge(...args: (ObservableInput<any> | SchedulerLike | number)[]): Observable<unknown> {
+export function merge(...args: unknown[]): Observable<unknown> {
   const scheduler = popScheduler(args);
   const concurrent = popNumber(args, Infinity);
   args = argsOrArgArray(args);

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { Concat, ObservableInput, ObservedValueOf, ObservedValueUnionFromArray, SchedulerLike } from '../types';
+import { ObservableInput, ObservedValueOf, ObservedValueUnionFromArray, SchedulerLike } from '../types';
 import { mergeAll } from '../operators/mergeAll';
 import { internalFromArray } from './fromArray';
 import { argsOrArgArray } from '../util/argsOrArgArray';
@@ -27,17 +27,17 @@ export function merge<Sources extends readonly ObservableInput<unknown>[]>(
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
 export function merge<Sources extends readonly ObservableInput<unknown>[]>(
-  ...sources: Concat<Sources, [number]>
+  ...sources: [...Sources, number]
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
 /** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
 export function merge<Sources extends readonly ObservableInput<unknown>[]>(
-  ...args: Concat<Sources, [SchedulerLike]>
+  ...args: [...Sources, SchedulerLike]
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
 /** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
 export function merge<Sources extends readonly ObservableInput<unknown>[]>(
-  ...args: Concat<Sources, [number, SchedulerLike]>
+  ...args: [...Sources, number, SchedulerLike]
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
 /**

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInput, ObservedValueOf, ObservedValueUnionFromArray, SchedulerLike } from '../types';
+import { ObservableInput, ObservedValueOf, ObservedValueUnionFromArray, SchedulerLike, OneOrMoreUnknownObservableInputs } from '../types';
 import { mergeAll } from '../operators/mergeAll';
 import { internalFromArray } from './fromArray';
 import { argsOrArgArray } from '../util/argsOrArgArray';
@@ -22,22 +22,28 @@ export function merge<O extends ObservableInput<unknown>>(sources: O[], concurre
 
 export function merge<O extends ObservableInput<unknown>>(sources: O[]): Observable<ObservedValueOf<O>>;
 
+/** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
+export function merge<T>(source: ObservableInput<T>, concurrency: number, scheduler: SchedulerLike): Observable<T>;
+export function merge<T>(source: ObservableInput<T>, concurrency: number): Observable<T>;
+/** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
+export function merge<T>(source: ObservableInput<T>, scheduler: SchedulerLike): Observable<T>;
+
 export function merge<Sources extends readonly ObservableInput<unknown>[]>(
   ...sources: Sources
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
-export function merge<Sources extends readonly ObservableInput<unknown>[]>(
-  ...sources: [...Sources, number]
+/** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
+export function merge<Sources extends OneOrMoreUnknownObservableInputs>(
+  ...args: [...Sources, number, SchedulerLike]
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
 /** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
-export function merge<Sources extends readonly ObservableInput<unknown>[]>(
+export function merge<Sources extends OneOrMoreUnknownObservableInputs>(
   ...args: [...Sources, SchedulerLike]
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
-/** @deprecated use {@link scheduled} and {@link mergeAll} (e.g. `scheduled([ob1, ob2, ob3], scheduler).pipe(mergeAll())*/
-export function merge<Sources extends readonly ObservableInput<unknown>[]>(
-  ...args: [...Sources, number, SchedulerLike]
+export function merge<Sources extends OneOrMoreUnknownObservableInputs>(
+  ...sources: [...Sources, number]
 ): Observable<ObservedValueUnionFromArray<Sources>>;
 
 /**

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -259,9 +259,3 @@ export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
       : undefined
     : never
   : never;
-
-/**
- * Combines two Tuples into one. For example: `Concat<[A, B], [C, D]>` is `[A, B, C, D]`.
- * For use with functions that have a tailing SchedulerLike, or perhaps a concurrency limit and a SchedulerLike.
- */
-export type Concat<T extends readonly unknown[], E extends readonly unknown[]> = readonly [...T, ...E];

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -202,7 +202,7 @@ export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
  * If you pass in `[Observable<string>, Observable<number>]` you would
  * get back a type of `string | number`.
  */
-export type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
+export type ObservedValueUnionFromArray<X> = X extends readonly ObservableInput<infer T>[] ? T : never;
 
 /** @deprecated use {@link ObservedValueUnionFromArray} */
 export type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
@@ -217,12 +217,12 @@ export type ObservedValueTupleFromArray<X> = { [K in keyof X]: ObservedValueOf<X
 
 /**
  * Used to infer types from arguments to functions like {@link forkJoin}.
- * So that you can have `forkJoin([Observable<A>, PromiseLike<B>]): Observable<[A, B]>` 
+ * So that you can have `forkJoin([Observable<A>, PromiseLike<B>]): Observable<[A, B]>`
  * et al.
  */
 export type ObservableInputTuple<T> = {
-  [K in keyof T]: ObservableInput<T[K]>
-}
+  [K in keyof T]: ObservableInput<T[K]>;
+};
 
 /**
  * Constructs a new tuple with the specified type at the head.
@@ -259,3 +259,9 @@ export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
       : undefined
     : never
   : never;
+
+/**
+ * Combines two Tuples into one. For example: `Concat<[A, B], [C, D]>` is `[A, B, C, D]`.
+ * For use with functions that have a tailing SchedulerLike, or perhaps a concurrency limit and a SchedulerLike.
+ */
+export type Concat<T extends readonly unknown[], E extends readonly unknown[]> = readonly [...T, ...E];

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -259,3 +259,8 @@ export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
       : undefined
     : never
   : never;
+
+/**
+ * Used to help deal with rest arguments of many observable inputs that are tailed by schedulers, etc.
+ */
+export type OneOrMoreUnknownObservableInputs = readonly [ObservableInput<unknown>, ...unknown[]];

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -263,4 +263,4 @@ export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
 /**
  * Used to help deal with rest arguments of many observable inputs that are tailed by schedulers, etc.
  */
-export type OneOrMoreUnknownObservableInputs = readonly [ObservableInput<unknown>, ...unknown[]];
+export type OneOrMoreUnknownObservableInputs = readonly [ObservableInput<unknown>, ...ObservableInput<unknown>[]];


### PR DESCRIPTION
- Now refers n-arguments in all cases, including arguments with tailing concurrency and Scheduler
- Adds dtslint tests


Please note the "unhappy path" in the dtslint tests. It's not ideal, but everything is _much_ better than it was before. I just struggled with how to ensure `merge(a$, 23, b$)` didn't match the signature for (pseudo-code here:) `merge(...args: ObservableInput<T>, concurrency: number)`