### PR TITLE
fix: forkJoin POJO signature should match only ObservableInput values

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -165,6 +165,7 @@ export declare type Falsy = null | undefined | false | 0 | -0 | 0n | '';
 
 export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
+export declare function forkJoin(scheduler: null | undefined): Observable<never>;
 export declare function forkJoin(sources: readonly []): Observable<never>;
 export declare function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
 export declare function forkJoin<A extends readonly unknown[], R>(sources: readonly [...ObservableInputTuple<A>], resultSelector: (...values: A) => R): Observable<R>;
@@ -173,7 +174,7 @@ export declare function forkJoin<A extends readonly unknown[], R>(...sourcesAndR
 export declare function forkJoin(sourcesObject: {
     [K in any]: never;
 }): Observable<never>;
-export declare function forkJoin<T>(sourcesObject: T): Observable<{
+export declare function forkJoin<T extends Record<any, ObservableInput<any>>>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
 

--- a/spec-dtslint/observables/forkJoin-spec.ts
+++ b/spec-dtslint/observables/forkJoin-spec.ts
@@ -72,6 +72,12 @@ describe('forkJoin({})', () => {
     const obj = { foo: of(1), bar: of('two'), baz: of(false) };
     const res = forkJoin(obj); // $ExpectType Observable<{ foo: number; bar: string; baz: boolean; }>
   });
+
+  it('should reject non-ObservableInput values', () => {
+    const obj = { answer: 42 };
+    const res = forkJoin(obj); // $ExpectError
+
+  });
 });
 
 describe('forkJoin([])', () => {

--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -471,11 +471,11 @@ describe('forkJoin', () => {
     it('should have same v5/v6 throwing behavior full argument of null', (done) => {
       rxTestScheduler.run(() => {
         // It doesn't throw when you pass null
-        expect(() => forkJoin(null)).not.to.throw();
+        expect(() => forkJoin(null as any)).not.to.throw();
 
         // It doesn't even throw if you subscribe to forkJoin(null).
         expect(() =>
-          forkJoin(null).subscribe({
+          forkJoin(null as any).subscribe({
             // It sends the error to the subscription.
             error: () => done(),
           })

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -1,11 +1,13 @@
 import { Observable } from '../Observable';
-import { ObservedValueOf, ObservableInputTuple } from '../types';
+import { ObservedValueOf, ObservableInputTuple, ObservableInput } from '../types';
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { innerFrom } from './from';
 import { popResultSelector } from '../util/args';
 import { OperatorSubscriber } from '../operators/OperatorSubscriber';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { createObject } from '../util/createObject';
+
+export function forkJoin(scheduler: null | undefined): Observable<never>;
 
 // forkJoin([a, b, c])
 export function forkJoin(sources: readonly []): Observable<never>;
@@ -26,7 +28,9 @@ export function forkJoin<A extends readonly unknown[], R>(
 
 // forkJoin({a, b, c})
 export function forkJoin(sourcesObject: { [K in any]: never }): Observable<never>;
-export function forkJoin<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+export function forkJoin<T extends Record<any, ObservableInput<any>>>(
+  sourcesObject: T
+): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /**
  * Accepts an `Array` of {@link ObservableInput} or a dictionary `Object` of {@link ObservableInput} and returns


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR tightens the `forkJoin` POJO signature so that only POJOs with `ObservableInput` values are matched. The implementation throws if the received POJO contains a value that is not an `ObservableInput`, so the types should reflect that.

**Related issue (if exists):** Nope
