### PR TITLE
chore(toArray): convert toArray tests to run mode

### DIFF
--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -1,115 +1,145 @@
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+/** @prettier */
 import { toArray, mergeMap } from 'rxjs/operators';
 import { of } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {toArray} */
-describe('toArray operator', () => {
-  it('should reduce the values of an observable into an array', () => {
-    const e1 =   hot('---a--b--|');
-    const e1subs =   '^        !';
-    const expected = '---------(w|)';
+describe('toArray', () => {
+  let rxTestScheduler: TestScheduler;
 
-    expectObservable(e1.pipe(toArray())).toBe(expected, { w: ['a', 'b'] });
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should reduce the values of an observable into an array', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---a--b--|   ');
+      const e1subs = '  ^--------!   ';
+      const expected = '---------(w|)';
+
+      expectObservable(e1.pipe(toArray())).toBe(expected, { w: ['a', 'b'] });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should be never when source is never', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    expectObservable(e1.pipe(toArray())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should be never when source is empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '(w|)';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '(w|)';
 
-    expectObservable(e1.pipe(toArray())).toBe(expected, { w: [] });
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray())).toBe(expected, { w: [] });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
-  it('should be never when source doesn\'t complete', () => {
-    const e1 = hot('--x--^--y--');
-    const e1subs =      '^     ';
-    const expected =    '------';
+  it("should be never when source doesn't complete", () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--x--^--y--');
+      const e1subs = '     ^-----';
+      const expected = '   ------';
 
-    expectObservable(e1.pipe(toArray())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should reduce observable without values into an array of length zero', () => {
-    const e1 = hot('-x-^---|');
-    const e1subs =    '^   !';
-    const expected =  '----(w|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('-x-^---|   ');
+      const e1subs = '   ^---!   ';
+      const expected = ' ----(w|)';
 
-    expectObservable(e1.pipe(toArray())).toBe(expected, { w: [] });
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray())).toBe(expected, { w: [] });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should reduce the a single value of an observable into an array', () => {
-    const e1 = hot('-x-^--y--|');
-    const e1subs =    '^     !';
-    const expected =  '------(w|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('-x-^--y--|  ');
+      const e1subs = '   ^-----!  ';
+      const expected = ' ------(w|)';
 
-    expectObservable(e1.pipe(toArray())).toBe(expected, { w: ['y'] });
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray())).toBe(expected, { w: ['y'] });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow multiple subscriptions', () => {
-    const e1 = hot('-x-^--y--|');
-    const e1subs =    '^     !';
-    const expected =  '------(w|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('-x-^--y--|   ');
+      const e1subs = '   ^-----!   ';
+      const expected = ' ------(w|)';
 
-    const result = e1.pipe(toArray());
-    expectObservable(result).toBe(expected, { w: ['y'] });
-    expectObservable(result).toBe(expected, { w: ['y'] });
-    expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
+      const result = e1.pipe(toArray());
+      expectObservable(result).toBe(expected, { w: ['y'] });
+      expectObservable(result).toBe(expected, { w: ['y'] });
+      expectSubscriptions(e1.subscriptions).toBe([e1subs, e1subs]);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 =   hot('--a--b----c-----d----e---|');
-    const unsub =    '        !                 ';
-    const e1subs =   '^       !                 ';
-    const expected = '---------                 ';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b----c-----d----e---|');
+      const e1subs = '  ^-------!                 ';
+      const expected = '---------                 ';
+      const unsub = '   --------!                 ';
 
-    expectObservable(e1.pipe(toArray()), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray()), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   hot('--a--b----c-----d----e---|');
-    const e1subs =   '^       !                 ';
-    const expected = '---------                 ';
-    const unsub =    '        !                 ';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b----c-----d----e---|');
+      const e1subs = '  ^-------!                 ';
+      const expected = '---------                 ';
+      const unsub = '   --------!                 ';
 
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      toArray(),
-      mergeMap((x: Array<string>) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        toArray(),
+        mergeMap((x: Array<string>) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with error', () => {
-    const e1 = hot('-x-^--y--z--#', { x: 1, y: 2, z: 3 }, 'too bad');
-    const e1subs =    '^        !';
-    const expected =  '---------#';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('-x-^--y--z--#', { x: 1, y: 2, z: 3 }, 'too bad');
+      const e1subs = '   ^--------!';
+      const expected = ' ---------#';
 
-    expectObservable(e1.pipe(toArray())).toBe(expected, null, 'too bad');
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray())).toBe(expected, null, 'too bad');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with throw', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    expectObservable(e1.pipe(toArray())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(toArray())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 });

--- a/spec/operators/toArray-spec.ts
+++ b/spec/operators/toArray-spec.ts
@@ -34,7 +34,7 @@ describe('toArray', () => {
     });
   });
 
-  it('should be never when source is empty', () => {
+  it('should be empty when source is empty', () => {
     rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
       const e1 = cold(' |   ');
       const e1subs = '  (^!)';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts the `toArray` operator tests to run mode.

**Related issue (if exists):**
None
