### PR TITLE
refactor(forkJoin): remove any-based signature

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -164,8 +164,8 @@ export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 export declare function forkJoin(sources: readonly []): Observable<never>;
 export declare function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin<A extends readonly unknown[], R>(sources: readonly [...ObservableInputTuple<A>], resultSelector: (...values: A) => R): Observable<R>;
-export declare function forkJoin<A extends readonly unknown[]>(...sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
-export declare function forkJoin<A extends readonly unknown[], R>(...sourcesAndResultSelector: readonly [...ObservableInputTuple<A>, (...values: A) => R]): Observable<R>;
+export declare function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
+export declare function forkJoin<A extends readonly unknown[], R>(...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]): Observable<R>;
 export declare function forkJoin(sourcesObject: {
     [K in any]: never;
 }): Observable<never>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -161,16 +161,17 @@ export declare type FactoryOrValue<T> = T | (() => T);
 
 export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
-export declare function forkJoin(sources: []): Observable<never>;
+export declare function forkJoin(sources: readonly []): Observable<never>;
 export declare function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
-export declare function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
+export declare function forkJoin<A extends readonly unknown[], R>(sources: readonly [...ObservableInputTuple<A>], resultSelector: (...values: A) => R): Observable<R>;
+export declare function forkJoin<A extends readonly unknown[]>(...sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+export declare function forkJoin<A extends readonly unknown[], R>(...sourcesAndResultSelector: readonly [...ObservableInputTuple<A>, (...values: A) => R]): Observable<R>;
 export declare function forkJoin(sourcesObject: {
     [K in any]: never;
 }): Observable<never>;
 export declare function forkJoin<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
-export declare function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
 
 export declare function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
 export declare function from<O extends ObservableInput<any>>(input: O, scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;

--- a/spec-dtslint/observables/forkJoin-spec.ts
+++ b/spec-dtslint/observables/forkJoin-spec.ts
@@ -77,6 +77,7 @@ describe('forkJoin({})', () => {
 describe('forkJoin([])', () => {
   it('should properly type empty arrays', () => {
     const res = forkJoin([]); // $ExpectType Observable<never>
+    const resConst = forkJoin([] as const); // $ExpectType Observable<never>
   });
 
     it('should properly type readonly arrays', () => {

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -7,20 +7,25 @@ import { innerFrom } from './from';
 import { popResultSelector } from '../util/args';
 
 // forkJoin([a, b, c])
-export function forkJoin(sources: []): Observable<never>;
+export function forkJoin(sources: readonly []): Observable<never>;
 export function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+/** @deprecated resultSelector is deprecated, pipe to map instead */
+export function forkJoin<A extends readonly unknown[], R>(
+  sources: readonly [...ObservableInputTuple<A>],
+  resultSelector: (...values: A) => R
+): Observable<R>;
 
 // forkJoin(a, b, c)
 /** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
+export function forkJoin<A extends readonly unknown[]>(...sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+/** @deprecated resultSelector is deprecated, pipe to map instead */
+export function forkJoin<A extends readonly unknown[], R>(
+  ...sourcesAndResultSelector: readonly [...ObservableInputTuple<A>, (...values: A) => R]
+): Observable<R>;
 
 // forkJoin({a, b, c})
 export function forkJoin(sourcesObject: { [K in any]: never }): Observable<never>;
 export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
-
-// forkJoin(a, b, c, resultSelector)
-/** @deprecated resultSelector is deprecated, pipe to map instead */
-export function forkJoin(...args: Array<ObservableInput<any> | ((...args: any[]) => any)>): Observable<any>;
 
 /**
  * Accepts an `Array` of {@link ObservableInput} or a dictionary `Object` of {@link ObservableInput} and returns

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -17,10 +17,10 @@ export function forkJoin<A extends readonly unknown[], R>(
 
 // forkJoin(a, b, c)
 /** @deprecated Use the version that takes an array of Observables instead */
-export function forkJoin<A extends readonly unknown[]>(...sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+export function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 /** @deprecated resultSelector is deprecated, pipe to map instead */
 export function forkJoin<A extends readonly unknown[], R>(
-  ...sourcesAndResultSelector: readonly [...ObservableInputTuple<A>, (...values: A) => R]
+  ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;
 
 // forkJoin({a, b, c})


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR tweaks the overload signatures for `forkJoin` to remove an `any`-based signature, replacing it with an N-args versions that accept (deprecated) result selectors.

<s>The PR also adds `readonly` qualifiers for the `[...ObservableInputTuple<A>]` types. I swear I tested `readonly` qualifiers with mapped tuple types for a blog post and found that they weren't necessary. However, without them, tests fail. IDK whether or not this is a TypeScript-version issue. I will look into it later and separately.</s>

**Related issue (if exists):** None