### PR TITLE
docs: add notifier breaking changes

### DIFF
--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -193,9 +193,21 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 ## Breaking Changes
 
+### audit
+
+- The observable returned by the `audit` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
+
 ### buffer
 
 - `buffer` now subscribes to the source observable before it subscribes to the closing notifier. Previously, it subscribed to the closing notifier first.
+
+### bufferToggle
+
+- The observable returned by the `bufferToggle` operator's closing selector must emit a next notification to close the buffer. Complete notifications no longer close the buffer.
+
+### bufferWhen
+
+- The observable returned by the `bufferWhen` operator's closing selector must emit a next notification to close the buffer. Complete notifications no longer close the buffer.
 
 ### combineLatest
 
@@ -214,9 +226,17 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
+### debounce
+
+- The observable returned by the `debounce` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
+
 ### defaultIfEmpty
 
 - Generic signatures have changed. Do not explicitly pass generics.
+
+### delayWhen
+
+- `delayWhen` will no longer emit if the duration selector simply completes without a value. Notifiers must notify with a value, not a completion.
 
 ### endWith
 
@@ -247,6 +267,10 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
+### sample
+
+- The `sample` operator's notifier observable must emit a next notification to effect a sample. Complete notifications no longer effect a sample.
+
 ### scan
 
 - Generic signatures have changed. Do not explicitly pass generics.
@@ -262,6 +286,14 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 ### switchMapTo
 
 - Generic signatures have changed. Do not explicitly pass generics.
+
+### throttle
+
+- The observable returned by the `throttle` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
+
+### windowToggle
+
+- The observable returned by the `windowToggle` operator's closing selector must emit a next notification to close the window. Complete notifications no longer close the window.
 
 ### withLatestFrom
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds the breaking changes that relate to notifiers having to emit a value to: `docs_app/content/6-to-7-change-summary.md`

**Related issue (if exists):** #6298