### PR TITLE
chore: remove concatAll overloads

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -39,8 +39,7 @@ export declare function concat<T, T2, T3, T4, T5, T6>(v2: ObservableInput<T2>, v
 export declare function concat<T>(...observables: Array<ObservableInput<T> | SchedulerLike>): MonoTypeOperatorFunction<T>;
 export declare function concat<T, R>(...observables: Array<ObservableInput<any> | SchedulerLike>): OperatorFunction<T, R>;
 
-export declare function concatAll<T>(): OperatorFunction<ObservableInput<T>, T>;
-export declare function concatAll<R>(): OperatorFunction<any, R>;
+export declare function concatAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>>;
 
 export declare function concatMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function concatMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;

--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -1,9 +1,6 @@
 import { mergeAll } from './mergeAll';
 import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
 
-export function concatAll<T>(): OperatorFunction<ObservableInput<T>, T>;
-export function concatAll<R>(): OperatorFunction<any, R>;
-
 /**
  * Converts a higher-order Observable into a first-order Observable by
  * concatenating the inner Observables in order.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Does what it says in the title. The overloads aren't needed; `mergeAll` does not have them - they've already been removed from that operator, so they should be removed here.

**Related issue (if exists):** Nope