### PR TITLE
feat(ReadableStreams): Support for ReadableStreams e.g. `from(readableStream)`

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -269,7 +269,7 @@ export declare class Observable<T> implements Subscribable<T> {
     static create: (...args: any[]) => any;
 }
 
-export declare type ObservableInput<T> = Observable<T> | InteropObservable<T> | AsyncIterable<T> | PromiseLike<T> | ArrayLike<T> | Iterable<T>;
+export declare type ObservableInput<T> = Observable<T> | InteropObservable<T> | AsyncIterable<T> | PromiseLike<T> | ArrayLike<T> | Iterable<T> | ReadableStreamLike<T>;
 
 export declare type ObservableInputTuple<T> = {
     [K in keyof T]: ObservableInput<T[K]>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -348,6 +348,10 @@ export declare function race<T extends readonly unknown[]>(...inputs: [...Observ
 export declare function range(start: number, count?: number): Observable<number>;
 export declare function range(start: number, count: number | undefined, scheduler: SchedulerLike): Observable<number>;
 
+export interface ReadableStreamLike<T> {
+    getReader(): ReadableStreamDefaultReaderLike<T>;
+}
+
 export declare class ReplaySubject<T> extends Subject<T> {
     constructor(bufferSize?: number, windowTime?: number, timestampProvider?: TimestampProvider);
     protected _subscribe(subscriber: Subscriber<T>): Subscription;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "rxjs",
-  "version": "7.0.0-beta.11",
+  "version": "7.0.0-beta.13",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "7.0.0-beta.11",
+      "version": "7.0.0-beta.13",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "~2.1.0"
@@ -68,6 +68,7 @@
         "typedoc": "^0.17.8",
         "typescript": "~4.2.2",
         "validate-commit-msg": "2.14.0",
+        "web-streams-polyfill": "^3.0.2",
         "webpack": "^4.31.0"
       }
     },
@@ -10475,6 +10476,15 @@
         "defaults": "^1.0.3"
       }
     },
