### PR TITLE
Fix types for configOrCount and configOrBufferSize to fix types in Google

### DIFF
--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -59,7 +59,7 @@ export function retry<T>(count?: number): MonoTypeOperatorFunction<T>;
 export function retry<T>(config: RetryConfig): MonoTypeOperatorFunction<T>;
 export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTypeOperatorFunction<T> {
   let config: RetryConfig;
-  if (configOrCount && typeof configOrCount === 'object') {
+  if (typeof configOrCount !== 'number') {
     config = configOrCount;
   } else {
     config = {

--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -126,18 +126,20 @@ export function shareReplay<T>(
 ): MonoTypeOperatorFunction<T> {
   let bufferSize: number;
   let refCount = false;
-  if (configOrBufferSize && typeof configOrBufferSize === 'object') {
+  if (!configOrBufferSize) {
+    bufferSize = Infinity;
+  } else if (typeof configOrBufferSize === 'number') {
+    bufferSize = configOrBufferSize;
+  } else {
     bufferSize = configOrBufferSize.bufferSize ?? Infinity;
     windowTime = configOrBufferSize.windowTime ?? Infinity;
     refCount = !!configOrBufferSize.refCount;
     scheduler = configOrBufferSize.scheduler;
-  } else {
-    bufferSize = configOrBufferSize ?? Infinity;
   }
   return share<T>({
     connector: () => new ReplaySubject(bufferSize, windowTime, scheduler),
     resetOnError: true,
     resetOnComplete: false,
-    resetOnRefCountZero: refCount
+    resetOnRefCountZero: refCount,
   });
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The current code would fail typescript check in non-strict-null mode. The proposed change does not change any behavior, but has better TypeScript inference so it also compiles in non-strict-null mode. 

**Related issue (if exists):**
This is a second attempt of https://github.com/ReactiveX/rxjs/pull/5705