### PR TITLE
Modified behavior on empty inputs for forkJoin, combineLatest and zip

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -40,12 +40,9 @@ export declare function bindCallback<A extends readonly unknown[], R extends rea
 export declare function bindNodeCallback(callbackFunc: (...args: any[]) => void, resultSelector: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
 export declare function bindNodeCallback<A extends readonly unknown[], R extends readonly unknown[]>(callbackFunc: (...args: [...A, (err: any, ...res: R) => void]) => void, schedulerLike?: SchedulerLike): (...arg: A) => Observable<R extends [] ? void : R extends [any] ? R[0] : R>;
 
-export declare function combineLatest(sources: []): Observable<never>;
 export declare function combineLatest<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+export declare function combineLatest(): Observable<never>;
 export declare function combineLatest<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-export declare function combineLatest(sourcesObject: {
-    [K in any]: never;
-}): Observable<never>;
 export declare function combineLatest<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
@@ -163,14 +160,11 @@ export declare type Falsy = null | undefined | false | 0 | -0 | 0n | '';
 
 export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
-export declare function forkJoin(sources: readonly []): Observable<never>;
 export declare function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin<A extends readonly unknown[], R>(sources: readonly [...ObservableInputTuple<A>], resultSelector: (...values: A) => R): Observable<R>;
+export declare function forkJoin(): Observable<never>;
 export declare function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin<A extends readonly unknown[], R>(...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]): Observable<R>;
-export declare function forkJoin(sourcesObject: {
-    [K in any]: never;
-}): Observable<never>;
 export declare function forkJoin<T>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
@@ -561,5 +555,9 @@ export declare class VirtualTimeScheduler extends AsyncScheduler {
 
 export declare function zip<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
 export declare function zip<A extends readonly unknown[], R>(sources: [...ObservableInputTuple<A>], resultSelector: (...values: A) => R): Observable<R>;
+export declare function zip(): Observable<never>;
 export declare function zip<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 export declare function zip<A extends readonly unknown[], R>(...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]): Observable<R>;
+export declare function zip<T>(sourcesObject: T): Observable<{
+    [K in keyof T]: ObservedValueOf<T[K]>;
+}>;

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -64,6 +64,11 @@ it('should accept 7 or more params and a result selector', () => {
   const o = combineLatest(a$, b$, c$, d$, e$, f$, g$, g$, g$, () => new A()); // $ExpectType Observable<A>
 });
 
+it('shoudd accept 0 params', () => {
+  const o = combineLatest([]); // $ExpectType Observable<[]>
+  const o1 = combineLatest(); // $ExpectType Observable<never>
+});
+
 it('should accept 1 param', () => {
   const o = combineLatest([a$]); // $ExpectType Observable<[A]>
 });
