### PR TITLE
chore: remove exhaustAll overloads

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -90,8 +90,7 @@ export declare function every<T>(predicate: (value: T, index: number, source: Ob
 
 export declare const exhaust: typeof exhaustAll;
 
-export declare function exhaustAll<T>(): OperatorFunction<ObservableInput<T>, T>;
-export declare function exhaustAll<R>(): OperatorFunction<any, R>;
+export declare function exhaustAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>>;
 
 export declare function exhaustMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function exhaustMap<T, O extends ObservableInput<any>>(project: (value: T, index: number) => O, resultSelector: undefined): OperatorFunction<T, ObservedValueOf<O>>;

--- a/spec/operators/exhaustAll-spec.ts
+++ b/spec/operators/exhaustAll-spec.ts
@@ -254,7 +254,7 @@ describe('exhaust', () => {
 
   it('should handle an observable of promises, where one rejects', (done) => {
     of(Promise.reject(2), Promise.resolve(1))
-      .pipe(exhaustAll<never | number>())
+      .pipe(exhaustAll())
       .subscribe(
         (x) => {
           done(new Error('should not be called'));

--- a/src/internal/operators/exhaustAll.ts
+++ b/src/internal/operators/exhaustAll.ts
@@ -1,11 +1,8 @@
 import { Subscription } from '../Subscription';
-import { ObservableInput, OperatorFunction } from '../types';
+import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/from';
 import { OperatorSubscriber } from './OperatorSubscriber';
-
-export function exhaustAll<T>(): OperatorFunction<ObservableInput<T>, T>;
-export function exhaustAll<R>(): OperatorFunction<any, R>;
 
 /**
  * Converts a higher-order Observable into a first-order Observable by dropping
@@ -49,7 +46,7 @@ export function exhaustAll<R>(): OperatorFunction<any, R>;
  * @return {Observable} An Observable that takes a source of Observables and propagates the first observable
  * exclusively until it completes before subscribing to the next.
  */
-export function exhaustAll<T>(): OperatorFunction<any, T> {
+export function exhaustAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>> {
   return operate((source, subscriber) => {
     let isComplete = false;
     let innerSub: Subscription | null = null;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Does what it says in the title. The overloads aren't needed; `mergeAll` does not have them - they've already been removed from that operator, so they should be removed here. The PR also changes the implementation signature to use `ObservedValueOf` - as in `concatAll` and `mergeAll`.

**Related issue (if exists):** Nope
