### PR TITLE
fix: unable to evaluate `instanceof AjaxError`

### DIFF
--- a/src/internal/ajax/errors.ts
+++ b/src/internal/ajax/errors.ts
@@ -40,7 +40,6 @@ export interface AjaxError extends Error {
 export interface AjaxErrorCtor {
   /**
    * Internal use only. Do not manually create instances of this type.
-   * @internal
    */
   new (message: string, xhr: XMLHttpRequest, request: AjaxRequest): AjaxError;
 }
@@ -80,7 +79,6 @@ export interface AjaxTimeoutError extends AjaxError {}
 export interface AjaxTimeoutErrorCtor {
   /**
    * Internal use only. Do not manually create instances of this type.
-   * @internal
    */
   new (xhr: XMLHttpRequest, request: AjaxRequest): AjaxTimeoutError;
 }


### PR DESCRIPTION
**Description:**

Because the constructor signature of `AjaxErrorCtor` and `AjaxTimeoutErrorCtor` are marked as @internal, and #6215 added `stripInternals: true`, the interface of these two constructors was exported as an empty interface.

Typescript would then complain on projects that use `error instanceof AjaxError`, as it doesn't identify AjaxError as callable.

**Related issue (if exists):** #6269 

I've found this solution, which I _think_ works nicely: The type is still exported, the constructor signature is still stripped (because it's internal) and typescript now allows to check instanceof AjaxError, while preventing the consumer from trying to call the constructor:

![image](https://user-images.githubusercontent.com/5365487/116313848-9c198b80-a7ae-11eb-9e03-6e72f6c2c7cd.png)
