### PR TITLE
feat: use optional config.Promise in firstValueFrom and lastValueFrom

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -9,6 +9,7 @@ import { observable as Symbol_observable } from './symbol/observable';
 import { pipeFromArray } from './util/pipe';
 import { config } from './config';
 import { isFunction } from './util/isFunction';
+import { getPromiseCtor } from './util/getPromiseCtor';
 
 /**
  * A representation of any set of values over any amount of time. This is the most basic building block
@@ -494,17 +495,6 @@ export class Observable<T> implements Subscribable<T> {
       );
     }) as Promise<T | undefined>;
   }
-}
-
-/**
- * Decides between a passed promise constructor from consuming code,
- * A default configured promise constructor, and the native promise
- * constructor and returns it. If nothing can be found, it will throw
- * an error.
- * @param promiseCtor The optional promise constructor to passed by consuming code
- */
-function getPromiseCtor(promiseCtor: PromiseConstructorLike | undefined) {
-  return promiseCtor ?? config.Promise ?? Promise;
 }
 
 function isObserver<T>(value: any): value is Observer<T> {

--- a/src/internal/firstValueFrom.ts
+++ b/src/internal/firstValueFrom.ts
@@ -1,6 +1,7 @@
 import { Observable } from './Observable';
 import { EmptyError } from './util/EmptyError';
 import { SafeSubscriber } from './Subscriber';
+import { getPromiseCtor } from './util/getPromiseCtor';
 
 export interface FirstValueFromConfig<T> {
   defaultValue: T;
@@ -51,9 +52,11 @@ export function firstValueFrom<T>(source: Observable<T>): Promise<T>;
  * @param source the observable to convert to a promise
  * @param config a configuration object to define the `defaultValue` to use if the source completes without emitting a value
  */
-export function firstValueFrom<T, D>(source: Observable<T>, config?: FirstValueFromConfig<D>) {
+export function firstValueFrom<T, D>(source: Observable<T>, config?: FirstValueFromConfig<D>): Promise<T | D> {
   const hasConfig = typeof config === 'object';
-  return new Promise<T | D>((resolve, reject) => {
+  const promiseCtor = getPromiseCtor();
+
+  return new promiseCtor<T | D>((resolve, reject) => {
     const subscriber = new SafeSubscriber<T>({
       next: (value) => {
         resolve(value);
@@ -69,5 +72,5 @@ export function firstValueFrom<T, D>(source: Observable<T>, config?: FirstValueF
       },
     });
     source.subscribe(subscriber);
-  });
+  }) as Promise<T | D>;
 }

--- a/src/internal/lastValueFrom.ts
+++ b/src/internal/lastValueFrom.ts
@@ -1,5 +1,6 @@
 import { Observable } from './Observable';
 import { EmptyError } from './util/EmptyError';
+import { getPromiseCtor } from './util/getPromiseCtor';
 
 export interface LastValueFromConfig<T> {
   defaultValue: T;
@@ -50,9 +51,11 @@ export function lastValueFrom<T>(source: Observable<T>): Promise<T>;
  * @param source the observable to convert to a promise
  * @param config a configuration object to define the `defaultValue` to use if the source completes without emitting a value
  */
-export function lastValueFrom<T, D>(source: Observable<T>, config?: LastValueFromConfig<D>) {
+export function lastValueFrom<T, D>(source: Observable<T>, config?: LastValueFromConfig<D>): Promise<T | D> {
   const hasConfig = typeof config === 'object';
-  return new Promise<T | D>((resolve, reject) => {
+  const promiseCtor = getPromiseCtor();
+
+  return new promiseCtor<T | D>((resolve, reject) => {
     let _hasValue = false;
     let _value: T;
     source.subscribe({
@@ -71,5 +74,5 @@ export function lastValueFrom<T, D>(source: Observable<T>, config?: LastValueFro
         }
       },
     });
-  });
+  }) as Promise<T | D>;
 }

--- a/src/internal/util/getPromiseCtor.ts
+++ b/src/internal/util/getPromiseCtor.ts
@@ -1,0 +1,11 @@
+import { config } from '../config';
+
+/**
+ * Decides between a passed promise constructor from consuming code,
+ * a promise constructor defined at global {@link config} or the native
+ * promise constructor and returns it.
+ * @param promiseCtor The optional promise constructor passed by consuming code
+ */
+export function getPromiseCtor(promiseCtor?: PromiseConstructorLike): PromiseConstructorLike {
+  return promiseCtor ?? config.Promise ?? Promise;
+}


### PR DESCRIPTION
**Description:**
This PR enables `firstValueFrom` and `lastValueFrom` to construct a Promise if `config.Promise` is defined.

**Related issue (if exists):**
None