### PR TITLE
chore(switchMapTo): convert switchMapTo tests to run mode

### DIFF
--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -79,13 +79,12 @@ describe('switchMapTo', () => {
   it('should switch a synchronous many outer to a synchronous many inner', (done) => {
     const a = of(1, 2, 3);
     const expected = ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
-    a.pipe(switchMapTo(of('a', 'b', 'c'))).subscribe(
-      (x) => {
+    a.pipe(switchMapTo(of('a', 'b', 'c'))).subscribe({
+      next(x) {
         expect(x).to.equal(expected.shift());
       },
-      null,
-      done
-    );
+      complete: done,
+    });
   });
 
   it('should unsub inner observables', () => {

--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -1,284 +1,342 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { Observable, of } from 'rxjs';
 import { switchMapTo, mergeMap, take } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {switchMapTo} */
 describe('switchMapTo', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should map-and-flatten each item to an Observable', () => {
-    const e1 =    hot('--1-----3--5-------|');
-    const e1subs =    '^                  !';
-    const e2 =   cold('x-x-x|              ', {x: 10});
-    const expected =  '--x-x-x-x-xx-x-x---|';
-    const values = {x: 10};
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --1-----3--5-------|');
+      const e1subs = '  ^------------------!';
+      const e2 = cold('   x-x-x|            ', { x: 10 });
+      //                        x-x-x|
+      //                           x-x-x|
+      const expected = '--x-x-x-x-xx-x-x---|';
+      const values = { x: 10 };
 
-    const result = e1.pipe(switchMapTo(e2));
+      const result = e1.pipe(switchMapTo(e2));
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should support the deprecated resultSelector', () => {
     const results: Array<number[]> = [];
 
-    of(1, 2, 3).pipe(
-      switchMapTo(
-        of(4, 5, 6),
-        (a, b, i, ii) => [a, b, i, ii]
-      )
-    )
-    .subscribe({
-      next (value) {
-        results.push(value);
-      },
-      error(err) {
-        throw err;
-      },
-      complete() {
-        expect(results).to.deep.equal([
-          [1, 4, 0, 0],
-          [1, 5, 0, 1],
-          [1, 6, 0, 2],
-          [2, 4, 1, 0],
-          [2, 5, 1, 1],
-          [2, 6, 1, 2],
-          [3, 4, 2, 0],
-          [3, 5, 2, 1],
-          [3, 6, 2, 2],
-        ]);
-      }
-    });
+    of(1, 2, 3)
+      .pipe(switchMapTo(of(4, 5, 6), (a, b, i, ii) => [a, b, i, ii]))
+      .subscribe({
+        next(value) {
+          results.push(value);
+        },
+        error(err) {
+          throw err;
+        },
+        complete() {
+          expect(results).to.deep.equal([
+            [1, 4, 0, 0],
+            [1, 5, 0, 1],
+            [1, 6, 0, 2],
+            [2, 4, 1, 0],
+            [2, 5, 1, 1],
+            [2, 6, 1, 2],
+            [3, 4, 2, 0],
+            [3, 5, 2, 1],
+            [3, 6, 2, 2],
+          ]);
+        },
+      });
   });
 
   it('should support a void resultSelector (still deprecated)', () => {
     const results: number[] = [];
 
-    of(1, 2, 3).pipe(
-      switchMapTo(
-        of(4, 5, 6),
-        void 0
-      )
-    )
-    .subscribe({
-      next (value) {
-        results.push(value);
-      },
-      error(err) {
-        throw err;
-      },
-      complete() {
-        expect(results).to.deep.equal([
-          4, 5, 6, 4, 5, 6, 4, 5, 6
-        ]);
-      }
-    });
+    of(1, 2, 3)
+      .pipe(switchMapTo(of(4, 5, 6), void 0))
+      .subscribe({
+        next(value) {
+          results.push(value);
+        },
+        error(err) {
+          throw err;
+        },
+        complete() {
+          expect(results).to.deep.equal([4, 5, 6, 4, 5, 6, 4, 5, 6]);
+        },
+      });
   });
 
   it('should switch a synchronous many outer to a synchronous many inner', (done) => {
     const a = of(1, 2, 3);
     const expected = ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
-    a.pipe(switchMapTo(of('a', 'b', 'c'))).subscribe((x) => {
-      expect(x).to.equal(expected.shift());
-    }, null, done);
+    a.pipe(switchMapTo(of('a', 'b', 'c'))).subscribe(
+      (x) => {
+        expect(x).to.equal(expected.shift());
+      },
+      null,
+      done
+    );
   });
 
   it('should unsub inner observables', () => {
     let unsubbed = 0;
 
-    of('a', 'b').pipe(switchMapTo(
-      new Observable<string>((subscriber) => {
-        subscriber.complete();
-        return () => {
-          unsubbed++;
-        };
-      })
-    )).subscribe();
+    of('a', 'b')
+      .pipe(
+        switchMapTo(
+          new Observable<string>((subscriber) => {
+            subscriber.complete();
+            return () => {
+              unsubbed++;
+            };
+          })
+        )
+      )
+      .subscribe();
 
     expect(unsubbed).to.equal(2);
   });
 
   it('should switch to an inner cold observable', () => {
-    const x =   cold(         '--a--b--c--d--e--|          ');
-    const xsubs =   ['         ^         !                 ',
-    //                                 --a--b--c--d--e--|
-                     '                   ^                !'];
-    const e1 =   hot('---------x---------x---------|       ');
-    const e1subs =   '^                            !       ';
-    const expected = '-----------a--b--c---a--b--c--d--e--|';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|          ');
+      const xsubs = [
+        '               ---------^---------!                 ',
+        //                                 --a--b--c--d--e--|
+        '               -------------------^----------------!',
+      ];
+      const e1 = hot('  ---------x---------x---------|       ');
+      const e1subs = '  ^----------------------------!       ';
+      const expected = '-----------a--b--c---a--b--c--d--e--|';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch to an inner cold observable, outer eventually throws', () => {
-    const x =   cold(         '--a--b--c--d--e--|');
-    const xsubs =    '         ^         !       ';
-    const e1 =   hot('---------x---------#       ');
-    const e1subs =   '^                  !       ';
-    const expected = '-----------a--b--c-#       ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|');
+      const xsubs = '   ---------^---------!       ';
+      const e1 = hot('  ---------x---------#       ');
+      const e1subs = '  ^------------------!       ';
+      const expected = '-----------a--b--c-#       ';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch to an inner cold observable, outer is unsubscribed early', () => {
-    const x =   cold(         '--a--b--c--d--e--|   ');
-    const xsubs =   ['         ^         !          ',
-    //                                 --a--b--c--d--e--|
-                     '                   ^  !       '];
-    const e1 =   hot('---------x---------x---------|');
-    const unsub =    '                      !       ';
-    const e1subs =   '^                     !       ';
-    const expected = '-----------a--b--c---a-       ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|   ');
+      const xsubs = [
+        '               ---------^---------!          ',
+        //                                 --a--b--c--d--e--|
+        '               -------------------^--!       ',
+      ];
+      const e1 = hot('  ---------x---------x---------|');
+      const unsub = '   ----------------------!       ';
+      const e1subs = '  ^---------------------!       ';
+      const expected = '-----------a--b--c---a-       ';
 
-    expectObservable(e1.pipe(switchMapTo(x)), unsub).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x)), unsub).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const x =   cold(         '--a--b--c--d--e--|   ');
-    const xsubs =   ['         ^         !          ',
-    //                                 --a--b--c--d--e--|
-                     '                   ^  !       '];
-    const e1 =   hot('---------x---------x---------|');
-    const e1subs =   '^                     !       ';
-    const expected = '-----------a--b--c---a-       ';
-    const unsub =    '                      !       ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('--a--b--c--d--e--|   ');
+      const xsubs = [
+        '               ---------^---------!          ',
+        //                                 --a--b--c--d--e--|
+        '               -------------------^--!       ',
+      ];
+      const e1 = hot('  ---------x---------x---------|');
+      const e1subs = '  ^---------------------!       ';
+      const expected = '-----------a--b--c---a-       ';
+      const unsub = '   ----------------------!       ';
 
-    const result = e1.pipe(
-      mergeMap(x => of(x)),
-      switchMapTo(x),
-      mergeMap(x => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x) => of(x)),
+        switchMapTo(x),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch to an inner cold observable, inner never completes', () => {
-    const x =   cold(         '--a--b--c--d--e-          ');
-    const xsubs =   ['         ^         !               ',
-    //                                 --a--b--c--d--e-
-                     '                   ^               '];
-    const e1 =   hot('---------x---------y---------|     ');
-    const e1subs =   '^                            !     ';
-    const expected = '-----------a--b--c---a--b--c--d--e-';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e-          ');
+      const xsubs = [
+        '               ---------^---------!               ',
+        //                                 --a--b--c--d--e-
+        '               -------------------^               ',
+      ];
+      const e1 = hot('  ---------x---------y---------|     ');
+      const e1subs = '  ^----------------------------!     ';
+      const expected = '-----------a--b--c---a--b--c--d--e-';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle a synchronous switch to the inner observable', () => {
-    const x =   cold(         '--a--b--c--d--e--|   ');
-    const xsubs =   ['         (^!)                 ',
-                     '         ^                !   '];
-    const e1 =   hot('---------(xx)----------------|');
-    const e1subs =   '^                            !';
-    const expected = '-----------a--b--c--d--e-----|';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|   ');
+      // prettier-ignore
+      const xsubs = [
+        '               ---------(^!)                 ', 
+        '               ---------^----------------!   '
+      ];
+      const e1 = hot('  ---------(xx)----------------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '-----------a--b--c--d--e-----|';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch to an inner cold observable, inner raises an error', () => {
-    const x =   cold(         '--a--b--#            ');
-    const xsubs =    '         ^       !            ';
-    const e1 =   hot('---------x---------x---------|');
-    const e1subs =   '^                !            ';
-    const expected = '-----------a--b--#            ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--#            ');
+      const xsubs = '   ---------^-------!            ';
+      const e1 = hot('  ---------x---------x---------|');
+      const e1subs = '  ^----------------!            ';
+      const expected = '-----------a--b--#            ';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch an inner hot observable', () => {
-    const x =    hot('--p-o-o-p---a--b--c--d-|      ');
-    const xsubs =   ['         ^         !          ',
-                     '                   ^   !      '];
-    const e1 =   hot('---------x---------x---------|');
-    const e1subs =   '^                            !';
-    const expected = '------------a--b--c--d-------|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const x = hot('   --p-o-o-p---a--b--c--d-|      ');
+      // prettier-ignore
+      const xsubs = [
+        '               ---------^---------!          ',
+        '               -------------------^---!      '
+      ];
+      const e1 = hot('  ---------x---------x---------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '------------a--b--c--d-------|';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch to an inner empty', () => {
-    const x = cold('|');
-    const xsubs =   ['         (^!)                 ',
-                     '                   (^!)       '];
-    const e1 =   hot('---------x---------x---------|');
-    const e1subs =   '^                            !';
-    const expected = '-----------------------------|';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           |                    ');
+      const xsubs = [
+        '               ---------(^!)                 ',
+        //                                 |
+        '               -------------------(^!)       ',
+      ];
+      const e1 = hot('  ---------x---------x---------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '-----------------------------|';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch to an inner never', () => {
-    const x = cold('-');
-    const xsubs =   ['         ^         !          ',
-                     '                   ^          '];
-    const e1 =   hot('---------x---------x---------|');
-    const e1subs =   '^                            !';
-    const expected = '------------------------------';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           -                    ');
+      const xsubs = [
+        '               ---------^---------!          ',
+        //                                 -
+        '               -------------------^          ',
+      ];
+      const e1 = hot('  ---------x---------x---------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '------------------------------';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch to an inner that just raises an error', () => {
-    const x = cold('#');
-    const xsubs =    '         (^!)                 ';
-    const e1 =   hot('---------x---------x---------|');
-    const e1subs =   '^        !                    ';
-    const expected = '---------#                    ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           #                    ');
+      const xsubs = '   ---------(^!)                 ';
+      const e1 = hot('  ---------x---------x---------|');
+      const e1subs = '  ^--------!                    ';
+      const expected = '---------#                    ';
 
-    expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(x))).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle an empty outer', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '|   ';
 
-    expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle a never outer', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle an outer that just raises and error', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMapTo(of('foo')))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -287,10 +345,9 @@ describe('switchMapTo', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      switchMapTo(of(0)),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(switchMapTo(of(0)), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `switchMapTo` tests to run mode.

**Related issue (if exists):**
None
