### PR TITLE
chore(exhaust-spec): replace cold with hot observable

### DIFF
--- a/spec/operators/exhaust-spec.ts
+++ b/spec/operators/exhaust-spec.ts
@@ -14,14 +14,22 @@ describe('exhaust', () => {
   });
 
   it('should handle a hot observable of hot observables', () => {
-    testScheduler.run(({ cold, hot, expectObservable }) => {
-      const x = cold('        --a---b---c--|               ');
-      const y = cold('                ---d--e---f---|      ');
-      const z = cold('                      ---g--h---i---|');
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const x = hot('   -----a---b---c--|                  ');
+      const xsubs = '   ------^---------!                  ';
+      const y = hot('   -------d--e---f---|                ');
+      const ysubs: string[] = [];
+      const z = hot('   --------------g--h---i---|         ');
+      const zsubs = '   --------------------^----!         ';
       const e1 = hot('  ------x-------y-----z-------------|', { x: x, y: y, z: z });
-      const expected = '--------a---b---c------g--h---i---|';
+      const e1subs = '  ^---------------------------------!';
+      const expected = '---------b---c-------i------------|';
 
       expectObservable(e1.pipe(exhaust())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(z.subscriptions).toBe(zsubs);
     });
   });
 


### PR DESCRIPTION
**Description:**
As mentioned in #5866, the test edited in this PR is exactly the same as the test with this description `should handle a hot observable of observables` with the exception of `expectSubscriptions` calls, so I changed it a bit. Since it handles `observable of hot observables`, I changed `cold` with `hot` and added missing `expectSubscriptions` calls. I don't know if this change is necessary, but I thought that it could be included since having two same tests doesn't bring much value.

**Related issue (if exists):**
None