### PR TITLE
chore: account for Node.js setTimeout return type

### DIFF
--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -111,7 +111,7 @@ describe('bindCallback', () => {
         // Need to cb async in order for the unsub to trigger
         timeout = setTimeout(() => {
           cb(datum);
-        });
+        }, 0);
       }
       const subscription = bindCallback(callback)(42)
         .subscribe(nextSpy, throwSpy, completeSpy);

--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -106,7 +106,7 @@ describe('bindCallback', () => {
       const nextSpy = sinon.spy();
       const throwSpy = sinon.spy();
       const completeSpy = sinon.spy();
-      let timeout: number;
+      let timeout: ReturnType<typeof setTimeout>;
       function callback(datum: number, cb: Function) {
         // Need to cb async in order for the unsub to trigger
         timeout = setTimeout(() => {

--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -104,7 +104,7 @@ describe('bindNodeCallback', () => {
       const nextSpy = sinon.spy();
       const throwSpy = sinon.spy();
       const completeSpy = sinon.spy();
-      let timeout: number;
+      let timeout: ReturnType<typeof setTimeout>;
       function callback(datum: number, cb: (err: any, n: number) => void) {
         // Need to cb async in order for the unsub to trigger
         timeout = setTimeout(() => {

--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -109,7 +109,7 @@ describe('bindNodeCallback', () => {
         // Need to cb async in order for the unsub to trigger
         timeout = setTimeout(() => {
           cb(null, datum);
-        });
+        }, 0);
       }
       const subscription = bindNodeCallback(callback)(42)
         .subscribe(nextSpy, throwSpy, completeSpy);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The `ts@latest` CI task installs the latest Node types, too. This effects some breakages in tests - where `setTimeout` is assumed to return `number`. This PR uses `ReturnType` instead.

Also, as there are two signatures for `setTimeout` - in the Node types and in TypeScipt's DOM types - the duration has to be specified - otherwise, the call will match the second signature (the TypeScript one) which returns `number`. 🙈

**Related PR:** #6038
