### PR TITLE
chore: install other @latest packages for ts@latest CI test

### DIFF
--- a/.github/workflows/ci_ts_latest.yml
+++ b/.github/workflows/ci_ts_latest.yml
@@ -23,6 +23,6 @@ jobs:
       run: |
         npm install -g npm@latest
         npm ci
-        npm install --no-save typescript@latest
+        npm install --no-save typescript@latest tslib@latest @types/node@latest
         npm run compile
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR installs `tslib@latest` and `@types/node@latest` in the `ts@latest` CI check. Doing so will avoid problems like those that occurred in #5932.

**Related PR:** #5932