### PR TITLE
feat: add config object to connectable

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -77,7 +77,7 @@ export declare const config: {
     useDeprecatedNextContext: boolean;
 };
 
-export declare function connectable<T>(source: ObservableInput<T>, connector?: Subject<T>): ConnectableObservableLike<T>;
+export declare function connectable<T>(source: ObservableInput<T>, config?: ConnectableConfig<T>): ConnectableObservableLike<T>;
 
 export declare class ConnectableObservable<T> extends Observable<T> {
     protected _connection: Subscription | null;

--- a/spec/observables/connectable-spec.ts
+++ b/spec/observables/connectable-spec.ts
@@ -1,0 +1,79 @@
+/** @prettier */
+import { expect } from 'chai';
+import { connectable, of, ReplaySubject } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+describe('connectable', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should mirror a simple source Observable', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2---3-4--5-|');
+      const sourceSubs = ' ^--------------!';
+      const expected = '   --1-2---3-4--5-|';
+
+      const obs = connectable(source);
+
+      expectObservable(obs).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+
+      obs.connect();
+    });
+  });
+
+  it('should do nothing if connect is not called, despite subscriptions', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2---3-4--5-|');
+      const sourceSubs: string[] = [];
+      const expected = '   -';
+
+      const obs = connectable(source);
+
+      expectObservable(obs).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+  });
+
+  it('should support resetOnDisconnect = true', () => {
+    const values: number[] = [];
+    const source = of(1, 2, 3);
+    const obs = connectable(source, {
+      connector: () => new ReplaySubject(1),
+      resetOnDisconnect: true,
+    });
+
+    obs.subscribe((value) => values.push(value));
+    const connection = obs.connect();
+    expect(values).to.deep.equal([1, 2, 3]);
+
+    connection.unsubscribe();
+
+    obs.subscribe((value) => values.push(value));
+    obs.connect();
+    expect(values).to.deep.equal([1, 2, 3, 1, 2, 3]);
+  });
+
+  it('should support resetOnDisconnect = false', () => {
+    const values: number[] = [];
+    const source = of(1, 2, 3);
+    const obs = connectable(source, {
+      connector: () => new ReplaySubject(1),
+      resetOnDisconnect: false,
+    });
+
+    obs.subscribe((value) => values.push(value));
+    const connection = obs.connect();
+    expect(values).to.deep.equal([1, 2, 3]);
+
+    connection.unsubscribe();
+
+    obs.subscribe((value) => values.push(value));
+    obs.connect();
+    expect(values).to.deep.equal([1, 2, 3, 3]);
+  });
+});

--- a/src/internal/observable/connectable.ts
+++ b/src/internal/observable/connectable.ts
@@ -28,7 +28,7 @@ export interface ConnectableConfig<T> {
    * If true, the resulting observable will reset internal state upon disconnetion
    * and return to a "cold" state. This allows the resulting observable to be
    * reconnected.
-   * If false, upon disconnection, the connecting subject will will remain the
+   * If false, upon disconnection, the connecting subject will remain the
    * connecting subject, meaning the resulting observable will not go "cold" again,
    * and subsequent repeats or resubscriptions will resubscribe to that same subject.
    */

--- a/src/internal/observable/connectable.ts
+++ b/src/internal/observable/connectable.ts
@@ -1,4 +1,4 @@
-import { ObservableInput } from '../types';
+import { ObservableInput, SubjectLike } from '../types';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
@@ -18,29 +18,58 @@ export interface ConnectableObservableLike<T> extends Observable<T> {
   connect(): Subscription;
 }
 
+export interface ConnectableConfig<T> {
+  /**
+   * A factory function used to create the Subject through which the source
+   * is multicast. By default this creates a {@link Subject}.
+   */
+  connector: () => SubjectLike<T>;
+  /**
+   * If true, the resulting observable will reset internal state upon disconnetion
+   * and return to a "cold" state. This allows the resulting observable to be
+   * reconnected.
+   * If false, upon disconnection, the connecting subject will will remain the
+   * connecting subject, meaning the resulting observable will not go "cold" again,
+   * and subsequent repeats or resubscriptions will resubscribe to that same subject.
+   */
+  resetOnDisconnect?: boolean;
+}
+
+/**
+ * The default configuration for `connectable`.
+ */
+const DEFAULT_CONFIG: ConnectableConfig<unknown> = {
+  connector: () => new Subject<unknown>(),
+  resetOnDisconnect: true,
+};
+
 /**
  * Creates an observable that multicasts once `connect()` is called on it.
  *
  * @param source The observable source to make connectable.
- * @param connector The subject to used to multicast the source observable to all subscribers.
- * Defaults to a new {@link Subject}.
+ * @param config The configuration object for `connectable`.
  * @returns A "connectable" observable, that has a `connect()` method, that you must call to
  * connect the source to all consumers through the subject provided as the connector.
  */
-export function connectable<T>(source: ObservableInput<T>, connector: Subject<T> = new Subject<T>()): ConnectableObservableLike<T> {
+export function connectable<T>(source: ObservableInput<T>, config: ConnectableConfig<T> = DEFAULT_CONFIG): ConnectableObservableLike<T> {
   // The subscription representing the connection.
   let connection: Subscription | null = null;
+  const { connector, resetOnDisconnect = true } = config;
+  let subject = connector();
 
   const result: any = new Observable<T>((subscriber) => {
-    return connector.subscribe(subscriber);
+    return subject.subscribe(subscriber);
   });
 
   // Define the `connect` function. This is what users must call
   // in order to "connect" the source to the subject that is
   // multicasting it.
   result.connect = () => {
-    if (!connection) {
-      connection = defer(() => source).subscribe(connector);
+    if (!connection || connection.closed) {
+      connection = defer(() => source).subscribe(subject);
+      if (resetOnDisconnect) {
+        connection.add(() => (subject = connector()));
+      }
     }
     return connection;
   };

--- a/src/internal/operators/connect.ts
+++ b/src/internal/operators/connect.ts
@@ -92,7 +92,7 @@ const DEFAULT_CONFIG: ConnectConfig<unknown> = {
  * and Observable, that when subscribed to, will utilize the multicast observable.
  * After this function is executed -- and its return value subscribed to -- the
  * the operator will subscribe to the source, and the connection will be made.
- * @param param0 The configuration object for `connect`.
+ * @param config The configuration object for `connect`.
  */
 export function connect<T, O extends ObservableInput<unknown>>(
   selector: (shared: Observable<T>) => O,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR changes the API of the new-to-version-7 `connectable` function. The changes introduce a config object (much like the one used in the `connect` and `share` operators) that:

- allows a `connector` subject factory to be passed;
- allows a `resetOnDisconnect` option to be specified.

Without these changes, it wasn't possible to refactor all use cases of `ConnectableObservable` to use `connectable` because `ConnectableObservable` would reset its subject upon disconnection - that is, on calling `unsubscribe` on the `Subscription` returned from the `connect` method.

This PR adds a few tests (there were none) for `connectable`.

**Related issue (if exists):** Nope
