### PR TITLE
fix(fromEvent): match targets properly; fix result selector type

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -142,9 +142,9 @@ export declare function from<O extends ObservableInput<any>>(input: O): Observab
 export declare function from<O extends ObservableInput<any>>(input: O, scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
 
 export declare function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
-export declare function fromEvent<T>(target: FromEventTarget<T>, eventName: string, resultSelector?: (...args: any[]) => T): Observable<T>;
-export declare function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options?: EventListenerOptions): Observable<T>;
-export declare function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions, resultSelector: (...args: any[]) => T): Observable<T>;
+export declare function fromEvent<T>(target: FromEventTarget<any>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
+export declare function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions): Observable<T>;
+export declare function fromEvent<T>(target: FromEventTarget<any>, eventName: string, options: EventListenerOptions, resultSelector: (...args: any[]) => T): Observable<T>;
 
 export declare function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any, removeHandler?: (handler: NodeEventHandler, signal?: any) => void): Observable<T>;
 export declare function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any, removeHandler?: (handler: NodeEventHandler, signal?: any) => void, resultSelector?: (...args: any[]) => T): Observable<T>;

--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -14,11 +14,19 @@ it('should support an event target source', () => {
   const a = fromEvent(eventTargetSource, "click"); // $ExpectType Observable<Event>
 });
 
+it('should support an event target source result selector', () => {
+  const a = fromEvent(eventTargetSource, "click", () => "clunk"); // $ExpectType Observable<string>
+});
+
 declare const documentSource: HTMLDocument;
 
 it('should support a document source', () => {
   const source: HasEventTargetAddRemove<Event> = documentSource;
   const a = fromEvent(documentSource, "click"); // $ExpectType Observable<Event>
+});
+
+it('should support a document source result selector', () => {
+  const a = fromEvent(documentSource, "click", () => "clunk"); // $ExpectType Observable<string>
 });
 
 // Pick the parts that will match NodeStyleEventEmitter. If this isn't done, it
