### PR TITLE
chore(ajax): rename `params` query string to `queryParams`

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -9,9 +9,9 @@ export interface AjaxConfig {
     includeDownloadProgress?: boolean;
     includeUploadProgress?: boolean;
     method?: string;
-    params?: string | URLSearchParams | Record<string, string | number | boolean | string[] | number[] | boolean[]> | [string, string | number | boolean | string[] | number[] | boolean[]][];
     password?: string;
     progressSubscriber?: PartialObserver<ProgressEvent>;
+    queryParams?: string | URLSearchParams | Record<string, string | number | boolean | string[] | number[] | boolean[]> | [string, string | number | boolean | string[] | number[] | boolean[]][];
     responseType?: XMLHttpRequestResponseType;
     timeout?: number;
     url: string;

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -1367,12 +1367,12 @@ x-custom-header: test
 x-headers-are-fun: <whatever/> {"weird": "things"}`);
   });
 
-  describe('with params', () => {
-    it('should allow passing of search params as a dictionary', () => {
+  describe('with queryParams', () => {
+    it('should allow passing of search queryParams as a dictionary', () => {
       ajax({
         method: 'GET',
         url: '/whatever',
-        params: { foo: 'bar', whatever: '123' },
+        queryParams: { foo: 'bar', whatever: '123' },
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;
@@ -1385,11 +1385,11 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       expect(mockXHR.url).to.equal('/whatever?foo=bar&whatever=123');
     });
 
-    it('should allow passing of search params as an entries array', () => {
+    it('should allow passing of search queryParams as an entries array', () => {
       ajax({
         method: 'GET',
         url: '/whatever',
-        params: [
+        queryParams: [
           ['foo', 'bar'],
           ['whatever', '123'],
         ],
@@ -1405,11 +1405,11 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       expect(mockXHR.url).to.equal('/whatever?foo=bar&whatever=123');
     });
 
-    it('should allow passing of search params as a string', () => {
+    it('should allow passing of search queryParams as a string', () => {
       ajax({
         method: 'GET',
         url: '/whatever',
-        params: '?foo=bar&whatever=123',
+        queryParams: '?foo=bar&whatever=123',
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;
@@ -1422,14 +1422,14 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       expect(mockXHR.url).to.equal('/whatever?foo=bar&whatever=123');
     });
 
-    it('should allow passing of search params as a URLSearchParams object', () => {
-      const params = new URLSearchParams();
-      params.set('foo', 'bar');
-      params.set('whatever', '123');
+    it('should allow passing of search queryParams as a URLSearchParams object', () => {
+      const queryParams = new URLSearchParams();
+      queryParams.set('foo', 'bar');
+      queryParams.set('whatever', '123');
       ajax({
         method: 'GET',
         url: '/whatever',
-        params,
+        queryParams,
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;
@@ -1446,7 +1446,7 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       ajax({
         method: 'GET',
         url: '/whatever?jays_face=is+a+param&lol=haha',
-        params: { foo: 'bar', whatever: '123' },
+        queryParams: { foo: 'bar', whatever: '123' },
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;
@@ -1463,7 +1463,7 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       ajax({
         method: 'GET',
         url: '/whatever?terminator=2&uncle_bob=huh',
-        params: { uncle_bob: '...okayyyyyyy', movie_quote: 'yes' },
+        queryParams: { uncle_bob: '...okayyyyyyy', movie_quote: 'yes' },
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;
@@ -1480,7 +1480,7 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       ajax({
         method: 'GET',
         url: '/whatever',
-        params: { 'this is a weird param name': '?#* value here rofl !!!' },
+        queryParams: { 'this is a weird param name': '?#* value here rofl !!!' },
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;
@@ -1497,7 +1497,7 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       ajax({
         method: 'GET',
         url: '/whatever',
-        params: { a: 123, b: true, c: ['one', 'two', 'three'], d: [1, 3, 3, 7], e: [true, false, true] },
+        queryParams: { a: 123, b: true, c: ['one', 'two', 'three'], d: [1, 3, 3, 7], e: [true, false, true] },
       }).subscribe();
 
       const mockXHR = MockXMLHttpRequest.mostRecent;
@@ -1514,7 +1514,7 @@ x-headers-are-fun: <whatever/> {"weird": "things"}`);
       ajax({
         method: 'GET',
         url: '/whatever',
-        params: [
+        queryParams: [
           ['a', 123],
           ['b', true],
           ['c', ['one', 'two', 'three']],

--- a/src/internal/ajax/ajax.ts
+++ b/src/internal/ajax/ajax.ts
@@ -278,14 +278,14 @@ export function fromAjax<T>(config: AjaxConfig): Observable<AjaxResponse<T>> {
     // Here we're pulling off each of the configuration arguments
     // that we don't want to add to the request information we're
     // passing around.
-    const { params, body: configuredBody, headers: configuredHeaders, ...remainingConfig } = config;
+    const { queryParams, body: configuredBody, headers: configuredHeaders, ...remainingConfig } = config;
 
     let { url } = remainingConfig;
     if (!url) {
       throw new TypeError('url is required');
     }
 
-    if (params) {
+    if (queryParams) {
       let searchParams: URLSearchParams;
       if (url.includes('?')) {
         // If the user has passed a URL with a querystring already in it,
@@ -295,21 +295,21 @@ export function fromAjax<T>(config: AjaxConfig): Observable<AjaxResponse<T>> {
         if (2 < parts.length) {
           throw new TypeError('invalid url');
         }
-        // Add the passed params to the params already in the url provided.
+        // Add the passed queryParams to the params already in the url provided.
         searchParams = new URLSearchParams(parts[1]);
-        // params is converted to any because the runtime is *much* more permissive than
+        // queryParams is converted to any because the runtime is *much* more permissive than
         // the types are.
-        new URLSearchParams(params as any).forEach((value, key) => searchParams.set(key, value));
+        new URLSearchParams(queryParams as any).forEach((value, key) => searchParams.set(key, value));
         // We have to do string concatenation here, because `new URL(url)` does
         // not like relative URLs like `/this` without a base url, which we can't
         // specify, nor can we assume `location` will exist, because of node.
         url = parts[0] + '?' + searchParams;
       } else {
         // There is no pre-existing querystring, so we can just use URLSearchParams
-        // to convert the passed params into the proper format and encodings.
-        // params is converted to any because the runtime is *much* more permissive than
+        // to convert the passed queryParams into the proper format and encodings.
+        // queryParams is converted to any because the runtime is *much* more permissive than
         // the types are.
-        searchParams = new URLSearchParams(params as any);
+        searchParams = new URLSearchParams(queryParams as any);
         url = url + '?' + searchParams;
       }
     }

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -205,9 +205,9 @@ export interface AjaxConfig {
    *
    * If, for some reason you have a query string in the `url` argument, this will append to the query string in the url,
    * but it will also overwrite the value of any keys that are an exact match. In other words, a url of `/test?a=1&b=2`,
-   * with params of `{ b: 5, c: 6 }` will result in a url of roughly `/test?a=1&b=5&c=6`.
+   * with queryParams of `{ b: 5, c: 6 }` will result in a url of roughly `/test?a=1&b=5&c=6`.
    */
-  params?:
+  queryParams?:
     | string
     | URLSearchParams
     | Record<string, string | number | boolean | string[] | number[] | boolean[]>


### PR DESCRIPTION
**Description:**
As @jayphelps  suggested in [this comment](https://github.com/ReactiveX/rxjs/pull/6174#issuecomment-811036029) `queryParams` is a better name.
