### PR TITLE
fix: VS code will now properly import operators, et al

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,12 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm5/index.js",
   "es2015": "./dist/esm/index.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "index.d.ts",
+  "typesVersions": {
+    ">=4.2": {
+      "*": ["dist/types/*"]
+    }
+  },
   "sideEffects": false,
   "exports": {
     ".": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,18 @@
+//////////////////////////////////////////////////////////
+// Here we need to reference our other deep imports
+// so VS code will figure out where they are
+// see conversation here:
+// https://github.com/microsoft/TypeScript/issues/43034
+//////////////////////////////////////////////////////////
+
+// tslint:disable: no-reference
+/// <reference path="./ajax/index.ts" />
+/// <reference path="./fetch/index.ts" />
+/// <reference path="./operators/index.ts" />
+/// <reference path="./testing/index.ts" />
+/// <reference path="./webSocket/index.ts" />
+// tslint:enable: no-reference
+
 /* Observable */
 export { Observable } from './internal/Observable';
 export { ConnectableObservable } from './internal/observable/ConnectableObservable';


### PR DESCRIPTION
- Adds typesVersions, enforcing TypeScript >= 4.2.
- Adds some superfluous imports required for TS and VS Code to find proper import locations for our strange deep import sites.
- Independantly tested by building the package and installing it locally in another project, then testing in VS code.

Fixes #6067
Related https://github.com/microsoft/TypeScript/issues/43034

NOTE: I'm worried about the `check-side-effects` run here, because it can't seem to figure out what to make of it. However, tested against an Angular build locally, this branch didn't have any problems tree-shaking or removing dead code. Given the importance of people getting their imports right, and the DX around this, we might want to disable `check-side-effects` if it causes us issues.