### PR TITLE
chore(throwIfEmpty): convert throwIfEmpty tests to run mode

### DIFF
--- a/spec/operators/throwIfEmpty-spec.ts
+++ b/spec/operators/throwIfEmpty-spec.ts
@@ -1,30 +1,38 @@
+/** @prettier */
 import { expect } from 'chai';
-import { cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { EMPTY, of, EmptyError, defer, throwError, Observable } from 'rxjs';
 import { throwIfEmpty, mergeMap, retry, take } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
-/** @test {timeout} */
+/** @test {throwIfEmpty} */
 describe('throwIfEmpty', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   describe('with errorFactory', () => {
     it('should error when empty', () => {
-      const source = cold('----|');
-      const expected =    '----#';
-      expectObservable(
-        source.pipe(throwIfEmpty(() => new Error('test')))
-      ).toBe(expected, undefined, new Error('test'));
+      rxTestScheduler.run(({ cold, expectObservable }) => {
+        const source = cold('----|');
+        const expected = '   ----#';
+
+        const result = source.pipe(throwIfEmpty(() => new Error('test')));
+
+        expectObservable(result).toBe(expected, undefined, new Error('test'));
+      });
     });
 
     it('should throw if empty', () => {
       const error = new Error('So empty inside');
       let thrown: any;
 
-      EMPTY.pipe(
-        throwIfEmpty(() => error),
-      )
-      .subscribe({
+      EMPTY.pipe(throwIfEmpty(() => error)).subscribe({
         error(err) {
           thrown = err;
-        }
+        },
       });
 
       expect(thrown).to.equal(error);
@@ -34,46 +42,54 @@ describe('throwIfEmpty', () => {
       const error = new Error('So empty inside');
       let thrown: any;
 
-      of('test').pipe(
-        throwIfEmpty(() => error),
-      )
-      .subscribe({
-        error(err) {
-          thrown = err;
-        }
-      });
+      of('test')
+        .pipe(throwIfEmpty(() => error))
+        .subscribe({
+          error(err) {
+            thrown = err;
+          },
+        });
 
       expect(thrown).to.be.undefined;
     });
 
     it('should pass values through', () => {
-      const source = cold('----a---b---c---|');
-      const sub1 =        '^               !';
-      const expected =    '----a---b---c---|';
-      expectObservable(
-        source.pipe(throwIfEmpty(() => new Error('test')))
-      ).toBe(expected);
-      expectSubscriptions(source.subscriptions).toBe([sub1]);
+      rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const source = cold('----a---b---c---|');
+        const sub1 = '       ^---------------!';
+        const expected = '   ----a---b---c---|';
+
+        const result = source.pipe(throwIfEmpty(() => new Error('test')));
+
+        expectObservable(result).toBe(expected);
+        expectSubscriptions(source.subscriptions).toBe([sub1]);
+      });
     });
 
     it('should never when never', () => {
-      const source = cold('-');
-      const sub1 =        '^';
-      const expected =    '-';
-      expectObservable(
-        source.pipe(throwIfEmpty(() => new Error('test')))
-      ).toBe(expected);
-      expectSubscriptions(source.subscriptions).toBe([sub1]);
+      rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const source = cold('-');
+        const sub1 = '       ^';
+        const expected = '   -';
+
+        const result = source.pipe(throwIfEmpty(() => new Error('test')));
+
+        expectObservable(result).toBe(expected);
+        expectSubscriptions(source.subscriptions).toBe([sub1]);
+      });
     });
 
     it('should error when empty', () => {
-      const source = cold('----|');
-      const sub1 =        '^   !';
-      const expected =    '----#';
-      expectObservable(
-        source.pipe(throwIfEmpty(() => new Error('test')))
-      ).toBe(expected, undefined, new Error('test'));
-      expectSubscriptions(source.subscriptions).toBe([sub1]);
+      rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const source = cold('----|');
+        const sub1 = '       ^---!';
+        const expected = '   ----#';
+
+        const result = source.pipe(throwIfEmpty(() => new Error('test')));
+
+        expectObservable(result).toBe(expected, undefined, new Error('test'));
+        expectSubscriptions(source.subscriptions).toBe([sub1]);
+      });
     });
 
     it('should throw if empty after retry', () => {
@@ -89,24 +105,25 @@ describe('throwIfEmpty', () => {
         return of(1, 2);
       });
 
-      source.pipe(
-        throwIfEmpty(() => error),
-        mergeMap(value => {
-          if (value > 1) {
-            return throwError(new Error());
-          }
+      source
+        .pipe(
+          throwIfEmpty(() => error),
+          mergeMap((value) => {
+            if (value > 1) {
+              return throwError(new Error());
+            }
 
-          return of(value);
-        }),
-        retry(1)
-      ).subscribe({
-        error(err) {
-          thrown = err;
-        }
-      });
+            return of(value);
+          }),
+          retry(1)
+        )
+        .subscribe({
+          error(err) {
+            thrown = err;
+          },
+        });
 
       expect(thrown).to.equal(error);
-
     });
   });
 
