### PR TITLE
fix: resolve run-time errors when using deprecated sync error handling

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -799,6 +799,17 @@ describe('Observable', () => {
         expect(results).to.deep.equal([1, 2]);
       });
 
+      // https://github.com/ReactiveX/rxjs/issues/6271      
+      it('should not have a run-time error if no errors are thrown and there are operators', () => {
+        expect(() => {
+          of(1, 2, 3).pipe(
+            map(x => x + x),
+            map(x => Math.log(x))
+          )
+          .subscribe();
+        }).not.to.throw();
+      });
+
       afterEach(() => {
         config.useDeprecatedSynchronousErrorHandling = false;
       });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -241,8 +241,8 @@ export class Observable<T> implements Subscribable<T> {
    * REMOVE THIS ENTIRE METHOD IN VERSION 8.
    */
   private _deprecatedSyncErrorSubscribe(subscriber: Subscriber<unknown>) {
-    let dest: any = subscriber;
-    dest._syncErrorHack_isSubscribing = true;
+    const localSubscriber: any = subscriber;
+    localSubscriber._syncErrorHack_isSubscribing = true;
     const { operator } = this;
     if (operator) {
       // We don't need to try/catch on operators, as they
@@ -253,7 +253,7 @@ export class Observable<T> implements Subscribable<T> {
       try {
         this._subscribe(subscriber);
       } catch (err) {
-        dest.__syncError = err;
+        localSubscriber.__syncError = err;
       }
     }
 
@@ -262,6 +262,7 @@ export class Observable<T> implements Subscribable<T> {
     // look to see if there's any synchronously thrown errors.
     // Does this suck for perf? Yes. So stop using the deprecated sync
     // error handling already. We're removing this in v8.
+    let dest = localSubscriber;
     while (dest) {
       // Technically, someone could throw something falsy, like 0, or "",
       // so we need to check to see if anything was thrown, and we know
@@ -275,7 +276,8 @@ export class Observable<T> implements Subscribable<T> {
       }
       dest = dest.destination;
     }
-    dest._syncErrorHack_isSubscribing = false;
+
+    localSubscriber._syncErrorHack_isSubscribing = false;
   }
 
   /** @internal */


### PR DESCRIPTION
Fixes a should-be-obvious issue where we were making sure `dest` was `undefined`, then trying to set a property on it.

fixes #6271

