### PR TITLE
refactor: use unknown in switchMapTo type parameter constraint

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -270,9 +270,9 @@ export declare function switchMap<T, O extends ObservableInput<any>>(project: (v
 export declare function switchMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function switchMap<T, R, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
-export declare function switchMapTo<R>(observable: ObservableInput<R>): OperatorFunction<any, R>;
-export declare function switchMapTo<R>(observable: ObservableInput<R>, resultSelector: undefined): OperatorFunction<any, R>;
-export declare function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
+export declare function switchMapTo<O extends ObservableInput<any>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
+export declare function switchMapTo<O extends ObservableInput<any>>(observable: O, resultSelector: undefined): OperatorFunction<any, ObservedValueOf<O>>;
+export declare function switchMapTo<T, R, O extends ObservableInput<any>>(observable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
 export declare function switchScan<T, R, O extends ObservableInput<any>>(accumulator: (acc: R, value: T, index: number) => O, seed: R): OperatorFunction<T, ObservedValueOf<O>>;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -270,9 +270,9 @@ export declare function switchMap<T, O extends ObservableInput<any>>(project: (v
 export declare function switchMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function switchMap<T, R, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
-export declare function switchMapTo<O extends ObservableInput<any>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-export declare function switchMapTo<O extends ObservableInput<any>>(observable: O, resultSelector: undefined): OperatorFunction<any, ObservedValueOf<O>>;
-export declare function switchMapTo<T, R, O extends ObservableInput<any>>(observable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
+export declare function switchMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
+export declare function switchMapTo<O extends ObservableInput<unknown>>(observable: O, resultSelector: undefined): OperatorFunction<any, ObservedValueOf<O>>;
+export declare function switchMapTo<T, R, O extends ObservableInput<unknown>>(observable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
 
 export declare function switchScan<T, R, O extends ObservableInput<any>>(accumulator: (acc: R, value: T, index: number) => O, seed: R): OperatorFunction<T, ObservedValueOf<O>>;
 

--- a/spec-dtslint/operators/switchMapTo-spec.ts
+++ b/spec-dtslint/operators/switchMapTo-spec.ts
@@ -45,6 +45,11 @@ it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(switchMapTo()); // $ExpectError
 });
 
+it('should enforce types of the observable parameter', () => {
+  const fn = () => {}
+  const o = of(1, 2, 3).pipe(switchMapTo(fn)); // $ExpectError
+});
+
 it('should enforce the return type', () => {
   const o = of(1, 2, 3).pipe(switchMapTo(p => p)); // $ExpectError
   const p = of(1, 2, 3).pipe(switchMapTo(4)); // $ExpectError

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -1,12 +1,19 @@
-import { ObservableInput, OperatorFunction } from '../types';
 import { switchMap } from './switchMap';
+import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
+import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
-export function switchMapTo<R>(observable: ObservableInput<R>): OperatorFunction<any, R>;
-/** @deprecated resultSelector is no longer supported. Switch to using switchMap with an inner map, Details https://rxjs.dev/deprecations/resultSelector */
-export function switchMapTo<R>(observable: ObservableInput<R>, resultSelector: undefined): OperatorFunction<any, R>;
-/** @deprecated resultSelector is no longer supported. Switch to using switchMap with an inner map, Details https://rxjs.dev/deprecations/resultSelector */
-export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R): OperatorFunction<T, R>;
+export function switchMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
+/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+export function switchMapTo<O extends ObservableInput<unknown>>(
+  observable: O,
+  resultSelector: undefined
+): OperatorFunction<any, ObservedValueOf<O>>;
+/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
+  observable: O,
+  resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
+): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -47,9 +54,9 @@ export function switchMapTo<T, I, R>(observable: ObservableInput<I>, resultSelec
  * every time a value is emitted on the source Observable, and taking only the values
  * from the most recently projected inner Observable.
  */
-export function switchMapTo<T, I, R>(
-  innerObservable: ObservableInput<I>,
-  resultSelector?: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R
-): OperatorFunction<T, I|R> {
-  return resultSelector ? switchMap(() => innerObservable, resultSelector) : switchMap(() => innerObservable);
+export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
+  innerObservable: O,
+  resultSelector?: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
+): OperatorFunction<T, ObservedValueOf<O> | R> {
+  return isFunction(resultSelector) ? switchMap(() => innerObservable, resultSelector) : switchMap(() => innerObservable);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR makes a similar change to what was made in #5839 so that functions are not matched - because of https://github.com/microsoft/TypeScript/issues/18757

Also:

- The signatures prior to this change weren't using `ObservedValueOf`.
- The PR also uses `isFunction` to check the result selector, as that's what's done in both `concatMapTo` and `mergeMapTo` in `master`.

**Related issue (if exists):** #5839