### PR TITLE
refactor: use ObservableInputTuple in xWith operators

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -192,7 +192,7 @@ export interface GroupedObservable<K, T> extends Observable<T> {
     readonly key: K;
 }
 
-export declare type Head<X extends readonly any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: readonly any[]) => any ? U : never;
+export declare type Head<X extends readonly any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
 
 export declare function identity<T>(x: T): T;
 

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -132,7 +132,7 @@ export declare class ConnectableObservable<T> extends Observable<T> {
     refCount(): Observable<T>;
 }
 
-export declare type Cons<X, Y extends any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
+export declare type Cons<X, Y extends readonly any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
 
 export declare function defer<R extends ObservableInput<any>>(observableFactory: () => R): Observable<ObservedValueOf<R>>;
 
@@ -192,7 +192,7 @@ export interface GroupedObservable<K, T> extends Observable<T> {
     readonly key: K;
 }
 
-export declare type Head<X extends any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
+export declare type Head<X extends readonly any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: readonly any[]) => any ? U : never;
 
 export declare function identity<T>(x: T): T;
 
@@ -501,7 +501,7 @@ export interface SubscriptionLike extends Unsubscribable {
     unsubscribe(): void;
 }
 
-export declare type Tail<X extends any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
+export declare type Tail<X extends readonly any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
 
 export declare type TeardownLogic = Subscription | Unsubscribable | (() => void) | void;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -36,7 +36,7 @@ export declare function combineLatest<T, R>(...observables: Array<ObservableInpu
 export declare function combineLatest<T, R>(array: ObservableInput<T>[]): OperatorFunction<T, Array<T>>;
 export declare function combineLatest<T, TOther, R>(array: ObservableInput<TOther>[], project: (v1: T, ...values: Array<TOther>) => R): OperatorFunction<T, R>;
 
-export declare function combineLatestWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, Cons<T, ObservedValueTupleFromArray<A>>>;
+export declare function combineLatestWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
 
 export declare function concat<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 export declare function concat<T, T2>(v2: ObservableInput<T2>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2>;
@@ -58,8 +58,7 @@ export declare function concatMapTo<O extends ObservableInput<any>>(observable: 
 export declare function concatMapTo<O extends ObservableInput<any>>(observable: O, resultSelector: undefined): OperatorFunction<any, ObservedValueOf<O>>;
 export declare function concatMapTo<T, R, O extends ObservableInput<any>>(observable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
-export declare function concatWith<T>(): OperatorFunction<T, T>;
-export declare function concatWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, ObservedValueUnionFromArray<A> | T>;
+export declare function concatWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 export declare function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number>;
 
@@ -164,7 +163,7 @@ export declare function mergeMapTo<T, R, O extends ObservableInput<unknown>>(inn
 
 export declare function mergeScan<T, R>(accumulator: (acc: R, value: T, index: number) => ObservableInput<R>, seed: R, concurrent?: number): OperatorFunction<T, R>;
 
-export declare function mergeWith<T, A extends unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+export declare function mergeWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 export declare function min<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T>;
 
@@ -208,7 +207,7 @@ export declare function race<T, R>(observables: Array<Observable<T>>): OperatorF
 export declare function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): MonoTypeOperatorFunction<T>;
 export declare function race<T, R>(...observables: Array<Observable<any> | Array<Observable<any>>>): OperatorFunction<T, R>;
 
-export declare function raceWith<T, A extends ObservableInput<any>[]>(...otherSources: A): OperatorFunction<T, T | ObservedValueUnionFromArray<A>>;
+export declare function raceWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 export declare function reduce<V, A = V>(accumulator: (acc: A | V, value: V, index: number) => A): OperatorFunction<V, V | A>;
 export declare function reduce<V, A>(accumulator: (acc: A, value: V, index: number) => A, seed: A): OperatorFunction<V, A>;
@@ -358,4 +357,4 @@ export declare function zipAll<T>(): OperatorFunction<any, T[]>;
 export declare function zipAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
 export declare function zipAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 
-export declare function zipWith<T, A extends ObservableInput<any>[]>(...otherInputs: A): OperatorFunction<T, Cons<T, ObservedValueTupleFromArray<A>>>;
+export declare function zipWith<T, A extends readonly unknown[]>(...otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;

--- a/spec/operators/combineLatest-spec.ts
+++ b/spec/operators/combineLatest-spec.ts
@@ -1,0 +1,31 @@
+import { combineLatest } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+/** @test {combineLatest} */
+describe('combineLatest', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should accept array of observables', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--|');
+      const e1subs = '     ^--------!';
+      const e2 = hot('---e-^---f--g--|');
+      const e2subs = '     ^---------!';
+      const e3 = hot('---h-^----i--j-|');
+      const e3subs = '     ^---------!';
+      const expected = '   -----wxyz-|';
+
+      const result = e1.pipe(combineLatest([e2, e3], (x: string, y: string, z: string) => x + y + z));
+
+      expectObservable(result).toBe(expected, { w: 'bfi', x: 'cfi', y: 'cgi', z: 'cgj' });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(e3.subscriptions).toBe(e3subs);
+    });
+  });
+});

