### PR TITLE
chore(timeInterval): convert timeInterval tests to run mode

### DIFF
--- a/spec/operators/timeInterval-spec.ts
+++ b/spec/operators/timeInterval-spec.ts
@@ -1,159 +1,186 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { timeInterval, map, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
 import { TimeInterval } from 'rxjs/internal/operators/timeInterval';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {timeInterval} */
-describe('timeInterval operator', () => {
+describe('timeInterval', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should record the time interval between source elements', () => {
-    const e1 = hot('--a--^b-c-----d--e--|');
-    const e1subs =      '^              !';
-    const expected =    '-w-x-----y--z--|';
-    const expectedValue = { w: 10, x: 20, y: 60, z: 30 };
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^b-c-----d--e--|');
+      const e1subs = '     ^--------------!';
+      const expected = '   -w-x-----y--z--|';
+      const expectedValue = { w: 1, x: 2, y: 6, z: 3 };
 
-    const result = (<any>e1).pipe(
-      timeInterval(rxTestScheduler),
-      map((x: any) => x.interval)
-    );
+      const result = e1.pipe(
+        timeInterval(rxTestScheduler),
+        map((x) => x.interval)
+      );
 
-    expectObservable(result).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should record interval if source emit elements', () => {
-    const e1 = hot('--a--^b--c----d---e--|');
-    const e1subs =      '^               !';
-    const expected =    '-w--x----y---z--|';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^b--c----d---e--|');
+      const e1subs = '     ^---------------!';
+      const expected = '   -w--x----y---z--|';
 
-    const expectedValue = {
-      w: new TimeInterval('b', 10),
-      x: new TimeInterval('c', 30),
-      y: new TimeInterval('d', 50),
-      z: new TimeInterval('e', 40)
-    };
+      const expectedValue = {
+        w: new TimeInterval('b', 1),
+        x: new TimeInterval('c', 3),
+        y: new TimeInterval('d', 5),
+        z: new TimeInterval('e', 4),
+      };
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should completes without record interval if source does not emits', () => {
-    const e1 =   hot('---------|');
-    const e1subs =   '^        !';
-    const expected = '---------|';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---------|');
+      const e1subs = '  ^--------!';
+      const expected = '---------|';
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should complete immediately if source is empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '|   ';
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should record interval then does not completes if source emits but not completes', () => {
-    const e1 =   hot('-a--b--');
-    const e1subs =   '^      ';
-    const expected = '-y--z--';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b--');
+      const e1subs = '  ^------';
+      const expected = '-y--z--';
 
-    const expectedValue = {
-      y: new TimeInterval('a', 10),
-      z: new TimeInterval('b', 30)
-    };
+      const expectedValue = {
+        y: new TimeInterval('a', 1),
+        z: new TimeInterval('b', 3),
+      };
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 =   hot('-a--b-----c---d---|');
-    const unsub =    '       !           ';
-    const e1subs =   '^      !           ';
-    const expected = '-y--z---           ';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b-----c---d---|');
+      const unsub = '   -------!           ';
+      const e1subs = '  ^------!           ';
+      const expected = '-y--z---           ';
 
-    const expectedValue = {
-      y: new TimeInterval('a', 10),
-      z: new TimeInterval('b', 30)
-    };
+      const expectedValue = {
+        y: new TimeInterval('a', 1),
+        z: new TimeInterval('b', 3),
+      };
 
-    const result = (<any>e1).pipe(timeInterval(rxTestScheduler));
+      const result = e1.pipe(timeInterval(rxTestScheduler));
 
-    expectObservable(result, unsub).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   hot('-a--b-----c---d---|');
-    const e1subs =   '^      !           ';
-    const expected = '-y--z---           ';
-    const unsub =    '       !           ';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b-----c---d---|');
+      const e1subs = '  ^------!           ';
+      const expected = '-y--z---           ';
+      const unsub = '   -------!           ';
 
-    const expectedValue = {
-      y: new TimeInterval('a', 10),
-      z: new TimeInterval('b', 30)
-    };
+      const expectedValue = {
+        y: new TimeInterval('a', 1),
+        z: new TimeInterval('b', 3),
+      };
 
-    const result = (<any>e1).pipe(
-      mergeMap((x: string) => of(x)),
-      timeInterval(rxTestScheduler),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        timeInterval(rxTestScheduler),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not completes if source never completes', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('raise error if source raises error', () => {
-    const e1 =   hot('---#');
-    const e1subs =   '^  !';
-    const expected = '---#';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---#');
+      const e1subs = '  ^--!';
+      const expected = '---#';
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should record interval then raise error if source raises error after emit', () => {
-    const e1 =   hot('-a--b--#');
-    const e1subs =   '^      !';
-    const expected = '-y--z--#';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a--b--#');
+      const e1subs = '  ^------!';
+      const expected = '-y--z--#';
 
-    const expectedValue = {
-      y: new TimeInterval('a', 10),
-      z: new TimeInterval('b', 30)
-    };
+      const expectedValue = {
+        y: new TimeInterval('a', 1),
+        z: new TimeInterval('b', 3),
+      };
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected, expectedValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raise error if source immediately throws', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    expectObservable((<any>e1).pipe(timeInterval(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(timeInterval(rxTestScheduler))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -162,10 +189,9 @@ describe('timeInterval operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      timeInterval(),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(timeInterval(), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts the `timeInterval` operator tests to run mode.

**Related issue (if exists):**
None
