### PR TITLE
Correct Progression Syntax example in the Marble Testing section

### DIFF
--- a/docs_app/content/guide/testing/marble-testing.md
+++ b/docs_app/content/guide/testing/marble-testing.md
@@ -145,7 +145,7 @@ expectObservable(result).toBe(expected);
 
 `'-----(a|)'`: on frame 5 emit `a` and `complete`.
 
-`'a 9ms b 9s c|'`: on frame 0 emit `a`, on frame 10 emit `b`, on frame 10,012 emit `c`, then on on frame 10,013 `complete`.
+`'a 9ms b 9s c|'`: on frame 0 emit `a`, on frame 10 emit `b`, on frame 9,011 emit `c`, then on on frame 9,012 `complete`.
 
 `'--a 2.5m b'`: on frame 2 emit `a`, on frame 150,003 emit `b` and never complete.
 


### PR DESCRIPTION
## Correct Time progression syntax example

**Description:**
In the Time Progression Syntax section under Marble Testing, one of the examples's description is incorrect. Please see the example and the updated description below:

**Current**: `'a 9ms b 9s c|'`: on frame 0 emit a, on frame 10 emit b, on frame 10,012 emit c, then on on frame 10,013 complete.
**Updated**: `'a 9ms b 9s c|'`: on frame 0 emit a, on frame 10 emit b, on frame **9,011** emit c, then on on frame **9,012** complete.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/5977