### PR TITLE
fix: add test from #5932 and plug leak in share

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -319,4 +319,26 @@ describe('shareReplay operator', () => {
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });
 
+  const FinalizationRegistry = (global as any).FinalizationRegistry;
+  if (FinalizationRegistry) {
+
+    it('should not leak the subscriber for sync sources', (done) => {
+      const registry = new FinalizationRegistry((value: any) => {
+        expect(value).to.equal('callback');
+        done();
+      });
+      let callback: (() => void) | undefined = () => { /* noop */ };
+      registry.register(callback, 'callback');
+
+      const shared = of(42).pipe(shareReplay(1));
+      shared.subscribe(callback);
+
+      callback = undefined;
+      global.gc();
+    });
+
+  } else {
+    console.warn(`No support for FinalizationRegistry in Node ${process.version}`);
+  }
+
 });

--- a/spec/support/.mocharc.js
+++ b/spec/support/.mocharc.js
@@ -1,14 +1,9 @@
 module.exports = {
-  require: [
-    'spec/support/mocha-path-mappings.js',
-    'dist/spec/helpers/polyfills.js',
-    'dist/spec/helpers/testScheduler-ui.js'
-  ],
-  ui: [
-    'dist/spec/helpers/testScheduler-ui.js'
-  ],
+  require: ['spec/support/mocha-path-mappings.js', 'dist/spec/helpers/polyfills.js', 'dist/spec/helpers/testScheduler-ui.js'],
+  ui: ['dist/spec/helpers/testScheduler-ui.js'],
   reporter: 'dot',
   timeout: 5000,
   recursive: true,
-  'enable-source-maps': true
+  'enable-source-maps': true,
+  'expose-gc': true,
 };

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -1,6 +1,6 @@
 import { Subject } from '../Subject';
 
-import { MonoTypeOperatorFunction, OperatorFunction, SubjectLike } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, SubjectLike, Unsubscribable } from '../types';
 import { Subscription } from '../Subscription';
 import { from } from '../observable/from';
 import { operate } from '../util/lift';
@@ -106,7 +106,7 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
       subject = connector!();
     }
 
-    const castSubscription = subject.subscribe(subscriber);
+    let castSubscription: Unsubscribable | null = subject.subscribe(subscriber);
 
     if (!connection) {
       connection = from(source).subscribe({
@@ -132,7 +132,8 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
 
     return () => {
       refCount--;
-      castSubscription.unsubscribe();
+      castSubscription!.unsubscribe();
+      castSubscription = null;
       if (!refCount && resetOnRefCountZero && !hasErrored && !hasCompleted) {
         const conn = connection;
         reset();

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -1,6 +1,6 @@
 import { Subject } from '../Subject';
 
-import { MonoTypeOperatorFunction, OperatorFunction, SubjectLike, Unsubscribable } from '../types';
+import { MonoTypeOperatorFunction, OperatorFunction, SubjectLike } from '../types';
 import { Subscription } from '../Subscription';
 import { from } from '../observable/from';
 import { operate } from '../util/lift';
@@ -95,6 +95,8 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
   let hasCompleted = false;
   let hasErrored = false;
 
+  // Used to reset the internal state to a "cold"
+  // state, as though it had never been subscribed to.
   const reset = () => {
     connection = subject = null;
     hasCompleted = hasErrored = false;
@@ -102,17 +104,21 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
 
   return operate((source, subscriber) => {
     refCount++;
-    if (!subject) {
-      subject = connector!();
-    }
 
-    let castSubscription: Unsubscribable | null = subject.subscribe(subscriber);
+    // Create the subject if we don't have one yet.
+    subject = subject ?? connector();
+
+    // The following line adds the subscription to the subscriber passed.
+    // Basically, `subscriber === subject.subscribe(subscriber)` is `true`.
+    subject.subscribe(subscriber);
 
     if (!connection) {
       connection = from(source).subscribe({
         next: (value) => subject!.next(value),
         error: (err) => {
           hasErrored = true;
+          // We need to capture the subject before
+          // we reset (if we need to reset).
           const dest = subject!;
           if (resetOnError) {
             reset();
@@ -122,6 +128,8 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
         complete: () => {
           hasCompleted = true;
           const dest = subject!;
+          // We need to capture the subject before
+          // we reset (if we need to reset).
           if (resetOnComplete) {
             reset();
           }
@@ -130,11 +138,16 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
       });
     }
 
+    // This is also added to `subscriber`, technically.
     return () => {
       refCount--;
-      castSubscription!.unsubscribe();
-      castSubscription = null;
-      if (!refCount && resetOnRefCountZero && !hasErrored && !hasCompleted) {
+
+      // If we're resetting on refCount === 0, and it's 0, we only want to do
+      // that on "unsubscribe", really. Resetting on error or completion is a different
+      // configuration.
+      if (resetOnRefCountZero && !refCount && !hasErrored && !hasCompleted) {
+        // We need to capture the connection before
+        // we reset (if we need to reset).
         const conn = connection;
         reset();
         conn?.unsubscribe();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR brings in the test from #5932 and fixes a leak that it exposed in the `share` implementation.

Maybe we should add the test to the specs for `share`, too, but this is all I have time for, ATM.

**Related PR:** #5932
