### PR TITLE
types(ajax): improve Ajax types and docs

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -21,6 +21,8 @@ export interface AjaxConfig {
     xsrfHeaderName?: string;
 }
 
+export declare type AjaxDirection = 'upload' | 'download';
+
 export interface AjaxError extends Error {
     request: AjaxRequest;
     response: any;

--- a/src/ajax/index.ts
+++ b/src/ajax/index.ts
@@ -1,4 +1,4 @@
 export { ajax } from '../internal/ajax/ajax';
 export { AjaxError, AjaxTimeoutError } from '../internal/ajax/errors';
 export { AjaxResponse } from '../internal/ajax/AjaxResponse';
-export { AjaxRequest, AjaxConfig } from '../internal/ajax/types';
+export { AjaxRequest, AjaxConfig, AjaxDirection } from '../internal/ajax/types';

--- a/src/internal/ajax/AjaxResponse.ts
+++ b/src/internal/ajax/AjaxResponse.ts
@@ -13,6 +13,7 @@ import { getXHRResponse } from './getXHRResponse';
  * request and response data.
  *
  * @see {@link ajax}
+ * @see {@link AjaxConfig}
  */
 export class AjaxResponse<T> {
   /** The HTTP status code */
@@ -32,17 +33,15 @@ export class AjaxResponse<T> {
 
   /**
    * The total number of bytes loaded so far. To be used with {@link total} while
-   * calcating progress. (You will want to set {@link includeDownloadProgress} or {@link includeDownloadProgress})
-   *
-   * {@see {@link AjaxConfig}}
+   * calculating progress. (You will want to set {@link includeDownloadProgress} or
+   * {@link includeDownloadProgress})
    */
   readonly loaded: number;
 
   /**
    * The total number of bytes to be loaded. To be used with {@link loaded} while
-   * calcating progress. (You will want to set {@link includeDownloadProgress} or {@link includeDownloadProgress})
-   *
-   * {@see {@link AjaxConfig}}
+   * calculating progress. (You will want to set {@link includeDownloadProgress} or
+   * {@link includeDownloadProgress})
    */
   readonly total: number;
 
@@ -61,6 +60,7 @@ export class AjaxResponse<T> {
    * @param originalEvent The original event object from the XHR `onload` event.
    * @param xhr The `XMLHttpRequest` object used to make the request. This is useful for examining status code, etc.
    * @param request The request settings used to make the HTTP request.
+   * @param type The type of the event emitted by the {@link ajax} Observable
    */
   constructor(
     /**
@@ -81,8 +81,16 @@ export class AjaxResponse<T> {
      * The event type. This can be used to discern between different events
      * if you're using progress events with {@link includeDownloadProgress} or
      * {@link includeUploadProgress} settings in {@link AjaxConfig}.
+     *
+     * The event type consists of two parts: the {@link AjaxDirection} and the
+     * the event type. Merged with `_`, they form the `type` string. The
+     * direction can be an `upload` or a `download` direction, while an event can
+     * be `loadstart`, `progress` or `load`.
+     *
+     * `download_load` is the type of event when download has finished and the
+     * response is available.
      */
-    public readonly type = 'download_load'
+    public readonly type: string = 'download_load'
   ) {
     const { status, responseType } = xhr;
     this.status = status ?? 0;

--- a/src/internal/ajax/errors.ts
+++ b/src/internal/ajax/errors.ts
@@ -11,27 +11,28 @@ import { createErrorClass } from '../util/createErrorClass';
  */
 export interface AjaxError extends Error {
   /**
-   * The XHR instance associated with the error
+   * The XHR instance associated with the error.
    */
   xhr: XMLHttpRequest;
 
   /**
-   * The AjaxRequest associated with the error
+   * The AjaxRequest associated with the error.
    */
   request: AjaxRequest;
 
   /**
-   *The HTTP status code
+   * The HTTP status code, if the request has completed. If not,
+   * it is set to `0`.
    */
   status: number;
 
   /**
-   *The responseType (e.g. 'json', 'arraybuffer', or 'xml')
+   * The responseType (e.g. 'json', 'arraybuffer', or 'xml').
    */
   responseType: XMLHttpRequestResponseType;
 
   /**
-   * The response data
+   * The response data.
    */
   response: any;
 }
@@ -85,7 +86,7 @@ export interface AjaxTimeoutErrorCtor {
 }
 
 /**
- * Thrown when an AJAX request timesout. Not to be confused with {@link TimeoutError}.
+ * Thrown when an AJAX request times out. Not to be confused with {@link TimeoutError}.
  *
  * This is exported only because it is useful for checking to see if errors are an
  * `instanceof AjaxTimeoutError`. DO NOT use the constructor to create an instance of

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -1,9 +1,17 @@
 import { PartialObserver } from '../types';
 
 /**
+ * Valid Ajax direction types. Prefixes the event `type` in the
+ * {@link AjaxResponse} object with "upload_" for events related
+ * to uploading and "download_" for events related to downloading.
+ */
+export type AjaxDirection = 'upload' | 'download';
+
+/**
  * The object containing values RxJS used to make the HTTP request.
  *
- * This is provided in {@link AjaxError} instances and
+ * This is provided in {@link AjaxError} instances as the `request`
+ * object.
  */
 export interface AjaxRequest {
   /**
@@ -74,7 +82,7 @@ export interface AjaxConfig {
   /**
    * The body of the HTTP request to send.
    *
-   * This is serialized, by default, based off of the valud of the `"content-type"` header.
+   * This is serialized, by default, based off of the value of the `"content-type"` header.
    * For example, if the `"content-type"` is `"application/json"`, the body will be serialized
    * as JSON. If the `"content-type"` is `"application/x-www-form-urlencoded"`, whatever object passed
    * to the body will be serialized as URL, using key-value pairs based off of the keys and values of the object.
@@ -179,8 +187,8 @@ export interface AjaxConfig {
   progressSubscriber?: PartialObserver<ProgressEvent>;
 
   /**
-   * If `true`, will emit all download progress and load complete events as {@link AjaxProgressEvents}
-   * from the observable. The final download event will also be emitted as a {@link AjaxDownloadCompleteEvent}
+   * If `true`, will emit all download progress and load complete events as {@link AjaxResponse}
+   * from the observable. The final download event will also be emitted as a {@link AjaxResponse}.
    *
    * If both this and {@link includeUploadProgress} are `false`, then only the {@link AjaxResponse} will
    * be emitted from the resulting observable.
@@ -188,8 +196,8 @@ export interface AjaxConfig {
   includeDownloadProgress?: boolean;
 
   /**
-   * If `true`, will emit all upload progress and load complete events as {@link AjaxUploadProgressEvents}
-   * from the observable. The final download event will also be emitted as a {@link AjaxDownloadCompleteEvent}
+   * If `true`, will emit all upload progress and load complete events as {@link AjaxResponse}
+   * from the observable. The final download event will also be emitted as a {@link AjaxResponse}.
    *
    * If both this and {@link includeDownloadProgress} are `false`, then only the {@link AjaxResponse} will
    * be emitted from the resulting observable.


### PR DESCRIPTION
**Description:**
This PR improves `ajax` docs, introduces `AjaxDirection` type and fixes multiple typos.

Also, some `npm run docs` failures are fixed with this PR, like:
- `No handler provided for inline tag "{@see {@link AjaxConfig}"` or
- `Error in {@link AjaxProgressEvents} - Invalid link (does not match any doc)`.

**Related issue (if exists):**
None