### PR TITLE
refactor(OperatorSubscriber): Move error handler arg

### DIFF
--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -66,13 +66,13 @@ export class ConnectableObservable<T> extends Observable<T> {
           new OperatorSubscriber(
             subject as any,
             undefined,
-            (err) => {
-              this._teardown();
-              subject.error(err);
-            },
             () => {
               this._teardown();
               subject.complete();
+            },
+            (err) => {
+              this._teardown();
+              subject.error(err);
             },
             () => this._teardown()
           )

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -251,7 +251,6 @@ export function combineLatestInit(
                       subscriber.next(valueTransform(values.slice()));
                     }
                   },
-                  undefined,
                   () => {
                     if (!--active) {
                       // We only complete the result if we have no more active

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -159,7 +159,6 @@ export function fromFetch<T>(
                 abortable = false;
                 subscriber.complete();
               },
-              // Error handling
               handleError
             )
           );

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -154,13 +154,13 @@ export function fromFetch<T>(
               subscriber,
               // Values are passed through to the subscriber
               undefined,
-              // Error handling
-              handleError,
               // The projected response is complete.
               () => {
                 abortable = false;
                 subscriber.complete();
-              }
+              },
+              // Error handling
+              handleError
             )
           );
         } else {

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -152,7 +152,6 @@ export function forkJoin(...args: any[]): Observable<any> {
             }
             values[sourceIndex] = value;
           },
-          undefined,
           () => {
             if (!--remainingCompletions || !hasValue) {
               if (!remainingEmissions) {

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -95,8 +95,6 @@ export function zip(...args: unknown[]): Observable<unknown> {
                   }
                 }
               },
-              // Any error is passed through the result.
-              undefined,
               () => {
                 // This source completed. Mark it as complete so we can check it later
                 // if we have to.

--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -20,8 +20,8 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
   constructor(
     destination: Subscriber<any>,
     onNext?: (value: T) => void,
-    onError?: (err: any) => void,
     onComplete?: () => void,
+    onError?: (err: any) => void,
     private onFinalize?: () => void
   ) {
     // It's important - for performance reasons - that all of this class's

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -81,11 +81,10 @@ export function audit<T>(durationSelector: (value: T) => ObservableInput<any>): 
           lastValue = value;
           if (!durationSubscriber) {
             innerFrom(durationSelector(value)).subscribe(
-              (durationSubscriber = new OperatorSubscriber(subscriber, endDuration, undefined, cleanupDuration))
+              (durationSubscriber = new OperatorSubscriber(subscriber, endDuration, cleanupDuration))
             );
           }
         },
-        undefined,
         () => {
           isComplete = true;
           (!hasValue || !durationSubscriber || durationSubscriber.closed) && subscriber.complete();

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -52,8 +52,6 @@ export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T,
       new OperatorSubscriber(
         subscriber,
         (value) => currentBuffer.push(value),
-        // Pass all errors to the consumer.
-        undefined,
         () => {
           subscriber.next(currentBuffer);
           subscriber.complete();
@@ -71,8 +69,6 @@ export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T,
           currentBuffer = [];
           subscriber.next(b);
         },
-        // Pass all errors to the consumer.
-        undefined,
         noop
       )
     );

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -102,7 +102,6 @@ export function bufferCount<T>(bufferSize: number, startBufferEvery: number | nu
             }
           }
         },
-        undefined,
         () => {
           // When the source completes, emit all of our
           // active buffers.
@@ -111,6 +110,8 @@ export function bufferCount<T>(bufferSize: number, startBufferEvery: number | nu
           }
           subscriber.complete();
         },
+        // Pass all errors through to consumer.
+        undefined,
         () => {
           // Clean up our memory when we teardown
           buffers = null!;

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -151,7 +151,6 @@ export function bufferTime<T>(bufferTimeSpan: number, ...otherArgs: any[]): Oper
           maxBufferSize <= buffer.length && emit(record);
         }
       },
