### PR TITLE
chore: simplify already-internal import locations

### DIFF
--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -1,6 +1,6 @@
 import { Observable } from '../Observable';
 import { EmptyError } from '../util/EmptyError';
-import { OperatorFunction } from '../../internal/types';
+import { OperatorFunction } from '../types';
 import { filter } from './filter';
 import { take } from './take';
 import { defaultIfEmpty } from './defaultIfEmpty';

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -1,6 +1,6 @@
 import { Observable } from '../Observable';
 import { EmptyError } from '../util/EmptyError';
-import { OperatorFunction } from '../../internal/types';
+import { OperatorFunction } from '../types';
 import { filter } from './filter';
 import { takeLast } from './takeLast';
 import { throwIfEmpty } from './throwIfEmpty';

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -1,6 +1,5 @@
-import { OperatorFunction, ObservedValueOf } from '../../internal/types';
+import { OperatorFunction, ObservedValueOf, ObservableInput } from '../types';
 import { mergeMap } from './mergeMap';
-import { ObservableInput } from '../types';
 import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR replaces a few uses of `../../internal/types` with `../types`.

**Related issue (if exists):** None