### PR TITLE
Fix typo in endWith summary

### DIFF
--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -15,7 +15,7 @@ export function endWith<T, A extends unknown[] = T[]>(...values: A): OperatorFun
 
 /**
  * Returns an observable that will emit all values from the source, then synchronously emit
- * he provided value(s) immediately after the source completes.
+ * the provided value(s) immediately after the source completes.
  *
  * NOTE: Passing a last argument of a Scheduler is _deprecated_, and may result in incorrect
  * types in TypeScript.


### PR DESCRIPTION
Correct "he" to be "the"

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

**Related issue (if exists):**
