### PR TITLE
fix(combineLatest): Ensure `EMPTY` is returned if no observables are …

### DIFF
--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -14,6 +14,50 @@ describe('static combineLatest', () => {
     rxTestScheduler = new TestScheduler(observableMatcher);
   });
 
+  it('should return EMPTY if passed an empty array as the only argument', () => {
+    const results: string[] = [];
+    combineLatest([]).subscribe({
+      next: () => {
+        throw new Error('should not emit')
+      },
+      complete: () => {
+        results.push('done');
+      }
+    });
+
+    expect(results).to.deep.equal(['done']);
+  });
+
+  it('should return EMPTY if passed an empty POJO as the only argument', () => {
+    const results: string[] = [];
+    combineLatest({}).subscribe({
+      next: () => {
+        throw new Error('should not emit')
+      },
+      complete: () => {
+        results.push('done');
+      }
+    });
+
+    expect(results).to.deep.equal(['done']);
+  });
+  
+  it('should return EMPTY if passed an empty array and scheduler as the only argument', () => {
+    const results: string[] = [];
+    combineLatest([], rxTestScheduler).subscribe({
+      next: () => {
+        throw new Error('should not emit')
+      },
+      complete: () => {
+        results.push('done');
+      }
+    });
+
+    expect(results).to.deep.equal([]);
+    rxTestScheduler.flush();
+    expect(results).to.deep.equal(['done']);
+  });
+
   it('should combineLatest the provided observables', () => {
     rxTestScheduler.run(({ hot, expectObservable }) => {
       const firstSource = hot(' ----a----b----c----|');

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -463,6 +463,13 @@ export function combineLatest<O extends ObservableInput<any>, R>(...args: any[])
 
   const { args: observables, keys } = argsArgArrayOrObject(args);
 
+  if (observables.length === 0) {
+    // If no observables are passed, or someone has passed an ampty array
+    // of observables, or even an empty object POJO, we need to just
+    // complete (EMPTY), but we have to honor the scheduler provided if any.
+    return from([], scheduler as any);
+  }
+
   const result = new Observable<ObservedValueOf<O>[]>(
     combineLatestInit(
       observables as ObservableInput<ObservedValueOf<O>>[],


### PR DESCRIPTION
…passed.

This resolves an issue found by testing Angular router. There was code that expected this behavior (rightfully so), and it was broken during a refactor in v7.
