### PR TITLE
chore(switchMap): convert switchMap tests to run mode

### DIFF
--- a/spec/operators/switchMap-spec.ts
+++ b/spec/operators/switchMap-spec.ts
@@ -1,200 +1,220 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { switchMap, mergeMap, map, takeWhile, take } from 'rxjs/operators';
 import { concat, defer, of, Observable, BehaviorSubject } from 'rxjs';
 import { asInteropObservable } from '../helpers/interop-helper';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {switchMap} */
 describe('switchMap', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should map-and-flatten each item to an Observable', () => {
-    const e1 =    hot('--1-----3--5-------|');
-    const e1subs =    '^                  !';
-    const e2 =   cold('x-x-x|              ', {x: 10});
-    const expected =  '--x-x-x-y-yz-z-z---|';
-    const values = {x: 10, y: 30, z: 50};
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('   --1-----3--5-------|');
+      const e1subs = '   ^------------------!';
+      const e2 = cold('    x-x-x|            ', { x: 10 });
+      //                         x-x-x|
+      //                            x-x-x|
+      const expected = ' --x-x-x-y-yz-z-z---|';
+      const values = { x: 10, y: 30, z: 50 };
 
-    const result = e1.pipe(switchMap(x => e2.pipe(map(i => i * +x))));
+      const result = e1.pipe(switchMap((x) => e2.pipe(map((i) => i * +x))));
 
-    expectObservable(result).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should support the deprecated resultSelector', () => {
     const results: Array<number[]> = [];
 
-    of(1, 2, 3).pipe(
-      switchMap(
-        x => of(x, x + 1, x + 2),
-        (a, b, i, ii) => [a, b, i, ii]
+    of(1, 2, 3)
+      .pipe(
+        switchMap(
+          (x) => of(x, x + 1, x + 2),
+          (a, b, i, ii) => [a, b, i, ii]
+        )
       )
-    )
-    .subscribe({
-      next (value) {
-        results.push(value);
-      },
-      error(err) {
-        throw err;
-      },
-      complete() {
-        expect(results).to.deep.equal([
-          [1, 1, 0, 0],
-          [1, 2, 0, 1],
-          [1, 3, 0, 2],
-          [2, 2, 1, 0],
-          [2, 3, 1, 1],
-          [2, 4, 1, 2],
-          [3, 3, 2, 0],
-          [3, 4, 2, 1],
-          [3, 5, 2, 2],
-        ]);
-      }
-    });
+      .subscribe({
+        next(value) {
+          results.push(value);
+        },
+        error(err) {
+          throw err;
+        },
+        complete() {
+          expect(results).to.deep.equal([
+            [1, 1, 0, 0],
+            [1, 2, 0, 1],
+            [1, 3, 0, 2],
+            [2, 2, 1, 0],
+            [2, 3, 1, 1],
+            [2, 4, 1, 2],
+            [3, 3, 2, 0],
+            [3, 4, 2, 1],
+            [3, 5, 2, 2],
+          ]);
+        },
+      });
   });
 
   it('should support a void resultSelector (still deprecated)', () => {
     const results: number[] = [];
 
-    of(1, 2, 3).pipe(
-      switchMap(
-        x => of(x, x + 1, x + 2),
-        void 0
-      )
-    )
-    .subscribe({
-      next (value) {
-        results.push(value);
-      },
-      error(err) {
-        throw err;
-      },
-      complete() {
-        expect(results).to.deep.equal([
-          1, 2, 3, 2, 3, 4, 3, 4, 5
-        ]);
-      }
-    });
+    of(1, 2, 3)
+      .pipe(switchMap((x) => of(x, x + 1, x + 2), void 0))
+      .subscribe({
+        next(value) {
+          results.push(value);
+        },
+        error(err) {
+          throw err;
+        },
+        complete() {
+          expect(results).to.deep.equal([1, 2, 3, 2, 3, 4, 3, 4, 5]);
+        },
+      });
   });
 
   it('should unsub inner observables', () => {
     const unsubbed: string[] = [];
 
-    of('a', 'b').pipe(
-      switchMap(x =>
-        new Observable<string>((subscriber) => {
-          subscriber.complete();
-          return () => {
-            unsubbed.push(x);
-          };
-        })
+    of('a', 'b')
+      .pipe(
+        switchMap(
+          (x) =>
+            new Observable<string>((subscriber) => {
+              subscriber.complete();
+              return () => {
+                unsubbed.push(x);
+              };
+            })
+        )
       )
-    ).subscribe();
+      .subscribe();
 
     expect(unsubbed).to.deep.equal(['a', 'b']);
   });
 
   it('should switch inner cold observables', () => {
-    const x =   cold(         '--a--b--c--d--e--|           ');
-    const xsubs =    '         ^         !                  ';
-    const y =   cold(                   '---f---g---h---i--|');
-    const ysubs =    '                   ^                 !';
-    const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                            !        ';
-    const expected = '-----------a--b--c----f---g---h---i--|';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|           ');
+      const xsubs = '   ---------^---------!                  ';
+      const y = cold('                     ---f---g---h---i--|');
+      const ysubs = '   -------------------^-----------------!';
+      const e1 = hot('  ---------x---------y---------|        ');
+      const e1subs = '  ^----------------------------!        ';
+      const expected = '-----------a--b--c----f---g---h---i--|';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raise error when projection throws', () => {
-    const e1 =   hot('-------x-----y---|');
-    const e1subs =   '^      !          ';
-    const expected = '-------#          ';
-    function project(): any[] {
-      throw 'error';
-    }
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -------x-----y---|');
+      const e1subs = '  ^------!          ';
+      const expected = '-------#          ';
+      function project(): any[] {
+        throw 'error';
+      }
 
-    expectObservable(e1.pipe(switchMap(project))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(switchMap(project))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner cold observables, outer is unsubscribed early', () => {
-    const x =   cold(         '--a--b--c--d--e--|           ');
-    const xsubs =    '         ^         !                  ';
-    const y =   cold(                   '---f---g---h---i--|');
-    const ysubs =    '                   ^ !                ';
-    const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                    !                ';
-    const unsub =    '                     !                ';
-    const expected = '-----------a--b--c----                ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|           ');
+      const xsubs = '   ---------^---------!                  ';
+      const y = cold('                     ---f---g---h---i--|');
+      const ysubs = '   -------------------^-!                ';
+      const e1 = hot('  ---------x---------y---------|        ');
+      const e1subs = '  ^--------------------!                ';
+      const unsub = '   ---------------------!                ';
+      const expected = '-----------a--b--c----                ';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const x =   cold(         '--a--b--c--d--e--|           ');
-    const xsubs =    '         ^         !                  ';
-    const y =   cold(                   '---f---g---h---i--|');
-    const ysubs =    '                   ^ !                ';
-    const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                    !                ';
-    const expected = '-----------a--b--c----                ';
-    const unsub =    '                     !                ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|           ');
+      const xsubs = '   ---------^---------!                  ';
+      const y = cold('                     ---f---g---h---i--|');
+      const ysubs = '   -------------------^-!                ';
+      const e1 = hot('  ---------x---------y---------|        ');
+      const e1subs = '  ^--------------------!                ';
+      const expected = '-----------a--b--c----                ';
+      const unsub = '   ---------------------!                ';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(
-      mergeMap(x => of(x)),
-      switchMap(value => observableLookup[value]),
-      mergeMap(x => of(x)),
-    );
+      const result = e1.pipe(
+        mergeMap((x) => of(x)),
+        switchMap((value) => observableLookup[value]),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains with interop inners when result is unsubscribed explicitly', () => {
-    const x =   cold(         '--a--b--c--d--e--|           ');
-    const xsubs =    '         ^         !                  ';
-    const y =   cold(                   '---f---g---h---i--|');
-    const ysubs =    '                   ^ !                ';
-    const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                    !                ';
-    const expected = '-----------a--b--c----                ';
-    const unsub =    '                     !                ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|           ');
+      const xsubs = '   ---------^---------!                  ';
+      const y = cold('                     ---f---g---h---i--|');
+      const ysubs = '   -------------------^-!                ';
+      const e1 = hot('  ---------x---------y---------|        ');
+      const e1subs = '  ^--------------------!                ';
+      const expected = '-----------a--b--c----                ';
+      const unsub = '   ---------------------!                ';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    // This test is the same as the previous test, but the observable is
-    // manipulated to make it look like an interop observable - an observable
-    // from a foreign library. Interop subscribers are treated differently:
-    // they are wrapped in a safe subscriber. This test ensures that
-    // unsubscriptions are chained all the way to the interop subscriber.
+      // This test is the same as the previous test, but the observable is
+      // manipulated to make it look like an interop observable - an observable
+      // from a foreign library. Interop subscribers are treated differently:
+      // they are wrapped in a safe subscriber. This test ensures that
+      // unsubscriptions are chained all the way to the interop subscriber.
 
-    const result = e1.pipe(
-      mergeMap(x => of(x)),
-      switchMap(value => asInteropObservable(observableLookup[value])),
-      mergeMap(x => of(x)),
-    );
+      const result = e1.pipe(
+        mergeMap((x) => of(x)),
+        switchMap((value) => asInteropObservable(observableLookup[value])),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
@@ -214,237 +234,267 @@ describe('switchMap', () => {
       })
     );
 
-    of(null).pipe(
-      switchMap(() => synchronousObservable),
-      takeWhile((x) => x != 2) // unsubscribe at the second side-effect
-    ).subscribe(() => { /* noop */ });
+    of(null)
+      .pipe(
+        switchMap(() => synchronousObservable),
+        takeWhile((x) => x != 2) // unsubscribe at the second side-effect
+      )
+      .subscribe(() => {
+        /* noop */
+      });
 
     expect(sideEffects).to.deep.equal([1, 2]);
   });
 
   it('should switch inner cold observables, inner never completes', () => {
-    const x =   cold(         '--a--b--c--d--e--|          ');
-    const xsubs =    '         ^         !                 ';
-    const y =   cold(                   '---f---g---h---i--');
-    const ysubs =    '                   ^                 ';
-    const e1 =   hot('---------x---------y---------|       ');
-    const e1subs =   '^                            !       ';
-    const expected = '-----------a--b--c----f---g---h---i--';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|          ');
+      const xsubs = '   ---------^---------!                 ';
+      const y = cold('                     ---f---g---h---i--');
+      const ysubs = '   -------------------^                 ';
+      const e1 = hot('  ---------x---------y---------|       ');
+      const e1subs = '  ^----------------------------!       ';
+      const expected = '-----------a--b--c----f---g---h---i--';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle a synchronous switch to the second inner observable', () => {
-    const x =   cold(         '--a--b--c--d--e--|   ');
-    const xsubs =    '         (^!)                 ';
-    const y =   cold(         '---f---g---h---i--|  ');
-    const ysubs =    '         ^                 !  ';
-    const e1 =   hot('---------(xy)----------------|');
-    const e1subs =   '^                            !';
-    const expected = '------------f---g---h---i----|';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|   ');
+      const xsubs = '   ---------(^!)                 ';
+      const y = cold('           ---f---g---h---i--|  ');
+      const ysubs = '   ---------^-----------------!  ';
+      const e1 = hot('  ---------(xy)----------------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '------------f---g---h---i----|';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner cold observables, one inner throws', () => {
-    const x =   cold(         '--a--b--#--d--e--|          ');
-    const xsubs =    '         ^       !                   ';
-    const y =   cold(                   '---f---g---h---i--');
-    const ysubs: string[] = [];
-    const e1 =   hot('---------x---------y---------|       ');
-    const e1subs =   '^                !                   ';
-    const expected = '-----------a--b--#                   ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--#--d--e--|          ');
+      const xsubs = '   ---------^-------!                   ';
+      const y = cold('                     ---f---g---h---i--');
+      const ysubs = '                                        ';
+      const e1 = hot('  ---------x---------y---------|       ');
+      const e1subs = '  ^----------------!                   ';
+      const expected = '-----------a--b--#                   ';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner hot observables', () => {
-    const x =    hot('-----a--b--c--d--e--|                 ');
-    const xsubs =    '         ^         !                  ';
-    const y =    hot('--p-o-o-p-------------f---g---h---i--|');
-    const ysubs =    '                   ^                 !';
-    const e1 =   hot('---------x---------y---------|        ');
-    const e1subs =   '^                            !        ';
-    const expected = '-----------c--d--e----f---g---h---i--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const x = hot('   -----a--b--c--d--e--|                 ');
+      const xsubs = '   ---------^---------!                  ';
+      const y = hot('   --p-o-o-p-------------f---g---h---i--|');
+      const ysubs = '   -------------------^-----------------!';
+      const e1 = hot('  ---------x---------y---------|        ');
+      const e1subs = '  ^----------------------------!        ';
+      const expected = '-----------c--d--e----f---g---h---i--|';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner empty and empty', () => {
-    const x = cold('|');
-    const y = cold('|');
-    const xsubs =    '         (^!)                 ';
-    const ysubs =    '                   (^!)       ';
-    const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^                            !';
-    const expected = '-----------------------------|';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           |                    ');
+      const y = cold('                     |          ');
+      const xsubs = '   ---------(^!)                 ';
+      const ysubs = '   -------------------(^!)       ';
+      const e1 = hot('  ---------x---------y---------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '-----------------------------|';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner empty and never', () => {
-    const x = cold('|');
-    const y = cold('-');
-    const xsubs =    '         (^!)                 ';
-    const ysubs =    '                   ^          ';
-    const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^                            !';
-    const expected = '------------------------------';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           |                    ');
+      const y = cold('                     -          ');
+      const xsubs = '   ---------(^!)                 ';
+      const ysubs = '   -------------------^          ';
+      const e1 = hot('  ---------x---------y---------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '------------------------------';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner never and empty', () => {
-    const x = cold('-');
-    const y = cold('|');
-    const xsubs =    '         ^         !          ';
-    const ysubs =    '                   (^!)       ';
-    const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^                            !';
-    const expected = '-----------------------------|';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           -                    ');
+      const y = cold('                     |          ');
+      const xsubs = '   ---------^---------!          ';
+      const ysubs = '   -------------------(^!)       ';
+      const e1 = hot('  ---------x---------y---------|');
+      const e1subs = '  ^----------------------------!';
+      const expected = '-----------------------------|';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner never and throw', () => {
-    const x = cold('-');
-    const y = cold('#', undefined, 'sad');
-    const xsubs =    '         ^         !          ';
-    const ysubs =    '                   (^!)       ';
-    const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^                  !          ';
-    const expected = '-------------------#          ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           -                    ');
+      const y = cold('                     #          ', undefined, 'sad');
+      const xsubs = '   ---------^---------!          ';
+      const ysubs = '   -------------------(^!)       ';
+      const e1 = hot('  ---------x---------y---------|');
+      const e1subs = '  ^------------------!          ';
+      const expected = '-------------------#          ';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected, undefined, 'sad');
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected, undefined, 'sad');
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should switch inner empty and throw', () => {
-    const x = cold('|');
-    const y = cold('#', undefined, 'sad');
-    const xsubs =    '         (^!)                 ';
-    const ysubs =    '                   (^!)       ';
-    const e1 =   hot('---------x---------y---------|');
-    const e1subs =   '^                  !          ';
-    const expected = '-------------------#          ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           |                    ');
+      const y = cold('                     #          ', undefined, 'sad');
+      const xsubs = '   ---------(^!)                 ';
+      const ysubs = '   -------------------(^!)       ';
+      const e1 = hot('  ---------x---------y---------|');
+      const e1subs = '  ^------------------!          ';
+      const expected = '-------------------#          ';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
+      const observableLookup: Record<string, Observable<string>> = { x: x, y: y };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected, undefined, 'sad');
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(y.subscriptions).toBe(ysubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected, undefined, 'sad');
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(y.subscriptions).toBe(ysubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle outer empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '|   ';
 
-    const result = e1.pipe(switchMap(value => of(value)));
+      const result = e1.pipe(switchMap((value) => of(value)));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle outer never', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    const result = e1.pipe(switchMap(value => of(value)));
+      const result = e1.pipe(switchMap((value) => of(value)));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle outer throw', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    const result = e1.pipe(switchMap(value => of(value)));
+      const result = e1.pipe(switchMap((value) => of(value)));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle outer error', () => {
-    const x =   cold(         '--a--b--c--d--e--|');
-    const xsubs =    '         ^         !       ';
-    const e1 =   hot('---------x---------#       ');
-    const e1subs =   '^                  !       ';
-    const expected = '-----------a--b--c-#       ';
+    testScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const x = cold('           --a--b--c--d--e--|');
+      const xsubs = '   ---------^---------!       ';
+      const e1 = hot('  ---------x---------#       ');
+      const e1subs = '  ^------------------!       ';
+      const expected = '-----------a--b--c-#       ';
 
-    const observableLookup: Record<string, Observable<string>> = { x: x };
+      const observableLookup: Record<string, Observable<string>> = { x: x };
 
-    const result = e1.pipe(switchMap(value => observableLookup[value]));
+      const result = e1.pipe(switchMap((value) => observableLookup[value]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(x.subscriptions).toBe(xsubs);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(x.subscriptions).toBe(xsubs);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -453,10 +503,14 @@ describe('switchMap', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      switchMap(value => of(value)),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable
+      .pipe(
+        switchMap((value) => of(value)),
+        take(3)
+      )
+      .subscribe(() => {
+        /* noop */
+      });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });
@@ -467,11 +521,14 @@ describe('switchMap', () => {
 
     e.pipe(
       take(3),
-      switchMap(value => new Observable<number>(subscriber => {
-        e.next(value+1);
-        subscriber.next(value);
-      })),
-    ).subscribe(value => results.push(value));
+      switchMap(
+        (value) =>
+          new Observable<number>((subscriber) => {
+            e.next(value + 1);
+            subscriber.next(value);
+          })
+      )
+    ).subscribe((value) => results.push(value));
 
     expect(results).to.deep.equal([3]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `switchMap` tests to run mode.

**Related issue (if exists):**
None
