### PR TITLE
fix: publish variants returning ConnectableObservable not properly utilizing lift

### DIFF
--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -4,6 +4,7 @@ import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { refCount as higherOrderRefCount } from '../operators/refCount';
 import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { hasLift } from '../util/lift';
 
 /**
  * @class ConnectableObservable<T>
@@ -28,6 +29,12 @@ export class ConnectableObservable<T> extends Observable<T> {
    */
   constructor(public source: Observable<T>, protected subjectFactory: () => Subject<T>) {
     super();
+    // If we have lift, monkey patch that here. This is done so custom observable
+    // types will compose through multicast. Otherwise the resulting observable would
+    // simply be an instance of `ConnectableObservable`.
+    if (hasLift(source)) {
+      this.lift = source.lift;
+    }
   }
 
   protected _subscribe(subscriber: Subscriber<T>) {

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -2,7 +2,6 @@ import { Subject } from '../Subject';
 import { Observable } from '../Observable';
 import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { OperatorFunction, UnaryFunction, ObservedValueOf, ObservableInput } from '../types';
-import { hasLift } from '../util/lift';
 import { isFunction } from '../util/isFunction';
 import { connect } from './connect';
 
@@ -81,16 +80,5 @@ export function multicast<T, R>(
     });
   }
 
-  return (source: Observable<T>) => {
-    const connectable: any = new ConnectableObservable(source, subjectFactory);
-    // If we have lift, monkey patch that here. This is done so custom observable
-    // types will compose through multicast. Otherwise the resulting observable would
-    // simply be an instance of `ConnectableObservable`.
-    if (hasLift(source)) {
-      connectable.lift = source.lift;
-    }
-    connectable.source = source;
-    connectable.subjectFactory = subjectFactory;
-    return connectable;
-  };
+  return (source: Observable<T>) => new ConnectableObservable<any>(source, subjectFactory);
 }


### PR DESCRIPTION
- Adds tests to show fixed issues
- Adds tests to show issues that simply can't be fixed, and support a case against removing operators that return ConnectableObservable, as well as possibly a case against lifting Subject.
- Moves logic that patched lift for ConnectableObservable to the constructor so it is used by all multicast operators
