### PR TITLE
feat(ajax): add `params` query string parameter configuration

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -9,7 +9,7 @@ export interface AjaxConfig {
     includeDownloadProgress?: boolean;
     includeUploadProgress?: boolean;
     method?: string;
-    params?: string | URLSearchParams | Record<string, string | number | boolean | string[] | number[] | boolean[]> | [string, string | number | boolean | string[] | number[] | boolean[]][] | undefined;
+    params?: string | URLSearchParams | Record<string, string | number | boolean | string[] | number[] | boolean[]> | [string, string | number | boolean | string[] | number[] | boolean[]][];
     password?: string;
     progressSubscriber?: PartialObserver<ProgressEvent>;
     responseType?: XMLHttpRequestResponseType;

--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -9,6 +9,7 @@ export interface AjaxConfig {
     includeDownloadProgress?: boolean;
     includeUploadProgress?: boolean;
     method?: string;
+    params?: string | URLSearchParams | Record<string, string | number | boolean | string[] | number[] | boolean[]> | [string, string | number | boolean | string[] | number[] | boolean[]][] | undefined;
     password?: string;
     progressSubscriber?: PartialObserver<ProgressEvent>;
     responseType?: XMLHttpRequestResponseType;

--- a/integration/side-effects/snapshots/esm/ajax.js
+++ b/integration/side-effects/snapshots/esm/ajax.js
@@ -1,1 +1,1 @@
-
+import "tslib";

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -1429,7 +1429,7 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       ajax({
         method: 'GET',
         url: '/whatever',
-        params: '?foo=bar&whatever=123',
+        params,
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -1366,6 +1366,173 @@ describe('ajax', () => {
 x-custom-header: test
 x-headers-are-fun: <whatever/> {"weird": "things"}`);
   });
+
+  describe('with params', () => {
+    it('should allow passing of search params as a dictionary', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever',
+        params: { foo: 'bar', whatever: '123' },
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?foo=bar&whatever=123');
+    });
+
+    it('should allow passing of search params as an entries array', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever',
+        params: [
+          ['foo', 'bar'],
+          ['whatever', '123'],
+        ],
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?foo=bar&whatever=123');
+    });
+
+    it('should allow passing of search params as a string', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever',
+        params: '?foo=bar&whatever=123',
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?foo=bar&whatever=123');
+    });
+
+    it('should allow passing of search params as a URLSearchParams object', () => {
+      const params = new URLSearchParams();
+      params.set('foo', 'bar');
+      params.set('whatever', '123');
+      ajax({
+        method: 'GET',
+        url: '/whatever',
+        params: '?foo=bar&whatever=123',
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?foo=bar&whatever=123');
+    });
+
+    it('should not screw things up if there is an existing search string in the url passed', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever?jays_face=is+a+param&lol=haha',
+        params: { foo: 'bar', whatever: '123' },
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?jays_face=is+a+param&lol=haha&foo=bar&whatever=123');
+    });
+
+    it('should overwrite existing args from existing search strings in the url passed', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever?terminator=2&uncle_bob=huh',
+        params: { uncle_bob: '...okayyyyyyy', movie_quote: 'yes' },
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?terminator=2&uncle_bob=...okayyyyyyy&movie_quote=yes');
+    });
+
+    it('should properly encode values', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever',
+        params: { 'this is a weird param name': '?#* value here rofl !!!' },
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?this+is+a+weird+param+name=%3F%23*+value+here+rofl+%21%21%21');
+    });
+
+    it('should handle dictionaries that have numbers, booleans, and arrays of numbers, strings or booleans', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever',
+        params: { a: 123, b: true, c: ['one', 'two', 'three'], d: [1, 3, 3, 7], e: [true, false, true] },
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?a=123&b=true&c=one%2Ctwo%2Cthree&d=1%2C3%2C3%2C7&e=true%2Cfalse%2Ctrue');
+    });
+
+    it('should handle entries that have numbers, booleans, and arrays of numbers, strings or booleans', () => {
+      ajax({
+        method: 'GET',
+        url: '/whatever',
+        params: [
+          ['a', 123],
+          ['b', true],
+          ['c', ['one', 'two', 'three']],
+          ['d', [1, 3, 3, 7]],
+          ['e', [true, false, true]],
+        ],
+      }).subscribe();
+
+      const mockXHR = MockXMLHttpRequest.mostRecent;
+
+      mockXHR.respondWith({
+        status: 200,
+        responseText: JSON.stringify({ whatever: 'I want' }),
+      });
+
+      expect(mockXHR.url).to.equal('/whatever?a=123&b=true&c=one%2Ctwo%2Cthree&d=1%2C3%2C3%2C7&e=true%2Cfalse%2Ctrue');
+    });
+  });
 });
 
 // Some of the older versions of node we test on don't have EventTarget.

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -195,4 +195,22 @@ export interface AjaxConfig {
    * be emitted from the resulting observable.
    */
   includeUploadProgress?: boolean;
+
+  /**
+   * Query string parameters to add to the URL in the request.
+   * <em>This will require a polyfill for `URL` and `URLSearchParams` in Internet Explorer!</em>
+   *
+   * Accepts either a query string, a `URLSearchParams` object, a dictionary of key/value pairs, or an
+   * array of key/value entry tuples. (Essentially, it takes anything that `new URLSearchParams` would normally take).
+   *
+   * If, for some reason you have a query string in the `url` argument, this will append to the query string in the url,
+   * but it will also overwrite the value of any keys that are an exact match. In other words, a url of `/test?a=1&b=2`,
+   * with params of `{ b: 5, c: 6 }` will result in a url of roughly `/test?a=1&b=5&c=6`.
+   */
+  params?:
+    | string
+    | URLSearchParams
+    | Record<string, string | number | boolean | string[] | number[] | boolean[]>
+    | [string, string | number | boolean | string[] | number[] | boolean[]][]
+    | undefined;
 }

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -211,6 +211,5 @@ export interface AjaxConfig {
     | string
     | URLSearchParams
     | Record<string, string | number | boolean | string[] | number[] | boolean[]>
-    | [string, string | number | boolean | string[] | number[] | boolean[]][]
-    | undefined;
+    | [string, string | number | boolean | string[] | number[] | boolean[]][];
 }


### PR DESCRIPTION
Adds a feature that will accept a wide variety of possible inputs for `params` to set the query string parameters for ajax.

Note that this feature will require a polyfill for `URLSearchParams` in IE, but this is not a breaking change for IE, as if they do not use this feature `URLSearchParams` is never accessed. Adds documentation and relatively thorough tests.

Related to #5384