### PR TITLE
chore: Add typesVersions to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "module": "./dist/esm5/index.js",
   "es2015": "./dist/esm/index.js",
   "types": "./dist/types/index.d.ts",
+  "typesVersions": {
+    ">=4.0": { "*": [ "dist/types/*" ] }
+  },
   "sideEffects": false,
   "exports": {
     ".": {


### PR DESCRIPTION
This is an attempt to fix issues with VS Code auto-import, as described here in this issue: https://github.com/microsoft/TypeScript/issues/43034\#issuecomment-820621280

Related #6067
