### PR TITLE
docs: highlight the delay operator

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -68,7 +68,7 @@ import { interval } from 'rxjs';
 const observable = interval(1000 /* number of milliseconds */);
 ```
 
-See the list of [all static creation operators here](#creation-operators-list).
+See the list of all static creation operators [here](#creation-operators-list).
 
 ## Higher-order Observables
 
@@ -349,4 +349,4 @@ Note that you must
 2. implement a "teardown" function that cleans up when the Observable completes (in this case by unsubscribing and clearing any pending timeouts).
 3. return that teardown function from the function passed to the Observable constructor.
 
-Of course, this is only an example; the `delay()` operator [already exists](/api/operators/delay).
+Of course, this is only an example; the [`delay()`](/api/operators/delay) operator already exists.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
