### PR TITLE
fix(symbol): revert unique symbol in #5874

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -238,7 +238,7 @@ export interface ObjectUnsubscribedError extends Error {
 
 export declare const ObjectUnsubscribedError: ObjectUnsubscribedErrorCtor;
 
-export declare const observable: string | SymbolConstructor["observable"];
+export declare const observable: string | symbol;
 
 export declare class Observable<T> implements Subscribable<T> {
     protected operator: Operator<any, T> | undefined;

--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,2 +1,11 @@
+/** Symbol.observable addition */
+/* Note: This will add Symbol.observable globally for all TypeScript users,
+  however, we are no longer polyfilling Symbol.observable */
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
 /** Symbol.observable or a string "@@observable". Used for interop */
 export const observable = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();

--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,11 +1,2 @@
-/** Symbol.observable addition */
-/* Note: This will add Symbol.observable globally for all TypeScript users,
-  however, we are no longer polyfilling Symbol.observable */
-declare global {
-  interface SymbolConstructor {
-    readonly observable: symbol;
-  }
-}
-
 /** Symbol.observable or a string "@@observable". Used for interop */
 export const observable = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -4,22 +4,6 @@
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
 
-/**
- * NOTE: This will add Symbol.observable globally for all TypeScript users,
- * however, we are no longer polyfilling Symbol.observable. Note that this will be at
- * odds with older version of @types/node and symbol-observable which incorrectly define
- * `Symbol.observable` as `symbol` rather than `unique symbol`. "What about not defining
- * this non-standard symbol at all?" you might ask... Well, that ship has sailed. There are
- * dozens of libraries using this symbol now and many of them are quite popular.
- * So here we are, and it's probably my fault. Sorry, "the web", if I have hurt you,
- * the world just needed a standard way to provide interop for these types. -Ben
- */
-declare global {
-  interface SymbolConstructor {
-    readonly observable: unique symbol;
-  }
-}
-
 /** OPERATOR INTERFACES */
 
 export interface UnaryFunction<T, R> {

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -4,6 +4,16 @@
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
 
+/**
+ * Note: This will add Symbol.observable globally for all TypeScript users,
+ * however, we are no longer polyfilling Symbol.observable
+ */
+declare global {
+  interface SymbolConstructor {
+    readonly observable: symbol;
+  }
+}
+
 /** OPERATOR INTERFACES */
 
 export interface UnaryFunction<T, R> {


### PR DESCRIPTION
- closes #5919

This is manual revert to #5874. 

Core team have discussed around #5919 for a while, and at this moment pretty much agreed

- there is no good suggestion to resolve all of problems we are facing
- current changes (#5784) is too much breaking especially we don't have good workaround to suggest.

At least, providing as-is experience between v6 to v7 is something we'd like to have instead of making huge breaking changes. This doesn't mean we'll stay with this forever, it's just hard enough find right solution (and doesn't break whole world).

I'm making this PR to v7 not slip this accidentally when we publish official release.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
