### PR TITLE
chore(skipWhile): convert skipWhile tests to run mode

### DIFF
--- a/spec/operators/skipWhile-spec.ts
+++ b/spec/operators/skipWhile-spec.ts
@@ -1,201 +1,273 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { skipWhile, mergeMap, tap, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {skipWhile} */
-describe('skipWhile operator', () => {
+describe('skipWhile', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should skip all elements until predicate is false', () => {
-    const source = hot('-1-^2--3--4--5--6--|');
-    const sourceSubs =    '^               !';
-    const expected =      '-------4--5--6--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('-1-^2--3--4--5--6--|');
+      const sourceSubs = '   ^---------------!';
+      const expected = '     -------4--5--6--|';
 
-    const predicate = function (v: string) {
-      return +v < 4;
-    };
+      const predicate = function (v: string) {
+        return +v < 4;
+      };
 
-    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(predicate));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should skip all elements with a true predicate', () => {
-    const source = hot('-1-^2--3--4--5--6--|');
-    const sourceSubs =    '^               !';
-    const expected =      '----------------|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('-1-^2--3--4--5--6--|');
+      const sourceSubs = '   ^---------------!';
+      const expected = '     ----------------|';
 
-    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(() => true));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should skip all elements with a truthy predicate', () => {
-    const source = hot('-1-^2--3--4--5--6--|');
-    const sourceSubs =    '^               !';
-    const expected =      '----------------|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('-1-^2--3--4--5--6--|');
+      const sourceSubs = '   ^---------------!';
+      const expected = '     ----------------|';
 
-    expectObservable(source.pipe(skipWhile((): any => { return {}; }))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(
+        skipWhile((): any => {
+          return {};
+        })
+      );
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should not skip any element with a false predicate', () => {
-    const source = hot('-1-^2--3--4--5--6--|');
-    const sourceSubs =    '^               !';
-    const expected =      '-2--3--4--5--6--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('-1-^2--3--4--5--6--|');
+      const sourceSubs = '   ^---------------!';
+      const expected = '     -2--3--4--5--6--|';
 
-    expectObservable(source.pipe(skipWhile(() => false))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(() => false));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should not skip any elements with a falsy predicate', () => {
-    const source = hot('-1-^2--3--4--5--6--|');
-    const sourceSubs =    '^               !';
-    const expected =      '-2--3--4--5--6--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('-1-^2--3--4--5--6--|');
+      const sourceSubs = '   ^---------------!';
+      const expected = '     -2--3--4--5--6--|';
 
-    expectObservable(source.pipe(skipWhile(() => undefined as any))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(() => undefined as any));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should skip elements on hot source', () => {
-    const source = hot('--1--2-^-3--4--5--6--7--8--');
-    const sourceSubs =        '^                   ';
-    const expected =          '--------5--6--7--8--';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--1--2-^-3--4--5--6--7--8--');
+      const sourceSubs = '       ^-------------------';
+      const expected = '         --------5--6--7--8--';
 
-    const predicate = function (v: string) {
-      return +v < 5;
-    };
+      const predicate = function (v: string) {
+        return +v < 5;
+      };
 
-    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(predicate));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
-  it('should be possible to skip using the element\'s index', () => {
-    const source = hot('--a--b-^-c--d--e--f--g--h--|');
-    const sourceSubs =        '^                   !';
-    const expected =          '--------e--f--g--h--|';
+  it("should be possible to skip using the element's index", () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b-^-c--d--e--f--g--h--|');
+      const sourceSubs = '       ^-------------------!';
+      const expected = '         --------e--f--g--h--|';
 
-    const predicate = function (v: string, index: number) {
-      return index < 2;
-    };
+      const predicate = function (_v: string, index: number) {
+        return index < 2;
+      };
 
-    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(predicate));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should skip using index with source unsubscribes early', () => {
-    const source = hot('--a--b-^-c--d--e--f--g--h--|');
-    const sourceSubs =        '^          !';
-    const unsub =             '-----------!';
-    const expected =          '-----d--e---';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b-^-c--d--e--f--g--h--|');
+      const sourceSubs = '       ^----------!         ';
+      const unsub = '            -----------!         ';
+      const expected = '         -----d--e---         ';
 
-    const predicate = function (v: string, index: number) {
-      return index < 1;
-    };
+      const predicate = function (_v: string, index: number) {
+        return index < 1;
+      };
 
-    expectObservable(source.pipe(skipWhile(predicate)), unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(predicate));
+
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const source = hot('--a--b-^-c--d--e--f--g--h--|');
-    const sourceSubs =        '^          !';
-    const expected =          '-----d--e---';
-    const unsub =             '           !';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b-^-c--d--e--f--g--h--|');
+      const sourceSubs = '       ^----------!         ';
+      const expected = '         -----d--e---         ';
+      const unsub = '            -----------!         ';
 
-    const predicate = function (v: string, index: number) {
-      return index < 1;
-    };
+      const predicate = function (_v: string, index: number) {
+        return index < 1;
+      };
 
-    const result = source.pipe(
-      mergeMap(function (x) { return of(x); }),
-      skipWhile(predicate),
-      mergeMap(function (x) { return of(x); })
-    );
+      const result = source.pipe(
+        mergeMap(function (x) {
+          return of(x);
+        }),
+        skipWhile(predicate),
+        mergeMap(function (x) {
+          return of(x);
+        })
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should skip using value with source throws', () => {
-    const source = hot('--a--b-^-c--d--e--f--g--h--#');
-    const sourceSubs =        '^                   !';
-    const expected =          '-----d--e--f--g--h--#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b-^-c--d--e--f--g--h--#');
+      const sourceSubs = '       ^-------------------!';
+      const expected = '         -----d--e--f--g--h--#';
 
-    const predicate = function (v: string) {
-      return v !== 'd';
-    };
+      const predicate = function (v: string) {
+        return v !== 'd';
+      };
 
-    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(predicate));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should invoke predicate while its false and never again', () => {
-    const source = hot('--a--b-^-c--d--e--f--g--h--|');
-    const sourceSubs =        '^                   !';
-    const expected =          '--------e--f--g--h--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b-^-c--d--e--f--g--h--|');
+      const sourceSubs = '       ^-------------------!';
+      const expected = '         --------e--f--g--h--|';
 
-    let invoked = 0;
-    const predicate = function (v: string) {
-      invoked++;
-      return v !== 'e';
-    };
+      let invoked = 0;
+      const predicate = function (v: string) {
+        invoked++;
+        return v !== 'e';
+      };
 
-    expectObservable(
-      source.pipe(
+      const result = source.pipe(
         skipWhile(predicate),
         tap(null, null, () => {
           expect(invoked).to.equal(3);
         })
-      )
-    ).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      );
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should handle predicate that throws', () => {
-    const source = hot('--a--b-^-c--d--e--f--g--h--|');
-    const sourceSubs =        '^       !';
-    const expected =          '--------#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--a--b-^-c--d--e--f--g--h--|');
+      const sourceSubs = '       ^-------!            ';
+      const expected = '         --------#            ';
 
-    const predicate = function (v: string) {
-      if (v === 'e') {
-        throw new Error('nom d\'une pipe !');
-      }
+      const predicate = function (v: string) {
+        if (v === 'e') {
+          throw new Error("nom d'une pipe !");
+        }
 
-      return v !== 'f';
-    };
+        return v !== 'f';
+      };
 
-    expectObservable(source.pipe(skipWhile(predicate))).toBe(expected, undefined, new Error('nom d\'une pipe !'));
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      const result = source.pipe(skipWhile(predicate));
+
+      expectObservable(result).toBe(expected, undefined, new Error("nom d'une pipe !"));
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should handle Observable.empty', () => {
-    const source = cold('|');
-    const subs =        '(^!)';
-    const expected =    '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('|   ');
+      const subs = '       (^!)';
+      const expected = '   |   ';
 
-    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      const result = source.pipe(skipWhile(() => true));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should handle Observable.never', () => {
-    const source = cold('-');
-    const subs =        '^';
-    const expected =    '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('-');
+      const subs = '       ^';
+      const expected = '   -';
 
-    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      const result = source.pipe(skipWhile(() => true));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should handle Observable.throw', () => {
-    const source = cold('#');
-    const subs =        '(^!)';
-    const expected =    '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('#   ');
+      const subs = '       (^!)';
+      const expected = '   #   ';
 
-    expectObservable(source.pipe(skipWhile(() => true))).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      const result = source.pipe(skipWhile(() => true));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -204,10 +276,14 @@ describe('skipWhile operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      skipWhile(value => value < 2),
-      take(1),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable
+      .pipe(
+        skipWhile((value) => value < 2),
+        take(1)
+      )
+      .subscribe(() => {
+        /* noop */
+      });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });

--- a/spec/operators/skipWhile-spec.ts
+++ b/spec/operators/skipWhile-spec.ts
@@ -195,8 +195,10 @@ describe('skipWhile', () => {
 
       const result = source.pipe(
         skipWhile(predicate),
-        tap(null, null, () => {
-          expect(invoked).to.equal(3);
+        tap({
+          complete() {
+            expect(invoked).to.equal(3);
+          },
         })
       );
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `skipWhile` tests to run mode. It also refactors a deprecated `tap` signature.

**Related issue (if exists):**
None