@@ -28,8 +36,12 @@ declare const nodeStyleSource: Pick<typeof process, 'addListener' | 'removeListe
 
 it('should support a node-style source', () => {
   const source: NodeStyleEventEmitter = nodeStyleSource;
-  const a = fromEvent(nodeStyleSource, "something"); // $ExpectType Observable<unknown>
-  const b = fromEvent<B>(nodeStyleSource, "something"); // $ExpectType Observable<B>
+  const a = fromEvent(nodeStyleSource, "exit"); // $ExpectType Observable<unknown>
+  const b = fromEvent<B>(nodeStyleSource, "exit"); // $ExpectType Observable<B>
+});
+
+it('should support a node-style source result selector', () => {
+  const a = fromEvent(nodeStyleSource, "exit", () => "bye"); // $ExpectType Observable<string>
 });
 
 const nodeCompatibleSource = {
@@ -43,6 +55,10 @@ it('should support a node-compatible source', () => {
   const b = fromEvent<B>(nodeCompatibleSource, "something"); // $ExpectType Observable<B>
 });
 
+it('should support a node-compatible source result selector', () => {
+  const a = fromEvent(nodeCompatibleSource, "something", () => "something else"); // $ExpectType Observable<string>
+});
+
 const jQueryStyleSource = {
   on(eventName: "something", handler: (this: any, b: B) => any) {},
   off(eventName: "something", handler: (this: any, b: B) => any) {}
@@ -52,4 +68,8 @@ it('should support a jQuery-style source', () => {
   const source: JQueryStyleEventEmitter<any, any> = jQueryStyleSource;
   const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<B>
   const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>
+});
+
+it('should support a jQuery-style source result selector', () => {
+  const a = fromEvent(jQueryStyleSource, "something", () => "something else"); // $ExpectType Observable<string>
 });

--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -1,44 +1,55 @@
 import { fromEvent } from 'rxjs';
-import { JQueryStyleEventEmitter } from '../../src/internal/observable/fromEvent';
-import { A, B } from '../helpers';
+import {
+  HasEventTargetAddRemove,
+  NodeStyleEventEmitter,
+  NodeCompatibleEventEmitter,
+  JQueryStyleEventEmitter
+} from '../../src/internal/observable/fromEvent';
+import { B } from '../helpers';
 
 declare const eventTargetSource: EventTarget;
 
 it('should support an event target source', () => {
+  const source: HasEventTargetAddRemove<Event> = eventTargetSource;
   const a = fromEvent(eventTargetSource, "click"); // $ExpectType Observable<Event>
 });
 
 declare const documentSource: HTMLDocument;
 
 it('should support a document source', () => {
+  const source: HasEventTargetAddRemove<Event> = documentSource;
   const a = fromEvent(documentSource, "click"); // $ExpectType Observable<Event>
 });
 
-interface NodeStyleSource {
-  addListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
-  removeListener: (eventName: string | symbol, handler: (...args: any[]) => void) => this;
-};
-
-declare const nodeStyleSource : NodeStyleSource;
+// Pick the parts that will match NodeStyleEventEmitter. If this isn't done, it
+// will match JQueryStyleEventEmitter - because of the `on` and `off` methods -
+// despite the latter being declared last in the EventTargetLike union.
+declare const nodeStyleSource: Pick<typeof process, 'addListener' | 'removeListener'>;
 
 it('should support a node-style source', () => {
+  const source: NodeStyleEventEmitter = nodeStyleSource;
   const a = fromEvent(nodeStyleSource, "something"); // $ExpectType Observable<unknown>
   const b = fromEvent<B>(nodeStyleSource, "something"); // $ExpectType Observable<B>
 });
 
-declare const nodeCompatibleSource: {
-  addListener: (eventName: string, handler: (...args: any[]) => void) => void;
-  removeListener: (eventName: string, handler: (...args: any[]) => void) => void;
+const nodeCompatibleSource = {
+  addListener(eventName: "something", handler: () => void) {},
+  removeListener(eventName: "something", handler: () => void) {}
 };
 
 it('should support a node-compatible source', () => {
+  const source: NodeCompatibleEventEmitter = nodeCompatibleSource;
   const a = fromEvent(nodeCompatibleSource, "something"); // $ExpectType Observable<unknown>
   const b = fromEvent<B>(nodeCompatibleSource, "something"); // $ExpectType Observable<B>
 });
 
-declare const jQueryStyleSource: JQueryStyleEventEmitter<A, B>;
+const jQueryStyleSource = {
+  on(eventName: "something", handler: (this: any, b: B) => any) {},
+  off(eventName: "something", handler: (this: any, b: B) => any) {}
+};
 
 it('should support a jQuery-style source', () => {
+  const source: JQueryStyleEventEmitter<any, any> = jQueryStyleSource;
   const a = fromEvent(jQueryStyleSource, "something"); // $ExpectType Observable<B>
   const b = fromEvent<B>(jQueryStyleSource, "something"); // $ExpectType Observable<B>
 });

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -70,11 +70,11 @@ export interface AddEventListenerOptions extends EventListenerOptions {
 
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
+export function fromEvent<T>(target: FromEventTarget<any>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEvent<T>(
-  target: FromEventTarget<T>,
+  target: FromEventTarget<any>,
   eventName: string,
   options: EventListenerOptions,
   resultSelector: (...args: any[]) => T

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -11,8 +11,8 @@ const eventTargetMethods = ['addEventListener', 'removeEventListener'] as const;
 const jqueryMethods = ['on', 'off'] as const;
 
 export interface NodeStyleEventEmitter {
-  addListener: (eventName: string | symbol, handler: NodeEventHandler) => this;
-  removeListener: (eventName: string | symbol, handler: NodeEventHandler) => this;
+  addListener(eventName: string | symbol, handler: NodeEventHandler): this;
+  removeListener(eventName: string | symbol, handler: NodeEventHandler): this;
 }
 
 export type NodeEventHandler = (...args: any[]) => void;
@@ -21,15 +21,15 @@ export type NodeEventHandler = (...args: any[]) => void;
 // not use the same arguments or return EventEmitter values
 // such as React Native
 export interface NodeCompatibleEventEmitter {
-  addListener: (eventName: string, handler: NodeEventHandler) => void | {};
-  removeListener: (eventName: string, handler: NodeEventHandler) => void | {};
+  addListener(eventName: string, handler: NodeEventHandler): void | {};
+  removeListener(eventName: string, handler: NodeEventHandler): void | {};
 }
 
 // Use handler types like those in @types/jquery. See:
 // https://github.com/DefinitelyTyped/DefinitelyTyped/blob/847731ba1d7fa6db6b911c0e43aa0afe596e7723/types/jquery/misc.d.ts#L6395
 export interface JQueryStyleEventEmitter<TContext, T> {
-  on: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
-  off: (eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any) => void;
+  on(eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any): void;
+  off(eventName: string, handler: (this: TContext, t: T, ...args: any[]) => any): void;
 }
 
 export interface EventListenerObject<E> {

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -70,8 +70,8 @@ export interface AddEventListenerOptions extends EventListenerOptions {
 
 export function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, resultSelector?: (...args: any[]) => T): Observable<T>;
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options?: EventListenerOptions): Observable<T>;
+export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
+export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions): Observable<T>;
 /** @deprecated resultSelector no longer supported, pipe to map instead */
 export function fromEvent<T>(
   target: FromEventTarget<T>,
@@ -211,7 +211,7 @@ export function fromEvent<T>(
   }
   if (resultSelector) {
     // DEPRECATED PATH
-    return fromEvent<T>(target, eventName, options as EventListenerOptions | undefined).pipe(mapOneOrManyArgs(resultSelector));
+    return fromEvent<T>(target, eventName, options as EventListenerOptions).pipe(mapOneOrManyArgs(resultSelector));
   }
 
   // Figure out our add and remove methods. In order to do this,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes some problems with `fromEvent`:

- The interfaces used to match targets need to use methods instead of props. Otherwise, [`extends` behaves in an unintended manner](https://www.typescriptlang.org/play?ts=4.2.0-beta#code/JYOwLgpgTgZghgYwgAgPIgIIGcAKUD2ADsgN4BQyy+IAXMgBQhwC2EdWYUoA5sgD7IsAT2YAjfABsAlMgC8APmQA3fMAAmAbjIBfMmVCRYiFOmwBZCGAAW+NaQpUQjFm0Gce-QSPHS6K9Vq6+uDQ8EjIePhIWFj2lNTOrHQARBAAHsBgyVJ+qpo6emBChCgAommQIGq4BMSyEQTRsemV1WiYNUTIAPzIyQCaEITJyCkAckQQyVpFJcjlrVgW1rZyDVEQMcgtEFWxpkuWNna9A0Mj45PTQA) and the types won't match.
- There is a signature that takes only the target and the event name, so the optional qualifiers on the other signatures are redundant.
- If the `resultSelector` returns `T`, the target's type should not be `FromEventTarget<T>`.

The typing of `fromEvent` could be improved, but I think the first step is to fix these problems. The next would be to replace the `FromEventTarget` type with separate signatures.

**Related issue (if exists):** Nope
