### PR TITLE
fix(types): Add a missing import for Symbol.observable

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,6 @@
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
+import './symbol/observable';
 
 /** OPERATOR INTERFACES */
 


### PR DESCRIPTION
This was reported previously on #3674, but instead of adding
this import, it was fixed in @types/node: DefinitelyTyped/DefinitelyTyped#26034.

This was removed in v14 of @types/node.

Fix it properly this time.

Fixes #5861

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->
