### PR TITLE
docs: audit(Time) breaking changes

### DIFF
--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -201,6 +201,11 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 ### audit
 
 - The observable returned by the `audit` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
+- `audit` now emits the last value from the source when the source completes. Previously, `audit` would mirror the completion without emitting the value.
+
+### auditTime
+
+- `auditTime` now emits the last value from the source when the source completes, after the audit duration elapses. Previously, `auditTime` would mirror the completion without emitting the value, without waiting for the audit duration to elapse.
 
 ### buffer
 

--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -205,7 +205,7 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 ### auditTime
 
-- `auditTime` now emits the last value from the source when the source completes, after the audit duration elapses. Previously, `auditTime` would mirror the completion without emitting the value, without waiting for the audit duration to elapse.
+- `auditTime` now emits the last value from the source when the source completes, after the audit duration elapses. Previously, `auditTime` would mirror the completion without emitting the value and without waiting for the audit duration to elapse.
 
 ### buffer
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds the breaking changes made to `audit` and, therefore, `auditTime` in https://github.com/ReactiveX/rxjs/pull/5799

That PR description did not include 'BREAKING CHANGE', so, AFAICT, the changes weren't mentioned in the CHANGELOG.

**Related issue (if exists):** #5799
