### PR TITLE
refactor(tap): remove deprecated signatures

### DIFF
--- a/spec/operators/delayWhen-spec.ts
+++ b/spec/operators/delayWhen-spec.ts
@@ -333,8 +333,10 @@ describe('delayWhen', () => {
 
       expectObservable(
         result.pipe(
-          tap(null, null, () => {
-            expect(indices).to.deep.equal([0, 1, 2]);
+          tap({
+            complete: () => {
+              expect(indices).to.deep.equal([0, 1, 2]);
+            },
           })
         )
       ).toBe(expected);

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -154,8 +154,10 @@ describe('filter', () => {
 
       const result = e1.pipe(
         filter(predicate),
-        tap(null, null, () => {
-          expect(invoked).to.equal(7);
+        tap({
+          complete: () => {
+            expect(invoked).to.equal(7);
+          },
         })
       );
 

--- a/spec/operators/map-spec.ts
+++ b/spec/operators/map-spec.ts
@@ -82,8 +82,10 @@ describe('map operator', () => {
     let invoked = 0;
     const r = a.pipe(
       map((x: any) => { invoked++; return x; }),
-      tap(null, null, () => {
-        expect(invoked).to.equal(0);
+      tap({
+        complete: () => {
+          expect(invoked).to.equal(0);
+        }
       })
     );
 
@@ -115,8 +117,10 @@ describe('map operator', () => {
         invoked++;
         return (parseInt(x) + 1) + (index * 10);
       }),
-      tap(null, null, () => {
-        expect(invoked).to.equal(4);
+      tap({
+        complete: () => {
+          expect(invoked).to.equal(4);
+        }
       })
     );
 
@@ -136,9 +140,11 @@ describe('map operator', () => {
         invoked++;
         return (parseInt(x) + 1) + (index * 10);
       }),
-      tap(null, null, () => {
-        expect(invoked).to.equal(4);
-      })
+        tap({
+          complete: () => {
+            expect(invoked).to.equal(4);
+          }
+        })
     );
 
     expectObservable(r).toBe(expected, values);
@@ -157,9 +163,11 @@ describe('map operator', () => {
         invoked++;
         return (parseInt(x) + 1) + (index * 10);
       }),
-      tap(null, null, () => {
-        expect(invoked).to.equal(4);
-      })
+        tap({
+          complete: () => {
+            expect(invoked).to.equal(4);
+          }
+        })
     );
 
     expectObservable(r).toBe(expected, values, 'too bad');
@@ -196,9 +204,11 @@ describe('map operator', () => {
     const r = a.pipe(
       map((x: string) => { invoked1++; return parseInt(x) * 2; }),
       map((x: number) => { invoked2++; return x / 2; }),
-      tap(null, null, () => {
-        expect(invoked1).to.equal(7);
-        expect(invoked2).to.equal(7);
+      tap({
+        complete: () => {
+          expect(invoked1).to.equal(7);
+          expect(invoked2).to.equal(7);
+        }
       })
     );
 

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -129,8 +129,10 @@ describe('pluck operator', () => {
     const invoked = 0;
     const r = a.pipe(
       pluck('whatever'),
-      tap(null, null, () => {
-        expect(invoked).to.equal(0);
+      tap({
+        complete: () => {
+          expect(invoked).to.equal(0);
+        }
       })
     );
 

--- a/spec/operators/single-spec.ts
+++ b/spec/operators/single-spec.ts
@@ -176,8 +176,10 @@ describe('single operator', () => {
       expectObservable(
         e1.pipe(
           single(predicate),
-          tap(null, null, () => {
-            expect(indices).to.deep.equal([0, 1, 2]);
+          tap({
+            complete: () => {
+              expect(indices).to.deep.equal([0, 1, 2]);
+            },
           })
         )
       ).toBe(expected);

--- a/spec/operators/skipWhile-spec.ts
+++ b/spec/operators/skipWhile-spec.ts
@@ -141,8 +141,10 @@ describe('skipWhile operator', () => {
     expectObservable(
       source.pipe(
         skipWhile(predicate),
-        tap(null, null, () => {
-          expect(invoked).to.equal(3);
+        tap({
+          complete: () => {
+            expect(invoked).to.equal(3);
+          }
         })
       )
     ).toBe(expected);

--- a/spec/operators/takeWhile-spec.ts
+++ b/spec/operators/takeWhile-spec.ts
@@ -164,8 +164,10 @@ describe('takeWhile operator', () => {
 
     const source = e1.pipe(
       takeWhile(predicate),
-      tap(null, null, () => {
-        expect(invoked).to.equal(3);
+      tap({
+        complete: () => {
+          expect(invoked).to.equal(3);
+        }
       })
     );
     expectObservable(source).toBe(expected);

--- a/spec/operators/tap-spec.ts
+++ b/spec/operators/tap-spec.ts
@@ -27,18 +27,6 @@ describe('tap operator', () => {
     expect(value).to.equal(42);
   });
 
-  it('should error with a callback', () => {
-    let err = null;
-    throwError('bad').pipe(tap(null, function (x) {
-      err = x;
-    }))
-    .subscribe(null, function (ex) {
-      expect(ex).to.equal('bad');
-    });
-
-    expect(err).to.equal('bad');
-  });
-
   it('should handle everything with an observer', (done: MochaDone) => {
     const expected = [1, 2, 3];
     const results: number[] = [];
@@ -81,18 +69,7 @@ describe('tap operator', () => {
     ).subscribe();
   });
 
-  it('should handle an error with a callback', () => {
-    let errored = false;
-    throwError('bad').pipe(tap(null, (err: any) => {
-      expect(err).to.equal('bad');
-    }))
-    .subscribe(null, (err: any) => {
-      errored = true;
-      expect(err).to.equal('bad');
-    });
 
-    expect(errored).to.be.true;
-  });
 
   it('should handle an error with observer', () => {
     let errored = false;

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -6,13 +6,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 
 /* tslint:disable:max-line-length */
-/** @deprecated Use an observer instead of a complete callback */
-export function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-/** @deprecated Use an observer instead of an error callback */
-export function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-/** @deprecated Use an observer instead of a complete callback */
-export function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-export function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+export function tap<T>(next: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
@@ -107,15 +101,11 @@ export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T
  * @param complete A completion handler
  */
 export function tap<T>(
-  observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
-  error?: ((e: any) => void) | null,
+  observerOrNext: PartialObserver<T> | ((value: T) => void) | null,
+  error?: ((e: unknown) => void) | null,
   complete?: (() => void) | null
 ): MonoTypeOperatorFunction<T> {
-  // We have to check to see not only if next is a function,
-  // but if error or complete were passed. This is because someone
-  // could technically call tap like `tap(null, fn)` or `tap(null, null, fn)`.
-  const tapObserver =
-    isFunction(observerOrNext) || error || complete ? { next: observerOrNext as (value: T) => void, error, complete } : observerOrNext;
+  const tapObserver = isFunction(observerOrNext) ? { next: observerOrNext, error, complete } : observerOrNext;
 
   // TODO: Use `operate` function once this PR lands: https://github.com/ReactiveX/rxjs/pull/5742
   return tapObserver


### PR DESCRIPTION
This removes the deprecated signatures, simplifies the code a little, makes `next` a required parameter, and updates all the unit tests to pass.

Ref #4159

**Description:**
This is my best attempt at understanding what is desired by #4159.


**Related issue (if exists):**
