### PR TITLE
docs: buffer and ReplaySubject breaking changes

### DIFF
--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -189,6 +189,10 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 ## Breaking Changes
 
+### buffer
+
+- `buffer` now subscribes to the source observable before it subscribes to the closing notifier. Previously, it subscribed to the closing notifier first.
+
 ### combineLatest
 
 - Generic signatures have changed. Do not explicitly pass generics.

--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -177,6 +177,10 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 - `ReadableStream` such as those returned by `fetch`, et al, can be passed to any API that accepts an observable, and can be converted to `Observable` directly using `from`.
 
+### ReplaySubject
+
+- A [bug was fixed](https://github.com/ReactiveX/rxjs/pull/5696) that prevented a completed or errored `ReplaySubject` from accumulating values in its buffer when resubscribed to another source. This breaks some uses - like [this StackOverflow answer](https://stackoverflow.com/a/54957061) - that depended upon the buggy behavior.
+
 ### Subscription
 
 - Now allows adding and removing of functions directly via `add` and `remove` methods.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds the `buffer` breaking change mentioned in #6255 and a `ReplaySubject` breaking change that stems from a v7 bug fix - from an issue opened in this repo (#6260) it's clear that some people are relying upon the buggy behaviour.

**Related issue (if exists):** Nope
