### PR TITLE
fix/refactor: use ObservedValueOf in connect

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -60,7 +60,7 @@ export declare function concatMapTo<T, R, O extends ObservableInput<any>>(observ
 
 export declare function concatWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
-export declare function connect<T, R>(selector: (shared: Observable<T>) => ObservableInput<R>, config?: ConnectConfig<T>): OperatorFunction<T, R>;
+export declare function connect<T, O extends ObservableInput<unknown>>(selector: (shared: Observable<T>) => O, config?: ConnectConfig<T>): OperatorFunction<T, ObservedValueOf<O>>;
 
 export declare function count<T>(predicate?: (value: T, index: number) => boolean): OperatorFunction<T, number>;
 

--- a/spec-dtslint/operators/connect-spec.ts
+++ b/spec-dtslint/operators/connect-spec.ts
@@ -1,0 +1,7 @@
+import { of } from 'rxjs';
+import { connect } from 'rxjs/operators';
+import { a$, b$ } from '../helpers';
+
+it('should infer from a union', () => {
+    const o = of(null).pipe(connect(() => Math.random() > 0.5 ? a$ : b$)); // $ExpectType Observable<A | B>
+});

--- a/src/internal/operators/connect.ts
+++ b/src/internal/operators/connect.ts
@@ -1,4 +1,4 @@
-import { OperatorFunction, ObservableInput, SubjectLike } from '../types';
+import { OperatorFunction, ObservableInput, ObservedValueOf, SubjectLike } from '../types';
 import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { from } from '../observable/from';
@@ -94,10 +94,10 @@ const DEFAULT_CONFIG: ConnectConfig<unknown> = {
  * the operator will subscribe to the source, and the connection will be made.
  * @param param0 The configuration object for `connect`.
  */
-export function connect<T, R>(
-  selector: (shared: Observable<T>) => ObservableInput<R>,
+export function connect<T, O extends ObservableInput<unknown>>(
+  selector: (shared: Observable<T>) => O,
   config: ConnectConfig<T> = DEFAULT_CONFIG
-): OperatorFunction<T, R> {
+): OperatorFunction<T, ObservedValueOf<O>> {
   const { connector } = config;
   return operate((source, subscriber) => {
     const subject = connector();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes `connect` to use `ObservedValueOf` for its `selector` function - as is done [elsewhere in the library](https://github.com/ReactiveX/rxjs/blob/65de22958f1b4cbf2b7a0de44be89a5bbf36ff90/src/internal/operators/mergeMap.ts#L9-L12).

**Related issue (if exists):** Nope
