### PR TITLE
refactor(withLatestFrom): support N-args with project function

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -323,20 +323,8 @@ export declare function windowToggle<T, O>(openings: ObservableInput<O>, closing
 
 export declare function windowWhen<T>(closingSelector: () => ObservableInput<any>): OperatorFunction<T, Observable<T>>;
 
-export declare function withLatestFrom<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, R>(source2: O2, project: (v1: T, v2: ObservedValueOf<O2>) => R): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, R>(v2: O2, v3: O3, project: (v1: T, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>) => R): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, R>(v2: O2, v3: O3, v4: O4, project: (v1: T, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>) => R): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, R>(v2: O2, v3: O3, v4: O4, v5: O5, project: (v1: T, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>, v5: ObservedValueOf<O5>) => R): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>, R>(v2: O2, v3: O3, v4: O4, v5: O5, v6: O6, project: (v1: T, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>, v5: ObservedValueOf<O5>, v6: ObservedValueOf<O6>) => R): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>>(source2: O2): OperatorFunction<T, [T, ObservedValueOf<O2>]>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(v2: O2, v3: O3): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(v2: O2, v3: O3, v4: O4): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>>(v2: O2, v3: O3, v4: O4, v5: O5): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export declare function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, O5 extends ObservableInput<any>, O6 extends ObservableInput<any>>(v2: O2, v3: O3, v4: O4, v5: O5, v6: O6): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
-export declare function withLatestFrom<T, R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, R>(array: ObservableInput<any>[]): OperatorFunction<T, R>;
-export declare function withLatestFrom<T, R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R): OperatorFunction<T, R>;
+export declare function withLatestFrom<T, O extends unknown[]>(...inputs: [...ObservableInputTuple<O>]): OperatorFunction<T, [T, ...O]>;
+export declare function withLatestFrom<T, O extends unknown[], R>(...inputs: [...ObservableInputTuple<O>, (...value: [T, ...O]) => R]): OperatorFunction<T, R>;
 
 export declare function zip<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
 export declare function zip<T, T2, R>(v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R): OperatorFunction<T, R>;

--- a/spec-dtslint/operators/withLatestFrom-spec.ts
+++ b/spec-dtslint/operators/withLatestFrom-spec.ts
@@ -12,46 +12,66 @@ describe('withLatestFrom', () => {
     it('should infer correctly with 2 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
-      const res = a.pipe(withLatestFrom(b, c)); // $ExpectType Observable<[number, string, string]>
+      const c = of(1, 2, 3);
+      const res = a.pipe(withLatestFrom(b, c)); // $ExpectType Observable<[number, string, number]>
     });
 
     it('should infer correctly with 3 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
+      const c = of(1, 2, 3);
       const d = of('g', 'h', 'i');
-      const res = a.pipe(withLatestFrom(b, c, d)); // $ExpectType Observable<[number, string, string, string]>
+      const res = a.pipe(withLatestFrom(b, c, d)); // $ExpectType Observable<[number, string, number, string]>
     });
 
     it('should infer correctly with 4 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
+      const c = of(1, 2, 3);
       const d = of('g', 'h', 'i');
-      const e = of('j', 'k', 'l');
-      const res = a.pipe(withLatestFrom(b, c, d, e)); // $ExpectType Observable<[number, string, string, string, string]>
+      const e = of(4, 5, 6);
+      const res = a.pipe(withLatestFrom(b, c, d, e)); // $ExpectType Observable<[number, string, number, string, number]>
     });
 
     it('should infer correctly with 5 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
+      const c = of(1, 2, 3);
       const d = of('g', 'h', 'i');
-      const e = of('j', 'k', 'l');
+      const e = of(4, 5, 6);
       const f = of('m', 'n', 'o');
-      const res = a.pipe(withLatestFrom(b, c, d, e, f)); // $ExpectType Observable<[number, string, string, string, string, string]>
+      const res = a.pipe(withLatestFrom(b, c, d, e, f)); // $ExpectType Observable<[number, string, number, string, number, string]>
     });
 
