### PR TITLE
chore: undeprecate flatMap

### DIFF
--- a/src/internal/operators/flatMap.ts
+++ b/src/internal/operators/flatMap.ts
@@ -1,6 +1,3 @@
 import { mergeMap } from './mergeMap';
 
-/**
- * @deprecated renamed. Use {@link mergeMap}.
- */
 export const flatMap = mergeMap;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Does what it says in the title. Given that VS Code now uses the strikethrough text style for deprecated APIs, IMO we should err on the side of not deprecating unless we have a plan for removing something. Devs have enough to deal with without having to wonder why things are struck out.

As Ben pointed out on Twitter, according to GitHub, the RxJS use count is over 5 million. And with `flatMap` being such an established term for that particular feature, I don't see why we'd want to remove the alias and break people.

IMO: specify a version in which it will be removed or undeprecate it. Clearly, my vote is for the latter. (We can always deprecate it again, when we have a plan - maybe with code mods - for its removal.)

**Related issue (if exists):** https://github.com/ReactiveX/rxjs/issues/5418#issuecomment-719735322
