### PR TITLE
docs: mention tighter fromEvent types

### DIFF
--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -42,6 +42,10 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
+### fromEvent
+
+- The `fromEvent` signatures have been changed and there are now separate signatures for each type of target - DOM, Node, jQuery, etc. That means that attempts to pass options - like `{ once: true }` - to targets that do not support options will result in a TypeScript error.
+
 ### GroupedObservable
 
 - No longer publicly exposes `_subscribe`

--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -44,7 +44,7 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 ### fromEvent
 
-- The `fromEvent` signatures have been changed and there are now separate signatures for each type of target - DOM, Node, jQuery, etc. That means that attempts to pass options - like `{ once: true }` - to targets that do not support options will result in a TypeScript error.
+- The `fromEvent` signatures have been changed and there are now separate signatures for each type of target - DOM, Node, jQuery, etc. That means that an attempt to pass options - like `{ once: true }` - to a target that does not support an options argument will result in a TypeScript error.
 
 ### GroupedObservable
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR mentions, in the changes doc, that prior to separating the `fromEvent` signatures by target type, it was possible to pass options to APIs that didn't support them. (The options are ignored in the `fromEvent` implementation for targets that don't support them.) Attempting to do this in v7 will effect a TypeScript compilation error.

**Related issue (if exists):** #6301