### PR TITLE
Fix two typos in docs

### DIFF
--- a/src/internal/operators/elementAt.ts
+++ b/src/internal/operators/elementAt.ts
@@ -43,7 +43,7 @@ import { take } from './take';
  * @see {@link take}
  *
  * @throws {ArgumentOutOfRangeError} When using `elementAt(i)`, it delivers an
- * ArgumentOutOrRangeError to the Observer's `error` callback if `i < 0` or the
+ * ArgumentOutOfRangeError to the Observer's `error` callback if `i < 0` or the
  * Observable has completed before emitting the i-th `next` notification.
  *
  * @param {number} index Is the number `i` for the i-th source emission that has
@@ -53,13 +53,14 @@ import { take } from './take';
  * Otherwise, will emit the default value if given. If not, then emits an error.
  */
 export function elementAt<T>(index: number, defaultValue?: T): MonoTypeOperatorFunction<T> {
-  if (index < 0) { throw new ArgumentOutOfRangeError(); }
+  if (index < 0) {
+    throw new ArgumentOutOfRangeError();
+  }
   const hasDefaultValue = arguments.length >= 2;
-  return (source: Observable<T>) => source.pipe(
-    filter((v, i) => i === index),
-    take(1),
-    hasDefaultValue
-      ? defaultIfEmpty(defaultValue)
-      : throwIfEmpty(() => new ArgumentOutOfRangeError()),
-  );
+  return (source: Observable<T>) =>
+    source.pipe(
+      filter((v, i) => i === index),
+      take(1),
+      hasDefaultValue ? defaultIfEmpty(defaultValue) : throwIfEmpty(() => new ArgumentOutOfRangeError())
+    );
 }

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -33,7 +33,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link take}
  *
  * @throws {ArgumentOutOfRangeError} When using `skipLast(i)`, it throws
- * ArgumentOutOrRangeError if `i < 0`.
+ * ArgumentOutOfRangeError if `i < 0`.
  *
  * @param {number} skipCount Number of elements to skip from the end of the source Observable.
  * @returns {Observable<T>} An Observable that skips the last count values


### PR DESCRIPTION
docs(skipLast): Fix a typo

docs(elementAt): Fix a typo