@@ -114,13 +131,10 @@ describe('throwIfEmpty', () => {
     it('should throw EmptyError if empty', () => {
       let thrown: any;
 
-      EMPTY.pipe(
-        throwIfEmpty(),
-      )
-      .subscribe({
+      EMPTY.pipe(throwIfEmpty()).subscribe({
         error(err) {
           thrown = err;
-        }
+        },
       });
 
       expect(thrown).to.be.instanceof(EmptyError);
@@ -129,46 +143,54 @@ describe('throwIfEmpty', () => {
     it('should NOT throw if NOT empty', () => {
       let thrown: any;
 
-      of('test').pipe(
-        throwIfEmpty(),
-      )
-      .subscribe({
-        error(err) {
-          thrown = err;
-        }
-      });
+      of('test')
+        .pipe(throwIfEmpty())
+        .subscribe({
+          error(err) {
+            thrown = err;
+          },
+        });
 
       expect(thrown).to.be.undefined;
     });
 
     it('should pass values through', () => {
-      const source = cold('----a---b---c---|');
-      const sub1 =        '^               !';
-      const expected =    '----a---b---c---|';
-      expectObservable(
-        source.pipe(throwIfEmpty())
-      ).toBe(expected);
-      expectSubscriptions(source.subscriptions).toBe([sub1]);
+      rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const source = cold('----a---b---c---|');
+        const sub1 = '       ^---------------!';
+        const expected = '   ----a---b---c---|';
+
+        const result = source.pipe(throwIfEmpty());
+
+        expectObservable(result).toBe(expected);
+        expectSubscriptions(source.subscriptions).toBe([sub1]);
+      });
     });
 
     it('should never when never', () => {
-      const source = cold('-');
-      const sub1 =        '^';
-      const expected =    '-';
-      expectObservable(
-        source.pipe(throwIfEmpty())
-      ).toBe(expected);
-      expectSubscriptions(source.subscriptions).toBe([sub1]);
+      rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const source = cold('-');
+        const sub1 = '       ^';
+        const expected = '   -';
+
+        const result = source.pipe(throwIfEmpty());
+
+        expectObservable(result).toBe(expected);
+        expectSubscriptions(source.subscriptions).toBe([sub1]);
+      });
     });
 
     it('should error when empty', () => {
-      const source = cold('----|');
-      const sub1 =        '^   !';
-      const expected =    '----#';
-      expectObservable(
-        source.pipe(throwIfEmpty())
-      ).toBe(expected, undefined, new EmptyError());
-      expectSubscriptions(source.subscriptions).toBe([sub1]);
+      rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+        const source = cold('----|');
+        const sub1 = '       ^---!';
+        const expected = '   ----#';
+
+        const result = source.pipe(throwIfEmpty());
+
+        expectObservable(result).toBe(expected, undefined, new EmptyError());
+        expectSubscriptions(source.subscriptions).toBe([sub1]);
+      });
     });
 
     it('should throw if empty after retry', () => {
@@ -183,30 +205,31 @@ describe('throwIfEmpty', () => {
         return of(1, 2);
       });
 
-      source.pipe(
-        throwIfEmpty(),
-        mergeMap(value => {
-          if (value > 1) {
-            return throwError(new Error());
-          }
+      source
+        .pipe(
+          throwIfEmpty(),
+          mergeMap((value) => {
+            if (value > 1) {
+              return throwError(new Error());
+            }
 
-          return of(value);
-        }),
-        retry(1)
-      ).subscribe({
-        error(err) {
-          thrown = err;
-        }
-      });
+            return of(value);
+          }),
+          retry(1)
+        )
+        .subscribe({
+          error(err) {
+            thrown = err;
+          },
+        });
 
       expect(thrown).to.be.instanceof(EmptyError);
-
     });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -215,10 +238,9 @@ describe('throwIfEmpty', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      throwIfEmpty(),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(throwIfEmpty(), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `throwIfEmpty` operator tests to run mode.

**Related issue (if exists):**
None
