### PR TITLE
test: Add tests to ensure finalize and teardown on sync init throw

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -577,6 +577,40 @@ describe('Observable', () => {
           });
       });
     });
+    
+    it('should teardown even with a synchronous thrown error', () => {
+      let called = false;
+      const badObservable = new Observable((subscriber) => {
+        subscriber.add(() => {
+          called = true;
+        });
+
+        throw new Error('bad');
+      });
+
+      badObservable.subscribe({
+        error: () => { /* do nothing */ }
+      });
+
+      expect(called).to.be.true;
+    });
+
+    
+    it('should handle empty string sync errors', () => {
+      const badObservable = new Observable(() => {
+        throw '';
+      });
+
+      let caught = false;
+      badObservable.subscribe({
+        error: (err) => {
+          caught = true;
+          expect(err).to.equal('');
+        }
+      });
+      expect(caught).to.be.true;
+    });
+      
 
     describe('if config.useDeprecatedSynchronousErrorHandling === true', () => {
       beforeEach(() => {

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { finalize, map, share, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
-import { of, timer, interval, NEVER, Observable } from 'rxjs';
+import { of, timer, interval, NEVER, Observable, noop } from 'rxjs';
 import { asInteropObservable } from '../helpers/interop-helper';
 
 /** @test {finalize} */
@@ -270,6 +270,62 @@ describe('finalize', () => {
       });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
+  });
+
+  it('should execute finalize even with a sync thrown error', () => {
+    let called = false;
+    const badObservable = new Observable(() => {
+      throw new Error('bad');
+    }).pipe(
+      finalize(() => {
+        called = true;
+      })
+    );
+
+    badObservable.subscribe({
+      error: noop,
+    });
+
+    expect(called).to.be.true;
+  });
+
+  it('should execute finalize in order even with a sync error', () => {
+    const results: any[] = [];
+    const badObservable = new Observable((subscriber) => {
+      subscriber.error(new Error('bad'));
+    }).pipe(
+      finalize(() => {
+        results.push(1);
+      }),
+      finalize(() => {
+        results.push(2);
+      })
+    );
+
+    badObservable.subscribe({
+      error: noop,
+    });
+
+    expect(results).to.deep.equal([1, 2]);
+  });
+
+  it('should execute finalize in order even with a sync thrown error', () => {
+    const results: any[] = [];
+    const badObservable = new Observable(() => {
+      throw new Error('bad');
+    }).pipe(
+      finalize(() => {
+        results.push(1);
+      }),
+      finalize(() => {
+        results.push(2);
+      })
+    );
+
+    badObservable.subscribe({
+      error: noop,
+    });
+    expect(results).to.deep.equal([1, 2]);
   });
 
   it('should finalize in the proper order', () => {


### PR DESCRIPTION
Related to the [comment here](https://github.com/ReactiveX/rxjs/pull/6251#issuecomment-825263480) on #6251. I didn't see anything that matched this scenario. So better safe than sorry.