### PR TITLE
chore: remove union-array signatures from combineLatest

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -55,10 +55,6 @@ export declare function combineLatest(sourcesObject: {
 export declare function combineLatest<T extends Record<string, ObservableInput<any>>>(sourcesObject: T): Observable<{
     [K in keyof T]: ObservedValueOf<T[K]>;
 }>;
-export declare function combineLatest<O extends ObservableInput<any>, R>(array: O[], resultSelector: (...values: ObservedValueOf<O>[]) => R, scheduler?: SchedulerLike): Observable<R>;
-export declare function combineLatest<O extends ObservableInput<any>>(...observables: Array<O | SchedulerLike>): Observable<any[]>;
-export declare function combineLatest<O extends ObservableInput<any>, R>(...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>): Observable<R>;
-export declare function combineLatest<R>(...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>): Observable<R>;
 
 export interface CompleteNotification {
     kind: 'C';

--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -37,31 +37,31 @@ it('should accept union types', () => {
 });
 
 it('should accept 1 param and a result selector', () => {
-  const o = combineLatest(a$, () => new A()); // $ExpectType Observable<A>
+  const o = combineLatest(a$, (...values) => new A()); // $ExpectType Observable<A>
 });
 
 it('should accept 2 params and a result selector', () => {
-  const o = combineLatest(a$, b$, () => new A()); // $ExpectType Observable<A>
+  const o = combineLatest(a$, b$, (...values) => new A()); // $ExpectType Observable<A>
 });
 
 it('should accept 3 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, () => new A()); // $ExpectType Observable<A>
+  const o = combineLatest(a$, b$, c$, (...values) => new A()); // $ExpectType Observable<A>
 });
 
 it('should accept 4 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, () => new A()); // $ExpectType Observable<A>
+  const o = combineLatest(a$, b$, c$, d$, (...values) => new A()); // $ExpectType Observable<A>
 });
 
 it('should accept 5 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, () => new A()); // $ExpectType Observable<A>
+  const o = combineLatest(a$, b$, c$, d$, e$, (...values) => new A()); // $ExpectType Observable<A>
 });
 
 it('should accept 6 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, f$, () => new A()); // $ExpectType Observable<A>
+  const o = combineLatest(a$, b$, c$, d$, e$, f$, (...values) => new A()); // $ExpectType Observable<A>
 });
 
 it('should accept 7 or more params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, f$, g$, g$, g$, () => new A()); // $ExpectType Observable<A>
+  const o = combineLatest(a$, b$, c$, d$, e$, f$, g$, g$, g$, (...values) => new A()); // $ExpectType Observable<A>
 });
 
 it('should accept 1 param', () => {

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -48,26 +48,6 @@ export function combineLatest<T extends Record<string, ObservableInput<any>>>(
   sourcesObject: T
 ): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
 
-/** @deprecated resultSelector no longer supported, pipe to map instead */
-export function combineLatest<O extends ObservableInput<any>, R>(
-  array: O[],
-  resultSelector: (...values: ObservedValueOf<O>[]) => R,
-  scheduler?: SchedulerLike
-): Observable<R>;
-
-/** @deprecated The scheduler argument is deprecated, use scheduled and combineLatestAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function combineLatest<O extends ObservableInput<any>>(...observables: Array<O | SchedulerLike>): Observable<any[]>;
-
-/** @deprecated The scheduler argument is deprecated, use scheduled and combineLatestAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function combineLatest<O extends ObservableInput<any>, R>(
-  ...observables: Array<O | ((...values: ObservedValueOf<O>[]) => R) | SchedulerLike>
-): Observable<R>;
-
-/** @deprecated The scheduler argument is deprecated, use scheduled and combineLatestAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function combineLatest<R>(
-  ...observables: Array<ObservableInput<any> | ((...values: Array<any>) => R) | SchedulerLike>
-): Observable<R>;
-
 /**
  * Combines multiple Observables to create an Observable whose values are
  * calculated from the latest values of each of its input Observables.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes union-array signatures - i.e. signatures that contain `Array<O | SchedulerLike>`, etc. - from `combineLatest`. The n-args signatures are after - as they prevent arbitrarily-place schedulers, etc. - and the union-array signatures have already been removed from some other functions/operators.

**Related issue (if exists):** Nope
