### PR TITLE
feat: support emoji in marble diagrams

### DIFF
--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -88,7 +88,7 @@ describe('TestScheduler', () => {
       ]);
     });
 
-    it('should suppport time progression syntax when runMode=true', () => {
+    it('should support time progression syntax when runMode=true', () => {
       const runMode = true;
       const result = TestScheduler.parseMarbles('10.2ms a 1.2s b 1m c|', { a: 'A', b: 'B', c: 'C' }, undefined, undefined, runMode);
       expect(result).deep.equal([
@@ -96,6 +96,16 @@ describe('TestScheduler', () => {
         { frame: 10.2 + 10 + (1.2 * 1000), notification: nextNotification('B') },
         { frame: 10.2 + 10 + (1.2 * 1000) + 10 + (1000 * 60), notification: nextNotification('C') },
         { frame: 10.2 + 10 + (1.2 * 1000) + 10 + (1000 * 60) + 10, notification: COMPLETE_NOTIFICATION }
+      ]);
+    });
+
+    it('should support emoji characters', () => {
+      const result = TestScheduler.parseMarbles('--🙈--🙉--🙊--|');
+      expect(result).deep.equal([
+        { frame: 20, notification: nextNotification('🙈') },
+        { frame: 50, notification: nextNotification('🙉') },
+        { frame: 80, notification: nextNotification('🙊') },
+        { frame: 110, notification: COMPLETE_NOTIFICATION }
       ]);
     });
   });

--- a/spec/tsconfig.json
+++ b/spec/tsconfig.json
@@ -4,6 +4,7 @@
     "noEmit": false,
     "outDir": "../dist/spec",
     "target": "es5",
+    "downlevelIteration": true,
     "module": "commonjs"
   },
   "references": [

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -204,7 +204,10 @@ export class TestScheduler extends VirtualTimeScheduler {
     if (typeof marbles !== 'string') {
       return new SubscriptionLog(Infinity);
     }
-    const len = marbles.length;
+    // Spreading the marbles into an array leverages ES2015's support for emoji
+    // characters when iterating strings.
+    const characters = [...marbles];
+    const len = characters.length;
     let groupStart = -1;
     let subscriptionFrame = Infinity;
     let unsubscriptionFrame = Infinity;
@@ -215,7 +218,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       const advanceFrameBy = (count: number) => {
         nextFrame += count * this.frameTimeFactor;
       };
-      const c = marbles[i];
+      const c = characters[i];
       switch (c) {
         case ' ':
           // Whitespace no longer advances time
@@ -252,10 +255,10 @@ export class TestScheduler extends VirtualTimeScheduler {
         default:
           // time progression syntax
           if (runMode && c.match(/^[0-9]$/)) {
-            // Time progression must be preceeded by at least one space
+            // Time progression must be preceded by at least one space
             // if it's not at the beginning of the diagram
-            if (i === 0 || marbles[i - 1] === ' ') {
-              const buffer = marbles.slice(i);
+            if (i === 0 || characters[i - 1] === ' ') {
+              const buffer = characters.slice(i).join('');
               const match = buffer.match(/^([0-9]+(?:\.[0-9]+)?)(ms|s|m) /);
               if (match) {
                 i += match[0].length - 1;
@@ -307,7 +310,10 @@ export class TestScheduler extends VirtualTimeScheduler {
       throw new Error('conventional marble diagrams cannot have the ' +
         'unsubscription marker "!"');
     }
-    const len = marbles.length;
+    // Spreading the marbles into an array leverages ES2015's support for emoji
+    // characters when iterating strings.
+    const characters = [...marbles];
+    const len = characters.length;
     const testMessages: TestMessage[] = [];
     const subIndex = runMode ? marbles.replace(/^[ ]+/, '').indexOf('^') : marbles.indexOf('^');
     let frame = subIndex === -1 ? 0 : (subIndex * -this.frameTimeFactor);
@@ -329,7 +335,7 @@ export class TestScheduler extends VirtualTimeScheduler {
       };
 
       let notification: ObservableNotification<any> | undefined;
-      const c = marbles[i];
+      const c = characters[i];
       switch (c) {
         case ' ':
           // Whitespace no longer advances time
@@ -364,8 +370,8 @@ export class TestScheduler extends VirtualTimeScheduler {
           if (runMode && c.match(/^[0-9]$/)) {
             // Time progression must be preceded by at least one space
             // if it's not at the beginning of the diagram
-            if (i === 0 || marbles[i - 1] === ' ') {
-              const buffer = marbles.slice(i);
+            if (i === 0 || characters[i - 1] === ' ') {
+              const buffer = characters.slice(i).join('');
               const match = buffer.match(/^([0-9]+(?:\.[0-9]+)?)(ms|s|m) /);
               if (match) {
                 i += match[0].length - 1;

--- a/src/tsconfig.cjs.json
+++ b/src/tsconfig.cjs.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "module": "commonjs",
     "target": "es5",
+    "downlevelIteration": true,
     "outDir": "../dist/cjs"
   },
   "exclude": ["./internal/umd.ts"]

--- a/src/tsconfig.esm5.json
+++ b/src/tsconfig.esm5.json
@@ -4,6 +4,7 @@
     "module": "esnext",
     "importHelpers": true,
     "target": "es5",
+    "downlevelIteration": true,
     "outDir": "../dist/esm5"
   },
   "exclude": ["./internal/umd.ts"]


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds support for emoji characters in marble diagrams by leveraging ES2015's built-in emoji support for string iteration.

An attempt to add this feature was made before - in #3857 - but that attempt sought to use `toArray` from `lodash`. This PR relies upon the built-in behaviour (and downleveled iteration for the ES5 builds):

```ts
const string = '🙈🙉🙊';
const { length } = string; // 6
const characters = [...string]; // ['🙈', '🙉', '🙊']
```

And, let's face it, this is something that everyone <s>wants</s> needs, right?

**Related issue (if exists):** None