### PR TITLE
fix: remove misused type parameter from static pipe

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -330,7 +330,7 @@ export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | Co
 export declare function partition<T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => boolean, thisArg: A): [Observable<T>, Observable<T>];
 export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
 
-export declare function pipe<T>(): UnaryFunction<T, T>;
+export declare function pipe(): typeof identity;
 export declare function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;
 export declare function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>): UnaryFunction<T, B>;
 export declare function pipe<T, A, B, C>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>): UnaryFunction<T, C>;

--- a/spec-dtslint/util/pipe-spec.ts
+++ b/spec-dtslint/util/pipe-spec.ts
@@ -22,7 +22,7 @@ function a<I extends string, O extends string>(input: I, output: O): UnaryFuncti
 }
 
 it('should infer unknown for no arguments', () => {
-  const o = pipe(); // $ExpectType UnaryFunction<unknown, unknown>
+  const o = pipe(); // $ExpectType <T>(x: T) => T
 });
 
 it('should infer for 1 argument', () => {

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -2,17 +2,73 @@ import { identity } from './identity';
 import { UnaryFunction } from '../types';
 
 /* tslint:disable:max-line-length */
-export function pipe<T>(): UnaryFunction<T, T>;
+export function pipe(): typeof identity;
 export function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;
 export function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>): UnaryFunction<T, B>;
 export function pipe<T, A, B, C>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>): UnaryFunction<T, C>;
-export function pipe<T, A, B, C, D>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>): UnaryFunction<T, D>;
-export function pipe<T, A, B, C, D, E>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>): UnaryFunction<T, E>;
-export function pipe<T, A, B, C, D, E, F>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>): UnaryFunction<T, F>;
-export function pipe<T, A, B, C, D, E, F, G>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>): UnaryFunction<T, G>;
-export function pipe<T, A, B, C, D, E, F, G, H>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>): UnaryFunction<T, H>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, fn9: UnaryFunction<H, I>): UnaryFunction<T, I>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>, fn4: UnaryFunction<C, D>, fn5: UnaryFunction<D, E>, fn6: UnaryFunction<E, F>, fn7: UnaryFunction<F, G>, fn8: UnaryFunction<G, H>, fn9: UnaryFunction<H, I>, ...fns: UnaryFunction<any, any>[]): UnaryFunction<T, {}>;
+export function pipe<T, A, B, C, D>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>
+): UnaryFunction<T, D>;
+export function pipe<T, A, B, C, D, E>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>
+): UnaryFunction<T, E>;
+export function pipe<T, A, B, C, D, E, F>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>
+): UnaryFunction<T, F>;
+export function pipe<T, A, B, C, D, E, F, G>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  fn7: UnaryFunction<F, G>
+): UnaryFunction<T, G>;
+export function pipe<T, A, B, C, D, E, F, G, H>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  fn7: UnaryFunction<F, G>,
+  fn8: UnaryFunction<G, H>
+): UnaryFunction<T, H>;
+export function pipe<T, A, B, C, D, E, F, G, H, I>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  fn7: UnaryFunction<F, G>,
+  fn8: UnaryFunction<G, H>,
+  fn9: UnaryFunction<H, I>
+): UnaryFunction<T, I>;
+export function pipe<T, A, B, C, D, E, F, G, H, I>(
+  fn1: UnaryFunction<T, A>,
+  fn2: UnaryFunction<A, B>,
+  fn3: UnaryFunction<B, C>,
+  fn4: UnaryFunction<C, D>,
+  fn5: UnaryFunction<D, E>,
+  fn6: UnaryFunction<E, F>,
+  fn7: UnaryFunction<F, G>,
+  fn8: UnaryFunction<G, H>,
+  fn9: UnaryFunction<H, I>,
+  ...fns: UnaryFunction<any, any>[]
+): UnaryFunction<T, {}>;
 /* tslint:enable:max-line-length */
 
 export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any, any> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The static `pipe` utility has a signature that accepts no argument yet has a type parameter - type parameters aren't really supposed to be used like this. This PR changes the return type for that signature to be `typeof identity` - which is what's returned. This means that the returned function can be used without losing the type of the argument passed to it:

```
const func = pipe();
const value = func(42); // type of value will be 42, not unknown
```

Calling `pipe` without passing arguments is something of an edge case, but I suppose it's more likely with spread tuples or something. Anyway, it's a misused type parameter, so we should remove it.

**Related issue (if exists):** #5557