### PR TITLE
chore(onErrorResumeNext): work around TS 4.1 RC bug

### DIFF
--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -87,7 +87,7 @@ export function onErrorResumeNext<T, A extends readonly unknown[]>(
   // result to be `A[number][]` - completely dropping the ObservableInput part
   // of the type. This makes no sense whatsoever. As a workaround, the type is
   // asserted explicitly.
-  const nextSources = (argsOrArgArray(sources) as unknown) as [[...ObservableInputTuple<A>]];
+  const nextSources = (argsOrArgArray(sources) as unknown) as ObservableInputTuple<A>;
 
   return operate((source, subscriber) => {
     const remaining = [source, ...nextSources];

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -83,7 +83,11 @@ export function onErrorResumeNext<T, A extends readonly unknown[]>(
 export function onErrorResumeNext<T, A extends readonly unknown[]>(
   ...sources: [[...ObservableInputTuple<A>]] | [...ObservableInputTuple<A>]
 ): OperatorFunction<T, T | A[number]> {
-  const nextSources = argsOrArgArray(sources);
+  // For some reason, TS 4.1 RC gets the inference wrong here and infers the
+  // result to be `A[number][]` - completely dropping the ObservableInput part
+  // of the type. This makes no sense whatsoever. As a workaround, the type is
+  // asserted explicitly.
+  const nextSources = (argsOrArgArray(sources) as unknown) as [[...ObservableInputTuple<A>]];
 
   return operate((source, subscriber) => {
     const remaining = [source, ...nextSources];
@@ -92,7 +96,7 @@ export function onErrorResumeNext<T, A extends readonly unknown[]>(
         if (remaining.length > 0) {
           let nextSource: Observable<A[number]>;
           try {
-            nextSource = innerFrom(remaining.shift()!);
+            nextSource = innerFrom<T | A[number]>(remaining.shift()!);
           } catch (err) {
             subscribeNext();
             return;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

After upgrading to TS 4.1 RC, there's an incorrect inference in the implementation of `onErrorResumeNext`. The problem didn't occur in the refactor of that operator - which was done under TS 4.0 - and the inference is clearly incorrect. This PR adds an explicit assertion - and a comment - as a workaround.

**Related issue (if exists):** None