### PR TITLE
fix/refactor: add type parameter for thisArg in partition

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -368,7 +368,8 @@ export declare function pairs(n: number | bigint | boolean | ((...args: any[]) =
 
 export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
-export declare function partition<T, A = any>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => boolean, thisArg?: A): [Observable<T>, Observable<T>];
+export declare function partition<T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => boolean, thisArg: A): [Observable<T>, Observable<T>];
+export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
 
 export declare function pipe<T>(): UnaryFunction<T, T>;
 export declare function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -368,7 +368,7 @@ export declare function pairs(n: number | bigint | boolean | ((...args: any[]) =
 
 export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
-export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean, thisArg?: any): [Observable<T>, Observable<T>];
+export declare function partition<T, A = any>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => boolean, thisArg?: A): [Observable<T>, Observable<T>];
 
 export declare function pipe<T>(): UnaryFunction<T, T>;
 export declare function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;

--- a/spec-dtslint/observables/partition-spec.ts
+++ b/spec-dtslint/observables/partition-spec.ts
@@ -18,3 +18,11 @@ it('should enforce predicate types', () => {
   const p = partition(of('a', 'b', 'c'), (value: number) => true); // $ExpectError
   const q = partition(of('a', 'b', 'c'), (value, index: string) => true); // $ExpectError
 });
+
+it('should support this', () => {
+  const thisArg = { limit: 2 };
+  const a = partition(of(1, 2, 3), function (val) {
+    const limit = this.limit; // $ExpectType number
+    return val < limit;
+  }, thisArg);
+});

--- a/src/internal/observable/partition.ts
+++ b/src/internal/observable/partition.ts
@@ -2,7 +2,7 @@ import { not } from '../util/not';
 import { filter } from '../operators/filter';
 import { ObservableInput } from '../types';
 import { Observable } from '../Observable';
-import {  innerFrom } from './from';
+import { innerFrom } from './from';
 
 /**
  * Splits the source Observable into two, one with values that satisfy a
@@ -55,13 +55,13 @@ import {  innerFrom } from './from';
  * with values that passed the predicate, and another with values that did not
  * pass the predicate.
  */
-export function partition<T>(
+export function partition<T, A = any>(
   source: ObservableInput<T>,
-  predicate: (value: T, index: number) => boolean,
-  thisArg?: any
+  predicate: (this: A, value: T, index: number) => boolean,
+  thisArg?: A
 ): [Observable<T>, Observable<T>] {
-  return [
-    filter(predicate, thisArg)(innerFrom(source)),
-    filter(not(predicate, thisArg))(innerFrom(source))
-  ] as [Observable<T>, Observable<T>];
+  return [filter(predicate, thisArg)(innerFrom(source)), filter(not(predicate, thisArg))(innerFrom(source))] as [
+    Observable<T>,
+    Observable<T>
+  ];
 }

--- a/src/internal/observable/partition.ts
+++ b/src/internal/observable/partition.ts
@@ -4,6 +4,13 @@ import { ObservableInput } from '../types';
 import { Observable } from '../Observable';
 import { innerFrom } from './from';
 
+export function partition<T, A>(
+  source: ObservableInput<T>,
+  predicate: (this: A, value: T, index: number) => boolean,
+  thisArg: A
+): [Observable<T>, Observable<T>];
+export function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
+
 /**
  * Splits the source Observable into two, one with values that satisfy a
  * predicate, and another with values that don't satisfy the predicate.
@@ -55,10 +62,10 @@ import { innerFrom } from './from';
  * with values that passed the predicate, and another with values that did not
  * pass the predicate.
  */
-export function partition<T, A = any>(
+export function partition<T>(
   source: ObservableInput<T>,
-  predicate: (this: A, value: T, index: number) => boolean,
-  thisArg?: A
+  predicate: (this: any, value: T, index: number) => boolean,
+  thisArg?: any
 ): [Observable<T>, Observable<T>] {
   return [filter(predicate, thisArg)(innerFrom(source)), filter(not(predicate, thisArg))(innerFrom(source))] as [
     Observable<T>,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds an overload signature with a type parameter for the `thisArg` parameter in `partition` so that if `this` is used in the predicate, it it correctly typed. If an arrow function is used, it behaves as before - regardless of whether a `thisArg` is specified or not.

**Related issue (if exists):** Nope
