### PR TITLE
feat: add (optional) defaultValue parameters to firstValueFrom and lastValueFrom

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -123,6 +123,7 @@ export declare type FactoryOrValue<T> = T | (() => T);
 
 export declare type Falsy = null | undefined | false | 0 | -0 | 0n | '';
 
+export declare function firstValueFrom<T, D>(source: Observable<T>, defaultValue: D): Promise<T | D>;
 export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
 export declare function forkJoin(scheduler: null | undefined): Observable<never>;
@@ -172,6 +173,7 @@ export declare function interval(period?: number, scheduler?: SchedulerLike): Ob
 
 export declare function isObservable(obj: any): obj is Observable<unknown>;
 
+export declare function lastValueFrom<T, D>(source: Observable<T>, defaultValue: D): Promise<T | D>;
 export declare function lastValueFrom<T>(source: Observable<T>): Promise<T>;
 
 export declare function merge<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A[number]>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -123,7 +123,7 @@ export declare type FactoryOrValue<T> = T | (() => T);
 
 export declare type Falsy = null | undefined | false | 0 | -0 | 0n | '';
 
-export declare function firstValueFrom<T, D>(source: Observable<T>, defaultValue: D): Promise<T | D>;
+export declare function firstValueFrom<T, D>(source: Observable<T>, config: FirstValueFromConfig<D>): Promise<T | D>;
 export declare function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
 export declare function forkJoin(scheduler: null | undefined): Observable<never>;
@@ -173,7 +173,7 @@ export declare function interval(period?: number, scheduler?: SchedulerLike): Ob
 
 export declare function isObservable(obj: any): obj is Observable<unknown>;
 
-export declare function lastValueFrom<T, D>(source: Observable<T>, defaultValue: D): Promise<T | D>;
+export declare function lastValueFrom<T, D>(source: Observable<T>, config: LastValueFromConfig<D>): Promise<T | D>;
 export declare function lastValueFrom<T>(source: Observable<T>): Promise<T>;
 
 export declare function merge<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A[number]>;

--- a/spec-dtslint/firstValueFrom-spec.ts
+++ b/spec-dtslint/firstValueFrom-spec.ts
@@ -2,7 +2,19 @@ import { firstValueFrom } from 'rxjs';
 import { a$ } from 'helpers';
 
 describe('firstValueFrom', () => {
-  const r0 = firstValueFrom(a$); // $ExpectType Promise<A>
-  const r1 = firstValueFrom(); // $ExpectError
-  const r2 = firstValueFrom(Promise.resolve(42)); // $ExpectError
+  it('should infer the element type', () => {
+    const r = firstValueFrom(a$); // $ExpectType Promise<A>
+  })
+
+  it('should infer the element type from a default value', () => {
+    const r = firstValueFrom(a$, null); // $ExpectType Promise<A | null>
+  });
+
+  it('should require an argument', () => {
+    const r = firstValueFrom(); // $ExpectError
+  });
+
+  it('should require an observable argument', () => {
+    const r = firstValueFrom(Promise.resolve(42)); // $ExpectError
+  });
 });

