### PR TITLE
docs: more breaking changes

### DIFF
--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -42,6 +42,10 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
+### fromEvent
+
+- The `fromEvent` signatures have been changed and there are now separate signatures for each type of target - DOM, Node, jQuery, etc. That means that an attempt to pass options - like `{ once: true }` - to a target that does not support an options argument will result in a TypeScript error.
+
 ### GroupedObservable
 
 - No longer publicly exposes `_subscribe`

--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -146,7 +146,7 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 ### animationFrames
 
-- A new method for creating a stream of animation frames. Each event will carry with it a high-resolution timestamp, and an ellapsed time since observation was started.
+- A new method for creating a stream of animation frames. Each event will carry with it a high-resolution timestamp, and an elapsed time since observation was started.
 
 ### config
 
@@ -168,7 +168,7 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 ### firstValueFrom
 
-- A better, more tree-shakable replacement for `toPromise()` (which is now deprecated). This function allows the user to convert any `Observable` in to a `Promise` that will resolve when the source observable emits its firsr value. If the source observable closes without emitting a value, the returned promise will reject with an `EmptyError`, or it will resolve with a configured `defaultValue`.
+- A better, more tree-shakable replacement for `toPromise()` (which is now deprecated). This function allows the user to convert any `Observable` in to a `Promise` that will resolve when the source observable emits its first value. If the source observable closes without emitting a value, the returned promise will reject with an `EmptyError`, or it will resolve with a configured `defaultValue`.
 
 ### ObservableInput
 
@@ -391,7 +391,7 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 ### AjaxResponse
 
 - Now includes `responseHeaders`.
-- Now includes event `type` and `total` numbers for examinining upload and download progress (see `includeUploadProgess` and `includeDownloadProgress`).
+- Now includes event `type` and `total` numbers for examining upload and download progress (see `includeUploadProgress` and `includeDownloadProgress`).
 
 ### includeUploadProgress
 

--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -201,6 +201,11 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 ### audit
 
 - The observable returned by the `audit` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
+- `audit` now emits the last value from the source when the source completes. Previously, `audit` would mirror the completion without emitting the value.
+
+### auditTime
+
+- `auditTime` now emits the last value from the source when the source completes, after the audit duration elapses. Previously, `auditTime` would mirror the completion without emitting the value and without waiting for the audit duration to elapse.
 
 ### buffer
 

--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -258,6 +258,10 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
+### finalize
+
+- `finalize` will now unsubscribe from its source _before_ it calls its callback. That means that `finalize` callbacks will run in the order in which they occur in the pipeline: `source.pipe(finalize(() => console.log(1)), finalize(() => console.log(2)))` will log `1` and then `2`. Previously, callbacks were called in the reverse order.
+
 ### map
 
 - `thisArg` will now default to `undefined`. The previous default of `MapSubscriber` never made any sense. This will only affect code that calls map with a `function` and references `this` like so: `source.pipe(map(function () { console.log(this); }))`. There wasn't anything useful about doing this, so the breakage is expected to be very minimal. If anything we're no longer leaking an implementation detail.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds more breaking changes that are missing from the v6/v7 changes doc:

- There were breaking changes made to `audit` and, therefore, `auditTime` in https://github.com/ReactiveX/rxjs/pull/5799

    That PR description did not include 'BREAKING CHANGE', so, AFAICT, the changes weren't mentioned in the CHANGELOG.

- Prior to separating the `fromEvent` signatures by target type - in https://github.com/ReactiveX/rxjs/pull/6214 - it was possible to pass options to APIs that didn't support them. (The options are ignored in the `fromEvent` implementation for targets that don't support them.) Attempting to do this in v7 will effect a TypeScript compilation error.
- In https://github.com/ReactiveX/rxjs/pull/5433, `finalize` was changed so that it unsubscribes from its source _before_ it calls the specified callback.

**Related issue (if exists):** Nope
