### PR TITLE
chore(windowWhen): convert windowWhen tests to run mode

### DIFF
--- a/spec/operators/windowWhen-spec.ts
+++ b/spec/operators/windowWhen-spec.ts
@@ -1,333 +1,422 @@
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+/** @prettier */
 import { windowWhen, mergeMap } from 'rxjs/operators';
 import { Observable, of } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {windowWhen} */
-describe('windowWhen operator', () => {
+describe('windowWhen', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should emit windows that close and reopen', () => {
-    const e1 = hot('--a--^--b--c--d--e--f--g--h--i--|');
-    const e1subs =      '^                          !';
-    const e2 = cold(    '-----------|                ');
-    const e2subs =     ['^          !                ',
-                      '           ^          !     ',
-                      '                      ^    !'];
-    const a = cold(     '---b--c--d-|                ');
-    const b = cold(                '-e--f--g--h|     ');
-    const c = cold(                           '--i--|');
-    const expected =    'a----------b----------c----|';
-    const values = { a: a, b: b, c: c };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('       -----------|                ');
+      //                                 -----------|
+      //                                            -----------|
+      const e2subs = [
+        '                     ^----------!                ',
+        '                     -----------^----------!     ',
+        '                     ----------------------^----!',
+      ];
+      const e1 = hot('   --a--^--b--c--d--e--f--g--h--i--|');
+      const e1subs = '        ^--------------------------!';
+      const expected = '      a----------b----------c----|';
 
-    const source = e1.pipe(windowWhen(() => e2));
+      const a = cold('        ---b--c--d-|                ');
+      const b = cold('                   -e--f--g--h|     ');
+      const c = cold('                              --i--|');
+      const values = { a: a, b: b, c: c };
 
-    expectObservable(source).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const source = e1.pipe(windowWhen(() => e2));
+
+      expectObservable(source).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit windows using constying cold closings', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|     ');
-    const e1subs =      '^                                  !     ';
-    const closings = [
-      cold(           '-----------------s--|                    '),
-      cold(                            '-----(s|)               '),
-      cold(                                 '---------------(s|)')];
-    const closeSubs =  ['^                !                       ',
-                      '                 ^    !                  ',
-                      '                      ^            !     '];
-    const expected =    'x----------------y----z------------|     ';
-    const x = cold(     '----b---c---d---e|                       ');
-    const y = cold(                      '---f-|                  ');
-    const z = cold(                           '--g---h------|     ');
-    const values = { x: x, y: y, z: z };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        cold('               -----------------s--|                    '),
+        cold('                                -----(s|)               '),
+        cold('                                     ---------------(s|)'),
+      ];
+      const closeSubs = [
+        '                    ^----------------!                       ',
+        '                    -----------------^----!                  ',
+        '                    ----------------------^------------!     ',
+      ];
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|     ');
+      const e1subs = '       ^----------------------------------!     ';
+      const expected = '     x----------------y----z------------|     ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => closings[i++]));
+      const x = cold('       ----b---c---d---e|                       ');
+      const y = cold('                        ---f-|                  ');
+      const z = cold('                             --g---h------|     ');
+      const values = { x: x, y: y, z: z };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
-    expectSubscriptions(closings[2].subscriptions).toBe(closeSubs[2]);
+      let i = 0;
+      const result = e1.pipe(windowWhen(() => closings[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      expectSubscriptions(closings[2].subscriptions).toBe(closeSubs[2]);
+    });
   });
 
   it('should emit windows using constying hot closings', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|   ');
-    const subs =        '^                                  !   ';
-    const closings = [
-      {obs: hot(  '-1--^----------------s-|                   '), // eslint-disable-line key-spacing
-       sub:           '^                !                     '}, // eslint-disable-line key-spacing
-      {obs: hot(      '-----3----4-----------(s|)             '), // eslint-disable-line key-spacing
-       sub:           '                 ^    !                '}, // eslint-disable-line key-spacing
-      {obs: hot(      '-------3----4-------5----------------s|'), // eslint-disable-line key-spacing
-       sub:           '                      ^            !   '}]; // eslint-disable-line key-spacing
-    const expected =    'x----------------y----z------------|   ';
-    const x = cold(     '----b---c---d---e|                     ');
-    const y = cold(                      '---f-|                ');
-    const z = cold(                           '--g---h------|   ');
-    const values = { x: x, y: y, z: z };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        hot('            -1--^----------------s-|                   '),
+        hot('                -----3----4-----------(s|)             '),
+        hot('                -------3----4-------5----------------s|'),
+      ];
+      const closeSubs = [
+        '                    ^----------------!                     ',
+        '                    -----------------^----!                ',
+        '                    ----------------------^------------!   ',
+      ];
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|   ');
+      const subs = '         ^----------------------------------!   ';
+      const expected = '     x----------------y----z------------|   ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => closings[i++].obs));
+      const x = cold('       ----b---c---d---e|                     ');
+      const y = cold('                        ---f-|                ');
+      const z = cold('                             --g---h------|   ');
+      const values = { x: x, y: y, z: z };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-    expectSubscriptions(closings[0].obs.subscriptions).toBe(closings[0].sub);
-    expectSubscriptions(closings[1].obs.subscriptions).toBe(closings[1].sub);
-    expectSubscriptions(closings[2].obs.subscriptions).toBe(closings[2].sub);
+      let i = 0;
+      const result = e1.pipe(windowWhen(() => closings[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      expectSubscriptions(closings[2].subscriptions).toBe(closeSubs[2]);
+    });
   });
 
   it('should emit windows using constying empty delayed closings', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|  ');
-    const e1subs =      '^                                  !  ';
-    const closings = [
-      cold(           '-----------------|                    '),
-      cold(                            '-----|               '),
-      cold(                                 '---------------|')];
-    const closeSubs =  ['^                !                    ',
-                      '                 ^    !               ',
-                      '                      ^            !  '];
-    const expected =    'x----------------y----z------------|  ';
-    const x = cold(     '----b---c---d---e|                    ');
-    const y = cold(                      '---f-|               ');
-    const z = cold(                           '--g---h------|  ');
-    const values = { x: x, y: y, z: z };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        cold('             -----------------|                    '),
+        cold('                              -----|               '),
+        cold('                                   ---------------|'),
+      ];
+      const closeSubs = [
+        '                  ^----------------!                    ',
+        '                  -----------------^----!               ',
+        '                  ----------------------^------------!  ',
+      ];
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|  ');
+      const e1subs = '     ^----------------------------------!  ';
+      const expected = '   x----------------y----z------------|  ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => closings[i++]));
+      const x = cold('     ----b---c---d---e|                    ');
+      const y = cold('                      ---f-|               ');
+      const z = cold('                           --g---h------|  ');
+      const values = { x: x, y: y, z: z };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
-    expectSubscriptions(closings[2].subscriptions).toBe(closeSubs[2]);
+      let i = 0;
+      const result = e1.pipe(windowWhen(() => closings[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      expectSubscriptions(closings[2].subscriptions).toBe(closeSubs[2]);
+    });
   });
 
   it('should emit windows using constying cold closings, outer unsubscribed early', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|     ');
-    const e1subs =      '^                    !                   ';
-    const closings = [
-      cold(           '-----------------s--|                    '),
-      cold(                            '---------(s|)           ')];
-    const closeSubs =  ['^                !                       ',
-                      '                 ^   !                   '];
-    const expected =    'x----------------y----                   ';
-    const x = cold(     '----b---c---d---e|                       ');
-    const y = cold(                      '---f-                   ');
-    const unsub =       '                     !                   ';
-    const values = { x: x, y: y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        cold('               -----------------s--|               '),
+        cold('                                ---------(s|)      '),
+      ];
+      const closeSubs = [
+        '                    ^----------------!                  ',
+        '                    -----------------^---!              ',
+      ];
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '       ^--------------------!              ';
+      const expected = '     x----------------y----              ';
+      const unsub = '        ---------------------!              ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => closings[i++]));
+      const x = cold('       ----b---c---d---e|                  ');
+      const y = cold('                        ---f-              ');
+      const values = { x: x, y: y };
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      let i = 0;
+      const result = e1.pipe(windowWhen(() => closings[i++]));
+
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+    });
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|     ');
-    const e1subs =      '^                    !                   ';
-    const closings = [
-      cold(           '-----------------s--|                    '),
-      cold(                            '---------(s|)           ')];
-    const closeSubs =  ['^                !                       ',
-                      '                 ^   !                   '];
-    const expected =    'x----------------y----                   ';
-    const x = cold(     '----b---c---d---e|                       ');
-    const y = cold(                      '---f-                   ');
-    const unsub =       '                     !                   ';
-    const values = { x: x, y: y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        cold('               -----------------s--|               '),
+        cold('                                ---------(s|)      '),
+      ];
+      const closeSubs = [
+        '                    ^----------------!                  ',
+        '                    -----------------^---!              ',
+      ];
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '       ^--------------------!              ';
+      const expected = '     x----------------y----              ';
+      const unsub = '        ---------------------!              ';
 
