### PR TITLE
chore: update type for multiplex operator

### DIFF
--- a/api_guard/dist/types/webSocket/index.d.ts
+++ b/api_guard/dist/types/webSocket/index.d.ts
@@ -5,7 +5,7 @@ export declare class WebSocketSubject<T> extends AnonymousSubject<T> {
     constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>);
     _subscribe(subscriber: Subscriber<T>): Subscription;
     lift<R>(operator: Operator<T, R>): WebSocketSubject<R>;
-    multiplex(subMsg: () => any, unsubMsg: () => any, messageFilter: (value: T) => boolean): Observable<any>;
+    multiplex(subMsg: () => any, unsubMsg: () => any, messageFilter: (value: T) => boolean): Observable<T>;
     unsubscribe(): void;
 }
 

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -223,7 +223,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
    */
   multiplex(subMsg: () => any, unsubMsg: () => any, messageFilter: (value: T) => boolean) {
     const self = this;
-    return new Observable((observer: Observer<any>) => {
+    return new Observable((observer: Observer<T>) => {
       try {
         self.next(subMsg());
       } catch (err) {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** update the type result for multiplex method on WebSocketSubjectConfig