### PR TITLE
refactor: separate fromEvent signatures by target type

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -141,10 +141,18 @@ export declare function forkJoin<T extends Record<string, ObservableInput<any>>>
 export declare function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
 export declare function from<O extends ObservableInput<any>>(input: O, scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
 
-export declare function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
-export declare function fromEvent<T>(target: FromEventTarget<any>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
-export declare function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions): Observable<T>;
-export declare function fromEvent<T>(target: FromEventTarget<any>, eventName: string, options: EventListenerOptions, resultSelector: (...args: any[]) => T): Observable<T>;
+export declare function fromEvent<T>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string): Observable<T>;
+export declare function fromEvent<T, R>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, resultSelector: (event: T) => R): Observable<R>;
+export declare function fromEvent<T>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, options: EventListenerOptions): Observable<T>;
+export declare function fromEvent<T, R>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, options: EventListenerOptions, resultSelector: (event: T) => R): Observable<T>;
+export declare function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<T>;
+export declare function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
+export declare function fromEvent<R>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string, resultSelector: (...args: any[]) => R): Observable<R>;
+export declare function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
+export declare function fromEvent(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<unknown>;
+export declare function fromEvent<R>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string, resultSelector: (...args: any[]) => R): Observable<R>;
+export declare function fromEvent<T>(target: JQueryStyleEventEmitter<any, T> | ArrayLike<JQueryStyleEventEmitter<any, T>>, eventName: string): Observable<T>;
+export declare function fromEvent<T, R>(target: JQueryStyleEventEmitter<any, T> | ArrayLike<JQueryStyleEventEmitter<any, T>>, eventName: string, resultSelector: (value: T, ...args: any[]) => R): Observable<R>;
 
 export declare function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any, removeHandler?: (handler: NodeEventHandler, signal?: any) => void): Observable<T>;
 export declare function fromEventPattern<T>(addHandler: (handler: NodeEventHandler) => any, removeHandler?: (handler: NodeEventHandler, signal?: any) => void, resultSelector?: (...args: any[]) => T): Observable<T>;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -145,11 +145,11 @@ export declare function fromEvent<T>(target: HasEventTargetAddRemove<T> | ArrayL
 export declare function fromEvent<T, R>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, resultSelector: (event: T) => R): Observable<R>;
 export declare function fromEvent<T>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, options: EventListenerOptions): Observable<T>;
 export declare function fromEvent<T, R>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, options: EventListenerOptions, resultSelector: (event: T) => R): Observable<T>;
-export declare function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<T>;
 export declare function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
+export declare function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<T>;
 export declare function fromEvent<R>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string, resultSelector: (...args: any[]) => R): Observable<R>;
-export declare function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
 export declare function fromEvent(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<unknown>;
+export declare function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
 export declare function fromEvent<R>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string, resultSelector: (...args: any[]) => R): Observable<R>;
 export declare function fromEvent<T>(target: JQueryStyleEventEmitter<any, T> | ArrayLike<JQueryStyleEventEmitter<any, T>>, eventName: string): Observable<T>;
 export declare function fromEvent<T, R>(target: JQueryStyleEventEmitter<any, T> | ArrayLike<JQueryStyleEventEmitter<any, T>>, eventName: string, resultSelector: (value: T, ...args: any[]) => R): Observable<R>;

--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -40,6 +40,12 @@ it('should support a node-style source', () => {
   const b = fromEvent<B>(nodeStyleSource, "exit"); // $ExpectType Observable<B>
 });
 
+it('should deprecate explicit type parameters for a node-style source', () => {
+  const source: NodeStyleEventEmitter = nodeStyleSource;
+  const a = fromEvent(nodeStyleSource, "exit"); // $ExpectNoDeprecation
+  const b = fromEvent<B>(nodeStyleSource, "exit"); // $ExpectDeprecation
+});
+
 it('should support a node-style source result selector', () => {
   const a = fromEvent(nodeStyleSource, "exit", () => "bye"); // $ExpectType Observable<string>
 });
