### PR TITLE
docs(general): dividing guide section in essential and advanced topics

### DIFF
--- a/docs_app/content/guide/custom-operators.md
+++ b/docs_app/content/guide/custom-operators.md
@@ -1,0 +1,72 @@
+# Creating Custom Operators
+
+## Use the `pipe()` function to make new operators
+
+If there is a commonly used sequence of operators in your code, use the `pipe()` function to extract the sequence into a new operator. Even if a sequence is not that common, breaking it out into a single operator can improve readability.
+
+For example, you could make a function that discarded odd values and doubled even values like this:
+
+```ts
+import { pipe } from "rxjs";
+import { filter, map } from "rxjs/operators";
+
+function discardOddDoubleEven() {
+  return pipe(
+    filter(v => !(v % 2)),
+    map(v => v + v)
+  );
+}
+```
+
+<div class="alert is-helpful">
+  <span>The `pipe()` function is analogous to, but not the same thing as, the `.pipe()` method on an Observable.</span>
+</div>
+
+## Creating new operators from scratch
+
+It is more complicated, but if you have to write an operator that cannot be made from a combination of existing operators (a rare occurrance), you can write an operator from scratch using the Observable constructor, like this:
+
+```ts
+import { Observable } from "rxjs";
+
+function delay(delayInMillis) {
+  return source =>
+    new Observable(observer => {
+      // this function will called each time this
+      // Observable is subscribed to.
+      const allTimerIDs = new Set();
+      const subscription = source.subscribe({
+        next(value) {
+          const timerID = setTimeout(() => {
+            observer.next(value);
+            allTimerIDs.delete(timerID);
+          }, delayInMillis);
+          allTimerIDs.add(timerID);
+        },
+        error(err) {
+          observer.error(err);
+        },
+        complete() {
+          observer.complete();
+        }
+      });
+      // the return value is the teardown function,
+      // which will be invoked when the new
+      // Observable is unsubscribed from.
+      return () => {
+        subscription.unsubscribe();
+        allTimerIDs.forEach(timerID => {
+          clearTimeout(timerID);
+        });
+      };
+    });
+}
+```
+
+Note that you must
+
+1. implement all three Observer functions, `next()`, `error()`, and `complete()` when subscribing to the input Observable.
+2. implement a "teardown" function that cleans up when the Observable completes (in this case by unsubscribing and clearing any pending timeouts).
+3. return that teardown function from the function passed to the Observable constructor.
+
+This is only an example, demonstrating how to implement an Operator from scratch. The [`delay()` operator](/api/operators/delay) already exists.

--- a/docs_app/content/guide/higher-order-observables.md
+++ b/docs_app/content/guide/higher-order-observables.md
@@ -1,0 +1,23 @@
+# Higher-order Observables
+
+Observables most commonly emit ordinary values like strings and numbers, but surprisingly often, it is necessary to handle Observables _of_ Observables, so-called higher-order Observables. For example, imagine you have an Observable emitting strings that are the URLs of files you want to fetch. The code might look like this:
+
+```ts
+const fileObservable = urlObservable.pipe(map(url => http.get(url)));
+```
+
+`http.get()` returns an Observable for each URL. Now you have an Observable _of_ Observables, a higher-order Observable.
+
+But how do you work with a higher-order Observable? Typically, by _flattening_: by converting a higher-order Observable into an ordinary Observable. For example:
+
+```ts
+const fileObservable = urlObservable.pipe(concatMap(url => http.get(url)));
+```
+
+The Observable returned in the `concatMap` function is usually referred to as a so-called "inner" Observable, while in this context the `urlObservable` is the so-called "outer" Observable.
+
+The [`concatMap()`](/api/operators/concatMap) operator subscribes to each "inner" Observable, buffers all further emissions of the "outer" Observable, and copies all the emitted values until the inner Observable completes, and continues processing the values of the "outer Observable". All of the values are in that way concatenated. Other useful flattening operators are
+
+- [`mergeMap()`](/api/operators/mergeMap) — subscribes to each inner Observable as it arrives, then emits each value as it arrives
+- [`switchMap()`](/api/operators/switchMap) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, but when the next inner Observable arrives, unsubscribes to the previous one, and subscribes to the new one.
+- [`exhaustMap()`](/api/operators/exhaustMap) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, discarding all newly arriving inner Observables until that first one completes, then waits for the next inner Observable.

--- a/docs_app/content/guide/installation.md
+++ b/docs_app/content/guide/installation.md
@@ -11,7 +11,7 @@ npm install rxjs
 To import the entire core set of functionality:
 
 ```js
-import * as rxjs from 'rxjs';
+import * as rxjs from "rxjs";
 
 rxjs.of(1, 2, 3);
 ```
@@ -19,12 +19,13 @@ rxjs.of(1, 2, 3);
 To import only what you need using pipeable operators:
 
 ```js
-import { of } from 'rxjs';
-import { map } from 'rxjs/operators';
+import { of } from "rxjs";
+import { map } from "rxjs/operators";
 
-of(1,2,3).pipe(map(x => x + '!!!')); // etc
+of(1, 2, 3).pipe(map(x => x + "!!!"));
 ```
