### PR TITLE
docs: remove dead link

### DIFF
--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -58,8 +58,6 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
  *
  * ## Example for refCount usage
  * ```ts
- * // Code take from https://blog.angularindepth.com/rxjs-whats-changed-with-sharereplay-65c098843e95
- * // and adapted to showcase the refCount property.
  * import { interval, Observable, defer } from 'rxjs';
  * import { shareReplay, take, tap, finalize } from 'rxjs/operators';
  *


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes a dead link from the comments/docs. It's a link to one of my blog posts, but the domain - which was once used for a Medium publication - seems to have been allowed to die, so lets just rid of the link altogether.

**Related issue (if exists):** None
