### PR TITLE
fix(esm): duplicate directory in export path

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,23 +14,23 @@
     },
     "./ajax": {
       "node": "./dist/cjs/ajax/index.js",
-      "default": "./dist/dist/esm5/ajax/index.js"
+      "default": "./dist/esm5/ajax/index.js"
     },
     "./fetch": {
       "node": "./dist/cjs/fetch/index.js",
-      "default": "./dist/dist/esm5/fetch/index.js"
+      "default": "./dist/esm5/fetch/index.js"
     },
     "./operators": {
       "node": "./dist/cjs/operators/index.js",
-      "default": "./dist/dist/esm5/operators/index.js"
+      "default": "./dist/esm5/operators/index.js"
     },
     "./testing": {
       "node": "./dist/cjs/testing/index.js",
-      "default": "./dist/dist/esm5/testing/index.js"
+      "default": "./dist/esm5/testing/index.js"
     },
     "./webSocket": {
       "node": "./dist/cjs/webSocket/index.js",
-      "default": "./dist/dist/esm5/webSocket/index.js"
+      "default": "./dist/esm5/webSocket/index.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Fixes default export path

I was rebasing 33a9f06f2c59c8aef3bb583bdb7d61d08ab597a0 and this was uncovered with the import integration tests I added in #6043 I'll see if I can update CI with those.

cc @samccone 