### PR TITLE
chore: constying

### DIFF
--- a/spec/operators/windowWhen-spec.ts
+++ b/spec/operators/windowWhen-spec.ts
@@ -39,7 +39,7 @@ describe('windowWhen', () => {
     });
   });
 
-  it('should emit windows using constying cold closings', () => {
+  it('should emit windows using varying cold closings', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const closings = [
         cold('               -----------------s--|                    '),
@@ -71,7 +71,7 @@ describe('windowWhen', () => {
     });
   });
 
-  it('should emit windows using constying hot closings', () => {
+  it('should emit windows using varying hot closings', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const closings = [
         hot('            -1--^----------------s-|                   '),
@@ -103,7 +103,7 @@ describe('windowWhen', () => {
     });
   });
 
-  it('should emit windows using constying empty delayed closings', () => {
+  it('should emit windows using varying empty delayed closings', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const closings = [
         cold('             -----------------|                    '),
@@ -135,7 +135,7 @@ describe('windowWhen', () => {
     });
   });
 
-  it('should emit windows using constying cold closings, outer unsubscribed early', () => {
+  it('should emit windows using varying cold closings, outer unsubscribed early', () => {
     rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
       const closings = [
         cold('               -----------------s--|               '),


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes the remaining test description typos that were effected by a search-replace of `var` with `const`.

**Related issue (if exists):** Nope
