### PR TITLE
refactor: use unknown in concatMapTo type parameter constraint

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -46,9 +46,9 @@ export declare function concatMap<T, O extends ObservableInput<any>>(project: (v
 export declare function concatMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function concatMap<T, R, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
-export declare function concatMapTo<O extends ObservableInput<any>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-export declare function concatMapTo<O extends ObservableInput<any>>(observable: O, resultSelector: undefined): OperatorFunction<any, ObservedValueOf<O>>;
-export declare function concatMapTo<T, R, O extends ObservableInput<any>>(observable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
+export declare function concatMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
+export declare function concatMapTo<O extends ObservableInput<unknown>>(observable: O, resultSelector: undefined): OperatorFunction<any, ObservedValueOf<O>>;
+export declare function concatMapTo<T, R, O extends ObservableInput<unknown>>(observable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
 export declare function concatWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 

--- a/spec-dtslint/operators/concatMapTo-spec.ts
+++ b/spec-dtslint/operators/concatMapTo-spec.ts
@@ -50,6 +50,11 @@ it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(concatMapTo()); // $ExpectError
 });
 
+it('should enforce types of the observable parameter', () => {
+  const fn = () => {}
+  const o = of(1, 2, 3).pipe(concatMapTo(fn)); // $ExpectError
+});
+
 it('should enforce the return type', () => {
   const o = of(1, 2, 3).pipe(concatMapTo(p => p)); // $ExpectError
   const p = of(1, 2, 3).pipe(concatMapTo(4)); // $ExpectError

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -3,14 +3,14 @@ import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
-export function concatMapTo<O extends ObservableInput<any>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
+export function concatMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
 /** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
-export function concatMapTo<O extends ObservableInput<any>>(
+export function concatMapTo<O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: undefined
 ): OperatorFunction<any, ObservedValueOf<O>>;
 /** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
-export function concatMapTo<T, R, O extends ObservableInput<any>>(
+export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, R>;
@@ -70,7 +70,7 @@ export function concatMapTo<T, R, O extends ObservableInput<any>>(
  * passed observable with itself, one after the other, for each value emitted
  * from the source.
  */
-export function concatMapTo<T, R, O extends ObservableInput<any>>(
+export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,
   resultSelector?: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, ObservedValueOf<O> | R> {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR makes a similar change to what was made in #5839 so that functions are not matched - because of https://github.com/microsoft/TypeScript/issues/18757

**Related issue (if exists):** #5839
