### PR TITLE
chore: Use prettier by default on all src/ files

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,6 +1,11 @@
 {
   "trailingComma": "es5",
   "singleQuote": true,
-  "requirePragma": true,
-  "printWidth": 140
+  "printWidth": 140,
+  "overrides": [{
+    "files": ["spec/**/*.ts", "spec-dtslint/**/*.ts"],
+    "options": {
+      "requirePragma": true
+    }
+  }]
 }

--- a/src/internal/AsyncSubject.ts
+++ b/src/internal/AsyncSubject.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subject } from './Subject';
 import { Subscriber } from './Subscriber';
 

--- a/src/internal/BehaviorSubject.ts
+++ b/src/internal/BehaviorSubject.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subject } from './Subject';
 import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';

--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { PartialObserver, ObservableNotification, CompleteNotification, NextNotification, ErrorNotification } from './types';
 import { Observable } from './Observable';
 import { EMPTY } from './observable/empty';

--- a/src/internal/NotificationFactories.ts
+++ b/src/internal/NotificationFactories.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { CompleteNotification, NextNotification, ErrorNotification } from './types';
 
 /**

--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subject } from './Subject';
 import { TimestampProvider } from './types';
 import { Subscriber } from './Subscriber';

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Operator } from './Operator';
 import { Observable } from './Observable';
 import { Subscriber } from './Subscriber';

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { isFunction } from './util/isFunction';
 import { Observer, ObservableNotification } from './types';
 import { isSubscription, Subscription } from './Subscription';

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { isFunction } from './util/isFunction';
 import { UnsubscriptionError } from './util/UnsubscriptionError';
 import { SubscriptionLike, TeardownLogic, Unsubscribable } from './types';

--- a/src/internal/ajax/AjaxResponse.ts
+++ b/src/internal/ajax/AjaxResponse.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 import { AjaxRequest } from './types';
 import { getXHRResponse } from './getXHRResponse';
 

--- a/src/internal/ajax/ajax.ts
+++ b/src/internal/ajax/ajax.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { map } from '../operators/map';
 import { Observable } from '../Observable';
 import { AjaxConfig, AjaxRequest } from './types';

--- a/src/internal/ajax/errors.ts
+++ b/src/internal/ajax/errors.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { AjaxRequest } from './types';
 import { getXHRResponse } from './getXHRResponse';
 import { createErrorClass } from '../util/createErrorClass';

--- a/src/internal/ajax/getXHRResponse.ts
+++ b/src/internal/ajax/getXHRResponse.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 /**
  * Gets what should be in the `response` property of the XHR. However,
  * since we still support the final versions of IE, we need to do a little

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { PartialObserver } from '../types';
 
 /**

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscriber } from './Subscriber';
 import { ObservableNotification } from './types';
 

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subject } from '../Subject';
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';

--- a/src/internal/observable/bindCallbackInternals.ts
+++ b/src/internal/observable/bindCallbackInternals.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { SchedulerLike } from '../types';
 import { isScheduler } from '../util/isScheduler';
 import { Observable } from '../Observable';

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { bindCallbackInternals } from './bindCallbackInternals';

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, SchedulerLike, ObservedValueOf, ObservableInputTuple } from '../types';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';

--- a/src/internal/observable/connectable.ts
+++ b/src/internal/observable/connectable.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 import { ObservableInput } from '../types';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';

--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservedValueOf, ObservableInput } from '../types';
 import { innerFrom } from './from';

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorSubscriber } from '../../operators/OperatorSubscriber';
 import { Observable } from '../../Observable';
 import { innerFrom } from '../../observable/from';

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, ObservedValueOf, ObservableInputTuple } from '../types';
 import { map } from '../operators/map';

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { isArrayLike } from '../util/isArrayLike';
 import { isPromise } from '../util/isPromise';
 import { iterator as Symbol_iterator } from '../symbol/iterator';

--- a/src/internal/observable/fromArray.ts
+++ b/src/internal/observable/fromArray.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { SchedulerLike } from '../types';
 import { scheduleArray } from '../scheduled/scheduleArray';
 import { fromArrayLike } from './from';

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { mergeMap } from '../operators/mergeMap';
 import { isArrayLike } from '../util/isArrayLike';

--- a/src/internal/observable/fromEventPattern.ts
+++ b/src/internal/observable/fromEventPattern.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { isFunction } from '../util/isFunction';
 import { NodeEventHandler } from './fromEvent';

--- a/src/internal/observable/fromSubscribable.ts
+++ b/src/internal/observable/fromSubscribable.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscribable } from '../types';

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { identity } from '../util/identity';
 import { ObservableInput, SchedulerLike } from '../types';

--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { defer } from './defer';
 import { ObservableInput } from '../types';

--- a/src/internal/observable/interval.ts
+++ b/src/internal/observable/interval.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { asyncScheduler } from '../scheduler/async';
 import { SchedulerLike } from '../types';

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, ObservableInputTuple, SchedulerLike } from '../types';
 import { mergeAll } from '../operators/mergeAll';

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { SchedulerLike, ValueFromArray } from '../types';
 import { internalFromArray } from './fromArray';
 import { Observable } from '../Observable';

--- a/src/internal/observable/onErrorResumeNext.ts
+++ b/src/internal/observable/onErrorResumeNext.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInputTuple } from '../types';
 import { EMPTY } from './empty';

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { from } from './from';

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { innerFrom } from './from';
 import { Subscription } from '../Subscription';

--- a/src/internal/observable/range.ts
+++ b/src/internal/observable/range.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { EMPTY } from './empty';

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { SchedulerLike } from '../types';

--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { async as asyncScheduler } from '../scheduler/async';

--- a/src/internal/observable/using.ts
+++ b/src/internal/observable/using.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Unsubscribable, ObservableInput } from '../types';
 import { innerFrom } from './from';

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInputTuple } from '../types';
 import { innerFrom } from './from';

--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscriber } from '../Subscriber';
 
 /**

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscription } from '../Subscription';
 import { OperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscription } from '../Subscription';
 import { OperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { combineLatest } from '../observable/combineLatest';
 import { OperatorFunction, ObservableInput } from '../types';
 import { joinAllInternals } from './joinAllInternals';

--- a/src/internal/operators/combineLatestWith.ts
+++ b/src/internal/operators/combineLatestWith.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { combineLatestInit } from '../observable/combineLatest';
 import { ObservableInput, ObservableInputTuple, OperatorFunction, Cons } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { mergeMap } from './mergeMap';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { isFunction } from '../util/isFunction';

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { concatMap } from './concatMap';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { isFunction } from '../util/isFunction';

--- a/src/internal/operators/concatWith.ts
+++ b/src/internal/operators/concatWith.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { ObservableInput, ObservableInputTuple, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { concatAll } from './concatAll';

--- a/src/internal/operators/connect.ts
+++ b/src/internal/operators/connect.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction, ObservableInput, SubjectLike } from '../types';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';

--- a/src/internal/operators/count.ts
+++ b/src/internal/operators/count.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { reduce } from './reduce';
 /**

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { asyncScheduler } from '../scheduler/async';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { debounce } from './debounce';

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { asyncScheduler } from '../scheduler/async';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { delayWhen } from './delayWhen';

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { concat } from '../observable/concat';
@@ -17,9 +16,7 @@ export function delayWhen<T>(
   delayDurationSelector: (value: T, index: number) => Observable<any>,
   subscriptionDelay: Observable<any>
 ): MonoTypeOperatorFunction<T>;
-export function delayWhen<T>(
-  delayDurationSelector: (value: T, index: number) => Observable<any>
-): MonoTypeOperatorFunction<T>;
+export function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>): MonoTypeOperatorFunction<T>;
 
 /**
  * Delays the emission of items from the source Observable by a given time span

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { observeNotification } from '../Notification';
 import { OperatorFunction, ObservableNotification, ValueFromNotification } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Falsy, OperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscription } from '../Subscription';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction, ObservableInput, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { mergeInternals } from './mergeInternals';

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction, MonoTypeOperatorFunction, TruthyTypesOf } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction, TruthyTypesOf } from '../types';

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Falsy, OperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/first.ts
+++ b/src/internal/operators/first.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { EmptyError } from '../util/EmptyError';
 import { OperatorFunction, TruthyTypesOf } from '../types';

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Observer, OperatorFunction } from '../types';

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/joinAllInternals.ts
+++ b/src/internal/operators/joinAllInternals.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction } from '../types';
 import { identity } from '../util/identity';

--- a/src/internal/operators/last.ts
+++ b/src/internal/operators/last.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { EmptyError } from '../util/EmptyError';
 import { OperatorFunction, TruthyTypesOf } from '../types';

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Notification } from '../Notification';
 import { OperatorFunction, ObservableNotification } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/max.ts
+++ b/src/internal/operators/max.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { reduce } from './reduce';
 import { MonoTypeOperatorFunction } from '../types';
 import { isFunction } from '../util/isFunction';

--- a/src/internal/operators/mergeInternals.ts
+++ b/src/internal/operators/mergeInternals.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { innerFrom } from '../observable/from';
 import { Subscriber } from '../Subscriber';

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
 import { innerFrom } from '../observable/from';

--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { mergeInternals } from './mergeInternals';

--- a/src/internal/operators/mergeWith.ts
+++ b/src/internal/operators/mergeWith.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { ObservableInput, ObservableInputTuple, OperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { argsOrArgArray } from '../util/argsOrArgArray';

--- a/src/internal/operators/min.ts
+++ b/src/internal/operators/min.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { reduce } from './reduce';
 import { MonoTypeOperatorFunction } from '../types';
 import { isFunction } from '../util/isFunction';

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subject } from '../Subject';
 import { Observable } from '../Observable';
 import { ConnectableObservable } from '../observable/ConnectableObservable';

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ObservableInputTuple, OperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { multicast } from './multicast';

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ReplaySubject } from '../ReplaySubject';
 import { multicast } from './multicast';

--- a/src/internal/operators/reduce.ts
+++ b/src/internal/operators/reduce.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { scanInternals } from './scanInternals';
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction } from '../types';

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscription } from '../Subscription';
 import { EMPTY } from '../observable/empty';
 import { operate } from '../util/lift';

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { Subscription } from '../Subscription';

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { asyncScheduler } from '../scheduler/async';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { sample } from './sample';

--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { scanInternals } from './scanInternals';

--- a/src/internal/operators/scanInternals.ts
+++ b/src/internal/operators/scanInternals.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 
 import { OperatorFunction } from '../types';

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 import { Subject } from '../Subject';
 
 import { MonoTypeOperatorFunction, OperatorFunction, SubjectLike } from '../types';

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { EmptyError } from '../util/EmptyError';
 

--- a/src/internal/operators/skip.ts
+++ b/src/internal/operators/skip.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction } from '../types';
 import { filter } from './filter';
 

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction } from '../types';
 import { identity } from '../util/identity';
 import { operate } from '../util/lift';

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/skipWhile.ts
+++ b/src/internal/operators/skipWhile.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Falsy, MonoTypeOperatorFunction, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { concat } from '../observable/concat';
 import { MonoTypeOperatorFunction, OperatorFunction, SchedulerLike, ValueFromArray } from '../types';
 import { popScheduler } from '../util/args';

--- a/src/internal/operators/subscribeOn.ts
+++ b/src/internal/operators/subscribeOn.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { innerFrom } from '../observable/from';

--- a/src/internal/operators/switchScan.ts
+++ b/src/internal/operators/switchScan.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { ObservableInput, ObservedValueOf, OperatorFunction } from '../types';
 import { switchMap } from './switchMap';
 import { operate } from '../util/lift';

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction } from '../types';
 import { EMPTY } from '../observable/empty';
 import { operate } from '../util/lift';

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { EMPTY } from '../observable/empty';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction, MonoTypeOperatorFunction, Falsy } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { MonoTypeOperatorFunction, PartialObserver } from '../types';
 import { isFunction } from '../util/isFunction';
 import { operate } from '../util/lift';

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscription } from '../Subscription';
 
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';

--- a/src/internal/operators/throttleTime.ts
+++ b/src/internal/operators/throttleTime.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { asyncScheduler } from '../scheduler/async';
 import { defaultThrottleConfig, throttle } from './throttle';
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { EmptyError } from '../util/EmptyError';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { asyncScheduler } from '../scheduler/async';
 import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction, ObservableInput } from '../types';
 import { isValidDate } from '../util/isDate';

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { async } from '../scheduler/async';
 import { isValidDate } from '../util/isDate';
 import { ObservableInput, OperatorFunction, SchedulerLike } from '../types';

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
 import { Subject } from '../Subject';

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subject } from '../Subject';
 import { asyncScheduler } from '../scheduler/async';
 import { Observable } from '../Observable';

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscriber } from '../Subscriber';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction, ObservableInputTuple } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';

--- a/src/internal/operators/zipAll.ts
+++ b/src/internal/operators/zipAll.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { OperatorFunction, ObservableInput } from '../types';
 import { zip } from '../observable/zip';
 import { joinAllInternals } from './joinAllInternals';

--- a/src/internal/operators/zipWith.ts
+++ b/src/internal/operators/zipWith.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { zip as zipStatic } from '../observable/zip';
 import { ObservableInput, ObservableInputTuple, OperatorFunction, Cons } from '../types';
 import { operate } from '../util/lift';

--- a/src/internal/scheduled/scheduleArray.ts
+++ b/src/internal/scheduled/scheduleArray.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 

--- a/src/internal/scheduled/scheduleIterable.ts
+++ b/src/internal/scheduled/scheduleIterable.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { iterator as Symbol_iterator } from '../symbol/iterator';

--- a/src/internal/scheduled/schedulePromise.ts
+++ b/src/internal/scheduled/schedulePromise.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 

--- a/src/internal/scheduled/scheduled.ts
+++ b/src/internal/scheduled/scheduled.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { scheduleObservable } from './scheduleObservable';
 import { schedulePromise } from './schedulePromise';
 import { scheduleArray } from './scheduleArray';

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Action } from './Action';
 import { SchedulerAction } from '../types';
 import { Subscription } from '../Subscription';

--- a/src/internal/scheduler/animationFrameProvider.ts
+++ b/src/internal/scheduler/animationFrameProvider.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Subscription } from '../Subscription';
 
 interface AnimationFrameProvider {

--- a/src/internal/scheduler/dateTimestampProvider.ts
+++ b/src/internal/scheduler/dateTimestampProvider.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { TimestampProvider } from '../types';
 
 interface DateTimestampProvider extends TimestampProvider {

--- a/src/internal/scheduler/immediateProvider.ts
+++ b/src/internal/scheduler/immediateProvider.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Immediate } from '../util/Immediate';
 const { setImmediate, clearImmediate } = Immediate;
 

--- a/src/internal/scheduler/intervalProvider.ts
+++ b/src/internal/scheduler/intervalProvider.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 type SetIntervalFunction = (handler: () => void, timeout?: number, ...args: any[]) => number;
 type ClearIntervalFunction = (handle: number) => void;
 

--- a/src/internal/scheduler/performanceTimestampProvider.ts
+++ b/src/internal/scheduler/performanceTimestampProvider.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { TimestampProvider } from '../types';
 
 interface PerformanceTimestampProvider extends TimestampProvider {

--- a/src/internal/scheduler/timeoutProvider.ts
+++ b/src/internal/scheduler/timeoutProvider.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 type SetTimeoutFunction = (handler: () => void, timeout?: number, ...args: any[]) => number;
 type ClearTimeoutFunction = (handle: number) => void;
 

--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,4 +1,2 @@
-/** @prettier */
-
 /** Symbol.observable or a string "@@observable". Used for interop */
 export const observable = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { ColdObservable } from './ColdObservable';
 import { HotObservable } from './HotObservable';

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 // https://github.com/microsoft/TypeScript/issues/40462#issuecomment-689879308
 /// <reference lib="esnext.asynciterable" />
 

