### PR TITLE
refactor: remove elementAt overload signatures

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -86,8 +86,7 @@ export declare function distinctUntilChanged<T, K>(comparator: (previous: K, cur
 export declare function distinctUntilKeyChanged<T>(key: keyof T): MonoTypeOperatorFunction<T>;
 export declare function distinctUntilKeyChanged<T, K extends keyof T>(key: K, compare: (x: T[K], y: T[K]) => boolean): MonoTypeOperatorFunction<T>;
 
-export declare function elementAt<T>(index: number): MonoTypeOperatorFunction<T>;
-export declare function elementAt<T, D>(index: number, defaultValue: D): OperatorFunction<T, T | D>;
+export declare function elementAt<T, D = T>(index: number, defaultValue?: D): OperatorFunction<T, T | D>;
 
 export declare function endWith<T>(scheduler: SchedulerLike): MonoTypeOperatorFunction<T>;
 export declare function endWith<T, A>(v1: A, scheduler: SchedulerLike): OperatorFunction<T, T | A>;

--- a/src/internal/operators/elementAt.ts
+++ b/src/internal/operators/elementAt.ts
@@ -1,13 +1,10 @@
 import { ArgumentOutOfRangeError } from '../util/ArgumentOutOfRangeError';
 import { Observable } from '../Observable';
-import { MonoTypeOperatorFunction, OperatorFunction } from '../types';
+import { OperatorFunction } from '../types';
 import { filter } from './filter';
 import { throwIfEmpty } from './throwIfEmpty';
 import { defaultIfEmpty } from './defaultIfEmpty';
 import { take } from './take';
-
-export function elementAt<T>(index: number): MonoTypeOperatorFunction<T>;
-export function elementAt<T, D>(index: number, defaultValue: D): OperatorFunction<T, T | D>;
 
 /**
  * Emits the single value at the specified `index` in a sequence of emissions
@@ -55,7 +52,7 @@ export function elementAt<T, D>(index: number, defaultValue: D): OperatorFunctio
  * @return {Observable} An Observable that emits a single item, if it is found.
  * Otherwise, will emit the default value if given. If not, then emits an error.
  */
-export function elementAt<T, D>(index: number, defaultValue?: D): OperatorFunction<T, T | D> {
+export function elementAt<T, D = T>(index: number, defaultValue?: D): OperatorFunction<T, T | D> {
   if (index < 0) {
     throw new ArgumentOutOfRangeError();
   }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes the overload signatures for `elementAt` and uses a default type parameter so that it's possible for (naughty) devs to explicitly specify a single type parameter. (This was the approach used with the related signatures in `first` and `last`.)

**Related issue (if exists):** Nope
