### PR TITLE
feat(ajax): Add option for streaming progress

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -6,6 +6,8 @@ export interface AjaxConfig {
     createXHR?: () => XMLHttpRequest;
     crossDomain?: boolean;
     headers?: Readonly<Record<string, any>>;
+    includeDownloadProgress?: boolean;
+    includeUploadProgress?: boolean;
     method?: string;
     password?: string;
     progressSubscriber?: PartialObserver<ProgressEvent>;
@@ -43,13 +45,20 @@ export interface AjaxRequest {
 }
 
 export declare class AjaxResponse<T> {
-    readonly originalEvent: Event;
+    readonly loaded: number;
+    readonly originalEvent: ProgressEvent;
     readonly request: AjaxRequest;
     readonly response: T;
     readonly responseType: XMLHttpRequestResponseType;
     readonly status: number;
+    readonly total: number;
+    readonly type: string;
     readonly xhr: XMLHttpRequest;
-    constructor(originalEvent: Event, xhr: XMLHttpRequest, request: AjaxRequest);
+    constructor(
+    originalEvent: ProgressEvent,
+    xhr: XMLHttpRequest,
+    request: AjaxRequest,
+    type?: string);
 }
 
 export interface AjaxTimeoutError extends AjaxError {

--- a/src/internal/ajax/AjaxResponse.ts
+++ b/src/internal/ajax/AjaxResponse.ts
@@ -8,17 +8,37 @@ import { getXHRResponse } from './getXHRResponse';
  * - DO NOT create instances of this class directly.
  * - DO NOT subclass this class.
  *
+ * It is advised not to hold this object in memory, as it has a reference to
+ * the original XHR used to make the request, as well as properties containing
+ * request and response data.
+ *
  * @see {@link ajax}
  */
 export class AjaxResponse<T> {
   /** The HTTP status code */
   readonly status: number;
 
-  /** The response data */
+  /** The response data, if any. Note that this will automatically be converted to the proper type.*/
   readonly response: T;
 
   /**  The responseType from the response. (For example: `""`, "arraybuffer"`, "blob"`, "document"`, "json"`, or `"text"`) */
   readonly responseType: XMLHttpRequestResponseType;
+
+  /**
+   * The total number of bytes loaded so far. To be used with {@link total} while
+   * calcating progress. (You will want to set {@link includeDownloadProgress} or {@link includeDownloadProgress})
+   *
+   * {@see {@link AjaxConfig}}
+   */
+  readonly loaded: number;
+
+  /**
+   * The total number of bytes to be loaded. To be used with {@link loaded} while
+   * calcating progress. (You will want to set {@link includeDownloadProgress} or {@link includeDownloadProgress})
+   *
+   * {@see {@link AjaxConfig}}
+   */
+  readonly total: number;
 
   /**
    * A normalized response from an AJAX request. To get the data from the response,
@@ -31,9 +51,34 @@ export class AjaxResponse<T> {
    * @param xhr The `XMLHttpRequest` object used to make the request. This is useful for examining status code, etc.
    * @param request The request settings used to make the HTTP request.
    */
-  constructor(public readonly originalEvent: Event, public readonly xhr: XMLHttpRequest, public readonly request: AjaxRequest) {
-    this.status = xhr.status;
-    this.responseType = xhr.responseType;
+  constructor(
+    /**
+     * The original event object from the raw XHR event.
+     */
+    public readonly originalEvent: ProgressEvent,
+    /**
+     * The XMLHttpRequest object used to make the request.
+     * NOTE: It is advised not to hold this in memory, as it will retain references to all of it's event handlers
+     * and many other things related to the request.
+     */
+    public readonly xhr: XMLHttpRequest,
+    /**
+     * The request parameters used to make the HTTP request.
+     */
+    public readonly request: AjaxRequest,
+    /**
+     * The event type. This can be used to discern between different events
+     * if you're using progress events with {@link includeDownloadProgress} or
+     * {@link includeUploadProgress} settings in {@link AjaxConfig}.
+     */
+    public readonly type = 'download_load'
+  ) {
+    const { status, responseType } = xhr;
+    this.status = status ?? 0;
+    this.responseType = responseType ?? '';
     this.response = getXHRResponse(xhr);
+    const { loaded, total } = originalEvent;
+    this.loaded = loaded;
+    this.total = total;
   }
 }

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -174,4 +174,22 @@ export interface AjaxConfig {
    * the HTTP response comes back.
    */
   progressSubscriber?: PartialObserver<ProgressEvent>;
+
+  /**
+   * If `true`, will emit all download progress and load complete events as {@link AjaxProgressEvents}
+   * from the observable. The final download event will also be emitted as a {@link AjaxDownloadCompleteEvent}
+   *
+   * If both this and {@link includeUploadProgress} are `false`, then only the {@link AjaxResponse} will
+   * be emitted from the resulting observable.
+   */
+  includeDownloadProgress?: boolean;
+
+  /**
+   * If `true`, will emit all upload progress and load complete events as {@link AjaxUploadProgressEvents}
+   * from the observable. The final download event will also be emitted as a {@link AjaxDownloadCompleteEvent}
+   *
+   * If both this and {@link includeDownloadProgress} are `false`, then only the {@link AjaxResponse} will
+   * be emitted from the resulting observable.
+   */
+  includeUploadProgress?: boolean;
 }

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -166,12 +166,15 @@ export interface AjaxConfig {
   createXHR?: () => XMLHttpRequest;
 
   /**
-   * An observer for watching the progress of an HTTP request. Will
-   * emit progress events, and completes on the final load event, will error for
+   * An observer for watching the upload progress of an HTTP request. Will
+   * emit progress events, and completes on the final upload load event, will error for
    * any XHR error or timeout.
    *
    * This will **not** error for errored status codes. Rather, it will always _complete_ when
    * the HTTP response comes back.
+   *
+   * @deprecated If you're looking for progress events, please try {@link includeDownloadProgress} and
+   * {@link includeUploadProgress}. This will be removed in version 8.
    */
   progressSubscriber?: PartialObserver<ProgressEvent>;
 


### PR DESCRIPTION
## Edit: I've moved the spec changes to another PR that should be reviewed first here: https://github.com/ReactiveX/rxjs/pull/6002

- Fixes a bunch of tests that were slightly off or had bad assumptions
- Adds two new features: `includeUploadProgress` and `includeDownloadProgress` that will add additional events to the output stream before the event that is usually emitted.

Resolves #2833

NOTE: We still need to add an example of usage.