### PR TITLE
refactor(fromFetch): remove redundant if wrap of init

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs",
-  "version": "7.0.0-beta.8",
+  "version": "7.0.0-beta.9",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
**Description:**

`init` object is created using rest operator
this means that `init` always will be an object which is a truthy value
this commit removes redundant `init` check

Related: https://github.com/ReactiveX/rxjs/pull/5306/files#r542228847