### PR TITLE
fix(Subscriber): don't leak destination

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -323,11 +323,12 @@ describe('shareReplay operator', () => {
   if (FinalizationRegistry) {
 
     it('should not leak the subscriber for sync sources', (done) => {
+      let callback: (() => void) | undefined = () => { /* noop */ };
+
       const registry = new FinalizationRegistry((value: any) => {
         expect(value).to.equal('callback');
         done();
       });
-      let callback: (() => void) | undefined = () => { /* noop */ };
       registry.register(callback, 'callback');
 
       const shared = of(42).pipe(shareReplay(1));

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -105,6 +105,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
     if (!this.closed) {
       this.isStopped = true;
       super.unsubscribe();
+      this.destination = null!;
     }
   }
 

--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -42,7 +42,7 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
           try {
             onNext(value);
           } catch (err) {
-            this.destination.error(err);
+            destination.error(err);
           }
         }
       : super._next;
@@ -52,7 +52,7 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
             onError(err);
           } catch (err) {
             // Send any errors that occur down stream.
-            this.destination.error(err);
+            destination.error(err);
           } finally {
             // Ensure teardown.
             this.unsubscribe();
@@ -65,7 +65,7 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
             onComplete();
           } catch (err) {
             // Send any errors that occur down stream.
-            this.destination.error(err);
+            destination.error(err);
           } finally {
             // Ensure teardown.
             this.unsubscribe();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds a failing test that shows that subscriptions - i.e. subscribers - returned from `subscribe` leak their destinations - i.e. their observers or callbacks.

The PR changes `Subscriber#unsubscribe` to null the `destination` after `super.unsubscribe` is called.

This change broke three operators - `bufferWhen` was one of them - because if unsubscription was effected within `onNext` and if an error was thrown from within `onNext` (after the unsubscription) it'd be caught in the `OperatorSubscriber` and an attempt would be made to call `this.destination.error`, but `this.destination` would be `null`.

Rather than capture `this.destination` before the `try/catch` around `onNext`, `onComplete`, and `onError`, I just used the `destination` that was passed in to the `OperatorSubscriber` constructor - AFAICT, we can be sure that it's a `Subscriber`, because `OperatorSubscriber` is an internal, impementation detail.

**Related issue (if exists):** Nope, but there is a discussion: https://github.com/ReactiveX/rxjs/discussions/6115