### PR TITLE
fix/refactor: add type parameter for thisArg in find/findIndex

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -107,11 +107,14 @@ export declare function filter<T>(predicate: (value: T, index: number) => boolea
 export declare function finalize<T>(callback: () => void): MonoTypeOperatorFunction<T>;
 
 export declare function find<T>(predicate: BooleanConstructor): OperatorFunction<T, TruthyTypesOf<T>>;
-export declare function find<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S, thisArg?: any): OperatorFunction<T, S | undefined>;
-export declare function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): OperatorFunction<T, T | undefined>;
+export declare function find<T, S extends T, A>(predicate: (this: A, value: T, index: number, source: Observable<T>) => value is S, thisArg: A): OperatorFunction<T, S | undefined>;
+export declare function find<T, S extends T>(predicate: (value: T, index: number, source: Observable<T>) => value is S): OperatorFunction<T, S | undefined>;
+export declare function find<T, A>(predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean, thisArg: A): OperatorFunction<T, T | undefined>;
+export declare function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, T | undefined>;
 
 export declare function findIndex<T>(predicate: BooleanConstructor, thisArg?: any): OperatorFunction<T, T extends Falsy ? -1 : number>;
-export declare function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, thisArg?: any): OperatorFunction<T, number>;
+export declare function findIndex<T, A>(predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean, thisArg: A): OperatorFunction<T, number>;
+export declare function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number>;
 
 export declare function first<T, D = T>(predicate?: null, defaultValue?: D): OperatorFunction<T, T | D>;
 export declare function first<T>(predicate: BooleanConstructor): OperatorFunction<T, TruthyTypesOf<T>>;

--- a/spec-dtslint/operators/find-spec.ts
+++ b/spec-dtslint/operators/find-spec.ts
@@ -33,3 +33,11 @@ it('should support Boolean properly', () => {
   // Intentionally weird looking: Because `Observable<boolean>` is `Observable<true | false>` and `true` is the truthy bit.
   const o4 = of(false, false, false, false).pipe(find(Boolean)); // $ExpectType Observable<true>
 });
+
+it('should support this', () => {
+  const thisArg = { wanted: 5 };
+  const a = of(1, 2, 3).pipe(find(function (val) {
+    const wanted = this.wanted; // $ExpectType number
+    return val < wanted;
+  }, thisArg));
+});

--- a/spec-dtslint/operators/findIndex-spec.ts
+++ b/spec-dtslint/operators/findIndex-spec.ts
@@ -42,3 +42,11 @@ it('should support inference from a predicate that returns any', () => {
   }
   const a = of(1).pipe(findIndex(isTruthy)); // $ExpectType Observable<number>
 });
+
+it('should support this', () => {
+  const thisArg = { wanted: 5 };
+  const a = of(1, 2, 3).pipe(findIndex(function (val) {
+    const wanted = this.wanted; // $ExpectType number
+    return val < wanted;
+  }, thisArg));
+});

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -5,14 +5,18 @@ import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 export function find<T>(predicate: BooleanConstructor): OperatorFunction<T, TruthyTypesOf<T>>;
-export function find<T, S extends T>(
-  predicate: (value: T, index: number, source: Observable<T>) => value is S,
-  thisArg?: any
+export function find<T, S extends T, A>(
+  predicate: (this: A, value: T, index: number, source: Observable<T>) => value is S,
+  thisArg: A
 ): OperatorFunction<T, S | undefined>;
-export function find<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
+export function find<T, S extends T>(
+  predicate: (value: T, index: number, source: Observable<T>) => value is S
+): OperatorFunction<T, S | undefined>;
+export function find<T, A>(
+  predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean,
+  thisArg: A
 ): OperatorFunction<T, T | undefined>;
+export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, T | undefined>;
 /**
  * Emits only the first value emitted by the source Observable that meets some
  * condition.

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -4,10 +4,11 @@ import { operate } from '../util/lift';
 import { createFind } from './find';
 
 export function findIndex<T>(predicate: BooleanConstructor, thisArg?: any): OperatorFunction<T, T extends Falsy ? -1 : number>;
-export function findIndex<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
+export function findIndex<T, A>(
+  predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean,
+  thisArg: A
 ): OperatorFunction<T, number>;
+export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number>;
 
 /**
  * Emits only the index of the first value emitted by the source Observable that


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds an overload signature with a type parameter for the `thisArg` parameter in `find` and `findIndex` so that if `this` is used in the predicate, it it correctly typed. If an arrow function is used, it behaves as before - regardless of whether a `thisArg` is specified or not.

**Related issue (if exists):** Nope