### PR TITLE
fix: remove misused type parameter from isObservable

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -209,7 +209,7 @@ export interface InteropObservable<T> {
 
 export declare function interval(period?: number, scheduler?: SchedulerLike): Observable<number>;
 
-export declare function isObservable<T>(obj: any): obj is Observable<T>;
+export declare function isObservable(obj: any): obj is Observable<unknown>;
 
 export declare function lastValueFrom<T>(source: Observable<T>): Promise<T>;
 

--- a/src/internal/util/isObservable.ts
+++ b/src/internal/util/isObservable.ts
@@ -1,3 +1,4 @@
+/** prettier */
 import { Observable } from '../Observable';
 import { isFunction } from './isFunction';
 
@@ -5,7 +6,7 @@ import { isFunction } from './isFunction';
  * Tests to see if the object is an RxJS {@link Observable}
  * @param obj the object to test
  */
-export function isObservable<T>(obj: any): obj is Observable<T> {
+export function isObservable(obj: any): obj is Observable<unknown> {
   // The !! is to ensure that this publicly exposed function returns
   // `false` if something like `null` or `0` is passed.
   return !!obj && (obj instanceof Observable || (isFunction(obj.lift) && isFunction(obj.subscribe)));


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes a misused type parameter from `isObservable`. The type parameter `T` is misused because there's no way it  can be inferred; it's nothing more than a type assertion. There is no way `isObservable` can know the element type of any value that it deems to be an `Observable`, so it should return `Observable<unknown>`. IMO, we should not be encouraging devs to write unsafe code.

**BREAKING CHANGE:** `isObservable` returns `is Observable<unknown>` and no longer accepts a type parameter.

**Related issue (if exists):** Nope