### PR TITLE
chore(sequenceEqual): convert sequenceEqual tests to run mode

### DIFF
--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -1,4 +1,3 @@
-import * as _ from 'lodash';
 import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
 import { sequenceEqual } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
@@ -199,7 +198,7 @@ describe('sequenceEqual operator', () => {
       z: { value: 'derp', weCouldBe: 'dancin, yeah' }
     };
 
-    expectObservable(source).toBe(expected, _.assign(booleans, values), new Error('shazbot'));
+    expectObservable(source).toBe(expected, {...booleans, ...values}, new Error('shazbot'));
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
     expectSubscriptions(s2.subscriptions).toBe(s2subs);
   });
@@ -223,7 +222,7 @@ describe('sequenceEqual operator', () => {
       z: { value: 'derp', weCouldBe: 'dancin, yeah' }
     };
 
-    expectObservable(source).toBe(expected, _.assign(booleans, values));
+    expectObservable(source).toBe(expected, {...booleans, ...values});
     expectSubscriptions(s1.subscriptions).toBe(s1subs);
     expectSubscriptions(s2.subscriptions).toBe(s2subs);
   });

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -173,7 +173,7 @@ describe('sequenceEqual operator', () => {
     expectObservable(source).toBe(expected);
   });
 
-  it('should error if the comparor errors', () => {
+  it('should error if the comparator function errors', () => {
     const s1 = hot('--a--^--b-----c------d--|');
     const s1subs =      '^            !';
     const s2 = hot('-----^--------x---y---z-------|');
@@ -203,7 +203,7 @@ describe('sequenceEqual operator', () => {
     expectSubscriptions(s2.subscriptions).toBe(s2subs);
   });
 
-  it('should use the provided comparor', () => {
+  it('should use the provided comparator function', () => {
     const s1 = hot('--a--^--b-----c------d--|');
     const s1subs =      '^                  !';
     const s2 = hot('-----^--------x---y---z-------|');

--- a/spec/operators/sequenceEqual-spec.ts
+++ b/spec/operators/sequenceEqual-spec.ts
@@ -1,322 +1,376 @@
-import { hot, cold, expectObservable, expectSubscriptions, time } from '../helpers/marble-testing';
+/** @prettier */
 import { sequenceEqual } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
-declare const rxTestScheduler: TestScheduler;
 const booleans = { T: true, F: false };
 
 /** @test {sequenceEqual} */
-describe('sequenceEqual operator', () => {
+describe('sequenceEqual', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should return true for two equal sequences', () => {
-    const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                    !';
-    const s2 = hot('-----^-----b--c--d-e-f------g-|');
-    const s2subs =      '^                        !';
-    const expected =    '-------------------------(T|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b--c--d--e--f--g--|       ');
+      const s1subs = '     ^--------------------!       ';
+      const s2 = hot('-----^-----b--c--d-e-f------g-|   ');
+      const s2subs = '     ^------------------------!   ';
+      const expected = '   -------------------------(T|)';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return false for two sync observables that are unequal in length', () => {
-    const s1 = cold('(abcdefg|)');
-    const s2 = cold('(abc|)');
-    const expected = '(F|)';
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' (abcdefg|)');
+      const s2 = cold(' (abc|)    ');
+      const expected = '(F|)      ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
+      expectObservable(source).toBe(expected, booleans);
+    });
   });
 
   it('should return true for two sync observables that match', () => {
-    const s1 = cold('(abcdefg|)');
-    const s2 = cold('(abcdefg|)');
-    const expected = '(T|)';
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' (abcdefg|)');
+      const s2 = cold(' (abcdefg|)');
+      const expected = '(T|)      ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
+      expectObservable(source).toBe(expected, booleans);
+    });
   });
 
   it('should return true for two observables that match when the last one emits and completes in the same frame', () => {
-    const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                    !';
-    const s2 = hot('-----^--b--c--d--e--f--g------|');
-    const s2subs =      '^                        !';
-    const expected =    '-------------------------(T|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b--c--d--e--f--g--|       ');
+      const s1subs = '     ^--------------------!       ';
+      const s2 = hot('-----^--b--c--d--e--f--g------|   ');
+      const s2subs = '     ^------------------------!   ';
+      const expected = '   -------------------------(T|)';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return true for two observables that match when the last one emits and completes in the same frame', () => {
-    const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                    !';
-    const s2 = hot('-----^--b--c--d--e--f---------(g|)');
-    const s2subs =      '^                        !';
-    const expected =    '-------------------------(T|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b--c--d--e--f--g--|       ');
+      const s1subs = '     ^--------------------!       ';
+      const s2 = hot('-----^--b--c--d--e--f---------(g|)');
+      const s2subs = '     ^------------------------!   ';
+      const expected = '   -------------------------(T|)';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should error with an errored source', () => {
-    const s1 = hot('--a--^--b---c---#');
-    const s2 = hot('--a--^--b---c-----|');
-    const expected =    '-----------#';
-    const sub =         '^          !';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b---c---#  ');
+      const s2 = hot('--a--^--b---c-----|');
+      const expected = '   -----------#  ';
+      const sub = '        ^----------!  ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(sub);
-    expectSubscriptions(s2.subscriptions).toBe(sub);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(sub);
+      expectSubscriptions(s2.subscriptions).toBe(sub);
+    });
   });
 
   it('should error with an errored compareTo', () => {
-    const s1 = hot('--a--^--b---c-----|');
-    const s2 = hot('--a--^--b---c---#');
-    const expected =    '-----------#';
-    const sub =         '^          !';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b---c-----|');
+      const s2 = hot('--a--^--b---c---#  ');
+      const expected = '   -----------#  ';
+      const sub = '        ^----------!  ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(sub);
-    expectSubscriptions(s2.subscriptions).toBe(sub);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(sub);
+      expectSubscriptions(s2.subscriptions).toBe(sub);
+    });
   });
 
   it('should error if the source is a throw', () => {
-    const s1 =  cold('#'); // throw
-    const s2 =  cold('---a--b--c--|');
-    const expected = '#'; // throw
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' #            ');
+      const s2 = cold(' ---a--b--c--|');
+      const expected = '#            ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected);
+      expectObservable(source).toBe(expected);
+    });
   });
 
   it('should never return if source is a never', () => {
-    const s1 =  cold('------------'); // never
-    const s2 =  cold('--a--b--c--|');
-    const expected = '------------'; // never
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' ------------');
+      const s2 = cold(' --a--b--c--|');
+      const expected = '------------';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected);
+      expectObservable(source).toBe(expected);
+    });
   });
 
   it('should never return if compareTo is a never', () => {
-    const s1 =  cold('--a--b--c--|');
-    const s2 =  cold('------------'); // never
-    const expected = '------------'; // never
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' --a--b--c--|');
+      const s2 = cold(' ------------');
+      const expected = '------------';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected);
+      expectObservable(source).toBe(expected);
+    });
   });
 
   it('should return false if source is empty and compareTo is not', () => {
-    const s1 =  cold('|'); // empty
-    const s2 =  cold('------a------');
-    const expected = '------(F|)';
-    const s1subs =   '(^!)';
-    const s2subs =   '^     !';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const s1 = cold(' |            ');
+      const s1subs = '  (^!)          ';
+      const s2 = cold(' ------a------');
+      const s2subs = '  ^-----!      ';
+      const expected = '------(F|)   ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return false if compareTo is empty and source is not', () => {
-    const s1 =  cold('------a------');
-    const s2 =  cold('|'); // empty
-    const expected = '------(F|)';
-    const s1subs =   '^     !';
-    const s2subs =   '(^!)';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const s1 = cold(' ------a------');
+      const s2 = cold(' |            ');
+      const expected = '------(F|)   ';
+      const s1subs = '  ^-----!      ';
+      const s2subs = '  (^!)         ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return never if compareTo is empty and source is never', () => {
-    const s1 = cold('-');
-    const s2 = cold('|');
-    const expected = '-';
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' -');
+      const s2 = cold(' |');
+      const expected = '-';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected);
+      expectObservable(source).toBe(expected);
+    });
   });
 
   it('should return never if source is empty and compareTo is never', () => {
-    const s1 = cold('|');
-    const s2 = cold('-');
-    const expected = '-';
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' |');
+      const s2 = cold(' -');
+      const expected = '-';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected);
+      expectObservable(source).toBe(expected);
+    });
   });
 
   it('should error if the comparator function errors', () => {
-    const s1 = hot('--a--^--b-----c------d--|');
-    const s1subs =      '^            !';
-    const s2 = hot('-----^--------x---y---z-------|');
-    const s2subs =      '^            !';
-    const expected =    '-------------#';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const values: { [key: string]: any } = {
+        a: null,
+        b: { value: 'bees knees' },
+        c: { value: 'carpy dumb' },
+        d: { value: 'derp' },
+        x: { value: 'bees knees', foo: 'lol' },
+        y: { value: 'carpy dumb', scooby: 'doo' },
+        z: { value: 'derp', weCouldBe: 'dancin, yeah' },
+      };
 
-    let i = 0;
-    const source = s1.pipe(sequenceEqual(s2, (a: any, b: any) => {
-      if (++i === 2) {
-        throw new Error('shazbot');
-      }
-      return a.value === b.value;
-    }));
+      const s1 = hot('--a--^--b-----c------d--|      ', values);
+      const s1subs = '     ^------------!            ';
+      const s2 = hot('-----^--------x---y---z-------|', values);
+      const s2subs = '     ^------------!            ';
+      const expected = '   -------------#            ';
 
-    const values: { [key: string]: any } = {
-      a: null,
-      b: { value: 'bees knees' },
-      c: { value: 'carpy dumb' },
-      d: { value: 'derp' },
-      x: { value: 'bees knees', foo: 'lol' },
-      y: { value: 'carpy dumb', scooby: 'doo' },
-      z: { value: 'derp', weCouldBe: 'dancin, yeah' }
-    };
+      let i = 0;
+      const source = s1.pipe(
+        sequenceEqual(s2, (a: any, b: any) => {
+          if (++i === 2) {
+            throw new Error('shazbot');
+          }
+          return a.value === b.value;
+        })
+      );
 
-    expectObservable(source).toBe(expected, {...booleans, ...values}, new Error('shazbot'));
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans, new Error('shazbot'));
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should use the provided comparator function', () => {
-    const s1 = hot('--a--^--b-----c------d--|');
-    const s1subs =      '^                  !';
-    const s2 = hot('-----^--------x---y---z-------|');
-    const s2subs =      '^                        !';
-    const expected =    '-------------------------(T|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const values: { [key: string]: any } = {
+        a: null,
+        b: { value: 'bees knees' },
+        c: { value: 'carpy dumb' },
+        d: { value: 'derp' },
+        x: { value: 'bees knees', foo: 'lol' },
+        y: { value: 'carpy dumb', scooby: 'doo' },
+        z: { value: 'derp', weCouldBe: 'dancin, yeah' },
+      };
 
