### PR TITLE
fix(docs): remove distinctKey from operators list

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -183,7 +183,6 @@ These are Observable creation operators that also have join functionality -- emi
 - [`debounce`](/api/operators/debounce)
 - [`debounceTime`](/api/operators/debounceTime)
 - [`distinct`](/api/operators/distinct)
-- [`distinctKey`](../class/es6/Observable.js~Observable.html#instance-method-distinctKey)
 - [`distinctUntilChanged`](/api/operators/distinctUntilChanged)
 - [`distinctUntilKeyChanged`](/api/operators/distinctUntilKeyChanged)
 - [`elementAt`](/api/operators/elementAt)


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The **distinctKey** operator does not exists anymore, but is listed in the /guide/operators page of the docs, with a link to a 404 page.

This PR just removes the reference.

**Related issue (if exists):**
https://github.com/ReactiveX/rxjs/issues/4980