### PR TITLE
fix(partition): add exclusion when using type guard

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -321,8 +321,8 @@ export declare function pairs(n: number | bigint | boolean | ((...args: any[]) =
 
 export declare type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
-export declare function partition<T, U extends T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => value is U, thisArg: A): [Observable<U>, Observable<T>];
-export declare function partition<T, U extends T>(source: ObservableInput<T>, predicate: (value: T, index: number) => value is U): [Observable<U>, Observable<T>];
+export declare function partition<T, U extends T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => value is U, thisArg: A): [Observable<U>, Observable<Exclude<T, U>>];
+export declare function partition<T, U extends T>(source: ObservableInput<T>, predicate: (value: T, index: number) => value is U): [Observable<U>, Observable<Exclude<T, U>>];
 export declare function partition<T, A>(source: ObservableInput<T>, predicate: (this: A, value: T, index: number) => boolean, thisArg: A): [Observable<T>, Observable<T>];
 export declare function partition<T>(source: ObservableInput<T>, predicate: (value: T, index: number) => boolean): [Observable<T>, Observable<T>];
 

--- a/spec-dtslint/observables/partition-spec.ts
+++ b/spec-dtslint/observables/partition-spec.ts
@@ -1,4 +1,4 @@
-import { of, partition } from 'rxjs';
+import { of, from, partition } from 'rxjs';
 
 it('should infer correctly', () => {
   const o = partition(of('a', 'b', 'c'), (value, index) => true); // $ExpectType [Observable<string>, Observable<string>]
@@ -7,6 +7,10 @@ it('should infer correctly', () => {
 
 it('should support a user-defined type guard', () => {
   const o = partition(of(1, 2, 3), (value: number): value is 1 => value === 1); // $ExpectType [Observable<1>, Observable<number>]
+});
+
+it('should support exclusion based on the user-defined type guard', () => {
+  const o = partition(from([1, 2] as const), (value: number): value is 1 => value === 1); // $ExpectType [Observable<1>, Observable<2>]
 });
 
 it('should enforce predicate', () => {
@@ -22,6 +26,14 @@ it('should enforce predicate types', () => {
 it('should support this with type guard', () => {
   const thisArg = { limit: 2 };
   const a = partition(of(1, 2, 3), function (val): val is 1 { // $ExpectType [Observable<1>, Observable<number>]
+    const limit = this.limit; // $ExpectType number
+    return val < limit;
+  }, thisArg);
+});
+
+it('should support this with exclusion based on the user-defined type guard', () => {
+  const thisArg = { limit: 2 };
+  const a = partition(from([1, 2] as const), function (val): val is 1 { // $ExpectType [Observable<1>, Observable<2>]
     const limit = this.limit; // $ExpectType number
     return val < limit;
   }, thisArg);

--- a/src/internal/observable/partition.ts
+++ b/src/internal/observable/partition.ts
@@ -8,11 +8,11 @@ export function partition<T, U extends T, A>(
   source: ObservableInput<T>,
   predicate: (this: A, value: T, index: number) => value is U,
   thisArg: A
-): [Observable<U>, Observable<T>];
+): [Observable<U>, Observable<Exclude<T, U>>];
 export function partition<T, U extends T>(
   source: ObservableInput<T>,
   predicate: (value: T, index: number) => value is U
-): [Observable<U>, Observable<T>];
+): [Observable<U>, Observable<Exclude<T, U>>];
 
 export function partition<T, A>(
   source: ObservableInput<T>,


### PR DESCRIPTION
**Description:**
Add exclusion to partition when using a type guard.

[Previously support for a user defined type guard was added to partition](https://github.com/ReactiveX/rxjs/pull/5756). This meant that Typescript could understand the first item in the resulting tuple to match a certain type. What was missing was Typescript understanding the second item in the tuple to _not_ be of that type. As an example:
```typescript
type AMessage = { a: number };
type BMessage = { b: number };
type Message = AMessage | BMessage;
const aMessage: AMessage = { a: 1 };
const bMessage: BMessage = { b: 2 };
const message$: Observable<Message> = from([aMessage, bMessage]);

function isAMessage(msg: Message): is AMessage { 
  return msg.a;
}
const [aMessage$, bMessage$] = partition(message$, isAMessage);
bMessage$.subscribe((msg) => console.log(msg.b)); // no longer fails with this change
```

Without this change Typescript would consider `bMessage$` to be the same type as `message$`: `Observable<AMessage | BMessage>`. Whereas we are sure `bMessage$` only emits `BMessage`, because all `AMessage` will be put in `aMessage$`.