### PR TITLE
chore(tap): convert tap tests to run mode 

### DIFF
--- a/spec/operators/tap-spec.ts
+++ b/spec/operators/tap-spec.ts
@@ -45,14 +45,16 @@ describe('tap', () => {
 
   it('should error with a callback', () => {
     let err = null;
-    throwError('bad')
+    throwError(() => 'bad')
       .pipe(
         tap(null, function (x) {
           err = x;
         })
       )
-      .subscribe(null, function (ex) {
-        expect(ex).to.equal('bad');
+      .subscribe({
+        error(ex) {
+          expect(ex).to.equal('bad');
+        },
       });
 
     expect(err).to.equal('bad');
@@ -103,15 +105,17 @@ describe('tap', () => {
 
   it('should handle an error with a callback', () => {
     let errored = false;
-    throwError('bad')
+    throwError(() => 'bad')
       .pipe(
         tap(null, (err: any) => {
           expect(err).to.equal('bad');
         })
       )
-      .subscribe(null, (err: any) => {
-        errored = true;
-        expect(err).to.equal('bad');
+      .subscribe({
+        error(err: any) {
+          errored = true;
+          expect(err).to.equal('bad');
+        },
       });
 
     expect(errored).to.be.true;
@@ -119,7 +123,7 @@ describe('tap', () => {
 
   it('should handle an error with observer', () => {
     let errored = false;
-    throwError('bad')
+    throwError(() => 'bad')
       .pipe(
         tap(<any>{
           error: function (err: string) {
@@ -127,9 +131,11 @@ describe('tap', () => {
           },
         })
       )
-      .subscribe(null, function (err) {
-        errored = true;
-        expect(err).to.equal('bad');
+      .subscribe({
+        error(err) {
+          errored = true;
+          expect(err).to.equal('bad');
+        },
       });
 
     expect(errored).to.be.true;
@@ -174,13 +180,15 @@ describe('tap', () => {
           },
         })
       )
-      .subscribe(null, (err: any) => {
-        expect(err.message).to.equal('bad');
+      .subscribe({
+        error(err: any) {
+          expect(err.message).to.equal('bad');
+        },
       });
   });
 
   it('should raise error if error handler raises error', () => {
-    throwError('ops')
+    throwError(() => 'ops')
       .pipe(
         tap(<any>{
           error: (x: any) => {
@@ -188,8 +196,10 @@ describe('tap', () => {
           },
         })
       )
-      .subscribe(null, (err: any) => {
-        expect(err.message).to.equal('bad');
+      .subscribe({
+        error(err: any) {
+          expect(err.message).to.equal('bad');
+        },
       });
   });
 
@@ -200,8 +210,10 @@ describe('tap', () => {
           throw new Error('bad');
         },
       })
-    ).subscribe(null, (err: any) => {
-      expect(err.message).to.equal('bad');
+    ).subscribe({
+      error(err: any) {
+        expect(err.message).to.equal('bad');
+      },
     });
   });
 

--- a/spec/operators/tap-spec.ts
+++ b/spec/operators/tap-spec.ts
@@ -1,40 +1,59 @@
+/** @prettier */
 import { expect } from 'chai';
 import { tap, mergeMap, take } from 'rxjs/operators';
 import { Subject, of, throwError, Observer, EMPTY, Observable } from 'rxjs';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {tap} */
-describe('tap operator', () => {
-  it('should mirror multiple values and complete', () => {
-    const e1 =  cold('--1--2--3--|');
-    const e1subs =   '^          !';
-    const expected = '--1--2--3--|';
+describe('tap', () => {
+  let testScheduler: TestScheduler;
 
-    const result = e1.pipe(tap(() => {
-      //noop
-    }));
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should mirror multiple values and complete', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --1--2--3--|');
+      const e1subs = '  ^----------!';
+      const expected = '--1--2--3--|';
+
+      const result = e1.pipe(
+        tap(() => {
+          //noop
+        })
+      );
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should next with a callback', () => {
     let value = null;
-    of(42).pipe(tap(function (x) {
-      value = x;
-    }))
-    .subscribe();
+    of(42)
+      .pipe(
+        tap(function (x) {
+          value = x;
+        })
+      )
+      .subscribe();
 
     expect(value).to.equal(42);
   });
 
   it('should error with a callback', () => {
     let err = null;
-    throwError('bad').pipe(tap(null, function (x) {
-      err = x;
-    }))
-    .subscribe(null, function (ex) {
-      expect(ex).to.equal('bad');
-    });
+    throwError('bad')
+      .pipe(
+        tap(null, function (x) {
+          err = x;
+        })
+      )
+      .subscribe(null, function (ex) {
+        expect(ex).to.equal('bad');
+      });
 
     expect(err).to.equal('bad');
   });
@@ -43,19 +62,22 @@ describe('tap operator', () => {
     const expected = [1, 2, 3];
     const results: number[] = [];
 
-    of(1, 2, 3).pipe(
-      tap(<Observer<number>>{
-        next: (x: number) => {
-          results.push(x);
-        },
-        error: (err: any) => {
-          done(new Error('should not be called'));
-        },
-        complete: () => {
-          expect(results).to.deep.equal(expected);
-          done();
-        }
-      })).subscribe();
+    of(1, 2, 3)
+      .pipe(
+        tap(<Observer<number>>{
+          next: (x: number) => {
+            results.push(x);
+          },
+          error: (err: any) => {
+            done(new Error('should not be called'));
+          },
+          complete: () => {
+            expect(results).to.deep.equal(expected);
+            done();
+          },
+        })
+      )
+      .subscribe();
   });
 
   it('should handle everything with a Subject', (done: MochaDone) => {
@@ -73,36 +95,42 @@ describe('tap operator', () => {
       complete: () => {
         expect(results).to.deep.equal(expected);
         done();
-      }
+      },
     });
 
-    of(1, 2, 3).pipe(
-      tap(subject)
-    ).subscribe();
+    of(1, 2, 3).pipe(tap(subject)).subscribe();
   });
 
   it('should handle an error with a callback', () => {
     let errored = false;
-    throwError('bad').pipe(tap(null, (err: any) => {
-      expect(err).to.equal('bad');
-    }))
-    .subscribe(null, (err: any) => {
-      errored = true;
-      expect(err).to.equal('bad');
-    });
+    throwError('bad')
+      .pipe(
+        tap(null, (err: any) => {
+          expect(err).to.equal('bad');
+        })
+      )
+      .subscribe(null, (err: any) => {
+        errored = true;
+        expect(err).to.equal('bad');
+      });
 
     expect(errored).to.be.true;
   });
 
   it('should handle an error with observer', () => {
     let errored = false;
-    throwError('bad').pipe(tap(<any>{ error: function (err: string) {
-      expect(err).to.equal('bad');
-    } }))
-    .subscribe(null, function (err) {
-      errored = true;
-      expect(err).to.equal('bad');
-    });
+    throwError('bad')
+      .pipe(
+        tap(<any>{
+          error: function (err: string) {
+            expect(err).to.equal('bad');
+          },
+        })
+      )
+      .subscribe(null, function (err) {
+        errored = true;
+        expect(err).to.equal('bad');
+      });
 
     expect(errored).to.be.true;
   });
@@ -110,11 +138,13 @@ describe('tap operator', () => {
   it('should handle complete with observer', () => {
     let completed = false;
 
-    EMPTY.pipe(tap(<any>{
-      complete: () => {
-        completed = true;
-      }
-    })).subscribe();
+    EMPTY.pipe(
+      tap(<any>{
+        complete: () => {
+          completed = true;
+        },
+      })
+    ).subscribe();
 
     expect(completed).to.be.true;
   });
@@ -122,103 +152,131 @@ describe('tap operator', () => {
   it('should handle next with observer', () => {
     let value = null;
 
-    of('hi').pipe(tap(<any>{
-      next: (x: string) => {
-        value = x;
-      }
-    })).subscribe();
+    of('hi')
+      .pipe(
+        tap(<any>{
+          next: (x: string) => {
+            value = x;
+          },
+        })
+      )
+      .subscribe();
 
     expect(value).to.equal('hi');
   });
 
   it('should raise error if next handler raises error', () => {
-    of('hi').pipe(tap(<any>{
-      next: (x: string) => {
-        throw new Error('bad');
-      }
-    })).subscribe(null, (err: any) => {
-      expect(err.message).to.equal('bad');
-    });
+    of('hi')
+      .pipe(
+        tap(<any>{
+          next: (x: string) => {
+            throw new Error('bad');
+          },
+        })
+      )
+      .subscribe(null, (err: any) => {
+        expect(err.message).to.equal('bad');
+      });
   });
 
   it('should raise error if error handler raises error', () => {
-    throwError('ops').pipe(tap(<any>{
-      error: (x: any) => {
-        throw new Error('bad');
-      }
-    })).subscribe(null, (err: any) => {
-      expect(err.message).to.equal('bad');
-    });
+    throwError('ops')
+      .pipe(
+        tap(<any>{
+          error: (x: any) => {
+            throw new Error('bad');
+          },
+        })
+      )
+      .subscribe(null, (err: any) => {
+        expect(err.message).to.equal('bad');
+      });
   });
 
   it('should raise error if complete handler raises error', () => {
-    EMPTY.pipe(tap(<any>{
-      complete: () => {
-        throw new Error('bad');
-      }
-    })).subscribe(null, (err: any) => {
+    EMPTY.pipe(
+      tap(<any>{
+        complete: () => {
+          throw new Error('bad');
+        },
+      })
+    ).subscribe(null, (err: any) => {
       expect(err.message).to.equal('bad');
     });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 =   hot('--1--2--3--#');
-    const unsub =    '       !    ';
-    const e1subs =   '^      !    ';
-    const expected = '--1--2--    ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --1--2--3--#');
+      const unsub = '   -------!    ';
+      const e1subs = '  ^------!    ';
+      const expected = '--1--2--    ';
 
-    const result = e1.pipe(tap(() => {
-      //noop
-    }));
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(
+        tap(() => {
+          //noop
+        })
+      );
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   hot('--1--2--3--#');
-    const e1subs =   '^      !    ';
-    const expected = '--1--2--    ';
-    const unsub =    '       !    ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --1--2--3--#');
+      const e1subs = '  ^------!    ';
+      const expected = '--1--2--    ';
+      const unsub = '   -------!    ';
 
-    const result = e1.pipe(
-      mergeMap((x: any) => of(x)),
-      tap(() => {
-        //noop
-      }),
-      mergeMap((x: any) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: any) => of(x)),
+        tap(() => {
+          //noop
+        }),
+        mergeMap((x: any) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should mirror multiple values and complete', () => {
-    const e1 =  cold('--1--2--3--|');
-    const e1subs =   '^          !';
-    const expected = '--1--2--3--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --1--2--3--|');
+      const e1subs = '  ^----------!';
+      const expected = '--1--2--3--|';
 
-    const result = e1.pipe(tap(() => {
-      //noop
-    }));
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(
+        tap(() => {
+          //noop
+        })
+      );
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should mirror multiple values and terminate with error', () => {
-    const e1 =  cold('--1--2--3--#');
-    const e1subs =   '^          !';
-    const expected = '--1--2--3--#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --1--2--3--#');
+      const e1subs = '  ^----------!';
+      const expected = '--1--2--3--#';
 
-    const result = e1.pipe(tap(() => {
-      //noop
-    }));
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(
+        tap(() => {
+          //noop
+        })
+      );
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -227,10 +285,16 @@ describe('tap operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      tap(() => { /* noop */ }),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable
+      .pipe(
+        tap(() => {
+          /* noop */
+        }),
+        take(3)
+      )
+      .subscribe(() => {
+        /* noop */
+      });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });

--- a/spec/operators/tap-spec.ts
+++ b/spec/operators/tap-spec.ts
@@ -58,7 +58,7 @@ describe('tap', () => {
     expect(err).to.equal('bad');
   });
 
-  it('should handle everything with an observer', (done: MochaDone) => {
+  it('should handle everything with an observer', (done: Mocha.Done) => {
     const expected = [1, 2, 3];
     const results: number[] = [];
 
@@ -80,7 +80,7 @@ describe('tap', () => {
       .subscribe();
   });
 
-  it('should handle everything with a Subject', (done: MochaDone) => {
+  it('should handle everything with a Subject', (done: Mocha.Done) => {
     const expected = [1, 2, 3];
     const results: number[] = [];
     const subject = new Subject<number>();

--- a/spec/operators/tap-spec.ts
+++ b/spec/operators/tap-spec.ts
@@ -70,7 +70,7 @@ describe('tap', () => {
           next: (x: number) => {
             results.push(x);
           },
-          error: (err: any) => {
+          error: () => {
             done(new Error('should not be called'));
           },
           complete: () => {
@@ -91,7 +91,7 @@ describe('tap', () => {
       next: (x: any) => {
         results.push(x);
       },
-      error: (err: any) => {
+      error: () => {
         done(new Error('should not be called'));
       },
       complete: () => {
@@ -175,7 +175,7 @@ describe('tap', () => {
     of('hi')
       .pipe(
         tap(<any>{
-          next: (x: string) => {
+          next: () => {
             throw new Error('bad');
           },
         })
@@ -191,7 +191,7 @@ describe('tap', () => {
     throwError(() => 'ops')
       .pipe(
         tap(<any>{
-          error: (x: any) => {
+          error: () => {
             throw new Error('bad');
           },
         })


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `tap` operator tests to run mode. There are also a few small refactorings:

1. Replace deprecated `MochaDone` type with `Mocha.Done`
2. Replace deprecated singnatures of `subscribe` and `throwError`. Note that the deprecated signature usages of `tap` have not been touched.
3. Removed unused parameters in callbacks.

The refactorings have been placed in separate commits to ease reviewing and the possibility to drop some of the refactorings.

**Related issue (if exists):**
None