### PR TITLE
refactor: use n-args for concat operator

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -30,14 +30,8 @@ export declare function combineLatestAll<R>(project: (...values: Array<any>) => 
 
 export declare function combineLatestWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
 
-export declare function concat<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
-export declare function concat<T, T2>(v2: ObservableInput<T2>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2>;
-export declare function concat<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3>;
-export declare function concat<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4>;
-export declare function concat<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-export declare function concat<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-export declare function concat<T>(...observables: Array<ObservableInput<T> | SchedulerLike>): MonoTypeOperatorFunction<T>;
-export declare function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike>): OperatorFunction<T, R>;
+export declare function concat<T, A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+export declare function concat<T, A extends readonly unknown[]>(...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike]): OperatorFunction<T, T | A[number]>;
 
 export declare function concatAll<T>(): OperatorFunction<ObservableInput<T>, T>;
 export declare function concatAll<R>(): OperatorFunction<any, R>;

--- a/src/internal/operators/concat.ts
+++ b/src/internal/operators/concat.ts
@@ -1,47 +1,15 @@
-import { ObservableInput, OperatorFunction, MonoTypeOperatorFunction, SchedulerLike } from '../types';
+import { ObservableInputTuple, OperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
 import { concatAll } from './concatAll';
 import { internalFromArray } from '../observable/fromArray';
 import { popScheduler } from '../util/args';
 
 /** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T>(scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
+export function concat<T, A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 /** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2>(v2: ObservableInput<T2>, scheduler?: SchedulerLike): OperatorFunction<T, T | T2>;
-/** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3>;
-/** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3, T4>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4>;
-/** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3, T4, T5>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4 | T5>;
-/** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, T2, T3, T4, T5, T6>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, T | T2 | T3 | T4 | T5 | T6>;
-/** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T>(...observables: Array<ObservableInput<T> | SchedulerLike>): MonoTypeOperatorFunction<T>;
-/** @deprecated remove in v8. Use {@link concatWith} */
-export function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike>): OperatorFunction<T, R>;
+export function concat<T, A extends readonly unknown[]>(
+  ...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike]
+): OperatorFunction<T, T | A[number]>;
 
 /**
  * @deprecated remove in v8. Use {@link concatWith}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the `concat` operator's signatures to use the n-args approach.

_I realize that these sigs are deprecated, but [we already have deprecated sigs in other operators](https://github.com/ReactiveX/rxjs/blob/a7a04d1110666606a1f2ca6fd38642e6ca74f287/src/internal/operators/mergeWith.ts#L8-L17) that use n-args, so, IMO, things are less confusing if n-args is used wherever possible._

**Related issue (if exists):** Nope