### PR TITLE
chore(startWith): convert startWith tests to run mode

### DIFF
--- a/spec/operators/startWith-spec.ts
+++ b/spec/operators/startWith-spec.ts
@@ -1,165 +1,225 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { startWith, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {startWith} */
-describe('startWith operator', () => {
+describe('startWith', () => {
   const defaultStartValue = 'x';
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
 
   it('should prepend to a cold Observable', () => {
-    const e1 =  cold('---a--b--c--|');
-    const e1subs =   '^           !';
-    const expected = 's--a--b--c--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a--b--c--|');
+      const e1subs = '  ^-----------!';
+      const expected = 's--a--b--c--|';
 
-    expectObservable(e1.pipe(startWith('s'))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith('s'));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start an observable with given value', () => {
-    const e1 =   hot('--a--|');
-    const e1subs =   '^    !';
-    const expected = 'x-a--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--|');
+      const e1subs = '  ^----!';
+      const expected = 'x-a--|';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given value and does not completes if source does not completes', () => {
-    const e1 =   hot('----a-');
-    const e1subs =   '^     ';
-    const expected = 'x---a-';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ----a-');
+      const e1subs = '  ^-----';
+      const expected = 'x---a-';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given value and does not completes if source never emits', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = 'x-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' - ');
+      const e1subs = '  ^ ';
+      const expected = 'x-';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given value and completes if source does not emits', () => {
-    const e1 =   hot('---|');
-    const e1subs =   '^  !';
-    const expected = 'x--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---|');
+      const e1subs = '  ^--!';
+      const expected = 'x--|';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given value and complete immediately if source is empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '(x|)';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '(x|)';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given value and source both if source emits single value', () => {
-    const e1 =  cold('(a|)');
-    const e1subs =   '(^!)';
-    const expected = '(xa|)';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' (a|)');
+      const e1subs = '  (^!)';
+      const expected = '(xa|)';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given values when given value is more than one', () => {
-    const e1 =   hot('-----a--|');
-    const e1subs =   '^       !';
-    const expected = '(yz)-a--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -----a--|');
+      const e1subs = '  ^-------!';
+      const expected = '(yz)-a--|';
 
-    expectObservable(e1.pipe(startWith('y', 'z'))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith('y', 'z'));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given value and raises error if source raises error', () => {
-    const e1 =   hot('--#');
-    const e1subs =   '^ !';
-    const expected = 'x-#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --#');
+      const e1subs = '  ^-!';
+      const expected = 'x-#';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected, defaultStartValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected, defaultStartValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with given value and raises error immediately if source throws error', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '(x#)';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '(x#)';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue))).toBe(expected, defaultStartValue);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue));
+
+      expectObservable(result).toBe(expected, defaultStartValue);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 =   hot('---a--b----c--d--|');
-    const unsub =    '         !        ';
-    const e1subs =   '^        !        ';
-    const expected = 's--a--b---';
-    const values = { s: 's', a: 'a', b: 'b' };
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---a--b----c--d--|');
+      const unsub = '   ---------!        ';
+      const e1subs = '  ^--------!        ';
+      const expected = 's--a--b---        ';
+      const values = { s: 's', a: 'a', b: 'b' };
 
-    const result = e1.pipe(startWith('s', rxTestScheduler));
+      const result = e1.pipe(startWith('s', testScheduler));
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   hot('---a--b----c--d--|');
-    const e1subs =   '^        !        ';
-    const expected = 's--a--b---        ';
-    const unsub =    '         !        ';
-    const values = { s: 's', a: 'a', b: 'b' };
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---a--b----c--d--|');
+      const e1subs = '  ^--------!        ';
+      const expected = 's--a--b---        ';
+      const unsub = '   ---------!        ';
+      const values = { s: 's', a: 'a', b: 'b' };
 
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      startWith('s', rxTestScheduler),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        startWith('s', testScheduler),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should start with empty if given value is not specified', () => {
-    const e1 =   hot('-a-|');
-    const e1subs =   '^  !';
-    const expected = '-a-|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -a-|');
+      const e1subs = '  ^--!';
+      const expected = '-a-|';
 
-    expectObservable(e1.pipe(startWith(rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(testScheduler));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should accept scheduler as last argument with single value', () => {
-    const e1 =   hot('--a--|');
-    const e1subs =   '^    !';
-    const expected = 'x-a--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--|');
+      const e1subs = '  ^----!';
+      const expected = 'x-a--|';
 
-    expectObservable(e1.pipe(startWith(defaultStartValue, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith(defaultStartValue, testScheduler));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should accept scheduler as last argument with multiple value', () => {
-    const e1 =   hot('-----a--|');
-    const e1subs =   '^       !';
-    const expected = '(yz)-a--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  -----a--|');
+      const e1subs = '  ^-------!';
+      const expected = '(yz)-a--|';
 
-    expectObservable(e1.pipe(startWith('y', 'z', rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      const result = e1.pipe(startWith('y', 'z', testScheduler));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -168,10 +228,9 @@ describe('startWith operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      startWith(-1),
-      take(4),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(startWith(-1), take(4)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `startWith` tests to run mode.

**Related issue (if exists):**
None