--- a/src/internal/util/ArgumentOutOfRangeError.ts
+++ b/src/internal/util/ArgumentOutOfRangeError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { createErrorClass } from './createErrorClass';
 
 export interface ArgumentOutOfRangeError extends Error {}

--- a/src/internal/util/NotFoundError.ts
+++ b/src/internal/util/NotFoundError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { createErrorClass } from './createErrorClass';
 
 export interface NotFoundError extends Error {}

--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { createErrorClass } from './createErrorClass';
 
 export interface ObjectUnsubscribedError extends Error {}

--- a/src/internal/util/SequenceError.ts
+++ b/src/internal/util/SequenceError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { createErrorClass } from './createErrorClass';
 
 export interface SequenceError extends Error {}

--- a/src/internal/util/UnsubscriptionError.ts
+++ b/src/internal/util/UnsubscriptionError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { createErrorClass } from './createErrorClass';
 
 export interface UnsubscriptionError extends Error {

--- a/src/internal/util/args.ts
+++ b/src/internal/util/args.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { SchedulerLike } from '../types';
 import { isFunction } from './isFunction';
 import { isScheduler } from './isScheduler';

--- a/src/internal/util/argsArgArrayOrObject.ts
+++ b/src/internal/util/argsArgArrayOrObject.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 const { isArray } = Array;
 const { getPrototypeOf, prototype: objectProto, keys: getKeys } = Object;
 

--- a/src/internal/util/argsOrArgArray.ts
+++ b/src/internal/util/argsOrArgArray.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 const { isArray } = Array;
 
 /**

--- a/src/internal/util/arrRemove.ts
+++ b/src/internal/util/arrRemove.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 /**
  * Removes an item from an array, mutating it.
  * @param arr The array to remove the item from

--- a/src/internal/util/caughtSchedule.ts
+++ b/src/internal/util/caughtSchedule.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { SchedulerAction, SchedulerLike } from '../types';

--- a/src/internal/util/createErrorClass.ts
+++ b/src/internal/util/createErrorClass.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 /**
  * Used to create Error subclasses until the community moves away from ES5.
  *

--- a/src/internal/util/isAsyncIterable.ts
+++ b/src/internal/util/isAsyncIterable.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { isFunction } from './isFunction';
 
 export function isAsyncIterable<T>(obj: any): obj is AsyncIterable<T> {

--- a/src/internal/util/isFunction.ts
+++ b/src/internal/util/isFunction.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 /**
  * Returns true if the object is a function.
  * @param value The value to check

--- a/src/internal/util/isObservable.ts
+++ b/src/internal/util/isObservable.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { isFunction } from './isFunction';
 

--- a/src/internal/util/lift.ts
+++ b/src/internal/util/lift.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction } from '../types';

--- a/src/internal/util/reportUnhandledError.ts
+++ b/src/internal/util/reportUnhandledError.ts
@@ -1,4 +1,3 @@
-/** @prettier */
 import { config } from '../config';
 import { timeoutProvider } from '../scheduler/timeoutProvider';
 

--- a/src/internal/util/throwUnobservableError.ts
+++ b/src/internal/util/throwUnobservableError.ts
@@ -1,5 +1,3 @@
-/** @prettier */
-
 /**
  * Creates the TypeError to throw if an invalid object is passed to `from` or `scheduled`.
  * @param input The object that was passed.


### PR DESCRIPTION
Basically, just changes the configuration to make sure that prettier is always run against `src/` files, but not run against test files unless they have the pragma (until we get run mode applied on all of the tests).

The goal here was to remove the `/** @prettier */` pragma from the `src/` files.

Resolves #5982
