### PR TITLE
test: add dtslint tests for combineLatestAll and zipAll

### DIFF
--- a/spec-dtslint/operators/combineLatestAll-spec.ts
+++ b/spec-dtslint/operators/combineLatestAll-spec.ts
@@ -9,8 +9,13 @@ it('should infer correctly with the projector', () => {
   const o = of([1, 2, 3]).pipe(combineLatestAll((values: number) => ['x', 'y', 'z'])); // $ExpectType Observable<string[]>
 });
 
-it('is possible to make the projector have an `any` type', () => {
-  const o = of([1, 2, 3]).pipe(combineLatestAll<string[]>(values => ['x', 'y', 'z'])); // $ExpectType Observable<string[]>
+it('should be accept projectors for observables with different types', () => {
+  // An `any` signature is required for the projector to deal with situations
+  // like this in which the source emits observables of different types. The
+  // types of the values passed to the projector depend on the order in which
+  // the source emits its observables and that can't be expressed in the type
+  // system.
+  const o = of(of(['a', 'b', 'c']), of([1, 2, 3])).pipe(combineLatestAll((a: string, b: number) => a + b)); // $ExpectType Observable<string>
 });
 
 it('should enforce types', () => {

--- a/spec-dtslint/operators/zipAll-spec.ts
+++ b/spec-dtslint/operators/zipAll-spec.ts
@@ -9,6 +9,15 @@ it('should support projecting values', () => {
   const o = of(of(1, 2, 3)).pipe(zipAll(value => String(value))); // $ExpectType Observable<string>
 });
 
+it('should be accept projectors for observables with different types', () => {
+  // An `any` signature is required for the projector to deal with situations
+  // like this in which the source emits observables of different types. The
+  // types of the values passed to the projector depend on the order in which
+  // the source emits its observables and that can't be expressed in the type
+  // system.
+  const o = of(of(['a', 'b', 'c']), of([1, 2, 3])).pipe(zipAll((a: string, b: number) => a + b)); // $ExpectType Observable<string>
+});
+
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(zipAll()); // $ExpectError
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds dtslint tests - with comments - that better represent why `combineLatestAll` and `zipAll` need signatures that accept project functions that take values of type `any`.

**Related issue (if exists):** Nope
