### PR TITLE
chore: remove a too-wide signature from combineLatestAll

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -26,7 +26,6 @@ export declare function combineLatest<T, A extends readonly unknown[], R>(...sou
 export declare function combineLatestAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export declare function combineLatestAll<T>(): OperatorFunction<any, T[]>;
 export declare function combineLatestAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
-export declare function combineLatestAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 
 export declare function combineLatestWith<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
 

--- a/spec-dtslint/operators/combineLatestAll-spec.ts
+++ b/spec-dtslint/operators/combineLatestAll-spec.ts
@@ -9,10 +9,6 @@ it('should infer correctly with the projector', () => {
   const o = of([1, 2, 3]).pipe(combineLatestAll((values: number) => ['x', 'y', 'z'])); // $ExpectType Observable<string[]>
 });
 
-it('is possible to make the projector have an `any` type', () => {
-  const o = of([1, 2, 3]).pipe(combineLatestAll<string[]>(values => ['x', 'y', 'z'])); // $ExpectType Observable<string[]>
-});
-
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(combineLatestAll()); // $ExpectError
 });

--- a/src/internal/operators/combineLatestAll.ts
+++ b/src/internal/operators/combineLatestAll.ts
@@ -5,7 +5,7 @@ import { joinAllInternals } from './joinAllInternals';
 export function combineLatestAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
 export function combineLatestAll<T>(): OperatorFunction<any, T[]>;
 export function combineLatestAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
-export function combineLatestAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
+
 /**
  * Flattens an Observable-of-Observables by applying {@link combineLatest} when the Observable-of-Observables completes.
  *
@@ -51,6 +51,6 @@ export function combineLatestAll<R>(project: (...values: Array<any>) => R): Oper
  * @param project optional function to map the most recent values from each inner Observable into a new result.
  * Takes each of the most recent values from each collected inner Observable as arguments, in order.
  */
-export function combineLatestAll<R>(project?: (...values: Array<any>) => R) {
+export function combineLatestAll<T, R>(project?: (...values: Array<T>) => R) {
   return joinAllInternals(combineLatest, project);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes a signature that will match `any`-thing as long as a result selector is specified - and the values received by the selector are `any`. This shenanigans has been removed from other places, so we should remove it here, too.

**Related issue (if exists):** Nope
