### PR TITLE
fix(merge): single array is not an array of sources

### DIFF
--- a/spec/observables/merge-spec.ts
+++ b/spec/observables/merge-spec.ts
@@ -282,4 +282,10 @@ describe('merge(...observables, Scheduler, number)', () => {
 
     expect(e1Subscribed).to.be.false;
   });
+
+  it('should deem a single array argument to be an ObservableInput', () => {
+    const array = ['foo', 'bar'];
+    const expected = '(fb|)';
+    expectObservable(merge(array)).toBe(expected, { f: 'foo', b: 'bar' });
+  });
 });

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -2,7 +2,6 @@ import { Observable } from '../Observable';
 import { ObservableInput, ObservableInputTuple, SchedulerLike } from '../types';
 import { mergeAll } from '../operators/mergeAll';
 import { internalFromArray } from './fromArray';
-import { argsOrArgArray } from '../util/argsOrArgArray';
 import { innerFrom } from './from';
 import { EMPTY } from './empty';
 import { popNumber, popScheduler } from '../util/args';
@@ -84,7 +83,7 @@ export function merge<A extends readonly unknown[]>(...args: [...ObservableInput
 export function merge(...args: (ObservableInput<unknown> | number | SchedulerLike)[]): Observable<unknown> {
   const scheduler = popScheduler(args);
   const concurrent = popNumber(args, Infinity);
-  const sources = argsOrArgArray(args) as ObservableInput<unknown>[];
+  const sources = args as ObservableInput<unknown>[];
   return !sources.length
     ? // No source provided
       EMPTY


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Prior to this change, the static `merge` behaved in a manner that was contrary to its types: it treated a single array as an array of sources. The static `concat` did not do this, so changing a `concat` to a `merge` or vice versa would effect wildly different behaviour if a single array was passed.

This PR adds a failing test and removes the call to `argsOrArgArray` - which did the sniffing and unpacking.

Regarding v7, there are a bunch of inconsistencies between `concat`, `merge`, `race`, `combineLatest`, `forkJoin` and `zip`, but most can be addressed through the application of deprecations. This change, however, addresses an inconsistency in the implementation.

**Related issue (if exists):** Nope
