### PR TITLE
fix(fromEvent): fixed HasEventTargetAddRemove to support EventTarget types

### DIFF
--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -1,30 +1,35 @@
 import { fromEvent } from 'rxjs';
 import { JQueryStyleEventEmitter } from '../../src/internal/observable/fromEvent';
-import { A, B } from "../helpers";
+import { A, B } from '../helpers';
 
-declare const eventTargetSource: HTMLDocument;
-
-interface NodeStyleSource {
-  addListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
-  removeListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
-};
-declare const nodeStyleSource : NodeStyleSource;
-
-declare const nodeCompatibleSource: {
-  addListener: (eventName: string, handler: (...args: any[]) => void) => void;
-  removeListener: (eventName: string, handler: (...args: any[]) => void) => void;
-};
-
-
+declare const eventTargetSource: EventTarget;
 
 it('should support an event target source', () => {
   const a = fromEvent(eventTargetSource, "click"); // $ExpectType Observable<Event>
 });
 
+declare const documentSource: HTMLDocument;
+
+it('should support a document source', () => {
+  const a = fromEvent(documentSource, "click"); // $ExpectType Observable<Event>
+});
+
+interface NodeStyleSource {
+  addListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
+  removeListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
+};
+
+declare const nodeStyleSource : NodeStyleSource;
+
 it('should support a node-style source', () => {
   const a = fromEvent(nodeStyleSource, "something"); // $ExpectType Observable<unknown>
   const b = fromEvent<B>(nodeStyleSource, "something"); // $ExpectType Observable<B>
 });
+
+declare const nodeCompatibleSource: {
+  addListener: (eventName: string, handler: (...args: any[]) => void) => void;
+  removeListener: (eventName: string, handler: (...args: any[]) => void) => void;
+};
 
 it('should support a node-compatible source', () => {
   const a = fromEvent(nodeCompatibleSource, "something"); // $ExpectType Observable<unknown>
@@ -32,6 +37,7 @@ it('should support a node-compatible source', () => {
 });
 
 declare const jQueryStyleSource: JQueryStyleEventEmitter<A, B>;
+
 it('should support a jQuery-style source', () => {
   const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<B>
   const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -33,9 +33,21 @@ export interface JQueryStyleEventEmitter<TContext, T> {
   off: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
 }
 
+export interface EventListenerObject<E> {
+  handleEvent(evt: E): void;
+}
+
 export interface HasEventTargetAddRemove<E> {
-  addEventListener(type: string, listener: ((evt: E) => void) | null, options?: boolean | AddEventListenerOptions): void;
-  removeEventListener(type: string, listener?: ((evt: E) => void) | null, options?: EventListenerOptions | boolean): void;
+  addEventListener(
+    type: string,
+    listener: ((evt: E) => void) | EventListenerObject<E> | null,
+    options?: boolean | AddEventListenerOptions
+  ): void;
+  removeEventListener(
+    type: string,
+    listener: ((evt: E) => void) | EventListenerObject<E> | null,
+    options?: EventListenerOptions | boolean
+  ): void;
 }
 
 export type EventTargetLike<T> =


### PR DESCRIPTION
**Description:**

Makes it possible to use `fromEvent()` with a simple `EventTarget`.

**Related issue (if exists):**

Closes #5944 