### PR TITLE
Fix/6052 ajax responseType should default to "json"

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -421,11 +421,14 @@ describe('ajax', () => {
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 404,
-      responseText: 'This is not what we expected is it? But that is okay',
+      responseText: 'Unparsable as json',
     });
 
     expect(error instanceof AjaxError).to.be.true;
-    expect(error.response).to.equal('This is not what we expected is it? But that is okay');
+    // The default behavior of XHR if you get something back that you can't
+    // parse as JSON, but you have a requestType of "json" is to
+    // have `response` set to `null`.
+    expect(error.response).to.be.null;
   });
 
   it('should succeed no settings', () => {
@@ -728,7 +731,10 @@ describe('ajax', () => {
         responseText: '',
       });
 
-      expect(result).to.deep.equal(undefined);
+      // Response will get set to null by the browser XHR
+      // This is sort of arbitrarily determined by our test harness
+      // but we want to be as accurate as possible.
+      expect(result).to.be.null;
       expect(complete).to.be.true;
     });
 
@@ -823,7 +829,10 @@ describe('ajax', () => {
         responseText: '',
       });
 
-      expect(result!.response).to.equal(undefined);
+      // Since the default setting for `responseType` is "json",
+      // and our `responseText` is an empty string (which isn't parsable as JSON),
+      // response should be `null` here.
+      expect(result!.response).to.be.null;
       expect(complete).to.be.true;
     });
 
@@ -1022,7 +1031,7 @@ describe('ajax', () => {
         },
         includeDownloadProgress: true,
         method: 'GET',
-        responseType: '',
+        responseType: 'json',
         timeout: 0,
         url: '/flibbertyJibbett',
         withCredentials: false,
@@ -1031,7 +1040,7 @@ describe('ajax', () => {
       expect(results).to.deep.equal([
         {
           type: 'download_loadstart',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 0,
           total: 5,
@@ -1042,7 +1051,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 1,
           total: 5,
@@ -1053,7 +1062,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 2,
           total: 5,
@@ -1064,7 +1073,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 3,
           total: 5,
@@ -1075,7 +1084,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 4,
           total: 5,
@@ -1086,7 +1095,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 5,
           total: 5,
@@ -1144,7 +1153,7 @@ describe('ajax', () => {
         includeUploadProgress: true,
         includeDownloadProgress: true,
         method: 'GET',
-        responseType: '',
+        responseType: 'json',
         timeout: 0,
         url: '/flibbertyJibbett',
         withCredentials: false,
@@ -1158,7 +1167,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
-          responseType: '',
+          responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'loadstart', loaded: 0, total: 5 },
         },
@@ -1169,7 +1178,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
-          responseType: '',
+          responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 1, total: 5 },
         },
@@ -1180,7 +1189,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
-          responseType: '',
+          responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 2, total: 5 },
         },
@@ -1191,7 +1200,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
-          responseType: '',
+          responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 3, total: 5 },
         },
@@ -1202,7 +1211,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
-          responseType: '',
+          responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 4, total: 5 },
         },
@@ -1213,7 +1222,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
-          responseType: '',
+          responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 5, total: 5 },
         },
@@ -1224,13 +1233,13 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
-          responseType: '',
+          responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'load', loaded: 5, total: 5 },
         },
         {
           type: 'download_loadstart',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 0,
           total: 5,
@@ -1241,7 +1250,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 1,
           total: 5,
@@ -1252,7 +1261,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 2,
           total: 5,
@@ -1263,7 +1272,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 3,
           total: 5,
@@ -1274,7 +1283,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 4,
           total: 5,
@@ -1285,7 +1294,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
-          responseType: '',
+          responseType: 'json',
           response: undefined,
           loaded: 5,
           total: 5,

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -78,7 +78,9 @@ describe('ajax', () => {
       withCredentials: true,
     };
 
-    ajax(obj).subscribe(null, (err) => expect(err).to.exist);
+    ajax(obj).subscribe({
+      error: (err) => expect(err).to.exist,
+    });
   });
 
   it('should set headers', () => {
@@ -294,7 +296,6 @@ describe('ajax', () => {
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 200,
-      responseType: 'json',
       responseText: JSON.stringify(expected),
     });
 
@@ -307,7 +308,6 @@ describe('ajax', () => {
     let error: any;
     const obj: AjaxConfig = {
       url: '/flibbertyJibbet',
-      responseType: 'json',
       method: '',
     };
 
@@ -328,7 +328,6 @@ describe('ajax', () => {
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 207,
-      responseType: 'json',
       responseText: 'Wee! I am text, but should be valid JSON!',
     });
 
@@ -360,7 +359,6 @@ describe('ajax', () => {
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 404,
-      responseType: 'text',
       responseText: 'Wee! I am text!',
     });
 
@@ -393,7 +391,6 @@ describe('ajax', () => {
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 300,
-      responseType: 'text',
       responseText: 'Wee! I am text!',
     });
 
@@ -424,7 +421,6 @@ describe('ajax', () => {
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 404,
-      responseType: 'text',
       responseText: 'This is not what we expected is it? But that is okay',
     });
 
@@ -449,7 +445,6 @@ describe('ajax', () => {
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 200,
-      responseType: 'text',
       responseText: expected,
     });
   });
@@ -474,7 +469,6 @@ describe('ajax', () => {
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 500,
-      responseType: 'text',
       responseText: expected,
     });
   });
