### PR TITLE
refactor(concat): support N-args with scheduler

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -107,8 +107,8 @@ export interface CompletionObserver<T> {
     next?: (value: T) => void;
 }
 
-export declare function concat<T extends readonly unknown[]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
 export declare function concat<T extends readonly unknown[]>(...inputs: [...ObservableInputTuple<T>]): Observable<T[number]>;
+export declare function concat<T extends readonly unknown[]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
 
 export declare const config: {
     onUnhandledError: ((err: any) => void) | null;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -107,13 +107,8 @@ export interface CompletionObserver<T> {
     next?: (value: T) => void;
 }
 
-export declare function concat<O1 extends ObservableInput<any>>(v1: O1, scheduler: SchedulerLike): Observable<ObservedValueOf<O1>>;
-export declare function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(v1: O1, v2: O2, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2>>;
-export declare function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3>>;
-export declare function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4>>;
-export declare function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4> | ObservedValueOf<O5>>;
-export declare function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4> | ObservedValueOf<O5> | ObservedValueOf<O6>>;
-export declare function concat<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
+export declare function concat<T extends readonly unknown[]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
+export declare function concat<T extends readonly unknown[]>(...inputs: [...ObservableInputTuple<T>]): Observable<T[number]>;
 
 export declare const config: {
     onUnhandledError: ((err: any) => void) | null;

--- a/spec-dtslint/observables/concat-spec.ts
+++ b/spec-dtslint/observables/concat-spec.ts
@@ -55,6 +55,11 @@ it('should infer correctly with multiple types', () => {
 it('should enforce types', () => {
   const o = concat(5); // $ExpectError
   const p = concat(of(5), 6); // $ExpectError
+  const q = concat(of(5), 6, asyncScheduler); // $ExpectError
+  const r = concat(of(5), asyncScheduler, asyncScheduler); // $ExpectError
+  const s = concat(asyncScheduler, asyncScheduler); // $ExpectError
+  const t = concat(asyncScheduler, of(1)); // $ExpectError
+  const u = concat(of(1), asyncScheduler, of(1)); // $ExpectError
 });
 
 it('should support union types', () => {

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -4,8 +4,8 @@ import { concatAll } from '../operators/concatAll';
 import { internalFromArray } from './fromArray';
 import { popScheduler } from '../util/args';
 
-export function concat<T extends readonly unknown[]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
 export function concat<T extends readonly unknown[]>(...inputs: [...ObservableInputTuple<T>]): Observable<T[number]>;
+export function concat<T extends readonly unknown[]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
 
 /**
  * Creates an output Observable which sequentially emits all values from the first given

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -4,7 +4,7 @@ import { concatAll } from '../operators/concatAll';
 import { internalFromArray } from './fromArray';
 import { popScheduler } from '../util/args';
 
-export function concat<T extends [unknown, ...unknown[]]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
+export function concat<T extends readonly unknown[]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
 export function concat<T extends readonly unknown[]>(...inputs: [...ObservableInputTuple<T>]): Observable<T[number]>;
 
 /**

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -1,26 +1,12 @@
 import { Observable } from '../Observable';
-import { ObservableInput, SchedulerLike, ObservedValueOf, ObservedValueUnionFromArray } from '../types';
+import { ObservableInputTuple, SchedulerLike } from '../types';
 import { concatAll } from '../operators/concatAll';
 import { internalFromArray } from './fromArray';
 import { popScheduler } from '../util/args';
 
-/* tslint:disable:max-line-length */
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function concat<O1 extends ObservableInput<any>>(v1: O1, scheduler: SchedulerLike): Observable<ObservedValueOf<O1>>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>>(v1: O1, v2: O2, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2>>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3>>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4>>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4> | ObservedValueOf<O5>>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function concat<O1 extends ObservableInput<any>, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v1: O1, v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, scheduler: SchedulerLike): Observable<ObservedValueOf<O1> | ObservedValueOf<O2> | ObservedValueOf<O3> | ObservedValueOf<O4> | ObservedValueOf<O5> | ObservedValueOf<O6>>;
+export function concat<T extends readonly [unknown, ...unknown[]]>(...inputsAndScheduler: readonly [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
+export function concat<T extends readonly unknown[]>(...inputs: readonly [...ObservableInputTuple<T>]): Observable<T[number]>;
 
-export function concat<A extends ObservableInput<any>[]>(...observables: A): Observable<ObservedValueUnionFromArray<A>>;
-
-/* tslint:enable:max-line-length */
 /**
  * Creates an output Observable which sequentially emits all values from the first given
  * Observable and then moves on to the next.

--- a/src/internal/observable/concat.ts
+++ b/src/internal/observable/concat.ts
@@ -4,8 +4,8 @@ import { concatAll } from '../operators/concatAll';
 import { internalFromArray } from './fromArray';
 import { popScheduler } from '../util/args';
 
-export function concat<T extends readonly [unknown, ...unknown[]]>(...inputsAndScheduler: readonly [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
-export function concat<T extends readonly unknown[]>(...inputs: readonly [...ObservableInputTuple<T>]): Observable<T[number]>;
+export function concat<T extends [unknown, ...unknown[]]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
+export function concat<T extends readonly unknown[]>(...inputs: [...ObservableInputTuple<T>]): Observable<T[number]>;
 
 /**
  * Creates an output Observable which sequentially emits all values from the first given


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the static `concat` to use N-args in the signature that accepts a trailing scheduler. And adds a bunch of this-usage-should-fail dtslint tests.

For whatever reason, the problems that occurred in the PRs that were opened for the static `merge` and `combineLastest` functions do not seem to occur here. A lot was going on in those PRs - and the conversations that took place in those PRs aren't especially easy to follow - but I would not be surprised if there is some small difference that effects different behaviour. For example, temporarily adding a signature that included a concurrency (for the purposes of experimentation) seemed to break things, so ... 🤷‍♂️ this seems fine here, but we might still have problems elsewhere. 🤞

**Related issue (if exists):** None