-* See [Pipeable Operator Documentation](https://github.com/ReactiveX/rxjs/blob/91088dae1df097be2370c73300ffa11b27fd0100/doc/pipeable-operators.md) for more information about pipeable operator.
+
+- See [Pipeable Operator Documentation](https://github.com/ReactiveX/rxjs/blob/91088dae1df097be2370c73300ffa11b27fd0100/doc/pipeable-operators.md) for more information about pipeable operator.
 
 To use with globally imported bundle:
 
@@ -32,7 +33,7 @@ To use with globally imported bundle:
 const { of } = rxjs;
 const { map } = rxjs.operators;
 
-of(1,2,3).pipe(map(x => x + '!!!')); // etc
+of(1, 2, 3).pipe(map(x => x + "!!!"));
 ```
 
 ## CommonJS via npm

--- a/docs_app/content/guide/observable.md
+++ b/docs_app/content/guide/observable.md
@@ -1,16 +1,16 @@
 # Observable
 
-Observables are lazy Push collections of multiple values. They fill the missing spot in the following table:
+Observables represent an unknown amount of values over an unknown range of time. Additionally they are push-based collections of multiple values and fill the missing spot in the following table:
 
-| | Single | Multiple |
-| --- | --- | --- |
-| **Pull** | [`Function`](https://developer.mozilla.org/en-US/docs/Glossary/Function) | [`Iterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) |
-| **Push** | [`Promise`](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise) | [`Observable`](../class/es6/Observable.js~Observable.html) |
+|          | Single Value                                                                                              | Multiple Values                                                                                     |
+| -------- | --------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| **Pull** | [`Function`](https://developer.mozilla.org/en-US/docs/Glossary/Function)                                  | [`Iterator`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Iteration_protocols) |
+| **Push** | [`Promise`](https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Promise) | [`Observable`](/api/index/class/Observable)                                                         |
 
 **Example.** The following is an Observable that pushes the values `1`, `2`, `3` immediately (synchronously) when subscribed, and the value `4` after one second has passed since the subscribe call, then completes:
 
 ```ts
-import { Observable } from 'rxjs';
+import { Observable } from "rxjs";
 
 const observable = new Observable(subscriber => {
   subscriber.next(1);
@@ -21,59 +21,22 @@ const observable = new Observable(subscriber => {
     subscriber.complete();
   }, 1000);
 });
-```
-
-To invoke the Observable and see these values, we need to *subscribe* to it:
-
-```ts
-import { Observable } from 'rxjs';
-
-const observable = new Observable(subscriber => {
-  subscriber.next(1);
-  subscriber.next(2);
-  subscriber.next(3);
-  setTimeout(() => {
-    subscriber.next(4);
-    subscriber.complete();
-  }, 1000);
-});
-
-console.log('just before subscribe');
-observable.subscribe({
-  next(x) { console.log('got value ' + x); },
-  error(err) { console.error('something wrong occurred: ' + err); },
-  complete() { console.log('done'); }
-});
-console.log('just after subscribe');
-```
-
-Which executes as such on the console:
-
-```none
-just before subscribe
-got value 1
-got value 2
-got value 3
-just after subscribe
-got value 4
-done
 ```
 
 ## Pull versus Push
 
-*Pull* and *Push* are two different protocols that describe how a data *Producer* can communicate with a data *Consumer*.
+_Pull_ and _Push_ are two different protocols that describe how a data _Producer_ can communicate with a data _Consumer_.
 
-**What is Pull?** In Pull systems, the Consumer determines when it receives data from the data Producer. The Producer itself is unaware of when the data will be delivered to the Consumer.
+**What is Pull?** In Pull systems, the Consumer determines when it receives data. The Producer itself is unaware of when the data will be delivered.
 
-Every JavaScript Function is a Pull system. The function is a Producer of data, and the code that calls the function is consuming it by "pulling" out a *single* return value from its call.
+Every JavaScript Function is a Pull system. The function is a Producer of data, and the code that calls the function is consuming it by "pulling" out a _single_ return value from its call.
 
-ES2015 introduced [generator functions and iterators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) (`function*`), another type of Pull system. Code that calls `iterator.next()` is the Consumer, "pulling" out *multiple* values from the iterator (the Producer).
+ES2015 introduced [generator functions and iterators](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/function*) (`function*`), another type of Pull system. Code that calls `iterator.next()` is the Consumer, "pulling" out _multiple_ values from the iterator (the Producer).
 
-
-| | Producer | Consumer |
-| --- | --- | --- |
+|          | Producer                                   | Consumer                                    |
+| -------- | ------------------------------------------ | ------------------------------------------- |
 | **Pull** | **Passive:** produces data when requested. | **Active:** decides when data is requested. |
-| **Push** | **Active:** produces data at its own pace. | **Passive:** reacts to received data. |
+| **Push** | **Active:** produces data at its own pace. | **Passive:** reacts to received data.       |
 
 **What is Push?** In Push systems, the Producer determines when to send data to the Consumer. The Consumer is unaware of when it will receive that data.
 
@@ -82,21 +45,16 @@ Promises are the most common type of Push system in JavaScript today. A Promise 
 RxJS introduces Observables, a new Push system for JavaScript. An Observable is a Producer of multiple values, "pushing" them to Observers (Consumers).
 
 - A **Function** is a lazily evaluated computation that synchronously returns a single value on invocation.
-- A **generator** is a lazily evaluated computation that synchronously returns zero to (potentially) infinite values on iteration.
-- A **Promise** is a computation that may (or may not) eventually return a single value.
+- A **Promise** is a computation that eventually return a single value.
 - An **Observable** is a lazily evaluated computation that can synchronously or asynchronously return zero to (potentially) infinite values from the time it's invoked onwards.
 
-## Observables as generalizations of functions
-
-Contrary to popular claims, Observables are not like EventEmitters nor are they like Promises for multiple values. Observables *may act* like EventEmitters in some cases, namely when they are multicasted using RxJS Subjects, but usually they don't act like EventEmitters.
-
-<span class="informal">Observables are like functions with zero arguments, but generalize those to allow multiple values.</span>
+## Observables are lazy
 
 Consider the following:
 
 ```ts
 function foo() {
-  console.log('Hello');
+  console.log("Hello");
   return 42;
 }
 
@@ -106,22 +64,13 @@ const y = foo.call(); // same as foo()
 console.log(y);
 ```
 
-We expect to see as output:
-
-```none
-"Hello"
-42
-"Hello"
-42
-```
-
 You can write the same behavior above, but with Observables:
 
 ```ts
-import { Observable } from 'rxjs';
+import { Observable } from "rxjs";
 
 const foo = new Observable(subscriber => {
-  console.log('Hello');
+  console.log("Hello");
   subscriber.next(42);
 });
 
@@ -133,64 +82,25 @@ foo.subscribe(y => {
 });
 ```
 
-And the output is the same:
+Both code examples have the exact same output!
 
-```none
-"Hello"
-42
-"Hello"
-42
-```
+This happens because both functions and Observables are lazy computations. If you don't call the function, the `console.log('Hello')` won't happen. Also with Observables, if you don't "call" it (with `subscribe`), the `console.log('Hello')` won't happen.
 
-This happens because both functions and Observables are lazy computations. If you don't call the function, the `console.log('Hello')` won't happen. Also with Observables, if you don't "call" it (with `subscribe`), the `console.log('Hello')` won't happen. Plus, "calling" or "subscribing" is an isolated operation: two function calls trigger two separate side effects, and two Observable subscribes trigger two separate side effects. As opposed to EventEmitters which share the side effects and have eager execution regardless of the existence of subscribers, Observables have no shared execution and are lazy.
+Additionally, "calling" or "subscribing" is an isolated operation: two function calls trigger two separate side effects, and two Observable subscribes trigger two separate side effects.
 
 <span class="informal">Subscribing to an Observable is analogous to calling a Function.</span>
 
-Some people claim that Observables are asynchronous. That is not true. If you surround a function call with logs, like this:
+## Observables are either synchronous or asynchronous
 
-```js
-console.log('before');
-console.log(foo.call());
-console.log('after');
-```
+Even though writing RxJS code looks pretty similar to asynchronous code, it is as synchronous as possible. As long as there are no asynchronous operations involved an Observable will be completely synchronous.
 
-You will see the output:
+## What is the difference between an Observable and a function
 
-```none
-"before"
-"Hello"
-42
-"after"
-```
-
-And this is the same behavior with Observables:
-
-```js
-console.log('before');
-foo.subscribe(x => {
-  console.log(x);
-});
-console.log('after');
-```
-
-And the output is:
-
-```none
-"before"
-"Hello"
-42
-"after"
-```
-
-Which proves the subscription of `foo` was entirely synchronous, just like a function.
-
-<span class="informal">Observables are able to deliver values either synchronously or asynchronously.</span>
-
-What is the difference between an Observable and a function? **Observables can "return" multiple values over time**, something which functions cannot. You can't do this:
+**Observables can "return" multiple values over time**, something which functions cannot. You can't do this:
 
 ```js
 function foo() {
-  console.log('Hello');
+  console.log("Hello");
   return 42;
   return 100; // dead code. will never happen
 }
@@ -199,81 +109,30 @@ function foo() {
 Functions can only return one value. Observables, however, can do this:
 
 ```ts
-import { Observable } from 'rxjs';
+import { Observable } from "rxjs";
 
 const foo = new Observable(subscriber => {
-  console.log('Hello');
+  console.log("Hello");
   subscriber.next(42);
   subscriber.next(100); // "return" another value
   subscriber.next(200); // "return" yet another
 });
 
-console.log('before');
+console.log("before");
 foo.subscribe(x => {
   console.log(x);
 });
-console.log('after');
-```
-
-With synchronous output:
-
-```none
-"before"
-"Hello"
-42
-100
-200
-"after"
-```
-
-But you can also "return" values asynchronously:
-
-```ts
-import { Observable } from 'rxjs';
-
-const foo = new Observable(subscriber => {
-  console.log('Hello');
-  subscriber.next(42);
-  subscriber.next(100);
-  subscriber.next(200);
-  setTimeout(() => {
-    subscriber.next(300); // happens asynchronously
-  }, 1000);
-});
-
-console.log('before');
-foo.subscribe(x => {
-  console.log(x);
-});
-console.log('after');
-```
-
-With output:
-
-```none
-"before"
-"Hello"
-42
-100
-200
-"after"
-300
+console.log("after");
 ```
 
 Conclusion:
 
-- `func.call()` means "*give me one value synchronously*"
-- `observable.subscribe()` means "*give me any amount of values, either synchronously or asynchronously*"
+- `func.call()` means "_give me one value synchronously_"
+- `observable.subscribe()` means "_give me any amount of values, either synchronously or asynchronously_"
 
 ## Anatomy of an Observable
 
 Observables are **created** using `new Observable` or a creation operator, are **subscribed** to with an Observer, **execute** to deliver `next` / `error` / `complete` notifications to the Observer, and their execution may be **disposed**. These four aspects are all encoded in an Observable instance, but some of these aspects are related to other types, like Observer and Subscription.
-
-Core Observable concerns:
-- **Creating** Observables
-- **Subscribing** to Observables
-- **Executing** the Observable
-- **Disposing** Observables
 
 ### Creating Observables
 
@@ -282,40 +141,34 @@ The `Observable` constructor takes one argument: the `subscribe` function.
 The following example creates an Observable to emit the string `'hi'` every second to a subscriber.
 
 ```ts
-import { Observable } from 'rxjs';
+import { Observable } from "rxjs";
 
-const observable = new Observable(function subscribe(subscriber) {
+const observable = new Observable(subscriber => {
   const id = setInterval(() => {
-    subscriber.next('hi')
+    subscriber.next("hi");
   }, 1000);
 });
 ```
 
 <span class="informal">Observables can be created with `new Observable`. Most commonly, observables are created using creation functions, like `of`, `from`, `interval`, etc.</span>
 
-In the example above, the `subscribe` function is the most important piece to describe the Observable. Let's look at what subscribing means.
-
 ### Subscribing to Observables
 
-The Observable `observable` in the example can be *subscribed* to, like this:
+The variable `observable` in the example can be _subscribed_ to, like this:
 
 ```ts
 observable.subscribe(x => console.log(x));
 ```
 
-It is not a coincidence that `observable.subscribe` and `subscribe` in `new Observable(function subscribe(subscriber) {...})` have the same name. In the library, they are different, but for practical purposes you can consider them conceptually equal.
-
-This shows how `subscribe` calls are not shared among multiple Observers of the same Observable. When calling `observable.subscribe` with an Observer, the function `subscribe` in `new Observable(function subscribe(subscriber) {...})` is run for that given subscriber. Each call to `observable.subscribe` triggers its own independent setup for that given subscriber.
+When calling `observable.subscribe`, the function passed to the constructor in `new Observable(subscriber => {...})` is run for that given subscriber. Each call to `observable.subscribe` triggers its own independent setup for that given subscriber.
 
 <span class="informal">Subscribing to an Observable is like calling a function, providing callbacks where the data will be delivered to.</span>
 
-This is drastically different to event handler APIs like `addEventListener` / `removeEventListener`. With `observable.subscribe`, the given Observer is not registered as a listener in the Observable. The Observable does not even maintain a list of attached Observers.
-
-A `subscribe` call is simply a way to start an "Observable execution" and deliver values or events to an Observer of that execution.
+A `subscribe` call is the way to start an "Observable execution" and deliver values to an Observer of that execution.
 
 ### Executing Observables
 
-The code inside `new Observable(function subscribe(subscriber) {...})` represents an "Observable execution", a lazy computation that only happens for each Observer that subscribes. The execution produces multiple values over time, either synchronously or asynchronously.
+The code inside `new Observable(subscriber => {...})` represents an "Observable execution", a lazy computation that only happens every time the `subscribe` method is called. The execution produces multiple values over time, either synchronously or asynchronously.
 
 There are three types of values an Observable Execution can deliver:
 
@@ -323,35 +176,16 @@ There are three types of values an Observable Execution can deliver:
 - "Error" notification: sends a JavaScript Error or exception.
 - "Complete" notification: does not send a value.
 
-"Next" notifications are the most important and most common type: they represent actual data being delivered to an subscriber. "Error" and "Complete" notifications may happen only once during the Observable Execution, and there can only be either one of them.
+"Next" notifications are the most important and most common type: they represent actual data being delivered to a subscriber. "Error" and "Complete" notifications happen only once during the Observable Execution, and there can only be either one of them.
 
-These constraints are expressed best in the so-called *Observable Grammar* or *Contract*, written as a regular expression:
-
-```none
-next*(error|complete)?
-```
-
-<span class="informal">In an Observable Execution, zero to infinite Next notifications may be delivered. If either an Error or Complete notification is delivered, then nothing else can be delivered afterwards.</span>
-
-The following is an example of an Observable execution that delivers three Next notifications, then completes:
-
-```ts
-import { Observable } from 'rxjs';
-
-const observable = new Observable(function subscribe(subscriber) {
-  subscriber.next(1);
-  subscriber.next(2);
-  subscriber.next(3);
-  subscriber.complete();
-});
-```
+<span class="informal">In an Observable Execution, zero to infinite Next notifications may be delivered. If either an Error or Complete notification is delivered, then nothing else can be delivered afterward.</span>
 
 Observables strictly adhere to the Observable Contract, so the following code would not deliver the Next notification `4`:
 
 ```ts
-import { Observable } from 'rxjs';
+import { Observable } from "rxjs";
 
-const observable = new Observable(function subscribe(subscriber) {
+const observable = new Observable(subscriber => {
   subscriber.next(1);
   subscriber.next(2);
   subscriber.next(3);
@@ -360,28 +194,11 @@ const observable = new Observable(function subscribe(subscriber) {
 });
 ```
 
-It is a good idea to wrap any code in `subscribe` with `try`/`catch` block that will deliver an Error notification if it catches an exception:
-
-```ts
-import { Observable } from 'rxjs';
-
-const observable = new Observable(function subscribe(subscriber) {
-  try {
-    subscriber.next(1);
-    subscriber.next(2);
-    subscriber.next(3);
-    subscriber.complete();
-  } catch (err) {
-    subscriber.error(err); // delivers an error if it caught one
-  }
-});
-```
-
 ### Disposing Observable Executions
 
-Because Observable Executions may be infinite, and it's common for an Observer to want to abort execution in finite time, we need an API for canceling an execution. Since each execution is exclusive to one Observer only, once the Observer is done receiving values, it has to have a way to stop the execution, in order to avoid wasting computation power or memory resources.
+Because Observable Executions may be infinite, and it's common for an Observer to want to abort execution in finite time. Therefore we need an API for canceling such an execution. Since each execution is exclusive to one Observer only, it has to have a way to stop the execution.
 
-When `observable.subscribe` is called, the Observer gets attached to the newly created Observable execution. This call also returns an object, the `Subscription`:
+Calling `observable.subscribe` returns an object, the `Subscription`:
 
 ```ts
 const subscription = observable.subscribe(x => console.log(x));
@@ -390,7 +207,7 @@ const subscription = observable.subscribe(x => console.log(x));
 The Subscription represents the ongoing execution, and has a minimal API which allows you to cancel that execution. Read more about the [`Subscription` type here](./guide/subscription). With `subscription.unsubscribe()` you can cancel the ongoing execution:
 
 ```ts
-import { from } from 'rxjs';
+import { from } from "rxjs";
 
 const observable = from([10, 20, 30]);
 const subscription = observable.subscribe(x => console.log(x));
@@ -400,7 +217,7 @@ subscription.unsubscribe();
 
 <span class="informal">When you subscribe, you get back a Subscription, which represents the ongoing execution. Just call `unsubscribe()` to cancel the execution.</span>
 
-Each Observable must define how to dispose resources of that execution when we create the Observable using `create()`. You can do that by returning a custom `unsubscribe` function from within `function subscribe()`.
+Each Observable must define how to dispose resources of that execution when instantiating the Observable. You can do that by returning a custom `unsubscribe` function from within the constructor.
 
 For instance, this is how we clear an interval execution set with `setInterval`:
 
@@ -408,7 +225,7 @@ For instance, this is how we clear an interval execution set with `setInterval`:
 const observable = new Observable(function subscribe(subscriber) {
   // Keep track of the interval resource
   const intervalId = setInterval(() => {
-    subscriber.next('hi');
+    subscriber.next("hi");
   }, 1000);
 
   // Provide a way of canceling and disposing the interval resource
@@ -417,24 +234,3 @@ const observable = new Observable(function subscribe(subscriber) {
   };
 });
 ```
-
-Just like `observable.subscribe` resembles `new Observable(function subscribe() {...})`, the `unsubscribe` we return from `subscribe` is conceptually equal to `subscription.unsubscribe`. In fact, if we remove the ReactiveX types surrounding these concepts, we're left with rather straightforward JavaScript.
-
-```js
-function subscribe(subscriber) {
-  const intervalId = setInterval(() => {
-    subscriber.next('hi');
-  }, 1000);
-
-  return function unsubscribe() {
-    clearInterval(intervalId);
-  };
-}
-
-const unsubscribe = subscribe({next: (x) => console.log(x)});
-
-// Later:
-unsubscribe(); // dispose the resources
-```
-
-The reason why we use Rx types like Observable, Observer, and Subscription is to get safety (such as the Observable Contract) and composability with Operators.

--- a/docs_app/content/guide/observer.md
+++ b/docs_app/content/guide/observer.md
@@ -1,46 +1,46 @@
 # Observer
 
-**What is an Observer?** An Observer is a consumer of values delivered by an Observable. Observers are simply a set of callbacks, one for each type of notification delivered by the Observable: `next`, `error`, and `complete`. The following is an example of a typical Observer object:
+**What is an Observer?** An Observer is a consumer of values delivered by an Observable. Observers are a set of callbacks, one for each type of notification delivered by the Observable: `next`, `error`, and `complete`. The following is an example of a typical Observer object:
 
 ```ts
 const observer = {
-  next: x => console.log('Observer got a next value: ' + x),
-  error: err => console.error('Observer got an error: ' + err),
-  complete: () => console.log('Observer got a complete notification'),
+  next: x => console.log("Observer got a next value: " + x),
+  error: err => console.error("Observer got an error: " + err),
+  complete: () => console.log("Observer got a complete notification")
 };
 ```
 
-To use the Observer, provide it to the `subscribe` of an Observable:
+To use the Observer, provide it to the `subscribe` call of an Observable:
 
 ```ts
 observable.subscribe(observer);
 ```
 
-<span class="informal">Observers are just objects with three callbacks, one for each type of notification that an Observable may deliver.</span>
+<span class="informal">Observers are objects with three callbacks, one for each type of notification that an Observable may deliver.</span>
 
-Observers in RxJS may also be *partial*. If you don't provide one of the callbacks, the execution of the Observable will still happen normally, except some types of notifications will be ignored, because they don't have a corresponding callback in the Observer.
+Observers in RxJS may also be _partial_. If you don't provide one of the callbacks, the execution of the Observable will still happen normally. Be aware that some types of notifications will be ignored because they don't have a corresponding callback registered.
 
 The example below is an Observer without the `complete` callback:
 
 ```ts
 const observer = {
-  next: x => console.log('Observer got a next value: ' + x),
-  error: err => console.error('Observer got an error: ' + err),
+  next: x => console.log("Observer got a next value: " + x),
+  error: err => console.error("Observer got an error: " + err)
 };
 ```
 
-When subscribing to an Observable, you may also just provide the callbacks as arguments, without being attached to an Observer object, for instance like this:
+When subscribing to an Observable, eferences to callback functions as the arguments, without wrapping it in an object:
 
 ```ts
-observable.subscribe(x => console.log('Observer got a next value: ' + x));
+observable.subscribe(x => console.log("Observer got a next value: " + x));
 ```
 
-Internally in `observable.subscribe`, it will create an Observer object using the first callback argument as the `next` handler. All three types of callbacks may be provided as arguments:
+You can also use this mechanism to provide all three types of callbacks as arguments:
 
 ```ts
 observable.subscribe(
-  x => console.log('Observer got a next value: ' + x),
-  err => console.error('Observer got an error: ' + err),
-  () => console.log('Observer got a complete notification')
+  x => console.log("Observer got a next value: " + x),
+  err => console.error("Observer got an error: " + err),
+  () => console.log("Observer got a complete notification")
 );
 ```

--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -1,133 +1,60 @@
-RxJS is mostly useful for its *operators*, even though the Observable is the foundation. Operators are the essential pieces that allow complex asynchronous code to be easily composed in a declarative manner.
+# About Operators
+
+RxJS' power is coming from the provided _operators_. Operators are the essential pieces that allow the composition of complex asynchronous code in a declarative manner.
 
 ## What are operators?
 
 Operators are **functions**. There are two kinds of operators:
 
-**Pipeable Operators** are the kind that can be piped to Observables  using the syntax `observableInstance.pipe(operator())`. These  include, [`filter(...)`](/api/operators/filter),  and  [`mergeMap(...)`](/api/operators/mergeMap). When called, they do not *change* the existing Observable instance. Instead, they return a *new* Observable, whose subscription logic is based on the first Observable.
+### Pipeable Operators
+
+**Pipeable Operators** are the kind that can be piped to Observables using the syntax `observableInstance.pipe(operator())`. These include, [`filter(...)`](/api/operators/filter), and [`mergeMap(...)`](/api/operators/mergeMap). When called, they do not _change_ the existing Observable instance. Instead, they return a _new_ Observable.
 
 <span class="informal">A Pipeable Operator is a function that takes an Observable as its input and returns another Observable. It is a pure operation: the previous Observable stays unmodified.</span>
 
-A Pipeable Operator is essentially a pure function which takes one Observable as input and generates another Observable as output. Subscribing to the output Observable will also subscribe to the input Observable.
+Subscribing to the output Observable will also subscribe to the input Observable.
 
-**Creation Operators** are the other kind of operator, which can be called as standalone functions to create a new Observable. For example: `of(1, 2, 3)` creates an observable that will emit 1, 2, and 3, one right after another. Creation operators will be discussed in more detail in a later section.
-
-For example, the operator called [`map`](/api/operators/map) is analogous to the Array method of the same name. Just as `[1, 2, 3].map(x => x * x)` will yield `[1, 4, 9]`, the Observable created like this:
-
-```ts
-import { of } from 'rxjs';
-import { map } from 'rxjs/operators';
-
-map(x => x * x)(of(1, 2, 3)).subscribe((v) => console.log(`value: ${v}`));
-
-// Logs:
-// value: 1
-// value: 4
-// value: 9
-
-```
-
-will emit `1`, `4`, `9`.  Another useful operator is [`first`](/api/operators/first):
-
-```ts
-import { of } from 'rxjs';
-import { first } from 'rxjs/operators';
-
-first()(of(1, 2, 3)).subscribe((v) => console.log(`value: ${v}`));
-
-// Logs:
-// value: 1
-```
-
-Note that `map` logically must be constructed on the fly, since it must be given the mapping function to.  By contrast, `first` could be a constant, but is nonetheless constructed on the fly.  As a general practice, all operators are constructed, whether they need arguments or not.
-
-## Piping
-
-Pipeable operators are functions, so they *could* be used like ordinary functions: `op()(obs)` — but in practice, there tend to be many of them convolved together, and quickly become unreadable: `op4()(op3()(op2()(op1()(obs))))`. For that reason, Observables have a method called `.pipe()` that accomplishes the same thing while being much easier to read:
+Pipeable operators are functions, so they _could_ be used like ordinary functions: `op()(obs)` — but in practice, there tend to be many of them convolved together, and quickly become unreadable: `op4()(op3()(op2()(op1()(obs))))`. For that reason, Observables have a method called `.pipe()` that accomplishes the same thing while being much easier to read:
 
 ```ts
 obs.pipe(
   op1(),
   op2(),
   op3(),
-  op3(),
-)
+  op4()
+);
 ```
 
 As a stylistic matter, `op()(obs)` is never used, even if there is only one operator; `obs.pipe(op())` is universally preferred.
 
+### Creation Operators
 
-## Creation Operators
+**Creation Operators** are the other kind of operator, which can be called as standalone functions to create a new Observable. For example: `of(1, 2, 3)` creates an observable that will emit 1, 2, and 3, one right after another. Distinct from pipeable operators, creation operators are functions that can be used to create an Observable with some common predefined behavior or by joining other Observables.
 
-**What are creation operators?** Distinct from pipeable operators, creation operators are functions that can be used to create an Observable with some common predefined behavior or by joining other Observables.
-
-A typical example of a creation operator would be the `interval` function. It takes a number (not an Observable) as input argument, and produces an Observable as output:
+A typical example of a creation operator would be the [`interval`](/api/index/function/interval) function. It takes a number (not an Observable) as input argument, and produces an Observable as output:
 
 ```ts
-import { interval } from 'rxjs';
+import { interval } from "rxjs";
 
 const observable = interval(1000 /* number of milliseconds */);
 ```
 
-See the list of [all static creation operators here](#creation-operators).
-
-
-## Higher-order Observables
-
-Observables most commonly emit ordinary values like strings and numbers, but surprisingly often, it is necessary to handle Observables *of* Observables, so-called higher-order Observables.  For example, imagine you had an Observable emitting strings that were the URLs of files you wanted to see.  The code might look like this:
-
-```ts
-const fileObservable = urlObservable.pipe(
-   map(url => http.get(url)),
-);
-```
-
-`http.get()` returns an Observable (of string or string arrays probably) for each individual URL.  Now you have an Observables *of* Observables, a higher-order Observable.
-
-But how do you work with a higher-order Observable? Typically, by _flattening_: by (somehow) converting a higher-order Observable into an ordinary Observable.  For example:
-
-```ts
-const fileObservable = urlObservable.pipe(
-   map(url => http.get(url)),
-   concatAll(),
-);
-```
-
-The [`concatAll()`](/api/operators/concatAll) operator subscribes to each "inner" Observable that comes out of the "outer" Observable, and copies all the emitted values until that Observable completes, and goes on to the next one.  All of the values are in that way concatenated.  Other useful flattening operators (called [*join operators*](#join-operators)) are
-
-* [`mergeAll()`](/api/operators/mergeAll) — subscribes to each inner Observable as it arrives, then emits each value as it arrives
-* [`switchAll()`](/api/operators/switchAll) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, but when the next inner Observable arrives, unsubscribes to the previous one, and subscribes to the new one.
-* [`exhaust()`](/api/operators/exhaust) — subscribes to the first inner Observable when it arrives, and emits each value as it arrives, discarding all newly arriving inner Observables until that first one completes, then waits for the next inner Observable.
-
-Just as many array library combine [`map()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map) and [`flat()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flat) (or `flatten()`) into a single [`flatMap()`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/flatMap), there are mapping equivalents of all the RxJS flattening operators [`concatMap()`](/api/operators/concatMap), [`mergeMap()`](/api/operators/mergeMap), [`switchMap()`](/api/operators/switchMap), and [`exhaustMap()`](/api/operators/exhaustMap).
-
-
-
-## Marble diagrams
-
-To explain how operators work, textual descriptions are often not enough. Many operators are related to time, they may for instance delay, sample, throttle, or debounce value emissions in different ways. Diagrams are often a better tool for that. *Marble Diagrams* are visual representations of how operators work, and include the input Observable(s), the operator and its parameters, and the output Observable.
-
-<span class="informal">In a marble diagram, time flows to the right, and the diagram describes how values ("marbles") are emitted on the Observable execution.</span>
-
-Below you can see the anatomy of a marble diagram.
-
-<img src="assets/images/guide/marble-diagram-anatomy.svg">
-
-Throughout this documentation site, we extensively use marble diagrams to explain how operators work. They may be really useful in other contexts too, like on a whiteboard or even in our unit tests (as ASCII diagrams).
+See the list of [all static creation operators here](#creation-operators-list).
 
 ## Categories of operators
 
 There are operators for different purposes, and they may be categorized as: creation, transformation, filtering, joining, multicasting, error handling, utility, etc. In the following list you will find all the operators organized in categories.
 
-For a complete overview, see the [references page](/api).
+For a complete overview, see the [reference page](/api).
 
-### Creation Operators
+### <a id="creation-operators-list"></a>Creation Operators
 
 - [`ajax`](/api/ajax/ajax)
 - [`bindCallback`](/api/index/function/bindCallback)
 - [`bindNodeCallback`](/api/index/function/bindNodeCallback)
 - [`defer`](/api/index/function/defer)
-- [`empty`](/api/index/function/empty)
+- [`EMPTY`](/api/index/const/EMPTY)
+- [`NEVER`](/api/index/const/NEVER)
 - [`from`](/api/index/function/from)
 - [`fromEvent`](/api/index/function/fromEvent)
 - [`fromEventPattern`](/api/index/function/fromEventPattern)
@@ -139,7 +66,8 @@ For a complete overview, see the [references page](/api).
 - [`timer`](/api/index/function/timer)
 - [`iif`](/api/index/function/iif)
 
-### Join Creation Operators
+### <a id="join-creation-operators"></a>Join Creation Operators
+
 These are Observable creation operators that also have join functionality -- emitting values of multiple source Observables.
 
 - [`combineLatest`](/api/index/function/combineLatest)
@@ -209,13 +137,15 @@ These are Observable creation operators that also have join functionality -- emi
 - [`throttle`](/api/operators/throttle)
 - [`throttleTime`](/api/operators/throttleTime)
 
-### Join Operators
+### <a id="join-operators"></a>Join Operators
+
 Also see the [Join Creation Operators](#join-creation-operators) section above.
 
 - [`combineAll`](/api/operators/combineAll)
 - [`concatAll`](/api/operators/concatAll)
 - [`exhaust`](/api/operators/exhaust)
 - [`mergeAll`](/api/operators/mergeAll)
+- [`switchAll`](/api/operators/switchAll)
 - [`startWith`](/api/operators/startWith)
 - [`withLatestFrom`](/api/operators/withLatestFrom)
 
@@ -263,77 +193,3 @@ Also see the [Join Creation Operators](#join-creation-operators) section above.
 - [`max`](/api/operators/max)
 - [`min`](/api/operators/min)
 - [`reduce`](/api/operators/reduce)
-
-
-
-## Creating custom operators
-
-### Use the `pipe()` function to make new operators
-
-If there is a commonly used sequence of operators in your code, use the `pipe()` function to extract the sequence into a new operator. Even if a sequence is not that common, breaking it out into a single operator can improve readability.
-
-For example, you could make a function that discarded odd values and doubled even values like this:
-
-```ts
-import { pipe } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
-
-function discardOddDoubleEven() {
-  return pipe(
-    filter(v => ! (v % 2)),
-    map(v => v + v),
-  );
-}
-```
-
-(The `pipe()` function is analogous to, but not the same thing as, the `.pipe()` method on an Observable.)
-
-### Creating new operators from scratch
-
-It is more complicated, but if you have to write an operator that cannot be made from a combination of existing operators (a rare occurrance), you can write an operator from scratch using the Observable constructor, like this:
-
-
-```ts
-import { Observable } from 'rxjs';
-
-function delay(delayInMillis) {
-  return (observable) => new Observable(observer => {
-    // this function will be called each time this
-    // Observable is subscribed to.
-    const allTimerIDs = new Set();
-    const subscription = observable.subscribe({
-      next(value) {
-        const timerID = setTimeout(() => {
-          observer.next(value);
-          allTimerIDs.delete(timerID);
-        }, delayInMillis);
-        allTimerIDs.add(timerID);
-      },
-      error(err) {
-        observer.error(err);
-      },
-      complete() {
-        observer.complete();
-      }
-    });
-    // the return value is the teardown function,
-    // which will be invoked when the new
-    // Observable is unsubscribed from.
-    return () => {
-      subscription.unsubscribe();
-      allTimerIDs.forEach(timerID => {
-        clearTimeout(timerID);
-      });
-    }
-  });
-}
-```
-
-Note that you must
-
-1. implement all three Observer functions, `next()`, `error()`, and `complete()` when subscribing to the input Observable.
-2. implement a "teardown" function that cleans up when the Observable completes (in this case by unsubscribing and clearing any pending timeouts).
-3. return that teardown function from the function passed to the Observable constructor.
-
-Of course, this is only an example; the `delay()` operator [already exists](/api/operators/delay).
-

--- a/docs_app/content/guide/overview.md
+++ b/docs_app/content/guide/overview.md
@@ -1,127 +1,50 @@
 # Introduction
 
-RxJS is a library for composing asynchronous and event-based programs by using observable sequences. It provides one core type, the [Observable](./guide/observable), satellite types (Observer, Schedulers, Subjects) and operators inspired by [Array#extras](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/1.6) (map, filter, reduce, every, etc) to allow handling asynchronous events as collections.
+RxJS is a library implementing the reactive programming paradigm for Javascript. This programming paradigm mainly handles the propagation of change. In reactive programming, one specifies how to "react" on such a propagated change. Taking a look at the following code example clarifies the behavior of reactive programming.
 
-<span class="informal">Think of RxJS as Lodash for events.</span>
+```ts
+let a = 10;
+let b = 10;
+let c = a + b;
+a = 20;
 
-ReactiveX combines the [Observer pattern](https://en.wikipedia.org/wiki/Observer_pattern) with the [Iterator pattern](https://en.wikipedia.org/wiki/Iterator_pattern) and [functional programming with collections](http://martinfowler.com/articles/collection-pipeline/#NestedOperatorExpressions) to fill the need for an ideal way of managing sequences of events.
+console.log(c);
+```
 
-The essential concepts in RxJS which solve async event management are:
+Generally, considering usual programming paradigms the code above will log `20`. In a fully reactive approach the code would consider the change in the variable `a` and therefore log `30` instead.
 
-- **Observable:** represents the idea of an invokable collection of future values or events.
+This is only an example demonstrating the behavior of reactive programming.
+
+## RxJS in a Nutshell
+
+RxJS comes with some mechanism to enable developers to implement in a reactive manner.
+
+- **Observable:** represents a set of an undefined amount of values.
 - **Observer:** is a collection of callbacks that knows how to listen to values delivered by the Observable.
-- **Subscription:** represents the execution of an Observable, is primarily useful for cancelling the execution.
-- **Operators:** are pure functions that enable a functional programming style of dealing with collections with operations like `map`, `filter`, `concat`, `reduce`, etc.
-- **Subject:** is the equivalent to an EventEmitter, and the only way of multicasting a value or event to multiple Observers.
-- **Schedulers:** are centralized dispatchers to control concurrency, allowing us to coordinate when computation happens on e.g. `setTimeout` or `requestAnimationFrame` or others.
+- **Subscription:** represents the life-cycle of an Observable.
+- **Operators:** are functions that manipulate an existing Observable.
+- **Subject:** is the equivalent to an EventEmitter.
+
+## Capabilities of RxJS
+
+RxJS provides one general mechanism to treat **synchronous** and **asynchronous** code the same way. On top of that, it provides functions similar to the [Array#extras](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/1.6). This enables developers to perform operations on an Observable in a similar way than they are already used to from working with Arrays.
+
+Additionally, it provides one single interface to handle callbacks, Promises and Event-Emitter the exact same way.
+
+All these features are provided by the [Observable](./guide/observable) class.
 
 ## First examples
 
 Normally you register event listeners.
 
 ```ts
-document.addEventListener('click', () => console.log('Clicked!'));
+document.addEventListener("click", () => console.log("Clicked!"));
 ```
 
-Using RxJS you create an observable instead.
+Using RxJS you create an Observable instead.
 
 ```ts
-import { fromEvent } from 'rxjs';
+import { fromEvent } from "rxjs";
 
-fromEvent(document, 'click').subscribe(() => console.log('Clicked!'));
+fromEvent(document, "click").subscribe(() => console.log("Clicked!"));
 ```
-
-### Purity
-
-What makes RxJS powerful is its ability to produce values using pure functions. That means your code is less prone to errors.
-
-Normally you would create an impure function, where other
-pieces of your code can mess up your state.
-
-```ts
-let count = 0;
-document.addEventListener('click', () => console.log(`Clicked ${++count} times`));
-```
-
-Using RxJS you isolate the state.
-
-```ts
-import { fromEvent } from 'rxjs';
-import { scan } from 'rxjs/operators';
-
-fromEvent(document, 'click')
-  .pipe(scan(count => count + 1, 0))
-  .subscribe(count => console.log(`Clicked ${count} times`));
-```
-
-The **scan** operator works just like **reduce** for arrays. It takes a value which is exposed to a callback. The returned value of the callback will then become the next value exposed the next time the callback runs.
-
-### Flow
-
-RxJS has a whole range of operators that helps you control how the events flow through your observables.
-
-This is how you would allow at most one click per second, with plain JavaScript:
-
-```ts
-let count = 0;
-let rate = 1000;
-let lastClick = Date.now() - rate;
-document.addEventListener('click', () => {
-  if (Date.now() - lastClick >= rate) {
-    console.log(`Clicked ${++count} times`);
-    lastClick = Date.now();
-  }
-});
-```
-
-With RxJS:
-
-```ts
-import { fromEvent } from 'rxjs';
-import { throttleTime, scan } from 'rxjs/operators';
-
-fromEvent(document, 'click')
-  .pipe(
-    throttleTime(1000),
-    scan(count => count + 1, 0)
-  )
-  .subscribe(count => console.log(`Clicked ${count} times`));
-```
-
-Other flow control operators are [**filter**](../api/operators/filter), [**delay**](../api/operators/delay), [**debounceTime**](../api/operators/debounceTime), [**take**](../api/operators/take), [**takeUntil**](../api/operators/takeUntil), [**distinct**](../api/operators/distinct), [**distinctUntilChanged**](../api/operators/distinctUntilChanged) etc.
-
-### Values
-
-You can transform the values passed through your observables.
-
-Here's how you can add the current mouse x position for every click, in plain JavaScript:
-
-```ts
-let count = 0;
-const rate = 1000;
-let lastClick = Date.now() - rate;
-document.addEventListener('click', event => {
-  if (Date.now() - lastClick >= rate) {
-    count += event.clientX;
-    console.log(count);
-    lastClick = Date.now();
-  }
-});
-```
-
-With RxJS:
-
-```ts
-import { fromEvent } from 'rxjs';
-import { throttleTime, map, scan } from 'rxjs/operators';
-
-fromEvent(document, 'click')
-  .pipe(
-    throttleTime(1000),
-    map(event => event.clientX),
-    scan((count, clientX) => count + clientX, 0)
-  )
-  .subscribe(count => console.log(count));
-```
-
-Other value producing operators are [**pluck**](../api/operators/pluck), [**pairwise**](../api/operators/pairwise), [**sample**](../api/operators/sample) etc.

--- a/docs_app/content/guide/v6/marble-diagrams.md
+++ b/docs_app/content/guide/v6/marble-diagrams.md
@@ -1,0 +1,11 @@
+# Marble diagrams
+
+To explain how operators work, textual descriptions are often not enough. Many operators are related to time. Diagrams are often a better tool for that. _Marble Diagrams_ are visual representations of how operators work, and include the input Observable(s), the operator and its parameters, and the output Observable.
+
+<span class="informal">In a marble diagram, time flows to the right, and the diagram describes how values ("marbles") are emitted on the Observable execution.</span>
+
+Below you can see the anatomy of a marble diagram.
+
+<img src="assets/images/guide/marble-diagram-anatomy.svg">
+
+Throughout this documentation site, we extensively use marble diagrams to explain how operators work. They may be really useful in other contexts too, like on a whiteboard or even in our unit tests (as ASCII diagrams).

--- a/docs_app/content/maintainer-guidelines.md
+++ b/docs_app/content/maintainer-guidelines.md
@@ -5,32 +5,31 @@ His Beardliness, @jeffbcross. They are words to live by for those that are taske
 shepherding the community. As the roster of trusted maintainers grows, we'll expect these guidelines to stay pretty
 much the same (but suggestions are always welcome).
 
+## The ~~10~~ 6 Commandments
 
-### The ~~10~~ 6 Commandments
- 
- * __[Code of Conduct](../CODE_OF_CONDUCT.md)__. We should be setting a good example and be welcoming to all. We should be listening
- to all feedback from everyone in our community and respect their viewpoints and opinions.
- * __Be sure PRs meet [Contribution Guidelines](../CONTRIBUTING.md)__. It's important we keep our code base 
- and repository consistent. The best way to do this is to know and enforce the contribution guidelines.
- * __Clean, flat commit history__. We never click the green merge button on PRs, but instead we pull down 
- the PR branch and rebase it against master then replace master with the PR branch. See 
- [example gist](https://gist.github.com/jeffbcross/307c6da45d26e29030ef). This reduces noise in the commit 
- history, removing all of the merge commits, and keeps history flat. The flat history is beneficial 
- to tools/scripts that analyze commit ancestry.
- * __Always green master__. Failing master builds tend to cascade into other broken builds, and 
- frustration among other contributors who have rebased against a broken master. Much of our deployment 
- and other infrastructure is based on the assumption that master is always green, nothing should be
- merged before Travis has confirmed that a PR is green, even for seemingly insignificant changes. 
- Nothing should be merged into a red master, and whomever broke it should drop everything and fix it 
- right away. Fixes should be submitted as a PR and verified as green instead of immediately merging 
- to master.
- * __No force pushes to master__. Only in rare circumstances should a force push to master be made, 
- and other maintainers should be notified beforehand. The most common situation for a justified force 
- push is when a commit has been pushed with an invalid message. The force push should be made as soon 
- as possible to reduce side effects.
- * __Small, logical commits__. A PR should be focused on a single problem, though that problem may be
- reasonable to be broken into a few logical commits. For example, a global renaming may be best to be 
- broken into a single commit that renames all files, and then a commit that renames symbols within files. 
- This makes the review process simpler easier, so the diff of the meaty commit (where symbols are 
- renamed) can be easily understood than if both were done in the same commit, in which case github would 
- just show a deleted file and an added file.
+- **[Code of Conduct](../CODE_OF_CONDUCT.md)**. We should be setting a good example and be welcoming to all. We should be listening
+  to all feedback from everyone in our community and respect their viewpoints and opinions.
+- **Be sure PRs meet [Contribution Guidelines](../CONTRIBUTING.md)**. It's important we keep our code base
+  and repository consistent. The best way to do this is to know and enforce the contribution guidelines.
+- **Clean, flat commit history**. We never click the green merge button on PRs, but instead we pull down
+  the PR branch and rebase it against master then replace master with the PR branch. See
+  [example gist](https://gist.github.com/jeffbcross/307c6da45d26e29030ef). This reduces noise in the commit
+  history, removing all of the merge commits, and keeps history flat. The flat history is beneficial
+  to tools/scripts that analyze commit ancestry.
+- **Always green master**. Failing master builds tend to cascade into other broken builds, and
+  frustration among other contributors who have rebased against a broken master. Much of our deployment
+  and other infrastructure is based on the assumption that master is always green, nothing should be
+  merged before Travis has confirmed that a PR is green, even for seemingly insignificant changes.
+  Nothing should be merged into a red master, and whomever broke it should drop everything and fix it
+  right away. Fixes should be submitted as a PR and verified as green instead of immediately merging
+  to master.
+- **No force pushes to master**. Only in rare circumstances should a force push to master be made,
+  and other maintainers should be notified beforehand. The most common situation for a justified force
+  push is when a commit has been pushed with an invalid message. The force push should be made as soon
+  as possible to reduce side effects.
+- **Small, logical commits**. A PR should be focused on a single problem, though that problem may be
+  reasonable to be broken into a few logical commits. For example, a global renaming may be best to be
+  broken into a single commit that renames all files, and then a commit that renames symbols within files.
+  This makes the review process simpler easier, so the diff of the meaty commit (where symbols are
+  renamed) can be easily understood than if both were done in the same commit, in which case github would
+  just show a deleted file and an added file.

--- a/docs_app/content/navigation.json
+++ b/docs_app/content/navigation.json
@@ -21,44 +21,65 @@
   "TopBarNarrow": [],
   "SideNav": [
     {
-      "url": "guide/overview",
-      "title": "Overview",
-      "tooltip": "RxJS Overview",
+      "title": "Guides",
+      "tooltip": "RxJS Guides",
       "children": [
         {
-          "url": "guide/observable",
-          "title": "Observables"
-        },
-        {
-          "url": "guide/observer",
-          "title": "Observer"
-        },
-        {
-          "url": "guide/operators",
-          "title": "Operators"
-        },
-        {
-          "url": "guide/subscription",
-          "title": "Subscription"
-        },
-        {
-          "url": "guide/subject",
-          "title": "Subjects"
-        },
-        {
-          "url": "guide/scheduler",
-          "title": "Scheduler"
-        },
-        {
-          "title": "Testing",
+          "title": "Essential",
+          "tooltip": "RxJS Essential Guides",
           "children": [
+            {
+              "url": "guide/overview",
+              "title": "Overview",
+              "tooltip": "Overview about RxJS"
+            },
+            {
+              "url": "guide/observable",
+              "title": "Observables",
+              "tooltip": "About Observables"
+            },
+            {
+              "url": "guide/observer",
+              "title": "Observer",
+              "tooltip": "About Observables"
+            },
+            {
+              "url": "guide/subscription",
+              "title": "Subscription"
+            },
+            {
+              "url": "guide/operators",
+              "title": "Operators"
+            },
+            {
+              "url": "guide/marble-diagrams",
+              "title": "Marble Diagrams"
+            }
+          ]
+        },
+        {
+          "title": "Advanced",
+          "tooltip": "RxJS Advanced Guides",
+          "children": [
+            {
+              "url": "guide/subject",
+              "title": "Subjects"
+            },
+            {
+              "url": "guide/higher-order-observables",
+              "title": "Higher-Order Observables"
+            },
+            {
+              "url": "guide/custom-operators",
+              "title": "Creating Custom Operators"
+            },
             {
               "url": "guide/testing/marble-testing",
               "title": "Marble Testing"
             },
             {
-              "url": "guide/testing/internal-marble-tests",
-              "title": "Contribute tests to RxJS"
+              "url": "guide/scheduler",
+              "title": "Scheduler"
             }
           ]
         }
@@ -111,7 +132,7 @@
   "docVersions": [
     {
       "title": "v7",
-      "url": "https://next-rxjs.web.app/"
+      "url": "https://next.rxjs.dev/"
     },
     {
       "title": "v6",


### PR DESCRIPTION
As discussed in #5419, this is a reworked version of the guide section for the *V6* docs!