### PR TITLE
refactor: refactor unit tests to include Mocha.Done type for done parameter

### DIFF
--- a/spec/operators/bufferTime-spec.ts
+++ b/spec/operators/bufferTime-spec.ts
@@ -72,7 +72,7 @@ describe('bufferTime operator', () => {
     });
   });
 
-  it('should handle situations with a creation interval of zero', (done) => {
+  it('should handle situations with a creation interval of zero', (done: Mocha.Done) => {
     // This is an odd scenario, and I can't imagine who is weird enough to want this, but here
     // it is. Someone scheduling buffers to open and close on microtasks, with values emitted on microtasks
     // NOTE: Trying this with a completely synchronous scheduler (like queueScheduler, which is

--- a/spec/operators/combineLatestAll-spec.ts
+++ b/spec/operators/combineLatestAll-spec.ts
@@ -516,7 +516,7 @@ describe('combineLatestAll operator', () => {
     });
   });
 
-  it('should combine two observables', (done) => {
+  it('should combine two observables', (done: Mocha.Done) => {
     const a = of(1, 2, 3);
     const b = of(4, 5, 6, 7, 8);
     const expected = [[3, 4], [3, 5], [3, 6], [3, 7], [3, 8]];
@@ -528,7 +528,7 @@ describe('combineLatestAll operator', () => {
     });
   });
 
-  it('should combine two immediately-scheduled observables', (done) => {
+  it('should combine two immediately-scheduled observables', (done: Mocha.Done) => {
     const a = of(1, 2, 3, queueScheduler);
     const b = of(4, 5, 6, 7, 8, queueScheduler);
     const r = [[1, 4], [2, 4], [2, 5], [3, 5], [3, 6], [3, 7], [3, 8]];

--- a/spec/operators/concat-legacy-spec.ts
+++ b/spec/operators/concat-legacy-spec.ts
@@ -22,7 +22,7 @@ describe('concat operator', () => {
     });
   });
 
-  it('should work properly with scalar observables', done => {
+  it('should work properly with scalar observables', (done: Mocha.Done) => {
     const results: string[] = [];
 
     const s1 = new Observable<number>(observer => {

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -26,7 +26,7 @@ describe('concatAll operator', () => {
     });
   });
 
-  it('should concat sources from promise', function(done) {
+  it('should concat sources from promise', function(done: Mocha.Done) {
     this.timeout(2000);
     const sources = from([
       new Promise<number>(res => {
@@ -92,7 +92,7 @@ describe('concatAll operator', () => {
       ]);
     });
 
-  it('should concat and raise error from promise', function(done) {
+  it('should concat and raise error from promise', function(done: Mocha.Done) {
     this.timeout(2000);
 
     const sources = from([

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -788,7 +788,7 @@ describe('Observable.prototype.concatMap', () => {
     );
   });
 
-  it('should map values to constant rejected promises and concatenate', done => {
+  it('should map values to constant rejected promises and concatenate', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
     const project = (value: any) => from(Promise.reject(42));
 
@@ -806,7 +806,7 @@ describe('Observable.prototype.concatMap', () => {
     );
   });
 
-  it('should map values to resolved promises and concatenate', done => {
+  it('should map values to resolved promises and concatenate', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
     const project = (value: number, index: number) => from(Promise.resolve(value + index));
 
@@ -825,7 +825,7 @@ describe('Observable.prototype.concatMap', () => {
     );
   });
 
-  it('should map values to rejected promises and concatenate', done => {
+  it('should map values to rejected promises and concatenate', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
     const project = (value: number, index: number) => from(Promise.reject('' + value + '-' + index));
 

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -396,7 +396,7 @@ describe('concatMapTo', () => {
       });
   });
 
-  it('should map values to constant rejected promises and concatenate', (done) => {
+  it('should map values to constant rejected promises and concatenate', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
 
     source.pipe(concatMapTo(from(Promise.reject(42)))).subscribe(

--- a/spec/operators/concatWith-spec.ts
+++ b/spec/operators/concatWith-spec.ts
@@ -23,7 +23,7 @@ describe('concat operator', () => {
     });
   });
 
-  it('should work properly with scalar observables', done => {
+  it('should work properly with scalar observables', (done: Mocha.Done) => {
     const results: string[] = [];
 
     const s1 = new Observable<number>(observer => {

--- a/spec/operators/exhaustAll-spec.ts
+++ b/spec/operators/exhaustAll-spec.ts
@@ -235,7 +235,7 @@ describe('exhaust', () => {
     });
   });
 
-  it('should handle an observable of promises', (done) => {
+  it('should handle an observable of promises', (done: Mocha.Done) => {
     const expected = [1];
 
     of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3))
@@ -252,7 +252,7 @@ describe('exhaust', () => {
       );
   });
 
-  it('should handle an observable of promises, where one rejects', (done) => {
+  it('should handle an observable of promises, where one rejects', (done: Mocha.Done) => {
     of(Promise.reject(2), Promise.resolve(1))
       .pipe(exhaustAll())
       .subscribe(

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -382,7 +382,7 @@ describe('expand', () => {
     });
   });
 
-  it('should recursively flatten promises', (done) => {
+  it('should recursively flatten promises', (done: Mocha.Done) => {
     const expected = [1, 2, 4, 8, 16];
     of(1)
       .pipe(
@@ -405,7 +405,7 @@ describe('expand', () => {
       );
   });
 
-  it('should recursively flatten Arrays', (done) => {
+  it('should recursively flatten Arrays', (done: Mocha.Done) => {
     const expected = [1, 2, 4, 8, 16];
     of(1)
       .pipe(
@@ -428,7 +428,7 @@ describe('expand', () => {
       );
   });
 
-  it('should recursively flatten lowercase-o observables', (done) => {
+  it('should recursively flatten lowercase-o observables', (done: Mocha.Done) => {
     const expected = [1, 2, 4, 8, 16];
     const project = (x: number): InteropObservable<number> => {
       if (x === 16) {
@@ -488,7 +488,7 @@ describe('expand', () => {
     });
   });
 
-  it('should work with the AsapScheduler', (done) => {
+  it('should work with the AsapScheduler', (done: Mocha.Done) => {
     const expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     of(0)
       .pipe(
@@ -499,7 +499,7 @@ describe('expand', () => {
       .subscribe((actual) => expect(actual).to.deep.equal(expected), done, done);
   });
 
-  it('should work with the AsyncScheduler', (done) => {
+  it('should work with the AsyncScheduler', (done: Mocha.Done) => {
     const expected = [0, 1, 2, 3, 4, 5, 6, 7, 8, 9];
     of(0)
       .pipe(

--- a/spec/operators/merge-legacy-spec.ts
+++ b/spec/operators/merge-legacy-spec.ts
@@ -3,7 +3,7 @@ import { queueScheduler, of } from 'rxjs';
 import { expect } from 'chai';
 
 describe('merge (legacy)', () => {
-  it('should merge an immediately-scheduled source with an immediately-scheduled second', done => {
+  it('should merge an immediately-scheduled source with an immediately-scheduled second', (done: Mocha.Done) => {
     const a = of(1, 2, 3, queueScheduler);
     const b = of(4, 5, 6, 7, 8, queueScheduler);
     const r = [1, 2, 4, 3, 5, 6, 7, 8];

--- a/spec/operators/mergeAll-spec.ts
+++ b/spec/operators/mergeAll-spec.ts
@@ -437,7 +437,7 @@ describe('mergeAll', () => {
     });
   });
 
-  it('should merge all promises in an observable', (done) => {
+  it('should merge all promises in an observable', (done: Mocha.Done) => {
     const e1 = from([
       new Promise<string>((res) => {
         res('a');
@@ -469,7 +469,7 @@ describe('mergeAll', () => {
     );
   });
 
-  it('should raise error when promise rejects', (done) => {
+  it('should raise error when promise rejects', (done: Mocha.Done) => {
     const error = 'error';
     const e1 = from([
       new Promise<string>((res) => {
@@ -531,7 +531,7 @@ describe('mergeAll', () => {
     expect(iterable.finalized).to.be.true;
   });
 
-  it('should merge two observables', (done) => {
+  it('should merge two observables', (done: Mocha.Done) => {
     const a = of(1, 2, 3);
     const b = of(4, 5, 6, 7, 8);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -547,7 +547,7 @@ describe('mergeAll', () => {
       );
   });
 
-  it('should merge two immediately-scheduled observables', (done) => {
+  it('should merge two immediately-scheduled observables', (done: Mocha.Done) => {
     const a = of(1, 2, 3, queueScheduler);
     const b = of(4, 5, 6, 7, 8, queueScheduler);
     const r = [1, 2, 4, 3, 5, 6, 7, 8];

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -132,7 +132,7 @@ describe('mergeMap', () => {
     });
   });
 
-  it('should map values to constant resolved promises and merge', (done) => {
+  it('should map values to constant resolved promises and merge', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
     const project = () => from(Promise.resolve(42));
 
@@ -151,7 +151,7 @@ describe('mergeMap', () => {
     );
   });
 
-  it('should map values to constant rejected promises and merge', (done) => {
+  it('should map values to constant rejected promises and merge', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
     const project = () => from(Promise.reject<number>(42));
 
@@ -169,7 +169,7 @@ describe('mergeMap', () => {
     );
   });
 
-  it('should map values to resolved promises and merge', (done) => {
+  it('should map values to resolved promises and merge', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
     const project = (value: number, index: number) => from(Promise.resolve(value + index));
 
@@ -188,7 +188,7 @@ describe('mergeMap', () => {
     );
   });
 
-  it('should map values to rejected promises and merge', (done) => {
+  it('should map values to rejected promises and merge', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
     const project = (value: number, index: number) => from(Promise.reject<string>('' + value + '-' + index));
 

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -106,7 +106,7 @@ describe('mergeMapTo', () => {
     });
   });
 
-  it('should map values to constant resolved promises and merge', (done) => {
+  it('should map values to constant resolved promises and merge', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
 
     const results: number[] = [];
@@ -124,7 +124,7 @@ describe('mergeMapTo', () => {
     );
   });
 
-  it('should map values to constant rejected promises and merge', (done) => {
+  it('should map values to constant rejected promises and merge', (done: Mocha.Done) => {
     const source = from([4, 3, 2, 1]);
 
     source.pipe(mergeMapTo(from(Promise.reject(42)))).subscribe(

--- a/spec/operators/mergeWith-spec.ts
+++ b/spec/operators/mergeWith-spec.ts
@@ -28,7 +28,7 @@ describe('merge operator', () => {
     });
   });
 
-  it('should merge a source with a second', done => {
+  it('should merge a source with a second', (done: Mocha.Done) => {
     const a = of(1, 2, 3);
     const b = of(4, 5, 6, 7, 8);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -306,7 +306,7 @@ describe('merge operator', () => {
 });
 
 describe('mergeAll operator', () => {
-  it('should merge two observables', done => {
+  it('should merge two observables', (done: Mocha.Done) => {
     const a = of(1, 2, 3);
     const b = of(4, 5, 6, 7, 8);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
@@ -322,7 +322,7 @@ describe('mergeAll operator', () => {
       );
   });
 
-  it('should merge two immediately-scheduled observables', done => {
+  it('should merge two immediately-scheduled observables', (done: Mocha.Done) => {
     const a = of(1, 2, 3, queueScheduler);
     const b = of(4, 5, 6, 7, 8, queueScheduler);
     const r = [1, 2, 4, 3, 5, 6, 7, 8];

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -28,7 +28,7 @@ describe('multicast', () => {
     });
   });
 
-  it('should accept Subjects', (done) => {
+  it('should accept Subjects', (done: Mocha.Done) => {
     const expected = [1, 2, 3, 4];
 
     const connectable = of(1, 2, 3, 4).pipe(multicast(new Subject<number>())) as ConnectableObservable<number>;
@@ -48,7 +48,7 @@ describe('multicast', () => {
     connectable.connect();
   });
 
-  it('should multicast a ConnectableObservable', (done) => {
+  it('should multicast a ConnectableObservable', (done: Mocha.Done) => {
     const expected = [1, 2, 3, 4];
 
     const source = new Subject<number>();
@@ -78,7 +78,7 @@ describe('multicast', () => {
       .subscribe(null, done, done);
   });
 
-  it('should accept Subject factory functions', (done) => {
+  it('should accept Subject factory functions', (done: Mocha.Done) => {
     const expected = [1, 2, 3, 4];
 
     const connectable = of(1, 2, 3, 4).pipe(multicast(() => new Subject<number>())) as ConnectableObservable<number>;
@@ -690,7 +690,7 @@ describe('multicast', () => {
     });
   });
 
-  it('should multicast one observable to multiple observers', (done) => {
+  it('should multicast one observable to multiple observers', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;
@@ -745,7 +745,7 @@ describe('multicast', () => {
   });
 
   describe('when given a subject factory', () => {
-    it('should allow you to reconnect by subscribing again', (done) => {
+    it('should allow you to reconnect by subscribing again', (done: Mocha.Done) => {
       const expected = [1, 2, 3, 4];
       let i = 0;
 
@@ -774,7 +774,7 @@ describe('multicast', () => {
       source.connect();
     });
 
-    it('should not throw ObjectUnsubscribedError when used in ' + 'a switchMap', (done) => {
+    it('should not throw ObjectUnsubscribedError when used in ' + 'a switchMap', (done: Mocha.Done) => {
       const source = of(1, 2, 3).pipe(
         multicast(() => new Subject<number>()),
         refCount()
@@ -800,7 +800,7 @@ describe('multicast', () => {
   });
 
   describe('when given a subject', () => {
-    it('should not throw ObjectUnsubscribedError when used in ' + 'a switchMap', (done) => {
+    it('should not throw ObjectUnsubscribedError when used in ' + 'a switchMap', (done: Mocha.Done) => {
       const source = of(1, 2, 3).pipe(multicast(new Subject<number>()), refCount());
 
       const expected = ['a1', 'a2', 'a3'];

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -228,7 +228,7 @@ describe('publish operator', () => {
     });
   });
 
-  it('should emit completed when subscribed after completed', (done) => {
+  it('should emit completed when subscribed after completed', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;
@@ -303,7 +303,7 @@ describe('publish operator', () => {
     published.connect();
   });
 
-  it('should multicast one observable to multiple observers', (done) => {
+  it('should multicast one observable to multiple observers', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -212,7 +212,7 @@ describe('publishBehavior operator', () => {
     });
   });
 
-  it('should emit completed when subscribed after completed', (done) => {
+  it('should emit completed when subscribed after completed', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;
@@ -287,7 +287,7 @@ describe('publishBehavior operator', () => {
     published.connect();
   });
 
-  it('should multicast one observable to multiple observers', (done) => {
+  it('should multicast one observable to multiple observers', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;
@@ -322,7 +322,7 @@ describe('publishBehavior operator', () => {
     done();
   });
 
-  it('should follow the RxJS 4 behavior and emit nothing to observer after completed', (done) => {
+  it('should follow the RxJS 4 behavior and emit nothing to observer after completed', (done: Mocha.Done) => {
     const results: number[] = [];
 
     const source = new Observable<number>((observer) => {

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -227,7 +227,7 @@ describe('publishLast operator', () => {
     published.connect();
   });
 
-  it('should multicast one observable to multiple observers', (done) => {
+  it('should multicast one observable to multiple observers', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -231,7 +231,7 @@ describe('publishReplay operator', () => {
     });
   });
 
-  it('should multicast one observable to multiple observers', (done) => {
+  it('should multicast one observable to multiple observers', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;
@@ -265,7 +265,7 @@ describe('publishReplay operator', () => {
     done();
   });
 
-  it('should replay as many events as specified by the bufferSize', (done) => {
+  it('should replay as many events as specified by the bufferSize', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;
@@ -342,7 +342,7 @@ describe('publishReplay operator', () => {
     expect(subscriptions).to.equal(2);
   });
 
-  it('should emit replayed values plus completed when subscribed after completed', (done) => {
+  it('should emit replayed values plus completed when subscribed after completed', (done: Mocha.Done) => {
     const results1: number[] = [];
     const results2: number[] = [];
     let subscriptions = 0;

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -322,7 +322,7 @@ describe('shareReplay operator', () => {
   const FinalizationRegistry = (global as any).FinalizationRegistry;
   if (FinalizationRegistry) {
 
-    it('should not leak the subscriber for sync sources', (done) => {
+    it('should not leak the subscriber for sync sources', (done: Mocha.Done) => {
       let callback: (() => void) | undefined = () => { /* noop */ };
 
       const registry = new FinalizationRegistry((value: any) => {

--- a/spec/operators/switchAll-spec.ts
+++ b/spec/operators/switchAll-spec.ts
@@ -32,7 +32,7 @@ describe('switchAll', () => {
     });
   });
 
-  it('should switch to each immediately-scheduled inner Observable', (done) => {
+  it('should switch to each immediately-scheduled inner Observable', (done: Mocha.Done) => {
     const a = scheduled([1, 2, 3], queueScheduler);
     const b = scheduled([4, 5, 6], queueScheduler);
     const r = [1, 4, 5, 6];
@@ -68,7 +68,7 @@ describe('switchAll', () => {
     expect(unsubbed).to.deep.equal(['a', 'b']);
   });
 
-  it('should switch to each inner Observable', (done) => {
+  it('should switch to each inner Observable', (done: Mocha.Done) => {
     const a = of(1, 2, 3);
     const b = of(4, 5, 6);
     const r = [1, 2, 3, 4, 5, 6];
@@ -252,7 +252,7 @@ describe('switchAll', () => {
     });
   });
 
-  it('should handle an observable of promises', (done) => {
+  it('should handle an observable of promises', (done: Mocha.Done) => {
     const expected = [3];
 
     of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3))
@@ -268,7 +268,7 @@ describe('switchAll', () => {
       });
   });
 
-  it('should handle an observable of promises, where last rejects', (done) => {
+  it('should handle an observable of promises, where last rejects', (done: Mocha.Done) => {
     of(Promise.resolve(1), Promise.resolve(2), Promise.reject(3))
       .pipe(switchAll())
       .subscribe({

--- a/spec/operators/switchMapTo-spec.ts
+++ b/spec/operators/switchMapTo-spec.ts
@@ -76,7 +76,7 @@ describe('switchMapTo', () => {
       });
   });
 
-  it('should switch a synchronous many outer to a synchronous many inner', (done) => {
+  it('should switch a synchronous many outer to a synchronous many inner', (done: Mocha.Done) => {
     const a = of(1, 2, 3);
     const expected = ['a', 'b', 'c', 'a', 'b', 'c', 'a', 'b', 'c'];
     a.pipe(switchMapTo(of('a', 'b', 'c'))).subscribe({

--- a/spec/operators/zip-legacy-spec.ts
+++ b/spec/operators/zip-legacy-spec.ts
@@ -15,7 +15,7 @@ describe('zip legacy', () => {
     rxTestScheduler = new TestScheduler(observableMatcher);
   });
 
-  it('should zip the provided observables', (done) => {
+  it('should zip the provided observables', (done: Mocha.Done) => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
 

--- a/spec/operators/zipAll-spec.ts
+++ b/spec/operators/zipAll-spec.ts
@@ -41,7 +41,7 @@ describe('zipAll operator', () => {
     });
   });
 
-  it('should take all observables from the source and zip them', (done) => {
+  it('should take all observables from the source and zip them', (done: Mocha.Done) => {
     const expected = ['a1', 'b2', 'c3'];
     let i = 0;
     of(of('a', 'b', 'c'), of(1, 2, 3))
@@ -379,7 +379,7 @@ describe('zipAll operator', () => {
     });
   });
 
-  it('should zip until one child terminates', (done) => {
+  it('should zip until one child terminates', (done: Mocha.Done) => {
     const expected = ['a1', 'b2'];
     let i = 0;
     of(of('a', 'b', 'c'), of(1, 2))
@@ -728,7 +728,7 @@ describe('zipAll operator', () => {
     });
   });
 
-  it('should combine two immediately-scheduled observables', (done) => {
+  it('should combine two immediately-scheduled observables', (done: Mocha.Done) => {
     rxTestScheduler.run(() => {
       const a = scheduled([1, 2, 3], queueScheduler);
       const b = scheduled([4, 5, 6, 7, 8], queueScheduler);
@@ -750,7 +750,7 @@ describe('zipAll operator', () => {
     });
   });
 
-  it('should combine a source with an immediately-scheduled source', (done) => {
+  it('should combine a source with an immediately-scheduled source', (done: Mocha.Done) => {
     const a = scheduled([1, 2, 3], queueScheduler);
     const b = of(4, 5, 6, 7, 8);
     const r = [

--- a/spec/operators/zipWith-spec.ts
+++ b/spec/operators/zipWith-spec.ts
@@ -459,7 +459,7 @@ describe('zipWith', () => {
     });
   });
 
-  it('should combine an immediately-scheduled source with an immediately-scheduled second', (done) => {
+  it('should combine an immediately-scheduled source with an immediately-scheduled second', (done: Mocha.Done) => {
     const a = scheduled([1, 2, 3], queueScheduler);
     const b = scheduled([4, 5, 6, 7, 8], queueScheduler);
     const r = [

--- a/spec/scheduled/scheduled-spec.ts
+++ b/spec/scheduled/scheduled-spec.ts
@@ -39,7 +39,7 @@ describe('scheduled', () => {
     });
   });
 
-  it('should schedule a promise', done => {
+  it('should schedule a promise', (done: Mocha.Done) => {
     const results: any[] = [];
     const input = Promise.resolve('x'); // strings are iterables
     scheduled(input, testScheduler).subscribe({


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
- Assigned type as Mocha.Done to done parameter of tests arrow function in order to keep it consistent with other tests in repository.
- type MochaDone is deprecating and we can use Mocha.Done as a type in every unit test. Please take a look into it.