+    "node_modules/web-streams-polyfill": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.2.tgz",
+      "integrity": "sha512-JTNkNbAKoSo8NKiqu2UUaqRFCDWWZaCOsXuJEsToWopikTA0YHKKUf91GNkS/SnD8JixOkJjVsiacNlrFnRECA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/webpack": {
       "version": "4.39.3",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-4.39.3.tgz",
@@ -19524,6 +19534,12 @@
       "requires": {
         "defaults": "^1.0.3"
       }
+    },
+    "web-streams-polyfill": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-3.0.2.tgz",
+      "integrity": "sha512-JTNkNbAKoSo8NKiqu2UUaqRFCDWWZaCOsXuJEsToWopikTA0YHKKUf91GNkS/SnD8JixOkJjVsiacNlrFnRECA==",
+      "dev": true
     },
     "webpack": {
       "version": "4.39.3",

--- a/package.json
+++ b/package.json
@@ -153,6 +153,7 @@
     "typedoc": "^0.17.8",
     "typescript": "~4.2.2",
     "validate-commit-msg": "2.14.0",
+    "web-streams-polyfill": "^3.0.2",
     "webpack": "^4.31.0"
   },
   "files": [

--- a/spec-dtslint/observables/from-spec.ts
+++ b/spec-dtslint/observables/from-spec.ts
@@ -1,4 +1,4 @@
-import { from, of, animationFrameScheduler } from 'rxjs';
+import { from, of, animationFrameScheduler, ReadableStreamLike } from 'rxjs';
 
 it('should accept an array', () => {
   const o = from([1, 2, 3, 4]); // $ExpectType Observable<number>
@@ -54,4 +54,14 @@ it('should accept an array of Observables', () => {
 
 it('should support scheduler', () => {
   const a = from([1, 2, 3], animationFrameScheduler); // $ExpectType Observable<number>
+});
+
+it('should accept a ReadableStream', () => {
+  const stream: ReadableStreamLike<string> = new ReadableStream<string>({
+    pull(controller) {
+      controller.enqueue('x');
+      controller.close();
+    },
+  });
+  const o = from(stream); // $ExpectType Observable<string>
 });

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -12,6 +12,7 @@ import { isInteropObservable } from '../util/isInteropObservable';
 import { isAsyncIterable } from '../util/isAsyncIterable';
 import { createInvalidObservableTypeError } from '../util/throwUnobservableError';
 import { isIterable } from '../util/isIterable';
+import { isReadableStreamLike, ReadableStreamLike, readableStreamLikeToAsyncGenerator } from '../util/isReadableStreamLike';
 
 export function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
 /** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
@@ -141,6 +142,9 @@ export function innerFrom<T>(input: ObservableInput<T>): Observable<T> {
     if (isIterable(input)) {
       return fromIterable(input);
     }
+    if (isReadableStreamLike(input)) {
+      return fromReadableStreamLike(input);
+    }
   }
 
   throw createInvalidObservableTypeError(input);
@@ -218,6 +222,10 @@ function fromAsyncIterable<T>(asyncIterable: AsyncIterable<T>) {
   return new Observable((subscriber: Subscriber<T>) => {
     process(asyncIterable, subscriber).catch((err) => subscriber.error(err));
   });
+}
+
+function fromReadableStreamLike<T>(readableStream: ReadableStreamLike<T>) {
+  return fromAsyncIterable(readableStreamLikeToAsyncGenerator(readableStream));
 }
 
 async function process<T>(asyncIterable: AsyncIterable<T>, subscriber: Subscriber<T>) {

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -4,7 +4,7 @@ import { observable as Symbol_observable } from '../symbol/observable';
 import { Subscriber } from '../Subscriber';
 
 import { Observable } from '../Observable';
-import { ObservableInput, SchedulerLike, ObservedValueOf } from '../types';
+import { ObservableInput, SchedulerLike, ObservedValueOf, ReadableStreamLike } from '../types';
 import { scheduled } from '../scheduled/scheduled';
 import { isFunction } from '../util/isFunction';
 import { reportUnhandledError } from '../util/reportUnhandledError';
@@ -12,7 +12,7 @@ import { isInteropObservable } from '../util/isInteropObservable';
 import { isAsyncIterable } from '../util/isAsyncIterable';
 import { createInvalidObservableTypeError } from '../util/throwUnobservableError';
 import { isIterable } from '../util/isIterable';
-import { isReadableStreamLike, ReadableStreamLike, readableStreamLikeToAsyncGenerator } from '../util/isReadableStreamLike';
+import { isReadableStreamLike, readableStreamLikeToAsyncGenerator } from '../util/isReadableStreamLike';
 
 export function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
 /** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */

--- a/src/internal/scheduled/scheduleReadableStreamLike.ts
+++ b/src/internal/scheduled/scheduleReadableStreamLike.ts
@@ -1,7 +1,7 @@
-import { SchedulerLike } from '../types';
+import { SchedulerLike, ReadableStreamLike } from '../types';
 import { Observable } from '../Observable';
 import { scheduleAsyncIterable } from './scheduleAsyncIterable';
-import { ReadableStreamLike, readableStreamLikeToAsyncGenerator } from '../util/isReadableStreamLike';
+import { readableStreamLikeToAsyncGenerator } from '../util/isReadableStreamLike';
 
 export function scheduleReadableStreamLike<T>(input: ReadableStreamLike<T>, scheduler: SchedulerLike): Observable<T> {
   return scheduleAsyncIterable(readableStreamLikeToAsyncGenerator(input), scheduler);

--- a/src/internal/scheduled/scheduleReadableStreamLike.ts
+++ b/src/internal/scheduled/scheduleReadableStreamLike.ts
@@ -1,0 +1,8 @@
+import { SchedulerLike } from '../types';
+import { Observable } from '../Observable';
+import { scheduleAsyncIterable } from './scheduleAsyncIterable';
+import { ReadableStreamLike, readableStreamLikeToAsyncGenerator } from '../util/isReadableStreamLike';
+
+export function scheduleReadableStreamLike<T>(input: ReadableStreamLike<T>, scheduler: SchedulerLike): Observable<T> {
+  return scheduleAsyncIterable(readableStreamLikeToAsyncGenerator(input), scheduler);
+}

--- a/src/internal/scheduled/scheduled.ts
+++ b/src/internal/scheduled/scheduled.ts
@@ -2,15 +2,17 @@ import { scheduleObservable } from './scheduleObservable';
 import { schedulePromise } from './schedulePromise';
 import { scheduleArray } from './scheduleArray';
 import { scheduleIterable } from './scheduleIterable';
+import { scheduleAsyncIterable } from './scheduleAsyncIterable';
 import { isInteropObservable } from '../util/isInteropObservable';
 import { isPromise } from '../util/isPromise';
 import { isArrayLike } from '../util/isArrayLike';
 import { isIterable } from '../util/isIterable';
 import { ObservableInput, SchedulerLike } from '../types';
 import { Observable } from '../Observable';
-import { scheduleAsyncIterable } from './scheduleAsyncIterable';
 import { isAsyncIterable } from '../util/isAsyncIterable';
 import { createInvalidObservableTypeError } from '../util/throwUnobservableError';
+import { isReadableStreamLike } from '../util/isReadableStreamLike';
+import { scheduleReadableStreamLike } from './scheduleReadableStreamLike';
 
 /**
  * Converts from a common {@link ObservableInput} type to an observable where subscription and emissions
@@ -39,6 +41,9 @@ export function scheduled<T>(input: ObservableInput<T>, scheduler: SchedulerLike
     }
     if (isIterable(input)) {
       return scheduleIterable(input, scheduler);
+    }
+    if (isReadableStreamLike(input)) {
+      return scheduleReadableStreamLike(input, scheduler);
     }
   }
   throw createInvalidObservableTypeError(input);

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -3,7 +3,6 @@
 
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
-import { ReadableStreamLike } from './util/isReadableStreamLike';
 
 /**
  * NOTE: This will add Symbol.observable globally for all TypeScript users,

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -3,6 +3,7 @@
 
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
+import { ReadableStreamLike } from './util/isReadableStreamLike';
 
 /**
  * NOTE: This will add Symbol.observable globally for all TypeScript users,
@@ -91,7 +92,14 @@ export interface Subscribable<T> {
 /**
  * Valid types that can be converted to observables.
  */
-export type ObservableInput<T> = Observable<T> | InteropObservable<T> | AsyncIterable<T> | PromiseLike<T> | ArrayLike<T> | Iterable<T>;
+export type ObservableInput<T> =
+  | Observable<T>
+  | InteropObservable<T>
+  | AsyncIterable<T>
+  | PromiseLike<T>
+  | ArrayLike<T>
+  | Iterable<T>
+  | ReadableStreamLike<T>;
 
 /** @deprecated use {@link InteropObservable } */
 export type ObservableLike<T> = InteropObservable<T>;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -284,3 +284,28 @@ export type ValueFromNotification<T> = T extends { kind: 'N' | 'E' | 'C' }
 export type Falsy = null | undefined | false | 0 | -0 | 0n | '';
 
 export type TruthyTypesOf<T> = T extends Falsy ? never : T;
+
+// We shouldn't rely on this type definition being available globally yet since it's
+// not necessarily available in every TS environment.
+interface ReadableStreamDefaultReaderLike<T> {
+  // HACK: As of TS 4.2.2, The provided types for the iterator results of a `ReadableStreamDefaultReader`
+  // are significantly different enough from `IteratorResult` as to cause compilation errors.
+  // The type at the time is `ReadableStreamDefaultReadResult`.
+  read(): PromiseLike<
+    | {
+        done: false;
+        value: T;
+      }
+    | { done: true; value?: undefined }
+  >;
+  releaseLock(): void;
+}
+
+/**
+ * The base signature RxJS will look for to identify and use
+ * a [ReadableStream](https://streams.spec.whatwg.org/#rs-class)
+ * as an {@link ObservableInput} source.
+ */
+export interface ReadableStreamLike<T> {
+  getReader(): ReadableStreamDefaultReaderLike<T>;
+}

--- a/src/internal/util/isReadableStreamLike.ts
+++ b/src/internal/util/isReadableStreamLike.ts
@@ -1,10 +1,13 @@
 import { isFunction } from './isFunction';
 
+// We shouldn't rely on this type definition being available globally yet since it's
+// not necessarily available in every TS environment.
 interface ReadableStreamDefaultReaderLike<T> {
   read(): IteratorResult<T>;
   releaseLock(): void;
 }
 
+// This is the only part that matters to us.
 export interface ReadableStreamLike<T> {
   getReader(): ReadableStreamDefaultReaderLike<T>;
 }
@@ -25,5 +28,7 @@ export async function* readableStreamLikeToAsyncGenerator<T>(readableStream: Rea
 }
 
 export function isReadableStreamLike<T>(obj: any): obj is ReadableStreamLike<T> {
+  // We don't want to use instanceof checks because they would return
+  // false for instances from another Realm, like an <iframe>.
   return isFunction(obj?.getReader);
 }

--- a/src/internal/util/isReadableStreamLike.ts
+++ b/src/internal/util/isReadableStreamLike.ts
@@ -1,7 +1,12 @@
 import { isFunction } from './isFunction';
 
+interface ReadableStreamDefaultReaderLike<T> {
+  read(): IteratorResult<T>;
+  releaseLock(): void;
+}
+
 export interface ReadableStreamLike<T> {
-  getReader(): ReadableStreamDefaultReader<T>;
+  getReader(): ReadableStreamDefaultReaderLike<T>;
 }
 
 export async function* readableStreamLikeToAsyncGenerator<T>(readableStream: ReadableStreamLike<T>): AsyncGenerator<T> {

--- a/src/internal/util/isReadableStreamLike.ts
+++ b/src/internal/util/isReadableStreamLike.ts
@@ -1,0 +1,24 @@
+import { isFunction } from './isFunction';
+
+export interface ReadableStreamLike<T> {
+  getReader(): ReadableStreamDefaultReader<T>;
+}
+
+export async function* readableStreamLikeToAsyncGenerator<T>(readableStream: ReadableStreamLike<T>): AsyncGenerator<T> {
+  const reader = readableStream.getReader();
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) {
+        return;
+      }
+      yield value!;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function isReadableStreamLike<T>(obj: any): obj is ReadableStreamLike<T> {
+  return isFunction(obj?.getReader);
+}

--- a/src/internal/util/isReadableStreamLike.ts
+++ b/src/internal/util/isReadableStreamLike.ts
@@ -1,3 +1,4 @@
+import { ReadableStreamLike } from '../types';
 import { isFunction } from './isFunction';
 
 export async function* readableStreamLikeToAsyncGenerator<T>(readableStream: ReadableStreamLike<T>): AsyncGenerator<T> {

--- a/src/internal/util/isReadableStreamLike.ts
+++ b/src/internal/util/isReadableStreamLike.ts
@@ -1,17 +1,5 @@
 import { isFunction } from './isFunction';
 
-// We shouldn't rely on this type definition being available globally yet since it's
-// not necessarily available in every TS environment.
-interface ReadableStreamDefaultReaderLike<T> {
-  read(): IteratorResult<T>;
-  releaseLock(): void;
-}
-
-// This is the only part that matters to us.
-export interface ReadableStreamLike<T> {
-  getReader(): ReadableStreamDefaultReaderLike<T>;
-}
-
 export async function* readableStreamLikeToAsyncGenerator<T>(readableStream: ReadableStreamLike<T>): AsyncGenerator<T> {
   const reader = readableStream.getReader();
   try {

--- a/src/internal/util/throwUnobservableError.ts
+++ b/src/internal/util/throwUnobservableError.ts
@@ -7,6 +7,6 @@ export function createInvalidObservableTypeError(input: any) {
   return new TypeError(
     `You provided ${
       input !== null && typeof input === 'object' ? 'an invalid object' : `'${input}'`
-    } where a stream was expected. You can provide an Observable, Promise, Array, AsyncIterable, or Iterable.`
+    } where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.`
   );
 }


### PR DESCRIPTION
**Description:**
Support ReadableStream and other similar objects by checking for `getReader()` existence. In theory this isn't foolproof, but in practice I can't see this ever actually causing issues in practice. `instanceof` checks don't work with cross-Realm instances and neither ReadableStream nor ReadableStreamDefaultReader implement Symbol.asyncIterator yet (which is why this custom support is needed)

**Related issue (if exists):**
Closes #6006