### PR TITLE
types(ajax): add HTTP Request methods

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -33,6 +33,8 @@ export interface AjaxError extends Error {
 
 export declare const AjaxError: AjaxErrorCtor;
 
+export declare type AjaxHttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH' | '';
+
 export interface AjaxRequest {
     async: boolean;
     body?: any;

--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -8,7 +8,7 @@ export interface AjaxConfig {
     headers?: Readonly<Record<string, any>>;
     includeDownloadProgress?: boolean;
     includeUploadProgress?: boolean;
-    method?: string;
+    method?: AjaxHttpMethod;
     password?: string;
     progressSubscriber?: PartialObserver<ProgressEvent>;
     queryParams?: string | URLSearchParams | Record<string, string | number | boolean | string[] | number[] | boolean[]> | [string, string | number | boolean | string[] | number[] | boolean[]][];
@@ -38,7 +38,7 @@ export interface AjaxRequest {
     body?: any;
     crossDomain: boolean;
     headers: Readonly<Record<string, any>>;
-    method: string;
+    method: AjaxHttpMethod;
     password?: string;
     responseType: XMLHttpRequestResponseType;
     timeout: number;

--- a/spec-dtslint/observables/dom/ajax-spec.ts
+++ b/spec-dtslint/observables/dom/ajax-spec.ts
@@ -1,4 +1,4 @@
-import { ajax } from 'rxjs/ajax';
+import { ajax, AjaxConfig, AjaxRequest } from 'rxjs/ajax';
 
 it('should enforce function parameter', () => {
   const o = ajax(); // $ExpectError
@@ -9,7 +9,7 @@ it('should accept string param', () => {
 });
 
 it('should accept AjaxRequest params', () => {
-  const ajaxRequest = {
+  const ajaxRequest: AjaxConfig = {
     method: 'GET',
     url: '/a',
     body: {a: 'a', b: 'b'},

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -566,7 +566,7 @@ describe('ajax', () => {
 
   describe('ajax request body', () => {
     it('can take string body', () => {
-      const obj = {
+      const obj: AjaxConfig = {
         url: '/flibbertyJibbet',
         method: 'POST',
         body: 'foobar',
@@ -580,7 +580,7 @@ describe('ajax', () => {
 
     it('can take FormData body', () => {
       const body = new root.FormData();
-      const obj = {
+      const obj: AjaxConfig = {
         url: '/flibbertyJibbet',
         method: 'POST',
         body: body,
@@ -599,7 +599,7 @@ describe('ajax', () => {
       const body = new URLSearchParams({
         '🌟': '🚀',
       });
-      const obj = {
+      const obj: AjaxConfig = {
         url: '/flibbertyJibbet',
         method: 'POST',
         body: body,
@@ -615,7 +615,7 @@ describe('ajax', () => {
       const body = {
         '🌟': '🚀',
       };
-      const obj = {
+      const obj: AjaxConfig = {
         url: '/flibbertyJibbet',
         method: 'POST',
         body: body,
@@ -632,7 +632,7 @@ describe('ajax', () => {
         hello: 'world',
       };
 
-      const requestObj = {
+      const requestObj: AjaxConfig = {
         url: '/flibbertyJibbet',
         method: '',
         body: body,

--- a/src/ajax/index.ts
+++ b/src/ajax/index.ts
@@ -1,4 +1,4 @@
 export { ajax } from '../internal/ajax/ajax';
 export { AjaxError, AjaxTimeoutError } from '../internal/ajax/errors';
 export { AjaxResponse } from '../internal/ajax/AjaxResponse';
-export { AjaxRequest, AjaxConfig, AjaxDirection } from '../internal/ajax/types';
+export { AjaxRequest, AjaxConfig, AjaxDirection, AjaxHttpMethod } from '../internal/ajax/types';

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -1,6 +1,12 @@
 import { PartialObserver } from '../types';
 
 /**
+ * Ajax HTTP Request methods
+ * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+ */
+export type AjaxHttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH'
+
+/**
  * Valid Ajax direction types. Prefixes the event `type` in the
  * {@link AjaxResponse} object with "upload_" for events related
  * to uploading and "download_" for events related to downloading.
@@ -27,7 +33,7 @@ export interface AjaxRequest {
   /**
    * The HTTP method used to make the HTTP request.
    */
-  method: string;
+  method: AjaxHttpMethod;
 
   /**
    * Whether or not the request was made asynchronously.
@@ -99,7 +105,7 @@ export interface AjaxConfig {
   /**
    * The HTTP Method to use for the request. Defaults to "GET".
    */
-  method?: string;
+  method?: AjaxHttpMethod;
 
   /**
    * The HTTP headers to apply.

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -3,8 +3,9 @@ import { PartialObserver } from '../types';
 /**
  * Ajax HTTP Request methods
  * Reference: https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods
+ * Uses empty string as optional type for testing.
  */
-export type AjaxHttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH'
+export type AjaxHttpMethod = 'GET' | 'HEAD' | 'POST' | 'PUT' | 'DELETE' | 'CONNECT' | 'OPTIONS' | 'TRACE' | 'PATCH' | '';
 
 /**
  * Valid Ajax direction types. Prefixes the event `type` in the


### PR DESCRIPTION
**Description:**
Adds types to AjaxRequest and AjaxConfig interfaces that uses http **method** property.

**Related issue (if exists):**
Noop