@@ -130,7 +135,7 @@ it('should accept 7 or more params and a result selector', () => {
 
 describe('combineLatest({})', () => {
   it('should properly type empty objects', () => {
-    const res = combineLatest({}); // $ExpectType Observable<never>
+    const res = combineLatest({}); // $ExpectType Observable<{}>
   });
 
   it('should work for the simple case', () => {

--- a/spec-dtslint/observables/forkJoin-spec.ts
+++ b/spec-dtslint/observables/forkJoin-spec.ts
@@ -61,7 +61,7 @@ it('should infer of type any for more than 6 parameters', () => {
 
 describe('forkJoin({})', () => {
   it('should properly type empty objects', () => {
-    const res = forkJoin({}); // $ExpectType Observable<never>
+    const res = forkJoin({}); // $ExpectType Observable<{}>
   });
 
   it('should work for the simple case', () => {
@@ -75,9 +75,13 @@ describe('forkJoin({})', () => {
 });
 
 describe('forkJoin([])', () => {
+  it('should property type empty parameters', () => {
+    const res = forkJoin(); // $ExpectType Observable<never>
+  });
+
   it('should properly type empty arrays', () => {
-    const res = forkJoin([]); // $ExpectType Observable<never>
-    const resConst = forkJoin([] as const); // $ExpectType Observable<never>
+    const res = forkJoin([]); // $ExpectType Observable<[]>
+    const resConst = forkJoin([] as const); // $ExpectType Observable<[]>
   });
 
     it('should properly type readonly arrays', () => {

--- a/spec-dtslint/observables/zip-spec.ts
+++ b/spec-dtslint/observables/zip-spec.ts
@@ -32,9 +32,19 @@ it('should return Array<T> when given a single promise', () => {
   const o1 = zip(a); // $ExpectType Observable<[number]>
 });
 
+it('should return an empty array when given no source', () => {
+  const o = zip([]); // $ExpectType Observable<[]>
+  const o1 = zip(); // $ExpectType Observable<never>
+});
+
 it('should return Array<T> when given a single observable', () => {
   const a = of(1); // $ExpectType Observable<number>
   const o1 = zip(a); // $ExpectType Observable<[number]>
+});
+
+it('should support object types', () => {
+  const u = Math.random() > 0.5 ? of(123) : of('abc');
+  const o = zip({ u }); // $ExpectType Observable<{ u: string | number; }>
 });
 
 it('should support union types', () => {

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -371,6 +371,33 @@ describe('static combineLatest', () => {
     });
   });
 
+  it('should complete if source is not provided', () => {
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = combineLatest();
+      const expected = '|';
+
+      expectObservable(e1).toBe(expected);
+    });
+  });
+
+  it('should emit an empty array if sources array is empty', () => {
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = combineLatest([]);
+      const expected = '(x|)';
+
+      expectObservable(e1).toBe(expected, { x: [] });
+    });
+  });
+
+  it('should emit an empty object if sources object is empty', () => {
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = combineLatest({});
+      const expected = '(x|)';
+
+      expectObservable(e1).toBe(expected, { x: {} });
+    });
+  });
+
   it('should work with throw and never', () => {
     rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('---^----#', undefined, 'wokka wokka');

--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -227,12 +227,12 @@ describe('forkJoin', () => {
       });
     });
 
-    it('should complete if sources list is empty', () => {
+    it('should emit an empty array if sources list is empty', () => {
       rxTestScheduler.run(({ expectObservable }) => {
         const e1 = forkJoin([]);
-        const expected = '|';
+        const expected = '(x|)';
 
-        expectObservable(e1).toBe(expected);
+        expectObservable(e1).toBe(expected, { x: [] });
       });
     });
 
@@ -483,12 +483,12 @@ describe('forkJoin', () => {
       });
     });
 
-    it('should complete if sources object is empty', () => {
+    it('should emit an empty object if sources object is empty', () => {
       rxTestScheduler.run(({ expectObservable }) => {
         const e1 = forkJoin({});
-        const expected = '|';
+        const expected = '(x|)';
 
-        expectObservable(e1).toBe(expected);
+        expectObservable(e1).toBe(expected, { x: {} });
       });
     });
 

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -795,12 +795,12 @@ describe('zipAll operator', () => {
     });
   });
 
-  it('should complete when empty source', () => {
+  it('should emit an empty list when empty source', () => {
     rxTestScheduler.run(({ hot, expectObservable }) => {
       const source = hot('|');
-      const expected = '  |';
+      const expected = '(x|)';
 
-      expectObservable(source.pipe(zipAll())).toBe(expected);
+      expectObservable(source.pipe(zipAll())).toBe(expected, { x: [] });
     });
   });
 });

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -131,7 +131,7 @@ export function forkJoin(...args: any[]): Observable<any> {
 
   if (args === sources && args.length === 0) {
     // deprecated path for forkJoin() without any argument
-    return (EMPTY as any) as Observable<any>;
+    return EMPTY;
   }
 
   if (resultSelector) {

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -1,23 +1,33 @@
 /** @prettier */
 import { Observable } from '../Observable';
-import { ObservableInputTuple } from '../types';
+import { ObservableInputTuple, ObservedValueOf } from '../types';
 import { innerFrom } from './from';
-import { argsOrArgArray } from '../util/argsOrArgArray';
+import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { EMPTY } from './empty';
 import { OperatorSubscriber } from '../operators/OperatorSubscriber';
 import { popResultSelector } from '../util/args';
+import { of } from './of';
 
+// zip([a, b, c])
 export function zip<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
 /** @deprecated resultSelector is no longer supported, pipe to map instead */
 export function zip<A extends readonly unknown[], R>(
   sources: [...ObservableInputTuple<A>],
   resultSelector: (...values: A) => R
 ): Observable<R>;
+
+// zip(a, b, c)
+/** @deprecated Use the version that takes an empty array of Observables instead */
+export function zip(): Observable<never>;
+/** @deprecated Use the version that takes an array of Observables instead */
 export function zip<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 /** @deprecated resultSelector is no longer supported, pipe to map instead */
 export function zip<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;
+
+// zip({a, b, c})
+export function zip<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /**
  * Combines multiple Observables to create an Observable whose values are calculated from the values, in order, of each
@@ -28,7 +38,7 @@ export function zip<A extends readonly unknown[], R>(
  *
  * ## Example
  *
- * Combine age and name from different sources
+ * Combine age and name from different sources (array)
  *
  * ```ts
  * import { zip, of } from 'rxjs';
@@ -38,9 +48,26 @@ export function zip<A extends readonly unknown[], R>(
  * let name$ = of('Foo', 'Bar', 'Beer');
  * let isDev$ = of(true, true, false);
  *
- * zip(age$, name$, isDev$).pipe(
- *   map(([age, name, isDev]) => ({ age, name, isDev }))
- * )
+ * zip([age$, name$, isDev$])
+ * .subscribe(x => console.log(x));
+ *
+ * // Outputs
+ * // [ 27, 'Foo', true ]
+ * // [ 25, 'Bar', true ]
+ * // [ 29, 'Beer', false ]
+ * ```
+ *
+ * Combine age and name from different sources (object)
+ *
+ * ```ts
+ * import { zip, of } from 'rxjs';
+ * import { map } from 'rxjs/operators';
+ *
+ * let age$ = of(27, 25, 29);
+ * let name$ = of('Foo', 'Bar', 'Beer');
+ * let isDev$ = of(true, true, false);
+ *
+ * zip({ age: age$, name: name$, isDev: isDev$)
  * .subscribe(x => console.log(x));
  *
  * // Outputs
@@ -48,73 +75,88 @@ export function zip<A extends readonly unknown[], R>(
  * // { age: 25, name: 'Bar', isDev: true }
  * // { age: 29, name: 'Beer', isDev: false }
  * ```
+
  * @param sources
  * @return {Observable<R>}
  */
 export function zip(...args: unknown[]): Observable<unknown> {
   const resultSelector = popResultSelector(args);
 
-  const sources = argsOrArgArray(args) as Observable<unknown>[];
+  const { args: sources, keys } = argsArgArrayOrObject(args);
 
-  return sources.length
-    ? new Observable<unknown[]>((subscriber) => {
-        // A collection of buffers of values from each source.
-        // Keyed by the same index with which the sources were passed in.
-        let buffers: unknown[][] = sources.map(() => []);
+  if (args === sources && args.length === 0) {
+    // deprecated path: empty zip()
+    return EMPTY;
+  }
 
-        // An array of flags of whether or not the sources have completed.
-        // This is used to check to see if we should complete the result.
-        // Keyed by the same index with which the sources were passed in.
-        let completed = sources.map(() => false);
+  if (sources.length === 0) {
+    return of(keys ? {} : []);
+  }
 
-        // When everything is done, release the arrays above.
-        subscriber.add(() => {
-          buffers = completed = null!;
-        });
+  return new Observable<unknown[]>((subscriber) => {
+    // A collection of buffers of values from each source.
+    // Keyed by the same index with which the sources were passed in.
+    let buffers: unknown[][] = sources.map(() => []);
 
-        // Loop over our sources and subscribe to each one. The index `i` is
-        // especially important here, because we use it in closures below to
-        // access the related buffers and completion properties
-        for (let sourceIndex = 0; !subscriber.closed && sourceIndex < sources.length; sourceIndex++) {
-          innerFrom(sources[sourceIndex]).subscribe(
-            new OperatorSubscriber(
-              subscriber,
-              (value) => {
-                buffers[sourceIndex].push(value);
-                // if every buffer has at least one value in it, then we
-                // can shift out the oldest value from each buffer and emit
-                // them as an array.
-                if (buffers.every((buffer) => buffer.length)) {
-                  const result: any = buffers.map((buffer) => buffer.shift()!);
-                  // Emit the array. If theres' a result selector, use that.
-                  subscriber.next(resultSelector ? resultSelector(...result) : result);
-                  // If any one of the sources is both complete and has an empty buffer
-                  // then we complete the result. This is because we cannot possibly have
-                  // any more values to zip together.
-                  if (buffers.some((buffer, i) => !buffer.length && completed[i])) {
-                    subscriber.complete();
-                  }
-                }
-              },
-              // Any error is passed through the result.
-              undefined,
-              () => {
-                // This source completed. Mark it as complete so we can check it later
-                // if we have to.
-                completed[sourceIndex] = true;
-                // But, if this complete source has nothing in its buffer, then we
-                // can complete the result, because we can't possibly have any more
-                // values from this to zip together with the other values.
-                !buffers[sourceIndex].length && subscriber.complete();
+    // An array of flags of whether or not the sources have completed.
+    // This is used to check to see if we should complete the result.
+    // Keyed by the same index with which the sources were passed in.
+    let completed = sources.map(() => false);
+
+    // When everything is done, release the arrays above.
+    subscriber.add(() => {
+      buffers = completed = null!;
+    });
+
+    // Loop over our sources and subscribe to each one. The index `i` is
+    // especially important here, because we use it in closures below to
+    // access the related buffers and completion properties
+    for (let sourceIndex = 0; !subscriber.closed && sourceIndex < sources.length; sourceIndex++) {
+      innerFrom(sources[sourceIndex] as Observable<unknown>).subscribe(
+        new OperatorSubscriber(
+          subscriber,
+          (value) => {
+            buffers[sourceIndex].push(value);
+            // if every buffer has at least one value in it, then we
+            // can shift out the oldest value from each buffer and emit
+            // them as an array.
+            if (buffers.every((buffer) => buffer.length)) {
+              const values: any = buffers.map((buffer) => buffer.shift()!);
+              //
+              // Emit the array. If theres' a result selector, use that.
+              if (resultSelector) {
+                // deprecated path with a result selector
+                subscriber.next(resultSelector(...values) as unknown[]);
+              } else {
+                subscriber.next(keys ? keys.reduce((result, key, i) => (((result as any)[key] = values[i]), result), {}) : values);
               }
-            )
-          );
-        }
 
-        // When everything is done, release the arrays above.
-        return () => {
-          buffers = completed = null!;
-        };
-      })
-    : EMPTY;
+              // If any one of the sources is both complete and has an empty buffer
+              // then we complete the result. This is because we cannot possibly have
+              // any more values to zip together.
+              if (buffers.some((buffer, i) => !buffer.length && completed[i])) {
+                subscriber.complete();
+              }
+            }
+          },
+          // Any error is passed through the result.
+          undefined,
+          () => {
+            // This source completed. Mark it as complete so we can check it later
+            // if we have to.
+            completed[sourceIndex] = true;
+            // But, if this complete source has nothing in its buffer, then we
+            // can complete the result, because we can't possibly have any more
+            // values from this to zip together with the other values.
+            !buffers[sourceIndex].length && subscriber.complete();
+          }
+        )
+      );
+    }
+
+    // When everything is done, release the arrays above.
+    return () => {
+      buffers = completed = null!;
+    };
+  });
 }


### PR DESCRIPTION
**Description:**

The `forkJoin`, `combineLatest` and `zip` functions have been modified so that:

```ts
combineLatest();   // Observable<never>: behavior kept for compatibility as the non-array version is deprecated
combineLatest([]); // Observable<[]>: now emits an empty array before completing
combineLatest({}); // Observable<{}>: now emits an empty object before completing

forkJoin();   // Observable<never>: behavior kept for compatibility as the non-array version is deprecated
forkJoin([]); // Observable<[]>: now emits an empty array before completing
forkJoin({}); // Observable<{}>, now emits an empty object before completing

zip();     // Observable<never>, behavior kept for compatibility as the non-array version is now deprecated
zip(a,b)   // /!\ has been marked as deprecated in this PR /!\
zip([]);   // Observable<[]>: now emits an empty array before completing
zip({a,b}) // Observable<{a: A, b: B}>: new behavior to align with the other ones
           // /!\ new behavior to align with the other ones /!\
zip({});   // Observable<{}>: emits an empty object then completes

// side effects
zipAll() // now emits [] for empty observables
```

**Related issue (if exists):**

Regarding the signature (#5066), in particular `needs N-args signature for observable inputs`:
All 3 functions seem to have the correct `<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>`

Closes #5209 
