### PR TITLE
fix: Resolve issues with deprecated synchronous error handling and chained operators

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -608,6 +608,27 @@ describe('Observable', () => {
         }).to.throw('error!');
       });
 
+
+      // From issue: https://github.com/ReactiveX/rxjs/issues/5979
+      it('should still rethrow synchronous errors from next handlers on synchronous observables', () => {
+        expect(() => {
+          of('test').pipe(
+            // Any operators here
+            map(x => x + '!!!'),
+            map(x => x + x),
+            map(x => x + x),
+            map(x => x + x),
+          ).subscribe({
+            next: () => {
+              throw new Error(
+                'hi there!'
+              )
+            }
+          })
+        }).to.throw();
+      });
+
+
       afterEach(() => {
         config.useDeprecatedSynchronousErrorHandling = false;
       });

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -45,7 +45,7 @@ export const config = {
    * in v6 and higher. This behavior enables bad patterns like wrapping a subscribe
    * call in a try/catch block. It also enables producer interference, a nasty bug
    * where a multicast can be broken for all observers by a downstream consumer with
-   * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BY TIME
+   * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BUY TIME
    * FOR MIGRATION REASONS.
    *
    * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing


### PR DESCRIPTION
Adds some logic to handle the deprecated case. This is unfortunate, but it's necessary to properly support people who are still using this feature until we can remove it. Note that there is potentially a severe performance penalty for people using this feature. But they're being warned at every turn, and the migration path to get away from this is easy: Stop relying on synchronously thrown errors.

fixes #5979