-      undefined,
       () => {
         // The source completed, emit all of the active
         // buffers we have before we complete.
@@ -162,6 +161,8 @@ export function bufferTime<T>(bufferTimeSpan: number, ...otherArgs: any[]): Oper
         subscriber.complete();
         subscriber.unsubscribe();
       },
+      // Pass all errors through to consumer.
+      undefined,
       // Clean up
       () => (bufferRecords = null)
     );

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -75,11 +75,8 @@ export function bufferToggle<T, O>(
           };
 
           // The line below will add the subscription to the parent subscriber *and* the closing subscription.
-          closingSubscription.add(
-            innerFrom(closingSelector(openValue)).subscribe(new OperatorSubscriber(subscriber, emitBuffer, undefined, noop))
-          );
+          closingSubscription.add(innerFrom(closingSelector(openValue)).subscribe(new OperatorSubscriber(subscriber, emitBuffer, noop)));
         },
-        undefined,
         noop
       )
     );
@@ -93,7 +90,6 @@ export function bufferToggle<T, O>(
             buffer.push(value);
           }
         },
-        undefined,
         () => {
           // Source complete. Emit all pending buffers.
           while (buffers.length > 0) {

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -68,7 +68,7 @@ export function bufferWhen<T>(closingSelector: () => ObservableInput<any>): Oper
       b && subscriber.next(b);
 
       // Get a new closing notifier and subscribe to it.
-      innerFrom(closingSelector()).subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openBuffer, undefined, noop)));
+      innerFrom(closingSelector()).subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openBuffer, noop)));
     };
 
     // Start the first buffer.
@@ -80,14 +80,14 @@ export function bufferWhen<T>(closingSelector: () => ObservableInput<any>): Oper
         subscriber,
         // Add every new value to the current buffer.
         (value) => buffer?.push(value),
-        // All errors are passed through to the consumer.
-        undefined,
         // When we complete, emit the buffer if we have one,
         // then complete the result.
         () => {
           buffer && subscriber.next(buffer);
           subscriber.complete();
         },
