### PR TITLE
refactor: use n-args for race operator

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -202,10 +202,8 @@ export declare function publishReplay<T>(bufferSize?: number, windowTime?: numbe
 export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize: number | undefined, windowTime: number | undefined, selector: (shared: Observable<T>) => O, timestampProvider?: TimestampProvider): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function publishReplay<T, O extends ObservableInput<any>>(bufferSize: number | undefined, windowTime: number | undefined, selector: undefined, timestampProvider: TimestampProvider): OperatorFunction<T, ObservedValueOf<O>>;
 
-export declare function race<T>(observables: Array<Observable<T>>): MonoTypeOperatorFunction<T>;
-export declare function race<T, R>(observables: Array<Observable<T>>): OperatorFunction<T, R>;
-export declare function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): MonoTypeOperatorFunction<T>;
-export declare function race<T, R>(...observables: Array<Observable<any> | Array<Observable<any>>>): OperatorFunction<T, R>;
+export declare function race<T, A extends readonly unknown[]>(otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+export declare function race<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 export declare function raceWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 

--- a/spec-dtslint/operators/race-spec.ts
+++ b/spec-dtslint/operators/race-spec.ts
@@ -15,22 +15,6 @@ it('should allow an array of observables', () => {
   const p = of('a', 'b', 'c').pipe(race([of('x', 'y', 'z'), of('t', 'i', 'm')])); // $ExpectType Observable<string>
 });
 
-it('should be possible to provide a return type', () => {
-  const o = of('a', 'b', 'c').pipe(race<string, number>([of(1, 2, 3)])); // $ExpectType Observable<number>
-  const p = of('a', 'b', 'c').pipe(race<string, number>([of(1, 2, 3), of('t', 'i', 'm')])); // $ExpectType Observable<number>
-  const q = of('a', 'b', 'c').pipe(race<string, number>(of(1, 2, 3), [of(1, 2, 3)])); // $ExpectType Observable<number>
-  const r = of('a', 'b', 'c').pipe(race<string, number>([of(1, 2, 3)], of('t', 'i', 'm'))); // $ExpectType Observable<number>
-});
-
 it('should be possible to use nested arrays', () => {
   const o = of('a', 'b', 'c').pipe(race([of('x', 'y', 'z')])); // $ExpectType Observable<string>
-});
-
-it('should enforce types', () => {
-  const o = of('a', 'b', 'c').pipe(race('aa')); // $ExpectError
-});
-
-it('should enforce argument types when not provided ', () => {
-  const o = of('a', 'b', 'c').pipe(race(of(1, 2, 3))); // $ExpectError
-  const p = of('a', 'b', 'c').pipe(race([of(1, 2, 3)])); // $ExpectError
 });

--- a/src/internal/operators/race.ts
+++ b/src/internal/operators/race.ts
@@ -2,7 +2,9 @@ import { ObservableInputTuple, OperatorFunction } from '../types';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { raceWith } from './raceWith';
 
+/** @deprecated Deprecated use {@link raceWith} */
 export function race<T, A extends readonly unknown[]>(otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+/** @deprecated Deprecated use {@link raceWith} */
 export function race<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 /**

--- a/src/internal/operators/race.ts
+++ b/src/internal/operators/race.ts
@@ -1,18 +1,9 @@
-import { Observable } from '../Observable';
-import { MonoTypeOperatorFunction, OperatorFunction } from '../types';
+import { ObservableInputTuple, OperatorFunction } from '../types';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { raceWith } from './raceWith';
 
-/* tslint:disable:max-line-length */
-/** @deprecated Deprecated use {@link raceWith} */
-export function race<T>(observables: Array<Observable<T>>): MonoTypeOperatorFunction<T>;
-/** @deprecated Deprecated use {@link raceWith} */
-export function race<T, R>(observables: Array<Observable<T>>): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link raceWith} */
-export function race<T>(...observables: Array<Observable<T> | Array<Observable<T>>>): MonoTypeOperatorFunction<T>;
-/** @deprecated Deprecated use {@link raceWith} */
-export function race<T, R>(...observables: Array<Observable<any> | Array<Observable<any>>>): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
+export function race<T, A extends readonly unknown[]>(otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
+export function race<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 /**
  * Returns an Observable that mirrors the first source Observable to emit a next,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the `race` operator's signatures to use the n-args approach and deletes tests that are no-longer-relevant with the n-args implementation.

_I realize that these sigs are deprecated, but [we already have deprecated sigs in other operators](https://github.com/ReactiveX/rxjs/blob/a7a04d1110666606a1f2ca6fd38642e6ca74f287/src/internal/operators/mergeWith.ts#L8-L17) that use n-args, so, IMO, things are less confusing if n-args is used wherever possible._

**Related issue (if exists):** Nope