### PR TITLE
chore: update delay tests

### DIFF
--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { of, concat } from 'rxjs';
 import { delay, repeatWhen, skip, take, tap, mergeMap, ignoreElements } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
@@ -14,185 +15,194 @@ describe('delay', () => {
   });
 
   it('should delay by specified timeframe', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-    const e1 =   hot('---a--b--|');
-    const t = 2; //      --|
-    const expected = '-----a--b|';
-    const subs =     '^--------!';
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---a--b--|');
+      const e1subs = '  ^--------!';
+      const t = time('     --|    ');
+      //                      --|
+      const expected = '-----a--b|';
 
-      const result = e1.pipe(delay(t, testScheduler));
+      const result = e1.pipe(delay(t));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should not delay at all if the delay number is negative', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('---a--b--|');
+      const e1 = hot('  ---a--b--|');
+      const e1subs = '  ^--------!';
       const t = -1;
       const expected = '---a--b--|';
-      const subs =     '^--------!';
 
-      const result = e1.pipe(delay(t, testScheduler));
+      const result = e1.pipe(delay(t));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should delay by absolute time period', () => {
     testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--a---a----a----a------------b---b---b---b--|');
-      const t = time('  --------------------|');
+      const e1subs = '  ^----------------------------------------------!';
+      const t = time('  --------------------|                           ');
       const expected = '--------------------(aaaaa)-----b---b---b---b--|';
-      const subs = '    ^----------------------------------------------!';
 
       const absoluteDelay = new Date(testScheduler.now() + t);
-      const result = e1.pipe(delay(absoluteDelay, testScheduler));
+      const result = e1.pipe(delay(absoluteDelay));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should not delay at all if the absolute time is in the past', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--a---a----a----a------------b---b---b---b--|');
+      const e1subs = '  ^----------------------------------------------!';
       const t = -10000;
       const expected = '--a--a---a----a----a------------b---b---b---b--|';
-      const subs = '    ^----------------------------------------------!';
 
       const absoluteDelay = new Date(testScheduler.now() + t);
-      const result = e1.pipe(delay(absoluteDelay, testScheduler));
+      const result = e1.pipe(delay(absoluteDelay));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should delay by absolute time period after source ends', () => {
     testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  ---^--a-----a---a-----a---|');
-      const t = time('     ------------------------------|');
-      const expected = '   ------------------------------(aaaa|)';
-      const subs = '       ^----------------------!   ';
+      const e1 = hot('---^--a-----a---a-----a---|             ');
+      const e1subs = '   ^----------------------!             ';
+      const t = time('   ------------------------------|      ');
+      const expected = ' ------------------------------(aaaa|)';
 
       const absoluteDelay = new Date(testScheduler.now() + t);
-      const result = e1.pipe(delay(absoluteDelay, testScheduler));
+      const result = e1.pipe(delay(absoluteDelay));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should raise error when source raises error', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a---b---#');
-      const t = 3; //      ---|
+      const e1subs = '  ^----------!';
+      const t = time('     ---|     ');
+      //                       ---|
       const expected = '------a---b#';
-      const subs = '    ^----------!';
 
-      const result = e1.pipe(delay(t, testScheduler));
+      const result = e1.pipe(delay(t));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should raise error when source raises error before absolute delay fires', () => {
     testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  --a--a---a-----#');
-      const t = time('  --------------------|')
-      const expected = '---------------#';
-      const subs = '    ^--------------!';
+      const e1 = hot('  --a--a---a-----#     ');
+      const e1subs = '  ^--------------!     ';
+      const t = time('  --------------------|');
+      const expected = '---------------#     ';
 
       const absoluteDelay = new Date(testScheduler.now() + t);
-      const result = e1.pipe(delay(absoluteDelay, testScheduler));
+      const result = e1.pipe(delay(absoluteDelay));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should raise error when source raises error after absolute delay fires', () => {
     testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  ---^---a--a---a---a--------b---b---b--#');
-      const t = time('     -----------------|');
-      const expected = '   -----------------(aaaa)-b---b---b--#';
-      const e1Sub = '      ^----------------------------------!';
+      const e1 = hot('---^---a--a---a---a--------b---b---b--#');
+      const e1subs = '   ^----------------------------------!';
+      const t = time('   -----------------|                  ');
+      const expected = ' -----------------(aaaa)-b---b---b--#';
 
       const absoluteDelay = new Date(testScheduler.now() + t);
