### PR TITLE
fix: Symbol.observable type no longer `unique symbol`.

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -238,7 +238,7 @@ export interface ObjectUnsubscribedError extends Error {
 
 export declare const ObjectUnsubscribedError: ObjectUnsubscribedErrorCtor;
 
-export declare const observable: string | SymbolConstructor["observable"];
+export declare const observable: string | symbol;
 
 export declare class Observable<T> implements Subscribable<T> {
     protected operator: Operator<any, T> | undefined;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -16,7 +16,7 @@ import { Subscription } from './Subscription';
  */
 declare global {
   interface SymbolConstructor {
-    readonly observable: unique symbol;
+    readonly observable: symbol;
   }
 }
 


### PR DESCRIPTION
This is to fix compatibility issues with our type definitions and those from other projects. Of note: `symbol-observable@4` as also reverted this typing to just `symbol` from `unique symbol`.
