### PR TITLE
replace UnobservableError "invalid object" with object type

### DIFF
--- a/spec/util/throwUnobservableError-spec.ts
+++ b/spec/util/throwUnobservableError-spec.ts
@@ -1,0 +1,67 @@
+import { expect } from 'chai';
+import { createInvalidObservableTypeError } from '../../src/internal/util/throwUnobservableError';
+import { from } from 'rxjs';
+
+/** @test {createInvalidObservableTypeError} */
+describe('createInvalidObservableTypeError', () => {
+  /** JSON types **/
+  it('Should handle a string', () => {
+    const error = createInvalidObservableTypeError('FooBar');
+    expect(error.message).to.match(/^You provided 'FooBar' where a stream was expected./);
+  });
+  it('Should handle a boolean', () => {
+    const error = createInvalidObservableTypeError(true);
+    expect(error.message).to.match(/^You provided 'true' where a stream was expected./);
+  });
+  it('Should handle a number', () => {
+    const error = createInvalidObservableTypeError(12.34);
+    expect(error.message).to.match(/^You provided '12.34' where a stream was expected./);
+  });
+  it('Should handle null', () => {
+    const error = createInvalidObservableTypeError(null);
+    expect(error.message).to.match(/^You provided 'null' where a stream was expected./);
+  });
+  it('Should handle an Array', () => {
+    const error = createInvalidObservableTypeError([]);
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+  it('Should handle an object literal', () => {
+    const error = createInvalidObservableTypeError({
+      foo: 'bar',
+      fiz: 'buz',
+    });
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+
+  /** objects with constructors **/
+  it('Should handle a Map', () => {
+    const error = createInvalidObservableTypeError(new Map());
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+  it('Should handle a Set', () => {
+    const error = createInvalidObservableTypeError(new Set());
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+  it('Should handle an Error', () => {
+    const error = createInvalidObservableTypeError(new Error());
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+  it('Should handle a TypeError', () => {
+    const error = createInvalidObservableTypeError(new TypeError());
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+  it('Should handle a Proxy', () => {
+    const error = createInvalidObservableTypeError(new Proxy(new Map(), {}));
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+  it('Should handle an Observable', () => {
+    const error = createInvalidObservableTypeError(from<string>('FooBar'));
+    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+  });
+
+  /** everything else **/
+  it('Should handle undefined', () => {
+    const error = createInvalidObservableTypeError(undefined);
+    expect(error.message).to.match(/^You provided 'undefined' where a stream was expected./);
+  });
+});

--- a/spec/util/throwUnobservableError-spec.ts
+++ b/spec/util/throwUnobservableError-spec.ts
@@ -23,40 +23,40 @@ describe('createInvalidObservableTypeError', () => {
   });
   it('Should handle an Array', () => {
     const error = createInvalidObservableTypeError([]);
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'Array' where a stream was expected./);
   });
   it('Should handle an object literal', () => {
     const error = createInvalidObservableTypeError({
       foo: 'bar',
       fiz: 'buz',
     });
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'Object' where a stream was expected./);
   });
 
   /** objects with constructors **/
   it('Should handle a Map', () => {
     const error = createInvalidObservableTypeError(new Map());
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'Map' where a stream was expected./);
   });
   it('Should handle a Set', () => {
     const error = createInvalidObservableTypeError(new Set());
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'Set' where a stream was expected./);
   });
   it('Should handle an Error', () => {
     const error = createInvalidObservableTypeError(new Error());
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'Error' where a stream was expected./);
   });
   it('Should handle a TypeError', () => {
     const error = createInvalidObservableTypeError(new TypeError());
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'TypeError' where a stream was expected./);
   });
   it('Should handle a Proxy', () => {
     const error = createInvalidObservableTypeError(new Proxy(new Map(), {}));
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'Map' where a stream was expected./);
   });
   it('Should handle an Observable', () => {
     const error = createInvalidObservableTypeError(from<string>('FooBar'));
-    expect(error.message).to.match(/^You provided an invalid object where a stream was expected./);
+    expect(error.message).to.match(/^You provided type 'Observable' where a stream was expected./);
   });
 
   /** everything else **/

--- a/src/internal/util/throwUnobservableError.ts
+++ b/src/internal/util/throwUnobservableError.ts
@@ -8,7 +8,7 @@ export function createInvalidObservableTypeError(input: any) {
   // TODO: We should create error codes that can be looked up, so this can be less verbose.
   return new TypeError(
     `You provided ${
-      input !== null && typeof input === 'object' ? 'an invalid object' : `'${input}'`
+      input !== null && typeof input === 'object' ? `type '${Object.getPrototypeOf(input).constructor.name}'` : `'${input}'`
     } where a stream was expected. You can provide an Observable, Promise, Array, AsyncIterable, or Iterable.`
   );
 }


### PR DESCRIPTION
**Description:**

My application was crashing with the following generic error.

> You provided an invalid object where a stream was expected. You can provide an Observable, Promise, Array, AsyncIterable, or Iterable.

Upon closer inspection, I discovered that the object was indeed an `Observable`. The underlying issue was that multiple versions of `rxjs` were installed in my application. Once I was able to see that the "invalid object" was an "Observable", I knew immediately to audit `node_modules` for this issue. I'm hopeful that providing additional information about this runtime error will help others.

**Related issue (if exists):**

None that I could find.