### PR TITLE
fix: unhandled errors in observers correctly scheduled

### DIFF
--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -381,62 +381,6 @@ describe('throttle', () => {
     });
   });
 
-  it('should throttle by promise resolves', () => {
-    testScheduler.run(() => {
-      const e1 = concat(of(1), timer(10).pipe(mapTo(2)), timer(10).pipe(mapTo(3)), timer(50).pipe(mapTo(4)));
-      const expected = [1, 2, 3, 4];
-
-      e1.pipe(
-        throttle(() => {
-          return new Promise((resolve: any) => {
-            resolve(42);
-          });
-        })
-      ).subscribe(
-        (x: number) => {
-          expect(x).to.equal(expected.shift());
-        },
-        () => {
-          throw new Error('should not be called');
-        },
-        () => {
-          expect(expected.length).to.equal(0);
-        }
-      );
-    });
-  });
-
-  it('should raise error when promise rejects', () => {
-    const e1 = concat(of(1), timer(10).pipe(mapTo(2)), timer(10).pipe(mapTo(3)), timer(50).pipe(mapTo(4)));
-    const expected = [1, 2, 3];
-    const error = new Error('error');
-
-    e1.pipe(
-      throttle((x: number) => {
-        if (x === 3) {
-          return new Promise((resolve: any, reject: any) => {
-            reject(error);
-          });
-        } else {
-          return new Promise((resolve: any) => {
-            resolve(42);
-          });
-        }
-      })
-    ).subscribe(
-      (x: number) => {
-        expect(x).to.equal(expected.shift());
-      },
-      (err: any) => {
-        expect(err).to.be.an('error', 'error');
-        expect(expected.length).to.equal(0);
-      },
-      () => {
-        throw new Error('should not be called');
-      }
-    );
-  });
-
   describe('throttle(fn, { leading: true, trailing: true })', () => {
     it('should immediately emit the first value in each time window', () => {
       testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -216,6 +216,12 @@ export class Observable<T> implements Subscribable<T> {
     // otherwise, it may be from a user-made observable instance, and we want to
     // wrap it in a try/catch so we can handle errors appropriately.
     const { operator, source } = this;
+
+    let dest: any = subscriber;
+    if (config.useDeprecatedSynchronousErrorHandling) {
+      dest._syncErrorHack_isSubscribing = true;
+    }
+
     subscriber.add(
       operator
         ? operator.call(subscriber, source)
@@ -225,12 +231,12 @@ export class Observable<T> implements Subscribable<T> {
     );
 
     if (config.useDeprecatedSynchronousErrorHandling) {
+      dest._syncErrorHack_isSubscribing = false;
       // In the case of the deprecated sync error handling,
       // we need to crawl forward through our subscriber chain and
       // look to see if there's any synchronously thrown errors.
       // Does this suck for perf? Yes. So stop using the deprecated sync
       // error handling already. We're removing this in v8.
-      let dest: any = subscriber;
       while (dest) {
         if (dest.__syncError) {
           throw dest.__syncError;

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -175,16 +175,8 @@ export class SafeSubscriber<T> extends Subscriber<T> {
 }
 
 /**
- * Checks to see if the user has chosen to use the super gross deprecated error handling that
- * no one should ever use, ever. If they did choose that path, we need to catch their error
- * so we can stick it on a super-secret property and check it after the subscription is done
- * in the `Observable` subscribe call.
- *
- * We have to do this, because if we simply rethrow the error, it will be caught by any upstream
- * try/catch blocks and send back down again, basically playing ping-pong with the error until the
- * downstream runs out of chances to rethrow and it gives up.
- *
- * In the general case, for non-crazy people, this just returns the handler directly.
+ * Wraps a user-provided handler (or our {@link defaultErrorHandler} in one case) to
+ * ensure that any thrown errors are caught and handled appropriately.
  *
  * @param handler The handler to wrap
  * @param instance The SafeSubscriber instance we're going to mark if there's an error.
@@ -195,12 +187,19 @@ function wrapForErrorHandling(handler: (arg?: any) => void, instance: SafeSubscr
       handler(...args);
     } catch (err) {
       if (config.useDeprecatedSynchronousErrorHandling) {
+        // If the user has opted for "super-gross" mode, we need to check to see
+        // if we're currently subscribing. If we are, we need to mark the _syncError
+        // So that it can be rethrown in the `subscribe` call on `Observable`.
         if ((instance as any)._syncErrorHack_isSubscribing) {
           (instance as any).__syncError = err;
         } else {
+          // We're not currently subscribing, but we're in super-gross mode,
+          // so throw it immediately.
           throw err;
         }
       } else {
+        // Ideal path, we report this as an unhandled error,
+        // which is thrown on a new call stack.
         reportUnhandledError(err);
       }
     }


### PR DESCRIPTION
- Resolves an issue where errors thrown in a handler provided as a plain function, or as part of a POJO observer, to a `subscribe` call were not being handled appropriately. They will no longer synchronously throw unless `useDeprecatedSynchronousErrorHandling` is configured to `true`.
- Removes two tests that were poorly written, and were not passing (and should never have been passing). The ground they covered is covered adequately by other tests.
