### PR TITLE
refactor(merge): support N-args with scheduler

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -148,26 +148,10 @@ export declare function materialize<T>(): OperatorFunction<T, Notification<T> & 
 
 export declare function max<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T>;
 
-export declare function merge<T>(): MonoTypeOperatorFunction<T>;
-export declare function merge<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, T | T2>;
-export declare function merge<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, T | T2 | T3>;
-export declare function merge<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, T | T2 | T3 | T4>;
-export declare function merge<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-export declare function merge<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-export declare function merge<T>(scheduler: SchedulerLike): MonoTypeOperatorFunction<T>;
-export declare function merge<T>(concurrent: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export declare function merge<T, T2>(v2: ObservableInput<T2>, scheduler: SchedulerLike): OperatorFunction<T, T | T2>;
-export declare function merge<T, T2>(v2: ObservableInput<T2>, concurrent: number, scheduler?: SchedulerLike): OperatorFunction<T, T | T2>;
-export declare function merge<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler: SchedulerLike): OperatorFunction<T, T | T2 | T3>;
-export declare function merge<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, concurrent: number, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3>;
-export declare function merge<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4>;
-export declare function merge<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, concurrent: number, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4>;
-export declare function merge<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-export declare function merge<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, concurrent: number, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-export declare function merge<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-export declare function merge<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, concurrent: number, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-export declare function merge<T>(...observables: Array<ObservableInput<T> | SchedulerLike | number>): MonoTypeOperatorFunction<T>;
-export declare function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number>): OperatorFunction<T, R>;
+export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number?]): OperatorFunction<T, T | A[number]>;
+export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, SchedulerLike?]): OperatorFunction<T, T | A[number]>;
+export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number?, SchedulerLike?]): OperatorFunction<T, T | A[number]>;
 
 export declare function mergeAll<O extends ObservableInput<any>>(concurrent?: number): OperatorFunction<O, ObservedValueOf<O>>;
 
@@ -180,8 +164,7 @@ export declare function mergeMapTo<T, R, O extends ObservableInput<unknown>>(inn
 
 export declare function mergeScan<T, R>(accumulator: (acc: R, value: T, index: number) => ObservableInput<R>, seed: R, concurrent?: number): OperatorFunction<T, R>;
 
-export declare function mergeWith<T>(): OperatorFunction<T, T>;
-export declare function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, T | ObservedValueUnionFromArray<A>>;
+export declare function mergeWith<T, A extends unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 export declare function min<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T>;
 

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -7,26 +7,15 @@ import { mergeAll } from './mergeAll';
 import { popNumber, popScheduler } from '../util/args';
 
 /** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T>(concurrency?: number, scheduler?: SchedulerLike): OperatorFunction<T, T>;
+export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 /** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T>(scheduler?: SchedulerLike): OperatorFunction<T, T>;
-
-// This is necessary because of the signature that follows this one:
+export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number?]): OperatorFunction<T, T | A[number]>;
 /** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown>(otherSource: ObservableInput<A>): OperatorFunction<T, T | A>;
-
-// Without the preceding signature, this signature breaks inference when passed a single source:
+export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, SchedulerLike?]): OperatorFunction<T, T | A[number]>;
 /** @deprecated use {@link mergeWith} or static {@link merge} */
 export function merge<T, A extends unknown[]>(
-  ...args: [...ObservableInputTuple<A>, number, SchedulerLike]
+  ...args: [...ObservableInputTuple<A>, number?, SchedulerLike?]
 ): OperatorFunction<T, T | A[number]>;
-
-/** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number]): OperatorFunction<T, T | A[number]>;
-/** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, SchedulerLike]): OperatorFunction<T, T | A[number]>;
-/** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 export function merge<T>(...args: unknown[]): OperatorFunction<T, unknown> {
   const scheduler = popScheduler(args);

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -1,126 +1,34 @@
 /** @prettier */
-import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike, ObservedValueUnionFromArray } from '../types';
+import { ObservableInput, ObservableInputTuple, OperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { internalFromArray } from '../observable/fromArray';
 import { mergeAll } from './mergeAll';
 import { popNumber, popScheduler } from '../util/args';
 
-/** @deprecated use {@link mergeWith} */
-export function merge<T>(): MonoTypeOperatorFunction<T>;
-/** @deprecated use {@link mergeWith} */
-export function merge<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, T | T2>;
-/** @deprecated use {@link mergeWith} */
-export function merge<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, T | T2 | T3>;
-/** @deprecated use {@link mergeWith} */
-export function merge<T, T2, T3, T4>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>
-): OperatorFunction<T, T | T2 | T3 | T4>;
-/** @deprecated use {@link mergeWith} */
-export function merge<T, T2, T3, T4, T5>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>
-): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-/** @deprecated use {@link mergeWith} */
-export function merge<T, T2, T3, T4, T5, T6>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>
-): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
+/** @deprecated use {@link mergeWith} or static {@link merge} */
+export function merge<T>(concurrency?: number, scheduler?: SchedulerLike): OperatorFunction<T, T>;
+/** @deprecated use {@link mergeWith} or static {@link merge} */
+export function merge<T>(scheduler?: SchedulerLike): OperatorFunction<T, T>;
 
