### PR TITLE
refactor: use n-args for zip operator

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -332,20 +332,10 @@ export declare function windowWhen<T>(closingSelector: () => ObservableInput<any
 export declare function withLatestFrom<T, O extends unknown[]>(...inputs: [...ObservableInputTuple<O>]): OperatorFunction<T, [T, ...O]>;
 export declare function withLatestFrom<T, O extends unknown[], R>(...inputs: [...ObservableInputTuple<O>, (...value: [T, ...O]) => R]): OperatorFunction<T, R>;
 
-export declare function zip<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
-export declare function zip<T, T2, R>(v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R): OperatorFunction<T, R>;
-export declare function zip<T, T2, T3, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, project: (v1: T, v2: T2, v3: T3) => R): OperatorFunction<T, R>;
-export declare function zip<T, T2, T3, T4, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, project: (v1: T, v2: T2, v3: T3, v4: T4) => R): OperatorFunction<T, R>;
-export declare function zip<T, T2, T3, T4, T5, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R): OperatorFunction<T, R>;
-export declare function zip<T, T2, T3, T4, T5, T6, R>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>, project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R): OperatorFunction<T, R>;
-export declare function zip<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
-export declare function zip<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
-export declare function zip<T, T2, T3, T4>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>): OperatorFunction<T, [T, T2, T3, T4]>;
-export declare function zip<T, T2, T3, T4, T5>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>): OperatorFunction<T, [T, T2, T3, T4, T5]>;
-export declare function zip<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v3: ObservableInput<T3>, v4: ObservableInput<T4>, v5: ObservableInput<T5>, v6: ObservableInput<T6>): OperatorFunction<T, [T, T2, T3, T4, T5, T6]>;
-export declare function zip<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): OperatorFunction<T, R>;
-export declare function zip<T, R>(array: Array<ObservableInput<T>>): OperatorFunction<T, R>;
-export declare function zip<T, TOther, R>(array: Array<ObservableInput<TOther>>, project: (v1: T, ...values: Array<TOther>) => R): OperatorFunction<T, R>;
+export declare function zip<T, A extends readonly unknown[]>(otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
+export declare function zip<T, A extends readonly unknown[], R>(otherInputsAndProject: [...ObservableInputTuple<A>], project: (...values: Cons<T, A>) => R): OperatorFunction<T, R>;
+export declare function zip<T, A extends readonly unknown[]>(...otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
+export declare function zip<T, A extends readonly unknown[], R>(...otherInputsAndProject: [...ObservableInputTuple<A>, (...values: Cons<T, A>) => R]): OperatorFunction<T, R>;
 
 export declare function zipAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export declare function zipAll<T>(): OperatorFunction<any, T[]>;

--- a/spec-dtslint/operators/zip-spec.ts
+++ b/spec-dtslint/operators/zip-spec.ts
@@ -1,16 +1,15 @@
 import { Observable, of } from 'rxjs';
 import { zip } from 'rxjs/operators';
 
+it('should support observables', () => {
+  const o = of(1); // $ExpectType Observable<number>
+  const a = o.pipe(zip(of(2))); // $ExpectType Observable<[number, number]>
+});
+
 it('should support rest parameter observables', () => {
   const o = of(1); // $ExpectType Observable<number>
   const z = [of(2)]; // $ExpectType Observable<number>[]
-  const a = o.pipe(zip(...z)); // $ExpectType Observable<unknown>
-});
-
-it('should support rest parameter observables with type parameters', () => {
-  const o = of(1); // $ExpectType Observable<number>
-  const z = [of(2)]; // $ExpectType Observable<number>[]
-  const a = o.pipe(zip<number, number[]>(...z)); // $ExpectType Observable<number[]>
+  const a = o.pipe(zip(...z)); // $ExpectType Observable<[arg: number, ...rest: number[]]>
 });
 
 it('should support projected rest parameter observables', () => {
@@ -19,20 +18,8 @@ it('should support projected rest parameter observables', () => {
   const a = o.pipe(zip(...z, (...r) => r.map(v => v.toString()))); // $ExpectType Observable<string[]>
 });
 
-it('should support projected rest parameter observables with type parameters', () => {
-  const o = of(1); // $ExpectType Observable<number>
-  const z = [of(2)]; // $ExpectType Observable<number>[]
-  const a = o.pipe(zip<number, string[]>(...z, (...r) => r.map(v => v.toString()))); // $ExpectType Observable<string[]>
-});
-
 it('should support projected arrays of observables', () => {
   const o = of(1); // $ExpectType Observable<number>
   const z = [of(2)]; // $ExpectType Observable<number>[]
   const a = o.pipe(zip(z, (...r: any[]) => r.map(v => v.toString()))); // $ExpectType Observable<any[]>
-});
-
-it('should support projected arrays of observables with type parameters', () => {
-  const o = of(1); // $ExpectType Observable<number>
-  const z = [of(2)]; // $ExpectType Observable<number>[]
-  const a = o.pipe(zip<number, number, string[]>(z, (...r: any[]) => r.map(v => v.toString()))); // $ExpectType Observable<string[]>
 });

--- a/src/internal/operators/zip.ts
+++ b/src/internal/operators/zip.ts
@@ -1,77 +1,20 @@
 import { zip as zipStatic } from '../observable/zip';
-import { ObservableInput, OperatorFunction } from '../types';
+import { ObservableInput, ObservableInputTuple, OperatorFunction, Cons } from '../types';
 import { operate } from '../util/lift';
 
-/* tslint:disable:max-line-length */
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, R>(project: (v1: T) => R): OperatorFunction<T, R>;
+export function zip<T, A extends readonly unknown[]>(otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, R>(v2: ObservableInput<T2>, project: (v1: T, v2: T2) => R): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  project: (v1: T, v2: T2, v3: T3) => R
+export function zip<T, A extends readonly unknown[], R>(
+  otherInputsAndProject: [...ObservableInputTuple<A>],
+  project: (...values: Cons<T, A>) => R
 ): OperatorFunction<T, R>;
 /** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  project: (v1: T, v2: T2, v3: T3, v4: T4) => R
+export function zip<T, A extends readonly unknown[]>(...otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
+/** @deprecated Deprecated use {@link zipWith} */
+export function zip<T, A extends readonly unknown[], R>(
+  ...otherInputsAndProject: [...ObservableInputTuple<A>, (...values: Cons<T, A>) => R]
 ): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5) => R
-): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5, T6, R>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>,
-  project: (v1: T, v2: T2, v3: T3, v4: T4, v5: T5, v6: T6) => R
-): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2>(v2: ObservableInput<T2>): OperatorFunction<T, [T, T2]>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3>(v2: ObservableInput<T2>, v3: ObservableInput<T3>): OperatorFunction<T, [T, T2, T3]>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>
-): OperatorFunction<T, [T, T2, T3, T4]>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>
-): OperatorFunction<T, [T, T2, T3, T4, T5]>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, T2, T3, T4, T5, T6>(
-  v2: ObservableInput<T2>,
-  v3: ObservableInput<T3>,
-  v4: ObservableInput<T4>,
-  v5: ObservableInput<T5>,
-  v6: ObservableInput<T6>
-): OperatorFunction<T, [T, T2, T3, T4, T5, T6]>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, R>(...observables: Array<ObservableInput<T> | ((...values: Array<T>) => R)>): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, R>(array: Array<ObservableInput<T>>): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link zipWith} */
-export function zip<T, TOther, R>(
-  array: Array<ObservableInput<TOther>>,
-  project: (v1: T, ...values: Array<TOther>) => R
-): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
 
 /**
  * @deprecated Deprecated. Use {@link zipWith}.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR refactors the `zip` operator's signatures to use the n-args approach and deletes tests that are no-longer-relevant with the n-args implementation.

_I realize that these sigs are deprecated, but [we already have deprecated sigs in other operators](https://github.com/ReactiveX/rxjs/blob/a7a04d1110666606a1f2ca6fd38642e6ca74f287/src/internal/operators/mergeWith.ts#L8-L17) that use n-args, so, IMO, things are less confusing if n-args is used wherever possible._

**Related issue (if exists):** Nope