### PR TITLE
chore(observeOn): convert observeOn tests to run mode

### DIFF
--- a/spec/operators/subscribeOn-spec.ts
+++ b/spec/operators/subscribeOn-spec.ts
@@ -1,97 +1,131 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { subscribeOn, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable, queueScheduler } from 'rxjs';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {subscribeOn} */
-describe('subscribeOn operator', () => {
-  it('should subscribe on specified scheduler', () => {
-    const e1 =   hot('--a--b--|');
-    const expected = '--a--b--|';
-    const sub =      '^       !';
+describe('subscribeOn', () => {
+  let testScheduler: TestScheduler;
 
-    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should subscribe on specified scheduler', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--|');
+      const expected = '--a--b--|';
+      const sub = '     ^-------!';
+
+      const result = e1.pipe(subscribeOn(testScheduler));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(sub);
+    });
   });
 
   it('should start subscribe after specified delay', () => {
-    const e1 =   hot('--a--b--|');
-    const expected = '-----b--|';
-    const sub =      '   ^    !';
+    testScheduler.run(({ hot, time, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('    --a--b--|');
+      const expected = '  -----b--|';
+      const delay = time('---|     ');
+      const sub = '       ---^----!';
 
-    expectObservable(e1.pipe(subscribeOn(rxTestScheduler, 30))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
+      const result = e1.pipe(subscribeOn(testScheduler, delay));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(sub);
+    });
   });
 
-  it('should subscribe when source raises error', () => {
-    const e1 =   hot('--a--#');
-    const expected = '--a--#';
-    const sub =      '^    !';
+  it('should unsubscribe when source raises error', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--#');
+      const expected = '--a--#';
+      const sub = '     ^----!';
 
-    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
+      const result = e1.pipe(subscribeOn(testScheduler));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(sub);
+    });
   });
 
   it('should subscribe when source is empty', () => {
-    const e1 =   hot('----|');
-    const expected = '----|';
-    const sub =      '^   !';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ----|');
+      const expected = '----|';
+      const sub = '     ^---!';
 
-    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
+      const result = e1.pipe(subscribeOn(testScheduler));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(sub);
+    });
   });
 
   it('should subscribe when source does not complete', () => {
-    const e1 =   hot('----');
-    const expected = '----';
-    const sub =      '^   ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ----');
+      const expected = '----';
+      const sub = '     ^---';
 
-    expectObservable(e1.pipe(subscribeOn(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
+      const result = e1.pipe(subscribeOn(testScheduler));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(sub);
+    });
   });
 
   it('should allow unsubscribing early and explicitly', () => {
-    const e1 =    hot('--a--b--|');
-    const sub =       '^   !    ';
-    const expected =  '--a--    ';
-    const unsub =     '    !    ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--|');
+      const sub = '     ^---!    ';
+      const expected = '--a--    ';
+      const unsub = '   ----!    ';
 
-    const result = e1.pipe(subscribeOn(rxTestScheduler));
+      const result = e1.pipe(subscribeOn(testScheduler));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(sub);
+    });
   });
 
   it('should not break unsubscription chains when the result is unsubscribed explicitly', () => {
-    const e1 =    hot('--a--b--|');
-    const sub =       '^   !    ';
-    const expected =  '--a--    ';
-    const unsub =     '    !    ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--|');
+      const sub = '     ^---!    ';
+      const expected = '--a--    ';
+      const unsub = '   ----!    ';
 
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      subscribeOn(rxTestScheduler),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        subscribeOn(testScheduler),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(sub);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(sub);
+    });
   });
 
   it('should properly support a delayTime of Infinity', () => {
-    const e1 =   hot('--a--b--|');
-    const expected = '---------';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--|');
+      const expected = '---------';
 
-    expectObservable(e1.pipe(subscribeOn(rxTestScheduler, Infinity))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe([]);
+      const result = e1.pipe(subscribeOn(testScheduler, Infinity));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe([]);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -100,10 +134,9 @@ describe('subscribeOn operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      subscribeOn(queueScheduler),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(subscribeOn(queueScheduler), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `subscribeOn` tests to run mode.

**Related issue (if exists):**
None