-// Below are signatures we no longer wish to support in this format.
-// They include either a concurrency argument or a scheduler argument.
-// For these, users should use the merge static, and in fact
-// for scheduling, they should compose that behavior with fromScheduled
-// and observeOn, etc.
+// This is necessary because of the signature that follows this one:
+/** @deprecated use {@link mergeWith} or static {@link merge} */
+export function merge<T, A extends unknown>(otherSource: ObservableInput<A>): OperatorFunction<T, T | A>;
 
-/** @deprecated use static {@link merge} */
-export function merge<T>(scheduler: SchedulerLike): MonoTypeOperatorFunction<T>;
-/** @deprecated use static {@link merge} */
-export function merge<T>(concurrent: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2>(v2: ObservableInput<T2>, scheduler: SchedulerLike): OperatorFunction<T, T | T2>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2>(v2: ObservableInput<T2>, concurrent: number, scheduler?: SchedulerLike): OperatorFunction<T, T | T2>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  scheduler: SchedulerLike
-): OperatorFunction<T, T | T2 | T3>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  concurrent: number,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3, T4>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  scheduler: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3, T4>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  concurrent: number,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3, T4, T5>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  scheduler: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3, T4, T5>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  concurrent: number,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3, T4, T5, T6>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  scheduler: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-/** @deprecated use static {@link merge} */
-export function merge<T, T2, T3, T4, T5, T6>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  concurrent: number,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-/** @deprecated use static {@link merge} */
-export function merge<T>(...observables: Array<ObservableInput<T> | SchedulerLike | number>): MonoTypeOperatorFunction<T>;
-/** @deprecated use static {@link merge} */
-export function merge<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike | number>): OperatorFunction<T, R>;
+// Without the preceding signature, this signature breaks inference when passed a single source:
+/** @deprecated use {@link mergeWith} or static {@link merge} */
+export function merge<T, A extends unknown[]>(
+  ...args: [...ObservableInputTuple<A>, number, SchedulerLike]
+): OperatorFunction<T, T | A[number]>;
 
-/**
- * @deprecated use {@link mergeWith} or static {@link merge}
- */
-export function merge<T, R>(...args: Array<ObservableInput<any> | SchedulerLike | number | undefined>): OperatorFunction<T, R> {
+/** @deprecated use {@link mergeWith} or static {@link merge} */
+export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number]): OperatorFunction<T, T | A[number]>;
+/** @deprecated use {@link mergeWith} or static {@link merge} */
+export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, SchedulerLike]): OperatorFunction<T, T | A[number]>;
+/** @deprecated use {@link mergeWith} or static {@link merge} */
+export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+
+export function merge<T>(...args: unknown[]): OperatorFunction<T, unknown> {
   const scheduler = popScheduler(args);
   const concurrent = popNumber(args, Infinity);
   args = argsOrArgArray(args);
@@ -130,8 +38,7 @@ export function merge<T, R>(...args: Array<ObservableInput<any> | SchedulerLike 
   });
 }
 
-export function mergeWith<T>(): OperatorFunction<T, T>;
-export function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, T | ObservedValueUnionFromArray<A>>;
+export function mergeWith<T, A extends unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 /**
  * Merge the values from all observables to an single observable result.
@@ -172,8 +79,6 @@ export function mergeWith<T, A extends ObservableInput<any>[]>(...otherSources: 
  * ```
  * @param otherSources the sources to combine the current source with.
  */
-export function mergeWith<T, A extends ObservableInput<any>[]>(
-  ...otherSources: A
-): OperatorFunction<T, T | ObservedValueUnionFromArray<A>> {
+export function mergeWith<T, A extends unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]> {
   return merge(...otherSources);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the signatures of the `merge` and `mergeWith` _operators_ to use the variadic tuple technique that was employed in the `concat` PR - see #5857.

Hopefully, it should serve as a template for what needs to be done elsewhere whenever there are trailing arguments. It seems that when there are, the correct behaviour of the inference is extremely sensitive to the ordering of the signatures.

IMO, we should also be moving to using `unknown[]` as the type parameter constraint - along with `ObservableInputTuple` - instead of using `ObservableInput` in the constraint and `ObservedValueOf` in the return type. The former is, IMO, idiomatic TypeScript and the latter is not.

**Related issue (if exists):** None

**Initial description (when it was still broken):**

This PR attempts to reduce the number of signatures for the `merge` _operator_ using the approach used for the static `concat` function. It seems that TypeScript does weird things and it's necessary to have a bunch of sigs that reflect no inputs being passed and another that reflects a single input being passed. Specifically, the signature that requires the single-input signature to be present is this one:

```ts
export function merge<T, A extends unknown[]>(
  ...args: [...ObservableInputTuple<A>, number, SchedulerLike]
): OperatorFunction<T, T | A[number]>;
```

If the single input signature is not present and the above signature is not commented out, the inference for a single argument will fail:

```ts
const result = of(1).pipe(merge(of('two')); // Infers Observable<unknown> instead of Observable<number | string>
```

IDK what is going on, but I'm done with this for now. I've opened this PR as it goes some way towards showing that this almost works and that we might need some seemingly unnecessary signatures just to stop TypeScript from going down the wrong path. I would have hoped that the variadic input tuples would work with zero inputs - like they do with `concat`. 🤷‍♂️🤬