### PR TITLE
docs(timeInterval): fix broken link to timeInterval marble diagram

### DIFF
--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -17,7 +17,7 @@ import { map } from './map';
  * <span class="informal">Convert an Observable that emits items into one that
  * emits indications of the amount of time elapsed between those emissions.</span>
  *
- * ![](timeinterval.png)
+ * ![](timeInterval.png)
  *
  * ## Examples
  * Emit interval between current value with the last value
@@ -51,16 +51,18 @@ import { map } from './map';
  * value and interval.
  */
 export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunction<T, TimeInterval<T>> {
-  return (source: Observable<T>) => defer(() => {
-    return source.pipe(
-      // TODO(benlesh): correct these typings.
-      scan(
-        ({ current }, value) => ({ value, current: scheduler.now(), last: current }),
-        { current: scheduler.now(), value: undefined,  last: undefined } as any
-      ) as OperatorFunction<T, any>,
-      map<any, TimeInterval<T>>(({ current, last, value }) => new TimeInterval(value, current - last)),
-    );
-  });
+  return (source: Observable<T>) =>
+    defer(() => {
+      return source.pipe(
+        // TODO(benlesh): correct these typings.
+        scan(({ current }, value) => ({ value, current: scheduler.now(), last: current }), {
+          current: scheduler.now(),
+          value: undefined,
+          last: undefined,
+        } as any) as OperatorFunction<T, any>,
+        map<any, TimeInterval<T>>(({ current, last, value }) => new TimeInterval(value, current - last))
+      );
+    });
 }
 
 // TODO(benlesh): make this an interface, export the interface, but not the implemented class,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR fixes a broken image source to the `timeInterval` marble diagram in the documentation. 

See documentation of [timeInterval V6](https://rxjs.dev/api/operators/timeInterval) and [timeInterval V7](https://next.rxjs.dev/api/operators/timeInterval)

**Related issue (if exists):**
#5207