### PR TITLE
Feat/ajax response headers

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -49,6 +49,7 @@ export declare class AjaxResponse<T> {
     readonly originalEvent: ProgressEvent;
     readonly request: AjaxRequest;
     readonly response: T;
+    readonly responseHeaders: Record<string, string>;
     readonly responseType: XMLHttpRequestResponseType;
     readonly status: number;
     readonly total: number;

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -1040,6 +1040,7 @@ describe('ajax', () => {
       expect(results).to.deep.equal([
         {
           type: 'download_loadstart',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 0,
@@ -1051,6 +1052,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 1,
@@ -1062,6 +1064,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 2,
@@ -1073,6 +1076,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 3,
@@ -1084,6 +1088,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 4,
@@ -1095,6 +1100,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 5,
@@ -1112,6 +1118,7 @@ describe('ajax', () => {
           originalEvent: { type: 'load', loaded: 5, total: 5 },
           xhr: mockXHR,
           response: { boo: 'I am a ghost' },
+          responseHeaders: {},
           responseType: 'json',
           status: 200,
         },
@@ -1167,6 +1174,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
+          responseHeaders: {},
           responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'loadstart', loaded: 0, total: 5 },
@@ -1178,6 +1186,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
+          responseHeaders: {},
           responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 1, total: 5 },
@@ -1189,6 +1198,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
+          responseHeaders: {},
           responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 2, total: 5 },
@@ -1200,6 +1210,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
+          responseHeaders: {},
           responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 3, total: 5 },
@@ -1211,6 +1222,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
+          responseHeaders: {},
           responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 4, total: 5 },
@@ -1222,6 +1234,7 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
+          responseHeaders: {},
           responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'progress', loaded: 5, total: 5 },
@@ -1233,12 +1246,14 @@ describe('ajax', () => {
           request,
           status: 0,
           response: undefined,
+          responseHeaders: {},
           responseType: 'json',
           xhr: mockXHR,
           originalEvent: { type: 'load', loaded: 5, total: 5 },
         },
         {
           type: 'download_loadstart',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 0,
@@ -1250,6 +1265,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 1,
@@ -1261,6 +1277,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 2,
@@ -1272,6 +1289,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 3,
@@ -1283,6 +1301,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 4,
@@ -1294,6 +1313,7 @@ describe('ajax', () => {
         },
         {
           type: 'download_progress',
+          responseHeaders: {},
           responseType: 'json',
           response: undefined,
           loaded: 5,
@@ -1311,12 +1331,40 @@ describe('ajax', () => {
           originalEvent: { type: 'load', loaded: 5, total: 5 },
           xhr: mockXHR,
           response: { boo: 'I am a ghost' },
+          responseHeaders: {},
           responseType: 'json',
           status: 200,
         },
         'done', // from completion.
       ]);
     });
+  });
+
+  it('should return an object that allows access to response headers', () => {
+    const sentResponseHeaders = {
+      'content-type': 'application/json',
+      'x-custom-header': 'test',
+      'x-headers-are-fun': '<whatever/> {"weird": "things"}',
+    };
+
+    ajax({
+      method: 'GET',
+      url: '/whatever',
+    }).subscribe((response) => {
+      expect(response.responseHeaders).to.deep.equal(sentResponseHeaders);
+    });
+
+    const mockXHR = MockXMLHttpRequest.mostRecent;
+
+    mockXHR.respondWith({
+      status: 200,
+      headers: sentResponseHeaders,
+      responseText: JSON.stringify({ iam: 'tired', and: 'should go to bed', but: 'I am doing open source for no good reason' }),
+    });
+
+    expect(mockXHR.getAllResponseHeaders()).to.equal(`content-type: application/json
+x-custom-header: test
+x-headers-are-fun: <whatever/> {"weird": "things"}`);
   });
 });
 
@@ -1449,9 +1497,20 @@ class MockXMLHttpRequest extends MockXHREventTarget {
     this.requestHeaders[key] = value;
   }
 
