### PR TITLE
docs(delay): add relevant operator links to delay docs

### DIFF
--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -41,6 +41,8 @@ import { timer } from '../observable/timer';
  * delayedClicks.subscribe(x => console.log(x));
  * ```
  *
+ * @see {@link delayWhen}
+ * @see {@link throttle}
  * @see {@link throttleTime}
  * @see {@link debounce}
  * @see {@link debounceTime}
@@ -48,7 +50,6 @@ import { timer } from '../observable/timer';
  * @see {@link sampleTime}
  * @see {@link audit}
  * @see {@link auditTime}
- * @see {@link delayWhen}
  *
  * @param {number|Date} due The delay duration in milliseconds (a `number`) or
  * a `Date` until which the emission of the source items is delayed.

--- a/src/internal/operators/delay.ts
+++ b/src/internal/operators/delay.ts
@@ -41,7 +41,13 @@ import { timer } from '../observable/timer';
  * delayedClicks.subscribe(x => console.log(x));
  * ```
  *
+ * @see {@link throttleTime}
+ * @see {@link debounce}
  * @see {@link debounceTime}
+ * @see {@link sample}
+ * @see {@link sampleTime}
+ * @see {@link audit}
+ * @see {@link auditTime}
  * @see {@link delayWhen}
  *
  * @param {number|Date} due The delay duration in milliseconds (a `number`) or


### PR DESCRIPTION
A minor doc change proposed by @BioPhoton in #4921

Created a new PR to remove unnecessary formatting changes

Related issue: #4921
