### PR TITLE
Zip legacy formatting

### DIFF
--- a/spec/operators/zip-legacy-spec.ts
+++ b/spec/operators/zip-legacy-spec.ts
@@ -21,13 +21,12 @@ describe('zip legacy', () => {
 
     from(['a', 'b', 'c'])
       .pipe(zip(from([1, 2, 3]), (a, b): string => a + b))
-      .subscribe(
-        function (x) {
+      .subscribe({
+        next(x) {
           expect(x).to.equal(expected[i++]);
         },
-        null,
-        done
-      );
+        complete: done,
+      });
   });
 
   it('should work with selector throws', () => {

--- a/spec/operators/zip-legacy-spec.ts
+++ b/spec/operators/zip-legacy-spec.ts
@@ -37,7 +37,7 @@ describe('zip legacy', () => {
       const bsubs = '     ^-------!     ';
       const expected = '  ---x----#     ';
 
-      const selector = function (x: string, y: string) {
+      const selector = (x: string, y: string) => {
         if (y === '5') {
           throw new Error('too bad');
         } else {
@@ -61,7 +61,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function (r1, r2) {
+          zip(b, (r1, r2) => {
             return r1 + r2;
           })
         )
@@ -81,7 +81,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function (r1, r2) {
+          zip(b, (r1, r2) => {
             return r1 + r2;
           })
         )
@@ -101,7 +101,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function (r1, r2) {
+          zip(b, (r1, r2) => {
             return r1 + r2;
           })
         )
@@ -121,7 +121,7 @@ describe('zip legacy', () => {
       const expected = '  ----x---y-|  ';
 
       const observable = a.pipe(
-        zip(b, c, function (r0, r1, r2) {
+        zip(b, c, (r0, r1, r2) => {
           return [r0, r1, r2];
         })
       );
@@ -141,7 +141,7 @@ describe('zip legacy', () => {
       const expected = '  ----x---y-|  ';
 
       const observable = a.pipe(
-        zip(b, c, function (r0, r1, r2) {
+        zip(b, c, (r0, r1, r2) => {
           return [r0, r1, r2];
         })
       );
@@ -161,7 +161,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function (e1, e2) {
+          zip(b, (e1, e2) => {
             return e1 + e2;
           })
         )

--- a/spec/operators/zip-legacy-spec.ts
+++ b/spec/operators/zip-legacy-spec.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { expect } from 'chai';
 import { zip } from 'rxjs/operators';
 import { from } from 'rxjs';
@@ -14,14 +15,14 @@ describe('zip legacy', () => {
     rxTestScheduler = new TestScheduler(observableMatcher);
   });
 
-  it('should zip the provided observables', done => {
+  it('should zip the provided observables', (done) => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
 
     from(['a', 'b', 'c'])
       .pipe(zip(from([1, 2, 3]), (a, b): string => a + b))
       .subscribe(
-        function(x) {
+        function (x) {
           expect(x).to.equal(expected[i++]);
         },
         null,
@@ -37,7 +38,7 @@ describe('zip legacy', () => {
       const bsubs = '     ^-------!     ';
       const expected = '  ---x----#     ';
 
-      const selector = function(x: string, y: string) {
+      const selector = function (x: string, y: string) {
         if (y === '5') {
           throw new Error('too bad');
         } else {
@@ -61,7 +62,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function(r1, r2) {
+          zip(b, function (r1, r2) {
             return r1 + r2;
           })
         )
@@ -81,7 +82,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function(r1, r2) {
+          zip(b, function (r1, r2) {
             return r1 + r2;
           })
         )
@@ -101,7 +102,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function(r1, r2) {
+          zip(b, function (r1, r2) {
             return r1 + r2;
           })
         )
@@ -121,7 +122,7 @@ describe('zip legacy', () => {
       const expected = '  ----x---y-|  ';
 
       const observable = a.pipe(
-        zip(b, c, function(r0, r1, r2) {
+        zip(b, c, function (r0, r1, r2) {
           return [r0, r1, r2];
         })
       );
@@ -141,7 +142,7 @@ describe('zip legacy', () => {
       const expected = '  ----x---y-|  ';
 
       const observable = a.pipe(
-        zip(b, c, function(r0, r1, r2) {
+        zip(b, c, function (r0, r1, r2) {
           return [r0, r1, r2];
         })
       );
@@ -161,7 +162,7 @@ describe('zip legacy', () => {
 
       expectObservable(
         a.pipe(
-          zip(b, function(e1, e2) {
+          zip(b, function (e1, e2) {
             return e1 + e2;
           })
         )


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR introduces prettier formatting in `zip` Legacy tests. One use of the deprecated subscribe signature is replaced and anonymous functions are converted to arrow functions.

**Related issue (if exists):**
None