### PR TITLE
refactor: use n-args for merge operator

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -148,10 +148,10 @@ export declare function materialize<T>(): OperatorFunction<T, Notification<T> & 
 
 export declare function max<T>(comparer?: (x: T, y: T) => number): MonoTypeOperatorFunction<T>;
 
-export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
-export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number?]): OperatorFunction<T, T | A[number]>;
-export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, SchedulerLike?]): OperatorFunction<T, T | A[number]>;
-export declare function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number?, SchedulerLike?]): OperatorFunction<T, T | A[number]>;
+export declare function merge<T, A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+export declare function merge<T, A extends readonly unknown[]>(...sourcesAndConcurrency: [...ObservableInputTuple<A>, number]): OperatorFunction<T, T | A[number]>;
+export declare function merge<T, A extends readonly unknown[]>(...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike]): OperatorFunction<T, T | A[number]>;
+export declare function merge<T, A extends readonly unknown[]>(...sourcesAndConcurrencyAndScheduler: [...ObservableInputTuple<A>, number, SchedulerLike]): OperatorFunction<T, T | A[number]>;
 
 export declare function mergeAll<O extends ObservableInput<any>>(concurrent?: number): OperatorFunction<O, ObservedValueOf<O>>;
 

--- a/src/internal/operators/merge.ts
+++ b/src/internal/operators/merge.ts
@@ -6,14 +6,18 @@ import { mergeAll } from './mergeAll';
 import { popNumber, popScheduler } from '../util/args';
 
 /** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+export function merge<T, A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 /** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, number?]): OperatorFunction<T, T | A[number]>;
+export function merge<T, A extends readonly unknown[]>(
+  ...sourcesAndConcurrency: [...ObservableInputTuple<A>, number]
+): OperatorFunction<T, T | A[number]>;
 /** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown[]>(...args: [...ObservableInputTuple<A>, SchedulerLike?]): OperatorFunction<T, T | A[number]>;
+export function merge<T, A extends readonly unknown[]>(
+  ...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike]
+): OperatorFunction<T, T | A[number]>;
 /** @deprecated use {@link mergeWith} or static {@link merge} */
-export function merge<T, A extends unknown[]>(
-  ...args: [...ObservableInputTuple<A>, number?, SchedulerLike?]
+export function merge<T, A extends readonly unknown[]>(
+  ...sourcesAndConcurrencyAndScheduler: [...ObservableInputTuple<A>, number, SchedulerLike]
 ): OperatorFunction<T, T | A[number]>;
 
 export function merge<T>(...args: unknown[]): OperatorFunction<T, unknown> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the `merge` operator's signatures to use the n-args approach.

_I realize that these sigs are deprecated, but [we already have deprecated sigs in other operators](https://github.com/ReactiveX/rxjs/blob/a7a04d1110666606a1f2ca6fd38642e6ca74f287/src/internal/operators/mergeWith.ts#L8-L17) that use n-args, so, IMO, things are less confusing if n-args is used wherever possible._

**Related issue (if exists):** Nope