### PR TITLE
fix/refactor: use ObservedValueOf in using

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -526,7 +526,7 @@ export interface UnsubscriptionError extends Error {
 
 export declare const UnsubscriptionError: UnsubscriptionErrorCtor;
 
-export declare function using<T>(resourceFactory: () => Unsubscribable | void, observableFactory: (resource: Unsubscribable | void) => ObservableInput<T> | void): Observable<T>;
+export declare function using<T extends ObservableInput<any>>(resourceFactory: () => Unsubscribable | void, observableFactory: (resource: Unsubscribable | void) => T | void): Observable<ObservedValueOf<T>>;
 
 export declare type ValueFromArray<A extends readonly unknown[]> = A extends Array<infer T> ? T : never;
 

--- a/spec-dtslint/observables/using-spec.ts
+++ b/spec-dtslint/observables/using-spec.ts
@@ -1,0 +1,10 @@
+import { using } from 'rxjs';
+import { a$, b$ } from '../helpers';
+
+it('should infer with a simple factory', () => {
+  const o = using(() => {}, () => a$); // $ExpectType Observable<A>
+});
+
+it('should infer with a factory that returns a union', () => {
+  const o = using(() => {}, () => Math.random() < 0.5 ? a$ : b$); // $ExpectType Observable<A | B>
+});

--- a/src/internal/observable/using.ts
+++ b/src/internal/observable/using.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { Unsubscribable, ObservableInput } from '../types';
+import { Unsubscribable, ObservableInput, ObservedValueOf } from '../types';
 import { innerFrom } from './from';
 import { EMPTY } from './empty';
 
@@ -31,11 +31,11 @@ import { EMPTY } from './empty';
  * @return {Observable<T>} An Observable that behaves the same as Observable returned by `observableFactory`, but
  * which - when completed, errored or unsubscribed - will also call `unsubscribe` on created resource object.
  */
-export function using<T>(
+export function using<T extends ObservableInput<any>>(
   resourceFactory: () => Unsubscribable | void,
-  observableFactory: (resource: Unsubscribable | void) => ObservableInput<T> | void
-): Observable<T> {
-  return new Observable<T>((subscriber) => {
+  observableFactory: (resource: Unsubscribable | void) => T | void
+): Observable<ObservedValueOf<T>> {
+  return new Observable<ObservedValueOf<T>>((subscriber) => {
     const resource = resourceFactory();
     const result = observableFactory(resource);
     const source = result ? innerFrom(result) : EMPTY;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR uses `ObservedValueOf` in `using` to extract the observable element type from factories that return union types - as is done [elsewhere in the library](https://github.com/ReactiveX/rxjs/blob/65de22958f1b4cbf2b7a0de44be89a5bbf36ff90/src/internal/operators/mergeMap.ts#L9-L12).

**Related issue (if exists):** Nope