### PR TITLE
refactor: use n-args for combineLatest operator

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -18,20 +18,10 @@ export declare function catchError<T, O extends ObservableInput<any>>(selector: 
 
 export declare const combineAll: typeof combineLatestAll;
 
-export declare function combineLatest<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
-export declare function combineLatest<T, T2, R>(v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R): OperatorFunction<T, R>;
-export declare function combineLatest<T, T2, T3, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R): OperatorFunction<T, R>;
-export declare function combineLatest<T, T2, T3, T4, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R): OperatorFunction<T, R>;
-export declare function combineLatest<T, T2, T3, T4, T5, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R): OperatorFunction<T, R>;
-export declare function combineLatest<T, T2, T3, T4, T5, T6, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R): OperatorFunction<T, R>;
-export declare function combineLatest<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
-export declare function combineLatest<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
-export declare function combineLatest<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, [T, T2, T3, T4]>;
-export declare function combineLatest<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, [T, T2, T3, T4, T5]>;
-export declare function combineLatest<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]>;
-export declare function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): OperatorFunction<T, R>;
-export declare function combineLatest<T, R>(array: ObservableInput<T>[]): OperatorFunction<T, Array<T>>;
-export declare function combineLatest<T, TOther, R>(array: ObservableInput<TOther>[], project: (v1: T, ...values: Array<TOther>) => R): OperatorFunction<T, R>;
+export declare function combineLatest<T, A extends readonly unknown[], R>(sources: [...ObservableInputTuple<A>], project: (...values: [T, ...A]) => R): OperatorFunction<T, R>;
+export declare function combineLatest<T, A extends readonly unknown[], R>(sources: [...ObservableInputTuple<A>]): OperatorFunction<T, [T, ...A]>;
+export declare function combineLatest<T, A extends readonly unknown[], R>(...sourcesAndProject: [...ObservableInputTuple<A>, (...values: [T, ...A]) => R]): OperatorFunction<T, R>;
+export declare function combineLatest<T, A extends readonly unknown[], R>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, [T, ...A]>;
 
 export declare function combineLatestAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export declare function combineLatestAll<T>(): OperatorFunction<any, T[]>;

--- a/spec-dtslint/operators/combineLatest-spec.ts
+++ b/spec-dtslint/operators/combineLatest-spec.ts
@@ -43,7 +43,7 @@ describe('combineLatest', () => {
       const res = a.pipe(combineLatest(b, c, d, e, f)); // $ExpectType Observable<[number, string, string, string, string, string]>
     });
 
-    it('should only accept maximum params of 5', () => {
+    it('should infer correctly with 6 params', () => {
       const a = of(1, 2, 3);
       const b = of('a', 'b', 'c');
       const c = of('d', 'e', 'f');
@@ -51,7 +51,7 @@ describe('combineLatest', () => {
       const e = of('j', 'k', 'l');
       const f = of('m', 'n', 'o');
       const g = of('p', 'q', 'r');
-      const res = a.pipe(combineLatest(b, c, d, e, f, g)); // $ExpectError
+      const res = a.pipe(combineLatest(b, c, d, e, f, g)); // $ExpectType Observable<[number, string, string, string, string, string, string]>
     });
   });
 

--- a/src/internal/operators/combineLatest.ts
+++ b/src/internal/operators/combineLatest.ts
@@ -1,81 +1,25 @@
 import { combineLatestInit } from '../observable/combineLatest';
-import { ObservableInput, OperatorFunction } from '../types';
+import { ObservableInput, ObservableInputTuple, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { pipe } from '../util/pipe';
 import { popResultSelector } from '../util/args';
 
-/* tslint:disable:max-line-length */
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, R>(v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R): OperatorFunction<T, R>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  project: (v1: T, v2: T2, v3: T3) => R
+export function combineLatest<T, A extends readonly unknown[], R>(
+  sources: [...ObservableInputTuple<A>],
+  project: (...values: [T, ...A]) => R
 ): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  project: (v1: T, v2: T2, v3: T3, v4: T4) => R
+export function combineLatest<T, A extends readonly unknown[], R>(sources: [...ObservableInputTuple<A>]): OperatorFunction<T, [T, ...A]>;
+
+/** @deprecated use {@link combineLatestWith} */
+export function combineLatest<T, A extends readonly unknown[], R>(
+  ...sourcesAndProject: [...ObservableInputTuple<A>, (...values: [T, ...A]) => R]
 ): OperatorFunction<T, R>;
 /** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R
-): OperatorFunction<T, R>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5, T6, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R
-): OperatorFunction<T, R>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>
-): OperatorFunction<T, [T, T2, T3, T4]>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>
-): OperatorFunction<T, [T, T2, T3, T4, T5]>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, T2, T3, T4, T5, T6>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>
-): OperatorFunction<T, [T, T2, T3, T4, T5, T6]>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): OperatorFunction<T, R>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, R>(array: ObservableInput<T>[]): OperatorFunction<T, Array<T>>;
-/** @deprecated use {@link combineLatestWith} */
-export function combineLatest<T, TOther, R>(
-  array: ObservableInput<TOther>[],
-  project: (v1: T, ...values: Array<TOther>) => R
-): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
+export function combineLatest<T, A extends readonly unknown[], R>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, [T, ...A]>;
 
 /**
  * @deprecated Deprecated, use {@link combineLatestWith} or static {@link combineLatest}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the `combineLatest` operator's signatures to use the n-args approach.

_I realize that these sigs are deprecated, but [we already have deprecated sigs in other operators](https://github.com/ReactiveX/rxjs/blob/a7a04d1110666606a1f2ca6fd38642e6ca74f287/src/internal/operators/mergeWith.ts#L8-L17) that use n-args, so, IMO, things are less confusing if n-args is used wherever possible._

**Related issue (if exists):** Nope
