### PR TITLE
docs(mergeScan): add parameter docs

### DIFF
--- a/src/internal/operators/mergeScan.ts
+++ b/src/internal/operators/mergeScan.ts
@@ -10,6 +10,30 @@ import { mergeInternals } from './mergeInternals';
  * <span class="informal">It's like {@link scan}, but the Observables returned
  * by the accumulator are merged into the outer Observable.</span>
  *
+ * The first parameter of the `mergeScan` is an `accumulator` function which is
+ * being called every time the source Observable emits a value. `mergeScan` will
+ * subscribe to the value returned by the `accumulator` function and will emit
+ * values to the subscriber emitted by inner Observable.
+ *
+ * The `accumulator` function is being called with three parameters passed to it:
+ * `acc`, `value` and `index`. The `acc` parameter is used as the state parameter
+ * whose value is initially set to the `seed` parameter (the second parameter
+ * passed to the `mergeScan` operator).
+ *
+ * `mergeScan` internally keeps the value of the `acc` parameter: as long as the
+ * source Observable emits without inner Observable emitting, the `acc` will be
+ * set to `seed`. The next time the inner Observable emits a value, `mergeScan`
+ * will internally remember it and it will be passed to the `accumulator`
+ * function as `acc` parameter the next time source emits.
+ *
+ * The `value` parameter of the `accumulator` function is the value emitted by the
+ * source Observable, while the `index` is a number which represent the order of the
+ * current emission by the source Observable. It starts with 0.
+ *
+ * The last parameter to the `mergeScan` is the `concurrent` value which defaults
+ * to Infinity. It represent the maximum number of inner Observable subscriptions
+ * at a time.
+ *
  * ## Example
  * Count the number of click events
  * ```ts


### PR DESCRIPTION
**Description:**
While working on converting `mergeScan` tests to run mode, I struggled with finding out how `acc` parameter of the `accumulator` function is being set, so I had to read the code to figure it out. Now, I'm adding some documentation about `mergeScan` parameters and `mergeScan` internals.

**Related issue (if exists):**
None