### PR TITLE
Add exports within package.json to enable scoped package loading.

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -38,4 +38,7 @@ jobs:
     - name: import
       if: ${{ matrix.node == '14' }}
       run: npm run test:import
+    - name: import
+      if: ${{ matrix.node == '14' || matrix.node == '15' }}
+      run: npm run test:esm
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,33 @@
   "es2015": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
   "sideEffects": false,
+  "exports": {
+    ".": {
+      "node": "./dist/cjs/index.js",
+      "default": "./dist/esm5/index.js"
+    },
+    "./ajax": {
+      "node": "./dist/cjs/ajax/index.js",
+      "default": "./dist/dist/esm5/ajax/index.js"
+    },
+    "./fetch": {
+      "node": "./dist/cjs/fetch/index.js",
+      "default": "./dist/dist/esm5/fetch/index.js"
+    },
+    "./operators": {
+      "node": "./dist/cjs/operators/index.js",
+      "default": "./dist/dist/esm5/operators/index.js"
+    },
+    "./testing": {
+      "node": "./dist/cjs/testing/index.js",
+      "default": "./dist/dist/esm5/testing/index.js"
+    },
+    "./webSocket": {
+      "node": "./dist/cjs/webSocket/index.js",
+      "default": "./dist/dist/esm5/webSocket/index.js"
+    },
+    "./package.json": "./package.json"
+  },
   "config": {
     "commitizen": {
       "path": "cz-conventional-changelog"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "prepublishOnly": "npm run build:package && npm run lint && npm run test && npm run test:circular && npm run dtslint && npm run test:side-effects && npm run api_guardian",
     "publish_docs": "./publish_docs.sh",
     "test": "npm run compile && mocha --config spec/support/.mocharc.js \"dist/spec/**/*-spec.js\"",
+    "test:esm": "node spec/module-test-spec.mjs",
     "test:browser": "echo \"Browser test is not working currently\" && exit -1 && npm-run-all build:spec:browser && opn spec/support/mocha-browser-runner.html",
     "test:circular": "dependency-cruiser --validate .dependency-cruiser.json -x \"^node_modules\" dist/esm5",
     "test:systemjs": "node integration/systemjs/systemjs-compatibility-spec.js",

--- a/spec/module-test-spec.mjs
+++ b/spec/module-test-spec.mjs
@@ -1,0 +1,13 @@
+/* Test file to ensure rxjs can be loaded from esm
+
+https://github.com/ReactiveX/rxjs/pull/6192
+If this fails node will error when running this with an error like
+node:internal/process/esm_loader:74
+    internalBinding('errors').triggerUncaughtException(
+*/
+import {Observable} from 'rxjs';
+import * as o from 'rxjs/operators';
+import * as a from 'rxjs/ajax';
+import * as f from 'rxjs/fetch';
+import * as t from 'rxjs/testing';
+import * as w from 'rxjs/webSocket';


### PR DESCRIPTION
In order for module resolution to work with .mjs or package: module code
we need to utilize the conditional export feature of node.

> The current specifier resolution does not support all default behavior of the CommonJS loader. One of the behavior differences is automatic resolution of file extensions and the ability to import directories that have an index file.

https://nodejs.org/api/esm.html#esm_customizing_esm_specifier_resolution_algorithm
https://nodejs.org/api/packages.html#packages_conditional_exports

This directly enables rxjs to work with mjs code and commonjs code since
mjs does not support loading bare folder paths.

This is a fix to:
https://github.com/sveltejs/kit/issues/612

and is directly related to the conversation in this issue within node
core https://github.com/nodejs/node/issues/27408

-----

#### Test case

```
import {Observable} from 'rxjs';
import {scan} from 'rxjs/operators';

console.log(Observable, scan);
```

```
{
  "type": "module",
  "dependencies": {
    "rxjs": "^7.0.0-beta.13" // With the above modification
  }
}
```