### PR TITLE
fix: predicates that return `any` will now behave property with findIndex

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -123,7 +123,6 @@ export declare function find<T>(predicate: BooleanConstructor): OperatorFunction
 export declare function find<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S, thisArg?: any): OperatorFunction<T, S | undefined>;
 export declare function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): OperatorFunction<T, T | undefined>;
 
-export declare function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => false, thisArg?: any): OperatorFunction<T, -1>;
 export declare function findIndex<T>(predicate: BooleanConstructor, thisArg?: any): OperatorFunction<T, T extends Falsy ? -1 : number>;
 export declare function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): OperatorFunction<T, number>;
 

--- a/spec-dtslint/operators/findIndex-spec.ts
+++ b/spec-dtslint/operators/findIndex-spec.ts
@@ -38,4 +38,11 @@ it('should support Boolean constructor', () => {
 
 it('should properly narrow an always false predicate', () => {
   const a = of('foo', 'bar', 'baz').pipe(findIndex(() => false)); // $ExpectType Observable<-1>
-})
+});
+
+it('should support inference from a predicate that returns any', () => {
+  function isTruthy(value: number): any {
+    return !!value;
+  }
+  const a = of(1).pipe(findIndex(isTruthy)); // $ExpectType Observable<number>
+});

--- a/spec-dtslint/operators/findIndex-spec.ts
+++ b/spec-dtslint/operators/findIndex-spec.ts
@@ -36,10 +36,6 @@ it('should support Boolean constructor', () => {
   const b = of(0 as const, -0 as const, null, 'hi there' as const, undefined, false as const, '' as const).pipe(findIndex(Boolean)); // $ExpectType Observable<number>
 });
 
-it('should properly narrow an always false predicate', () => {
-  const a = of('foo', 'bar', 'baz').pipe(findIndex(() => false)); // $ExpectType Observable<-1>
-});
-
 it('should support inference from a predicate that returns any', () => {
   function isTruthy(value: number): any {
     return !!value;

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -3,7 +3,6 @@ import { Falsy, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { createFind } from './find';
 
-export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => false, thisArg?: any): OperatorFunction<T, -1>;
 export function findIndex<T>(predicate: BooleanConstructor, thisArg?: any): OperatorFunction<T, T extends Falsy ? -1 : number>;
 export function findIndex<T>(
   predicate: (value: T, index: number, source: Observable<T>) => boolean,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The changes in #5987 missed a `findIndex` signature that matched predicates that always returned `false` and was not compatible with predicates typed as returning `any`.

**Related issue (if exists):** #5986 and #5987
