### PR TITLE
fix(share): handle reentrant subscribes

### DIFF
--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -1,6 +1,6 @@
 import { Subject } from '../Subject';
 import { MonoTypeOperatorFunction, OperatorFunction, SubjectLike } from '../types';
-import { Subscriber } from '../Subscriber';
+import { SafeSubscriber } from '../Subscriber';
 import { from } from '../observable/from';
 import { operate } from '../util/lift';
 
@@ -93,7 +93,7 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
   options = options || {};
   const { connector = () => new Subject<T>(), resetOnComplete = true, resetOnError = true, resetOnRefCountZero = true } = options;
 
-  let connection: Subscriber<T> | null = null;
+  let connection: SafeSubscriber<T> | null = null;
   let subject: SubjectLike<T> | null = null;
   let refCount = 0;
   let hasCompleted = false;
@@ -122,7 +122,7 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
       // for reentrant subscriptions to the shared observable to occur and in
       // those situations we don't want connection to be already-assigned so
       // that we don't create another connection to the source.
-      connection = new Subscriber({
+      connection = new SafeSubscriber({
         next: (value: T) => subject!.next(value),
         error: (err: any) => {
           hasErrored = true;

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -122,7 +122,7 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
       // for reentrant subscriptions to the shared observable to occur and in
       // those situations we don't want connection to be already-assigned so
       // that we don't create another connection to the source.
-      connection = new Subscriber<T>({
+      connection = new Subscriber({
         next: (value: T) => subject!.next(value),
         error: (err: any) => {
           hasErrored = true;

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -120,8 +120,8 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
       // We need to create a subscriber here - rather than pass an observer and
       // assign the returned subscription to connection - because it's possible
       // for reentrant subscriptions to the shared observable to occur and in
-      // those situations we don't want connection to be already-assigned so
-      // that we don't create another connection to the source.
+      // those situations we want connection to be already-assigned so that we
+      // don't create another connection to the source.
       connection = new SafeSubscriber({
         next: (value: T) => subject!.next(value),
         error: (err: any) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR replaces the observer-based subscription that's made within the `share` implementation with a `Subcriber`-based subscription - so that the `connection` variable is assigned _before_ the `subscribe` call is made - to support reentrant calls to `subscribe`.

**Related issue (if exists):** #6144
