### PR TITLE
chore(windowToggle): convert windowToggle tests to run mode

### DIFF
--- a/spec/operators/windowToggle-spec.ts
+++ b/spec/operators/windowToggle-spec.ts
@@ -77,12 +77,12 @@ describe('windowToggle', () => {
     });
   });
 
-  it('should emit windows using constying cold closings', () => {
+  it('should emit windows using varying cold closings', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const e2 = cold('    --x-----------y--------z---|            ');
       const e2subs = '     ^--------------------------!            ';
       const close = [
-        cold('             ---------------s--|                     '),
+        cold('               ---------------s--|                   '),
         cold('                           ----(s|)                  '),
         cold('                                  ---------------(s|)'),
       ];
@@ -112,7 +112,7 @@ describe('windowToggle', () => {
     });
   });
 
-  it('should emit windows using constying hot closings', () => {
+  it('should emit windows using varying hot closings', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const e2 = cold('    --x-----------y--------z---|           ');
       const e2subs = '     ^--------------------------!           ';
@@ -174,7 +174,7 @@ describe('windowToggle', () => {
     });
   });
 
-  it('should emit windows using constying cold closings, outer unsubscribed early', () => {
+  it('should emit windows using varying cold closings, outer unsubscribed early', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const e2 = cold('    --x-----------y--------z---|              ');
       const e2subs = '     ^----------------!                        ';

--- a/spec/operators/windowToggle-spec.ts
+++ b/spec/operators/windowToggle-spec.ts
@@ -1,432 +1,527 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
 import { Observable, NEVER, of, ObjectUnsubscribedError, EMPTY } from 'rxjs';
 import { windowToggle, tap, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {windowToggle} */
 describe('windowToggle', () => {
-  it('should emit windows governed by openings and closings', () => {
-    const source = hot('--1--2--^-a--b--c--d--e--f--g--h-|');
-    const subs =               '^                        !';
-    const e2 = cold(           '----w--------w--------w--|');
-    const e2subs =             '^                        !';
-    const e3 = cold(               '-----x                ');
-    //                                     -----x
-    //                                              -----x
-    const e3subs = [           '    ^    !                ', // eslint-disable-line array-bracket-spacing
-                             '             ^    !       ',
-                             '                      ^  !'];
-    const expected =           '----x--------y--------z--|';
-    const x = cold(                '-b--c|                ');
-    const y = cold(                         '-e--f|       ');
-    const z = cold(                                  '-h-|');
-    const values = { x, y, z };
+  let rxTestScheduler: TestScheduler;
 
-    const result = source.pipe(windowToggle(e2, () => e3));
-
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(source.subscriptions).toBe(subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(e3.subscriptions).toBe(e3subs);
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
   });
 
-  it('should emit windows that are opened by an observable from the first argument ' +
-    'and closed by an observable returned by the function in the second argument',
-  () => {
-    const e1 = hot('--1--2--^--a--b--c--d--e--f--g--h--|');
-    const e1subs =         '^                          !';
-    const e2 = cold(       '--------x-------x-------x--|');
-    const e2subs =         '^                          !';
-    const e3 = cold(               '----------(x|)      ');
-    //                                    ----------(x|)
-    //                                            ----------(x|)
-    const e3subs = [       '        ^         !         ', // eslint-disable-line array-bracket-spacing
-                         '                ^         ! ',
-                         '                        ^  !'];
-    const expected =       '--------x-------y-------z--|';
-    const x = cold(                '-c--d--e--(f|)      ');
-    const y = cold(                        '--f--g--h-| ');
-    const z = cold(                                '---|');
-    const values = { x, y, z };
+  it('should emit windows governed by openings and closings', () => {
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('         ----w--------w--------w--|');
+      const e2subs = '          ^------------------------!';
+      const e3 = cold('             -----x                ');
+      //                                     -----x
+      //                                              -----x
+      const e3subs = [
+        '                       ----^----!                ',
+        '                       -------------^----!       ',
+        '                       ----------------------^--!',
+      ];
+      const e1 = hot('  --1--2--^-a--b--c--d--e--f--g--h-|');
+      const e1subs = '          ^------------------------!';
+      const expected = '        ----x--------y--------z--|';
+      const x = cold('              -b--c|                ');
+      const y = cold('                       -e--f|       ');
+      const z = cold('                                -h-|');
+      const values = { x, y, z };
 
-    const source = e1.pipe(windowToggle(e2, (value: string) => {
-      expect(value).to.equal('x');
-      return e3;
-    }));
+      const result = e1.pipe(windowToggle(e2, () => e3));
 
-    expectObservable(source).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(e3.subscriptions).toBe(e3subs);
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(e3.subscriptions).toBe(e3subs);
+    });
+  });
+
+  it('should emit windows that are opened by an observable from the first argument and closed by an observable returned by the function in the second argument', () => {
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('       --------x-------x-------x--|');
+      const e2subs = '        ^--------------------------!';
+      const e3 = cold('               ----------(x|)      ');
+      //                                      ----------(x|)
+      //                                              ----------(x|)
+      const e3subs = [
+        '                     --------^---------!         ',
+        '                     ----------------^---------! ',
+        '                     ------------------------^--!',
+      ];
+
+      const e1 = hot('--1--2--^--a--b--c--d--e--f--g--h--|');
+      const e1subs = '        ^--------------------------!';
+      const expected = '      --------x-------y-------z--|';
+      const x = cold('                -c--d--e--(f|)      ');
+      const y = cold('                        --f--g--h-| ');
+      const z = cold('                                ---|');
+      const values = { x, y, z };
+
+      const source = e1.pipe(
+        windowToggle(e2, (value: string) => {
+          expect(value).to.equal('x');
+          return e3;
+        })
+      );
+
+      expectObservable(source).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(e3.subscriptions).toBe(e3subs);
+    });
   });
 
   it('should emit windows using constying cold closings', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
-    const e1subs =      '^                                  !      ';
-    const e2 =     cold('--x-----------y--------z---|              ');
-    const e2subs =      '^                          !              ';
-    const close = [
-      cold(             '---------------s--|                     '),
-      cold(                         '----(s|)                    '),
-      cold(                                  '---------------(s|)')];
-    const closeSubs = [ '  ^              !                        ', // eslint-disable-line array-bracket-spacing
-                      '              ^   !                       ',
-                      '                       ^           !      '];
-    const expected =    '--x-----------y--------z-----------|      ';
-    const x = cold(       '--b---c---d---e|                        ');
-    const y = cold(                   '--e-|                       ');
-    const z = cold(                            '-g---h------|      ');
-    const values = { x, y, z };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|            ');
+      const e2subs = '     ^--------------------------!            ';
+      const close = [
+        cold('             ---------------s--|                     '),
+        cold('                           ----(s|)                  '),
+        cold('                                  ---------------(s|)'),
+      ];
+      const closeSubs = [
+        '                  --^--------------!                      ',
+        '                  --------------^---!                     ',
+        '                  -----------------------^-----------!    ',
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => close[i++]));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|    ');
+      const e1subs = '     ^----------------------------------!    ';
+      const expected = '   --x-----------y--------z-----------|    ';
+      const x = cold('       --b---c---d---e|                      ');
+      const y = cold('                   --e-|                     ');
+      const z = cold('                            -g---h------|    ');
+      const values = { x, y, z };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(close[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(close[1].subscriptions).toBe(closeSubs[1]);
-    expectSubscriptions(close[2].subscriptions).toBe(closeSubs[2]);
+      let i = 0;
+      const result = e1.pipe(windowToggle(e2, () => close[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(close[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(close[1].subscriptions).toBe(closeSubs[1]);
+      expectSubscriptions(close[2].subscriptions).toBe(closeSubs[2]);
+    });
   });
 
   it('should emit windows using constying hot closings', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|   ');
-    const e1subs =      '^                                  !   ';
-    const e2 =     cold('--x-----------y--------z---|           ');
-    const e2subs =      '^                          !           ';
-    const closings = [
-      {obs: hot(  '-1--^----------------s-|                   '), // eslint-disable-line key-spacing
-       sub:           '  ^              !                     '}, // eslint-disable-line key-spacing
-      {obs: hot(      '-----3----4-------(s|)                 '), // eslint-disable-line key-spacing
-       sub:           '              ^   !                    '}, // eslint-disable-line key-spacing
-      {obs: hot(      '-------3----4-------5----------------s|'), // eslint-disable-line key-spacing
-       sub:           '                       ^           !   '}]; // eslint-disable-line key-spacing
-    const expected =    '--x-----------y--------z-----------|   ';
-    const x = cold(       '--b---c---d---e|                     ');
-    const y = cold(                   '--e-|                    ');
-    const z = cold(                            '-g---h------|   ');
-    const values = { x, y, z };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|           ');
+      const e2subs = '     ^--------------------------!           ';
+      const closings = [
+        hot('          -1--^----------------s-|                   '),
+        hot('              -----3----4-------(s|)                 '),
+        hot('              -------3----4-------5----------------s|'),
+      ];
+      const closingSubs = [
+        '                  --^--------------!                     ',
+        '                  --------------^---!                    ',
+        '                  -----------------------^-----------!   ',
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => closings[i++].obs));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|   ');
+      const e1subs = '     ^----------------------------------!   ';
+      const expected = '   --x-----------y--------z-----------|   ';
+      const x = cold('       --b---c---d---e|                     ');
+      const y = cold('                   --e-|                    ');
+      const z = cold('                            -g---h------|   ');
+      const values = { x, y, z };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(closings[0].obs.subscriptions).toBe(closings[0].sub);
-    expectSubscriptions(closings[1].obs.subscriptions).toBe(closings[1].sub);
-    expectSubscriptions(closings[2].obs.subscriptions).toBe(closings[2].sub);
+      let i = 0;
+      const result = e1.pipe(windowToggle(e2, () => closings[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(closings[0].subscriptions).toBe(closingSubs[0]);
+      expectSubscriptions(closings[1].subscriptions).toBe(closingSubs[1]);
+      expectSubscriptions(closings[2].subscriptions).toBe(closingSubs[2]);
+    });
   });
 
   it('should emit windows using varying empty delayed closings', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|   ');
-    const e1subs =      '^                                  !   ';
-    const e2 =     cold('--x-----------y--------z---|           ');
-    const e2subs =      '^                          !           ';
-    const close = [cold(  '---------------|                     '),
-      cold(                           '----|                    '),
-      cold(                                    '---------------|')];
-    const expected =    '--x-----------y--------z-----------|   ';
-    const x = cold(       '--b---c---d---e---f---g---h------|   ');
-    const y = cold(                   '--e---f---g---h------|   ');
-    const z = cold(                            '-g---h------|   ');
-    const values = { x, y, z };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|           ');
+      const e2subs = '     ^--------------------------!           ';
+      const close = [
+        cold('               ---------------|                     '),
+        cold('                           ----|                    '),
+        cold('                                    ---------------|'),
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => close[i++]));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|   ');
+      const e1subs = '     ^----------------------------------!   ';
+      const expected = '   --x-----------y--------z-----------|   ';
+      const x = cold('       --b---c---d---e---f---g---h------|   ');
+      const y = cold('                   --e---f---g---h------|   ');
+      const z = cold('                            -g---h------|   ');
+      const values = { x, y, z };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      let i = 0;
+      const result = e1.pipe(windowToggle(e2, () => close[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should emit windows using constying cold closings, outer unsubscribed early', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
-    const e1subs =      '^                !                        ';
-    const e2 =     cold('--x-----------y--------z---|              ');
-    const e2subs =      '^                !                        ';
-    const close = [cold(  '-------------s---|                     '),
-      cold(                         '-----(s|)                   '),
-      cold(                                  '---------------(s|)')];
-    const closeSubs =  ['  ^            !                          ',
-                      '              ^  !                        '];
-    const expected =    '--x-----------y---                        ';
-    const x = cold(       '--b---c---d--|                          ');
-    const y = cold(                   '--e-                        ');
-    const unsub =       '                 !                        ';
-    const values = { x, y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|              ');
+      const e2subs = '     ^----------------!                        ';
+      const close = [
+        cold('               -------------s---|                      '),
+        cold('                           -----(s|)                   '),
+        cold('                                    ---------------(s|)'),
+      ];
+      const closeSubs = [
+        '                  --^------------!                          ',
+        '                  --------------^--!                        ',
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => close[i++]));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
+      const e1subs = '     ^----------------!                        ';
+      const expected = '   --x-----------y---                        ';
+      const x = cold('       --b---c---d--|                          ');
+      const y = cold('                   --e-                        ');
+      const unsub = '      -----------------!                        ';
+      const values = { x, y };
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(close[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(close[1].subscriptions).toBe(closeSubs[1]);
-    expectSubscriptions(close[2].subscriptions).toBe([]);
+      let i = 0;
+      const result = e1.pipe(windowToggle(e2, () => close[i++]));
+
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(close[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(close[1].subscriptions).toBe(closeSubs[1]);
+      expectSubscriptions(close[2].subscriptions).toBe([]);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
-    const e1subs =      '^              !                          ';
-    const e2 =     cold('--x-----------y--------z---|              ');
-    const e2subs =      '^              !                          ';
-    const close = [cold(  '---------------s--|                     '),
-      cold(                         '----(s|)                    '),
-      cold(                                  '---------------(s|)')];
-    const closeSubs =  ['  ^            !                          ',
-                      '              ^!                          '];
-    const expected =    '--x-----------y-                          ';
-    const x = cold(       '--b---c---d---                          ');
-    const y = cold(                   '--                          ');
-    const unsub =       '               !                          ';
-    const values = { x, y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|              ');
+      const e2subs = '     ^--------------!                          ';
+      const close = [
+        cold('               ---------------s--|                     '),
+        cold('                           ----(s|)                    '),
+        cold('                                    ---------------(s|)'),
+      ];
+      const closeSubs = [
+        '                  --^------------!                          ',
+        '                  --------------^!                          ',
+      ];
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
+      const e1subs = '     ^--------------!                          ';
+      const expected = '   --x-----------y-                          ';
+      const x = cold('       --b---c---d---                          ');
+      const y = cold('                   --                          ');
+      const unsub = '      ---------------!                          ';
+      const values = { x, y };
 
-    let i = 0;
-    const result = e1.pipe(
-      mergeMap(x => of(x)),
-      windowToggle(e2, () => close[i++]),
-      mergeMap(x => of(x)),
-    );
+      let i = 0;
+      const result = e1.pipe(
+        mergeMap((x) => of(x)),
+        windowToggle(e2, () => close[i++]),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
-    expectSubscriptions(close[0].subscriptions).toBe(closeSubs[0]);
-    expectSubscriptions(close[1].subscriptions).toBe(closeSubs[1]);
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectSubscriptions(close[0].subscriptions).toBe(closeSubs[0]);
+      expectSubscriptions(close[1].subscriptions).toBe(closeSubs[1]);
+    });
   });
 
   it('should dispose window Subjects if the outer is unsubscribed early', () => {
-    const source = hot('--a--b--c--d--e--f--g--h--|');
-    const open =  cold('o-------------------------|');
-    const sourceSubs = '^        !                 ';
-    const expected =   'x---------                 ';
-    const x = cold(    '--a--b--c-                 ');
-    const unsub =      '         !                 ';
-    const late =  time('---------------|           ');
-    const values = { x };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions, time }) => {
+      const open = cold(' o-------------------------|');
+      const e1 = hot('    --a--b--c--d--e--f--g--h--|');
+      const e1subs = '    ^--------!                 ';
+      const expected = '  x---------                 ';
+      const x = cold('    --a--b--c-                 ');
+      const unsub = '     ---------!                 ';
+      const late = time(' ---------------|           ');
+      const values = { x };
 
-    let window: Observable<string>;
-    const result = source.pipe(
-      windowToggle(open, () => NEVER),
-      tap(w => { window = w; }),
-    );
+      let window: Observable<string>;
+      const result = e1.pipe(
+        windowToggle(open, () => NEVER),
+        tap((w) => {
+          window = w;
+        })
+      );
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
-    rxTestScheduler.schedule(() => {
-      expect(() => {
-        window.subscribe();
-      }).to.throw(ObjectUnsubscribedError);
-    }, late);
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      rxTestScheduler.schedule(() => {
+        expect(() => {
+          window.subscribe();
+        }).to.throw(ObjectUnsubscribedError);
+      }, late);
+    });
   });
 
   it('should propagate error thrown from closingSelector', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
-    const e1subs =      '^             !                           ';
-    const e2 =     cold('--x-----------y--------z---|              ');
-    const e2subs =      '^             !                           ';
-    const close = [cold(  '---------------s--|                     '),
-      cold(                         '----(s|)                    '),
-      cold(                                  '---------------(s|)')];
-    const expected =    '--x-----------#----                       ';
-    const x = cold(       '--b---c---d-#                           ');
-    const values = { x: x };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|              ');
+      const e2subs = '     ^-------------!                           ';
+      const close = [
+        cold('               ---------------s--|                     '),
+        cold('                           ----(s|)                    '),
+        cold('                                    ---------------(s|)'),
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => {
-      if (i === 1) {
-        throw 'error';
-      }
-      return close[i++];
-    }));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|      ');
+      const e1subs = '     ^-------------!                           ';
+      const expected = '   --x-----------#----                       ';
+      const x = cold('       --b---c---d-#                           ');
+      const values = { x: x };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      let i = 0;
+      const result = e1.pipe(
+        windowToggle(e2, () => {
+          if (i === 1) {
+            throw 'error';
+          }
+          return close[i++];
+        })
+      );
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should propagate error emitted from a closing', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '^             !                     ';
-    const e2 =     cold('--x-----------y--------z---|        ');
-    const e2subs =      '^             !                     ';
-    const close = [cold(  '---------------s--|               '),
-      cold(                         '#                     ')];
-    const expected =    '--x-----------(y#)                  ';
-    const x = cold(       '--b---c---d-#                     ');
-    const y = cold(                   '#                     ');
-    const values = { x, y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|        ');
+      const e2subs = '     ^-------------!                     ';
+      // prettier-ignore
+      const close = [
+        cold('               ---------------s--|               '),
+        cold('                           #                     ')
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => close[i++]));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '     ^-------------!                     ';
+      const expected = '   --x-----------(y#)                  ';
+      const x = cold('       --b---c---d-#                     ');
+      const y = cold('                   #                     ');
+      const values = { x, y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      let i = 0;
+      const result = e1.pipe(windowToggle(e2, () => close[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should propagate error emitted late from a closing', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '^                  !                ';
-    const e2 =     cold('--x-----------y--------z---|        ');
-    const e2subs =      '^                  !                ';
-    const close = [cold(  '---------------s--|               '),
-      cold(                         '-----#                ')];
-    const expected =    '--x-----------y----#                ';
-    const x = cold(       '--b---c---d---e|                  ');
-    const y = cold(                   '--e--#                ');
-    const values = { x, y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|        ');
+      const e2subs = '     ^------------------!                ';
+      // prettier-ignore
+      const close = [
+        cold('               ---------------s--|               '),
+        cold('                           -----#                ')
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => close[i++]));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '     ^------------------!                ';
+      const expected = '   --x-----------y----#                ';
+      const x = cold('       --b---c---d---e|                  ');
+      const y = cold('                   --e--#                ');
+      const values = { x, y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      let i = 0;
+      const result = e1.pipe(windowToggle(e2, () => close[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle errors', () => {
-    const e1 = hot('--a--^---b---c---d---e--#                ');
-    const e1subs =      '^                  !                ';
-    const e2 =     cold('--x-----------y--------z---|        ');
-    const e2subs =      '^                  !                ';
-    const close = [cold(  '---------------s--|               '),
-      cold(                         '-------s|             ')];
-    const expected =    '--x-----------y----#                ';
-    const x = cold(       '--b---c---d---e|                  ');
-    const y = cold(                   '--e--#                ');
-    const values = { x, y };
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    --x-----------y--------z---|        ');
+      const e2subs = '     ^------------------!                ';
+      // prettier-ignore
+      const close = [
+        cold('               ---------------s--|               '),
+        cold('                           -------s|             ')
+      ];
 
-    let i = 0;
-    const result = e1.pipe(windowToggle(e2, () => close[i++]));
+      const e1 = hot('--a--^---b---c---d---e--#                ');
+      const e1subs = '     ^------------------!                ';
+      const expected = '   --x-----------y----#                ';
+      const x = cold('       --b---c---d---e|                  ');
+      const y = cold('                   --e--#                ');
+      const values = { x, y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      let i = 0;
+      const result = e1.pipe(windowToggle(e2, () => close[i++]));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle empty source', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const e2 =  cold('--o-----|');
-    const e2subs =   '(^!)';
-    const e3 = cold(   '-----c--|');
-    const expected = '|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('--o-----|');
+      const e2subs = '   (^!)';
+      const e3 = cold('  -----c--|');
 
-    const result = e1.pipe(windowToggle(e2, () => e3));
+      const e1 = cold('  |');
+      const e1subs = '   (^!)';
+      const expected = ' |';
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowToggle(e2, () => e3));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle throw', () => {
-    const e1 = cold('#');
-    const e1subs =  '(^!)';
-    const e2 = cold('--o-----|');
-    const e2subs =  '(^!)';
-    const e3 = cold('-----c--|');
-    const expected = '#';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e2 = cold(' --o-----|');
+      const e2subs = '  (^!)';
+      const e3 = cold(' -----c--|');
 
-    const result = e1.pipe(windowToggle(e2, () => e3));
+      const e1 = cold(' #');
+      const e1subs = '  (^!)';
+      const expected = '#';
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowToggle(e2, () => e3));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle never', () => {
-    const e1 =   hot('-');
-    const e1subs =   '^                                           !';
-    const e2 =  cold('--o-----o------o-----o---o-----|             ');
-    const e2subs =   '^                              !             ';
-    const e3 =  cold(  '--c-|                                      ');
-    const expected = '--u-----v------x-----y---z-------------------';
-    const u = cold(    '--|                                        ');
-    const v = cold(          '--|                                  ');
-    const x = cold(                 '--|                           ');
-    const y = cold(                       '--|                     ');
-    const z = cold(                           '--|                 ');
-    const unsub =    '                                            !';
-    const values = { u: u, v: v, x, y, z };
+    rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e2 = cold(' --o-----o------o-----o---o-----|             ');
+      const e2subs = '  ^------------------------------!             ';
+      const e3 = cold('   --c-|                                      ');
 
-    const result = e1.pipe(windowToggle(e2, () => e3));
+      const e1 = hot('  -                                            ');
+      const e1subs = '  ^-------------------------------------------!';
+      const expected = '--u-----v------x-----y---z-------------------';
+      const u = cold('    --|                                        ');
+      const v = cold('          --|                                  ');
+      const x = cold('                 --|                           ');
+      const y = cold('                       --|                     ');
+      const z = cold('                           --|                 ');
+      const unsub = '   --------------------------------------------!';
+      const values = { u: u, v: v, x, y, z };
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowToggle(e2, () => e3));
+
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle a never opening Observable', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '^                                  !';
-    const e2 = cold(    '-');
-    const e2subs =      '^                                  !';
-    const e3 =  cold(   '--c-|                               ');
-    const expected =    '-----------------------------------|';
+    rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    -                                   ');
+      const e2subs = '     ^----------------------------------!';
+      const e3 = cold('    --c-|                               ');
 
-    const result = e1.pipe(windowToggle(e2, () => e3));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '     ^----------------------------------!';
+      const expected = '   -----------------------------------|';
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowToggle(e2, () => e3));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle a never closing Observable', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '^                                  !';
-    const e2 = cold(    '---o---------------o-----------|    ');
-    const e2subs =      '^                              !    ';
-    const e3 =  cold('-');
-    const expected =    '---x---------------y---------------|';
-    const x = cold(        '-b---c---d---e---f---g---h------|');
-    const y = cold(                        '-f---g---h------|');
-    const values = { x, y };
+    rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    ---o---------------o-----------|    ');
+      const e2subs = '     ^------------------------------!    ';
+      const e3 = cold('       -                                ');
+      //                                      -
 
-    const result = e1.pipe(windowToggle(e2, () => e3));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '     ^----------------------------------!';
+      const expected = '   ---x---------------y---------------|';
+      const x = cold('        -b---c---d---e---f---g---h------|');
+      const y = cold('                        -f---g---h------|');
+      const values = { x, y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowToggle(e2, () => e3));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should handle opening Observable that just throws', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '(^!)';
-    const e2 = cold(    '#');
-    const e2subs =      '(^!)';
-    const e3 = cold(    '--c-|');
-    const subs =        '(^!)';
-    const expected =    '#';
+    rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    #                                   ');
+      const e2subs = '     (^!)                                ';
+      const e3 = cold('    --c-|                               ');
+      const subs = '       (^!)                                ';
 
-    const result = e1.pipe(windowToggle(e2, () => e3));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '     (^!)                                ';
+      const expected = '   #                                   ';
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowToggle(e2, () => e3));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
-  it ('should handle empty closing observable', () => {
-    const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
-    const e1subs =      '^                                  !';
-    const e2 = cold(    '---o---------------o-----------|    ');
-    const e2subs =      '^                              !    ';
-    const e3 =  EMPTY;
-    const expected =    '---x---------------y---------------|';
-    const x = cold(        '-b---c---d---e---f---g---h------|');
-    const y = cold(                        '-f---g---h------|');
-    const values = { x, y };
+  it('should handle empty closing observable', () => {
+    rxTestScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e2 = cold('    ---o---------------o-----------|    ');
+      const e2subs = '     ^------------------------------!    ';
+      const e3 = EMPTY;
 
-    const result = e1.pipe(windowToggle(e2, () => e3));
+      const e1 = hot('--a--^---b---c---d---e---f---g---h------|');
+      const e1subs = '     ^----------------------------------!';
+      const expected = '   ---x---------------y---------------|';
+      const x = cold('        -b---c---d---e---f---g---h------|');
+      const y = cold('                        -f---g---h------|');
+      const values = { x, y };
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      const result = e1.pipe(windowToggle(e2, () => e3));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `windowToggle` tests to run mode.

**Related issue (if exists):**
None
