### PR TITLE
fix: reorder overloads so typescript doesn't prefer deprecations

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -69,13 +69,13 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   subscribe(observer?: Partial<Observer<T>>): Subscription;
+  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
   /** @deprecated Use an observer instead of a complete callback */
   subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
   /** @deprecated Use an observer instead of an error callback */
   subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
   /** @deprecated Use an observer instead of a complete callback */
   subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
-  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
   /**
    * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.
    *

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -349,16 +349,9 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /* tslint:disable:max-line-length */
-  pipe(...operations: OperatorFunction<T, T>[]): Observable<T>;
-  pipe<A>(
-    op1: OperatorFunction<T, A>,
-    ...operations: OperatorFunction<A, A>[]
-  ): Observable<A>;
-  pipe<A, B>(
-    op1: OperatorFunction<T, A>,
-    op2: OperatorFunction<A, B>,
-    ...operations: OperatorFunction<B, B>[]
-  ): Observable<B>;
+  pipe(): Observable<T>;
+  pipe<A>(op1: OperatorFunction<T, A>, ...operations: OperatorFunction<A, A>[]): Observable<A>;
+  pipe<A, B>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, ...operations: OperatorFunction<B, B>[]): Observable<B>;
   pipe<A, B, C>(
     op1: OperatorFunction<T, A>,
     op2: OperatorFunction<A, B>,
@@ -423,6 +416,7 @@ export class Observable<T> implements Subscribable<T> {
     ...operations: OperatorFunction<I, I>[]
   ): Observable<I>;
 
+  pipe(...operations: OperatorFunction<T, T>[]): Observable<T>;
   pipe(...operations: OperatorFunction<any, any>[]): Observable<unknown>;
 
   /* tslint:enable:max-line-length */

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -70,12 +70,17 @@ export class Observable<T> implements Subscribable<T> {
 
   subscribe(observer?: Partial<Observer<T>>): Subscription;
   subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
+
   /** @deprecated Use an observer instead of a complete callback */
   subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
   /** @deprecated Use an observer instead of an error callback */
   subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
   /** @deprecated Use an observer instead of a complete callback */
   subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
+
+  // This is intentionally duplicated
+  // because TS resolves to the last overload of a function when doing `typeof` on it
+  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
   /**
    * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.
    *

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -414,10 +414,13 @@ export class Observable<T> implements Subscribable<T> {
     op7: OperatorFunction<F, G>,
     op8: OperatorFunction<G, H>,
     op9: OperatorFunction<H, I>,
-    ...operations: OperatorFunction<any, any>[]
-  ): Observable<unknown>;
-  /* tslint:enable:max-line-length */
+    ...operations: OperatorFunction<I, I>[]
+  ): Observable<I>;
 
+  pipe<T>(...operations: OperatorFunction<T, T>[]): Observable<T>;
+  pipe(...operations: OperatorFunction<any, any>[]): Observable<unknown>;
+
+  /* tslint:enable:max-line-length */
   /**
    * Used to stitch together functional operators into a chain.
    * @method pipe

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -349,22 +349,36 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /* tslint:disable:max-line-length */
-  pipe(): Observable<T>;
-  pipe<A>(op1: OperatorFunction<T, A>): Observable<A>;
-  pipe<A, B>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>): Observable<B>;
-  pipe<A, B, C>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>): Observable<C>;
+  pipe(...operations: OperatorFunction<T, T>[]): Observable<T>;
+  pipe<A>(
+    op1: OperatorFunction<T, A>,
+    ...operations: OperatorFunction<A, A>[]
+  ): Observable<A>;
+  pipe<A, B>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    ...operations: OperatorFunction<B, B>[]
+  ): Observable<B>;
+  pipe<A, B, C>(
+    op1: OperatorFunction<T, A>,
+    op2: OperatorFunction<A, B>,
+    op3: OperatorFunction<B, C>,
+    ...operations: OperatorFunction<C, C>[]
+  ): Observable<C>;
   pipe<A, B, C, D>(
     op1: OperatorFunction<T, A>,
     op2: OperatorFunction<A, B>,
     op3: OperatorFunction<B, C>,
-    op4: OperatorFunction<C, D>
+    op4: OperatorFunction<C, D>,
+    ...operations: OperatorFunction<D, D>[]
   ): Observable<D>;
   pipe<A, B, C, D, E>(
     op1: OperatorFunction<T, A>,
     op2: OperatorFunction<A, B>,
     op3: OperatorFunction<B, C>,
     op4: OperatorFunction<C, D>,
-    op5: OperatorFunction<D, E>
+    op5: OperatorFunction<D, E>,
+    ...operations: OperatorFunction<E, E>[]
   ): Observable<E>;
   pipe<A, B, C, D, E, F>(
     op1: OperatorFunction<T, A>,
@@ -372,7 +386,8 @@ export class Observable<T> implements Subscribable<T> {
     op3: OperatorFunction<B, C>,
     op4: OperatorFunction<C, D>,
     op5: OperatorFunction<D, E>,
-    op6: OperatorFunction<E, F>
+    op6: OperatorFunction<E, F>,
+    ...operations: OperatorFunction<F, F>[]
   ): Observable<F>;
   pipe<A, B, C, D, E, F, G>(
     op1: OperatorFunction<T, A>,
@@ -381,7 +396,8 @@ export class Observable<T> implements Subscribable<T> {
     op4: OperatorFunction<C, D>,
     op5: OperatorFunction<D, E>,
     op6: OperatorFunction<E, F>,
-    op7: OperatorFunction<F, G>
+    op7: OperatorFunction<F, G>,
+    ...operations: OperatorFunction<G, G>[]
   ): Observable<G>;
   pipe<A, B, C, D, E, F, G, H>(
     op1: OperatorFunction<T, A>,
@@ -391,19 +407,9 @@ export class Observable<T> implements Subscribable<T> {
     op5: OperatorFunction<D, E>,
     op6: OperatorFunction<E, F>,
     op7: OperatorFunction<F, G>,
-    op8: OperatorFunction<G, H>
-  ): Observable<H>;
-  pipe<A, B, C, D, E, F, G, H, I>(
-    op1: OperatorFunction<T, A>,
-    op2: OperatorFunction<A, B>,
-    op3: OperatorFunction<B, C>,
-    op4: OperatorFunction<C, D>,
-    op5: OperatorFunction<D, E>,
-    op6: OperatorFunction<E, F>,
-    op7: OperatorFunction<F, G>,
     op8: OperatorFunction<G, H>,
-    op9: OperatorFunction<H, I>
-  ): Observable<I>;
+    ...operations: OperatorFunction<H, H>[]
+  ): Observable<H>;
   pipe<A, B, C, D, E, F, G, H, I>(
     op1: OperatorFunction<T, A>,
     op2: OperatorFunction<A, B>,
@@ -417,7 +423,6 @@ export class Observable<T> implements Subscribable<T> {
     ...operations: OperatorFunction<I, I>[]
   ): Observable<I>;
 
-  pipe<T>(...operations: OperatorFunction<T, T>[]): Observable<T>;
   pipe(...operations: OperatorFunction<any, any>[]): Observable<unknown>;
 
   /* tslint:enable:max-line-length */

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -2,12 +2,12 @@ import { SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { bindCallbackInternals } from './bindCallbackInternals';
 
+// args is the arguments array and we push the callback on the rest tuple since the rest parameter must be last (only item) in a parameter list
+export function bindCallback<A extends readonly unknown[], R extends readonly unknown[]>(callbackFunc: (...args: [...A, (...res: R) => void]) => void, schedulerLike?: SchedulerLike): (...arg: A) => Observable<R extends [] ? void : R extends [any] ? R[0] : R>;
+
 // tslint:disable:max-line-length
 /** @deprecated resultSelector is no longer supported, use a mapping function. */
 export function bindCallback(callbackFunc: (...args: any[]) => void, resultSelector: (...args: any[]) => any, scheduler?: SchedulerLike): (...args: any[]) => Observable<any>;
-
-// args is the arguments array and we push the callback on the rest tuple since the rest parameter must be last (only item) in a parameter list
-export function bindCallback<A extends readonly unknown[], R extends readonly unknown[]>(callbackFunc: (...args: [...A, (...res: R) => void]) => void, schedulerLike?: SchedulerLike): (...arg: A) => Observable<R extends [] ? void : R extends [any] ? R[0] : R>;
 
 // tslint:enable:max-line-length
 

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -2,18 +2,18 @@ import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { bindCallbackInternals } from './bindCallbackInternals';
 
+// args is the arguments array and we push the callback on the rest tuple since the rest parameter must be last (only item) in a parameter list
+export function bindNodeCallback<A extends readonly unknown[], R extends readonly unknown[]>(
+  callbackFunc: (...args: [...A, (err: any, ...res: R) => void]) => void,
+  schedulerLike?: SchedulerLike
+): (...arg: A) => Observable<R extends [] ? void : R extends [any] ? R[0] : R>;
+
 /** @deprecated resultSelector is deprecated, pipe to map instead */
 export function bindNodeCallback(
   callbackFunc: (...args: any[]) => void,
   resultSelector: (...args: any[]) => any,
   scheduler?: SchedulerLike
 ): (...args: any[]) => Observable<any>;
-
-// args is the arguments array and we push the callback on the rest tuple since the rest parameter must be last (only item) in a parameter list
-export function bindNodeCallback<A extends readonly unknown[], R extends readonly unknown[]>(
-  callbackFunc: (...args: [...A, (err: any, ...res: R) => void]) => void,
-  schedulerLike?: SchedulerLike
-): (...arg: A) => Observable<R extends [] ? void : R extends [any] ? R[0] : R>;
 
 /**
  * Converts a Node.js-style callback API to a function that returns an

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -9,10 +9,6 @@ import { popResultSelector } from '../util/args';
 export function forkJoin(sources: readonly []): Observable<never>;
 export function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 
-// forkJoin({a, b, c})
-export function forkJoin(sourcesObject: { [K in any]: never }): Observable<never>;
-export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
-
 /** @deprecated resultSelector is deprecated, pipe to map instead */
 export function forkJoin<A extends readonly unknown[], R>(
   sources: readonly [...ObservableInputTuple<A>],
@@ -26,6 +22,10 @@ export function forkJoin<A extends readonly unknown[]>(...sources: [...Observabl
 export function forkJoin<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;
+
+// forkJoin({a, b, c})
+export function forkJoin(sourcesObject: { [K in any]: never }): Observable<never>;
+export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /**
  * Accepts an `Array` of {@link ObservableInput} or a dictionary `Object` of {@link ObservableInput} and returns

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -8,6 +8,11 @@ import { popResultSelector } from '../util/args';
 // forkJoin([a, b, c])
 export function forkJoin(sources: readonly []): Observable<never>;
 export function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+
+// forkJoin({a, b, c})
+export function forkJoin(sourcesObject: { [K in any]: never }): Observable<never>;
+export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+
 /** @deprecated resultSelector is deprecated, pipe to map instead */
 export function forkJoin<A extends readonly unknown[], R>(
   sources: readonly [...ObservableInputTuple<A>],
@@ -21,10 +26,6 @@ export function forkJoin<A extends readonly unknown[]>(...sources: [...Observabl
 export function forkJoin<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;
-
-// forkJoin({a, b, c})
-export function forkJoin(sourcesObject: { [K in any]: never }): Observable<never>;
-export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /**
  * Accepts an `Array` of {@link ObservableInput} or a dictionary `Object` of {@link ObservableInput} and returns

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -69,9 +69,9 @@ export interface AddEventListenerOptions extends EventListenerOptions {
 }
 
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
+export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options?: EventListenerOptions): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, resultSelector?: (...args: any[]) => T): Observable<T>;
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options?: EventListenerOptions): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEvent<T>(
   target: FromEventTarget<T>,

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -42,6 +42,91 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  * Generates an observable sequence by running a state-driven loop
  * producing the sequence's elements, using the specified scheduler
  * to send out observer messages.
+ * The overload accepts options object that might contain initial state, iterate,
+ * condition and scheduler.
+ *
+ * ![](generate.png)
+ *
+ * ## Examples
+ *
+ * ### Use options object with condition function
+ *
+ * ```ts
+ * import { generate } from 'rxjs';
+ *
+ * const result = generate({
+ *   initialState: 0,
+ *   condition: x => x < 3,
+ *   iterate: x => x + 1,
+ * });
+ *
+ * result.subscribe({
+ *   next: value => console.log(value),
+ *   complete: () => console.log('complete!')
+ * });
+ *
+ * // Logs:
+ * // 0
+ * // 1
+ * // 2
+ * // "Complete!".
+ * ```
+ *
+ * @see {@link from}
+ * @see {@link Observable}
+ *
+ * @param {GenerateBaseOptions<S>} options Object that must contain initialState, iterate and might contain condition and scheduler.
+ * @returns {Observable<S>} The generated sequence.
+ */
+export function generate<S>(options: GenerateBaseOptions<S>): Observable<S>;
+
+/**
+ * Generates an observable sequence by running a state-driven loop
+ * producing the sequence's elements, using the specified scheduler
+ * to send out observer messages.
+ * The overload accepts options object that might contain initial state, iterate,
+ * condition, result selector and scheduler.
+ *
+ * ![](generate.png)
+ *
+ * ## Examples
+ *
+ * ### Use options object with condition and iterate function
+ *
+ * ```ts
+ * import { generate } from 'rxjs';
+ *
+ * const result = generate({
+ *   initialState: 0,
+ *   condition: x => x < 3,
+ *   iterate: x => x + 1,
+ *   resultSelector: x => x,
+ * });
+ *
+ * result.subscribe({
+ *   next: value => console.log(value),
+ *   complete: () => console.log('complete!')
+ * });
+ *
+ * // Logs:
+ * // 0
+ * // 1
+ * // 2
+ * // "Complete!".
+ * ```
+ *
+ * @see {@link from}
+ * @see {@link Observable}
+ *
+ * @param {GenerateOptions<T, S>} options Object that must contain initialState, iterate, resultSelector and might contain condition and scheduler.
+ * @returns {Observable<T>} The generated sequence.
+ */
+export function generate<T, S>(options: GenerateOptions<T, S>): Observable<T>;
+
+/**
+ * Generates an observable sequence by running a state-driven loop
+ * producing the sequence's elements, using the specified scheduler
+ * to send out observer messages.
  *
  * ![](generate.png)
  *
@@ -245,91 +330,6 @@ export function generate<S>(
   iterate: IterateFunc<S>,
   scheduler?: SchedulerLike
 ): Observable<S>;
-
-/**
- * Generates an observable sequence by running a state-driven loop
- * producing the sequence's elements, using the specified scheduler
- * to send out observer messages.
- * The overload accepts options object that might contain initial state, iterate,
- * condition and scheduler.
- *
- * ![](generate.png)
- *
- * ## Examples
- *
- * ### Use options object with condition function
- *
- * ```ts
- * import { generate } from 'rxjs';
- *
- * const result = generate({
- *   initialState: 0,
- *   condition: x => x < 3,
- *   iterate: x => x + 1,
- * });
- *
- * result.subscribe({
- *   next: value => console.log(value),
- *   complete: () => console.log('complete!')
- * });
- *
- * // Logs:
- * // 0
- * // 1
- * // 2
- * // "Complete!".
- * ```
- *
- * @see {@link from}
- * @see {@link Observable}
- *
- * @param {GenerateBaseOptions<S>} options Object that must contain initialState, iterate and might contain condition and scheduler.
- * @returns {Observable<S>} The generated sequence.
- */
-export function generate<S>(options: GenerateBaseOptions<S>): Observable<S>;
-
-/**
- * Generates an observable sequence by running a state-driven loop
- * producing the sequence's elements, using the specified scheduler
- * to send out observer messages.
- * The overload accepts options object that might contain initial state, iterate,
- * condition, result selector and scheduler.
- *
- * ![](generate.png)
- *
- * ## Examples
- *
- * ### Use options object with condition and iterate function
- *
- * ```ts
- * import { generate } from 'rxjs';
- *
- * const result = generate({
- *   initialState: 0,
- *   condition: x => x < 3,
- *   iterate: x => x + 1,
- *   resultSelector: x => x,
- * });
- *
- * result.subscribe({
- *   next: value => console.log(value),
- *   complete: () => console.log('complete!')
- * });
- *
- * // Logs:
- * // 0
- * // 1
- * // 2
- * // "Complete!".
- * ```
- *
- * @see {@link from}
- * @see {@link Observable}
- *
- * @param {GenerateOptions<T, S>} options Object that must contain initialState, iterate, resultSelector and might contain condition and scheduler.
- * @returns {Observable<T>} The generated sequence.
- */
-export function generate<T, S>(options: GenerateOptions<T, S>): Observable<T>;
 
 export function generate<T, S>(
   initialStateOrOptions: S | GenerateOptions<T, S>,

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -4,6 +4,10 @@ import { Observable } from '../Observable';
 import { scheduleArray } from '../scheduled/scheduleArray';
 import { popScheduler } from '../util/args';
 
+export function of(): Observable<never>;
+export function of<T>(value: T): Observable<T>;
+export function of<A extends readonly unknown[]>(...args: A): Observable<ValueFromArray<A>>;
+
 /** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function of(scheduler: SchedulerLike): Observable<never>;
 /** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
@@ -63,11 +67,8 @@ export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(
   scheduler: SchedulerLike
 ): Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
 
-export function of(): Observable<never>;
 /** @deprecated remove in v8. Do not use generic arguments directly, allow inference or cast with `as` */
 export function of<T>(): Observable<T>;
-export function of<T>(value: T): Observable<T>;
-export function of<A extends readonly unknown[]>(...args: A): Observable<ValueFromArray<A>>;
 
 /**
  * Converts the arguments to an observable sequence.

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -6,7 +6,6 @@ import { popScheduler } from '../util/args';
 
 export function of(): Observable<never>;
 export function of<T>(value: T): Observable<T>;
-export function of<A extends readonly unknown[]>(...args: A): Observable<ValueFromArray<A>>;
 
 /** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function of(scheduler: SchedulerLike): Observable<never>;
@@ -69,6 +68,8 @@ export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(
 
 /** @deprecated remove in v8. Do not use generic arguments directly, allow inference or cast with `as` */
 export function of<T>(): Observable<T>;
+
+export function of<A extends readonly unknown[]>(...args: A): Observable<ValueFromArray<A>>;
 
 /**
  * Converts the arguments to an observable sequence.

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -7,12 +7,13 @@ import { OperatorSubscriber } from '../operators/OperatorSubscriber';
 import { popResultSelector } from '../util/args';
 
 export function zip<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
+export function zip<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
+
 /** @deprecated resultSelector is no longer supported, pipe to map instead */
 export function zip<A extends readonly unknown[], R>(
   sources: [...ObservableInputTuple<A>],
   resultSelector: (...values: A) => R
 ): Observable<R>;
-export function zip<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
 /** @deprecated resultSelector is no longer supported, pipe to map instead */
 export function zip<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -3,6 +3,8 @@ import { concat } from '../observable/concat';
 import { of } from '../observable/of';
 import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction, ValueFromArray } from '../types';
 
+export function endWith<T, A extends any[] = T[]>(...args: A): OperatorFunction<T, T | ValueFromArray<A>>;
+
 /* tslint:disable:max-line-length */
 /** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function endWith<T>(scheduler: SchedulerLike): MonoTypeOperatorFunction<T>;
@@ -18,8 +20,6 @@ export function endWith<T, A, B, C, D>(v1: A, v2: B, v3: C, v4: D, scheduler: Sc
 export function endWith<T, A, B, C, D, E>(v1: A, v2: B, v3: C, v4: D, v5: E, scheduler: SchedulerLike): OperatorFunction<T, T | A | B | C | D | E>;
 /** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function endWith<T, A, B, C, D, E, F>(v1: A, v2: B, v3: C, v4: D, v5: E, v6: F, scheduler: SchedulerLike): OperatorFunction<T, T | A | B | C | D | E | F>;
-
-export function endWith<T, A extends any[] = T[]>(...args: A): OperatorFunction<T, T | ValueFromArray<A>>;
 
 /* tslint:enable:max-line-length */
 

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -4,7 +4,8 @@ import { popScheduler } from '../util/args';
 import { operate } from '../util/lift';
 
 export function startWith<T>(value: T): OperatorFunction<T, T>;
-export function startWith<T, A extends any[] = T[]>(...values: A): OperatorFunction<T, ValueFromArray<A>>;
+export function startWith<T, A extends T[]>(...values: A): OperatorFunction<T, ValueFromArray<A>>;
+export function startWith<T, A extends any[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>>;
 
 /* tslint:disable:max-line-length */
 /** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -3,6 +3,9 @@ import { MonoTypeOperatorFunction, OperatorFunction, SchedulerLike, ValueFromArr
 import { popScheduler } from '../util/args';
 import { operate } from '../util/lift';
 
+export function startWith<T>(value: T): OperatorFunction<T, T>;
+export function startWith<T, A extends any[] = T[]>(...values: A): OperatorFunction<T, ValueFromArray<A>>;
+
 /* tslint:disable:max-line-length */
 /** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function startWith<T>(scheduler: SchedulerLike): MonoTypeOperatorFunction<T>;
@@ -33,8 +36,6 @@ export function startWith<T, D, E, F, G, H, I>(
   v6: I,
   scheduler: SchedulerLike
 ): OperatorFunction<T, T | D | E | F | G | H | I>;
-
-export function startWith<T, A extends any[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>>;
 
 /**
  * Returns an observable that, at the moment of subscription, will synchronously emit all

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -4,6 +4,9 @@ import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 
+export function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
+
 /* tslint:disable:max-line-length */
 /** @deprecated Use an observer instead of a complete callback */
 export function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
@@ -11,8 +14,6 @@ export function tap<T>(next: null | undefined, error: null | undefined, complete
 export function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 /** @deprecated Use an observer instead of a complete callback */
 export function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-export function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -2,6 +2,7 @@ import { identity } from './identity';
 import { UnaryFunction } from '../types';
 
 /* tslint:disable:max-line-length */
+export function pipe(): typeof identity;
 export function pipe<T>(...fns: UnaryFunction<T, T>[]): UnaryFunction<T, T>;
 export function pipe<T, A>(fn1: UnaryFunction<T, A>, ...fns: UnaryFunction<A, A>[]): UnaryFunction<T, A>;
 export function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, ...fns: UnaryFunction<B, B>[]): UnaryFunction<T, B>;

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -6,14 +6,70 @@ export function pipe(): typeof identity;
 export function pipe<T>(...fns: UnaryFunction<T, T>[]): UnaryFunction<T, T>;
 export function pipe<T, A>(fn1: UnaryFunction<T, A>, ...fns: UnaryFunction<A, A>[]): UnaryFunction<T, A>;
 export function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, ...fns: UnaryFunction<B, B>[]): UnaryFunction<T, B>;
-export function pipe<T, A, B, C>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, ...fns: UnaryFunction<C, C>[]): UnaryFunction<T, C>;
-export function pipe<T, A, B, C, D>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, ...fns: UnaryFunction<D, D>[]): UnaryFunction<T, D>;
-export function pipe<T, A, B, C, D, E>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, ...fns: UnaryFunction<E, E>[]): UnaryFunction<T, E>;
-export function pipe<T, A, B, C, D, E, F>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, ...fns: UnaryFunction<F, F>[]): UnaryFunction<T, F>;
-export function pipe<T, A, B, C, D, E, F, G>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, ...fns: UnaryFunction<G, G>[]): UnaryFunction<T, G>;
-export function pipe<T, A, B, C, D, E, F, G, H>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, ...fns: UnaryFunction<H, H>[]): UnaryFunction<T, H>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, fn9: UnaryFunction<H, I>, ...fns: UnaryFunction<I, I>[]): UnaryFunction<T, I>;
-export function pipe<T>(...fns: UnaryFunction<any, any>[]): UnaryFunction<T, unknown>;
+export function pipe<T, A, B, C>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  ...fns: UnaryFunction<C, C>[]
+): UnaryFunction<T, C>;
+export function pipe<T, A, B, C, D>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  ...fns: UnaryFunction<D, D>[]
+): UnaryFunction<T, D>;
+export function pipe<T, A, B, C, D, E>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  ...fns: UnaryFunction<E, E>[]
+): UnaryFunction<T, E>;
+export function pipe<T, A, B, C, D, E, F>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  ...fns: UnaryFunction<F, F>[]
+): UnaryFunction<T, F>;
+export function pipe<T, A, B, C, D, E, F, G>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  fn7: UnaryFunction<F, G>,
+  ...fns: UnaryFunction<G, G>[]
+): UnaryFunction<T, G>;
+export function pipe<T, A, B, C, D, E, F, G, H>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  fn7: UnaryFunction<F, G>,
+  fn8: UnaryFunction<G, H>,
+  ...fns: UnaryFunction<H, H>[]
+): UnaryFunction<T, H>;
+export function pipe<T, A, B, C, D, E, F, G, H, I>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  fn7: UnaryFunction<F, G>,
+  fn8: UnaryFunction<G, H>,
+  fn9: UnaryFunction<H, I>,
+  ...fns: UnaryFunction<I, I>[]
+): UnaryFunction<T, I>;
+export function pipe(...fns: UnaryFunction<any, any>[]): UnaryFunction<any, unknown>;
 /* tslint:enable:max-line-length */
 
 export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any, any> {

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -3,7 +3,6 @@ import { UnaryFunction } from '../types';
 
 /* tslint:disable:max-line-length */
 export function pipe(): typeof identity;
-export function pipe<T>(...fns: UnaryFunction<T, T>[]): UnaryFunction<T, T>;
 export function pipe<T, A>(fn1: UnaryFunction<T, A>, ...fns: UnaryFunction<A, A>[]): UnaryFunction<T, A>;
 export function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, ...fns: UnaryFunction<B, B>[]): UnaryFunction<T, B>;
 export function pipe<T, A, B, C>(
@@ -69,6 +68,7 @@ export function pipe<T, A, B, C, D, E, F, G, H, I>(
   fn9: UnaryFunction<H, I>,
   ...fns: UnaryFunction<I, I>[]
 ): UnaryFunction<T, I>;
+export function pipe<T>(...fns: UnaryFunction<T, T>[]): UnaryFunction<T, T>;
 export function pipe(...fns: UnaryFunction<any, any>[]): UnaryFunction<any, unknown>;
 /* tslint:enable:max-line-length */
 

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -2,17 +2,17 @@ import { identity } from './identity';
 import { UnaryFunction } from '../types';
 
 /* tslint:disable:max-line-length */
-export function pipe<T>(): UnaryFunction<T, T>;
-export function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;
-export function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>): UnaryFunction<T, B>;
-export function pipe<T, A, B, C>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>): UnaryFunction<T, C>;
-export function pipe<T, A, B, C, D>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>): UnaryFunction<T, D>;
-export function pipe<T, A, B, C, D, E>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>): UnaryFunction<T, E>;
-export function pipe<T, A, B, C, D, E, F>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>): UnaryFunction<T, F>;
-export function pipe<T, A, B, C, D, E, F, G>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>): UnaryFunction<T, G>;
-export function pipe<T, A, B, C, D, E, F, G, H>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>): UnaryFunction<T, H>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, fn9: UnaryFunction<H, I>): UnaryFunction<T, I>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, fn9: UnaryFunction<H, I>, ...fns: UnaryFunction<any, any>[]): UnaryFunction<T, {}>;
+export function pipe<T>(...fns: UnaryFunction<T, T>[]): UnaryFunction<T, T>;
+export function pipe<T, A>(fn1: UnaryFunction<T, A>, ...fns: UnaryFunction<A, A>[]): UnaryFunction<T, A>;
+export function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, ...fns: UnaryFunction<B, B>[]): UnaryFunction<T, B>;
+export function pipe<T, A, B, C>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, ...fns: UnaryFunction<C, C>[]): UnaryFunction<T, C>;
+export function pipe<T, A, B, C, D>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, ...fns: UnaryFunction<D, D>[]): UnaryFunction<T, D>;
+export function pipe<T, A, B, C, D, E>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, ...fns: UnaryFunction<E, E>[]): UnaryFunction<T, E>;
+export function pipe<T, A, B, C, D, E, F>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, ...fns: UnaryFunction<F, F>[]): UnaryFunction<T, F>;
+export function pipe<T, A, B, C, D, E, F, G>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, ...fns: UnaryFunction<G, G>[]): UnaryFunction<T, G>;
+export function pipe<T, A, B, C, D, E, F, G, H>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, ...fns: UnaryFunction<H, H>[]): UnaryFunction<T, H>;
+export function pipe<T, A, B, C, D, E, F, G, H, I>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, fn9: UnaryFunction<H, I>, ...fns: UnaryFunction<I, I>[]): UnaryFunction<T, I>;
+export function pipe<T>(...fns: UnaryFunction<any, any>[]): UnaryFunction<T, unknown>;
 /* tslint:enable:max-line-length */
 
 export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any, any> {


### PR DESCRIPTION
**Description:**
This is mostly a reordering of overloads, which moves deprecated overloads to the bottom, which in turn makes TS evaluate them last and solves most "false-positives" for usages of deprecated overloads.

As a bonus, this PR also solves inability of `pipe` and some other functions to accept unrestricted amounts of arguments, while maintaining the type integrity.
As a cost for this, however, the `pipe` function does not explicitly error on incorrect operator type chains and simply defaults to `Observable<unknown>`.

All current unit tests pass.

However, some tests actively use deprecated functions, and I don't know if its intentional or not, so I didn't take the courage of rewriting those (specifically, the `forkJoin` ones that use deprecated "...spread" overloads) and adjusted overloads accordingly.


**Related issue (if exists):**
fixes #5064, fixes #5966, fixes #5557, fixes #4177, fixes #3989, and many, many more.

Most discussions in related issues have become stale or full of workarounds instead of solutions, so this PR aims to resolve a bunch of them at once.
