### PR TITLE
chore: deprecate error ctors

### DIFF
--- a/spec-dtslint/errors-spec.ts
+++ b/spec-dtslint/errors-spec.ts
@@ -1,0 +1,35 @@
+import { AjaxError, AjaxTimeoutError } from 'rxjs/ajax';
+import {
+  ArgumentOutOfRangeError,
+  EmptyError,
+  NotFoundError,
+  ObjectUnsubscribedError,
+  SequenceError,
+  TimeoutError,
+  UnsubscriptionError
+} from 'rxjs';
+
+it('should deprecate error construction', () => {
+  let error: Error;
+  error = new AjaxError('message', null!, null!); // $ExpectDeprecation
+  error = new ArgumentOutOfRangeError(); // $ExpectDeprecation
+  error = new EmptyError(); // $ExpectDeprecation
+  error = new NotFoundError('message'); // $ExpectDeprecation
+  error = new ObjectUnsubscribedError(); // $ExpectDeprecation
+  error = new SequenceError('message'); // $ExpectDeprecation
+  error = new TimeoutError(); // $ExpectDeprecation
+  error = new UnsubscriptionError([]); // $ExpectDeprecation
+});
+
+it('should not deprecate instanceof use', () => {
+  const error = new Error('message');
+  let b: boolean;
+  b = error instanceof AjaxError; // $ExpectNoDeprecation
+  b = error instanceof ArgumentOutOfRangeError; // $ExpectNoDeprecation
+  b = error instanceof EmptyError; // $ExpectNoDeprecation
+  b = error instanceof NotFoundError; // $ExpectNoDeprecation
+  b = error instanceof ObjectUnsubscribedError; // $ExpectNoDeprecation
+  b = error instanceof SequenceError; // $ExpectNoDeprecation
+  b = error instanceof TimeoutError; // $ExpectNoDeprecation
+  b = error instanceof UnsubscriptionError; // $ExpectNoDeprecation
+});

--- a/spec-dtslint/index.d.ts
+++ b/spec-dtslint/index.d.ts
@@ -1,1 +1,0 @@
-// TypeScript Version: 2.8

--- a/src/internal/ajax/errors.ts
+++ b/src/internal/ajax/errors.ts
@@ -39,7 +39,8 @@ export interface AjaxError extends Error {
 
 export interface AjaxErrorCtor {
   /**
-   * Internal use only. Do not manually create instances of this type.
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
    */
   new (message: string, xhr: XMLHttpRequest, request: AjaxRequest): AjaxError;
 }
@@ -78,7 +79,8 @@ export interface AjaxTimeoutError extends AjaxError {}
 
 export interface AjaxTimeoutErrorCtor {
   /**
-   * Internal use only. Do not manually create instances of this type.
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
    */
   new (xhr: XMLHttpRequest, request: AjaxRequest): AjaxTimeoutError;
 }

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -67,8 +67,8 @@ export interface TimeoutError<T = unknown, M = unknown> extends Error {
 
 export interface TimeoutErrorCtor {
   /**
-   * Internal use only. DO NOT create new instances of TimeoutError directly.
-   * This type is exported for the purpose of `instanceof` checks.
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
    */
   new <T = unknown, M = unknown>(info?: TimeoutInfo<T, M>): TimeoutError<T, M>;
 }

--- a/src/internal/util/ArgumentOutOfRangeError.ts
+++ b/src/internal/util/ArgumentOutOfRangeError.ts
@@ -3,6 +3,10 @@ import { createErrorClass } from './createErrorClass';
 export interface ArgumentOutOfRangeError extends Error {}
 
 export interface ArgumentOutOfRangeErrorCtor {
+  /**
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
+   */
   new (): ArgumentOutOfRangeError;
 }
 

--- a/src/internal/util/EmptyError.ts
+++ b/src/internal/util/EmptyError.ts
@@ -1,10 +1,13 @@
 import { createErrorClass } from './createErrorClass';
 
-export interface EmptyError extends Error {
-}
+export interface EmptyError extends Error {}
 
 export interface EmptyErrorCtor {
-  new(): EmptyError;
+  /**
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
+   */
+  new (): EmptyError;
 }
 
 /**
@@ -17,8 +20,11 @@ export interface EmptyErrorCtor {
  *
  * @class EmptyError
  */
-export const EmptyError: EmptyErrorCtor = createErrorClass((_super) => function EmptyErrorImpl(this: any) {
-  _super(this);
-  this.name = 'EmptyError';
-  this.message = 'no elements in sequence';
-});
+export const EmptyError: EmptyErrorCtor = createErrorClass(
+  (_super) =>
+    function EmptyErrorImpl(this: any) {
+      _super(this);
+      this.name = 'EmptyError';
+      this.message = 'no elements in sequence';
+    }
+);

--- a/src/internal/util/NotFoundError.ts
+++ b/src/internal/util/NotFoundError.ts
@@ -3,6 +3,10 @@ import { createErrorClass } from './createErrorClass';
 export interface NotFoundError extends Error {}
 
 export interface NotFoundErrorCtor {
+  /**
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
+   */
   new (message: string): NotFoundError;
 }
 

--- a/src/internal/util/ObjectUnsubscribedError.ts
+++ b/src/internal/util/ObjectUnsubscribedError.ts
@@ -3,6 +3,10 @@ import { createErrorClass } from './createErrorClass';
 export interface ObjectUnsubscribedError extends Error {}
 
 export interface ObjectUnsubscribedErrorCtor {
+  /**
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
+   */
   new (): ObjectUnsubscribedError;
 }
 

--- a/src/internal/util/SequenceError.ts
+++ b/src/internal/util/SequenceError.ts
@@ -3,6 +3,10 @@ import { createErrorClass } from './createErrorClass';
 export interface SequenceError extends Error {}
 
 export interface SequenceErrorCtor {
+  /**
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
+   */
   new (message: string): SequenceError;
 }
 

--- a/src/internal/util/UnsubscriptionError.ts
+++ b/src/internal/util/UnsubscriptionError.ts
@@ -5,6 +5,10 @@ export interface UnsubscriptionError extends Error {
 }
 
 export interface UnsubscriptionErrorCtor {
+  /**
+   * @deprecated Internal implementation detail. Do not construct error instances.
+   * Cannot be tagged as internal: https://github.com/ReactiveX/rxjs/issues/6269
+   */
   new (errors: any[]): UnsubscriptionError;
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds __@deprecated__ tags to the error constructors so that devs attempting to create instances of this package's errors will be told they're being naughty. We can't tag them as __@internal__ because TypeScript gets too upset about it - see linked issue and PR.

This PR also adds some dtslint tests to make sure the deprecations work properly and don't interfere with `instanceof` usage.

**Related issue (if exists):** #6269 and #6275
