### PR TITLE
fix: finalize behaves well with useDeprecatedSynchronousErrorHandling

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -722,6 +722,48 @@ describe('Observable', () => {
         }
         expect(called).to.be.true;
       });
+      
+      it('should execute finalize in order even with a sync error', () => {
+        const results: any[] = [];
+        const badObservable = new Observable((subscriber) => {
+          subscriber.error(new Error('bad'));
+        }).pipe(
+          finalize(() => {
+            results.push(1);
+          }),
+          finalize(() => {
+            results.push(2)
+          })
+        );
+
+        try {
+          badObservable.subscribe();
+        } catch (err) {
+          // do nothing
+        }
+        expect(results).to.deep.equal([1, 2]);
+      });
+
+      it('should execute finalize in order even with a sync thrown error', () => {
+        const results: any[] = [];
+        const badObservable = new Observable(() => {
+          throw new Error('bad');
+        }).pipe(
+          finalize(() => {
+            results.push(1);
+          }),
+          finalize(() => {
+            results.push(2)
+          })
+        );
+
+        try {
+          badObservable.subscribe();
+        } catch (err) {
+          // do nothing
+        }
+        expect(results).to.deep.equal([1, 2]);
+      });
 
       afterEach(() => {
         config.useDeprecatedSynchronousErrorHandling = false;

--- a/src/internal/operators/finalize.ts
+++ b/src/internal/operators/finalize.ts
@@ -58,7 +58,12 @@ import { operate } from '../util/lift';
  */
 export function finalize<T>(callback: () => void): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
-    source.subscribe(subscriber);
-    subscriber.add(callback);
+    // TODO: This try/finally was only added for `useDeprecatedSynchronousErrorHandling`.
+    // REMOVE THIS WHEN THAT HOT GARBAGE IS REMOVED IN V8.
+    try {
+      source.subscribe(subscriber);
+    } finally {
+      subscriber.add(callback);
+    }
   });
 }


### PR DESCRIPTION
Adds tests and ensures a few more scenarios that were hit in Google because they use the deprecated synchronous error handling.

fixes #6250

cc @leggechr 