-    const source = s1.pipe(sequenceEqual(s2, (a: any, b: any) => a.value === b.value));
+      const s1 = hot('--a--^--b-----c------d--|         ', values);
+      const s1subs = '     ^------------------!         ';
+      const s2 = hot('-----^--------x---y---z-------|   ', values);
+      const s2subs = '     ^------------------------!   ';
+      const expected = '   -------------------------(T|)';
 
-    const values: { [key: string]: any } = {
-      a: null,
-      b: { value: 'bees knees' },
-      c: { value: 'carpy dumb' },
-      d: { value: 'derp' },
-      x: { value: 'bees knees', foo: 'lol' },
-      y: { value: 'carpy dumb', scooby: 'doo' },
-      z: { value: 'derp', weCouldBe: 'dancin, yeah' }
-    };
+      const source = s1.pipe(sequenceEqual(s2, (a: any, b: any) => a.value === b.value));
 
-    expectObservable(source).toBe(expected, {...booleans, ...values});
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return false for two unequal sequences, compareTo finishing last', () => {
-    const s1 = hot('--a--^--b--c--d--e--f--g--|');
-    const s1subs =      '^                    !';
-    const s2 = hot('-----^-----b--c--d-e-f------z-|');
-    const s2subs =      '^                      !';
-    const expected =    '-----------------------(F|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b--c--d--e--f--g--|    ');
+      const s1subs = '     ^--------------------!    ';
+      const s2 = hot('-----^-----b--c--d-e-f------z-|');
+      const s2subs = '     ^----------------------!   ';
+      const expected = '   -----------------------(F|)';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return false for two unequal sequences, early wrong value from source', () => {
-    const s1 = hot('--a--^--b--c---x-----------|');
-    const s1subs =      '^         !';
-    const s2 = hot('-----^--b--c--d--e--f--|');
-    const s2subs =      '^         !';
-    const expected =    '----------(F|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b--c---x-----------|');
+      const s1subs = '     ^---------!            ';
+      const s2 = hot('-----^--b--c--d--e--f--|    ');
+      const s2subs = '     ^---------!            ';
+      const expected = '   ----------(F|)         ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return false when the source emits an extra value after the compareTo completes', () => {
-    const s1 = hot('--a--^--b--c--d--e--f--g--h--|');
-    const s1subs =      '^           !';
-    const s2 = hot('-----^--b--c--d-|');
-    const s2subs =      '^          !';
-    const expected =    '------------(F|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b--c--d--e--f--g--h--|');
+      const s1subs = '     ^-----------!            ';
+      const s2 = hot('-----^--b--c--d-|             ');
+      const s2subs = '     ^----------!             ';
+      const expected = '   ------------(F|)         ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return false when the compareTo emits an extra value after the source completes', () => {
-    const s1 = hot('--a--^--b--c--d-|');
-    const s1subs =      '^          !';
-    const s2 = hot('-----^--b--c--d--e--f--g--h--|');
-    const s2subs =      '^           !';
-    const expected =    '------------(F|)';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('--a--^--b--c--d-|             ');
+      const s1subs = '     ^----------!             ';
+      const s2 = hot('-----^--b--c--d--e--f--g--h--|');
+      const s2subs = '     ^-----------!            ';
+      const expected = '   ------------(F|)         ';
 
-    const source = s1.pipe(sequenceEqual(s2));
+      const source = s1.pipe(sequenceEqual(s2));
 
-    expectObservable(source).toBe(expected, booleans);
-    expectSubscriptions(s1.subscriptions).toBe(s1subs);
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectObservable(source).toBe(expected, booleans);
+      expectSubscriptions(s1.subscriptions).toBe(s1subs);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+    });
   });
 
   it('should return true for two empty observables', () => {
-    const s1 =  cold('|');
-    const s2 =  cold('|');
-    const expected = '(T|)';
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' |   ');
+      const s2 = cold(' |   ');
+      const expected = '(T|)';
 
-    const source = s1.pipe(sequenceEqual(s2));
-    expectObservable(source).toBe(expected, booleans);
+      const source = s1.pipe(sequenceEqual(s2));
+      expectObservable(source).toBe(expected, booleans);
+    });
   });
 
   it('should return false for an empty observable and an observable that emits', () => {
-    const s1 =  cold('|');
-    const s2 =  cold('---a--|');
-    const expected = '---(F|)';
+    rxTestScheduler.run(({ cold, expectObservable }) => {
+      const s1 = cold(' |      ');
+      const s2 = cold(' ---a--|');
+      const expected = '---(F|)';
 
-    const source = s1.pipe(sequenceEqual(s2));
-    expectObservable(source).toBe(expected, booleans);
+      const source = s1.pipe(sequenceEqual(s2));
+      expectObservable(source).toBe(expected, booleans);
+    });
   });
 
   it('should return compare hot and cold observables', () => {
-    const s1 = hot('---a--^---b---c---d---e---f---g---h---i---j---|');
-    const s2 = cold(     '----b---c-|');
-    const expected1 =    '------------(F|)';
-    const s2subs =       '^         !';
-    const delay =        '-------------------|';
-    const s3 = cold(                        '-f---g---h---i---j---|');
-    const expected2 =    '                   ---------------------(T|)';
-    const s3subs =       '                   ^                    !';
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('---a--^---b---c---d---e---f---g---h---i---j---|   ');
+      const s2 = cold('     ----b---c-|                                 ');
+      const s2subs = '      ^---------!                                 ';
+      const expected1 = '   ------------(F|)                            ';
+      const s3 = cold('                        -f---g---h---i---j---|   ');
+      const test2subs = '   -------------------^                        ';
+      const expected2 = '   ----------------------------------------(T|)';
+      const s3subs = '      -------------------^--------------------!   ';
 
-    const test1 = s1.pipe(sequenceEqual(s2));
-    const test2 = s1.pipe(sequenceEqual(s3));
+      const test1 = s1.pipe(sequenceEqual(s2));
+      const test2 = s1.pipe(sequenceEqual(s3));
 
-    expectObservable(test1).toBe(expected1, booleans);
-    rxTestScheduler.schedule(() => expectObservable(test2).toBe(expected2, booleans), time(delay));
-    expectSubscriptions(s2.subscriptions).toBe(s2subs);
-    expectSubscriptions(s3.subscriptions).toBe(s3subs);
+      expectObservable(test1).toBe(expected1, booleans);
+      expectObservable(test2, test2subs).toBe(expected2, booleans);
+      expectSubscriptions(s2.subscriptions).toBe(s2subs);
+      expectSubscriptions(s3.subscriptions).toBe(s3subs);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `sequenceEqual` tests to run mode. There are two more things that i believe where not correct which are also adressed in this PR.
* Two of the tests are using `values` instead of the default string values. They where defined however not used with the correct marble source.
* The same tests where modifying the `booleans` constant by using `_.assign`. This side effect was removed.

I also had to modify the last test in the test file from a subscription within `scheduler.schedule` to subscription marbles. While I believe that this change is semantically equal I am not totally sure if that is the case.

**Related issue (if exists):**
None
