### PR TITLE
distinctUntilChanged should set `prev` value with `keySelector` even at the first time

### DIFF
--- a/spec/operators/distinctUntilChanged-spec.ts
+++ b/spec/operators/distinctUntilChanged-spec.ts
@@ -252,6 +252,18 @@ describe('distinctUntilChanged', () => {
     });
   });
 
+  it('should use the keySelector even for the first emit', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--|', { a: 2, b: 4 });
+      const e1subs = '  ^-------!';
+      const expected = '--a-----|';
+      const keySelector = (x: number) => x % 2;
+
+      expectObservable(e1.pipe(distinctUntilChanged(null!, keySelector))).toBe(expected, { a: 2 });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
   it('should raise error when keySelector throws', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--b--c--d--e--f--|');

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -67,13 +67,11 @@ export function distinctUntilChanged<T, K>(compare?: (a: K, b: K) => boolean, ke
     let first = true;
     source.subscribe(
       new OperatorSubscriber(subscriber, (value) => {
-        // WARNING: Intentionally terse code for library size.
-        // If this is the first value, set the previous value state, the `1` is to allow it to move to the next
-        // part of the terse conditional. Then we capture `prev` to pass to `compare`, but set `prev` to the result of
-        // either the `keySelector` -- if provided -- or the `value`, *then* it will execute the `compare`.
-        // If `compare` returns truthy, it will move on to call `subscriber.next()`.
-        ((first && ((prev = value), 1)) || !compare!(prev, (prev = keySelector ? keySelector(value) : (value as any)))) &&
+        const key: any = keySelector ? keySelector(value) : value;
+        if (first || !compare!(prev, key)) {
           subscriber.next(value);
+        }
+        prev = key;
         first = false;
       })
     );


### PR DESCRIPTION
**Description:**
distinctUntilChanged should set `prev` value with `keySelector` even at the first time

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/6012