### PR TITLE
chore: undeprecate some result selectors

### DIFF
--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -25,7 +25,7 @@ describe('bindCallback', () => {
       expect(results).to.deep.equal(['undefined', 'done']);
     });
 
-    it('should still support deprecated resultSelector', () => {
+    it('should support a resultSelector', () => {
       function callback(datum: number, cb: Function) {
         cb(datum);
       }
@@ -46,7 +46,7 @@ describe('bindCallback', () => {
       expect(results).to.deep.equal([43, 'done']);
     });
 
-    it('should still support deprecated resultSelector if its void', () => {
+    it('should support a resultSelector if its void', () => {
       function callback(datum: number, cb: Function) {
         cb(datum);
       }

--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -26,7 +26,7 @@ describe('bindNodeCallback', () => {
       expect(results).to.deep.equal(['undefined', 'done']);
     });
 
-    it('should support the deprecated resultSelector', () => {
+    it('should a resultSelector', () => {
       function callback(cb: (err: any, n: number) => any) {
         cb(null, 42);
       }

--- a/spec/observables/forkJoin-spec.ts
+++ b/spec/observables/forkJoin-spec.ts
@@ -25,7 +25,7 @@ describe('forkJoin', () => {
     });
   });
 
-  it('should support the deprecated resultSelector with an Array of ObservableInputs', () => {
+  it('should support a resultSelector with an Array of ObservableInputs', () => {
     const results: Array<number | string> = [];
     forkJoin([of(1, 2, 3), of(4, 5, 6), of(7, 8, 9)], (a: number, b: number, c: number) => a + b + c).subscribe({
       next(value) {
@@ -42,7 +42,7 @@ describe('forkJoin', () => {
     expect(results).to.deep.equal([18, 'done']);
   });
 
-  it('should support the deprecated resultSelector with a spread of ObservableInputs', () => {
+  it('should support a resultSelector with a spread of ObservableInputs', () => {
     const results: Array<number | string> = [];
     forkJoin(of(1, 2, 3), of(4, 5, 6), of(7, 8, 9), (a: number, b: number, c: number) => a + b + c).subscribe({
       next(value) {

--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -3,8 +3,6 @@ import { SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { bindCallbackInternals } from './bindCallbackInternals';
 
-// tslint:disable:max-line-length
-/** @deprecated resultSelector is no longer supported, use a mapping function. */
 export function bindCallback(
   callbackFunc: (...args: any[]) => void,
   resultSelector: (...args: any[]) => any,
@@ -16,8 +14,6 @@ export function bindCallback<A extends readonly unknown[], R extends readonly un
   callbackFunc: (...args: [...A, (...res: R) => void]) => void,
   schedulerLike?: SchedulerLike
 ): (...arg: A) => Observable<R extends [] ? void : R extends [any] ? R[0] : R>;
-
-// tslint:enable:max-line-length
 
 /**
  * Converts a callback API to a function that returns an Observable.

--- a/src/internal/observable/bindCallbackInternals.ts
+++ b/src/internal/observable/bindCallbackInternals.ts
@@ -16,7 +16,6 @@ export function bindCallbackInternals(
     if (isScheduler(resultSelector)) {
       scheduler = resultSelector;
     } else {
-      // DEPRECATED PATH
       // The user provided a result selector.
       return function (this: any, ...args: any[]) {
         return (bindCallbackInternals(isNodeStyle, callbackFunc, scheduler) as any)

--- a/src/internal/observable/bindNodeCallback.ts
+++ b/src/internal/observable/bindNodeCallback.ts
@@ -3,7 +3,6 @@ import { Observable } from '../Observable';
 import { SchedulerLike } from '../types';
 import { bindCallbackInternals } from './bindCallbackInternals';
 
-/** @deprecated resultSelector is deprecated, pipe to map instead */
 export function bindNodeCallback(
   callbackFunc: (...args: any[]) => void,
   resultSelector: (...args: any[]) => any,

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -36,7 +36,7 @@ export function combineLatest<A extends readonly unknown[]>(...sources: [...Obse
 export function combineLatest<A extends readonly unknown[], R>(
   ...sourcesAndResultSelectorAndScheduler: [...ObservableInputTuple<A>, (...values: A) => R, SchedulerLike]
 ): Observable<R>;
-/** @deprecated Use the version that takes an array of Observables instead */
+/** @deprecated Use the version that takes an array of Observables instead. (e.g. `combineLatest([a$, b$], (a, b) => a + b)`) */
 export function combineLatest<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -19,7 +19,6 @@ export function combineLatest<A extends readonly unknown[], R>(
   resultSelector: (...values: A) => R,
   scheduler: SchedulerLike
 ): Observable<R>;
-/** @deprecated resultSelector no longer supported, pipe to map instead, Details https://rxjs.dev/deprecations/resultSelector */
 export function combineLatest<A extends readonly unknown[], R>(
   sources: readonly [...ObservableInputTuple<A>],
   resultSelector: (...values: A) => R
@@ -37,7 +36,7 @@ export function combineLatest<A extends readonly unknown[]>(...sources: [...Obse
 export function combineLatest<A extends readonly unknown[], R>(
   ...sourcesAndResultSelectorAndScheduler: [...ObservableInputTuple<A>, (...values: A) => R, SchedulerLike]
 ): Observable<R>;
-/** @deprecated resultSelector no longer supported, pipe to map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated Use the version that takes an array of Observables instead */
 export function combineLatest<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -12,7 +12,6 @@ export function forkJoin(scheduler: null | undefined): Observable<never>;
 // forkJoin([a, b, c])
 export function forkJoin(sources: readonly []): Observable<never>;
 export function forkJoin<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
-/** @deprecated resultSelector is deprecated, pipe to map instead */
 export function forkJoin<A extends readonly unknown[], R>(
   sources: readonly [...ObservableInputTuple<A>],
   resultSelector: (...values: A) => R
@@ -21,7 +20,7 @@ export function forkJoin<A extends readonly unknown[], R>(
 // forkJoin(a, b, c)
 /** @deprecated Use the version that takes an array of Observables instead, Details https://rxjs.dev/deprecations/array-argument */
 export function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-/** @deprecated resultSelector is deprecated, pipe to map instead */
+/** @deprecated Use the version that takes an array of Observables instead, Details https://rxjs.dev/deprecations/array-argument */
 export function forkJoin<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -69,10 +69,8 @@ export interface AddEventListenerOptions extends EventListenerOptions {
 }
 
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
-/** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEvent<T>(target: FromEventTarget<any>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions): Observable<T>;
-/** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEvent<T>(
   target: FromEventTarget<any>,
   eventName: string,
@@ -205,12 +203,10 @@ export function fromEvent<T>(
   resultSelector?: (...args: any[]) => T
 ): Observable<T> {
   if (isFunction(options)) {
-    // DEPRECATED PATH
     resultSelector = options;
     options = undefined;
   }
   if (resultSelector) {
-    // DEPRECATED PATH
     return fromEvent<T>(target, eventName, options as EventListenerOptions).pipe(mapOneOrManyArgs(resultSelector));
   }
 

--- a/src/internal/observable/fromEventPattern.ts
+++ b/src/internal/observable/fromEventPattern.ts
@@ -8,7 +8,6 @@ export function fromEventPattern<T>(
   addHandler: (handler: NodeEventHandler) => any,
   removeHandler?: (handler: NodeEventHandler, signal?: any) => void
 ): Observable<T>;
-/** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEventPattern<T>(
   addHandler: (handler: NodeEventHandler) => any,
   removeHandler?: (handler: NodeEventHandler, signal?: any) => void,
@@ -146,7 +145,6 @@ export function fromEventPattern<T>(
   resultSelector?: (...args: any[]) => T
 ): Observable<T | T[]> {
   if (resultSelector) {
-    // DEPRECATED PATH
     return fromEventPattern<T>(addHandler, removeHandler).pipe(mapOneOrManyArgs(resultSelector));
   }
 

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -7,13 +7,11 @@ import { OperatorSubscriber } from '../operators/OperatorSubscriber';
 import { popResultSelector } from '../util/args';
 
 export function zip<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
-/** @deprecated resultSelector is no longer supported, pipe to map instead, Details https://rxjs.dev/deprecations/resultSelector */
 export function zip<A extends readonly unknown[], R>(
   sources: [...ObservableInputTuple<A>],
   resultSelector: (...values: A) => R
 ): Observable<R>;
 export function zip<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-/** @deprecated resultSelector is no longer supported, pipe to map instead, Details https://rxjs.dev/deprecations/resultSelector */
 export function zip<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

As outlined in #5824, this PR undeprecates the result selectors for:

- bindCallback
- bindNodeCallback
- combineLatest
- forkJoin
- fromEvent
- fromEventPattern
- zip

In addition to the reasons given in that issue for the undeprecation, there is another [in this comment](https://github.com/ReactiveX/rxjs/issues/4736#issuecomment-811065078) that applies to `bindCallback`, `bindNodeCallback`, `fromEvent` and `fromEventPattern`.

AFAICT, the docs that related to these deprecations have already been removed/updated to reflect said undeprecation. Anyway, the docs, etc. is what I'm looking at right now.

**Related issue (if exists):** #5824
