### PR TITLE
test(throttle): test leading: false

### DIFF
--- a/spec/operators/throttle-spec.ts
+++ b/spec/operators/throttle-spec.ts
@@ -455,9 +455,9 @@ describe('throttle', () => {
           '               ------------------^---!    ',
           '               ----------------------^---!',
         ];
-        const expected = '-a---y----b---x---x---x---|';
+        const expected = '-----y--------x---x---x---|';
 
-        const result = e1.pipe(throttle(() => e2, { leading: true, trailing: true }));
+        const result = e1.pipe(throttle(() => e2, { leading: false, trailing: true }));
 
         expectObservable(result).toBe(expected);
         expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -467,13 +467,13 @@ describe('throttle', () => {
 
     it('should work for individual values', () => {
       testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
-        const s1 = hot('-^-x------------------|     ');
-        const s1Subs = ' ^--------------------!     ';
-        const n1 = cold('  ------------------------x');
-        const n1Subs = ['--^------------------!     '];
-        const exp = '    --x------------------|     ';
+        const s1 = hot('-^-x------------------|        ');
+        const s1Subs = ' ^--------------------!        ';
+        const n1 = cold('  ------------------------x   ');
+        const n1Subs = ['--^-----------------------!   '];
+        const exp = '    --------------------------(x|)';
 
-        const result = s1.pipe(throttle(() => n1, { leading: true, trailing: true }));
+        const result = s1.pipe(throttle(() => n1, { leading: false, trailing: true }));
         expectObservable(result).toBe(exp);
         expectSubscriptions(s1.subscriptions).toBe(s1Subs);
         expectSubscriptions(n1.subscriptions).toBe(n1Subs);
@@ -482,13 +482,13 @@ describe('throttle', () => {
 
     it('should wait for trailing throttle before completing, even if source completes', () => {
       testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
-        const source = hot('  -^--x--------y---------|');
-        const sourceSubs = '   ^---------------------!';
-        const duration = cold('   ------------------------x');
-        const durationSubs = ' ---^-----------------------!';
-        const exp = '          ---x-----------------------(y|)';
+        const source = hot('  -^--x--------y---------|        ');
+        const sourceSubs = '   ^---------------------!        ';
+        const duration = cold('   ------------------------x   ');
+        const durationSubs = ' ---^-----------------------!   ';
+        const exp = '          ---------------------------(y|)';
 
-        const result = source.pipe(throttle(() => duration, { leading: true, trailing: true }));
+        const result = source.pipe(throttle(() => duration, { leading: false, trailing: true }));
         expectObservable(result).toBe(exp);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
         expectSubscriptions(duration.subscriptions).toBe(durationSubs);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

There are a bunch of `throttle` tests that are in a `describe` section that's devoted to testing with `leading: false`. However, some of those tests seem to have been copied from the section devoted to testing with `leading: true`. This PR changes the copied tests so that they do in fact test with the `leading` option set to `false`.

Basically, the tests weren't testing what they were said to be testing and they were testing scenarios that are tested elsewhere in the file.

**Related issue (if exists):** #5360