### PR TITLE
fix(fromEvent): throw if passed invalid target

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -181,20 +181,15 @@ describe('fromEvent', () => {
     expect(offHandler).to.equal(onHandler);
   });
 
-  it('should error on invalid event targets', () => {
+  it('should throw if passed an invalid event target', () => {
     const obj = {
       addListener: () => {
         //noop
       }
     };
-
-    fromEvent(obj as any, 'click').subscribe({
-      error(err: any) {
-        expect(err).to.exist
-          .and.be.instanceof(Error)
-          .and.have.property('message', 'Invalid event target');
-      }
-    });
+    expect(() => {
+      fromEvent(obj as any, 'click');
+    }).to.throw(/Invalid event target/)
   });
 
   it('should pass through options to addEventListener and removeEventListener', () => {

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -245,15 +245,13 @@ export function fromEvent<T>(
     }
   }
 
+  // If add is falsy and we made it here, it's because we didn't
+  // match any valid target objects above.
+  if (!add) {
+    throw new TypeError('Invalid event target');
+  }
+
   return new Observable<T>((subscriber) => {
-    // If add is falsy and we made it here, it's because we didn't
-    // match any valid target objects above.
-    if (!add) {
-      // TODO: We should probably discuss if throwing this at subscription-time
-      // is appropriate. It seems like it would be better (and easier to debug)
-      // to throw this when `fromEvent()` is called.
-      throw new TypeError('Invalid event target');
-    }
     // The handler we are going to register. Forwards the event object, by itself, or
     // an array of arguments to the event handler, if there is more than one argument,
     // to the consumer.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes the implementation of `fromEvent` so that it throws when called - rather than when subscribed - if the passed event target is invalid.

**BREAKING CHANGE:** if passed an invalid event targed `fromEvent` will throw an error when called. Previously, it would emit an error notification when a subscription was made.

**Related issue (if exists):** #5823