+  private _responseHeaders: any;
+
+  getAllResponseHeaders() {
+    return this._responseHeaders
+      ? Object.entries(this._responseHeaders)
+          .map((entryParts) => entryParts.join(': '))
+          .join('\n')
+      : '';
+  }
+
   respondWith(
     response: {
       status?: number;
+      headers?: any;
       responseText?: string | undefined;
       total?: number;
       loaded?: number;
@@ -1477,10 +1536,13 @@ class MockXMLHttpRequest extends MockXHREventTarget {
       }
     }
 
-    // Set the readyState to 4.
+    // Store our headers locally. This is used in `getAllResponseHeaders` mock impl.
+    this._responseHeaders = response.headers;
+
+    // Set the readyState to DONE (4)
     this.readyState = 4;
 
-    // Default to OK 200.
+    // Default to OK
     this.status = response.status || 200;
     this.responseText = response.responseText;
 

--- a/src/internal/ajax/AjaxResponse.ts
+++ b/src/internal/ajax/AjaxResponse.ts
@@ -97,14 +97,15 @@ export class AjaxResponse<T> {
     // other-header-here: some, other, values, or, whatever
     const allHeaders = xhr.getAllResponseHeaders();
     this.responseHeaders = allHeaders
-      ? Object.fromEntries(
-          // Split the header text into lines
-          allHeaders.split('\n').map((line) => {
-            // Split the lines on the first ": ". The value could technically have a ": " in it.
-            const index = line.indexOf(': ');
-            return [line.slice(0, index), line.slice(index + 2)];
-          })
-        )
+      ? // Split the header text into lines
+        allHeaders.split('\n').reduce((headers: Record<string, string>, line) => {
+          // Split the lines on the first ": " as
+          // "key: value". Note that the value could
+          // technically have a ": " in it.
+          const index = line.indexOf(': ');
+          headers[line.slice(0, index)] = line.slice(index + 2);
+          return headers;
+        }, {})
       : {};
 
     this.response = getXHRResponse(xhr);

--- a/src/internal/ajax/AjaxResponse.ts
+++ b/src/internal/ajax/AjaxResponse.ts
@@ -18,10 +18,16 @@ export class AjaxResponse<T> {
   /** The HTTP status code */
   readonly status: number;
 
-  /** The response data, if any. Note that this will automatically be converted to the proper type.*/
+  /**
+   * The response data, if any. Note that this will automatically be converted to the proper type
+   */
   readonly response: T;
 
-  /**  The responseType from the response. (For example: `""`, "arraybuffer"`, "blob"`, "document"`, "json"`, or `"text"`) */
+  /**
+   * The responseType set on the request. (For example: `""`, "arraybuffer"`, "blob"`, "document"`, "json"`, or `"text"`)
+   * @deprecated There isn't much reason to examine this. It's the same responseType set (or defaulted) on the ajax config
+   * if you really need to examine this value, you can check it on the `request` or the `xhr`.
+   */
   readonly responseType: XMLHttpRequestResponseType;
 
   /**
@@ -39,6 +45,11 @@ export class AjaxResponse<T> {
    * {@see {@link AjaxConfig}}
    */
   readonly total: number;
+
+  /**
+   * A dictionary of the response headers.
+   */
+  readonly responseHeaders: Record<string, string>;
 
   /**
    * A normalized response from an AJAX request. To get the data from the response,
@@ -76,6 +87,26 @@ export class AjaxResponse<T> {
     const { status, responseType } = xhr;
     this.status = status ?? 0;
     this.responseType = responseType ?? '';
+
+    // Parse the response headers in advance for the user. There's really
+    // not a great way to get all of them. So we need to parse the header string
+    // we get back. It comes in a simple enough format:
+    //
+    // header-name: value here
+    // content-type: application/json
+    // other-header-here: some, other, values, or, whatever
+    const allHeaders = xhr.getAllResponseHeaders();
+    this.responseHeaders = allHeaders
+      ? Object.fromEntries(
+          // Split the header text into lines
+          allHeaders.split('\n').map((line) => {
+            // Split the lines on the first ": ". The value could technically have a ": " in it.
+            const index = line.indexOf(': ');
+            return [line.slice(0, index), line.slice(index + 2)];
+          })
+        )
+      : {};
+
     this.response = getXHRResponse(xhr);
     const { loaded, total } = originalEvent;
     this.loaded = loaded;


### PR DESCRIPTION
Adds a feature that allows the user to examine response headers more easily (based loosely off of prior art from contemporary libraries):

```ts
ajax(url).subscribe(response => {
   console.log(response.responseHeaders); 
});
   /**
    * logs:
    * { "content-type": "application/json", "x-custom-header": "etc" }
    */
```
