### PR TITLE
refactor: refactor throwError operator to use factory function in unit tests and .ts file

### DIFF
--- a/spec-dtslint/observables/throwError-spec.ts
+++ b/spec-dtslint/observables/throwError-spec.ts
@@ -1,12 +1,23 @@
 import { throwError, animationFrameScheduler } from 'rxjs';
 
 it('should accept any type and return never observable', () => {
-  const a = throwError(() => (1)); // $ExpectType Observable<never>
-  const b = throwError(() => ('a')); // $ExpectType Observable<never>
-  const c = throwError(() => ({a: 1})); // $ExpectType Observable<never>
+  const a = throwError(1); // $ExpectType Observable<never>
+  const b = throwError('a'); // $ExpectType Observable<never>
+  const c = throwError({ a: 1 }); // $ExpectType Observable<never>
   const d = throwError(() => ({ a: 2 })); // $ExpectType Observable<never>
 });
 
-it('should support scheduler', () => {
-  const a = throwError(() => (1, animationFrameScheduler)); // $ExpectType Observable<never>
+it('should support an error value and a scheduler', () => {
+  const a = throwError(1, animationFrameScheduler); // $ExpectType Observable<never>
+});
+
+it('should accept any type and return never observable with support of factory', () => {
+  const a = throwError(() => (1)); // $ExpectType Observable<never>
+  const b = throwError(() => ('a')); // $ExpectType Observable<never>
+  const c = throwError(() => ({ a: 1 })); // $ExpectType Observable<never>
+  const d = throwError(() => ({ a: 2 })); // $ExpectType Observable<never>
+});
+
+it('should support a factory and a scheduler', () => {
+  const a = throwError(() => 1, animationFrameScheduler); // $ExpectType Observable<never>
 });

--- a/spec-dtslint/observables/throwError-spec.ts
+++ b/spec-dtslint/observables/throwError-spec.ts
@@ -1,12 +1,12 @@
 import { throwError, animationFrameScheduler } from 'rxjs';
 
 it('should accept any type and return never observable', () => {
-  const a = throwError(1); // $ExpectType Observable<never>
-  const b = throwError('a'); // $ExpectType Observable<never>
-  const c = throwError({a: 1}); // $ExpectType Observable<never>
+  const a = throwError(() => (1)); // $ExpectType Observable<never>
+  const b = throwError(() => ('a')); // $ExpectType Observable<never>
+  const c = throwError(() => ({a: 1})); // $ExpectType Observable<never>
   const d = throwError(() => ({ a: 2 })); // $ExpectType Observable<never>
 });
 
 it('should support scheduler', () => {
-  const a = throwError(1, animationFrameScheduler); // $ExpectType Observable<never>
+  const a = throwError(() => (1, animationFrameScheduler)); // $ExpectType Observable<never>
 });

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -577,6 +577,40 @@ describe('Observable', () => {
           });
       });
     });
