### PR TITLE
fix/refactor: use ObservedValueOf in expand

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -110,8 +110,8 @@ export declare function exhaustMap<T, O extends ObservableInput<any>>(project: (
 export declare function exhaustMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function exhaustMap<T, I, R>(project: (value: T, index: number) => ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
-export declare function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent?: number, scheduler?: SchedulerLike): OperatorFunction<T, R>;
-export declare function expand<T, R>(project: (value: T, index: number) => ObservableInput<R>, concurrent: number | undefined, scheduler: SchedulerLike): OperatorFunction<T, R>;
+export declare function expand<T, O extends ObservableInput<unknown>>(project: (value: T, index: number) => O, concurrent?: number, scheduler?: SchedulerLike): OperatorFunction<T, ObservedValueOf<O>>;
+export declare function expand<T, O extends ObservableInput<unknown>>(project: (value: T, index: number) => O, concurrent: number | undefined, scheduler: SchedulerLike): OperatorFunction<T, ObservedValueOf<O>>;
 
 export declare function filter<T, S extends T>(predicate: (value: T, index: number) => value is S, thisArg?: any): OperatorFunction<T, S>;
 export declare function filter<T>(predicate: BooleanConstructor): OperatorFunction<T, TruthyTypesOf<T>>;

--- a/spec-dtslint/operators/expand-spec.ts
+++ b/spec-dtslint/operators/expand-spec.ts
@@ -46,9 +46,6 @@ it('should enforce scheduler type', () => {
   const o = of(1, 2, 3).pipe(expand(value => of(1), 47, 'foo')); // $ExpectError
 });
 
-// TODO(benlesh): Fix this when TypeScript is capable of handling typing this.
-// Currently we can't type this one properly because the projection function is
-// recursively called with the values from the returned ObservableInput.
-// it('should support union types', () => {
-//   const o = of(1).pipe(expand(x => typeof x === 'string' ? of(123) : of('test'))); // $ExpectType Observable<string | number>
-// });
+it('should support union types', () => {
+  const o = of(1).pipe(expand(x => typeof x === 'string' ? of(123) : of('test'))); // $ExpectType Observable<string | number>
+});

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,22 +1,22 @@
-import { OperatorFunction, ObservableInput, SchedulerLike } from '../types';
+import { OperatorFunction, ObservableInput, ObservedValueOf, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { mergeInternals } from './mergeInternals';
 
 /* tslint:disable:max-line-length */
-export function expand<T, R>(
-  project: (value: T, index: number) => ObservableInput<R>,
+export function expand<T, O extends ObservableInput<unknown>>(
+  project: (value: T, index: number) => O,
   concurrent?: number,
   scheduler?: SchedulerLike
-): OperatorFunction<T, R>;
+): OperatorFunction<T, ObservedValueOf<O>>;
 /**
  * @deprecated Will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
  */
-export function expand<T, R>(
-  project: (value: T, index: number) => ObservableInput<R>,
+export function expand<T, O extends ObservableInput<unknown>>(
+  project: (value: T, index: number) => O,
   concurrent: number | undefined,
   scheduler: SchedulerLike
-): OperatorFunction<T, R>;
+): OperatorFunction<T, ObservedValueOf<O>>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -69,11 +69,11 @@ export function expand<T, R>(
  * output Observable and merging the results of the Observables obtained
  * from this transformation.
  */
-export function expand<T, R>(
-  project: (value: T, index: number) => ObservableInput<R>,
+export function expand<T, O extends ObservableInput<unknown>>(
+  project: (value: T, index: number) => O,
   concurrent = Infinity,
   scheduler?: SchedulerLike
-): OperatorFunction<T, R> {
+): OperatorFunction<T, ObservedValueOf<O>> {
   concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
   return operate((source, subscriber) =>
     mergeInternals(


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes `expand` to use `ObservedValueOf` for its `project` function - as is done [elsewhere in the library](https://github.com/ReactiveX/rxjs/blob/65de22958f1b4cbf2b7a0de44be89a5bbf36ff90/src/internal/operators/mergeMap.ts#L9-L12).

**Related issue (if exists):** Nope
