### PR TITLE
perf: ensure same hidden class for OperatorSubscriber

### DIFF
--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -25,40 +25,48 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
     onComplete?: () => void,
     private onUnsubscribe?: () => void
   ) {
+    // It's important - for performance reasons - that all of this class's
+    // members are initialized and that they are always initialized in the same
+    // order. This will ensure that all OperatorSubscriber instances have the
+    // same hidden class in V8. This, in turn, will help keep the number of
+    // hidden classes involved in property accesses within the base class as
+    // low as possible. If the number of hidden classes involved exceeds four,
+    // the property accesses will become megamorphic and performance penalties
+    // will be incurred - i.e. inline caches won't be used.
     super(destination);
-    if (onNext) {
-      this._next = function (value: T) {
-        try {
-          onNext(value);
-        } catch (err) {
-          this.destination.error(err);
+    this._next = onNext
+      ? function (this: OperatorSubscriber<T>, value: T) {
+          try {
+            onNext(value);
+          } catch (err) {
+            this.destination.error(err);
+          }
         }
-      };
-    }
-    if (onError) {
-      this._error = function (err) {
-        try {
-          onError(err);
-        } catch (err) {
-          // Send any errors that occur down stream.
-          this.destination.error(err);
+      : super._next;
+    this._error = onError
+      ? function (this: OperatorSubscriber<T>, err: any) {
+          try {
+            onError(err);
+          } catch (err) {
+            // Send any errors that occur down stream.
+            this.destination.error(err);
+          }
+          // Ensure teardown.
+          this.unsubscribe();
         }
-        // Ensure teardown.
-        this.unsubscribe();
-      };
-    }
-    if (onComplete) {
-      this._complete = function () {
-        try {
-          onComplete();
-        } catch (err) {
-          // Send any errors that occur down stream.
-          this.destination.error(err);
+      : super._error;
+    this._complete = onComplete
+      ? function (this: OperatorSubscriber<T>) {
+          try {
+            onComplete();
+          } catch (err) {
+            // Send any errors that occur down stream.
+            this.destination.error(err);
+          }
+          // Ensure teardown.
+          this.unsubscribe();
         }
-        // Ensure teardown.
-        this.unsubscribe();
-      };
-    }
+      : super._complete;
   }
 
   unsubscribe() {

--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -33,6 +33,10 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
     // low as possible. If the number of hidden classes involved exceeds four,
     // the property accesses will become megamorphic and performance penalties
     // will be incurred - i.e. inline caches won't be used.
+    //
+    // The reasons for ensuring all instances have the same hidden class are
+    // further discussed in this blog post from Benedikt Meurer:
+    // https://benediktmeurer.de/2018/03/23/impact-of-polymorphism-on-component-based-frameworks-like-react/
     super(destination);
     this._next = onNext
       ? function (this: OperatorSubscriber<T>, value: T) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

See the comments within the change. This PR should help realise one of the advantages of replacing operator-specific subscribers with a general-purpose subscriber - reducing/eliminating megamorphic property accesses within `Subscriber`.

I've not done any micro optimization/analysis, yet. I'll look at doing that after the version 7 release. However, I think that what's in this PR makes sense and shouldn't be controversial. 🤞

**Related issue (if exists):** None