### PR TITLE
fix: do not reference DOM-related imports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,10 @@
 //////////////////////////////////////////////////////////
 
 // tslint:disable: no-reference
-/// <reference path="./ajax/index.ts" />
-/// <reference path="./fetch/index.ts" />
+// It's tempting to put add references to all of the deep-import locations, but
+// adding references to those that require DOM types breaks Node projects.
 /// <reference path="./operators/index.ts" />
 /// <reference path="./testing/index.ts" />
-/// <reference path="./webSocket/index.ts" />
 // tslint:enable: no-reference
 
 /* Observable */

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@
 //////////////////////////////////////////////////////////
 
 // tslint:disable: no-reference
-// It's tempting to put add references to all of the deep-import locations, but
+// It's tempting to add references to all of the deep-import locations, but
 // adding references to those that require DOM types breaks Node projects.
 /// <reference path="./operators/index.ts" />
 /// <reference path="./testing/index.ts" />


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes all DOM-related imports from the references that were added to help VS Code choose the correct import locations for its automatic imports feature.

I've confirmed - using https://github.com/OliverJAsh/rxjs-v7-no-dom-lib-test - that this resolves the problem.

**Related issue (if exists):** #6297