### PR TITLE
Test fixes

### DIFF
--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { of, from, Observable } from 'rxjs';
 import { concatMapTo, mergeMap, take } from 'rxjs/operators';
-import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
+import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {concatMapTo} */

--- a/spec/operators/count-spec.ts
+++ b/spec/operators/count-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { of, range } from 'rxjs';
 import { count, skip, take, mergeMap } from 'rxjs/operators';
-import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
+import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {count} */

--- a/spec/operators/debounceTime-spec.ts
+++ b/spec/operators/debounceTime-spec.ts
@@ -21,7 +21,7 @@ describe('debounceTime', () => {
       const expected = '---a---c--d-|';
       const t = time('  --|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -33,7 +33,7 @@ describe('debounceTime', () => {
       const expected = '------a--------b------(c|)';
       const t = time('  -----|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -45,7 +45,7 @@ describe('debounceTime', () => {
       const expected = '---------c--------------d--|';
       const t = time('  -----|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -57,7 +57,7 @@ describe('debounceTime', () => {
       const expected = '-----|';
       const t = time('  -|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -69,7 +69,7 @@ describe('debounceTime', () => {
       const expected = '|';
       const t = time('  -|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -81,7 +81,7 @@ describe('debounceTime', () => {
       const expected = '-----#';
       const t = time('  -|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -93,7 +93,7 @@ describe('debounceTime', () => {
       const expected = '#';
       const t = time('  -|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -106,7 +106,7 @@ describe('debounceTime', () => {
       const unsub = '   -------!       ';
       const t = time('  --|');
 
-      const result = e1.pipe(debounceTime(t, testScheduler));
+      const result = e1.pipe(debounceTime(t));
 
       expectObservable(result, unsub).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -123,7 +123,7 @@ describe('debounceTime', () => {
 
       const result = e1.pipe(
         mergeMap((x: any) => of(x)),
-        debounceTime(t, testScheduler),
+        debounceTime(t),
         mergeMap((x: any) => of(x))
       );
 
@@ -139,7 +139,7 @@ describe('debounceTime', () => {
       const expected = '---------c--------------d--';
       const t = time('  -----|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -151,7 +151,7 @@ describe('debounceTime', () => {
       const expected = '-';
       const t = time('  -|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -163,7 +163,7 @@ describe('debounceTime', () => {
       const expected = '-';
       const t = time('  -|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -175,7 +175,7 @@ describe('debounceTime', () => {
       const expected = '------a--------b------#';
       const t = time('  -----|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -187,7 +187,7 @@ describe('debounceTime', () => {
       const expected = '-------------------------(h|)';
       const t = time('  ----|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
@@ -199,7 +199,7 @@ describe('debounceTime', () => {
       const expected = '-------------------------#';
       const t = time('  ----|');
 
-      expectObservable(e1.pipe(debounceTime(t, testScheduler))).toBe(expected);
+      expectObservable(e1.pipe(debounceTime(t))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });

--- a/spec/operators/distinct-spec.ts
+++ b/spec/operators/distinct-spec.ts
@@ -91,13 +91,11 @@ describe('distinct', () => {
   });
 
   it('should emit if source is scalar', () => {
-    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 = cold(' (a|)');
-      const e1subs = '  (^!)';
+    testScheduler.run(({ expectObservable }) => {
+      const e1 = of('a');
       const expected = '(a|)';
 
       expectObservable(e1.pipe(distinct())).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 

--- a/spec/operators/distinctUntilChanged-spec.ts
+++ b/spec/operators/distinctUntilChanged-spec.ts
@@ -102,13 +102,11 @@ describe('distinctUntilChanged', () => {
   });
 
   it('should emit if source is scalar', () => {
-    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
-      const e1 = cold(' (a|)');
-      const e1subs = '  (^!)';
+    testScheduler.run(({ expectObservable }) => {
+      const e1 = of('a');
       const expected = '(a|)';
 
       expectObservable(e1.pipe(distinctUntilChanged())).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 

--- a/spec/operators/distinctUntilKeyChanged-spec.ts
+++ b/spec/operators/distinctUntilKeyChanged-spec.ts
@@ -132,14 +132,12 @@ describe('distinctUntilKeyChanged', () => {
   });
 
   it('should emit if source is scalar', () => {
-    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+    testScheduler.run(({ expectObservable }) => {
       const values = { a: { val: 1 } };
-      const e1 = cold(' (a|)', values);
-      const e1subs = '  (^!)';
+      const e1 = of(values.a);
       const expected = '(a|)';
 
       expectObservable(e1.pipe(distinctUntilKeyChanged('val'))).toBe(expected, values);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 

--- a/spec/operators/skip-spec.ts
+++ b/spec/operators/skip-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { skip, mergeMap, take } from 'rxjs/operators';
-import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
+import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 import { of, Observable } from 'rxjs';
 

--- a/spec/operators/skipLast-spec.ts
+++ b/spec/operators/skipLast-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { skipLast, mergeMap, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
-import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
+import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {skipLast} */


### PR DESCRIPTION
- Reverted use of `of` from couple of test where I replaced them earlier (I could only find 3 such tests). See #5860.
- Improved imports, see #5820.
- Stopped passing scheduler to `debounceTime` now that it's been moved to run mode.