### PR TITLE
test: add empty-sources-array test for zip

### DIFF
--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -380,7 +380,7 @@ describe('forkJoin', () => {
       });
     });
 
-    it('should accept array of observables', () => {
+    it('should accept an object of observables', () => {
       rxTestScheduler.run(({ hot, expectObservable }) => {
         const e1 = forkJoin({
           foo: hot('      --a--b--c--d--|'),

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -541,5 +541,19 @@ describe('static zip', () => {
       ['c','3','z'],
       'complete'
     ]);
-  })
+  });
+
+  it('should return EMPTY if passed an empty array as the only argument', () => {
+    const results: string[] = [];
+    zip([]).subscribe({
+      next: () => {
+        throw new Error('should not emit')
+      },
+      complete: () => {
+        results.push('done');
+      }
+    });
+
+    expect(results).to.deep.equal(['done']);
+  });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a test for `zip` that's similar to the one that was added for `combineLatest` in #5963.

**Related <s>issue</s> PR:** #5963