### PR TITLE
feat(AjaxResponse): add stricter `type` (`AjaxResponseType`)

### DIFF
--- a/api_guard/dist/types/ajax/index.d.ts
+++ b/api_guard/dist/types/ajax/index.d.ts
@@ -56,13 +56,13 @@ export declare class AjaxResponse<T> {
     readonly responseType: XMLHttpRequestResponseType;
     readonly status: number;
     readonly total: number;
-    readonly type: string;
+    readonly type: AjaxResponseType;
     readonly xhr: XMLHttpRequest;
     constructor(
     originalEvent: ProgressEvent,
     xhr: XMLHttpRequest,
     request: AjaxRequest,
-    type?: string);
+    type?: AjaxResponseType);
 }
 
 export interface AjaxTimeoutError extends AjaxError {

--- a/src/internal/ajax/AjaxResponse.ts
+++ b/src/internal/ajax/AjaxResponse.ts
@@ -1,4 +1,4 @@
-import { AjaxRequest } from './types';
+import { AjaxRequest, AjaxResponseType } from './types';
 import { getXHRResponse } from './getXHRResponse';
 
 /**
@@ -90,7 +90,7 @@ export class AjaxResponse<T> {
      * `download_load` is the type of event when download has finished and the
      * response is available.
      */
-    public readonly type: string = 'download_load'
+    public readonly type: AjaxResponseType = 'download_load'
   ) {
     const { status, responseType } = xhr;
     this.status = status ?? 0;

--- a/src/internal/ajax/ajax.ts
+++ b/src/internal/ajax/ajax.ts
@@ -1,6 +1,6 @@
 import { map } from '../operators/map';
 import { Observable } from '../Observable';
-import { AjaxConfig, AjaxRequest, AjaxDirection } from './types';
+import { AjaxConfig, AjaxRequest, AjaxDirection, ProgressEventType } from './types';
 import { AjaxResponse } from './AjaxResponse';
 import { AjaxTimeoutError, AjaxError } from './errors';
 
@@ -414,7 +414,7 @@ export function fromAjax<T>(config: AjaxConfig): Observable<AjaxResponse<T>> {
        * @param event the actual event object.
        */
       const createResponse = (direction: AjaxDirection, event: ProgressEvent) =>
-        new AjaxResponse<T>(event, xhr, _request, `${direction}_${event.type}`);
+        new AjaxResponse<T>(event, xhr, _request, `${direction}_${event.type as ProgressEventType}` as const);
 
       /**
        * Wires up an event handler that emits a Response object to the consumer, used for

--- a/src/internal/ajax/types.ts
+++ b/src/internal/ajax/types.ts
@@ -7,6 +7,10 @@ import { PartialObserver } from '../types';
  */
 export type AjaxDirection = 'upload' | 'download';
 
+export type ProgressEventType = 'loadstart' | 'progress' | 'load';
+
+export type AjaxResponseType = `${AjaxDirection}_${ProgressEventType}`;
+
 /**
  * The object containing values RxJS used to make the HTTP request.
  *


### PR DESCRIPTION
**Description:** currently `AjaxResponse['type']` is typed as `string`, but we can use a stricter type for this since we know which strings will be used. This will help users `switch` over the various types.