+    
+    it('should teardown even with a synchronous thrown error', () => {
+      let called = false;
+      const badObservable = new Observable((subscriber) => {
+        subscriber.add(() => {
+          called = true;
+        });
+
+        throw new Error('bad');
+      });
+
+      badObservable.subscribe({
+        error: () => { /* do nothing */ }
+      });
+
+      expect(called).to.be.true;
+    });
+
+    
+    it('should handle empty string sync errors', () => {
+      const badObservable = new Observable(() => {
+        throw '';
+      });
+
+      let caught = false;
+      badObservable.subscribe({
+        error: (err) => {
+          caught = true;
+          expect(err).to.equal('');
+        }
+      });
+      expect(caught).to.be.true;
+    });
+      
 
     describe('if config.useDeprecatedSynchronousErrorHandling === true', () => {
       beforeEach(() => {

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -71,7 +71,7 @@ describe('Observable', () => {
     });
 
     it('should reject promise when in error', (done) => {
-      throwError('bad')
+      throwError(() => ('bad'))
         .forEach(() => {
           done(new Error('should not be called'));
         }, Promise)
@@ -460,7 +460,7 @@ describe('Observable', () => {
             },
           };
 
-          throwError('bad').subscribe(o);
+          throwError(() => ('bad')).subscribe(o);
         }
       );
 
@@ -618,7 +618,7 @@ describe('Observable', () => {
       });
 
       it('should throw synchronously', () => {
-        expect(() => throwError(new Error('thrown error')).subscribe()).to.throw(Error, 'thrown error');
+        expect(() => throwError(() => new Error('thrown error')).subscribe()).to.throw(Error, 'thrown error');
       });
 
       it('should rethrow if next handler throws', () => {
@@ -658,13 +658,13 @@ describe('Observable', () => {
       it('should rethrow synchronous errors from flattened observables', () => {
         expect(() => {
           of(1)
-            .pipe(concatMap(() => throwError(new Error('Ahoy! An error!'))))
+            .pipe(concatMap(() => throwError(() => new Error('Ahoy! An error!'))))
             .subscribe(console.log);
         }).to.throw('Ahoy! An error!');
 
         expect(() => {
           of(1)
-            .pipe(switchMap(() => throwError(new Error('Avast! Thar be a new error!'))))
+            .pipe(switchMap(() => throwError(() => new Error('Avast! Thar be a new error!'))))
             .subscribe(console.log);
         }).to.throw('Avast! Thar be a new error!');
       });

--- a/spec/firstValueFrom-spec.ts
+++ b/spec/firstValueFrom-spec.ts
@@ -40,7 +40,7 @@ describe('firstValueFrom', () => {
   });
 
   it('should error for errored observables', async () => {
-    const source = throwError(new Error('blorp!'));
+    const source = throwError(() => new Error('blorp!'));
     let error: any = null;
     try {
       await firstValueFrom(source);

--- a/spec/lastValueFrom-spec.ts
+++ b/spec/lastValueFrom-spec.ts
@@ -43,7 +43,7 @@ describe('lastValueFrom', () => {
   });
 
   it('should error for errored observables', async () => {
-    const source = throwError(new Error('blorp!'));
+    const source = throwError(() => new Error('blorp!'));
     let error: any = null;
     try {
       await lastValueFrom(source);

--- a/spec/observables/throwError-spec.ts
+++ b/spec/observables/throwError-spec.ts
@@ -15,14 +15,14 @@ describe('throwError', () => {
   it('should create a cold observable that just emits an error', () => {
     rxTest.run(({ expectObservable }) => {
       const expected = '#';
-      const e1 = throwError('error');
+      const e1 = throwError(() => 'error');
       expectObservable(e1).toBe(expected);
     });
   });
 
   it('should emit one value', (done) => {
     let calls = 0;
-    throwError('bad').subscribe(
+    throwError(() => 'bad').subscribe(
       () => {
         done(new Error('should not be called'));
       },

--- a/spec/operators/buffer-spec.ts
+++ b/spec/operators/buffer-spec.ts
@@ -122,7 +122,7 @@ describe('Observable.prototype.buffer', () => {
   it('should work with non-empty and throw selector', () => {
     testScheduler.run(({ hot, expectObservable }) => {
       const a = hot('---^--a--');
-      const b = throwError(new Error('too bad'));
+      const b = throwError(() => new Error('too bad'));
       const expected = '#';
       expectObservable(a.pipe(buffer(b))).toBe(expected, null, new Error('too bad'));
     });
@@ -130,7 +130,7 @@ describe('Observable.prototype.buffer', () => {
 
   it('should work with throw and non-empty selector', () => {
     testScheduler.run(({ hot, expectObservable }) => {
-      const a = throwError(new Error('too bad'));
+      const a = throwError(() => new Error('too bad'));
       const b = hot('---^--a--');
       const expected = '#';
       expectObservable(a.pipe(buffer(b))).toBe(expected, null, new Error('too bad'));

--- a/spec/operators/bufferTime-spec.ts
+++ b/spec/operators/bufferTime-spec.ts
@@ -305,7 +305,7 @@ describe('bufferTime operator', () => {
 
   it('should handle throw', () => {
     testScheduler.run(({ time, expectObservable }) => {
-      const e1 = throwError(new Error('haha'));
+      const e1 = throwError(() => new Error('haha'));
       const expected = '#';
       const t = time('----------|');
 

--- a/spec/operators/catchError-spec.ts
+++ b/spec/operators/catchError-spec.ts
@@ -178,7 +178,7 @@ describe('catchError operator', () => {
       })
     );
 
-    throwError(new Error('Some error')).pipe(
+    throwError(() => new Error('Some error')).pipe(
       catchError(() => synchronousObservable),
       takeWhile((x) => x != 2) // unsubscribe at the second side-effect
     ).subscribe(() => { /* noop */ });
@@ -339,7 +339,7 @@ describe('catchError operator', () => {
   });
 
   it('should pass the error as the first argument', (done: MochaDone) => {
-    throwError('bad').pipe(
+    throwError(() => ('bad')).pipe(
       catchError((err: any) => {
         expect(err).to.equal('bad');
         return EMPTY;
@@ -358,7 +358,7 @@ describe('catchError operator', () => {
 
     input$.pipe(
       mergeMap(input =>
-        throwError('bad').pipe(catchError(err => input))
+        throwError(() => ('bad')).pipe(catchError(err => input))
       )
     ).subscribe(x => {
       expect(x).to.be.equal(42);
@@ -410,7 +410,7 @@ describe('catchError operator', () => {
       const testError = new Error('BROKEN PROMISE');
       from(Promise.reject(testError)).pipe(
         catchError(err =>
-          throwError(thrownError)
+          throwError(() => (thrownError))
         )
       ).subscribe(subscribeSpy, errorSpy);
 

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -137,7 +137,7 @@ describe('concatAll operator', () => {
 
   it('should throw if any child observable throws', () => {
     testScheduler.run(({ expectObservable }) => {
-      const e1 = from([of('a'), throwError('error'), of('c')]).pipe(take(10));
+      const e1 = from([of('a'), throwError(() => ('error')), of('c')]).pipe(take(10));
       const expected = '(a#)';
 
       expectObservable(e1.pipe(concatAll())).toBe(expected);

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { finalize, map, share, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
-import { of, timer, interval, NEVER, Observable } from 'rxjs';
+import { of, timer, interval, NEVER, Observable, noop } from 'rxjs';
 import { asInteropObservable } from '../helpers/interop-helper';
 
 /** @test {finalize} */
@@ -270,6 +270,62 @@ describe('finalize', () => {
       });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
+  });
+
+  it('should execute finalize even with a sync thrown error', () => {
+    let called = false;
+    const badObservable = new Observable(() => {
+      throw new Error('bad');
+    }).pipe(
+      finalize(() => {
+        called = true;
+      })
+    );
+
+    badObservable.subscribe({
+      error: noop,
+    });
+
+    expect(called).to.be.true;
+  });
+
+  it('should execute finalize in order even with a sync error', () => {
+    const results: any[] = [];
+    const badObservable = new Observable((subscriber) => {
+      subscriber.error(new Error('bad'));
+    }).pipe(
+      finalize(() => {
+        results.push(1);
+      }),
+      finalize(() => {
+        results.push(2);
+      })
+    );
+
+    badObservable.subscribe({
+      error: noop,
+    });
+
+    expect(results).to.deep.equal([1, 2]);
+  });
+
+  it('should execute finalize in order even with a sync thrown error', () => {
+    const results: any[] = [];
+    const badObservable = new Observable(() => {
+      throw new Error('bad');
+    }).pipe(
+      finalize(() => {
+        results.push(1);
+      }),
+      finalize(() => {
+        results.push(2);
+      })
+    );
+
+    badObservable.subscribe({
+      error: noop,
+    });
+    expect(results).to.deep.equal([1, 2]);
   });
 
   it('should finalize in the proper order', () => {

--- a/spec/operators/mergeAll-spec.ts
+++ b/spec/operators/mergeAll-spec.ts
@@ -49,7 +49,7 @@ describe('mergeAll', () => {
       // prettier-ignore
       const e1 = from([
         of('a'),
-        throwError('error'),
+        throwError(() => ('error')),
         of('c')
       ]);
       const expected = '(a#)';

--- a/spec/operators/mergeScan-spec.ts
+++ b/spec/operators/mergeScan-spec.ts
@@ -220,7 +220,7 @@ describe('mergeScan', () => {
       const e1subs = '     ^--!';
       const expected = '   ---#';
 
-      const result = e1.pipe(mergeScan(() => throwError(new Error('bad!')), []));
+      const result = e1.pipe(mergeScan(() => throwError(() => new Error('bad!')), []));
 
       expectObservable(result).toBe(expected, undefined, new Error('bad!'));
       expectSubscriptions(e1.subscriptions).toBe(e1subs);

--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -114,7 +114,7 @@ describe('onErrorResumeNext operator', () => {
       }
     });
 
-    throwError(new Error('Some error')).pipe(
+    throwError(() => new Error('Some error')).pipe(
       onErrorResumeNext(synchronousObservable),
       take(3),
     ).subscribe(() => { /* noop */ });
@@ -141,7 +141,7 @@ describe('onErrorResumeNext operator', () => {
 
   it('should work with promise', (done: MochaDone) => {
     const expected = [1, 2];
-    const source = concat(of(1), throwError('meh'));
+    const source = concat(of(1), throwError(() => ('meh')));
 
     source.pipe(onErrorResumeNext(Promise.resolve(2)))
       .subscribe(x => {

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -478,7 +478,7 @@ describe('publishReplay operator', () => {
 
   it('should emit error when the selector returns Observable.throw', () => {
     const error = "It's broken";
-    const selector = () => throwError(error);
+    const selector = () => throwError(() => (error));
     const source = cold('--1--2---3---|');
     const sourceSubs =  '(^!)';
     const published = source.pipe(publishReplay(1, Infinity, selector));

--- a/spec/operators/race-legacy-spec.ts
+++ b/spec/operators/race-legacy-spec.ts
@@ -198,7 +198,7 @@ describe('race operator', () => {
   it('should ignore latter observables if a former one errors immediately', () => {
     const onError = sinon.spy();
     const onSubscribe = sinon.spy() as any;
-    const e1 = throwError('kaboom'); // Wins the race
+    const e1 = throwError(() => ('kaboom')); // Wins the race
     const e2 = defer(onSubscribe); // Should be ignored
 
     e1.pipe(race(e2)).subscribe({ error: onError });

--- a/spec/operators/raceWith-spec.ts
+++ b/spec/operators/raceWith-spec.ts
@@ -184,7 +184,7 @@ describe('raceWith operator', () => {
   it('should ignore latter observables if a former one errors immediately', () => {
     const onError = sinon.spy();
     const onSubscribe = sinon.spy() as any;
-    const e1 = throwError('kaboom'); // Wins the race
+    const e1 = throwError(() => ('kaboom')); // Wins the race
     const e2 = defer(onSubscribe); // Should be ignored
 
     e1.pipe(raceWith(e2)).subscribe({ error: onError });

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -99,7 +99,7 @@ describe('retry operator', () => {
         index++;
         if (index === 1 || index === 3) {
           errors++;
-          return throwError('bad');
+          return throwError(() => ('bad'));
         } else {
           return of(42);
         }
@@ -145,7 +145,7 @@ describe('retry operator', () => {
         index++;
         if (index === 1 || index === 3) {
           errors++;
-          return throwError('bad');
+          return throwError(() => ('bad'));
         } else {
           return of(42);
         }
@@ -293,7 +293,7 @@ describe('retry operator', () => {
     const expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
 
     of(1, 2, 3).pipe(
-      concat(throwError('bad!')),
+      concat(throwError(() => ('bad!'))),
       multicast(() => new Subject<number>()),
       refCount(),
       retry(4)

--- a/spec/operators/retryWhen-spec.ts
+++ b/spec/operators/retryWhen-spec.ts
@@ -341,7 +341,7 @@ describe('retryWhen operator', () => {
       }
     });
     const subscription = source.pipe(retryWhen(errors$ => errors$.pipe(
-      mergeMap((err, i) => i < 3 ? of(true) : throwError(err))
+      mergeMap((err, i) => i < 3 ? of(true) : throwError(() => (err)))
     ))).subscribe({
       next: value => results.push(value),
       error: (err) => results.push(err)

--- a/spec/operators/throwIfEmpty-spec.ts
+++ b/spec/operators/throwIfEmpty-spec.ts
@@ -110,7 +110,7 @@ describe('throwIfEmpty', () => {
           throwIfEmpty(() => error),
           mergeMap((value) => {
             if (value > 1) {
-              return throwError(new Error());
+              return throwError(() => new Error());
             }
 
             return of(value);
@@ -210,7 +210,7 @@ describe('throwIfEmpty', () => {
           throwIfEmpty(),
           mergeMap((value) => {
             if (value > 1) {
-              return throwError(new Error());
+              return throwError(() => new Error());
             }
 
             return of(value);

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -21,7 +21,7 @@ describe('Observable.toPromise', () => {
   });
 
   it('should handle errors properly', (done: Mocha.Done) => {
-    throwError('bad')
+    throwError(() => 'bad')
       .toPromise(Promise)
       .then(
         () => {

--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -163,7 +163,7 @@ export class Notification<T> {
         : //
         kind === 'E'
         ? // Error kind. Return an observable that emits the error.
-          throwError(error)
+          throwError(() => error)
         : //
         kind === 'C'
         ? // Completion kind. Kind is "C", return an observable that just completes.


### PR DESCRIPTION
…
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
- As per docs, throwError accepts factory functions to emit an error and no longer able to accept an error directly. That's why i went ahead and made changes in all unit tests wherever throwError is getting used to accept factory function.

**Related issue (if exists):**
Noop
