### PR TITLE
chore: bump TypeScript version to 4.1 RC

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8568,9 +8568,9 @@
       }
     },
     "typescript": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.0.2.tgz",
-      "integrity": "sha512-e4ERvRV2wb+rRZ/IQeb3jm2VxBsirQLpQhdxplZ2MEzGvDkkMmPglecnNDfSUBivMjP93vRbngYYDQqQ/78bcQ==",
+      "version": "4.1.1-rc",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.1.1-rc.tgz",
+      "integrity": "sha512-tgNcFrLIjlaMWEc7bKC0bxLNIt8BIAauY/HLUOQDyTP75HGskETtXOt46x4EKAHRKhWVLMc7yM02puTHa/yhCA==",
       "dev": true
     },
     "uglify-js": {

--- a/package.json
+++ b/package.json
@@ -151,7 +151,7 @@
     "tslint-no-toplevel-property-access": "0.0.2",
     "tslint-no-unused-expression-chai": "0.0.3",
     "typedoc": "^0.17.8",
-    "typescript": "~4.0.2",
+    "typescript": "4.1.1-rc",
     "validate-commit-msg": "2.14.0",
     "webpack": "^4.31.0"
   },

--- a/src/internal/util/deferred.ts
+++ b/src/internal/util/deferred.ts
@@ -1,5 +1,5 @@
 export class Deferred<T> {
-  resolve: (value?: T | PromiseLike<T> | undefined) => void = null!;
+  resolve: (value: T | PromiseLike<T>) => void = null!;
   reject: (reason?: any) => void = null!;
   promise = new Promise<T>((a, b) => {
     this.resolve = a;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The TypeScript 4.1 RC was released on 5 November and - according the the [official release schedule/process](https://github.com/microsoft/TypeScript/wiki/TypeScript's-Release-Process) - actual releases occur two weeks after the RC. That means we can expect the 4.1 release in a week or so. IMO, we should aim at establishing 4.1 as our minimum version for version 7 - so that its features (recursive conditional types, in particular) are available to us (even if we don't rely upon them in the initial version 7 types).

**Related issue (if exists):** None