+        // Pass all errors through to consumer.
+        undefined,
         // Release memory on teardown
         () => (buffer = closingSubscriber = null!)
       )

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -112,7 +112,7 @@ export function catchError<T, O extends ObservableInput<any>>(
     let handledResult: Observable<ObservedValueOf<O>>;
 
     innerSub = source.subscribe(
-      new OperatorSubscriber(subscriber, undefined, (err) => {
+      new OperatorSubscriber(subscriber, undefined, undefined, (err) => {
         handledResult = innerFrom(selector(err, catchError(selector)(source)));
         if (innerSub) {
           innerSub.unsubscribe();

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -96,17 +96,18 @@ export function debounce<T>(durationSelector: (value: T) => ObservableInput<any>
           lastValue = value;
           // Capture our duration subscriber, so we can unsubscribe it when we're notified
           // and we're going to emit the value.
-          durationSubscriber = new OperatorSubscriber(subscriber, emit, undefined, noop);
+          durationSubscriber = new OperatorSubscriber(subscriber, emit, noop);
           // Subscribe to the duration.
           innerFrom(durationSelector(value)).subscribe(durationSubscriber);
         },
-        undefined,
         () => {
           // Source completed.
           // Emit any pending debounced values then complete
           emit();
           subscriber.complete();
         },
+        // Pass all errors through to consumer
+        undefined,
         () => {
           // Teardown.
           lastValue = durationSubscriber = null;

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -104,13 +104,14 @@ export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = asyn
             activeTask = scheduler.schedule(emitWhenIdle, dueTime);
           }
         },
-        undefined,
         () => {
           // Source completed.
           // Emit any pending debounced values then complete
           emit();
           subscriber.complete();
         },
+        // Pass all errors through to consumer.
+        undefined,
         () => {
           // Teardown.
           lastValue = activeTask = null;

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -46,7 +46,6 @@ export function defaultIfEmpty<T, R>(defaultValue: R): OperatorFunction<T, T | R
           hasValue = true;
           subscriber.next(value);
         },
-        undefined,
         () => {
           if (!hasValue) {
             subscriber.next(defaultValue!);

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -84,6 +84,6 @@ export function distinct<T, K>(keySelector?: (value: T) => K, flushes?: Observab
       })
     );
 
-    flushes?.subscribe(new OperatorSubscriber(subscriber, () => distinctKeys.clear(), undefined, noop));
+    flushes?.subscribe(new OperatorSubscriber(subscriber, () => distinctKeys.clear(), noop));
   });
 }

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -53,7 +53,6 @@ export function every<T>(
             subscriber.complete();
           }
         },
-        undefined,
         () => {
           subscriber.next(true);
           subscriber.complete();

--- a/src/internal/operators/exhaustAll.ts
+++ b/src/internal/operators/exhaustAll.ts
@@ -57,14 +57,13 @@ export function exhaustAll<O extends ObservableInput<any>>(): OperatorFunction<O
         (inner) => {
           if (!innerSub) {
             innerSub = innerFrom(inner).subscribe(
-              new OperatorSubscriber(subscriber, undefined, undefined, () => {
+              new OperatorSubscriber(subscriber, undefined, () => {
                 innerSub = null;
                 isComplete && subscriber.complete();
               })
             );
           }
         },
-        undefined,
         () => {
           isComplete = true;
           !innerSub && subscriber.complete();

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -83,14 +83,13 @@ export function exhaustMap<T, R, O extends ObservableInput<any>>(
         subscriber,
         (outerValue) => {
           if (!innerSub) {
-            innerSub = new OperatorSubscriber(subscriber, undefined, undefined, () => {
+            innerSub = new OperatorSubscriber(subscriber, undefined, () => {
               innerSub = null;
               isComplete && subscriber.complete();
             });
             innerFrom(project(outerValue, index++)).subscribe(innerSub);
           }
         },
-        undefined,
         () => {
           isComplete = true;
           !innerSub && subscriber.complete();

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -79,7 +79,6 @@ export function createFind<T>(
             subscriber.complete();
           }
         },
-        undefined,
         () => {
           subscriber.next(findIndex ? -1 : undefined);
           subscriber.complete();

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -175,10 +175,10 @@ export function groupBy<T, K, R>(
                   group!.complete();
                   durationSubscriber?.unsubscribe();
                 },
+                // Completions are also sent to the group, but just the group.
+                undefined,
                 // Errors on the duration subscriber are sent to the group
                 // but only the group. They are not sent to the main subscription.
-                undefined,
-                // Completions are also sent to the group, but just the group.
                 undefined,
                 // Teardown: Remove this group from our map.
                 () => groups.delete(key)
@@ -195,10 +195,10 @@ export function groupBy<T, K, R>(
           handleError(err);
         }
       },
-      // Error from the source.
-      handleError,
       // Source completes.
       () => notify((consumer) => consumer.complete()),
+      // Error from the source.
+      handleError,
       // Free up memory.
       // When the source subscription is _finally_ torn down, release the subjects and keys
       // in our groups Map, they may be quite large and we don't want to keep them around if we

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -74,7 +74,6 @@ export function isEmpty<T>(): OperatorFunction<T, boolean> {
           subscriber.next(false);
           subscriber.complete();
         },
-        undefined,
         () => {
           subscriber.next(true);
           subscriber.complete();

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -65,12 +65,12 @@ export function materialize<T>(): OperatorFunction<T, Notification<T> & Observab
         (value) => {
           subscriber.next(Notification.createNext(value));
         },
-        (err) => {
-          subscriber.next(Notification.createError(err));
-          subscriber.complete();
-        },
         () => {
           subscriber.next(Notification.createComplete());
+          subscriber.complete();
+        },
+        (err) => {
+          subscriber.next(Notification.createError(err));
           subscriber.complete();
         }
       )

--- a/src/internal/operators/mergeInternals.ts
+++ b/src/internal/operators/mergeInternals.ts
@@ -84,13 +84,13 @@ export function mergeInternals<T, R>(
             subscriber.next(innerValue);
           }
         },
-        // Errors are passed to the destination.
-        undefined,
         () => {
           // Flag that we have completed, so we know to check the buffer
           // during finalization.
           innerComplete = true;
         },
+        // Errors are passed to the destination.
+        undefined,
         () => {
           // During finalization, if the inner completed (it wasn't errored or
           // cancelled), then we want to try the next item in the buffer if
@@ -129,17 +129,11 @@ export function mergeInternals<T, R>(
 
   // Subscribe to our source observable.
   source.subscribe(
-    new OperatorSubscriber(
-      subscriber,
-      outerNext,
-      // Errors are passed through
-      undefined,
-      () => {
-        // Outer completed, make a note of it, and check to see if we can complete everything.
-        isComplete = true;
-        checkComplete();
-      }
-    )
+    new OperatorSubscriber(subscriber, outerNext, () => {
+      // Outer completed, make a note of it, and check to see if we can complete everything.
+      isComplete = true;
+      checkComplete();
+    })
   );
 
   // Additional teardown (for when the destination is torn down).

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -60,8 +60,8 @@ export function observeOn<T>(scheduler: SchedulerLike, delay: number = 0): MonoT
       new OperatorSubscriber(
         subscriber,
         (value) => subscriber.add(scheduler.schedule(() => subscriber.next(value), delay)),
-        (err) => subscriber.add(scheduler.schedule(() => subscriber.error(err), delay)),
-        () => subscriber.add(scheduler.schedule(() => subscriber.complete(), delay))
+        () => subscriber.add(scheduler.schedule(() => subscriber.complete(), delay)),
+        (err) => subscriber.add(scheduler.schedule(() => subscriber.error(err), delay))
       )
     );
   });

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -67,7 +67,7 @@ export function repeat<T>(count = Infinity): MonoTypeOperatorFunction<T> {
         const subscribeForRepeat = () => {
           let syncUnsub = false;
           innerSub = source.subscribe(
-            new OperatorSubscriber(subscriber, undefined, undefined, () => {
+            new OperatorSubscriber(subscriber, undefined, () => {
               if (++soFar < count) {
                 if (innerSub) {
                   innerSub.unsubscribe();

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -71,7 +71,6 @@ export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Obs
                 syncResub = true;
               }
             },
-            undefined,
             () => {
               isNotifierComplete = true;
               checkComplete();
@@ -86,7 +85,7 @@ export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Obs
       isMainComplete = false;
 
       innerSub = source.subscribe(
-        new OperatorSubscriber(subscriber, undefined, undefined, () => {
+        new OperatorSubscriber(subscriber, undefined, () => {
           isMainComplete = true;
           // Check to see if we are complete, and complete if so.
           // If we are not complete. Get the subject. This calls the `notifier` function.

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -84,6 +84,8 @@ export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTy
                 }
                 subscriber.next(value);
               },
+              // Completions are passed through to consumer.
+              undefined,
               (err) => {
                 if (soFar++ < count) {
                   if (innerSub) {

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -66,7 +66,7 @@ export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<a
 
     const subscribeForRetryWhen = () => {
       innerSub = source.subscribe(
-        new OperatorSubscriber(subscriber, undefined, (err) => {
+        new OperatorSubscriber(subscriber, undefined, undefined, (err) => {
           if (!errors$) {
             errors$ = new Subject();
             notifier(errors$).subscribe(

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -60,6 +60,6 @@ export function sample<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T
         subscriber.next(value);
       }
     };
-    notifier.subscribe(new OperatorSubscriber(subscriber, emit, undefined, noop));
+    notifier.subscribe(new OperatorSubscriber(subscriber, emit, noop));
   });
 }

--- a/src/internal/operators/scanInternals.ts
+++ b/src/internal/operators/scanInternals.ts
@@ -49,7 +49,6 @@ export function scanInternals<V, A, S>(
           // Maybe send it to the consumer.
           emitOnNext && subscriber.next(state);
         },
-        undefined,
         // If an onComplete was given, call it, otherwise
         // just pass through the complete notification to the consumer.
         emitBeforeComplete &&

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -101,7 +101,6 @@ export function sequenceEqual<T>(
             !comparator(a, buffer.shift()!) && emit(false);
           }
         },
-        undefined,
         () => {
           // Or observable completed
           selfState.complete = true;

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -107,7 +107,6 @@ export function single<T>(predicate?: (value: T, index: number, source: Observab
             singleValue = value;
           }
         },
-        undefined,
         () => {
           if (hasValue) {
             subscriber.next(singleValue);

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -53,7 +53,6 @@ export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunctio
         skipSubscriber?.unsubscribe();
         taking = true;
       },
-      undefined,
       noop
     );
 

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -110,7 +110,6 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
               // handling the deprecate result selector here. This is because with this architecture
               // it ends up being smaller than using the map operator.
               (innerValue) => subscriber.next(resultSelector ? resultSelector(value, innerValue, outerIndex, innerIndex++) : innerValue),
-              undefined,
               () => {
                 // The inner has completed. Null out the inner subcriber to
                 // free up memory and to signal that we have no inner subscription
@@ -121,7 +120,6 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
             ))
           );
         },
-        undefined,
         () => {
           isComplete = true;
           checkComplete();

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -62,7 +62,6 @@ export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
               // want to take, we remove the oldest value from the buffer.
               count < buffer.length && buffer.shift();
             },
-            undefined,
             () => {
               // The source completed, we now know what are last values
               // are, emit them in the order they were received.
@@ -71,6 +70,8 @@ export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
               }
               subscriber.complete();
             },
+            // Errors are passed through to the consumer
+            undefined,
             () => {
               // During teardown release the values in our buffer.
               buffer = null!;

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -44,7 +44,7 @@ import { noop } from '../util/noop';
  */
 export function takeUntil<T>(notifier: ObservableInput<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
-    innerFrom(notifier).subscribe(new OperatorSubscriber(subscriber, () => subscriber.complete(), undefined, noop));
+    innerFrom(notifier).subscribe(new OperatorSubscriber(subscriber, () => subscriber.complete(), noop));
     !subscriber.closed && source.subscribe(subscriber);
   });
 }

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -126,13 +126,13 @@ export function tap<T>(
               tapObserver.next?.(value);
               subscriber.next(value);
             },
-            (err) => {
-              tapObserver.error?.(err);
-              subscriber.error(err);
-            },
             () => {
               tapObserver.complete?.();
               subscriber.complete();
+            },
+            (err) => {
+              tapObserver.error?.(err);
+              subscriber.error(err);
             }
           )
         );

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -84,9 +84,7 @@ export function throttle<T>(
     };
 
     const startThrottle = (value: T) =>
-      (throttled = innerFrom(durationSelector(value)).subscribe(
-        new OperatorSubscriber(subscriber, endThrottling, undefined, cleanupThrottling)
-      ));
+      (throttled = innerFrom(durationSelector(value)).subscribe(new OperatorSubscriber(subscriber, endThrottling, cleanupThrottling)));
 
     const send = () => {
       if (hasValue) {
@@ -115,7 +113,6 @@ export function throttle<T>(
           sendValue = value;
           !(throttled && !throttled.closed) && (leading ? send() : startThrottle(value));
         },
-        undefined,
         () => {
           isComplete = true;
           !(trailing && hasValue && throttled && !throttled.closed) && subscriber.complete();

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -45,7 +45,6 @@ export function throwIfEmpty<T>(errorFactory: () => any = defaultErrorFactory): 
           hasValue = true;
           subscriber.next(value);
         },
-        undefined,
         () => (hasValue ? subscriber.complete() : subscriber.error(errorFactory()))
       )
     );

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -62,11 +62,11 @@ export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T
       new OperatorSubscriber(
         subscriber,
         (value) => windowSubject?.next(value),
-        errorHandler,
         () => {
           windowSubject.complete();
           subscriber.complete();
-        }
+        },
+        errorHandler
       )
     );
 
@@ -78,8 +78,8 @@ export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T
           windowSubject.complete();
           subscriber.next((windowSubject = new Subject()));
         },
-        errorHandler,
-        noop
+        noop,
+        errorHandler
       )
     );
 

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -107,17 +107,17 @@ export function windowCount<T>(windowSize: number, startWindowEvery: number = 0)
             subscriber.next(window.asObservable());
           }
         },
-        (err) => {
-          while (windows.length > 0) {
-            windows.shift()!.error(err);
-          }
-          subscriber.error(err);
-        },
         () => {
           while (windows.length > 0) {
             windows.shift()!.complete();
           }
           subscriber.complete();
+        },
+        (err) => {
+          while (windows.length > 0) {
+            windows.shift()!.error(err);
+          }
+          subscriber.error(err);
         },
         () => {
           starts = null!;

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -183,10 +183,10 @@ export function windowTime<T>(windowTimeSpan: number, ...otherArgs: any[]): Oper
             maxWindowSize <= ++record.seen && closeWindow(record);
           });
         },
-        // Notify the windows and the downstream subscriber of the error and clean up.
-        (err) => terminate((consumer) => consumer.error(err)),
         // Complete the windows and the downstream subscriber and clean up.
-        () => terminate((consumer) => consumer.complete())
+        () => terminate((consumer) => consumer.complete()),
+        // Notify the windows and the downstream subscriber of the error and clean up.
+        (err) => terminate((consumer) => consumer.error(err))
       )
     );
 

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -91,9 +91,8 @@ export function windowToggle<T, O>(
 
           subscriber.next(window.asObservable());
 
-          closingSubscription.add(closingNotifier.subscribe(new OperatorSubscriber(subscriber, closeWindow, handleError, noop)));
+          closingSubscription.add(closingNotifier.subscribe(new OperatorSubscriber(subscriber, closeWindow, noop, handleError)));
         },
-        undefined,
         noop
       )
     );
@@ -110,7 +109,6 @@ export function windowToggle<T, O>(
             window.next(value);
           }
         },
-        handleError,
         () => {
           // Complete all of our windows before we complete.
           while (0 < windows.length) {
@@ -118,6 +116,7 @@ export function windowToggle<T, O>(
           }
           subscriber.complete();
         },
+        handleError,
         () => {
           // Add this teardown so that all window subjects are
           // disposed of. This way, if a user tries to subscribe

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -94,7 +94,7 @@ export function windowWhen<T>(closingSelector: () => ObservableInput<any>): Oper
       // to capture the subscriber (aka Subscription)
       // so we can clean it up when we close the window
       // and open a new one.
-      closingNotifier.subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openWindow, handleError, openWindow)));
+      closingNotifier.subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openWindow, openWindow, handleError)));
     };
 
     // Start the first window.
@@ -105,12 +105,12 @@ export function windowWhen<T>(closingSelector: () => ObservableInput<any>): Oper
       new OperatorSubscriber(
         subscriber,
         (value) => window!.next(value),
-        handleError,
         () => {
           // The source completed, close the window and complete.
           window!.complete();
           subscriber.complete();
         },
+        handleError,
         () => {
           // Be sure to clean up our closing subscription
           // when this tears down.

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -88,7 +88,6 @@ export function withLatestFrom<T, R>(...inputs: any[]): OperatorFunction<T, R | 
               (ready = hasValue.every(identity)) && (hasValue = null!);
             }
           },
-          undefined,
           // Completing one of the other sources has
           // no bearing on the completion of our result.
           noop


### PR DESCRIPTION
Moves the error handler arg in `OperatorSubscriber`, because in most cases we were passing `undefined` and then a complete handler.

```ts
new OperatorSubscriber(
  subscriber,
  (value) => { /* ... */ },
  undefined,
  () => { /* complete */ }
)

// becomes

new OperatorSubscriber(
  subscriber,
  (value) => { /* ... */ },
  () => { /* complete */ }
)
```
