### PR TITLE
chore: use workaround type instead of any

### DIFF
--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -2,6 +2,7 @@
 import { SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { bindCallbackInternals } from './bindCallbackInternals';
+import { TS_IncompatibleSignature } from '../util/workarounds';
 
 // tslint:disable:max-line-length
 /** @deprecated resultSelector is no longer supported, use a mapping function. */
@@ -141,8 +142,7 @@ export function bindCallback<A extends readonly unknown[], R extends readonly un
  * Observable that delivers the same values the callback would deliver.
  */
 export function bindCallback(
-  // Need to use `any` here instead of `(...args: any[]) => void` because of TypeScript 4.2:
-  callbackFunc: any,
+  callbackFunc: TS_IncompatibleSignature,
   resultSelector?: ((...args: any[]) => any) | SchedulerLike,
   scheduler?: SchedulerLike
 ): (...args: any[]) => Observable<unknown> {

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -2,6 +2,7 @@
 import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { bindCallbackInternals } from './bindCallbackInternals';
+import { TS_IncompatibleSignature } from '../util/workarounds';
 
 /** @deprecated resultSelector is deprecated, pipe to map instead */
 export function bindNodeCallback(
@@ -121,8 +122,7 @@ export function bindNodeCallback<A extends readonly unknown[], R extends readonl
  * deliver.
  */
 export function bindNodeCallback(
-  // Need to use `any` here instead of `(...args: any[]) => void` because of TypeScript 4.2:
-  callbackFunc: any,
+  callbackFunc: TS_IncompatibleSignature,
   resultSelector?: ((...args: any[]) => any) | SchedulerLike,
   scheduler?: SchedulerLike
 ): (...args: any[]) => Observable<any> {

--- a/src/internal/util/workarounds.ts
+++ b/src/internal/util/workarounds.ts
@@ -1,0 +1,10 @@
+// Instead of using any - or another less-than-ideal type - to workaround a
+// TypeScript problem or bug, create a type alias and use that instead.
+// Wherever possible, use a TypeScript issue number in the type - something
+// like TS_18757 - or use a descriptive name and leave a detailed comment
+// alongside the type alias.
+
+// When TypeScript was bumped to version 4.2, there was an issue with
+// signatures being deemed incompatible when they ought to be compatible.
+// Really, any function should be compatible with `(...args: any[]) => void`.
+export type TS_IncompatibleSignature = any;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR replaces the workaround - for what seems to be a TS 4.2 problem - with an explicit type instead of an `any`.

**Related PR:** #6048