### PR TITLE
feat(testScheduler): support nested observables within objects

### DIFF
--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -281,6 +281,16 @@ describe('TestScheduler', () => {
         expectObservable(NEVER).toBe('---', {});
       });
 
+      it('handles observables of observables', () => {
+        expectObservable(cold('a', { a: cold('b') }))
+                        .toBe('a', { a: cold('b') })
+      })
+      
+      it('handles observables of nested observables', () => {
+        expectObservable(cold('-a-b', { a: {a: cold('--b'), b: 3} }))
+                        .toBe('-a-b', { a: {a: cold('--b'), b: 3}})
+      })
+
       it('should accept an unsubscription marble diagram', () => {
         const source = hot('---^-a-b-|');
         const unsubscribe  =  '---!';


### PR DESCRIPTION
**Description:**

Adds deep unwrapping of observables in marble tests, so that we can write tests such as:

```ts
expectObservable(
  cold('---a-|'),
  {
    a: {
      nestedObservable: cold('-1-2-3')
    }
  }
).toBe(
  '---a-|',
  {
    a: {
      nestedObservable: cold('-1-2-3')
    }
  }
)
```

Previously we had a similar feature, but would only work for just observables of observables (and only 1-level deep).

**Related issue (if exists):** #6243 

I'm sorry I went ahead and implemented this before any member of the core team had the chance to express if it's a feature you even want to support, but I found it interesting as an exercise. I also understand v7 is around the corner and there are things probably more important than this.

If you want this PR to move forward, I'll need to add a few more tests and tweak edge cases (circular references), but so far I have a proof-of-concept.