### PR TITLE
fix/refactor: add type parameter for thisArg in map

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -152,7 +152,8 @@ export declare function last<T, D = T>(predicate?: null, defaultValue?: D): Oper
 export declare function last<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S, defaultValue?: S): OperatorFunction<T, S>;
 export declare function last<T, D = T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, defaultValue?: D): OperatorFunction<T, T | D>;
 
-export declare function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): OperatorFunction<T, R>;
+export declare function map<T, R>(project: (value: T, index: number) => R): OperatorFunction<T, R>;
+export declare function map<T, R, A>(project: (this: A, value: T, index: number) => R, thisArg: A): OperatorFunction<T, R>;
 
 export declare function mapTo<R>(value: R): OperatorFunction<any, R>;
 export declare function mapTo<T, R>(value: R): OperatorFunction<T, R>;

--- a/spec-dtslint/operators/map-spec.ts
+++ b/spec-dtslint/operators/map-spec.ts
@@ -25,3 +25,11 @@ it('should enforce the projecter types', () => {
   const o = of(1, 2, 3).pipe(map((value: string) => value)); // $ExpectError
   const p = of(1, 2, 3).pipe(map((value, index: string) => value)); // $ExpectError
 });
+
+it('should support this', () => {
+  const thisArg = { limit: 2 };
+  const o = of(1, 2, 3).pipe(map(function (val) {
+    const limit = this.limit; // $ExpectType number
+    return val < limit ? val : limit;
+  }, thisArg));
+});

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -2,6 +2,9 @@ import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
+export function map<T, R>(project: (value: T, index: number) => R): OperatorFunction<T, R>;
+export function map<T, R, A>(project: (this: A, value: T, index: number) => R, thisArg: A): OperatorFunction<T, R>;
+
 /**
  * Applies a given `project` function to each value emitted by the source
  * Observable, and emits the resulting values as an Observable.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds an overload signature with a type parameter for the `thisArg` parameter in `map` so that if `this` is used in the predicate, it it correctly typed. If an arrow function is used, it behaves as before - regardless of whether a `thisArg` is specified or not.

**Related issue (if exists):** Nope
