### PR TITLE
chore: update deprecations

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -57,7 +57,6 @@ export declare function defaultIfEmpty<T, R>(defaultValue: R): OperatorFunction<
 
 export declare function delay<T>(due: number | Date, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 
-export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<never>, subscriptionDelay?: Observable<any>): MonoTypeOperatorFunction<T>;
 export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>, subscriptionDelay: Observable<any>): MonoTypeOperatorFunction<T>;
 export declare function delayWhen<T>(delayDurationSelector: (value: T, index: number) => Observable<any>): MonoTypeOperatorFunction<T>;
 

--- a/docs_app/content/deprecations/multicasting.md
+++ b/docs_app/content/deprecations/multicasting.md
@@ -46,10 +46,9 @@ tick$.connect();
 ```ts
 import { connectable, Subject, timer } from 'rxjs';
 // suggested refactor
-const tick$ = connectable(
-  timer(1_000),
-  () => new Subject() // TODO: connectable takes an instance?
-);
+const tick$ = connectable(timer(1_000), {
+  connector: () => new Subject()
+});
 tick$.connect();
 ```
 
@@ -78,43 +77,50 @@ const tick$ = timer(1_000).pipe(
 
 Where [multicast](/api/operators/multicast) is called with a subject factory, can be replaced with [connectable](/api/index/function/connectable).
 
+<!-- prettier-ignore -->
 ```ts
 import { ConnectableObservable, timer, Subject } from 'rxjs';
 import { multicast } from 'rxjs/operators';
 // deprecated
-const tick$ = timer(1_000).pipe(multicast(() => new Subject())) as ConnectableObservable<number>;
+const tick$ = timer(1_000).pipe(
+  multicast(() => new Subject())
+) as ConnectableObservable<number>;
 ```
 
+<!-- prettier-ignore -->
 ```ts
 import { connectable, timer, Subject } from 'rxjs';
 // suggested refactor
-const tick$ = connectable(
-  timer(1_000),
-  () => new Subject() // TODO: connectable takes an instance?
-);
+const tick$ = connectable(timer(1_000), {
+  connector: () => new Subject()
+});
 ```
 
 Where [multicast](/api/operators/multicast) is called with a subject instance, it can be replaced with [connectable](/api/index/function/connectable) and a local subject instance.
 
+<!-- prettier-ignore -->
 ```ts
 import { ConnectableObservable, timer, Subject } from 'rxjs';
 import { multicast } from 'rxjs/operators';
 // deprecated
-const tick$ = timer(1_000).pipe(multicast(new Subject())) as ConnectableObservable<number>;
+const tick$ = timer(1_000).pipe(
+  multicast(new Subject())
+) as ConnectableObservable<number>;
 ```
 
+<!-- prettier-ignore -->
 ```ts
 import { connectable, timer, Subject } from 'rxjs';
 // suggested refactor
-const subject = new Subject();
-const tick$ = connectable(
-  timer(1_000),
-  () => subject // TODO: connectable takes an instance?
-);
+const tick$ = connectable(timer(1_000), {
+  connector: () => new Subject(),
+  resetOnDisconnect: false
+});
 ```
 
 Where [multicast](/api/operators/multicast) is used in conjunction with [refCount](/api/operators/refCount), it can be replaced with [share](/api/index/function/connectable).
 
+<!-- prettier-ignore -->
 ```ts
 import { timer, Subject } from 'rxjs';
 import { multicast, refCount } from 'rxjs/operators';
@@ -125,14 +131,13 @@ const tick$ = timer(1_000).pipe(
 );
 ```
 
+<!-- prettier-ignore -->
 ```ts
 import { timer, Subject } from 'rxjs';
 import { share } from 'rxjs/operators';
 // suggested refactor
 const tick$ = timer(1_000).pipe(
-  share({
-    connector: () => new Subject(),
-  })
+  share({ connector: () => new Subject() })
 );
 ```
 
@@ -167,18 +172,24 @@ const tick$ = timer(1_000).pipe(
 
 If you're using [publish](/api/operators/publish) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) instead.
 
+<!-- prettier-ignore -->
 ```ts
 import { ConnectableObservable, timer } from 'rxjs';
 import { publish } from 'rxjs/operators';
 // deprecated
-const tick$ = timer(1_000).pipe(publish()) as ConnectableObservable<number>;
+const tick$ = timer(1_000).pipe(
+  publish()
+) as ConnectableObservable<number>;
 ```
 
+<!-- prettier-ignore -->
 ```ts
 import { connectable, timer } from 'rxjs';
 // suggested refactor
-const subject = new Subject<number>();
-const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+const tick$ = connectable(timer(1_000), {
+  connector: () => new Subject<number>(),
+  resetOnDisconnect: false
+});
 ```
 
 And if [refCount](/api/operators/refCount) is being applied to the result of [publish](/api/operators/publish), you can use [share](/api/operators/share) to replace both.
@@ -234,18 +245,24 @@ const tick$ = timer(1_000).pipe(
 
 If you're using [publishBehavior](/api/operators/publishBehavior) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) and a [BehaviorSubject](api/index/class/BehaviorSubject) instead.
 
+<!-- prettier-ignore -->
 ```ts
 import { ConnectableObservable, timer } from 'rxjs';
 import { publishBehavior } from 'rxjs/operators';
 // deprecated
-const tick$ = timer(1_000).pipe(publishBehavior(0)) as ConnectableObservable<number>;
+const tick$ = timer(1_000).pipe(
+  publishBehavior(0)
+) as ConnectableObservable<number>;
 ```
 
+<!-- prettier-ignore -->
 ```ts
 import { connectable, timer, BehaviorSubject } from 'rxjs';
 // suggested refactor
-const subject = new BehaviorSubject(0);
-const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+const tick$ = connectable(timer(1_000), {
+  connector: () => new BehaviorSubject(0),
+  resetOnDisconnect: false
+});
 ```
 
 And if [refCount](/api/operators/refCount) is being applied to the result of [publishBehavior](/api/operators/publishBehavior), you can use the [share](/api/operators/share) operator - with a [BehaviorSubject](api/index/class/BehaviorSubject) connector - to replace both.
@@ -280,18 +297,24 @@ const tick$ = timer(1_000).pipe(
 
 If you're using [publishLast](/api/operators/publishLast) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) and an [AsyncSubject](api/index/class/AsyncSubject) instead.
 
+<!-- prettier-ignore -->
 ```ts
 import { ConnectableObservable, timer } from 'rxjs';
 import { publishLast } from 'rxjs/operators';
 // deprecated
-const tick$ = timer(1_000).pipe(publishLast()) as ConnectableObservable<number>;
+const tick$ = timer(1_000).pipe(
+  publishLast()
+) as ConnectableObservable<number>;
 ```
 
+<!-- prettier-ignore -->
 ```ts
 import { connectable, timer, AsyncSubject } from 'rxjs';
 // suggested refactor
-const subject = new AsyncSubject<number>();
-const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+const tick$ = connectable(timer(1_000), {
+  connector: () => new AsyncSubject<number>(),
+  resetOnDisconnect: false
+});
 ```
 
 And if [refCount](/api/operators/refCount) is being applied to the result of [publishLast](/api/operators/publishLast), you can use the [share](/api/operators/share) operator - with an [AsyncSubject](api/index/class/AsyncSubject) connector - to replace both.
@@ -326,18 +349,24 @@ const tick$ = timer(1_000).pipe(
 
 If you're using [publishReplay](/api/operators/publishReplay) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) and a [ReplaySubject](api/index/class/ReplaySubject) instead.
 
+<!-- prettier-ignore -->
 ```ts
 import { ConnectableObservable, timer } from 'rxjs';
 import { publishReplay } from 'rxjs/operators';
 // deprecated
-const tick$ = timer(1_000).pipe(publishReplay(1)) as ConnectableObservable<number>;
+const tick$ = timer(1_000).pipe(
+  publishReplay(1)
+) as ConnectableObservable<number>;
 ```
 
+<!-- prettier-ignore -->
 ```ts
 import { connectable, timer, ReplaySubject } from 'rxjs';
 // suggested refactor
-const subject = new ReplaySubject<number>(1);
-const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+const tick$ = connectable(timer(1_000), {
+  connector: () => new ReplaySubject<number>(1),
+  resetOnDisconnect: false
+});
 ```
 
 And if [refCount](/api/operators/refCount) is being applied to the result of [publishReplay](/api/operators/publishReplay), you can use the [share](/api/operators/share) operator - with a [ReplaySubject](api/index/class/ReplaySubject) connector - to replace both.

--- a/docs_app/content/deprecations/multicasting.md
+++ b/docs_app/content/deprecations/multicasting.md
@@ -1,0 +1,400 @@
+# Multicasting
+
+In version 7, the multicasting APIs were simplified to just a few functions:
+
+- [connectable](/api/index/function/connectable)
+- [connect](/api/operators/connect)
+- [share](/api/operators/share)
+
+And [shareReplay](/api/operators/shareReplay) - which is a thin wrapper around the now highly-configurable [share](/api/operators/share) operator.
+
+Other APIs that relate to multicasting are now deprecated.
+
+<div class="alert is-important">
+    <span>
+        These deprecations were introduced in RxJS 7.0 and will become breaking in RxJS 8.
+    </span>
+</div>
+
+## APIs affected by this Change
+
+- [ConnectableObservable](/api/index/class/ConnectableObservable)
+- [multicast](/api/operators/multicast)
+- [publish](/api/operators/publish)
+- [publishBehavior](/api/operators/publishBehavior)
+- [publishLast](/api/operators/publishLast)
+- [publishReplay](/api/operators/publishReplay)
+- [refCount](/api/operators/refCount)
+
+## How to refactor
+
+### ConnectableObservable
+
+Instead of creating a [ConnectableObservable](/api/index/class/ConnectableObservable) instance, call the [connectable](/api/index/function/connectable) function to obtain a connectable observable.
+
+<!-- prettier-ignore -->
+```ts
+import { ConnectableObservable, Subject, timer } from 'rxjs';
+// deprecated
+const tick$ = new ConnectableObservable(
+  timer(1_000),
+  () => new Subject());
+tick$.connect();
+```
+
+<!-- prettier-ignore -->
+```ts
+import { connectable, Subject, timer } from 'rxjs';
+// suggested refactor
+const tick$ = connectable(
+  timer(1_000),
+  () => new Subject() // TODO: connectable takes an instance?
+);
+tick$.connect();
+```
+
+In situations in which the `refCount` method is used, the [share](/api/operators/share) operator can be used instead.
+
+<!-- prettier-ignore -->
+```ts
+import { ConnectableObservable, Subject, timer } from 'rxjs';
+// deprecated
+const tick$ = new ConnectableObservable(
+  timer(1_000),
+  () => new Subject()
+).refCount();
+```
+
+<!-- prettier-ignore -->
+```ts
+import { share, Subject, timer } from 'rxjs';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  share({ connector: () => new Subject() })
+);
+```
+
+### multicast
+
+Where [multicast](/api/operators/multicast) is called with a subject factory, can be replaced with [connectable](/api/index/function/connectable).
+
+```ts
+import { ConnectableObservable, timer, Subject } from 'rxjs';
+import { multicast } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(multicast(() => new Subject())) as ConnectableObservable<number>;
+```
+
+```ts
+import { connectable, timer, Subject } from 'rxjs';
+// suggested refactor
+const tick$ = connectable(
+  timer(1_000),
+  () => new Subject() // TODO: connectable takes an instance?
+);
+```
+
+Where [multicast](/api/operators/multicast) is called with a subject instance, it can be replaced with [connectable](/api/index/function/connectable) and a local subject instance.
+
+```ts
+import { ConnectableObservable, timer, Subject } from 'rxjs';
+import { multicast } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(multicast(new Subject())) as ConnectableObservable<number>;
+```
+
+```ts
+import { connectable, timer, Subject } from 'rxjs';
+// suggested refactor
+const subject = new Subject();
+const tick$ = connectable(
+  timer(1_000),
+  () => subject // TODO: connectable takes an instance?
+);
+```
+
+Where [multicast](/api/operators/multicast) is used in conjunction with [refCount](/api/operators/refCount), it can be replaced with [share](/api/index/function/connectable).
+
+```ts
+import { timer, Subject } from 'rxjs';
+import { multicast, refCount } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  multicast(() => new Subject()),
+  refCount()
+);
+```
+
+```ts
+import { timer, Subject } from 'rxjs';
+import { share } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  share({
+    connector: () => new Subject(),
+  })
+);
+```
+
+Where [multicast](/api/operators/multicast) is used with a selector, it can be replaced with [connect](/api/index/function/connect).
+
+<!-- prettier-ignore -->
+```ts
+import { timer, combineLatest } from 'rxjs';
+import { multicast } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  multicast(
+    () => new Subject(),
+    (source) => combineLatest([source, source])
+  )
+);
+```
+
+<!-- prettier-ignore -->
+```ts
+import { timer, combineLatest } from 'rxjs';
+import { connect } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  connect((source) => combineLatest([source, source]), {
+    connector: () => new Subject()
+  })
+);
+```
+
+### publish
+
+If you're using [publish](/api/operators/publish) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) instead.
+
+```ts
+import { ConnectableObservable, timer } from 'rxjs';
+import { publish } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(publish()) as ConnectableObservable<number>;
+```
+
+```ts
+import { connectable, timer } from 'rxjs';
+// suggested refactor
+const subject = new Subject<number>();
+const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+```
+
+And if [refCount](/api/operators/refCount) is being applied to the result of [publish](/api/operators/publish), you can use [share](/api/operators/share) to replace both.
+
+<!-- prettier-ignore -->
+```ts
+import { timer } from 'rxjs';
+import { publish, refCount } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  publish(),
+  refCount()
+);
+```
+
+<!-- prettier-ignore -->
+```ts
+import { timer } from 'rxjs';
+import { share } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  share({
+    resetOnError: false,
+    resetOnComplete: false,
+    resetOnRefCountZero: false,
+  })
+);
+```
+
+If [publish](/api/operators/publish) is being called with a selector, you can use the [connect](/api/operators/connect) operator instead.
+
+<!-- prettier-ignore -->
+```ts
+import { timer, combineLatest } from 'rxjs';
+import { publish } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  publish((source) => combineLatest([source, source]))
+);
+```
+
+<!-- prettier-ignore -->
+```ts
+import { timer, combineLatest } from 'rxjs';
+import { connect } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  connect((source) => combineLatest([source, source]))
+);
+```
+
+### publishBehavior
+
+If you're using [publishBehavior](/api/operators/publishBehavior) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) and a [BehaviorSubject](api/index/class/BehaviorSubject) instead.
+
+```ts
+import { ConnectableObservable, timer } from 'rxjs';
+import { publishBehavior } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(publishBehavior(0)) as ConnectableObservable<number>;
+```
+
+```ts
+import { connectable, timer, BehaviorSubject } from 'rxjs';
+// suggested refactor
+const subject = new BehaviorSubject(0);
+const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+```
+
+And if [refCount](/api/operators/refCount) is being applied to the result of [publishBehavior](/api/operators/publishBehavior), you can use the [share](/api/operators/share) operator - with a [BehaviorSubject](api/index/class/BehaviorSubject) connector - to replace both.
+
+<!-- prettier-ignore -->
+```ts
+import { timer } from 'rxjs';
+import { publishBehavior, refCount } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  publishBehavior(0),
+  refCount()
+);
+```
+
+<!-- prettier-ignore -->
+```ts
+import { timer, BehaviorSubject } from 'rxjs';
+import { share } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  share({
+    connector: () => new BehaviorSubject(0),
+    resetOnError: false,
+    resetOnComplete: false,
+    resetOnRefCountZero: false,
+  })
+);
+```
+
+### publishLast
+
+If you're using [publishLast](/api/operators/publishLast) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) and an [AsyncSubject](api/index/class/AsyncSubject) instead.
+
+```ts
+import { ConnectableObservable, timer } from 'rxjs';
+import { publishLast } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(publishLast()) as ConnectableObservable<number>;
+```
+
+```ts
+import { connectable, timer, AsyncSubject } from 'rxjs';
+// suggested refactor
+const subject = new AsyncSubject<number>();
+const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+```
+
+And if [refCount](/api/operators/refCount) is being applied to the result of [publishLast](/api/operators/publishLast), you can use the [share](/api/operators/share) operator - with an [AsyncSubject](api/index/class/AsyncSubject) connector - to replace both.
+
+<!-- prettier-ignore -->
+```ts
+import { timer } from 'rxjs';
+import { publishLast, refCount } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  publishLast(),
+  refCount()
+);
+```
+
+<!-- prettier-ignore -->
+```ts
+import { timer, AsyncSubject } from 'rxjs';
+import { share } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  share({
+    connector: () => new AsyncSubject(),
+    resetOnError: false,
+    resetOnComplete: false,
+    resetOnRefCountZero: false,
+  })
+);
+```
+
+### publishReplay
+
+If you're using [publishReplay](/api/operators/publishReplay) to create a [ConnectableObservable](/api/index/class/ConnectableObservable), you can use [connectable](/api/index/function/connectable) and a [ReplaySubject](api/index/class/ReplaySubject) instead.
+
+```ts
+import { ConnectableObservable, timer } from 'rxjs';
+import { publishReplay } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(publishReplay(1)) as ConnectableObservable<number>;
+```
+
+```ts
+import { connectable, timer, ReplaySubject } from 'rxjs';
+// suggested refactor
+const subject = new ReplaySubject<number>(1);
+const tick$ = connectable(timer(1_000), () => subject); // TODO: connectable takes an instance?
+```
+
+And if [refCount](/api/operators/refCount) is being applied to the result of [publishReplay](/api/operators/publishReplay), you can use the [share](/api/operators/share) operator - with a [ReplaySubject](api/index/class/ReplaySubject) connector - to replace both.
+
+<!-- prettier-ignore -->
+```ts
+import { timer } from 'rxjs';
+import { publishReplay, refCount } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  publishReplay(1),
+  refCount()
+);
+```
+
+<!-- prettier-ignore -->
+```ts
+import { timer, ReplaySubject } from 'rxjs';
+import { share } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  share({
+    connector: () => new ReplaySubject(1),
+    resetOnError: false,
+    resetOnComplete: false,
+    resetOnRefCountZero: false,
+  })
+);
+```
+
+If [publishReplay](/api/operators/publishReplay) is being called with a selector, you can use the [connect](/api/operators/connect) operator - with a [ReplaySubject](api/index/class/ReplaySubject) connector - instead.
+
+<!-- prettier-ignore -->
+```ts
+import { timer, combineLatest } from 'rxjs';
+import { publishReplay } from 'rxjs/operators';
+// deprecated
+const tick$ = timer(1_000).pipe(
+  publishReplay(1, undefined, (source) => combineLatest([source, source]))
+);
+```
+
+<!-- prettier-ignore -->
+```ts
+import { timer, combineLatest, ReplaySubject } from 'rxjs';
+import { connect } from 'rxjs/operators';
+// suggested refactor
+const tick$ = timer(1_000).pipe(
+  connect((source) => combineLatest([source, source]), {
+    connector: () => new ReplaySubject(1)
+  })
+);
+```
+
+### refCount
+
+Instead of applying the [refCount](/api/operators/refCount) operator to the [ConnectableObservable](/api/index/class/ConnectableObservable) obtained from a [multicast](/api/operators/multicast)
+or [publish](/api/operators/publish) operator, use the [share](/api/operators/share) operator to replace both.
+
+The properties passed to [share](/api/operators/share) will depend upon the operators that are being replaced. The refactors for using [refCount](/api/operators/refCount) with [multicast](/api/operators/multicast), [publish](/api/operators/publish), [publishBehavior](/api/operators/publishBehavior), [publishLast](/api/operators/publishLast) and [publishReplay](/api/operators/publishReplay) are detailed above.

--- a/docs_app/content/navigation.json
+++ b/docs_app/content/navigation.json
@@ -92,6 +92,10 @@
         {
           "url": "deprecations/array-argument",
           "title": "Array Arguments"
+        },
+        {
+          "url": "deprecations/multicasting",
+          "title": "Multicasting"
         }
       ]
     },

--- a/spec-dtslint/operators/delayWhen-spec.ts
+++ b/spec-dtslint/operators/delayWhen-spec.ts
@@ -27,9 +27,3 @@ it('should enforce types of delayWhenDurationSelector', () => {
 it('should enforce types of subscriptiondelayWhen', () => {
   const o = of(1, 2, 3).pipe(delayWhen(() => of('a', 'b', 'c'), 'a')); // $ExpectError
 });
-
-it('should deprecates', () => {
-  of(1, 2, 3).pipe(delayWhen(() => NEVER)); // $ExpectDeprecation
-  of(1, 2, 3).pipe(delayWhen(() => of('a', 'b', 'c'), of(0))); // $ExpectDeprecation
-  of(1, 2, 3).pipe(delayWhen(() => of('a', 'b', 'c'))); // $ExpectNoDeprecation
-});

--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -7,7 +7,8 @@ import { isFunction } from './util/isFunction';
 
 // TODO: When this enum is removed, replace it with a type alias. See #4556.
 /**
- * @deprecated NotificationKind is deprecated as const enums are not compatible with isolated modules. Use a string literal instead.
+ * @deprecated Use a string literal instead. `NotificationKind` will be replaced with a type alias in v8.
+ * It will not be replaced with a const enum as those are not compatible with isolated modules.
  */
 export enum NotificationKind {
   NEXT = 'N',
@@ -26,15 +27,16 @@ export enum NotificationKind {
  * @see {@link materialize}
  * @see {@link dematerialize}
  * @see {@link observeOn}
- * @deprecated remove in v8. It is NOT recommended to create instances of `Notification` directly
- * and use them. Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
- * For example: `{ kind: 'N', value: 1 }`, `{kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+ * @deprecated It is NOT recommended to create instances of `Notification` directly.
+ * Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
+ * For example: `{ kind: 'N', value: 1 }`, `{ kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+ * Will be removed in v8.
  */
 export class Notification<T> {
   /**
    * A value signifying that the notification will "next" if observed. In truth,
-   * This is really synonomous with just checking `kind === "N"`.
-   * @deprecated remove in v8. Instead, just check to see if the value of `kind` is `"N"`.
+   * This is really synonymous with just checking `kind === "N"`.
+   * @deprecated Will be removed in v8. Instead, just check to see if the value of `kind` is `"N"`.
    */
   readonly hasValue: boolean;
 
@@ -42,7 +44,7 @@ export class Notification<T> {
    * Creates a "Next" notification object.
    * @param kind Always `'N'`
    * @param value The value to notify with if observed.
-   * @deprecated internal as of v8. Use {@link createNext} instead.
+   * @deprecated Internal implementation detail. Use {@link createNext} instead.
    */
   constructor(kind: 'N', value?: T);
   /**
@@ -50,13 +52,13 @@ export class Notification<T> {
    * @param kind Always `'E'`
    * @param value Always `undefined`
    * @param error The error to notify with if observed.
-   * @deprecated internal as of v8. Use {@link createError} instead.
+   * @deprecated Internal implementation detail. Use {@link createError} instead.
    */
   constructor(kind: 'E', value: undefined, error: any);
   /**
    * Creates a "completion" notification object.
    * @param kind Always `'C'`
-   * @deprecated internal as of v8. Use {@link createComplete} instead.
+   * @deprecated Internal implementation detail. Use {@link createComplete} instead.
    */
   constructor(kind: 'C');
   constructor(public readonly kind: 'N' | 'E' | 'C', public readonly value?: T, public readonly error?: any) {
@@ -80,7 +82,7 @@ export class Notification<T> {
    * @param next A next handler
    * @param error An error handler
    * @param complete A complete handler
-   * @deprecated remove in v8. use {@link Notification.prototype.observe} instead.
+   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
    */
   do(next: (value: T) => void, error: (err: any) => void, complete: () => void): void;
   /**
@@ -89,14 +91,14 @@ export class Notification<T> {
    * and no error is thrown, it will be a noop.
    * @param next A next handler
    * @param error An error handler
-   * @deprecated remove in v8. use {@link Notification.prototype.observe} instead.
+   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
    */
   do(next: (value: T) => void, error: (err: any) => void): void;
   /**
    * Executes the next handler if the Notification is of `kind` `"N"`. Otherwise
    * this will not error, and it will be a noop.
    * @param next The next handler
-   * @deprecated remove in v8. use {@link Notification.prototype.observe} instead.
+   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
    */
   do(next: (value: T) => void): void;
   do(nextHandler: (value: T) => void, errorHandler?: (err: any) => void, completeHandler?: () => void): void {
@@ -111,7 +113,7 @@ export class Notification<T> {
    * @param next A next handler
    * @param error An error handler
    * @param complete A complete handler
-   * @deprecated remove in v8. use {@link Notification.prototype.observe} instead.
+   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
    */
   accept(next: (value: T) => void, error: (err: any) => void, complete: () => void): void;
   /**
@@ -120,14 +122,14 @@ export class Notification<T> {
    * and no error is thrown, it will be a noop.
    * @param next A next handler
    * @param error An error handler
-   * @deprecated remove in v8. use {@link Notification.prototype.observe} instead.
+   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
    */
   accept(next: (value: T) => void, error: (err: any) => void): void;
   /**
    * Executes the next handler if the Notification is of `kind` `"N"`. Otherwise
    * this will not error, and it will be a noop.
    * @param next The next handler
-   * @deprecated remove in v8. use {@link Notification.prototype.observe} instead.
+   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
    */
   accept(next: (value: T) => void): void;
 
@@ -136,7 +138,7 @@ export class Notification<T> {
    * If the handler is missing it will do nothing. Even if the notification is an error, if
    * there is no error handler on the observer, an error will not be thrown, it will noop.
    * @param observer The observer to notify.
-   * @deprecated remove in v8. Use {@link Notification.prototype.observe} instead.
+   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
    */
   accept(observer: PartialObserver<T>): void;
   accept(nextOrObserver: PartialObserver<T> | ((value: T) => void), error?: (err: any) => void, complete?: () => void) {
@@ -149,9 +151,8 @@ export class Notification<T> {
    * Returns a simple Observable that just delivers the notification represented
    * by this Notification instance.
    *
-   * @deprecated remove in v8. In order to accomplish converting `Notification` to an {@link Observable}
-   * you may use {@link of} and {@link dematerialize}: `of(notification).pipe(dematerialize())`. This is
-   * being removed as it has limited usefulness, and we're trying to streamline the library.
+   * @deprecated Will be removed in v8. To convert a `Notification` to an {@link Observable},
+   * use {@link of} and {@link dematerialize}: `of(notification).pipe(dematerialize())`.
    */
   toObservable(): Observable<T> {
     const { kind, value, error } = this;
@@ -187,9 +188,10 @@ export class Notification<T> {
    * @return {Notification<T>} The "next" Notification representing the
    * argument.
    * @nocollapse
-   * @deprecated remove in v8. It is NOT recommended to create instances of `Notification` directly
-   * and use them. Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
-   * For example: `{ kind: 'N', value: 1 }`, `{kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+   * @deprecated It is NOT recommended to create instances of `Notification` directly.
+   * Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
+   * For example: `{ kind: 'N', value: 1 }`, `{ kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+   * Will be removed in v8.
    */
   static createNext<T>(value: T) {
     return new Notification('N', value) as Notification<T> & NextNotification<T>;
@@ -202,9 +204,10 @@ export class Notification<T> {
    * @return {Notification<T>} The "error" Notification representing the
    * argument.
    * @nocollapse
-   * @deprecated remove in v8. It is NOT recommended to create instances of `Notification` directly
-   * and use them. Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
-   * For example: `{ kind: 'N', value: 1 }`, `{kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+   * @deprecated It is NOT recommended to create instances of `Notification` directly.
+   * Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
+   * For example: `{ kind: 'N', value: 1 }`, `{ kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+   * Will be removed in v8.
    */
   static createError(err?: any) {
     return new Notification('E', undefined, err) as Notification<never> & ErrorNotification;
@@ -214,9 +217,10 @@ export class Notification<T> {
    * A shortcut to create a Notification instance of the type `complete`.
    * @return {Notification<any>} The valueless "complete" Notification.
    * @nocollapse
-   * @deprecated remove in v8. It is NOT recommended to create instances of `Notification` directly
-   * and use them. Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
-   * For example: `{ kind: 'N', value: 1 }`, `{kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+   * @deprecated It is NOT recommended to create instances of `Notification` directly.
+   * Rather, try to create POJOs matching the signature outlined in {@link ObservableNotification}.
+   * For example: `{ kind: 'N', value: 1 }`, `{ kind: 'E', error: new Error('bad') }`, or `{ kind: 'C' }`.
+   * Will be removed in v8.
    */
   static createComplete(): Notification<never> & CompleteNotification {
     return Notification.completeNotification;

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -18,12 +18,12 @@ import { isFunction } from './util/isFunction';
  */
 export class Observable<T> implements Subscribable<T> {
   /**
-   * @deprecated This is an internal implementation detail, do not use.
+   * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
    */
   source: Observable<any> | undefined;
 
   /**
-   * @deprecated This is an internal implementation detail, do not use.
+   * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
    */
   operator: Operator<any, T> | undefined;
 
@@ -43,13 +43,13 @@ export class Observable<T> implements Subscribable<T> {
   // HACK: Since TypeScript inherits static properties too, we have to
   // fight against TypeScript here so Subject can have a different static create signature
   /**
-   * Creates a new cold Observable by calling the Observable constructor
+   * Creates a new Observable by calling the Observable constructor
    * @owner Observable
    * @method create
    * @param {Function} subscribe? the subscriber function to be passed to the Observable constructor
-   * @return {Observable} a new cold observable
+   * @return {Observable} a new observable
    * @nocollapse
-   * @deprecated use new Observable() instead
+   * @deprecated Use `new Observable()` instead. Will be removed in v8.
    */
   static create: (...args: any[]) => any = <T>(subscribe?: (subscriber: Subscriber<T>) => TeardownLogic) => {
     return new Observable<T>(subscribe);
@@ -61,9 +61,10 @@ export class Observable<T> implements Subscribable<T> {
    * @method lift
    * @param operator the operator defining the operation to take on the observable
    * @return a new observable with the Operator applied
-   * @deprecated This is an internal implementation detail, do not use directly. If you have implemented an operator
-   * using `lift`, it is recommended that you create an operator by simply returning `new Observable()` directly.
-   * See "Creating new operators from scratch" section here: https://rxjs.dev/guide/operators
+   * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
+   * If you have implemented an operator using `lift`, it is recommended that you create an
+   * operator by simply returning `new Observable()` directly. See "Creating new operators from
+   * scratch" section here: https://rxjs.dev/guide/operators
    */
   lift<R>(operator?: Operator<T, R>): Observable<R> {
     const observable = new Observable<R>();
@@ -74,7 +75,7 @@ export class Observable<T> implements Subscribable<T> {
 
   subscribe(observer?: Partial<Observer<T>>): Subscription;
   subscribe(next: (value: T) => void): Subscription;
-  /** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
+  /** @deprecated Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments */
   subscribe(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): Subscription;
   /**
    * Invokes an execution of an Observable and registers Observer handlers for notifications it will emit.
@@ -341,11 +342,11 @@ export class Observable<T> implements Subscribable<T> {
    * @param promiseCtor a constructor function used to instantiate the Promise
    * @return a promise that either resolves on observable completion or
    *  rejects with the handled error
-   * @deprecated remove in v8. Passing a Promise constructor will no longer be available
+   * @deprecated Passing a Promise constructor will no longer be available
    * in upcoming versions of RxJS. This is because it adds weight to the library, for very
    * little benefit. If you need this functionality, it is recommended that you either
    * polyfill Promise, or you create an adapter to convert the returned native promise
-   * to whatever promise implementation you wanted.
+   * to whatever promise implementation you wanted. Will be removed in v8.
    */
   forEach(next: (value: T) => void, promiseCtor: PromiseConstructorLike): Promise<void>;
 
@@ -480,11 +481,11 @@ export class Observable<T> implements Subscribable<T> {
   }
 
   /* tslint:disable:max-line-length */
-  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
+  /** @deprecated Replaced with {@link firstValueFrom} and {@link lastValueFrom}. Will be removed in v8. */
   toPromise(): Promise<T | undefined>;
-  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
+  /** @deprecated Replaced with {@link firstValueFrom} and {@link lastValueFrom}. Will be removed in v8. */
   toPromise(PromiseCtor: typeof Promise): Promise<T | undefined>;
-  /** @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead */
+  /** @deprecated Replaced with {@link firstValueFrom} and {@link lastValueFrom}. Will be removed in v8. */
   toPromise(PromiseCtor: PromiseConstructorLike): Promise<T | undefined>;
   /* tslint:enable:max-line-length */
 
@@ -504,7 +505,7 @@ export class Observable<T> implements Subscribable<T> {
    * @return A Promise that resolves with the last value emit, or
    * rejects on an error. If there were no emissions, Promise
    * resolves with undefined.
-   * @deprecated Deprecated use {@link firstValueFrom} or {@link lastValueFrom} instead
+   * @deprecated Replaced with {@link firstValueFrom} and {@link lastValueFrom}. Will be removed in v8.
    */
   toPromise(promiseCtor?: PromiseConstructorLike): Promise<T | undefined> {
     promiseCtor = getPromiseCtor(promiseCtor);

--- a/src/internal/Operator.ts
+++ b/src/internal/Operator.ts
@@ -2,7 +2,7 @@ import { Subscriber } from './Subscriber';
 import { TeardownLogic } from './types';
 
 /***
- * @deprecated Internal implementation detail, do not use.
+ * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
  */
 export interface Operator<T, R> {
   call(subscriber: Subscriber<R>, source: any): TeardownLogic;

--- a/src/internal/Scheduler.ts
+++ b/src/internal/Scheduler.ts
@@ -1,7 +1,7 @@
 import { Action } from './scheduler/Action';
 import { Subscription } from './Subscription';
 import { SchedulerLike, SchedulerAction } from './types';
-import { dateTimestampProvider } from "./scheduler/dateTimestampProvider";
+import { dateTimestampProvider } from './scheduler/dateTimestampProvider';
 
 /**
  * An execution context and a data structure to order tasks and schedule their
@@ -20,14 +20,12 @@ import { dateTimestampProvider } from "./scheduler/dateTimestampProvider";
  * @class Scheduler
  * @deprecated Scheduler is an internal implementation detail of RxJS, and
  * should not be used directly. Rather, create your own class and implement
- * {@link SchedulerLike}
+ * {@link SchedulerLike}. Will be made internal in v8.
  */
 export class Scheduler implements SchedulerLike {
-
   public static now: () => number = dateTimestampProvider.now;
 
-  constructor(private schedulerActionCtor: typeof Action,
-              now: () => number = Scheduler.now) {
+  constructor(private schedulerActionCtor: typeof Action, now: () => number = Scheduler.now) {
     this.now = now;
   }
 

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -15,20 +15,20 @@ import { arrRemove } from './util/arrRemove';
  */
 export class Subject<T> extends Observable<T> implements SubscriptionLike {
   closed = false;
-  /** @deprecated This is an internal implementation detail, do not use directly. */
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   observers: Observer<T>[] = [];
-  /** @deprecated This is an internal implementation detail, do not use directly. */
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   isStopped = false;
-  /** @deprecated This is an internal implementation detail, do not use directly. */
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   hasError = false;
-  /** @deprecated This is an internal implementation detail, do not use directly. */
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   thrownError: any = null;
 
   /**
    * Creates a "subject" by basically gluing an observer to an observable.
    *
    * @nocollapse
-   * @deprecated Recommended you do not use, will be removed at some point in the future. Plans for replacement still under discussion.
+   * @deprecated Recommended you do not use. Will be removed at some point in the future. Plans for replacement still under discussion.
    */
   static create: (...args: any[]) => any = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
     return new AnonymousSubject<T>(destination, source);
@@ -39,7 +39,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     super();
   }
 
-  /** @deprecated This is an internal implementation detail, do not use directly. */
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   lift<R>(operator: Operator<T, R>): Observable<R> {
     const subject = new AnonymousSubject(this, this);
     subject.operator = operator as any;
@@ -140,7 +140,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
  */
 export class AnonymousSubject<T> extends Subject<T> {
   constructor(
-    /** @deprecated Internal implementation detail, do not use. */
+    /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
     public destination?: Observer<T>,
     source?: Observable<T>
   ) {

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -29,19 +29,22 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
    * @return A Subscriber wrapping the (partially defined)
    * Observer represented by the given arguments.
    * @nocollapse
-   * @deprecated Do not use. Will be removed in v8. There is no replacement for this method, and there is no reason to be creating instances of `Subscriber` directly. If you have a specific use case, please file an issue.
+   * @deprecated Do not use. Will be removed in v8. There is no replacement for this
+   * method, and there is no reason to be creating instances of `Subscriber` directly.
+   * If you have a specific use case, please file an issue.
    */
   static create<T>(next?: (x?: T) => void, error?: (e?: any) => void, complete?: () => void): Subscriber<T> {
     return new SafeSubscriber(next, error, complete);
   }
 
-  /** @deprecated This is an internal implementation detail, do not use directly. */
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   protected isStopped: boolean = false;
-  /** @deprecated This is an internal implementation detail, do not use directly. */
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   protected destination: Subscriber<any> | Observer<any>; // this `any` is the escape hatch to erase extra type param (e.g. R)
 
   /**
-   * @deprecated Do not use directly. There is no reason to directly create an instance of Subscriber. This type is exported for typings reasons.
+   * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
+   * There is no reason to directly create an instance of Subscriber. This type is exported for typings reasons.
    */
   constructor(destination?: Subscriber<any> | Observer<any>) {
     super();

--- a/src/internal/ajax/AjaxResponse.ts
+++ b/src/internal/ajax/AjaxResponse.ts
@@ -25,9 +25,9 @@ export class AjaxResponse<T> {
   readonly response: T;
 
   /**
-   * The responseType set on the request. (For example: `""`, "arraybuffer"`, "blob"`, "document"`, "json"`, or `"text"`)
-   * @deprecated There isn't much reason to examine this. It's the same responseType set (or defaulted) on the ajax config
-   * if you really need to examine this value, you can check it on the `request` or the `xhr`.
+   * The responseType set on the request. (For example: `""`, `"arraybuffer"`, `"blob"`, `"document"`, `"json"`, or `"text"`)
+   * @deprecated There isn't much reason to examine this. It's the same responseType set (or defaulted) on the ajax config.
+   * If you really need to examine this value, you can check it on the `request` or the `xhr`. Will be removed in v8.
    */
   readonly responseType: XMLHttpRequestResponseType;
 

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -181,8 +181,8 @@ export interface AjaxConfig {
    * This will **not** error for errored status codes. Rather, it will always _complete_ when
    * the HTTP response comes back.
    *
-   * @deprecated If you're looking for progress events, please try {@link includeDownloadProgress} and
-   * {@link includeUploadProgress}. This will be removed in version 8.
+   * @deprecated If you're looking for progress events, use {@link includeDownloadProgress} and
+   * {@link includeUploadProgress} instead. Will be removed in v8.
    */
   progressSubscriber?: PartialObserver<ProgressEvent>;
 

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -33,9 +33,9 @@ export const config = {
    * The promise constructor used by default for methods such as
    * {@link toPromise} and {@link forEach}
    *
-   * @deprecated remove in v8. RxJS will no longer support this sort of injection of a
+   * @deprecated As of version 8, RxJS will no longer support this sort of injection of a
    * Promise constructor. If you need a Promise implementation other than native promises,
-   * please polyfill/patch Promises as you see appropriate.
+   * please polyfill/patch Promise as you see appropriate. Will be removed in v8.
    */
   Promise: undefined as PromiseConstructorLike | undefined,
 
@@ -47,9 +47,9 @@ export const config = {
    * an unhandled error. DO NOT USE THIS FLAG UNLESS IT'S NEEDED TO BUY TIME
    * FOR MIGRATION REASONS.
    *
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support synchronous throwing
+   * @deprecated As of version 8, RxJS will no longer support synchronous throwing
    * of unhandled errors. All errors will be thrown on a separate call stack to prevent bad
-   * behaviors described above.
+   * behaviors described above. Will be removed in v8.
    */
   useDeprecatedSynchronousErrorHandling: false,
 
@@ -62,10 +62,10 @@ export const config = {
    * issues when types other than POJOs are passed to subscribe as subscribers, as they will likely have
    * their `this` context overwritten.
    *
-   * @deprecated remove in v8. As of version 8, RxJS will no longer support altering the
+   * @deprecated As of version 8, RxJS will no longer support altering the
    * context of next functions provided as part of an observer to Subscribe. Instead,
    * you will have access to a subscription or a signal or token that will allow you to do things like
-   * unsubscribe and test closed status.
+   * unsubscribe and test closed status. Will be removed in v8.
    */
   useDeprecatedNextContext: false,
 };

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -23,7 +23,7 @@ export class ConnectableObservable<T> extends Observable<T> {
    * @param subjectFactory The factory that creates the subject used internally.
    * @deprecated Will be removed in v8. Use {@link connectable} to create a connectable observable.
    * `new ConnectableObservable(source, factory)` is equivalent to
-   * `connectable(source, factory)`.
+   * `connectable(source, { connector: factory })`.
    * When the `refCount()` method is needed, the {@link share} operator should be used instead:
    * `new ConnectableObservable(source, factory).refCount()` is equivalent to
    * `source.pipe(share({ connector: factory }))`.

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -8,9 +8,10 @@ import { hasLift } from '../util/lift';
 
 /**
  * @class ConnectableObservable<T>
- * @deprecated To be removed in version 8. Please use {@link connectable} to create a connectable observable.
- * If you are using the `refCount` method of `ConnectableObservable` you can use the updated {@link share} operator
- * instead, which is now highly configurable.
+ * @deprecated Will be removed in v8. Use {@link connectable} to create a connectable observable.
+ * If you are using the `refCount` method of `ConnectableObservable`, use the {@link share} operator
+ * instead.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export class ConnectableObservable<T> extends Observable<T> {
   protected _subject: Subject<T> | null = null;
@@ -20,12 +21,13 @@ export class ConnectableObservable<T> extends Observable<T> {
   /**
    * @param source The source observable
    * @param subjectFactory The factory that creates the subject used internally.
-   * @deprecated To be removed in version 8. Please use {@link connectable} to create a connectable observable.
-   * If you are using the `refCount` method of `ConnectableObservable` you can use the {@link share} operator
-   * instead, which is now highly configurable. `new ConnectableObservable(source, fn)` is equivalent
-   * to `connectable(source, fn)`. With the exception of when the `refCount()` method is needed, in which
-   * case, the new {@link share} operator should be used: `new ConnectableObservable(source, fn).refCount()`
-   * is equivalent to `source.pipe(share({ connector: fn }))`.
+   * @deprecated Will be removed in v8. Use {@link connectable} to create a connectable observable.
+   * `new ConnectableObservable(source, factory)` is equivalent to
+   * `connectable(source, factory)`.
+   * When the `refCount()` method is needed, the {@link share} operator should be used instead:
+   * `new ConnectableObservable(source, factory).refCount()` is equivalent to
+   * `source.pipe(share({ connector: factory }))`.
+   * Details: https://rxjs.dev/deprecations/multicasting
    */
   constructor(public source: Observable<T>, protected subjectFactory: () => Subject<T>) {
     super();
@@ -57,6 +59,10 @@ export class ConnectableObservable<T> extends Observable<T> {
     _connection?.unsubscribe();
   }
 
+  /**
+   * @deprecated {@link ConnectableObservable} will be removed in v8. Use {@link connecatble} instead.
+   * Details: https://rxjs.dev/deprecations/multicasting
+   */
   connect(): Subscription {
     let connection = this._connection;
     if (!connection) {
@@ -89,8 +95,8 @@ export class ConnectableObservable<T> extends Observable<T> {
   }
 
   /**
-   * @deprecated The {@link ConnectableObservable} class is scheduled for removal in version 8.
-   * Please use the {@link share} operator, which is now highly configurable.
+   * @deprecated {@link ConnectableObservable} will be removed in v8. Use the {@link share} operator instead.
+   * Details: https://rxjs.dev/deprecations/multicasting
    */
   refCount(): Observable<T> {
     return higherOrderRefCount()(this) as Observable<T>;

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -27,7 +27,7 @@ export function combineLatest<T extends AnyCatcher>(arg: T): Observable<unknown>
 // combineLatest([a, b, c])
 export function combineLatest(sources: []): Observable<never>;
 export function combineLatest<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and combineLatestAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `combineLatestAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function combineLatest<A extends readonly unknown[], R>(
   sources: readonly [...ObservableInputTuple<A>],
   resultSelector: (...values: A) => R,
@@ -37,24 +37,24 @@ export function combineLatest<A extends readonly unknown[], R>(
   sources: readonly [...ObservableInputTuple<A>],
   resultSelector: (...values: A) => R
 ): Observable<R>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and combineLatestAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `combineLatestAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function combineLatest<A extends readonly unknown[]>(
   sources: readonly [...ObservableInputTuple<A>],
   scheduler: SchedulerLike
 ): Observable<A>;
 
 // combineLatest(a, b, c)
-/** @deprecated Use the version that takes an array of Observables instead */
+/** @deprecated Pass an array of sources instead. The rest-parameters signature will be removed in v8. Details: https://rxjs.dev/deprecations/array-argument */
 export function combineLatest<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and combineLatestAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `combineLatestAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function combineLatest<A extends readonly unknown[], R>(
   ...sourcesAndResultSelectorAndScheduler: [...ObservableInputTuple<A>, (...values: A) => R, SchedulerLike]
 ): Observable<R>;
-/** @deprecated Use the version that takes an array of Observables instead. (e.g. `combineLatest([a$, b$], (a, b) => a + b)`) */
+/** @deprecated Pass an array of sources instead. The rest-parameters signature will be removed in v8. Details: https://rxjs.dev/deprecations/array-argument */
 export function combineLatest<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and combineLatestAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `combineLatestAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function combineLatest<A extends readonly unknown[]>(
   ...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike]
 ): Observable<A>;

--- a/src/internal/observable/defer.ts
+++ b/src/internal/observable/defer.ts
@@ -41,7 +41,7 @@ import { innerFrom } from './from';
  *
  * @see {@link Observable}
  *
- * @param {function(): SubscribableOrPromise} observableFactory The Observable
+ * @param {function(): ObservableInput} observableFactory The Observable
  * factory function to invoke for each Observer that subscribes to the output
  * Observable. May also return a Promise, which will be converted on the fly
  * to an Observable.

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -104,7 +104,7 @@ export interface WebSocketSubjectConfig<T> {
   url: string;
   /** The protocol to use to connect */
   protocol?: string | Array<string>;
-  /** @deprecated use {@link deserializer} */
+  /** @deprecated Will be removed in v8. Use {@link deserializer} instead. */
   resultSelector?: (e: MessageEvent) => T;
   /**
    * A serializer used to create messages from passed values before the
@@ -187,6 +187,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     }
   }
 
+  /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   lift<R>(operator: Operator<T, R>): WebSocketSubject<R> {
     const sock = new WebSocketSubject<R>(this._config as WebSocketSubjectConfig<any>, this.destination as any);
     sock.operator = operator;

--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -25,7 +25,7 @@ import { SchedulerLike } from '../types';
  * // Complete!
  * ```
  */
-export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
+export const EMPTY = new Observable<never>((subscriber) => subscriber.complete());
 
 /**
  * Creates an Observable that emits no items to the Observer and immediately
@@ -82,12 +82,12 @@ export const EMPTY = new Observable<never>(subscriber => subscriber.complete());
  * the emission of the complete notification.
  * @return An "empty" Observable: emits only the complete
  * notification.
- * @deprecated Deprecated in favor of using {@link EMPTY} constant, or {@link scheduled} (e.g. `scheduled([], scheduler)`)
+ * @deprecated Replaced with the {@link EMPTY} constant or {@link scheduled} (e.g. `scheduled([], scheduler)`). Will be removed in v8.
  */
 export function empty(scheduler?: SchedulerLike) {
   return scheduler ? emptyScheduled(scheduler) : EMPTY;
 }
 
 function emptyScheduled(scheduler: SchedulerLike) {
-  return new Observable<never>(subscriber => scheduler.schedule(() => subscriber.complete()));
+  return new Observable<never>((subscriber) => scheduler.schedule(() => subscriber.complete()));
 }

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -33,9 +33,9 @@ export function forkJoin<A extends readonly unknown[], R>(
 ): Observable<R>;
 
 // forkJoin(a, b, c)
-/** @deprecated Use the version that takes an array of Observables instead, Details https://rxjs.dev/deprecations/array-argument */
+/** @deprecated Pass an array of sources instead. The rest-parameters signature will be removed in v8. Details: https://rxjs.dev/deprecations/array-argument */
 export function forkJoin<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A>;
-/** @deprecated Use the version that takes an array of Observables instead, Details https://rxjs.dev/deprecations/array-argument */
+/** @deprecated Pass an array of sources instead. The rest-parameters signature will be removed in v8. Details: https://rxjs.dev/deprecations/array-argument */
 export function forkJoin<A extends readonly unknown[], R>(
   ...sourcesAndResultSelector: [...ObservableInputTuple<A>, (...values: A) => R]
 ): Observable<R>;

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -15,7 +15,7 @@ import { isIterable } from '../util/isIterable';
 import { isReadableStreamLike, readableStreamLikeToAsyncGenerator } from '../util/isReadableStreamLike';
 
 export function from<O extends ObservableInput<any>>(input: O): Observable<ObservedValueOf<O>>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function from<O extends ObservableInput<any>>(input: O, scheduler: SchedulerLike): Observable<ObservedValueOf<O>>;
 
 /**

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -79,7 +79,7 @@ export function fromEvent<T, R>(
 ): Observable<T>;
 
 export function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
-/** @deprecated type parameters that cannot be inferred will be removed in v8 */
+/** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */
 export function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<T>;
 export function fromEvent<R>(
   target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>,
@@ -91,7 +91,7 @@ export function fromEvent(
   target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,
   eventName: string
 ): Observable<unknown>;
-/** @deprecated type parameters that cannot be inferred will be removed in v8 */
+/** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */
 export function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
 export function fromEvent<R>(
   target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,

--- a/src/internal/observable/generate.ts
+++ b/src/internal/observable/generate.ts
@@ -86,7 +86,7 @@ export interface GenerateOptions<T, S> extends GenerateBaseOptions<S> {
  * @param {function (state: S): T} resultSelector Selector function for results produced in the sequence. (deprecated)
  * @param {SchedulerLike} [scheduler] A {@link SchedulerLike} on which to run the generator loop. If not provided, defaults to emit immediately.
  * @returns {Observable<T>} The generated sequence.
- * @deprecated Removing in v8. Use configuration object argument instead.
+ * @deprecated Instead of passing separate arguments, use the options argument. Signatures taking separate arguments will be removed in v8.
  */
 export function generate<T, S>(
   initialState: S,
@@ -237,7 +237,7 @@ export function generate<T, S>(
  * @param {function (state: S): T} [resultSelector] Selector function for results produced in the sequence.
  * @param {Scheduler} [scheduler] A {@link Scheduler} on which to run the generator loop. If not provided, defaults to emitting immediately.
  * @return {Observable<T>} The generated sequence.
- * @deprecated Removing in v8. Use configuration object argument instead.
+ * @deprecated Instead of passing separate arguments, use the options argument. Signatures taking separate arguments will be removed in v8.
  */
 export function generate<S>(
   initialState: S,

--- a/src/internal/observable/merge.ts
+++ b/src/internal/observable/merge.ts
@@ -8,11 +8,11 @@ import { popNumber, popScheduler } from '../util/args';
 
 export function merge<A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): Observable<A[number]>;
 export function merge<A extends readonly unknown[]>(...sourcesAndConcurrency: [...ObservableInputTuple<A>, number?]): Observable<A[number]>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `mergeAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function merge<A extends readonly unknown[]>(
   ...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike?]
 ): Observable<A[number]>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and mergeAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `mergeAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function merge<A extends readonly unknown[]>(
   ...sourcesAndConcurrencyAndScheduler: [...ObservableInputTuple<A>, number?, SchedulerLike?]
 ): Observable<A[number]>;

--- a/src/internal/observable/never.ts
+++ b/src/internal/observable/never.ts
@@ -34,8 +34,8 @@ import { noop } from '../util/noop';
 export const NEVER = new Observable<never>(noop);
 
 /**
- * @deprecated Deprecated in favor of using {@link NEVER} constant.
+ * @deprecated Replaced with the {@link NEVER} constant. Will be removed in v8.
  */
-export function never () {
+export function never() {
   return NEVER;
 }

--- a/src/internal/observable/of.ts
+++ b/src/internal/observable/of.ts
@@ -12,13 +12,13 @@ import { popScheduler } from '../util/args';
 export function of(value: null): Observable<null>;
 export function of(value: undefined): Observable<undefined>;
 
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function of(scheduler: SchedulerLike): Observable<never>;
-/** @deprecated The scheduler argument is deprecated, use scheduled. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function of<A extends readonly unknown[]>(...valuesAndScheduler: [...A, SchedulerLike]): Observable<ValueFromArray<A>>;
 
 export function of(): Observable<never>;
-/** @deprecated remove in v8. Do not use generic arguments directly, allow inference or cast with `as` */
+/** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */
 export function of<T>(): Observable<T>;
 export function of<T>(value: T): Observable<T>;
 export function of<A extends readonly unknown[]>(...values: A): Observable<ValueFromArray<A>>;

--- a/src/internal/observable/pairs.ts
+++ b/src/internal/observable/pairs.ts
@@ -3,19 +3,19 @@ import { SchedulerLike } from '../types';
 import { from } from './from';
 
 /**
- * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
+ * @deprecated Use `from(Object.entries(obj))` instead. Will be removed in v8.
  */
 export function pairs<T>(arr: readonly T[], scheduler?: SchedulerLike): Observable<[string, T]>;
 /**
- * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
+ * @deprecated Use `from(Object.entries(obj))` instead. Will be removed in v8.
  */
 export function pairs<O extends Record<string, unknown>>(obj: O, scheduler?: SchedulerLike): Observable<[keyof O, O[keyof O]]>;
 /**
- * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
+ * @deprecated Use `from(Object.entries(obj))` instead. Will be removed in v8.
  */
 export function pairs<T>(iterable: Iterable<T>, scheduler?: SchedulerLike): Observable<[string, T]>;
 /**
- * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
+ * @deprecated Use `from(Object.entries(obj))` instead. Will be removed in v8.
  */
 export function pairs(
   n: number | bigint | boolean | ((...args: any[]) => any) | symbol,
@@ -73,7 +73,7 @@ export function pairs(
  * when resulting Observable will emit values.
  * @returns {(Observable<Array<string|T>>)} An observable sequence of
  * [key, value] pairs from the object.
- * @deprecated To be removed in version 8. Use `from(Object.entries(obj))` instead.
+ * @deprecated Use `from(Object.entries(obj))` instead. Will be removed in v8.
  */
 export function pairs(obj: any, scheduler?: SchedulerLike) {
   return from(Object.entries(obj), scheduler as any);

--- a/src/internal/observable/range.ts
+++ b/src/internal/observable/range.ts
@@ -5,7 +5,7 @@ import { EMPTY } from './empty';
 export function range(start: number, count?: number): Observable<number>;
 
 /**
- * @deprecated To be removed in v8. Passing a scheduler is deprecated, use `range(start, count).pipe(observeOn(scheduler))` instead.
+ * @deprecated The `scheduler` parameter will be removed in v8. Use `range(start, count).pipe(observeOn(scheduler))` instead. Details: Details: https://rxjs.dev/deprecations/scheduler-argument
  */
 export function range(start: number, count: number | undefined, scheduler: SchedulerLike): Observable<number>;
 

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -103,7 +103,7 @@ export function throwError(errorFactory: () => any): Observable<never>;
  * Returns an observable that will error with the specified error immediately upon subscription.
  *
  * @param error The error instance to emit
- * @deprecated Removed in v8. Instead, pass a factory function to `throwError(() => new Error('test'))`. This is
+ * @deprecated Support for passing an error value will be removed in v8. Instead, pass a factory function to `throwError(() => new Error('test'))`. This is
  * because it will create the error at the moment it should be created and capture a more appropriate stack trace. If
  * for some reason you need to create the error ahead of time, you can still do that: `const err = new Error('test'); throwError(() => err);`.
  */
@@ -114,8 +114,9 @@ export function throwError(error: any): Observable<never>;
  *
  * @param errorOrErrorFactory An error instance or error factory
  * @param scheduler A scheduler to use to schedule the error notification
- * @deprecated Use `throwError` in combination with {@link observeOn}:
- * `throwError(() => new Error('test')).pipe(observeOn(scheduler));`
+ * @deprecated The `scheduler` parameter will be removed in v8.
+ * Use `throwError` in combination with {@link observeOn}: `throwError(() => new Error('test')).pipe(observeOn(scheduler));`.
+ * Details: https://rxjs.dev/deprecations/scheduler-argument
  */
 export function throwError(errorOrErrorFactory: any, scheduler: SchedulerLike): Observable<never>;
 

--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -129,7 +129,7 @@ export function timer(due: number | Date, scheduler?: SchedulerLike): Observable
 export function timer(startDue: number | Date, intervalDuration: number, scheduler?: SchedulerLike): Observable<number>;
 
 /**
- * @deprecated Use `timer(dueTime, scheduler?)` instead. This call pattern will be removed in version 8.
+ * @deprecated The signature allowing `undefined` to be passed for `intervalDuration` will be removed in v8. Use the `timer(dueTime, scheduler?)` signature instead.
  */
 export function timer(dueTime: number | Date, unused: undefined, scheduler?: SchedulerLike): Observable<0>;
 

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -1,6 +1,6 @@
 import { combineLatestAll } from './combineLatestAll';
 
 /**
- * @deprecated renamed. Use {@link combineLatestAll}.
+ * @deprecated Renamed to {@link combineLatestAll}. Will be removed in v8.
  */
 export const combineAll = combineLatestAll;

--- a/src/internal/operators/combineLatest.ts
+++ b/src/internal/operators/combineLatest.ts
@@ -6,23 +6,23 @@ import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { pipe } from '../util/pipe';
 import { popResultSelector } from '../util/args';
 
-/** @deprecated use {@link combineLatestWith} */
+/** @deprecated Replaced with {@link combineLatestWith}. Will be removed in v8. */
 export function combineLatest<T, A extends readonly unknown[], R>(
   sources: [...ObservableInputTuple<A>],
   project: (...values: [T, ...A]) => R
 ): OperatorFunction<T, R>;
-/** @deprecated use {@link combineLatestWith} */
+/** @deprecated Replaced with {@link combineLatestWith}. Will be removed in v8. */
 export function combineLatest<T, A extends readonly unknown[], R>(sources: [...ObservableInputTuple<A>]): OperatorFunction<T, [T, ...A]>;
 
-/** @deprecated use {@link combineLatestWith} */
+/** @deprecated Replaced with {@link combineLatestWith}. Will be removed in v8. */
 export function combineLatest<T, A extends readonly unknown[], R>(
   ...sourcesAndProject: [...ObservableInputTuple<A>, (...values: [T, ...A]) => R]
 ): OperatorFunction<T, R>;
-/** @deprecated use {@link combineLatestWith} */
+/** @deprecated Replaced with {@link combineLatestWith}. Will be removed in v8. */
 export function combineLatest<T, A extends readonly unknown[], R>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, [T, ...A]>;
 
 /**
- * @deprecated Deprecated, use {@link combineLatestWith} or static {@link combineLatest}
+ * @deprecated Replaced with {@link combineLatestWith}. Will be removed in v8.
  */
 export function combineLatest<T, R>(...args: (ObservableInput<any> | ((...values: any[]) => R))[]): OperatorFunction<T, unknown> {
   const resultSelector = popResultSelector(args);

--- a/src/internal/operators/concat.ts
+++ b/src/internal/operators/concat.ts
@@ -4,15 +4,15 @@ import { concatAll } from './concatAll';
 import { internalFromArray } from '../observable/fromArray';
 import { popScheduler } from '../util/args';
 
-/** @deprecated remove in v8. Use {@link concatWith} */
+/** @deprecated Replaced with {@link concatWith}. Will be removed in v8. */
 export function concat<T, A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
-/** @deprecated remove in v8. Use {@link concatWith} */
+/** @deprecated Replaced with {@link concatWith}. Will be removed in v8. */
 export function concat<T, A extends readonly unknown[]>(
   ...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike]
 ): OperatorFunction<T, T | A[number]>;
 
 /**
- * @deprecated remove in v8. Use {@link concatWith}
+ * @deprecated Replaced with {@link concatWith}. Will be removed in v8.
  */
 export function concat<T, R>(...args: any[]): OperatorFunction<T, R> {
   const scheduler = popScheduler(args);

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -6,12 +6,12 @@ import { isFunction } from '../util/isFunction';
 export function concatMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -6,12 +6,12 @@ import { isFunction } from '../util/isFunction';
 export function concatMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function concatMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function concatMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/concatMap.ts
+++ b/src/internal/operators/concatMap.ts
@@ -6,12 +6,12 @@ import { isFunction } from '../util/isFunction';
 export function concatMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -4,12 +4,12 @@ import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
 export function concatMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMapTo<O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: undefined
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -4,12 +4,12 @@ import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
 export function concatMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function concatMapTo<O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: undefined
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -4,12 +4,12 @@ import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
 export function concatMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMapTo<O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: undefined
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/delayWhen.ts
+++ b/src/internal/operators/delayWhen.ts
@@ -6,12 +6,7 @@ import { ignoreElements } from './ignoreElements';
 import { mapTo } from './mapTo';
 import { mergeMap } from './mergeMap';
 
-/** @deprecated In future versions, empty notifiers will no longer re-emit the source value on the output observable. */
-export function delayWhen<T>(
-  delayDurationSelector: (value: T, index: number) => Observable<never>,
-  subscriptionDelay?: Observable<any>
-): MonoTypeOperatorFunction<T>;
-/** @deprecated In future versions, `subscriptionDelay` will no longer be supported. */
+/** @deprecated The `subscriptionDelay` parameter will be removed in v8. */
 export function delayWhen<T>(
   delayDurationSelector: (value: T, index: number) => Observable<any>,
   subscriptionDelay: Observable<any>

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -4,9 +4,9 @@ import { concat } from '../observable/concat';
 import { of } from '../observable/of';
 import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction, ValueFromArray } from '../types';
 
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `concatAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function endWith<T>(scheduler: SchedulerLike): MonoTypeOperatorFunction<T>;
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `concatAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function endWith<T, A extends unknown[] = T[]>(
   ...valuesAndScheduler: [...A, SchedulerLike]
 ): OperatorFunction<T, T | ValueFromArray<A>>;

--- a/src/internal/operators/exhaust.ts
+++ b/src/internal/operators/exhaust.ts
@@ -1,6 +1,6 @@
 import { exhaustAll } from './exhaustAll';
 
 /**
- * @deprecated renamed. Use {@link exhaustAll}.
+ * @deprecated Renamed to {@link exhaustAll}. Will be removed in v8.
  */
 export const exhaust = exhaustAll;

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -10,12 +10,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function exhaustMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector is no longer supported. Use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function exhaustMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector is no longer supported. Use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function exhaustMap<T, I, R>(
   project: (value: T, index: number) => ObservableInput<I>,
   resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -10,12 +10,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function exhaustMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function exhaustMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function exhaustMap<T, I, R>(
   project: (value: T, index: number) => ObservableInput<I>,
   resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -10,12 +10,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function exhaustMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function exhaustMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function exhaustMap<T, I, R>(
   project: (value: T, index: number) => ObservableInput<I>,
   resultSelector: (outerValue: T, innerValue: I, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -9,8 +9,9 @@ export function expand<T, O extends ObservableInput<unknown>>(
   scheduler?: SchedulerLike
 ): OperatorFunction<T, ObservedValueOf<O>>;
 /**
- * @deprecated Will be removed in v8. If you need to schedule the inner subscription,
+ * @deprecated The `scheduler` parameter will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
+ * Details: Details: https://rxjs.dev/deprecations/scheduler-argument
  */
 export function expand<T, O extends ObservableInput<unknown>>(
   project: (value: T, index: number) => O,

--- a/src/internal/operators/flatMap.ts
+++ b/src/internal/operators/flatMap.ts
@@ -1,6 +1,6 @@
 import { mergeMap } from './mergeMap';
 
 /**
- * @deprecated renamed. Use {@link mergeMap}.
+ * @deprecated Renamed to {@link mergeMap}. Will be removed in v8.
  */
 export const flatMap = mergeMap;

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -3,7 +3,7 @@ import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
 export function mapTo<R>(value: R): OperatorFunction<any, R>;
-/** @deprecated remove in v8. Use mapTo<R>(value: R): OperatorFunction<any, R> signature instead **/
+/** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */
 export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
 
 /**

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -52,10 +52,6 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @return A function that returns an Observable that emits
  * {@link Notification} objects that wrap the original emissions from the
  * source Observable with metadata.
- *
- * @deprecated In version 8, materialize will start to emit {@link ObservableNotification} objects, and not
- * {@link Notification} instances. This means that methods that are not commonly used, like `Notification.observe`
- * will not be available on the emitted values at that time.
  */
 export function materialize<T>(): OperatorFunction<T, Notification<T> & ObservableNotification<T>> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/merge.ts
+++ b/src/internal/operators/merge.ts
@@ -5,17 +5,17 @@ import { internalFromArray } from '../observable/fromArray';
 import { mergeAll } from './mergeAll';
 import { popNumber, popScheduler } from '../util/args';
 
-/** @deprecated use {@link mergeWith} or static {@link merge} */
+/** @deprecated Replaced with {@link mergeWith}. Will be removed in v8. */
 export function merge<T, A extends readonly unknown[]>(...sources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
-/** @deprecated use {@link mergeWith} or static {@link merge} */
+/** @deprecated Replaced with {@link mergeWith}. Will be removed in v8. */
 export function merge<T, A extends readonly unknown[]>(
   ...sourcesAndConcurrency: [...ObservableInputTuple<A>, number]
 ): OperatorFunction<T, T | A[number]>;
-/** @deprecated use {@link mergeWith} or static {@link merge} */
+/** @deprecated Replaced with {@link mergeWith}. Will be removed in v8. */
 export function merge<T, A extends readonly unknown[]>(
   ...sourcesAndScheduler: [...ObservableInputTuple<A>, SchedulerLike]
 ): OperatorFunction<T, T | A[number]>;
-/** @deprecated use {@link mergeWith} or static {@link merge} */
+/** @deprecated Replaced with {@link mergeWith}. Will be removed in v8. */
 export function merge<T, A extends readonly unknown[]>(
   ...sourcesAndConcurrencyAndScheduler: [...ObservableInputTuple<A>, number, SchedulerLike]
 ): OperatorFunction<T, T | A[number]>;

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -10,13 +10,13 @@ export function mergeMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   concurrent?: number
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function mergeMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined,
   concurrent?: number
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function mergeMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R,

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -10,13 +10,13 @@ export function mergeMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   concurrent?: number
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function mergeMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined,
   concurrent?: number
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function mergeMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R,

--- a/src/internal/operators/mergeMap.ts
+++ b/src/internal/operators/mergeMap.ts
@@ -10,13 +10,13 @@ export function mergeMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   concurrent?: number
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function mergeMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined,
   concurrent?: number
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function mergeMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R,

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -3,9 +3,16 @@ import { mergeMap } from './mergeMap';
 import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
-export function mergeMapTo<O extends ObservableInput<unknown>>(innerObservable: O, concurrent?: number): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated */
-export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(innerObservable: O, resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R, concurrent?: number): OperatorFunction<T, R>;
+export function mergeMapTo<O extends ObservableInput<unknown>>(
+  innerObservable: O,
+  concurrent?: number
+): OperatorFunction<any, ObservedValueOf<O>>;
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
+  innerObservable: O,
+  resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R,
+  concurrent?: number
+): OperatorFunction<T, R>;
 /* tslint:enable:max-line-length */
 
 /**

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -7,7 +7,7 @@ export function mergeMapTo<O extends ObservableInput<unknown>>(
   innerObservable: O,
   concurrent?: number
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R,

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -7,7 +7,7 @@ export function mergeMapTo<O extends ObservableInput<unknown>>(
   innerObservable: O,
   concurrent?: number
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R,

--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -12,11 +12,11 @@ import { connect } from './connect';
  *
  * @param subject The subject to multicast through.
  * @return A function that returns a {@link ConnectableObservable}
- * @deprecated This will be removed in version 8. Please use the {@link connectable} creation
- * function, which creates a connectable observable. If you were using the {@link refCount} operator
- * on the result of the `multicast` operator, then use the {@link share} operator, which is now
- * highly configurable. `multicast(subject), refCount()` is equivalent to
+ * @deprecated Will be removed in v8. To create a connectable observable, use {@link connectable}.
+ * If you're using {@link refCount} after `multicast`, use the {@link share} operator instead.
+ * `multicast(subject), refCount()` is equivalent to
  * `share({ connector: () => subject, resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 
@@ -28,8 +28,10 @@ export function multicast<T>(subject: Subject<T>): UnaryFunction<Observable<T>, 
  * @param subject The subject used to multicast.
  * @param selector A setup function to setup the multicast
  * @return A function that returns an observable that mirrors the observable returned by the selector.
- * @deprecated To be removed in version 8. Please use the new {@link connect} operator.
- * `multicast(subject, fn)` is equivalent to `connect({ connector: () => subject, setup: fn })`.
+ * @deprecated Will be removed in v8. Use the {@link connect} operator instead.
+ * `multicast(subject, selector)` is equivalent to
+ * `connect(selector, { connector: () => subject })`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function multicast<T, O extends ObservableInput<any>>(
   subject: Subject<T>,
@@ -45,11 +47,11 @@ export function multicast<T, O extends ObservableInput<any>>(
  * will cause the underlying subject to be "reset" on error, completion, or refCounted unsubscription of
  * the source.
  * @return A function that returns a {@link ConnectableObservable}
- * @deprecated This will be removed in version 8. Please use the {@link connectable} creation
- * function, which creates a connectable observable. If you were using the {@link refCount} operator
- * on the result of the `multicast` operator, then use the {@link share} operator, which is now
- * highly configurable. `multicast(() => new BehaviorSubject('test'))), refCount()` is equivalent to
+ * @deprecated Will be removed in v8. To create a connectable observable, use {@link connectable}.
+ * If you're using {@link refCount} after `multicast`, use the {@link share} operator instead.
+ * `multicast(() => new BehaviorSubject('test')), refCount()` is equivalent to
  * `share({ connector: () => new BehaviorSubject('test') })`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function multicast<T>(subjectFactory: () => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 
@@ -61,8 +63,10 @@ export function multicast<T>(subjectFactory: () => Subject<T>): UnaryFunction<Ob
  * @param subjectFactory A factory that creates the subject used to multicast.
  * @param selector A function to setup the multicast and select the output.
  * @return A function that returns an observable that mirrors the observable returned by the selector.
- * @deprecated To be removed in version 8. Please use the new {@link connect} operator.
- * `multicast(subjectFactor, selector)` is equivalent to `connect(selector, { connector: subjectFactory })`.
+ * @deprecated Will be removed in v8. Use the {@link connect} operator instead.
+ * `multicast(subjectFactory, selector)` is equivalent to
+ * `connect(selector, { connector: subjectFactory })`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function multicast<T, O extends ObservableInput<any>>(
   subjectFactory: () => Subject<T>,

--- a/src/internal/operators/partition.ts
+++ b/src/internal/operators/partition.ts
@@ -47,12 +47,12 @@ import { UnaryFunction } from '../types';
  * @return A function that returns an array with two Observables: one with
  * values that passed the predicate, and another with values that did not pass
  * the predicate.
- * @deprecated use `partition` static creation function instead
+ * @deprecated Replaced with the `partition` static creation function. Will be removed in v8.
  */
-export function partition<T>(predicate: (value: T, index: number) => boolean,
-                             thisArg?: any): UnaryFunction<Observable<T>, [Observable<T>, Observable<T>]> {
-  return (source: Observable<T>) => [
-    filter(predicate, thisArg)(source),
-    filter(not(predicate, thisArg))(source)
-  ] as [Observable<T>, Observable<T>];
+export function partition<T>(
+  predicate: (value: T, index: number) => boolean,
+  thisArg?: any
+): UnaryFunction<Observable<T>, [Observable<T>, Observable<T>]> {
+  return (source: Observable<T>) =>
+    [filter(predicate, thisArg)(source), filter(not(predicate, thisArg))(source)] as [Observable<T>, Observable<T>];
 }

--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -4,11 +4,43 @@ import { OperatorFunction } from '../types';
 /* tslint:disable:max-line-length */
 export function pluck<T, K1 extends keyof T>(k1: K1): OperatorFunction<T, T[K1]>;
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1]>(k1: K1, k2: K2): OperatorFunction<T, T[K1][K2]>;
-export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(k1: K1, k2: K2, k3: K3): OperatorFunction<T, T[K1][K2][K3]>;
-export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3]>(k1: K1, k2: K2, k3: K3, k4: K4): OperatorFunction<T, T[K1][K2][K3][K4]>;
-export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): OperatorFunction<T, T[K1][K2][K3][K4][K5]>;
-export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4], K6 extends keyof T[K1][K2][K3][K4][K5]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6): OperatorFunction<T, T[K1][K2][K3][K4][K5][K6]>;
-export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3], K5 extends keyof T[K1][K2][K3][K4], K6 extends keyof T[K1][K2][K3][K4][K5]>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6, ...rest: string[]): OperatorFunction<T, unknown>;
+export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(
+  k1: K1,
+  k2: K2,
+  k3: K3
+): OperatorFunction<T, T[K1][K2][K3]>;
+export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3]>(
+  k1: K1,
+  k2: K2,
+  k3: K3,
+  k4: K4
+): OperatorFunction<T, T[K1][K2][K3][K4]>;
+export function pluck<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+  K5 extends keyof T[K1][K2][K3][K4]
+>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): OperatorFunction<T, T[K1][K2][K3][K4][K5]>;
+export function pluck<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+  K5 extends keyof T[K1][K2][K3][K4],
+  K6 extends keyof T[K1][K2][K3][K4][K5]
+>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6): OperatorFunction<T, T[K1][K2][K3][K4][K5][K6]>;
+export function pluck<
+  T,
+  K1 extends keyof T,
+  K2 extends keyof T[K1],
+  K3 extends keyof T[K1][K2],
+  K4 extends keyof T[K1][K2][K3],
+  K5 extends keyof T[K1][K2][K3][K4],
+  K6 extends keyof T[K1][K2][K3][K4][K5]
+>(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6, ...rest: string[]): OperatorFunction<T, unknown>;
 export function pluck<T>(...properties: string[]): OperatorFunction<T, unknown>;
 /* tslint:enable:max-line-length */
 
@@ -42,7 +74,7 @@ export function pluck<T>(...properties: string[]): OperatorFunction<T, unknown>;
  * value.
  * @return A function that returns an Observable of property values from the
  * source values.
- * @deprecated Remove in v8. Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`.
+ * @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8.
  */
 export function pluck<T, R>(...properties: Array<string | number | symbol>): OperatorFunction<T, R> {
   const length = properties.length;

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -11,7 +11,7 @@ import { connect } from './connect';
  *
  * @deprecated Will be removed in v8. To create a connectable observable, use {@link connectable}.
  * `source.pipe(publish())` is equivalent to
- * `connectable(source, () => new Subject())`.
+ * `connectable(source, { connector: () => new Subject(), resetOnDisconnect: false })`.
  * If you're using {@link refCount} after `publish`, use {@link share} operator instead.
  * `source.pipe(publish(), refCount())` is equivalent to
  * `source.pipe(share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))`.

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -9,12 +9,13 @@ import { connect } from './connect';
  * Returns a connectable observable that, when connected, will multicast
  * all values through a single underlying {@link Subject} instance.
  *
- * @deprecated To be removed in version 8. If you're using `publish()` to get a connectable observable,
- * please use the new {@link connectable} creation function. `source.pipe(publish())` is
- * equivalent to `connectable(source, () => new Subject())`. If you're calling {@link refCount} on the result
- * of `publish`, please use the updated {@link share} operator which is highly configurable.
+ * @deprecated Will be removed in v8. To create a connectable observable, use {@link connectable}.
+ * `source.pipe(publish())` is equivalent to
+ * `connectable(source, () => new Subject())`.
+ * If you're using {@link refCount} after `publish`, use {@link share} operator instead.
  * `source.pipe(publish(), refCount())` is equivalent to
  * `source.pipe(share({ resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publish<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 
@@ -26,8 +27,9 @@ export function publish<T>(): UnaryFunction<Observable<T>, ConnectableObservable
  *
  * @param selector A function used to setup multicasting prior to automatic connection.
  *
- * @deprecated To be removed in version 8. Use the new {@link connect} operator.
- * If you're using `publish(fn)`, it is equivalent to `connect(fn)`.
+ * @deprecated Will be removed in v8. Use the {@link connect} operator instead.
+ * `publish(selector)` is equivalent to `connect(selector)`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publish<T, O extends ObservableInput<any>>(selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
 

--- a/src/internal/operators/publishBehavior.ts
+++ b/src/internal/operators/publishBehavior.ts
@@ -5,17 +5,19 @@ import { UnaryFunction } from '../types';
 
 /**
  * Creates a {@link ConnectableObservable} that utilizes a {@link BehaviorSubject}.
- * 
+ *
  * @param initialValue The initial value passed to the {@link BehaviorSubject}.
  * @return A function that returns a {@link ConnectableObservable}
- * @deprecated to be removed in version 8. If you want to get a connectable observable that uses a 
- * {@link BehaviorSubject} under the hood, please use {@link connectable}. `source.pipe(publishBehavior(initValue))` 
- * is equivalent to: `connectable(source, () => new BehaviorSubject(initValue))`.
- * If you're using {@link refCount} after the call to `publishBehavior`, use the {@link share} operator, which is now
- * highly configurable. `source.pipe(publishBehavior(initValue), refCount())` is equivalent to:
+ * @deprecated Will be removed in v8. To create a connectable observable that uses a
+ * {@link BehaviorSubject} under the hood, use {@link connectable}.
+ * `source.pipe(publishBehavior(initValue))` is equivalent to
+ * `connectable(source, () => new BehaviorSubject(initValue))`.
+ * If you're using {@link refCount} after `publishBehavior`, use the {@link share} operator instead.
+ * `source.pipe(publishBehavior(initValue), refCount())` is equivalent to
  * `source.pipe(share({ connector: () => new BehaviorSubject(initValue), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false  }))`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
-export function publishBehavior<T>(initialValue: T):  UnaryFunction<Observable<T>, ConnectableObservable<T>> {
+export function publishBehavior<T>(initialValue: T): UnaryFunction<Observable<T>, ConnectableObservable<T>> {
   const subject = new BehaviorSubject<T>(initialValue);
   // Note that this has *never* supported the selector function.
   return (source) => new ConnectableObservable(source, () => subject);

--- a/src/internal/operators/publishBehavior.ts
+++ b/src/internal/operators/publishBehavior.ts
@@ -11,7 +11,7 @@ import { UnaryFunction } from '../types';
  * @deprecated Will be removed in v8. To create a connectable observable that uses a
  * {@link BehaviorSubject} under the hood, use {@link connectable}.
  * `source.pipe(publishBehavior(initValue))` is equivalent to
- * `connectable(source, () => new BehaviorSubject(initValue))`.
+ * `connectable(source, { connector: () => new BehaviorSubject(initValue), resetOnDisconnect: false })`.
  * If you're using {@link refCount} after `publishBehavior`, use the {@link share} operator instead.
  * `source.pipe(publishBehavior(initValue), refCount())` is equivalent to
  * `source.pipe(share({ connector: () => new BehaviorSubject(initValue), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false  }))`.

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -57,12 +57,14 @@ import { UnaryFunction } from '../types';
  *
  * @return A function that returns an Observable that emits elements of a
  * sequence produced by multicasting the source sequence.
- * @deprecated To be removed in version 8. If you're trying to create a connectable observable
- * with an {@link AsyncSubject} under the hood, please use the new {@link connectable} creation function.
- * `source.pipe(publishLast())` is equivalent to `connectable(source, () => new AsyncSubject())`.
- * If you're using {@link refCount} on the result of `publishLast`, you can use the updated {@link share}
- * operator, which is now highly configurable. `source.pipe(publishLast(), refCount())`
- * is equivalent to `source.pipe(share({ connector: () => new AsyncSubject(), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))`.
+ * @deprecated Will be removed in v8. To create a connectable observable with an
+ * {@link AsyncSubject} under the hood, use {@link connectable}.
+ * `source.pipe(publishLast())` is equivalent to
+ * `connectable(source, () => new AsyncSubject())`.
+ * If you're using {@link refCount} after `publishLast`, use the {@link share} operator instead.
+ * `source.pipe(publishLast(), refCount())` is equivalent to
+ * `source.pipe(share({ connector: () => new AsyncSubject(), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>> {
   const subject = new AsyncSubject<T>();

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -60,7 +60,7 @@ import { UnaryFunction } from '../types';
  * @deprecated Will be removed in v8. To create a connectable observable with an
  * {@link AsyncSubject} under the hood, use {@link connectable}.
  * `source.pipe(publishLast())` is equivalent to
- * `connectable(source, () => new AsyncSubject())`.
+ * `connectable(source, { connector: () => new AsyncSubject(), resetOnDisconnect: false })`.
  * If you're using {@link refCount} after `publishLast`, use the {@link share} operator instead.
  * `source.pipe(publishLast(), refCount())` is equivalent to
  * `source.pipe(share({ connector: () => new AsyncSubject(), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false }))`.

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -11,12 +11,14 @@ import { isFunction } from '../util/isFunction';
  * @param bufferSize The buffer size for the underlying {@link ReplaySubject}.
  * @param windowTime The window time for the underlying {@link ReplaySubject}.
  * @param timestampProvider The timestamp provider for the underlying {@link ReplaySubject}.
- * @deprecated To be removed in version 8. Use the new {@link connectable} create method to create
- * a connectable observable. `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
+ * @deprecated Will be removed in v8. To create a connectable observable that uses a
+ * {@link ReplaySubject} under the hood, use {@link connectable}.
+ * `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
  * `connectable(source, () => new ReplaySubject(size, time, scheduler))`.
- * If you're using this with {@link refCount}, then use the new {@link share} operator,
- * which is now highly configurable. `publishReplay(size, time, scheduler), refCount()`
- * is equivalent to `share({ connector: () => new ReplaySubject(size, time, scheduler) })`.
+ * If you're using {@link refCount} after `publishReplay`, use the {@link share} operator instead.
+ * `publishReplay(size, time, scheduler), refCount()` is equivalent to
+ * `share({ connector: () => new ReplaySubject(size, time, scheduler), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publishReplay<T>(
   bufferSize?: number,
@@ -36,9 +38,10 @@ export function publishReplay<T>(
  * @param windowTime The window time for the underlying {@link ReplaySubject}.
  * @param selector A function used to setup the multicast.
  * @param timestampProvider The timestamp provider for the underlying {@link ReplaySubject}.
- * @deprecated To be removed in version 8. Use the new {@link connect} operator.
- * `source.pipe(publishReplay(size, window, fn, scheduler))` is equivalent to
- * `const subject = new ReplaySubject(size, window, scheduler), source.pipe(connect(fn, { connector: () => subject }))`.
+ * @deprecated Will be removed in v8. Use the {@link connect} operator instead.
+ * `source.pipe(publishReplay(size, window, selector, scheduler))` is equivalent to
+ * `source.pipe(connect(selector, { connector: () => new ReplaySubject(size, window, scheduler) }))`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publishReplay<T, O extends ObservableInput<any>>(
   bufferSize: number | undefined,
@@ -55,12 +58,14 @@ export function publishReplay<T, O extends ObservableInput<any>>(
  * @param windowTime The window time for the underlying {@link ReplaySubject}.
  * @param selector Passing `undefined` here determines that this operator will return a {@link ConnectableObservable}.
  * @param timestampProvider The timestamp provider for the underlying {@link ReplaySubject}.
- * @deprecated To be removed in version 8. Use the new {@link connectable} create method to create
- * a connectable observable. `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
+ * @deprecated Will be removed in v8. To create a connectable observable that uses a
+ * {@link ReplaySubject} under the hood, use {@link connectable}.
+ * `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
  * `connectable(source, () => new ReplaySubject(size, time, scheduler))`.
- * If you're using this with {@link refCount}, then use the new {@link share} operator,
- * which is now highly configurable. `publishReplay(size, time, scheduler), refCount()`
- * is equivalent to `share({ connector: () => new ReplaySubject(size, time, scheduler) })`.
+ * If you're using {@link refCount} after `publishReplay`, use the {@link share} operator instead.
+ * `publishReplay(size, time, scheduler), refCount()` is equivalent to
+ * `share({ connector: () => new ReplaySubject(size, time, scheduler), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })`.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publishReplay<T, O extends ObservableInput<any>>(
   bufferSize: number | undefined,

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -14,7 +14,7 @@ import { isFunction } from '../util/isFunction';
  * @deprecated Will be removed in v8. To create a connectable observable that uses a
  * {@link ReplaySubject} under the hood, use {@link connectable}.
  * `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
- * `connectable(source, () => new ReplaySubject(size, time, scheduler))`.
+ * `connectable(source, { connector: () => new ReplaySubject(size, time, scheduler), resetOnDisconnect: false })`.
  * If you're using {@link refCount} after `publishReplay`, use the {@link share} operator instead.
  * `publishReplay(size, time, scheduler), refCount()` is equivalent to
  * `share({ connector: () => new ReplaySubject(size, time, scheduler), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })`.
@@ -61,7 +61,7 @@ export function publishReplay<T, O extends ObservableInput<any>>(
  * @deprecated Will be removed in v8. To create a connectable observable that uses a
  * {@link ReplaySubject} under the hood, use {@link connectable}.
  * `source.pipe(publishReplay(size, time, scheduler))` is equivalent to
- * `connectable(source, () => new ReplaySubject(size, time, scheduler))`.
+ * `connectable(source, { connector: () => new ReplaySubject(size, time, scheduler), resetOnDisconnect: false })`.
  * If you're using {@link refCount} after `publishReplay`, use the {@link share} operator instead.
  * `publishReplay(size, time, scheduler), refCount()` is equivalent to
  * `share({ connector: () => new ReplaySubject(size, time, scheduler), resetOnError: false, resetOnComplete: false, resetOnRefCountZero: false })`.

--- a/src/internal/operators/race.ts
+++ b/src/internal/operators/race.ts
@@ -2,9 +2,9 @@ import { ObservableInputTuple, OperatorFunction } from '../types';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { raceWith } from './raceWith';
 
-/** @deprecated Deprecated use {@link raceWith} */
+/** @deprecated Replaced with {@link raceWith}. Will be removed in v8. */
 export function race<T, A extends readonly unknown[]>(otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
-/** @deprecated Deprecated use {@link raceWith} */
+/** @deprecated Replaced with {@link raceWith}. Will be removed in v8. */
 export function race<T, A extends readonly unknown[]>(...otherSources: [...ObservableInputTuple<A>]): OperatorFunction<T, T | A[number]>;
 
 /**
@@ -13,7 +13,7 @@ export function race<T, A extends readonly unknown[]>(...otherSources: [...Obser
  * @param args Sources used to race for which Observable emits first.
  * @return A function that returns an Observable that mirrors the output of the
  * first Observable to emit an item.
- * @deprecated Deprecated use {@link raceWith}
+ * @deprecated Replaced with {@link raceWith}. Will be removed in v8.
  */
 export function race<T>(...args: any[]): OperatorFunction<T, unknown> {
   return raceWith(...argsOrArgArray(args));

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -58,11 +58,10 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * @see {@link ConnectableObservable}
  * @see {@link share}
  * @see {@link publish}
- * @deprecated to be removed in version 8. Use the updated {@link share} operator,
- * which now is highly configurable. How `share` is used will depend on the connectable
- * observable you created just prior to the `refCount` operator. For examples on how
- * to replace this, see documentation in {@link multicast}, {@link publish}, {@link publishReplay},
- * {@link publishBehavior}, {@link publishLast} or {@link ConnectableObservable}.
+ * @deprecated Replaced with the {@link share} operator. How `share` is used
+ * will depend on the connectable observable you created just prior to the
+ * `refCount` operator.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function refCount<T>(): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/sampleTime.ts
+++ b/src/internal/operators/sampleTime.ts
@@ -43,7 +43,6 @@ import { interval } from '../observable/interval';
  * @return A function that returns an Observable that emits the results of
  * sampling the values emitted by the source Observable at the specified time
  * interval.
- * @deprecated To be removed in v8. Use `sample(interval(period, scheduler?))`, it's the same thing.
  */
 export function sampleTime<T>(period: number, scheduler: SchedulerLike = asyncScheduler): MonoTypeOperatorFunction<T> {
   return sample(interval(period, scheduler));

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -11,7 +11,7 @@ import { operate } from '../util/lift';
 export function startWith<T>(value: null): OperatorFunction<T, T | null>;
 export function startWith<T>(value: undefined): OperatorFunction<T, T | undefined>;
 
-/** @deprecated The scheduler argument is deprecated, use scheduled and concatAll. Details: https://rxjs.dev/deprecations/scheduler-argument */
+/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `concatAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
 export function startWith<T, A extends readonly unknown[] = T[]>(
   ...valuesAndScheduler: [...A, SchedulerLike]
 ): OperatorFunction<T, T | ValueFromArray<A>>;

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -8,12 +8,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function switchMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector is no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated resultSelector is no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -8,12 +8,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function switchMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -8,12 +8,12 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function switchMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function switchMap<T, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: undefined
 ): OperatorFunction<T, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function switchMap<T, R, O extends ObservableInput<any>>(
   project: (value: T, index: number) => O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -4,12 +4,12 @@ import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
 export function switchMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: undefined
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -4,12 +4,12 @@ import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
 export function switchMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: undefined
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated resultSelector no longer supported, use inner map instead, Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The resultSelector parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -4,12 +4,12 @@ import { isFunction } from '../util/isFunction';
 
 /* tslint:disable:max-line-length */
 export function switchMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: undefined
 ): OperatorFunction<any, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details https://rxjs.dev/deprecations/resultSelector */
+/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -6,7 +6,7 @@ import { identity } from '../util/identity';
 
 export function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
 export function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
-/** @deprecated Use an observer instead of a complete callback, Details: https://rxjs.dev/deprecations/subscribe-arguments */
+/** @deprecated Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments */
 export function tap<T>(
   next?: ((value: T) => void) | null,
   error?: ((error: any) => void) | null,

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -68,9 +68,9 @@ export function timeInterval<T>(scheduler: SchedulerLike = async): OperatorFunct
 // TODO(benlesh): make this an interface, export the interface, but not the implemented class,
 // there's no reason users should be manually creating this type.
 
-/**
- * @deprecated exposed API, use as interface only.
- */
 export class TimeInterval<T> {
+  /**
+   * @deprecated Internal implementation detail, do not construct directly. Will be made an interface in v8.
+   */
   constructor(public value: T, public interval: number) {}
 }

--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -15,7 +15,7 @@ import { timeout } from './timeout';
  * @param dueBy The exact time, as a `Date`, at which the timeout will be triggered if the first value does not arrive.
  * @param switchTo The observable to switch to when timeout occurs.
  * @param scheduler The scheduler to use with time-related operations within this operator. Defaults to {@link asyncScheduler}
- * @deprecated This will be removed in v8. Use the configuration object with {@link timeout} instead: `timeoutWith(someDate, a$, scheduler)` -> `timeout({ first: someDate, with: () => a$, scheduler })`
+ * @deprecated Replaced with {@link timeout}. Instead of `timeoutWith(someDate, a$, scheduler)`, use the configuration object `timeout({ first: someDate, with: () => a$, scheduler })`. Will be removed in v8.
  */
 export function timeoutWith<T, R>(dueBy: Date, switchTo: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;
 
@@ -79,7 +79,7 @@ export function timeoutWith<T, R>(dueBy: Date, switchTo: ObservableInput<R>, sch
  * @return A function that returns an Observable that mirrors behaviour of the
  * source Observable, unless timeout happens when it starts emitting values
  * from the Observable passed as a second parameter.
- * @deprecated This will be removed in v8. Use the configuration object with {@link timeout} instead: `timeoutWith(100, a$, scheduler)` -> `timeout({ each: 100, with: () => a$, scheduler })`
+ * @deprecated Replaced with {@link timeout}. Instead of `timeoutWith(100, a$, scheduler)`, use the configuration object `timeout({ each: 100, with: () => a$, scheduler })`. Will be removed in v8.
  */
 export function timeoutWith<T, R>(waitFor: number, switchTo: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;
 

--- a/src/internal/operators/zip.ts
+++ b/src/internal/operators/zip.ts
@@ -2,22 +2,22 @@ import { zip as zipStatic } from '../observable/zip';
 import { ObservableInput, ObservableInputTuple, OperatorFunction, Cons } from '../types';
 import { operate } from '../util/lift';
 
-/** @deprecated Deprecated use {@link zipWith} */
+/** @deprecated Replaced with {@link zipWith}. Will be removed in v8. */
 export function zip<T, A extends readonly unknown[]>(otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
-/** @deprecated Deprecated use {@link zipWith} */
+/** @deprecated Replaced with {@link zipWith}. Will be removed in v8. */
 export function zip<T, A extends readonly unknown[], R>(
   otherInputsAndProject: [...ObservableInputTuple<A>],
   project: (...values: Cons<T, A>) => R
 ): OperatorFunction<T, R>;
-/** @deprecated Deprecated use {@link zipWith} */
+/** @deprecated Replaced with {@link zipWith}. Will be removed in v8. */
 export function zip<T, A extends readonly unknown[]>(...otherInputs: [...ObservableInputTuple<A>]): OperatorFunction<T, Cons<T, A>>;
-/** @deprecated Deprecated use {@link zipWith} */
+/** @deprecated Replaced with {@link zipWith}. Will be removed in v8. */
 export function zip<T, A extends readonly unknown[], R>(
   ...otherInputsAndProject: [...ObservableInputTuple<A>, (...values: Cons<T, A>) => R]
 ): OperatorFunction<T, R>;
 
 /**
- * @deprecated Deprecated. Use {@link zipWith}.
+ * @deprecated Replaced with {@link zipWith}. Will be removed in v8.
  */
 export function zip<T, R>(...sources: Array<ObservableInput<any> | ((...values: Array<any>) => R)>): OperatorFunction<T, any> {
   return operate((source, subscriber) => {

--- a/src/internal/scheduler/animationFrame.ts
+++ b/src/internal/scheduler/animationFrame.ts
@@ -36,6 +36,6 @@ import { AnimationFrameScheduler } from './AnimationFrameScheduler';
 export const animationFrameScheduler = new AnimationFrameScheduler(AnimationFrameAction);
 
 /**
- * @deprecated renamed. Use {@link animationFrameScheduler}.
+ * @deprecated Renamed to {@link animationFrameScheduler}. Will be removed in v8.
  */
 export const animationFrame = animationFrameScheduler;

--- a/src/internal/scheduler/asap.ts
+++ b/src/internal/scheduler/asap.ts
@@ -39,6 +39,6 @@ import { AsapScheduler } from './AsapScheduler';
 export const asapScheduler = new AsapScheduler(AsapAction);
 
 /**
- * @deprecated Renamed. Use {@link asapScheduler}.
+ * @deprecated Renamed to {@link asapScheduler}. Will be removed in v8.
  */
 export const asap = asapScheduler;

--- a/src/internal/scheduler/async.ts
+++ b/src/internal/scheduler/async.ts
@@ -51,6 +51,6 @@ import { AsyncScheduler } from './AsyncScheduler';
 export const asyncScheduler = new AsyncScheduler(AsyncAction);
 
 /**
- * @deprecated Renamed. Use {@link asyncScheduler}.
+ * @deprecated Renamed to {@link asyncScheduler}. Will be removed in v8.
  */
 export const async = asyncScheduler;

--- a/src/internal/scheduler/queue.ts
+++ b/src/internal/scheduler/queue.ts
@@ -67,6 +67,6 @@ import { QueueScheduler } from './QueueScheduler';
 export const queueScheduler = new QueueScheduler(QueueAction);
 
 /**
- * @deprecated renamed. Use {@link queueScheduler}.
+ * @deprecated Renamed to {@link queueScheduler}. Will be removed in v8.
  */
 export const queue = queueScheduler;

--- a/src/internal/symbol/iterator.ts
+++ b/src/internal/symbol/iterator.ts
@@ -7,8 +7,3 @@ export function getSymbolIterator(): symbol {
 }
 
 export const iterator = getSymbolIterator();
-
-/**
- * @deprecated use {@link iterator} instead
- */
-export const $$iterator = iterator;

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -45,12 +45,12 @@ export class TestScheduler extends VirtualTimeScheduler {
   static frameTimeFactor = 10;
 
   /**
-   * @deprecated remove in v8. Not for public use.
+   * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
    */
   public readonly hotObservables: HotObservable<any>[] = [];
 
   /**
-   * @deprecated remove in v8. Not for public use.
+   * @deprecated Internal implementation detail, do not use directly. Will be made internal in v8.
    */
   public readonly coldObservables: ColdObservable<any>[] = [];
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -73,7 +73,9 @@ export interface SubscriptionLike extends Unsubscribable {
   readonly closed: boolean;
 }
 
-/** @deprecated To be removed in v8. Do not use. Most likely you want to use `ObservableInput` */
+/**
+ * @deprecated Do not use. Most likely you want to use `ObservableInput`. Will be removed in v8.
+ */
 export type SubscribableOrPromise<T> = Subscribable<T> | Subscribable<never> | PromiseLike<T> | InteropObservable<T>;
 
 /** OBSERVABLE INTERFACES */
@@ -94,7 +96,9 @@ export type ObservableInput<T> =
   | Iterable<T>
   | ReadableStreamLike<T>;
 
-/** @deprecated use {@link InteropObservable } */
+/**
+ * @deprecated Renamed to {@link InteropObservable }. Will be removed in v8.
+ */
 export type ObservableLike<T> = InteropObservable<T>;
 
 /**
@@ -213,7 +217,9 @@ export type ObservedValueOf<O> = O extends ObservableInput<infer T> ? T : never;
  */
 export type ObservedValueUnionFromArray<X> = X extends Array<ObservableInput<infer T>> ? T : never;
 
-/** @deprecated use {@link ObservedValueUnionFromArray} */
+/**
+ * @deprecated Renamed to {@link ObservedValueUnionFromArray}. Will be removed in v8.
+ */
 export type ObservedValuesFromArray<X> = ObservedValueUnionFromArray<X>;
 
 /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR updates the `@deprecation` tags in the TSDoc. Most of the deprecation messages were sufficiently informative, but some were confusing. And, coupled with the false positives that used to be effected, this seemed to confused some folks - well, it resulted in numerous issues being opened.

The changes in the PR make the messages more consistent and informative. Where appropriate links to the deprecation docs are provided so that devs can read a more detailed explanation of what's deprecated and what refactoring is necessary.

I've edited the messages in an attempt to optimize them for display in VS Code, as that's where they're going to be read most often, IMO. VS Code collapses whitespace within the message and displays the message as single, wrapped line - with code formatting and proper links to the deprecation details. It leaves the TSDoc `{@link whatever}` tags as they are - which is unfortunate, but we'll just have to live with it, I suppose. I've removed a fair bit of verbosity - 'please', lots of adjectives, etc. - so that the messages are shorter and are less overwhelming when shown as a single line.

I've created a `multicasting.md` deprecations document that has refactor examples for all of the multicasting deprecations. They are much easier to read in that format. And there is more context.

**IMPORTANT**: the multicasting deprecations and refactors use an upcoming change to the `connectable` API - it's going to get a config object with `connector` and `resetOnDisconnect` properties. This change will be in an upcoming PR (I've discussed this with Ben) - see #6267.

Some specific changes:

- This PR remove the unused and unexported `$$iterator` symbol
- The `defer` TSDoc has been updated to use the same type - `ObservableInput` - that's used in the actual API
- `delayWhen` had a signature that only existed so that a deprecation could be applied. That deprecation was specific to v6. AFAICT, the deprecation was supposed to serve as a warning, but the behaviour about which it was warning has now been changed. I've removed that signature.
- I've removed the `materialize` deprecation. IMO, we cannot use a deprecation on an operator to warn people about the values it emits. The operator is not deprecated. There are deprecations on the methods of `Notification`, so if people call those methods, they'll see deprecations at the call site. Deprecating an operator that is not going to be removed will be confusing and counterproductive, IMO.
- I've removed the deprecation from `sampleTime` 'cause `auditTime`, et al. are not deprecated. If we really want to deprecate this, we can do it later - after a discussion.
- I've used HTML comments to disable Prettier from formatting snippets in `multicasting.md` 'cause it's too hard to read long lines of 'pretty' code.

There are additional deprecations that I think need to be added - as there are several places in the API in which either an array of sources or rest parameters can be passed - but I will include these in a separate PR.

**Related issue (if exists):** Nope
