### PR TITLE
fix/refactor: add type parameter for thisArg in every

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -99,7 +99,8 @@ export declare function endWith<T, A, B, C, D, E, F>(v1: A, v2: B, v3: C, v4: D,
 export declare function endWith<T, A extends any[] = T[]>(...args: A): OperatorFunction<T, T | ValueFromArray<A>>;
 
 export declare function every<T>(predicate: BooleanConstructor, thisArg?: any): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
-export declare function every<T, A = any>(predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean, thisArg?: A): OperatorFunction<T, boolean>;
+export declare function every<T, A>(predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean, thisArg: A): OperatorFunction<T, boolean>;
+export declare function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, boolean>;
 
 export declare const exhaust: typeof exhaustAll;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -99,7 +99,7 @@ export declare function endWith<T, A, B, C, D, E, F>(v1: A, v2: B, v3: C, v4: D,
 export declare function endWith<T, A extends any[] = T[]>(...args: A): OperatorFunction<T, T | ValueFromArray<A>>;
 
 export declare function every<T>(predicate: BooleanConstructor, thisArg?: any): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
-export declare function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): OperatorFunction<T, boolean>;
+export declare function every<T, A = any>(predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean, thisArg?: A): OperatorFunction<T, boolean>;
 
 export declare const exhaust: typeof exhaustAll;
 

--- a/spec-dtslint/operators/every-spec.ts
+++ b/spec-dtslint/operators/every-spec.ts
@@ -44,3 +44,11 @@ it('should handle the Boolean constructor', () => {
   const d = of(NaN, NaN, NaN).pipe(every(Boolean)); // $ExpectType Observable<boolean>
   const e = of(0, 1, 0).pipe(every(Boolean)); // $ExpectType Observable<boolean>
 })
+
+it('should support this', () => {
+  const thisArg = { limit: 5 };
+  const a = of(1, 2, 3).pipe(every(function (val) {
+    const limit = this.limit; // $ExpectType number
+    return val < limit;
+  }, thisArg));
+});

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -7,9 +7,9 @@ export function every<T>(
   predicate: BooleanConstructor,
   thisArg?: any
 ): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
-export function every<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
+export function every<T, A = any>(
+  predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean,
+  thisArg?: A
 ): OperatorFunction<T, boolean>;
 
 /**

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -7,10 +7,11 @@ export function every<T>(
   predicate: BooleanConstructor,
   thisArg?: any
 ): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
-export function every<T, A = any>(
+export function every<T, A>(
   predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: A
+  thisArg: A
 ): OperatorFunction<T, boolean>;
+export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, boolean>;
 
 /**
  * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds an overload signature with a type parameter for the `thisArg` parameter in `every` so that if `this` is used in the predicate, it it correctly typed. If an arrow function is used, it behaves as before - regardless of whether a `thisArg` is specified or not.

**Related issue (if exists):** Nope