@@ -53,6 +59,12 @@ it('should support a node-compatible source', () => {
   const source: NodeCompatibleEventEmitter = nodeCompatibleSource;
   const a = fromEvent(nodeCompatibleSource, "something"); // $ExpectType Observable<unknown>
   const b = fromEvent<B>(nodeCompatibleSource, "something"); // $ExpectType Observable<B>
+});
+
+it('should deprecate explicit type parameters for a node-compatible source', () => {
+  const source: NodeCompatibleEventEmitter = nodeCompatibleSource;
+  const a = fromEvent(nodeCompatibleSource, "something"); // $ExpectNoDeprecation
+  const b = fromEvent<B>(nodeCompatibleSource, "something"); // $ExpectDeprecation
 });
 
 it('should support a node-compatible source result selector', () => {

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -78,21 +78,21 @@ export function fromEvent<T, R>(
   resultSelector: (event: T) => R
 ): Observable<T>;
 
+export function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
 /** @deprecated type parameters that cannot be inferred will be removed in v8 */
 export function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<T>;
-export function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
 export function fromEvent<R>(
   target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>,
   eventName: string,
   resultSelector: (...args: any[]) => R
 ): Observable<R>;
 
-/** @deprecated type parameters that cannot be inferred will be removed in v8 */
-export function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
 export function fromEvent(
   target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,
   eventName: string
 ): Observable<unknown>;
+/** @deprecated type parameters that cannot be inferred will be removed in v8 */
+export function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
 export function fromEvent<R>(
   target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,
   eventName: string,

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -49,14 +49,6 @@ export interface HasEventTargetAddRemove<E> {
   ): void;
 }
 
-export type EventTargetLike<T> =
-  | HasEventTargetAddRemove<T>
-  | NodeStyleEventEmitter
-  | NodeCompatibleEventEmitter
-  | JQueryStyleEventEmitter<any, T>;
-
-export type FromEventTarget<T> = EventTargetLike<T> | ArrayLike<EventTargetLike<T>>;
-
 export interface EventListenerOptions {
   capture?: boolean;
   passive?: boolean;
@@ -68,15 +60,54 @@ export interface AddEventListenerOptions extends EventListenerOptions {
   passive?: boolean;
 }
 
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string): Observable<T>;
-export function fromEvent<T>(target: FromEventTarget<any>, eventName: string, resultSelector: (...args: any[]) => T): Observable<T>;
-export function fromEvent<T>(target: FromEventTarget<T>, eventName: string, options: EventListenerOptions): Observable<T>;
+export function fromEvent<T>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string): Observable<T>;
+export function fromEvent<T, R>(
+  target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>,
+  eventName: string,
+  resultSelector: (event: T) => R
+): Observable<R>;
 export function fromEvent<T>(
-  target: FromEventTarget<any>,
+  target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>,
+  eventName: string,
+  options: EventListenerOptions
+): Observable<T>;
+export function fromEvent<T, R>(
+  target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>,
   eventName: string,
   options: EventListenerOptions,
-  resultSelector: (...args: any[]) => T
+  resultSelector: (event: T) => R
 ): Observable<T>;
+
+/** @deprecated type parameters that cannot be inferred will be removed in v8 */
+export function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<T>;
+export function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
+export function fromEvent<R>(
+  target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>,
+  eventName: string,
+  resultSelector: (...args: any[]) => R
+): Observable<R>;
+
+/** @deprecated type parameters that cannot be inferred will be removed in v8 */
+export function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
+export function fromEvent(
+  target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,
+  eventName: string
+): Observable<unknown>;
+export function fromEvent<R>(
+  target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,
+  eventName: string,
+  resultSelector: (...args: any[]) => R
+): Observable<R>;
+
+export function fromEvent<T>(
+  target: JQueryStyleEventEmitter<any, T> | ArrayLike<JQueryStyleEventEmitter<any, T>>,
+  eventName: string
+): Observable<T>;
+export function fromEvent<T, R>(
+  target: JQueryStyleEventEmitter<any, T> | ArrayLike<JQueryStyleEventEmitter<any, T>>,
+  eventName: string,
+  resultSelector: (value: T, ...args: any[]) => R
+): Observable<R>;
 
 /**
  * Creates an Observable that emits events of a specific type coming from the


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes the `FromEventTarget` union and separates the `fromEvent` signatures so that each target type - DOM, Node, etc. - has its own group of overload signatures. This makes the typing of the result selectors and options (AFAICT, only `addEventListener` targets support an options argument) more accurate.

I left the type-parameters-as-type-assertions for the Node signatures, but deprecated them in favour of signatures that return `Observable<unknown>`. Elsewhere, IIRC, we've just removed/replaced such signatures 'cause this is type parameter misuse, but I think doing that here might be a little too breaking? The result selectors for the Node signatures are more relaxed than they could be - `...args: any[]` instead of `...args: unknown[]`. I suppose we could use `...args: unknown[]` and add a deprecated `...args: any[]` that comes afterwards, but IDK that will make a big difference. We can always to it later, as it won't be breaking.

With the separation, it might be possible to implement smarter inference for `addEventListener` targets - see [here](https://github.com/ReactiveX/rxjs/issues/5512#issuecomment-812878583) - but whether or not that's done for v7, IDK. I guess we'll just have to see how complicated it is.

FWIW, I don't think it's possible to implement smart inference for the Node targets without an overwhelming amount of type-level programming (and I would not be in favour of that) and, in any case, I don't think that would be something we'd want to do until [this has been considered/decided](https://github.com/ReactiveX/rxjs/issues/4736#issuecomment-811065078).

**Related issue (if exists):** Nope