### PR TITLE
refactor: use n-args for of scheduler signatures

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -336,16 +336,10 @@ export interface Observer<T> {
     next: (value: T) => void;
 }
 
+export declare function of(value: null): Observable<null>;
+export declare function of(value: undefined): Observable<undefined>;
 export declare function of(scheduler: SchedulerLike): Observable<never>;
-export declare function of<T>(a: T, scheduler: SchedulerLike): Observable<T>;
-export declare function of<T, T2>(a: T, b: T2, scheduler: SchedulerLike): Observable<T | T2>;
-export declare function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler: SchedulerLike): Observable<T | T2 | T3>;
-export declare function of<T, T2, T3, T4>(a: T, b: T2, c: T3, d: T4, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4>;
-export declare function of<T, T2, T3, T4, T5>(a: T, b: T2, c: T3, d: T4, e: T5, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
-export declare function of<T, T2, T3, T4, T5, T6>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6>;
-export declare function of<T, T2, T3, T4, T5, T6, T7>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6 | T7>;
-export declare function of<T, T2, T3, T4, T5, T6, T7, T8>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
-export declare function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(a: T, b: T2, c: T3, d: T4, e: T5, f: T6, g: T7, h: T8, i: T9, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+export declare function of<A extends readonly unknown[]>(...args: [...A, SchedulerLike]): Observable<ValueFromArray<A>>;
 export declare function of(): Observable<never>;
 export declare function of<T>(): Observable<T>;
 export declare function of<T>(value: T): Observable<T>;

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -4,64 +4,18 @@ import { Observable } from '../Observable';
 import { scheduleArray } from '../scheduled/scheduleArray';
 import { popScheduler } from '../util/args';
 
+// Devs are more likely to pass null or undefined than they are a scheduler
+// without accompanying values. To make things easier for (naughty) devs who
+// use the `strictNullChecks: false` TypeScript compiler option, these
+// overloads with explicit null and undefined values are included.
+
+export function of(value: null): Observable<null>;
+export function of(value: undefined): Observable<undefined>;
+
 /** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function of(scheduler: SchedulerLike): Observable<never>;
 /** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T>(a: T, scheduler: SchedulerLike): Observable<T>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2>(a: T, b: T2, scheduler: SchedulerLike): Observable<T | T2>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2, T3>(a: T, b: T2, c: T3, scheduler: SchedulerLike): Observable<T | T2 | T3>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2, T3, T4>(a: T, b: T2, c: T3, d: T4, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2, T3, T4, T5>(a: T, b: T2, c: T3, d: T4, e: T5, scheduler: SchedulerLike): Observable<T | T2 | T3 | T4 | T5>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2, T3, T4, T5, T6>(
-  a: T,
-  b: T2,
-  c: T3,
-  d: T4,
-  e: T5,
-  f: T6,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5 | T6>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2, T3, T4, T5, T6, T7>(
-  a: T,
-  b: T2,
-  c: T3,
-  d: T4,
-  e: T5,
-  f: T6,
-  g: T7,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5 | T6 | T7>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2, T3, T4, T5, T6, T7, T8>(
-  a: T,
-  b: T2,
-  c: T3,
-  d: T4,
-  e: T5,
-  f: T6,
-  g: T7,
-  h: T8,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function of<T, T2, T3, T4, T5, T6, T7, T8, T9>(
-  a: T,
-  b: T2,
-  c: T3,
-  d: T4,
-  e: T5,
-  f: T6,
-  g: T7,
-  h: T8,
-  i: T9,
-  scheduler: SchedulerLike
-): Observable<T | T2 | T3 | T4 | T5 | T6 | T7 | T8 | T9>;
+export function of<A extends readonly unknown[]>(...args: [...A, SchedulerLike]): Observable<ValueFromArray<A>>;
 
 export function of(): Observable<never>;
 /** @deprecated remove in v8. Do not use generic arguments directly, allow inference or cast with `as` */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR:

- refactors the `Scheduler`-related `of` signatures to use the n-args approach; and
- adds explicit `null` and `undefined` signatures to avoid incorrect types and confusing deprecation warnings for devs using `strictNullChecks: false` (even though they are naughty).

_I realize that these sigs are deprecated, but [we already have deprecated sigs in operators](https://github.com/ReactiveX/rxjs/blob/a7a04d1110666606a1f2ca6fd38642e6ca74f287/src/internal/operators/mergeWith.ts#L8-L17) that use n-args, so, IMO, things are less confusing if n-args is useds wherever possible. See also the reasons listed in https://github.com/ReactiveX/rxjs/pull/6092#issue-585989828_

**Related issue (if exists):** Nope