### PR TITLE
fix(Symbol.observable): properly defined as a `unique symbol`.

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -298,7 +298,7 @@ export interface ObjectUnsubscribedError extends Error {
 
 export declare const ObjectUnsubscribedError: ObjectUnsubscribedErrorCtor;
 
-export declare const observable: string | symbol;
+export declare const observable: string | SymbolConstructor["observable"];
 
 export declare class Observable<T> implements Subscribable<T> {
     protected operator: Operator<any, T> | undefined;

--- a/package-lock.json
+++ b/package-lock.json
@@ -231,9 +231,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "12.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.7.tgz",
-      "integrity": "sha512-E6Zn0rffhgd130zbCbAr/JdXfXkoOUFAKNs/rF8qnafSJ8KYaA/j3oz7dcwal+lYjLA7xvdd5J4wdYpCTlP8+w==",
+      "version": "14.14.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
+      "integrity": "sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==",
       "dev": true
     },
     "@types/parse-json": {

--- a/package.json
+++ b/package.json
@@ -101,7 +101,7 @@
     "@types/chai": "^4.2.11",
     "@types/lodash": "4.14.102",
     "@types/mocha": "^7.0.2",
-    "@types/node": "^12.12.5",
+    "@types/node": "^14.14.6",
     "@types/shelljs": "^0.8.8",
     "@types/sinon": "4.1.3",
     "@types/sinon-chai": "2.7.29",

--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,11 +1,4 @@
-/** Symbol.observable addition */
-/* Note: This will add Symbol.observable globally for all TypeScript users,
-  however, we are no longer polyfilling Symbol.observable */
-declare global {
-  interface SymbolConstructor {
-    readonly observable: symbol;
-  }
-}
+/** @prettier */
 
 /** Symbol.observable or a string "@@observable". Used for interop */
-export const observable = (() => typeof Symbol === 'function' && Symbol.observable || '@@observable')();
+export const observable = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -6,6 +6,22 @@
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
 
+/**
+ * NOTE: This will add Symbol.observable globally for all TypeScript users,
+ * however, we are no longer polyfilling Symbol.observable. Note that this will be at
+ * odds with older version of @types/node and symbol-observable which incorrectly define
+ * `Symbol.observable` as `symbol` rather than `unique symbol`. "What about not defining
+ * this non-standard symbol at all?" you might ask... Well, that ship has sailed. There are
+ * dozens of libraries using this symbol now and many of them are quite popular.
+ * So here we are, and it's probably my fault. Sorry, "the web", if I have hurt you,
+ * the world just needed a standard way to provide interop for these types. -Ben
+ */
+declare global {
+  interface SymbolConstructor {
+    readonly observable: unique symbol;
+  }
+}
+
 /** OPERATOR INTERFACES */
 
 export interface UnaryFunction<T, R> {
@@ -217,12 +233,12 @@ export type ObservedValueTupleFromArray<X> = { [K in keyof X]: ObservedValueOf<X
 
 /**
  * Used to infer types from arguments to functions like {@link forkJoin}.
- * So that you can have `forkJoin([Observable<A>, PromiseLike<B>]): Observable<[A, B]>` 
+ * So that you can have `forkJoin([Observable<A>, PromiseLike<B>]): Observable<[A, B]>`
  * et al.
  */
 export type ObservableInputTuple<T> = {
-  [K in keyof T]: ObservableInput<T[K]>
-}
+  [K in keyof T]: ObservableInput<T[K]>;
+};
 
 /**
  * Constructs a new tuple with the specified type at the head.


### PR DESCRIPTION
Resolves #5861
Resolves #4415


This is also related to issues here: https://github.com/benlesh/symbol-observable/issues/41

I don't think we can publish this in 6.x, as it will break people using older versions of `@types/node`, however, we do need to set an upper bounds for `@types/node` and version 6.x.