### PR TITLE
fix(doc): fix broken image link

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -113,7 +113,7 @@ To explain how operators work, textual descriptions are often not enough. Many o
 
 Below you can see the anatomy of a marble diagram.
 
-<img src="../src/assets/images/guide/marble-diagram-anatomy.svg">
+<img src="../../src/assets/images/guide/marble-diagram-anatomy.svg">
 
 Throughout this documentation site, we extensively use marble diagrams to explain how operators work. They may be really useful in other contexts too, like on a whiteboard or even in our unit tests (as ASCII diagrams).
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Hello! While learning about RxJS I came across a broken image link in the documentation. Not the biggest problem but I wanted to help fix it. Looks like it was a simple path issue.

With this fix, the image should now be properly displayed. You can see it in action on my [working branch](https://github.com/seanforyou23/rxjs/blob/docs-img-fix/docs_app/content/guide/operators.md#marble-diagrams). Hope it helps!

<img width="984" alt="Screen Shot 2020-12-08 at 5 32 37 PM" src="https://user-images.githubusercontent.com/5942899/101549422-a7912500-397b-11eb-8618-ba3af114d876.png">


**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/5923
