### PR TITLE
fix(types): move Symbol.observable into types.ts

### DIFF
--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,11 +1,2 @@
-/** Symbol.observable addition */
-/* Note: This will add Symbol.observable globally for all TypeScript users,
-  however, we are no longer polyfilling Symbol.observable */
-declare global {
-  interface SymbolConstructor {
-    readonly observable: symbol;
-  }
-}
-
 /** Symbol.observable or a string "@@observable". Used for interop */
 export const observable = (() => typeof Symbol === 'function' && Symbol.observable || '@@observable')();

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -1,6 +1,16 @@
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
 
+/**
+ * Note: This will add Symbol.observable globally for all TypeScript users,
+ * however, we are no longer polyfilling Symbol.observable
+ */
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
 /** OPERATOR INTERFACES */
 
 export interface UnaryFunction<T, R> { (source: T): R; }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Note that this PR targets the `6.x` branch.**

**Description:**

This PR moves the declaration merging associated with `Symbol.observable` from `internal/symbol/observable.ts` to `internal/types.ts` - which is where it's located in the v7 codebase. This fixes the problem raised in #6175.

**Related issue (if exists):** #6175