-    it('should only accept maximum params of 5', () => {
+    it('should infer correctly with 6 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
+      const c = of(1, 2, 3);
       const d = of('g', 'h', 'i');
-      const e = of('j', 'k', 'l');
+      const e = of(4, 5, 6);
       const f = of('m', 'n', 'o');
-      const g = of('p', 'q', 'r');
-      const res = a.pipe(withLatestFrom(b, c, d, e, f, g)); // $ExpectType Observable<unknown>
+      const g = of(7, 8, 9);
+      const res = a.pipe(withLatestFrom(b, c, d, e, f, g)); // $ExpectType Observable<[number, string, number, string, number, string, number]>
+    });
+
+    it('should allow the spreading of input params', () => {
+      const a = of(1, 2, 3);
+      const b = [a, a, a];
+      const res = a.pipe(withLatestFrom(...b)); // $ExpectType Observable<[number, ...number[]]>
+    });
+
+    it('should error with non Observable input', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = 1;
+      const d = of('g', 'h', 'i');
+      const res = a.pipe(withLatestFrom(b, c, d)); // $ExpectError
+    });
+
+    it('should error with non Observable input at last position', () => {
+      const a = of(1, 2, 3);
+      const b = 1;
+      const res = a.pipe(withLatestFrom(b)); // $ExpectError
     });
   });
 
@@ -70,14 +90,14 @@ describe('withLatestFrom', () => {
     it('should infer correctly with 2 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
-      const res = a.pipe(withLatestFrom(b, c, (a, b, c) => b + c)); // $ExpectType Observable<string>
+      const c = of(1, 2, 3);
+      const res = a.pipe(withLatestFrom(b, c, (a, b, c) => c)); // $ExpectType Observable<number>
     });
 
     it('should infer correctly with 3 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
+      const c = of(1, 2, 3);
       const d = of('g', 'h', 'i');
       const ref = a.pipe(withLatestFrom(b, c, d, (a, b, c, d) => b + c)); // $ExpectType Observable<string>
     });
@@ -85,20 +105,64 @@ describe('withLatestFrom', () => {
     it('should infer correctly with 4 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
+      const c = of(1, 2, 3);
       const d = of('g', 'h', 'i');
-      const e = of('j', 'k', 'l');
+      const e = of(4, 5, 6);
       const res = a.pipe(withLatestFrom(b, c, d, e, (a, b, c, d, e) => b + c)); // $ExpectType Observable<string>
     });
 
     it('should infer correctly with 5 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
-      const c = of('d', 'e', 'f');
+      const c = of(1, 2, 3);
       const d = of('g', 'h', 'i');
-      const e = of('j', 'k', 'l');
+      const e = of(4, 5, 6);
       const f = of('m', 'n', 'o');
-      const res = a.pipe(withLatestFrom(b, c, d, e, f, (a, b, c, d, e, f) => b + c)); // $ExpectType Observable<string>
+      const res = a.pipe(withLatestFrom(b, c, d, e, f, (a, b, c, d, e, f) => c + e)); // $ExpectType Observable<number>
     });
+
+    it('should infer correctly with 6 params', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = of(1, 2, 3);
+      const d = of('g', 'h', 'i');
+      const e = of(4, 5, 6);
+      const f = of('m', 'n', 'o');
+      const g = of(7, 8, 9);
+      const res = a.pipe(withLatestFrom(b, c, d, e, f, g, (a, b, c, d, e, f, g) => b + f)); // $ExpectType Observable<string>
+    });
+
+    it('should error with non Observable input', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const c = 1;
+      const d = of('g', 'h', 'i');
+      const res = a.pipe(withLatestFrom(b, c, d, (a, b, c, d) => a + d)); // $ExpectError
+    });
+
+    it('should error with non Observable input at last position', () => {
+      const a = of(1, 2, 3);
+      const b = 1;
+      const res = a.pipe(withLatestFrom(b, (a, b) => a + b)); // $ExpectError
+    });
+
+    it('should error with incorrect number of projected params', () => {
+      const a = of(1, 2, 3);
+      const b = of('a', 'b', 'c');
+      const res = a.pipe(withLatestFrom(b, (a, b, c) => a)); // $ExpectError
+    });
+
+    /*
+     * The following test does not typecheck because the project function is missing a third parameter.
+     * If such an issue occurs in a consumer code base the fix is to specify the missing parameters.
+     * 
+     * It looks like this is a TS bug.
+     */
+    // it('should infer correct parameters with fewer arguments to project function', () => {
+    //   const a = of(1, 2, 3);
+    //   const b = of('a', 'b', 'c');
+    //   const c = of(1, 2, 3);
+    //   const res = a.pipe(withLatestFrom(b, c, (a, b) => b)); // $ExpectType Observable<string>
+    // });
   });
 });

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -1,5 +1,5 @@
 /** @prettier */
-import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
+import { OperatorFunction, ObservableInputTuple } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/from';
@@ -7,101 +7,11 @@ import { identity } from '../util/identity';
 import { noop } from '../util/noop';
 import { popResultSelector } from '../util/args';
 
