### PR TITLE
chore: display types of API const docs correctly

### DIFF
--- a/docs_app/tools/transforms/templates/api/var.template.html
+++ b/docs_app/tools/transforms/templates/api/var.template.html
@@ -2,7 +2,7 @@
 
 {% block overview %}
   <code-example language="ts" hideCopy="true" class="no-box api-heading">
-  const {$ doc.name $}: {$ doc.symbolTypeName or 'any' $};
+  const {$ doc.name $}: {$ (doc.type | escape) or 'any' $};
   </code-example>
 {% endblock %}
 


### PR DESCRIPTION
**Description:**
Fix `const` docs that were showing `any` for any constant. The docs now show/infer the constant type correctly. `dgeni-packages` version is high enough for this to work.

**Related issue (if exists):**
None related to RxJS, a fix taken from angular/angular#23850. Please read that PR for more info and visual description.