--- a/spec/operators/combineLatestWith-spec.ts
+++ b/spec/operators/combineLatestWith-spec.ts
@@ -184,25 +184,6 @@ describe('combineLatestWith', () => {
     });
   });
 
-  it('should accept array of observables', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('--a--^--b--c--|');
-      const e1subs = '     ^--------!';
-      const e2 = hot('---e-^---f--g--|');
-      const e2subs = '     ^---------!';
-      const e3 = hot('---h-^----i--j-|');
-      const e3subs = '     ^---------!';
-      const expected = '   -----wxyz-|';
-
-      const result = e1.pipe(combineLatestWith([e2, e3], (x: string, y: string, z: string) => x + y + z));
-
-      expectObservable(result).toBe(expected, { w: 'bfi', x: 'cfi', y: 'cgi', z: 'cgj' });
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-      expectSubscriptions(e2.subscriptions).toBe(e2subs);
-      expectSubscriptions(e3.subscriptions).toBe(e3subs);
-    });
-  });
-
   it('should work with empty and error', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ----------|'); //empty

--- a/spec/operators/zip-spec.ts
+++ b/spec/operators/zip-spec.ts
@@ -1,0 +1,31 @@
+import { zip } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+/** @test {zip} */
+describe('zip', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should work with non-empty observable and non-empty iterable selector that throws', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const a = hot('---^--1--2--3--|');
+      const asubs = '   ^-----!';
+      const expected = '---x--#';
+      const b = [4, 5, 6];
+
+      const selector = function(x: string, y: number) {
+        if (y === 5) {
+          throw new Error('too bad');
+        } else {
+          return x + y;
+        }
+      };
+      expectObservable(a.pipe(zip(b, selector))).toBe(expected, { x: '14' }, new Error('too bad'));
+      expectSubscriptions(a.subscriptions).toBe(asubs);
+    });
+  });
+});

--- a/spec/operators/zipWith-spec.ts
+++ b/spec/operators/zipWith-spec.ts
@@ -192,25 +192,6 @@ describe('zipWith', () => {
         expectSubscriptions(a.subscriptions).toBe(asubs);
       });
     });