--- a/spec-dtslint/firstValueFrom-spec.ts
+++ b/spec-dtslint/firstValueFrom-spec.ts
@@ -7,7 +7,7 @@ describe('firstValueFrom', () => {
   })
 
   it('should infer the element type from a default value', () => {
-    const r = firstValueFrom(a$, null); // $ExpectType Promise<A | null>
+    const r = firstValueFrom(a$, { defaultValue: null }); // $ExpectType Promise<A | null>
   });
 
   it('should require an argument', () => {

--- a/spec-dtslint/lastValueFrom-spec.ts
+++ b/spec-dtslint/lastValueFrom-spec.ts
@@ -2,7 +2,19 @@ import { lastValueFrom } from 'rxjs';
 import { a$ } from 'helpers';
 
 describe('lastValueFrom', () => {
-  const r0 = lastValueFrom(a$); // $ExpectType Promise<A>
-  const r1 = lastValueFrom(); // $ExpectError
-  const r2 = lastValueFrom(Promise.resolve(42)); // $ExpectError
+  it('should infer the element type', () => {
+    const r = lastValueFrom(a$); // $ExpectType Promise<A>
+  });
+
+  it('should infer the element type from a default value', () => {
+    const r = lastValueFrom(a$, null); // $ExpectType Promise<A | null>
+  });
+
+  it('should require an argument', () => {
+    const r = lastValueFrom(); // $ExpectError
+  });
+
+  it('should require an observable argument', () => {
+    const r = lastValueFrom(Promise.resolve(42)); // $ExpectError
+  });
 });

--- a/spec-dtslint/lastValueFrom-spec.ts
+++ b/spec-dtslint/lastValueFrom-spec.ts
@@ -7,7 +7,7 @@ describe('lastValueFrom', () => {
   });
 
   it('should infer the element type from a default value', () => {
-    const r = lastValueFrom(a$, null); // $ExpectType Promise<A | null>
+    const r = lastValueFrom(a$, { defaultValue: null }); // $ExpectType Promise<A | null>
   });
 
   it('should require an argument', () => {

--- a/spec/firstValueFrom-spec.ts
+++ b/spec/firstValueFrom-spec.ts
@@ -17,6 +17,17 @@ describe('firstValueFrom', () => {
     expect(result).to.equal(0);
   });
 
+  it('should support an undefined config', async () => {
+    const source = EMPTY;
+    let error: any = null;
+    try {
+      await firstValueFrom(source, undefined as any);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).to.be.an.instanceOf(EmptyError);
+  });
+
   it('should error for empty observables', async () => {
     const source = EMPTY;
     let error: any = null;

--- a/spec/firstValueFrom-spec.ts
+++ b/spec/firstValueFrom-spec.ts
@@ -11,6 +11,12 @@ describe('firstValueFrom', () => {
     expect(finalized).to.be.true;
   });
 
+  it('should support a default value', async () => {
+    const source = EMPTY;
+    const result = await firstValueFrom(source, 0);
+    expect(result).to.equal(0);
+  });
+
   it('should error for empty observables', async () => {
     const source = EMPTY;
     let error: any = null;

--- a/spec/firstValueFrom-spec.ts
+++ b/spec/firstValueFrom-spec.ts
@@ -13,7 +13,7 @@ describe('firstValueFrom', () => {
 
   it('should support a default value', async () => {
     const source = EMPTY;
-    const result = await firstValueFrom(source, 0);
+    const result = await firstValueFrom(source, { defaultValue: 0 });
     expect(result).to.equal(0);
   });
 

--- a/spec/lastValueFrom-spec.ts
+++ b/spec/lastValueFrom-spec.ts
@@ -20,6 +20,17 @@ describe('lastValueFrom', () => {
     expect(result).to.equal(0);
   });
 
+  it('should support an undefined config', async () => {
+    const source = EMPTY;
+    let error: any = null;
+    try {
+      await lastValueFrom(source, undefined as any);
+    } catch (err) {
+      error = err;
+    }
+    expect(error).to.be.an.instanceOf(EmptyError);
+  });
+
   it('should error for empty observables', async () => {
     const source = EMPTY;
     let error: any = null;

--- a/spec/lastValueFrom-spec.ts
+++ b/spec/lastValueFrom-spec.ts
@@ -16,7 +16,7 @@ describe('lastValueFrom', () => {
 
   it('should support a default value', async () => {
     const source = EMPTY;
-    const result = await lastValueFrom(source, 0);
+    const result = await lastValueFrom(source, { defaultValue: 0 });
     expect(result).to.equal(0);
   });
 

--- a/spec/lastValueFrom-spec.ts
+++ b/spec/lastValueFrom-spec.ts
@@ -14,6 +14,12 @@ describe('lastValueFrom', () => {
     expect(finalized).to.be.true;
   });
 
+  it('should support a default value', async () => {
+    const source = EMPTY;
+    const result = await lastValueFrom(source, 0);
+    expect(result).to.equal(0);
+  });
+
   it('should error for empty observables', async () => {
     const source = EMPTY;
     let error: any = null;

--- a/src/internal/firstValueFrom.ts
+++ b/src/internal/firstValueFrom.ts
@@ -2,7 +2,11 @@ import { Observable } from './Observable';
 import { EmptyError } from './util/EmptyError';
 import { SafeSubscriber } from './Subscriber';
 
-export function firstValueFrom<T, D>(source: Observable<T>, defaultValue: D): Promise<T | D>;
+export interface FirstValueFromConfig<T> {
+  defaultValue: T;
+}
+
+export function firstValueFrom<T, D>(source: Observable<T>, config: FirstValueFromConfig<D>): Promise<T | D>;
 export function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 
 /**
@@ -45,10 +49,10 @@ export function firstValueFrom<T>(source: Observable<T>): Promise<T>;
  * ```
  *
  * @param source the observable to convert to a promise
- * @param defaultValue the value to use if the source completes without emitting a value
+ * @param config a configuration object to define the `defaultValue` to use if the source completes without emitting a value
  */
-export function firstValueFrom<T, D>(source: Observable<T>, defaultValue?: D) {
-  const hasDefaultValue = arguments.length >= 2;
+export function firstValueFrom<T, D>(source: Observable<T>, config?: FirstValueFromConfig<D>) {
+  const hasConfig = arguments.length >= 2;
   return new Promise<T | D>((resolve, reject) => {
     const subscriber = new SafeSubscriber<T>({
       next: (value) => {
@@ -57,8 +61,8 @@ export function firstValueFrom<T, D>(source: Observable<T>, defaultValue?: D) {
       },
       error: reject,
       complete: () => {
-        if (hasDefaultValue) {
-          resolve(defaultValue!);
+        if (hasConfig) {
+          resolve(config!.defaultValue);
         } else {
           reject(new EmptyError());
         }

--- a/src/internal/firstValueFrom.ts
+++ b/src/internal/firstValueFrom.ts
@@ -52,7 +52,7 @@ export function firstValueFrom<T>(source: Observable<T>): Promise<T>;
  * @param config a configuration object to define the `defaultValue` to use if the source completes without emitting a value
  */
 export function firstValueFrom<T, D>(source: Observable<T>, config?: FirstValueFromConfig<D>) {
-  const hasConfig = arguments.length >= 2;
+  const hasConfig = typeof config === 'object';
   return new Promise<T | D>((resolve, reject) => {
     const subscriber = new SafeSubscriber<T>({
       next: (value) => {

--- a/src/internal/lastValueFrom.ts
+++ b/src/internal/lastValueFrom.ts
@@ -51,7 +51,7 @@ export function lastValueFrom<T>(source: Observable<T>): Promise<T>;
  * @param config a configuration object to define the `defaultValue` to use if the source completes without emitting a value
  */
 export function lastValueFrom<T, D>(source: Observable<T>, config?: LastValueFromConfig<D>) {
-  const hasConfig = arguments.length >= 2;
+  const hasConfig = typeof config === 'object';
   return new Promise<T | D>((resolve, reject) => {
     let _hasValue = false;
     let _value: T;

--- a/src/internal/lastValueFrom.ts
+++ b/src/internal/lastValueFrom.ts
@@ -1,7 +1,11 @@
 import { Observable } from './Observable';
 import { EmptyError } from './util/EmptyError';
 
-export function lastValueFrom<T, D>(source: Observable<T>, defaultValue: D): Promise<T | D>;
+export interface LastValueFromConfig<T> {
+  defaultValue: T;
+}
+
+export function lastValueFrom<T, D>(source: Observable<T>, config: LastValueFromConfig<D>): Promise<T | D>;
 export function lastValueFrom<T>(source: Observable<T>): Promise<T>;
 
 /**
@@ -44,10 +48,10 @@ export function lastValueFrom<T>(source: Observable<T>): Promise<T>;
  * ```
  *
  * @param source the observable to convert to a promise
- * @param defaultValue the value to use if the source completes without emitting a value
+ * @param config a configuration object to define the `defaultValue` to use if the source completes without emitting a value
  */
-export function lastValueFrom<T, D>(source: Observable<T>, defaultValue?: D) {
-  const hasDefaultValue = arguments.length >= 2;
+export function lastValueFrom<T, D>(source: Observable<T>, config?: LastValueFromConfig<D>) {
+  const hasConfig = arguments.length >= 2;
   return new Promise<T | D>((resolve, reject) => {
     let _hasValue = false;
     let _value: T;
@@ -60,8 +64,8 @@ export function lastValueFrom<T, D>(source: Observable<T>, defaultValue?: D) {
       complete: () => {
         if (_hasValue) {
           resolve(_value);
-        } else if (hasDefaultValue) {
-          resolve(defaultValue!);
+        } else if (hasConfig) {
+          resolve(config!.defaultValue);
         } else {
           reject(new EmptyError());
         }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds an optional `defaultValue` parameter to `firstValueFrom` and `lastValueFrom`. The parameters are added using an overload to [avoid this issue](https://github.com/ReactiveX/rxjs/issues/4866) (for some usage, at least).

The `first` and `last` operators both support defaults and I see no reason why `firstValueFrom` and `lastValueFrom` should not do the same. Sure, you could apply `defaultIfEmpty` to the source, but you say the same for `first` and `last`. And, IMO, including `defaultValue` in the signatures serves as a reminder that the functions expect a value and that not having an available value is an unexpected/error situation.

Also, supporting default values would make implementing [a user-land equivalent that resolves with an `Option`](https://github.com/ReactiveX/rxjs/issues/5075#issuecomment-757908538) straightforward. (IMO, introducing a `Option` isn't something we should do while there are bunch of APIs that throw for empty sources.)

**Related issue (if exists):** Nope