-/* tslint:disable:max-line-length */
-export function withLatestFrom<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
-export function withLatestFrom<T, O2 extends ObservableInput<any>, R>(
-  source2: O2,
-  project: (v1: T, v2: ObservedValueOf<O2>) => R
-): OperatorFunction<T, R>;
-export function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, R>(
-  v2: O2,
-  v3: O3,
-  project: (v1: T, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>) => R
-): OperatorFunction<T, R>;
-export function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>, R>(
-  v2: O2,
-  v3: O3,
-  v4: O4,
-  project: (v1: T, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>) => R
-): OperatorFunction<T, R>;
-export function withLatestFrom<
-  T,
-  O2 extends ObservableInput<any>,
-  O3 extends ObservableInput<any>,
-  O4 extends ObservableInput<any>,
-  O5 extends ObservableInput<any>,
-  R
->(
-  v2: O2,
-  v3: O3,
-  v4: O4,
-  v5: O5,
-  project: (v1: T, v2: ObservedValueOf<O2>, v3: ObservedValueOf<O3>, v4: ObservedValueOf<O4>, v5: ObservedValueOf<O5>) => R
-): OperatorFunction<T, R>;
-export function withLatestFrom<
-  T,
-  O2 extends ObservableInput<any>,
-  O3 extends ObservableInput<any>,
-  O4 extends ObservableInput<any>,
-  O5 extends ObservableInput<any>,
-  O6 extends ObservableInput<any>,
-  R
->(
-  v2: O2,
-  v3: O3,
-  v4: O4,
-  v5: O5,
-  v6: O6,
-  project: (
-    v1: T,
-    v2: ObservedValueOf<O2>,
-    v3: ObservedValueOf<O3>,
-    v4: ObservedValueOf<O4>,
-    v5: ObservedValueOf<O5>,
-    v6: ObservedValueOf<O6>
-  ) => R
-): OperatorFunction<T, R>;
-export function withLatestFrom<T, O2 extends ObservableInput<any>>(source2: O2): OperatorFunction<T, [T, ObservedValueOf<O2>]>;
-export function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>>(
-  v2: O2,
-  v3: O3
-): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>]>;
-export function withLatestFrom<T, O2 extends ObservableInput<any>, O3 extends ObservableInput<any>, O4 extends ObservableInput<any>>(
-  v2: O2,
-  v3: O3,
-  v4: O4
-): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>]>;
-export function withLatestFrom<
-  T,
-  O2 extends ObservableInput<any>,
-  O3 extends ObservableInput<any>,
-  O4 extends ObservableInput<any>,
-  O5 extends ObservableInput<any>
->(
-  v2: O2,
-  v3: O3,
-  v4: O4,
-  v5: O5
-): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>]>;
-export function withLatestFrom<
-  T,
-  O2 extends ObservableInput<any>,
-  O3 extends ObservableInput<any>,
-  O4 extends ObservableInput<any>,
-  O5 extends ObservableInput<any>,
-  O6 extends ObservableInput<any>
->(
-  v2: O2,
-  v3: O3,
-  v4: O4,
-  v5: O5,
-  v6: O6
-): OperatorFunction<T, [T, ObservedValueOf<O2>, ObservedValueOf<O3>, ObservedValueOf<O4>, ObservedValueOf<O5>, ObservedValueOf<O6>]>;
-export function withLatestFrom<T, R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, R>;
-export function withLatestFrom<T, R>(array: ObservableInput<any>[]): OperatorFunction<T, R>;
-export function withLatestFrom<T, R>(array: ObservableInput<any>[], project: (...values: Array<any>) => R): OperatorFunction<T, R>;
+export function withLatestFrom<T, O extends unknown[]>(...inputs: [...ObservableInputTuple<O>]): OperatorFunction<T, [T, ...O]>;
 
-/* tslint:enable:max-line-length */
+export function withLatestFrom<T, O extends unknown[], R>(
+  ...inputs: [...ObservableInputTuple<O>, (...value: [T, ...O]) => R]
+): OperatorFunction<T, R>;
 
 /**
  * Combines the source Observable with other Observables to create an Observable


### PR DESCRIPTION
**Description:**
This PR refactors the signatures of the `withLatestFrom` operator to use N-args in the signature.

I also added a few more dtslint tests and altered the current ones to better reflect the intent of the typings.

There is one issue with the typings I could not get to work correctly.
```typescript
const a = of(1, 2, 3);
const b = [a, a, a];
const res = a.pipe(withLatestFrom(...b, (a, b, c, d) => d); // Should be Observable<number> but is infered as Observable<unknown>
```

**Related issue (if exists):**
#5066 