-
-    it('should work with non-empty observable and non-empty iterable selector that throws', () => {
-      rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-        const a = hot('---^--1--2--3--|');
-        const asubs = '   ^-----!';
-        const expected = '---x--#';
-        const b = [4, 5, 6];
-
-        const selector = function(x: string, y: number) {
-          if (y === 5) {
-            throw new Error('too bad');
-          } else {
-            return x + y;
-          }
-        };
-        expectObservable(a.pipe(zipWith(b, selector))).toBe(expected, { x: '14' }, new Error('too bad'));
-        expectSubscriptions(a.subscriptions).toBe(asubs);
-      });
-    });
   });
 
   it('should work with n-ary symmetric', () => {

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { combineLatestInit } from '../observable/combineLatest';
-import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
+import { ObservableInput, ObservableInputTuple, OperatorFunction, Cons } from '../types';
 import { operate } from '../util/lift';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
@@ -126,8 +126,8 @@ export function combineLatest<T, R>(...args: (ObservableInput<any> | ((...values
  * ```
  * @param otherSources the other sources to subscribe to.
  */
-export function combineLatestWith<T, A extends ObservableInput<any>[]>(
-  ...otherSources: A
-): OperatorFunction<T, Cons<T, ObservedValueTupleFromArray<A>>> {
+export function combineLatestWith<T, A extends readonly unknown[]>(
+  ...otherSources: [...ObservableInputTuple<A>]
+): OperatorFunction<T, Cons<T, A>> {
   return combineLatest(...otherSources);
 }

--- a/src/internal/operators/concatWith.ts
+++ b/src/internal/operators/concatWith.ts
@@ -1,14 +1,9 @@
 /** @prettier */
-import { ObservableInput, OperatorFunction, ObservedValueUnionFromArray, MonoTypeOperatorFunction, SchedulerLike } from '../types';
+import { ObservableInput, ObservableInputTuple, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { concatAll } from './concatAll';
 import { internalFromArray } from '../observable/fromArray';
 import { popScheduler } from '../util/args';
-
-export function concatWith<T>(): OperatorFunction<T, T>;
-export function concatWith<T, A extends ObservableInput<any>[]>(
-  ...otherSources: A
-): OperatorFunction<T, ObservedValueUnionFromArray<A> | T>;
 
 /**
  * Emits all of the values from the source observable, then, once it completes, subscribes
@@ -48,9 +43,9 @@ export function concatWith<T, A extends ObservableInput<any>[]>(
  *
  * @param otherSources Other observable sources to subscribe to, in sequence, after the original source is complete.
  */
-export function concatWith<T, A extends ObservableInput<any>[]>(
-  ...otherSources: A
-): OperatorFunction<T, ObservedValueUnionFromArray<A> | T> {
+export function concatWith<T, A extends readonly unknown[]>(
+  ...otherSources: [...ObservableInputTuple<A>]
+): OperatorFunction<T, T | A[number]> {
   return concat(...otherSources);
 }
 

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -27,8 +27,6 @@ export function merge<T>(...args: unknown[]): OperatorFunction<T, unknown> {
   });
 }
 
-export function mergeWith<T, A extends unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
-
 /**
  * Merge the values from all observables to an single observable result.
  *
@@ -68,6 +66,8 @@ export function mergeWith<T, A extends unknown[]>(...otherSources: [...Observabl
  * ```
  * @param otherSources the sources to combine the current source with.
  */
-export function mergeWith<T, A extends unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]> {
+export function mergeWith<T, A extends readonly unknown[]>(
+  ...otherSources: [...ObservableInputTuple<A>]
+): OperatorFunction<T, T | A[number]> {
   return merge(...otherSources);
 }

--- a/src/internal/operators/raceWith.ts
+++ b/src/internal/operators/raceWith.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { MonoTypeOperatorFunction, OperatorFunction, ObservableInput, ObservedValueUnionFromArray } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, ObservableInputTuple } from '../types';
 import { raceInit } from '../observable/race';
 import { operate } from '../util/lift';
 import { argsOrArgArray } from "../util/argsOrArgArray";
@@ -55,10 +55,10 @@ export function race<T>(...args: any[]): OperatorFunction<T, unknown> {
  * @param otherSources Sources used to race for which Observable emits first.
  */
 
-export function raceWith<T, A extends ObservableInput<any>[]>(
-  ...otherSources: A
-): OperatorFunction<T, T | ObservedValueUnionFromArray<A>> {
+export function raceWith<T, A extends readonly unknown[]>(
+  ...otherSources: [...ObservableInputTuple<A>]
+): OperatorFunction<T, T | A[number]> {
   return !otherSources.length ? identity : operate((source, subscriber) => {
-    raceInit([source, ...otherSources])(subscriber);
+    raceInit<T | A[number]>([source, ...otherSources])(subscriber);
   });
 }

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { zip as zipStatic } from '../observable/zip';
-import { ObservableInput, OperatorFunction, ObservedValueTupleFromArray, Cons } from '../types';
+import { ObservableInput, ObservableInputTuple, OperatorFunction, Cons } from '../types';
 import { operate } from '../util/lift';
 
 /* tslint:disable:max-line-length */
@@ -103,8 +103,6 @@ export function zip<T, R>(...sources: Array<ObservableInput<any> | ((...values: 
  *
  * @param otherInputs other observable inputs to collate values from.
  */
-export function zipWith<T, A extends ObservableInput<any>[]>(
-  ...otherInputs: A
-): OperatorFunction<T, Cons<T, ObservedValueTupleFromArray<A>>> {
+export function zipWith<T, A extends readonly unknown[]>(...otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>> {
   return zip(...otherInputs);
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -244,19 +244,19 @@ export type ObservableInputTuple<T> = {
  * Constructs a new tuple with the specified type at the head.
  * If you declare `Cons<A, [B, C]>` you will get back `[A, B, C]`.
  */
-export type Cons<X, Y extends any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
+export type Cons<X, Y extends readonly any[]> = ((arg: X, ...rest: Y) => any) extends (...args: infer U) => any ? U : never;
 
 /**
  * Extracts the head of a tuple.
  * If you declare `Head<[A, B, C]>` you will get back `A`.
  */
-export type Head<X extends any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
+export type Head<X extends readonly any[]> = ((...args: X) => any) extends (arg: infer U, ...rest: any[]) => any ? U : never;
 
 /**
  * Extracts the tail of a tuple.
  * If you declare `Tail<[A, B, C]>` you will get back `[B, C]`.
  */
-export type Tail<X extends any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
+export type Tail<X extends readonly any[]> = ((...args: X) => any) extends (arg: any, ...rest: infer U) => any ? U : never;
 
 /**
  * Extracts the generic value from an Array type.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the `xWith` operators - `concatWith`, et al. - to use `ObservableInputTuple` with a type-parameter constraint of `readonly unknown[]` - instead of `ObservableInput<any>[]`. The former is simpler, more idiomatic and doesn't rely on the `ObservedValueOf` type.

Interestingly, this change uncovered two tests that use result selectors. I have no idea how those tests compiled without effecting TypeScript compilation errors. I've split the tests out into separate files `combineLatest-spec.ts` and `zip-spec.ts`, as the non-`With` operators are deprecated, but still exported. I guess this shows that the `ObservableInputTuple` approach has some advantages.

The refactor also removed some unnecessary overload signatures.

This PR deliberately does not refactor the deprecated, non-`With` signatures. Those aren't yet N-args and their refactor will involve changes to the tests. I wanted to keep this PR as simple as possible. I'll do the non-`With` operators in separate PRs.

**Related issue (if exists):** None
