### PR TITLE
docs: fix instruction demos in tap operator

### DIFF
--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -88,9 +88,9 @@ export function tap<T>(
  *  concatMap(n => interval(1000).pipe(
  *    take(Math.round(Math.random() * 10)),
  *    map(() => 'X'),
- *    tap(n => ({
+ *    tap({
  *      complete: () => console.log(`Done with ${n}`)
- *    }))
+ *    })
  *  ))
  * )
  * .subscribe(console.log);

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -58,7 +58,7 @@ export function tap<T>(
  * using `tap`.
  *
  * ```ts
- * import { of } from 'rxjs':
+ * import { of } from 'rxjs';
  * import { tap } from 'rxjs/operators';
  *
  * const source = of(1, 2, 3, 4, 5)
@@ -81,16 +81,16 @@ export function tap<T>(
  *
  * ```ts
  * import { of, interval } from 'rxjs';
- * import { tap, concatMap, take } from 'rxjs';
+ * import { tap, map, concatMap, take } from 'rxjs/operators';
  *
  *
  * of(1, 2, 3).pipe(
- *  concatMap(n => interval.pipe(
+ *  concatMap(n => interval(1000).pipe(
  *    take(Math.round(Math.random() * 10)),
  *    map(() => 'X'),
- *    tap({
+ *    tap(n => ({
  *      complete: () => console.log(`Done with ${n}`)
- *    })
+ *    }))
  *  ))
  * )
  * .subscribe(console.log);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [x] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [x] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

there are several errors in the origin documentation, and i fixed them, already tested.

**Related issue (if exists):**
