### PR TITLE
chore: add breaking change notice to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -14,4 +14,10 @@ If your PR is the addition of a new operator, please make sure all these boxes a
 
 **Description:**
 
+<!--
+If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
+-->
+
+**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->
+
 **Related issue (if exists):**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR updates the repo's PR template to include the breaking-change notice along with instructions on how it should be used. It has been missed numerous times, so a reminder is warranted, IMO.

**Related issue (if exists):** Nope