@@ -505,7 +499,6 @@ describe('ajax', () => {
 
     request.respondWith({
       status: 200,
-      responseType: 'text',
       responseText: 'Wee! I am text!',
     });
   });
@@ -539,7 +532,6 @@ describe('ajax', () => {
     rxTestScheduler.schedule(() => {
       request.respondWith({
         status: 200,
-        responseType: 'text',
         responseText: 'Wee! I am text!',
       });
     }, 1000);
@@ -565,7 +557,6 @@ describe('ajax', () => {
 
     mockXHR.respondWith({
       status: 200,
-      responseType: 'text',
       responseText: 'Wee! I am text!',
     });
   });
@@ -707,7 +698,6 @@ describe('ajax', () => {
 
       request.respondWith({
         status: 200,
-        responseType: 'json',
         responseText: JSON.stringify(expected),
       });
 
@@ -735,7 +725,6 @@ describe('ajax', () => {
 
       request.respondWith({
         status: 204,
-        responseType: '',
         responseText: '',
       });
 
@@ -764,7 +753,6 @@ describe('ajax', () => {
 
       request.respondWith({
         status: 200,
-        responseType: 'json',
         responseText: JSON.stringify(expected),
       });
 
@@ -800,7 +788,6 @@ describe('ajax', () => {
 
       request.respondWith({
         status: 200,
-        responseType: 'json',
         responseText: JSON.stringify(expected),
       });
 
@@ -833,7 +820,6 @@ describe('ajax', () => {
 
       request.respondWith({
         status: 204,
-        responseType: '',
         responseText: '',
       });
 
@@ -857,7 +843,6 @@ describe('ajax', () => {
       request.respondWith(
         {
           status: 200,
-          responseType: 'json',
           responseText: JSON.stringify({}),
         },
         { uploadProgressTimes: 3 }
@@ -888,7 +873,6 @@ describe('ajax', () => {
       request.respondWith(
         {
           status: 200,
-          responseType: 'json',
           responseText: JSON.stringify({}),
         },
         { uploadProgressTimes: 3 }
@@ -925,7 +909,6 @@ describe('ajax', () => {
 
       request.respondWith({
         status: 200,
-        responseType: 'json',
         responseText: JSON.stringify(expected),
       });
 
@@ -1025,7 +1008,6 @@ describe('ajax', () => {
           status: 200,
           total: 5,
           loaded: 5,
-          responseType: 'json',
           responseText: JSON.stringify({ boo: 'I am a ghost' }),
         },
         { uploadProgressTimes: 5, downloadProgressTimes: 5 }
@@ -1147,7 +1129,6 @@ describe('ajax', () => {
           status: 200,
           total: 5,
           loaded: 5,
-          responseType: 'json',
           responseText: JSON.stringify({ boo: 'I am a ghost' }),
         },
         { uploadProgressTimes: 5, downloadProgressTimes: 5 }
@@ -1463,7 +1444,6 @@ class MockXMLHttpRequest extends MockXHREventTarget {
     response: {
       status?: number;
       responseText?: string | undefined;
-      responseType: XMLHttpRequestResponseType;
       total?: number;
       loaded?: number;
     },
@@ -1494,7 +1474,6 @@ class MockXMLHttpRequest extends MockXHREventTarget {
     // Default to OK 200.
     this.status = response.status || 200;
     this.responseText = response.responseText;
-    this.responseType = response.responseType;
 
     switch (this.responseType) {
       case 'json':
@@ -1505,14 +1484,17 @@ class MockXMLHttpRequest extends MockXHREventTarget {
           // response somehow, where responseType is "json" but the responseText
           // is not JSON. In truth, we need to invert these tests to just use
           // response, because `responseText` is a legacy path.
-          this.response = undefined;
+          this.response = null;
         }
         break;
+      case 'arraybuffer':
+      case 'document':
+      case 'blob':
+        throw new Error('Test harness does not support the responseType: ' + this.responseType);
       case 'text':
-        this.response = response.responseText;
-        break;
+      case '':
       default:
-        // response remains undefined
+        this.response = response.responseText;
         break;
     }
 

--- a/src/internal/ajax/ajax.ts
+++ b/src/internal/ajax/ajax.ts
@@ -320,7 +320,7 @@ export function fromAjax<T>(config: AjaxConfig): Observable<AjaxResponse<T>> {
       withCredentials: false,
       method: 'GET',
       timeout: 0,
-      responseType: '' as XMLHttpRequestResponseType,
+      responseType: 'json' as XMLHttpRequestResponseType,
 
       // Override with passed user values
       ...config,


### PR DESCRIPTION
fix(ajax): Ensure that `responseType` defaults to `"json"`

    - Updates tests to be more accurate

    Resolves #6052

chore: Fix XHR mock to not change responseType on its own