### PR TITLE
fix: catch within innerSubscribe

### DIFF
--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -691,4 +691,17 @@ describe('Observable.prototype.concatMap', () => {
         done(new Error('Subscriber complete handler not supposed to be called.'));
       });
   });
+
+  it('should report invalid observable inputs via error notifications', () => {
+    const e1 =    hot('--1|');
+    const e1subs =    '^ !';
+    const expected =  '--#';
+
+    const result = e1.pipe(concatMap(() => null as any));
+
+    expectObservable(result).toBe(expected, null, new TypeError(
+      "You provided 'null' where a stream was expected. You can provide an Observable, Promise, Array, or Iterable."
+    ));
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
 });

--- a/spec/operators/exhaustMap-spec.ts
+++ b/spec/operators/exhaustMap-spec.ts
@@ -434,4 +434,17 @@ describe('exhaustMap', () => {
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
+
+  it('should report invalid observable inputs via error notifications', () => {
+    const e1 =    hot('--1|');
+    const e1subs =    '^ !';
+    const expected =  '--#';
+
+    const result = e1.pipe(exhaustMap(() => null as any));
+
+    expectObservable(result).toBe(expected, null, new TypeError(
+      "You provided 'null' where a stream was expected. You can provide an Observable, Promise, Array, or Iterable."
+    ));
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
 });

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -852,4 +852,17 @@ describe('mergeMap', () => {
       expectObservable(result).toBe(expected, undefined, noXError);
     });
   });
+
+  it('should report invalid observable inputs via error notifications', () => {
+    const e1 =    hot('--1|');
+    const e1subs =    '^ !';
+    const expected =  '--#';
+
+    const result = e1.pipe(mergeMap(() => null as any));
+
+    expectObservable(result).toBe(expected, null, new TypeError(
+      "You provided 'null' where a stream was expected. You can provide an Observable, Promise, Array, or Iterable."
+    ));
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
 });

--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -444,4 +444,17 @@ describe('switchMap', () => {
     expectSubscriptions(x.subscriptions).toBe(xsubs);
     expectSubscriptions(e1.subscriptions).toBe(e1subs);
   });
+
+  it('should report invalid observable inputs via error notifications', () => {
+    const e1 =    hot('--1|');
+    const e1subs =    '^ !';
+    const expected =  '--#';
+
+    const result = e1.pipe(switchMap(() => null as any));
+
+    expectObservable(result).toBe(expected, null, new TypeError(
+      "You provided 'null' where a stream was expected. You can provide an Observable, Promise, Array, or Iterable."
+    ));
+    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  });
 });

--- a/src/internal/innerSubscribe.ts
+++ b/src/internal/innerSubscribe.ts
@@ -110,5 +110,11 @@ export function innerSubscribe(result: any, innerSubscriber: Subscriber<any>): S
   if (result instanceof Observable) {
     return result.subscribe(innerSubscriber);
   }
-  return subscribeTo(result)(innerSubscriber) as Subscription;
+  let subscription: Subscription;
+  try {
+    subscription = subscribeTo(result)(innerSubscriber) as Subscription;
+  } catch (error) {
+    innerSubscriber.error(error);
+  }
+  return subscription;
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Note that this PR targets the `6.x` branch.**

**Description:**

AFAICT, `innerSubscribe` is pretty much always called outside of a `try`/`catch` and that means that the error that `subscribeTo` throws if it receives an invalid `ObservableInput` won't be reported via the chained subscribers. Given that `innerSubscribe` is an internal v6 implementation detail and that's its always passed a known-to-be-safe `Subscriber`, it seems that any error effected could be reported directly to said `Subscriber`.

With this change, the bug reported in #5344 - which occurs only in v6 - is fixed.

**Related issue (if exists):** #5344
