### PR TITLE
refactor: align tap sigs with subscribe

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -265,10 +265,8 @@ export declare class Observable<T> implements Subscribable<T> {
     pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>): Observable<I>;
     pipe<A, B, C, D, E, F, G, H, I>(op1: OperatorFunction<T, A>, op2: OperatorFunction<A, B>, op3: OperatorFunction<B, C>, op4: OperatorFunction<C, D>, op5: OperatorFunction<D, E>, op6: OperatorFunction<E, F>, op7: OperatorFunction<F, G>, op8: OperatorFunction<G, H>, op9: OperatorFunction<H, I>, ...operations: OperatorFunction<any, any>[]): Observable<unknown>;
     subscribe(observer?: Partial<Observer<T>>): Subscription;
-    subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
-    subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
-    subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
-    subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
+    subscribe(next: (value: T) => void): Subscription;
+    subscribe(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): Subscription;
     toPromise(): Promise<T | undefined>;
     toPromise(PromiseCtor: typeof Promise): Promise<T | undefined>;
     toPromise(PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -289,11 +289,11 @@ export declare function takeWhile<T, S extends T>(predicate: (value: T, index: n
 export declare function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S, inclusive: false): OperatorFunction<T, S>;
 export declare function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive?: boolean): MonoTypeOperatorFunction<T>;
 
+export declare function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
+export declare function tap<T>(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 
 export declare function throttle<T>(durationSelector: (value: T) => ObservableInput<any>, { leading, trailing }?: ThrottleConfig): MonoTypeOperatorFunction<T>;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -290,10 +290,8 @@ export declare function takeWhile<T, S extends T>(predicate: (value: T, index: n
 export declare function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive?: boolean): MonoTypeOperatorFunction<T>;
 
 export declare function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+export declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
+export declare function tap<T>(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): MonoTypeOperatorFunction<T>;
 
 export declare function throttle<T>(durationSelector: (value: T) => ObservableInput<any>, { leading, trailing }?: ThrottleConfig): MonoTypeOperatorFunction<T>;
 

--- a/spec-dtslint/Observable-spec.ts
+++ b/spec-dtslint/Observable-spec.ts
@@ -131,3 +131,27 @@ describe('pipe', () => {
     const o = of('foo').toPromise(); // $ExpectType Promise<string | undefined>
   });
 });
+
+describe('subscribe', () => {
+  it('should deprecate the multi-argument usage', () => {
+    const next = (value: number) => {};
+    const error = (error: any) => {};
+    const complete = () => {};
+    const o = of(42);
+    o.subscribe(); // $ExpectNoDeprecation
+    o.subscribe({ next }); // $ExpectNoDeprecation
+    o.subscribe({ next, error }); // $ExpectNoDeprecation
+    o.subscribe({ next, complete }); // $ExpectNoDeprecation
+    o.subscribe({ next, error, complete }); // $ExpectNoDeprecation
+    o.subscribe({ error }); // $ExpectNoDeprecation
+    o.subscribe({ error, complete }); // $ExpectNoDeprecation
+    o.subscribe({ complete }); // $ExpectNoDeprecation
+    o.subscribe(next); // $ExpectNoDeprecation
+    o.subscribe(null, error); // $ExpectDeprecation
+    o.subscribe(undefined, error); // $ExpectDeprecation
+    o.subscribe(null, error, complete); // $ExpectDeprecation
+    o.subscribe(undefined, error, complete); // $ExpectDeprecation
+    o.subscribe(null, null, complete); // $ExpectDeprecation
+    o.subscribe(undefined, undefined, complete); // $ExpectDeprecation
+  });
+});

--- a/spec-dtslint/operators/tap-spec.ts
+++ b/spec-dtslint/operators/tap-spec.ts
@@ -14,3 +14,25 @@ it('should accept partial observer', () => {
 it('should enforce type for next observer function', () => {
   const a = of(1, 2, 3).pipe(tap({ next: (x: string) => { } })); // $ExpectError
 });
+
+it('should deprecate the multi-argument usage', () => {
+  const next = (value: number) => {};
+  const error = (error: any) => {};
+  const complete = () => {};
+  const o = of(42);
+  o.pipe(tap()); // $ExpectNoDeprecation
+  o.pipe(tap({ next })); // $ExpectNoDeprecation
+  o.pipe(tap({ next, error })); // $ExpectNoDeprecation
+  o.pipe(tap({ next, complete })); // $ExpectNoDeprecation
+  o.pipe(tap({ next, error, complete })); // $ExpectNoDeprecation
+  o.pipe(tap({ error })); // $ExpectNoDeprecation
+  o.pipe(tap({ error, complete })); // $ExpectNoDeprecation
+  o.pipe(tap({ complete })); // $ExpectNoDeprecation
+  o.pipe(tap(next)); // $ExpectNoDeprecation
+  o.pipe(tap(null, error)); // $ExpectDeprecation
+  o.pipe(tap(undefined, error)); // $ExpectDeprecation
+  o.pipe(tap(null, error, complete)); // $ExpectDeprecation
+  o.pipe(tap(undefined, error, complete)); // $ExpectDeprecation
+  o.pipe(tap(null, null, complete)); // $ExpectDeprecation
+  o.pipe(tap(undefined, undefined, complete)); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/tap-spec.ts
+++ b/spec-dtslint/operators/tap-spec.ts
@@ -11,10 +11,6 @@ it('should accept partial observer', () => {
   const c = of(1, 2, 3).pipe(tap({ complete: () => { } })); // $ExpectType Observable<number>
 });
 
-it('should not accept empty observer', () => {
-  const a = of(1, 2, 3).pipe(tap({})); // $ExpectError
-});
-
 it('should enforce type for next observer function', () => {
   const a = of(1, 2, 3).pipe(tap({ next: (x: string) => { } })); // $ExpectError
 });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -69,13 +69,9 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   subscribe(observer?: Partial<Observer<T>>): Subscription;
+  subscribe(next: (value: T) => void): Subscription;
   /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
-  subscribe(next: null | undefined, error: null | undefined, complete: () => void): Subscription;
-  /** @deprecated Use an observer instead of an error callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
-  subscribe(next: null | undefined, error: (error: any) => void, complete?: () => void): Subscription;
-  /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
-  subscribe(next: (value: T) => void, error: null | undefined, complete: () => void): Subscription;
-  subscribe(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): Subscription;
+  subscribe(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): Subscription;
   /**
    * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.
    *

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -4,7 +4,6 @@ import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 
-/* tslint:disable:max-line-length */
 export function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
 /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
 export function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
@@ -13,7 +12,6 @@ export function tap<T>(next: null | undefined, error: (error: any) => void, comp
 /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
 export function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
 export function tap<T>(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-/* tslint:disable:max-line-length */
 
 /**
  * Used to perform side-effects for notifications from the source observable

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -1,19 +1,19 @@
-import { MonoTypeOperatorFunction, PartialObserver } from '../types';
+import { MonoTypeOperatorFunction, Observer } from '../types';
 import { isFunction } from '../util/isFunction';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 
 /* tslint:disable:max-line-length */
+export function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
 /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
 export function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
 /** @deprecated Use an observer instead of an error callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
 export function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
 /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
 export function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-export function tap<T>(next?: (x: T) => void, error?: (e: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T>;
-/* tslint:enable:max-line-length */
+export function tap<T>(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+/* tslint:disable:max-line-length */
 
 /**
  * Used to perform side-effects for notifications from the source observable
@@ -106,7 +106,7 @@ export function tap<T>(observer: PartialObserver<T>): MonoTypeOperatorFunction<T
  * @param complete A completion handler
  */
 export function tap<T>(
-  observerOrNext?: PartialObserver<T> | ((value: T) => void) | null,
+  observerOrNext?: Partial<Observer<T>> | ((value: T) => void) | null,
   error?: ((e: any) => void) | null,
   complete?: (() => void) | null
 ): MonoTypeOperatorFunction<T> {

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -5,13 +5,13 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 
 export function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
+export function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
 /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
-export function tap<T>(next: null | undefined, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-/** @deprecated Use an observer instead of an error callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
-export function tap<T>(next: null | undefined, error: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
-/** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
-export function tap<T>(next: (value: T) => void, error: null | undefined, complete: () => void): MonoTypeOperatorFunction<T>;
-export function tap<T>(next?: (value: T) => void, error?: (error: any) => void, complete?: () => void): MonoTypeOperatorFunction<T>;
+export function tap<T>(
+  next?: ((value: T) => void) | null,
+  error?: ((error: any) => void) | null,
+  complete?: (() => void) | null
+): MonoTypeOperatorFunction<T>;
 
 /**
  * Used to perform side-effects for notifications from the source observable


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Does what it says in the title.

**Related issue (if exists):** Nope
