### PR TITLE
chore: remove switchAll overload

### DIFF
--- a/src/internal/operators/switchAll.ts
+++ b/src/internal/operators/switchAll.ts
@@ -2,8 +2,6 @@ import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
 import { switchMap } from './switchMap';
 import { identity } from '../util/identity';
 
-export function switchAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>>;
-
 /**
  * Converts a higher-order Observable into a first-order Observable
  * producing values only from the most recent observable sequence
@@ -59,6 +57,6 @@ export function switchAll<O extends ObservableInput<any>>(): OperatorFunction<O,
  * @see {@link mergeAll}
  */
 
-export function switchAll<T>(): OperatorFunction<ObservableInput<T>, T> {
+export function switchAll<O extends ObservableInput<any>>(): OperatorFunction<O, ObservedValueOf<O>> {
   return switchMap(identity);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes the `switchAll` overload - there was only one, so it might as well be the implementation signature.

**Related issue (if exists):** Nope
