### PR TITLE
chore(timestamp): convert timestamp tests to run mode

### DIFF
--- a/spec/operators/timestamp-spec.ts
+++ b/spec/operators/timestamp-spec.ts
@@ -1,158 +1,185 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { timestamp, map, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {timestamp} */
-describe('timestamp operator', () => {
+describe('timestamp', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should record the time stamp per each source elements', () => {
-    const e1 =   hot('-b-c-----d--e--|');
-    const e1subs =   '^              !';
-    const expected = '-w-x-----y--z--|';
-    const expectedValue = { w: 10, x: 30, y: 90, z: 120 };
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -b-c-----d--e--|');
+      const e1subs = '  ^--------------!';
+      const expected = '-w-x-----y--z--|';
+      const expectedValue = { w: 1, x: 3, y: 9, z: 12 };
 
-    const result = e1.pipe(
-      timestamp(rxTestScheduler),
-      map(x => x.timestamp)
-    );
+      const result = e1.pipe(
+        timestamp(rxTestScheduler),
+        map((x) => x.timestamp)
+      );
 
-    expectObservable(result).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should record stamp if source emit elements', () => {
-    const e1 = hot('--a--^b--c----d---e--|');
-    const e1subs =      '^               !';
-    const expected =    '-w--x----y---z--|';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^b--c----d---e--|');
+      const e1subs = '     ^---------------!';
+      const expected = '   -w--x----y---z--|';
 
-    const expectedValue = {
-      w: { value: 'b', timestamp: 10 },
-      x: { value: 'c', timestamp: 40 },
-      y: { value: 'd', timestamp: 90 },
-      z: { value: 'e', timestamp: 130 }
-    };
+      const expectedValue = {
+        w: { value: 'b', timestamp: 1 },
+        x: { value: 'c', timestamp: 4 },
+        y: { value: 'd', timestamp: 9 },
+        z: { value: 'e', timestamp: 13 },
+      };
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should completes without record stamp if source does not emits', () => {
-    const e1 =   hot('---------|');
-    const e1subs =   '^        !';
-    const expected = '---------|';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---------|');
+      const e1subs = '  ^--------!';
+      const expected = '---------|';
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should complete immediately if source is empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '|   ';
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should record stamp then does not completes if source emits but not completes', () => {
-    const e1 =   hot('-a--b--');
-    const e1subs =   '^      ';
-    const expected = '-y--z--';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b--');
+      const e1subs = '  ^------';
+      const expected = '-y--z--';
 
-    const expectedValue = {
-      y: { value: 'a', timestamp: 10 },
-      z: { value: 'b', timestamp: 40 }
-    };
+      const expectedValue = {
+        y: { value: 'a', timestamp: 1 },
+        z: { value: 'b', timestamp: 4 },
+      };
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 =   hot('-a--b-----c---d---|');
-    const unsub =    '       !           ';
-    const e1subs =   '^      !           ';
-    const expected = '-y--z---           ';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b-----c---d---|');
+      const unsub = '   -------!           ';
+      const e1subs = '  ^------!           ';
+      const expected = '-y--z---           ';
 
-    const expectedValue = {
-      y: { value: 'a', timestamp: 10 },
-      z: { value: 'b', timestamp: 40 }
-    };
+      const expectedValue = {
+        y: { value: 'a', timestamp: 1 },
+        z: { value: 'b', timestamp: 4 },
+      };
 
-    const result = e1.pipe(timestamp(rxTestScheduler));
+      const result = e1.pipe(timestamp(rxTestScheduler));
 
-    expectObservable(result, unsub).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   hot('-a--b-----c---d---|');
-    const e1subs =   '^      !           ';
-    const expected = '-y--z---           ';
-    const unsub =    '       !           ';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b-----c---d---|');
+      const e1subs = '  ^------!           ';
+      const expected = '-y--z---           ';
+      const unsub = '   -------!           ';
 
-    const expectedValue = {
-      y: { value: 'a', timestamp: 10 },
-      z: { value: 'b', timestamp: 40 }
-    };
+      const expectedValue = {
+        y: { value: 'a', timestamp: 1 },
+        z: { value: 'b', timestamp: 4 },
+      };
 
-    const result = e1.pipe(
-      mergeMap(x => of(x)),
-      timestamp(rxTestScheduler),
-      mergeMap(x => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x) => of(x)),
+        timestamp(rxTestScheduler),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not completes if source never completes', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('raise error if source raises error', () => {
-    const e1 =   hot('---#');
-    const e1subs =   '^  !';
-    const expected = '---#';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---#');
+      const e1subs = '  ^--!';
+      const expected = '---#';
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should record stamp then raise error if source raises error after emit', () => {
-    const e1 =   hot('-a--b--#');
-    const e1subs =   '^      !';
-    const expected = '-y--z--#';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b--#');
+      const e1subs = '  ^------!';
+      const expected = '-y--z--#';
 
-    const expectedValue = {
-      y: { value: 'a', timestamp: 10 },
-      z: { value: 'b', timestamp: 40 }
-    };
+      const expectedValue = {
+        y: { value: 'a', timestamp: 1 },
+        z: { value: 'b', timestamp: 4 },
+      };
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raise error if source immediately throws', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timestamp(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -161,10 +188,9 @@ describe('timestamp operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      timestamp(),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(timestamp(), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `timestamp` operator tests to run mode.

**Related issue (if exists):**
None
