### PR TITLE
types(config): add GlobalConfig interface

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -69,13 +69,7 @@ export interface CompletionObserver<T> {
 export declare function concat<T extends readonly unknown[]>(...inputs: [...ObservableInputTuple<T>]): Observable<T[number]>;
 export declare function concat<T extends readonly unknown[]>(...inputsAndScheduler: [...ObservableInputTuple<T>, SchedulerLike]): Observable<T[number]>;
 
-export declare const config: {
-    onUnhandledError: ((err: any) => void) | null;
-    onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
-    Promise: PromiseConstructorLike | undefined;
-    useDeprecatedSynchronousErrorHandling: boolean;
-    useDeprecatedNextContext: boolean;
-};
+export declare const config: GlobalConfig;
 
 export declare function connectable<T>(source: ObservableInput<T>, connector?: Subject<T>): ConnectableObservableLike<T>;
 
@@ -161,6 +155,14 @@ export declare function generate<T, S>(initialState: S, condition: ConditionFunc
 export declare function generate<S>(initialState: S, condition: ConditionFunc<S>, iterate: IterateFunc<S>, scheduler?: SchedulerLike): Observable<S>;
 export declare function generate<S>(options: GenerateBaseOptions<S>): Observable<S>;
 export declare function generate<T, S>(options: GenerateOptions<T, S>): Observable<T>;
+
+export interface GlobalConfig {
+    Promise: PromiseConstructorLike | undefined;
+    onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
+    onUnhandledError: ((err: any) => void) | null;
+    useDeprecatedNextContext: boolean;
+    useDeprecatedSynchronousErrorHandling: boolean;
+}
 
 export interface GroupedObservable<K, T> extends Observable<T> {
     readonly key: K;

--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -157,7 +157,7 @@ export declare function generate<S>(options: GenerateBaseOptions<S>): Observable
 export declare function generate<T, S>(options: GenerateOptions<T, S>): Observable<T>;
 
 export interface GlobalConfig {
-    Promise: PromiseConstructorLike | undefined;
+    Promise?: PromiseConstructorLike;
     onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
     onUnhandledError: ((err: any) => void) | null;
     useDeprecatedNextContext: boolean;

--- a/src/index.ts
+++ b/src/index.ts
@@ -83,4 +83,4 @@ export { NEVER } from './internal/observable/never';
 export * from './internal/types';
 
 /* Config */
-export { config } from './internal/config';
+export { config, GlobalConfig } from './internal/config';

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,71 +1,18 @@
 import { Subscriber } from './Subscriber';
-import { ObservableNotification } from './types';
+import { ObservableNotification, GlobalConfig } from './types';
 
 /**
- * The global configuration object for RxJS, used to configure things
- * like what Promise constructor should used to create Promises
+ * The {@link GlobalConfig} object for RxJS. It is used to configure things
+ * like how to react on unhandled errors.
  */
-export const config = {
-  /**
-   * A registration point for unhandled errors from RxJS. These are errors that
-   * cannot were not handled by consuming code in the usual subscription path. For
-   * example, if you have this configured, and you subscribe to an observable without
-   * providing an error handler, errors from that subscription will end up here. This
-   * will _always_ be called asynchronously on another job in the runtime. This is because
-   * we do not want errors thrown in this user-configured handler to interfere with the
-   * behavior of the library.
-   */
+export const config: GlobalConfig = {
   onUnhandledError: null as ((err: any) => void) | null,
 
-  /**
-   * A registration point for notifications that cannot be sent to subscribers because they
-   * have completed, errored or have been explicitly unsubscribed. By default, next, complete
-   * and error notifications sent to stopped subscribers are noops. However, sometimes callers
-   * might want a different behavior. For example, with sources that attempt to report errors
-   * to stopped subscribers, a caller can configure RxJS to throw an unhandled error instead.
-   * This will _always_ be called asynchronously on another job in the runtime. This is because
-   * we do not want errors thrown in this user-configured handler to interfere with the
-   * behavior of the library.
-   */
   onStoppedNotification: null as ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null,
 
-  /**
-   * The promise constructor used by default for methods such as
-   * {@link toPromise} and {@link forEach}
-   *
-   * @deprecated remove in v8. RxJS will no longer support this sort of injection of a
-   * Promise constructor. If you need a Promise implementation other than native promises,
-   * please polyfill/patch Promises as you see appropriate.
-   */
   Promise: undefined as PromiseConstructorLike | undefined,
 
-  /**
-   * If true, turns on synchronous error rethrowing, which is a deprecated behavior
-   * in v6 and higher. This behavior enables bad patterns like wrapping a subscribe
-   * call in a try/catch block. It also enables producer interference, a nasty bug
-   * where a multicast can be broken for all observers by a downstream consumer with
-   * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BUY TIME
-   * FOR MIGRATION REASONS.
-   *
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
-   * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
-   * behaviors described above.
-   */
   useDeprecatedSynchronousErrorHandling: false,
 
-  /**
-   * If true, enables an as-of-yet undocumented feature from v5: The ability to access
-   * `unsubscribe()` via `this` context in `next` functions created in observers passed
-   * to `subscribe`.
-   *
-   * This is being removed because the performance was severely problematic, and it could also cause
-   * issues when types other than POJOs are passed to subscribe as subscribers, as they will likely have
-   * their `this` context overwritten.
-   *
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
-   * context of next functions provided as part of an observer to Subscribe. Instead,
-   * you will have access to a subscription or a signal or token that will allow you to do things like
-   * unsubscribe and test closed status.
-   */
   useDeprecatedNextContext: false,
 };

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -1,5 +1,5 @@
 import { Subscriber } from './Subscriber';
-import { ObservableNotification, GlobalConfig } from './types';
+import { ObservableNotification } from './types';
 
 /**
  * The {@link GlobalConfig} object for RxJS. It is used to configure things
@@ -16,3 +16,73 @@ export const config: GlobalConfig = {
 
   useDeprecatedNextContext: false,
 };
+
+/**
+ * The global configuration object for RxJS, used to configure things
+ * like how to react on unhandled errors. Accessible via {@link config}
+ * object.
+ */
+export interface GlobalConfig {
+  /**
+   * A registration point for unhandled errors from RxJS. These are errors that
+   * cannot were not handled by consuming code in the usual subscription path. For
+   * example, if you have this configured, and you subscribe to an observable without
+   * providing an error handler, errors from that subscription will end up here. This
+   * will _always_ be called asynchronously on another job in the runtime. This is because
+   * we do not want errors thrown in this user-configured handler to interfere with the
+   * behavior of the library.
+   */
+  onUnhandledError: ((err: any) => void) | null;
+
+  /**
+   * A registration point for notifications that cannot be sent to subscribers because they
+   * have completed, errored or have been explicitly unsubscribed. By default, next, complete
+   * and error notifications sent to stopped subscribers are noops. However, sometimes callers
+   * might want a different behavior. For example, with sources that attempt to report errors
+   * to stopped subscribers, a caller can configure RxJS to throw an unhandled error instead.
+   * This will _always_ be called asynchronously on another job in the runtime. This is because
+   * we do not want errors thrown in this user-configured handler to interfere with the
+   * behavior of the library.
+   */
+  onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
+
+  /**
+   * The promise constructor used by default for {@link toPromise} and {@link forEach}
+   * methods.
+   *
+   * @deprecated remove in v8. RxJS will no longer support this sort of injection of a
+   * Promise constructor. If you need a Promise implementation other than native promises,
+   * please polyfill/patch Promises as you see appropriate.
+   */
+  Promise?: PromiseConstructorLike;
+
+  /**
+   * If true, turns on synchronous error rethrowing, which is a deprecated behavior
+   * in v6 and higher. This behavior enables bad patterns like wrapping a subscribe
+   * call in a try/catch block. It also enables producer interference, a nasty bug
+   * where a multicast can be broken for all observers by a downstream consumer with
+   * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BUY TIME
+   * FOR MIGRATION REASONS.
+   *
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
+   * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
+   * behaviors described above.
+   */
+  useDeprecatedSynchronousErrorHandling: boolean;
+
+  /**
+   * If true, enables an as-of-yet undocumented feature from v5: The ability to access
+   * `unsubscribe()` via `this` context in `next` functions created in observers passed
+   * to `subscribe`.
+   *
+   * This is being removed because the performance was severely problematic, and it could also cause
+   * issues when types other than POJOs are passed to subscribe as subscribers, as they will likely have
+   * their `this` context overwritten.
+   *
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
+   * context of next functions provided as part of an observer to Subscribe. Instead,
+   * you will have access to a subscription or a signal or token that will allow you to do things like
+   * unsubscribe and test closed status.
+   */
+  useDeprecatedNextContext: boolean;
+}

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -6,11 +6,11 @@ import { ObservableNotification } from './types';
  * like how to react on unhandled errors.
  */
 export const config: GlobalConfig = {
-  onUnhandledError: null as ((err: any) => void) | null,
+  onUnhandledError: null,
 
-  onStoppedNotification: null as ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null,
+  onStoppedNotification: null,
 
-  Promise: undefined as PromiseConstructorLike | undefined,
+  Promise: undefined,
 
   useDeprecatedSynchronousErrorHandling: false,
 

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -7,13 +7,9 @@ import { ObservableNotification } from './types';
  */
 export const config: GlobalConfig = {
   onUnhandledError: null,
-
   onStoppedNotification: null,
-
   Promise: undefined,
-
   useDeprecatedSynchronousErrorHandling: false,
-
   useDeprecatedNextContext: false,
 };
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -3,7 +3,6 @@
 
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
-import { Subscriber } from './Subscriber';
 
 /**
  * Note: This will add Symbol.observable globally for all TypeScript users,
@@ -302,74 +301,4 @@ interface ReadableStreamDefaultReaderLike<T> {
  */
 export interface ReadableStreamLike<T> {
   getReader(): ReadableStreamDefaultReaderLike<T>;
-}
-
-/**
- * The global configuration object for RxJS, used to configure things
- * like how to react on unhandled errors. Accessible via {@link config}
- * object.
- */
-export interface GlobalConfig {
-  /**
-   * A registration point for unhandled errors from RxJS. These are errors that
-   * cannot were not handled by consuming code in the usual subscription path. For
-   * example, if you have this configured, and you subscribe to an observable without
-   * providing an error handler, errors from that subscription will end up here. This
-   * will _always_ be called asynchronously on another job in the runtime. This is because
-   * we do not want errors thrown in this user-configured handler to interfere with the
-   * behavior of the library.
-   */
-  onUnhandledError: ((err: any) => void) | null;
-
-  /**
-   * A registration point for notifications that cannot be sent to subscribers because they
-   * have completed, errored or have been explicitly unsubscribed. By default, next, complete
-   * and error notifications sent to stopped subscribers are noops. However, sometimes callers
-   * might want a different behavior. For example, with sources that attempt to report errors
-   * to stopped subscribers, a caller can configure RxJS to throw an unhandled error instead.
-   * This will _always_ be called asynchronously on another job in the runtime. This is because
-   * we do not want errors thrown in this user-configured handler to interfere with the
-   * behavior of the library.
-   */
-  onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
-
-  /**
-   * The promise constructor used by default for methods such as
-   * {@link Observable/toPromise} and {@link Observable/forEach}
-   *
-   * @deprecated remove in v8. RxJS will no longer support this sort of injection of a
-   * Promise constructor. If you need a Promise implementation other than native promises,
-   * please polyfill/patch Promises as you see appropriate.
-   */
-  Promise: PromiseConstructorLike | undefined;
-
-  /**
-   * If true, turns on synchronous error rethrowing, which is a deprecated behavior
-   * in v6 and higher. This behavior enables bad patterns like wrapping a subscribe
-   * call in a try/catch block. It also enables producer interference, a nasty bug
-   * where a multicast can be broken for all observers by a downstream consumer with
-   * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BUY TIME
-   * FOR MIGRATION REASONS.
-   *
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
-   * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
-   * behaviors described above.
-   */
-  useDeprecatedSynchronousErrorHandling: boolean;
-
-  /**
-   * If true, enables an as-of-yet undocumented feature from v5: The ability to access
-   * `unsubscribe()` via `this` context in `next` functions created in observers passed
-   * to `subscribe`.
-   *
-   * This is being removed because the performance was severely problematic, and it could also cause
-   * issues when types other than POJOs are passed to subscribe as subscribers, as they will likely have
-   * their `this` context overwritten.
-   *
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
-   * context of next functions provided as part of an observer to Subscribe. Instead,
-   * you will have access to a subscription or a signal or token that will allow you to do things like
-   * unsubscribe and test closed status.
-   */
-  useDeprecatedNextContext: boolean;
 }

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -3,6 +3,7 @@
 
 import { Observable } from './Observable';
 import { Subscription } from './Subscription';
+import { Subscriber } from './Subscriber';
 
 /**
  * Note: This will add Symbol.observable globally for all TypeScript users,
@@ -301,4 +302,74 @@ interface ReadableStreamDefaultReaderLike<T> {
  */
 export interface ReadableStreamLike<T> {
   getReader(): ReadableStreamDefaultReaderLike<T>;
+}
+
+/**
+ * The global configuration object for RxJS, used to configure things
+ * like how to react on unhandled errors. Accessible via {@link config}
+ * object.
+ */
+export interface GlobalConfig {
+  /**
+   * A registration point for unhandled errors from RxJS. These are errors that
+   * cannot were not handled by consuming code in the usual subscription path. For
+   * example, if you have this configured, and you subscribe to an observable without
+   * providing an error handler, errors from that subscription will end up here. This
+   * will _always_ be called asynchronously on another job in the runtime. This is because
+   * we do not want errors thrown in this user-configured handler to interfere with the
+   * behavior of the library.
+   */
+  onUnhandledError: ((err: any) => void) | null;
+
+  /**
+   * A registration point for notifications that cannot be sent to subscribers because they
+   * have completed, errored or have been explicitly unsubscribed. By default, next, complete
+   * and error notifications sent to stopped subscribers are noops. However, sometimes callers
+   * might want a different behavior. For example, with sources that attempt to report errors
+   * to stopped subscribers, a caller can configure RxJS to throw an unhandled error instead.
+   * This will _always_ be called asynchronously on another job in the runtime. This is because
+   * we do not want errors thrown in this user-configured handler to interfere with the
+   * behavior of the library.
+   */
+  onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
+
+  /**
+   * The promise constructor used by default for methods such as
+   * {@link Observable/toPromise} and {@link Observable/forEach}
+   *
+   * @deprecated remove in v8. RxJS will no longer support this sort of injection of a
+   * Promise constructor. If you need a Promise implementation other than native promises,
+   * please polyfill/patch Promises as you see appropriate.
+   */
+  Promise: PromiseConstructorLike | undefined;
+
+  /**
+   * If true, turns on synchronous error rethrowing, which is a deprecated behavior
+   * in v6 and higher. This behavior enables bad patterns like wrapping a subscribe
+   * call in a try/catch block. It also enables producer interference, a nasty bug
+   * where a multicast can be broken for all observers by a downstream consumer with
+   * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BUY TIME
+   * FOR MIGRATION REASONS.
+   *
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
+   * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
+   * behaviors described above.
+   */
+  useDeprecatedSynchronousErrorHandling: boolean;
+
+  /**
+   * If true, enables an as-of-yet undocumented feature from v5: The ability to access
+   * `unsubscribe()` via `this` context in `next` functions created in observers passed
+   * to `subscribe`.
+   *
+   * This is being removed because the performance was severely problematic, and it could also cause
+   * issues when types other than POJOs are passed to subscribe as subscribers, as they will likely have
+   * their `this` context overwritten.
+   *
+   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
+   * context of next functions provided as part of an observer to Subscribe. Instead,
+   * you will have access to a subscription or a signal or token that will allow you to do things like
+   * unsubscribe and test closed status.
+   */
+  useDeprecatedNextContext: boolean;
 }


### PR DESCRIPTION
**Description:**
The reason why I wanted to add an interface for `config` object is so that we can have a proper documentation page for it. Constant documentation pages don't have a list of properties like interface documentation pages do.
Also, by introducing this interface, we will fix an error while building the docs (`npm run docs`) from this line:

https://github.com/ReactiveX/rxjs/blob/23bc7fdc16acd76dd71a4faf57b8b949684c3249/src/internal/Observable.ts#L101

because a link to `onUnhandledError` will now be available.

I was thinking about naming this interface with just as `Config`, but I chose `GlobalConfig` in the end. If needed, I can change to `Config` if it feels more appropriate.

**Related issue (if exists):**
None
