### PR TITLE
chore(toPromise): replace deprecated types and use prettier

### DIFF
--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -1,13 +1,16 @@
+/** @prettier */
 import { expect } from 'chai';
 import { of, EMPTY, throwError, config } from 'rxjs';
 
 /** @test {toPromise} */
 describe('Observable.toPromise', () => {
   it('should convert an Observable to a promise of its last value', (done: Mocha.Done) => {
-    of(1, 2, 3).toPromise(Promise).then(x => {
-      expect(x).to.equal(3);
-      done();
-    });
+    of(1, 2, 3)
+      .toPromise(Promise)
+      .then((x) => {
+        expect(x).to.equal(3);
+        done();
+      });
   });
 
   it('should convert an empty Observable to a promise of undefined', (done: Mocha.Done) => {
@@ -18,12 +21,17 @@ describe('Observable.toPromise', () => {
   });
 
   it('should handle errors properly', (done: Mocha.Done) => {
-    throwError('bad').toPromise(Promise).then(() => {
-      done(new Error('should not be called'));
-    }, (err: any) => {
-      expect(err).to.equal('bad');
-      done();
-    });
+    throwError('bad')
+      .toPromise(Promise)
+      .then(
+        () => {
+          done(new Error('should not be called'));
+        },
+        (err: any) => {
+          expect(err).to.equal('bad');
+          done();
+        }
+      );
   });
 
   it('should allow for global config via config.Promise', (done: Mocha.Done) => {
@@ -33,10 +41,12 @@ describe('Observable.toPromise', () => {
       return new Promise(callback as any);
     } as any;
 
-    of(42).toPromise().then(x => {
-      expect(wasCalled).to.be.true;
-      expect(x).to.equal(42);
-      done();
-    });
+    of(42)
+      .toPromise()
+      .then((x) => {
+        expect(wasCalled).to.be.true;
+        expect(x).to.equal(42);
+        done();
+      });
   });
 });

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -3,21 +3,21 @@ import { of, EMPTY, throwError, config } from 'rxjs';
 
 /** @test {toPromise} */
 describe('Observable.toPromise', () => {
-  it('should convert an Observable to a promise of its last value', (done: MochaDone) => {
+  it('should convert an Observable to a promise of its last value', (done: Mocha.Done) => {
     of(1, 2, 3).toPromise(Promise).then(x => {
       expect(x).to.equal(3);
       done();
     });
   });
 
-  it('should convert an empty Observable to a promise of undefined', (done: MochaDone) => {
+  it('should convert an empty Observable to a promise of undefined', (done: Mocha.Done) => {
     EMPTY.toPromise(Promise).then((x) => {
       expect(x).to.be.undefined;
       done();
     });
   });
 
-  it('should handle errors properly', (done: MochaDone) => {
+  it('should handle errors properly', (done: Mocha.Done) => {
     throwError('bad').toPromise(Promise).then(() => {
       done(new Error('should not be called'));
     }, (err: any) => {
@@ -26,7 +26,7 @@ describe('Observable.toPromise', () => {
     });
   });
 
-  it('should allow for global config via config.Promise', (done: MochaDone) => {
+  it('should allow for global config via config.Promise', (done: Mocha.Done) => {
     let wasCalled = false;
     config.Promise = function MyPromise(callback: Function) {
       wasCalled = true;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts`toPromise` operator tests to run mode. I did a few intermediate commits formatting the code before introducing `TestScheduler` as I was not sure if these tests should really be converted to run mode.
Also `toPromise` is not an operator, so the tests should not be located with the other operators. I am not sure where the tests should be moved to instead. Maybe it is just fine to leave them where they are since `toPromise` is deprecated and will be removed sometime in the future.

**Related issue (if exists):**
None
