### PR TITLE
fix/refactor: use ObservedValueOf in timeout

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -316,9 +316,9 @@ export declare function throwIfEmpty<T>(errorFactory?: () => any): MonoTypeOpera
 
 export declare function timeInterval<T>(scheduler?: SchedulerLike): OperatorFunction<T, TimeInterval<T>>;
 
-export declare function timeout<T, R, M = unknown>(config: TimeoutConfig<T, R, M> & {
-    with: (info: TimeoutInfo<T, M>) => ObservableInput<R>;
-}): OperatorFunction<T, T | R>;
+export declare function timeout<T, O extends ObservableInput<unknown>, M = unknown>(config: TimeoutConfig<T, O, M> & {
+    with: (info: TimeoutInfo<T, M>) => O;
+}): OperatorFunction<T, T | ObservedValueOf<O>>;
 export declare function timeout<T, M = unknown>(config: Omit<TimeoutConfig<T, any, M>, 'with'>): OperatorFunction<T, T>;
 export declare function timeout<T>(first: Date, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 export declare function timeout<T>(each: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;

--- a/spec-dtslint/operators/timeout-spec.ts
+++ b/spec-dtslint/operators/timeout-spec.ts
@@ -1,6 +1,6 @@
 import { of, asyncScheduler } from 'rxjs';
 import { timeout } from 'rxjs/operators';
-import { A } from '../helpers';
+import { A, a$, b$, c$ } from '../helpers';
 
 it('should infer correctly', () => {
   const o = of('a', 'b', 'c').pipe(timeout(10)); // $ExpectType Observable<string>
@@ -50,6 +50,14 @@ it('Check config arguments', () => {
   const o = of('a').pipe( // $ExpectType Observable<string>
     timeout({
       first: 1000
+    })
+  );
+});
+
+it('should support a union', () => {
+  const o = a$.pipe( // $ExpectType Observable<A | B | C>
+    timeout({ 
+      with: () => Math.random() > 0.5 ? b$ : c$
     })
   );
 });

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -107,7 +107,7 @@ export function timeoutWith<T, R>(
     throw new TypeError('No timeout provided.');
   }
 
-  return timeout<T, R>({
+  return timeout<T, ObservableInput<R>>({
     first,
     each,
     scheduler,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes `timeout` to use `ObservedValueOf` for its `with` option - as is done [elsewhere in the library](https://github.com/ReactiveX/rxjs/blob/65de22958f1b4cbf2b7a0de44be89a5bbf36ff90/src/internal/operators/mergeMap.ts#L9-L12).

**Related issue (if exists):** Nope