-    let i = 0;
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      windowWhen(() => closings[i++]),
-      mergeMap((x: Observable<string>) => of(x))
-    );
+      const x = cold('       ----b---c---d---e|                  ');
+      const y = cold('                        ---f-              ');
+      const values = { x: x, y: y };
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      let i = 0;
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        windowWhen(() => closings[i++]),
+        mergeMap((x: Observable<string>) => of(x))
+      );
+
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+    });
   });
 
   it('should propagate error thrown from closingSelector', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|     ');
-    const e1subs =      '^                !                       ';
-    const closings = [
-      cold(           '-----------------s--|                    '),
-      cold(                            '-----(s|)               '),
-      cold(                                 '---------------(s|)')];
-    const closeSubs =  ['^                !                       '];
-    const expected =    'x----------------(y#)                    ';
-    const x = cold(     '----b---c---d---e|                       ');
-    const y = cold(                      '#                       ');
-    const values = { x: x, y: y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        cold('                 -----------------s--|                    '),
+        cold('                                  -----(s|)               '),
+        cold('                                       ---------------(s|)'),
+      ];
+      const closeSubs = ['     ^----------------!                       '];
+      const e1 = hot('    --a--^---b---c---d---e---f---g---h------|     ');
+      const e1subs = '         ^----------------!                       ';
+      const expected = '       x----------------(y#)                    ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => {
-      if (i === 1) {
-        throw 'error';
-      }
-      return closings[i++];
-    }));
+      const x = cold('         ----b---c---d---e|                       ');
+      const y = cold('                          #                       ');
+      const values = { x: x, y: y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      let i = 0;
+      const result = e1.pipe(
+        windowWhen(() => {
+          if (i === 1) {
+            throw 'error';
+          }
+          return closings[i++];
+        })
+      );
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+    });
   });
 
   it('should propagate error emitted from a closing', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|     ');
-    const e1subs =      '^                !                       ';
-    const closings = [
-      cold(           '-----------------s--|                    '),
-      cold(                            '#                       ')];
-    const closeSubs =  ['^                !                       ',
-                      '                 (^!)                    '];
-    const expected =    'x----------------(y#)                    ';
-    const x = cold(     '----b---c---d---e|                       ');
-    const y = cold(                      '#                       ');
-    const values = { x: x, y: y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        cold('               -----------------s--|               '),
+        cold('                                #                  '),
+      ];
+      const closeSubs = [
+        '                    ^----------------!                  ',
+        '                    -----------------(^!)               ',
+      ];
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '       ^----------------!                  ';
+      const expected = '     x----------------(y#)               ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => closings[i++]));
+      const x = cold('       ----b---c---d---e|                  ');
+      const y = cold('                        #                  ');
+      const values = { x: x, y: y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      let i = 0;
+      const result = e1.pipe(windowWhen(() => closings[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+    });
   });
 
   it('should propagate error emitted late from a closing', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|     ');
-    const e1subs =      '^                     !                  ';
-    const closings = [
-      cold(           '-----------------s--|                    '),
-      cold(                            '-----#                  ')];
-    const closeSubs =  ['^                !                       ',
-                      '                 ^    !                  '];
-    const expected =    'x----------------y----#                  ';
-    const x = cold(     '----b---c---d---e|                       ');
-    const y = cold(                      '---f-#                  ');
-    const values = { x: x, y: y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const closings = [
+        cold('               -----------------s--|               '),
+        cold('                                -----#             '),
+      ];
+      const closeSubs = [
+        '                    ^----------------!                  ',
+        '                    -----------------^----!             ',
+      ];
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '       ^---------------------!             ';
+      const expected = '     x----------------y----#             ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => closings[i++]));
+      const x = cold('       ----b---c---d---e|                  ');
+      const y = cold('                        ---f-#             ');
+      const values = { x: x, y: y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      let i = 0;
+      const result = e1.pipe(windowWhen(() => closings[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+    });
   });
 
   it('should propagate errors emitted from the source', () => {
-    const e1 = hot('--a--^---b---c---d---e---f-#                  ');
-    const e1subs =      '^                     !                  ';
-    const closings = [
-      cold(           '-----------------s--|                    '),
-      cold(                            '-------(s|)             ')];
-    const closeSubs =  ['^                !                       ',
-                      '                 ^    !                  '];
-    const expected =    'x----------------y----#                  ';
-    const x = cold(     '----b---c---d---e|                       ');
-    const y = cold(                      '---f-#                  ');
-    const values = { x: x, y: y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      // prettier-ignore
+      const closings = [
+        cold('               -----------------s--|       '),
+        cold('                                -------(s|)'),
+      ];
+      // prettier-ignore
+      const closeSubs = [
+        '                    ^----------------!          ',
+        '                    -----------------^----!     ',
+      ];
+      const e1 = hot('  --a--^---b---c---d---e---f-#     ');
+      const e1subs = '       ^---------------------!     ';
+      const expected = '     x----------------y----#     ';
 
-    let i = 0;
-    const result = e1.pipe(windowWhen(() => closings[i++]));
+      const x = cold('       ----b---c---d---e|          ');
+      const y = cold('                        ---f-#     ');
+      const values = { x: x, y: y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+      let i = 0;
+      const result = e1.pipe(windowWhen(() => closings[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closeSubs[1]);
+    });
   });
 
   it('should handle empty source', () => {
-    const e1 = cold( '|');
-    const e1subs =   '(^!)';
-    const e2 = cold( '-----c--|');
-    const e2subs =   '(^!)';
-    const expected = '(w|)';
-    const values = { w: cold('|') };
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold(' -----c--|');
+      const e2subs = '  (^!)     ';
+      const e1 = cold(' |        ');
+      const e1subs = '  (^!)     ';
+      const expected = '(w|)     ';
+      const win = cold('|        ');
+      const values = { w: win };
 
-    const result = e1.pipe(windowWhen(() => e2));
+      const result = e1.pipe(windowWhen(() => e2));
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle a never source', () => {
-    const e1 = cold( '-');
-    const unsub =    '                 !';
-    const e1subs =   '^                !';
-    const e2 = cold( '-----c--|');
-    //                   -----c--|
-    //                        -----c--|
-    //                             -----c--|
-    const e2subs =  ['^    !            ',
-                   '     ^    !       ',
-                   '          ^    !  ',
-                   '               ^ !'];
-    const win = cold('-----|');
-    const d =   cold(               '---');
-    const expected = 'a----b----c----d--';
-    const values = { a: win, b: win, c: win, d: d };
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold(' -----c--|         ');
+      //                     -----c--|
+      //                        -----c--|
+      //                             -----
+      const e2subs = [
+        '               ^----!            ',
+        '               -----^----!       ',
+        '               ----------^----!  ',
+        '               ---------------^-!',
+      ];
+      const e1 = cold(' -                 ');
+      const e1subs = '  ^----------------!';
+      const expected = 'a----b----c----d--';
+      const unsub = '   -----------------!';
 
-    const result = e1.pipe(windowWhen(() => e2));
+      const win = cold('-----|');
+      //                     -----|
+      //                          -----|
+      const d = cold('                 ---');
+      const values = { a: win, b: win, c: win, d: d };
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowWhen(() => e2));
+
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle throw', () => {
-    const e1 = cold('#');
-    const e1subs =  '(^!)';
-    const e2 = cold('-----c--|');
-    const e2subs =  '(^!)';
-    const win = cold('#');
-    const expected = '(w#)';
-    const values = { w: win };
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold(' -----c--|');
+      const e2subs = '  (^!)     ';
+      const e1 = cold(' #        ');
+      const e1subs = '  (^!)     ';
+      const expected = '(w#)     ';
+      const win = cold('#        ');
+      const values = { w: win };
 
-    const result = e1.pipe(windowWhen(() => e2));
+      const result = e1.pipe(windowWhen(() => e2));
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle a never closing Observable', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '^                                  !';
-    const e2 =  cold(   '-');
-    const e2subs =      '^                                  !';
-    const expected =    'x----------------------------------|';
-    const x = cold(     '----b---c---d---e---f---g---h------|');
-    const values = { x: x };
+    rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('      -                                  ');
+      const e2subs = '       ^----------------------------------!';
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '       ^----------------------------------!';
+      const expected = '     x----------------------------------|';
 
-    const result = e1.pipe(windowWhen(() => e2));
+      const x = cold('       ----b---c---d---e---f---g---h------|');
+      const values = { x: x };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowWhen(() => e2));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle a throw closing Observable', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '(^!)                                ';
-    const e2 =  cold(   '#');
-    const e2subs =      '(^!)                                ';
-    const expected =    '(x#)                                ';
-    const x = cold(     '#                                   ');
-    const values = { x: x };
+    rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('      #                                   ');
+      const e2subs = '       (^!)                                ';
+      const e1 = hot('  --a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '       (^!)                                ';
+      const expected = '     (x#)                                ';
 
-    const result = e1.pipe(windowWhen(() => e2));
+      const x = cold('       #                                   ');
+      const values = { x: x };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowWhen(() => e2));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `windowWhen` tests to run mode.

**Related issue (if exists):**
None