### PR TITLE
fix: combineLatest POJO signature should match only ObservableInput values

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -52,7 +52,7 @@ export declare function combineLatest<A extends readonly unknown[]>(...args: [..
 export declare function combineLatest(sourcesObject: {
     [K in any]: never;
 }): Observable<never>;
-export declare function combineLatest<T extends Record<any, ObservableInput<any>>>(sourcesObject: T): Observable<{
+export declare function combineLatest<T extends Record<string, ObservableInput<any>>>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(array: O[], resultSelector: (...values: ObservedValueOf<O>[]) => R, scheduler?: SchedulerLike): Observable<R>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -52,7 +52,7 @@ export declare function combineLatest<A extends readonly unknown[]>(...args: [..
 export declare function combineLatest(sourcesObject: {
     [K in any]: never;
 }): Observable<never>;
-export declare function combineLatest<T>(sourcesObject: T): Observable<{
+export declare function combineLatest<T extends Record<any, ObservableInput<any>>>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
 export declare function combineLatest<O extends ObservableInput<any>, R>(array: O[], resultSelector: (...values: ObservedValueOf<O>[]) => R, scheduler?: SchedulerLike): Observable<R>;

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -141,4 +141,9 @@ describe('combineLatest({})', () => {
     const obj = { foo: a$, bar: b$, baz: c$ };
     const res = combineLatest(obj); // $ExpectType Observable<{ foo: A; bar: B; baz: C; }>
   });
+
+  it('should reject non-ObservableInput values', () => {
+    const obj = { answer: 42 };
+    const res = combineLatest(obj); // $ExpectError
+  });
 });

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -44,7 +44,9 @@ export function combineLatest<A extends readonly unknown[]>(...args: [...Observa
 
 // combineLatest({a, b, c})
 export function combineLatest(sourcesObject: { [K in any]: never }): Observable<never>;
-export function combineLatest<T>(sourcesObject: T): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+export function combineLatest<T extends Record<any, ObservableInput<any>>>(
+  sourcesObject: T
+): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
 /** @deprecated resultSelector no longer supported, pipe to map instead */
 export function combineLatest<O extends ObservableInput<any>, R>(

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -44,7 +44,7 @@ export function combineLatest<A extends readonly unknown[]>(...args: [...Observa
 
 // combineLatest({a, b, c})
 export function combineLatest(sourcesObject: { [K in any]: never }): Observable<never>;
-export function combineLatest<T extends Record<any, ObservableInput<any>>>(
+export function combineLatest<T extends Record<string, ObservableInput<any>>>(
   sourcesObject: T
 ): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR tightens the `combineLatest` POJO signature so that only POJOs with `ObservableInput` values are matched. The implementation throws if the received POJO contains a value that is not an `ObservableInput`, so the types should reflect that.

**Related issue (if exists):** Nope