-      const result = e1.pipe(delay(absoluteDelay, testScheduler));
+      const result = e1.pipe(delay(absoluteDelay));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1Sub);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
-  it('should delay when source does not emits', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  ----|   ');
-      const t = 3; //       ---|
+  it('should delay when source does not emit', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ----|');
+      const e1subs = '  ^---!';
+      const t = time('  ---| ');
       const expected = '----|';
-      const subs = '    ^---!   ';
 
-      const result = e1.pipe(delay(t, testScheduler));
+      const result = e1.pipe(delay(t));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should not delay when source is empty', () => {
-    testScheduler.run(({ cold, expectObservable }) => {
-    const e1 =  cold('|');
-    const t =  3; // ---|
-    const expected = '|';
+    testScheduler.run(({ cold, time, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const t = time('  ---|');
+      const expected = '|   ';
 
-    const result = e1.pipe(delay(t, testScheduler));
-
-    expectObservable(result).toBe(expected);
-  }); });
-
-  it('should delay complete when a value is scheduled', () => {
-    testScheduler.run(({ cold, expectObservable }) => {
-    const e1 =  cold('-a-|');
-    const t = 3; //    ---|
-    const expected = '----(a|)';
-
-      const result = e1.pipe(delay(t, testScheduler));
+      const result = e1.pipe(delay(t));
 
       expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
-  it('should not complete when source does not completes', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+  it('should delay complete when a value is scheduled', () => {
+    testScheduler.run(({ cold, time, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -a-|    ');
+      const e1subs = '  ^--!    ';
+      const t = time('   ---|   ');
+      const expected = '----(a|)';
+
+      const result = e1.pipe(delay(t));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
+  it('should not complete when source does not complete', () => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a---b---------');
-      const t = 3; //      ---|
+      const e1subs = '  ^---------------!';
+      const t = time('     ---|          ');
+      //                       ---|
       const expected = '------a---b------';
       const unsub = '   ----------------!';
-      const subs = '    ^---------------!';
 
-      const result = e1.pipe(delay(t, testScheduler));
+      const result = e1.pipe(delay(t));
 
       expectObservable(result, unsub).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a---b----');
-      const t = 3; //      ---|
       const e1subs = '  ^-------!   ';
+      const t = time('     ---|     ');
+      //                       ---|
       const expected = '------a--   ';
       const unsub = '   --------!   ';
 
       const result = e1.pipe(
         mergeMap((x: any) => of(x)),
-        delay(t, testScheduler),
+        delay(t),
         mergeMap((x: any) => of(x))
       );
 
@@ -202,28 +212,31 @@ describe('delay', () => {
   });
 
   it('should not complete when source never completes', () => {
-    testScheduler.run(({ cold, expectObservable }) => {
-      const e1 = cold(' -');
-      const t = 3; //   ---|
-      const expected = '-';
+    testScheduler.run(({ cold, time, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -   ');
+      const e1subs = '  ^   ';
+      const t = time('  ---|');
+      const expected = '-   ';
 
-      const result = e1.pipe(delay(t, testScheduler));
+      const result = e1.pipe(delay(t));
 
       expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 
   it('should unsubscribe scheduled actions after execution', () => {
-    testScheduler.run(({ cold, expectObservable }) => {
+    testScheduler.run(({ cold, time, expectObservable, expectSubscriptions }) => {
       let subscribeSpy: any = null;
       const counts: number[] = [];
 
-      const e1 = cold('      a|');
-      const expected = '     --a-(a|)';
-      const duration = 1; // -|
+      const e1 = cold(' a|      ');
+      const t = time('  -|      ');
+      const expected = '--a-(a|)';
+
       const result = e1.pipe(
-        repeatWhen(notifications => {
-          const delayed = notifications.pipe(delay(duration, testScheduler));
+        repeatWhen((notifications) => {
+          const delayed = notifications.pipe(delay(t));
           subscribeSpy = sinon.spy((delayed as any)['source'], 'subscribe');
           return delayed;
         }),
@@ -236,7 +249,7 @@ describe('delay', () => {
           },
           complete() {
             expect(counts).to.deep.equal([1, 1]);
-          }
+          },
         })
       );
 
@@ -245,19 +258,18 @@ describe('delay', () => {
   });
 
   it('should be possible to delay complete by composition', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 =   hot('---a--b--|');
-      const t = 2; //      --|--|
-      const expected = '-----a--b--|';
-      const subs = '    ^--------!';
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---a--b---|  ');
+      const e1subs = '  ^---------!  ';
+      const t = time('     --|       ');
+      //                      --|
+      //                          --|
+      const expected = '-----a--b---|';
 
-      const result = concat(
-        e1.pipe(delay(t, testScheduler)),
-        of(undefined).pipe(delay(t, testScheduler), ignoreElements()),
-      );
+      const result = concat(e1.pipe(delay(t)), of(undefined).pipe(delay(t), ignoreElements()));
 
       expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });
 });


### PR DESCRIPTION
**Description:**

- Enabled Prettier.
- Stopped passing scheduler to `delay` since run mode is already used.
- Used `time` helper to convert time units where possible (only negative time units were left out).
- Ordered variables so that they, where possible, have this order: `e1`, `e1subs` (where needed, renamed from `subs`), `t` and then `expected` since this is the most common ordering in many other tests.

**Related issue (if exists):**
None