### PR TITLE
Fix/3990 buffer emit remainder on complete

### DIFF
--- a/spec/operators/buffer-spec.ts
+++ b/spec/operators/buffer-spec.ts
@@ -49,7 +49,7 @@ describe('Observable.prototype.buffer', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
       const b = EMPTY;
-      const expected = '|';
+      const expected = '     --------------------------------|';
       expectObservable(a.pipe(buffer(b))).toBe(expected);
     });
   });
@@ -67,7 +67,7 @@ describe('Observable.prototype.buffer', () => {
     testScheduler.run(({ expectObservable }) => {
       const a = NEVER;
       const b = EMPTY;
-      const expected = '|';
+      const expected = '-';
       expectObservable(a.pipe(buffer(b))).toBe(expected);
     });
   });
@@ -139,9 +139,9 @@ describe('Observable.prototype.buffer', () => {
     // Buffshoulder Boundaries onCompletedBoundaries (RxJS 4)
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const a = hot('--1--2--^--3--4--5---6----7--8--9---0---|');
-      const subs = '         ^----------------!               ';
+      const subs = '         ^-------------------------------!';
       const b = hot('--------^--a-------b---cd|               ');
-      const expected = '     ---a-------b---cd|               ';
+      const expected = '     ---a-------b---cd---------------|';
       const expectedValues = {
         a: ['3'],
         b: ['4', '5'],

--- a/spec/operators/buffer-spec.ts
+++ b/spec/operators/buffer-spec.ts
@@ -28,7 +28,7 @@ describe('Observable.prototype.buffer', () => {
     });
   });
 
-  it('should not emit a final buffer if the closingNotifier is already complete', () => {
+  it('should emit a final buffer if the closingNotifier is already complete', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const a = hot('   -a-b-c-d-e-f-g-h-i-|');
       const b = hot('   -----B-----B--|');

--- a/spec/operators/buffer-spec.ts
+++ b/spec/operators/buffer-spec.ts
@@ -27,6 +27,27 @@ describe('Observable.prototype.buffer', () => {
     });
   });
 
+  it('should emit all buffered values if the source completes before the closingNotifier does', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('---^---a---b---c---d---e--f----|');
+      const sourceSubs = '   ^---------------------------!';
+      const closer = hot('---^-------------B----------------');
+      const closerSubs = '   ^---------------------------!';
+      const expected = '     --------------x-------------(F|)';
+
+      const result = source.pipe(buffer(closer));
+
+      const expectedValues = {
+        x: ['a', 'b', 'c'],
+        F: ['d', 'e', 'f'],
+      };
+
+      expectObservable(result).toBe(expected, expectedValues);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectSubscriptions(closer.subscriptions).toBe(closerSubs);
+    });
+  });
+
   it('should work with empty and empty selector', () => {
     testScheduler.run(({ expectObservable }) => {
       const a = EMPTY;

--- a/spec/operators/window-spec.ts
+++ b/spec/operators/window-spec.ts
@@ -106,13 +106,13 @@ describe('window operator', () => {
 
   it('should be able to split a never Observable into timely empty windows', () => {
     const source =    hot('^--------');
-    const sourceSubs =    '^       !';
+    const sourceSubs =    '^        ';
     const closings = cold('--x--x--|');
     const closingSubs =   '^       !';
-    const expected =      'a-b--c--|';
+    const expected =      'a-b--c---';
     const a =        cold('--|      ');
     const b =        cold(  '---|   ');
-    const c =        cold(     '---|');
+    const c =        cold(     '----');
     const expectedValues = { a: a, b: b, c: c };
 
     const result = source.pipe(window(closings));
@@ -234,13 +234,13 @@ describe('window operator', () => {
 
   it('should complete the resulting Observable when window closings completes', () => {
     const source = hot('-1-2-^3-4-5-6-7-8-9-|');
-    const subs =            '^           !   ';
+    const subs =            '^              !';
     const closings = hot('---^---x---x---|   ');
     const closingSubs =     '^           !   ';
-    const expected =        'a---b---c---|   ';
+    const expected =        'a---b---c------|';
     const a = cold(         '-3-4|           ');
     const b = cold(             '-5-6|       ');
-    const c = cold(                 '-7-8|   ');
+    const c = cold(                 '-7-8-9-|');
     const expectedValues = { a: a, b: b, c: c };
 
     const result = source.pipe(window(closings));

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -1,6 +1,7 @@
 import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
+import { noop } from '../util/noop';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 /**
@@ -50,12 +51,19 @@ export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T,
 
     // Subscribe to the closing notifier.
     closingNotifier.subscribe(
-      new OperatorSubscriber(subscriber, () => {
-        // Start a new buffer and emit the previous one.
-        const b = currentBuffer;
-        currentBuffer = [];
-        subscriber.next(b);
-      })
+      new OperatorSubscriber(
+        subscriber,
+        () => {
+          // Start a new buffer and emit the previous one.
+          const b = currentBuffer;
+          currentBuffer = [];
+          subscriber.next(b);
+        },
+        // Pass all errors to the consumer.
+        undefined,
+        // Closing notifier should not complete the resulting observable.
+        noop
+      )
     );
 
     return () => {

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -44,8 +44,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
   return operate((source, subscriber) => {
-    // The current buffered values. If this is null, it's because the
-    // closingNotifier has completed before the source.
+    // The current buffered values.
     let currentBuffer: T[] = [];
 
     // Subscribe to our source.


### PR DESCRIPTION
### fix(buffer): Remaining buffer will be emited on source close if `closingNotifier` active
    
Gives the author control over the emission of the final buffer. If the `closingNotifier` completes before the source does, no more buffers will be emitted. If the `closingNotifier` is still active when the source completes, then whatever is in the buffer at the time will be emitted from the resulting observable before it completes.
    
BREAKING CHANGE: Final buffered values will now be emitted from the resulting observable if the `closingNotifier` is still active. The simplest workaround if you want the original behavior (where you possibly miss values), is to add a `skipLast(1)` at the end. Otherwise, you can try to complete the `closingNotifier` prior to the completion of the source.
    
Fixes #3990, #6035
    
    
### fix(buffer): closingNotifier completion does not complete resulting observable
    
Resolves an issue where the resulting observable would complete when the closingNotifier completed. Notifier completion should not complete the result, only source completion should do that.
    
BREAKING CHANGE: closingNotifier no longer closes the result of `buffer`. If that is truly a desired behavior, then you should use `takeUntil`. Something like: `source$.pipe(buffer(notifier$), takeUntil(notifier$.pipe(ignoreElements(), endWith(true))))`, where `notifier$` is multicast, although there are many ways to compose this behavior.