### PR TITLE
chore(scan): convert scan tests to run mode

### DIFF
--- a/spec/operators/scan-spec.ts
+++ b/spec/operators/scan-spec.ts
@@ -1,243 +1,281 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { scan, mergeMap, finalize, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {scan} */
-describe('scan operator', () => {
+describe('scan', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should scan', () => {
-    const values = {
-      a: 1, b: 3, c: 5,
-      x: 1, y: 4, z: 9
-    };
-    const e1 =     hot('--a--b--c--|', values);
-    const e1subs =     '^          !';
-    const expected =   '--x--y--z--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      // prettier-ignore
+      const values = {
+        a: 1, b: 3, c: 5,
+        x: 1, y: 4, z: 9,
+      };
+      const e1 = hot('  --a--b--c--|', values);
+      const e1subs = '  ^----------!';
+      const expected = '--x--y--z--|';
 
-    const scanFunction = function (o: number, x: number) {
-      return o + x;
-    };
+      const scanFunction = function (o: number, x: number) {
+        return o + x;
+      };
 
-    expectObservable(e1.pipe(scan(scanFunction, 0))).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(scan(scanFunction, 0))).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should scan things', () => {
-    const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const e1subs =      '^                    !';
-    const expected =    '---u--v--w--x--y--z--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--d--e--f--g--|');
+      const e1subs = '     ^--------------------!';
+      const expected = '   ---u--v--w--x--y--z--|';
 
-    const values = {
-      u: ['b'],
-      v: ['b', 'c'],
-      w: ['b', 'c', 'd'],
-      x: ['b', 'c', 'd', 'e'],
-      y: ['b', 'c', 'd', 'e', 'f'],
-      z: ['b', 'c', 'd', 'e', 'f', 'g']
-    };
+      const values = {
+        u: ['b'],
+        v: ['b', 'c'],
+        w: ['b', 'c', 'd'],
+        x: ['b', 'c', 'd', 'e'],
+        y: ['b', 'c', 'd', 'e', 'f'],
+        z: ['b', 'c', 'd', 'e', 'f', 'g'],
+      };
 
-    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
+      const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
-    expectObservable(source).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should provide the proper index if seed is skipped', () => {
     const expected = [1, 2];
-    of(3, 3, 3).pipe(
-      scan((_: any, __, i) => {
-        expect(i).to.equal(expected.shift());
-        return null;
-      })
-    ).subscribe();
+    of(3, 3, 3)
+      .pipe(
+        scan((_: any, __, i) => {
+          expect(i).to.equal(expected.shift());
+          return null;
+        })
+      )
+      .subscribe();
   });
 
   it('should scan with a seed of undefined', () => {
-    const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const e1subs =      '^                    !';
-    const expected =    '---u--v--w--x--y--z--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--d--e--f--g--|');
+      const e1subs = '     ^--------------------!';
+      const expected = '   ---u--v--w--x--y--z--|';
 
-    const values = {
-      u: 'undefined b',
-      v: 'undefined b c',
-      w: 'undefined b c d',
-      x: 'undefined b c d e',
-      y: 'undefined b c d e f',
-      z: 'undefined b c d e f g'
-    };
+      const values = {
+        u: 'undefined b',
+        v: 'undefined b c',
+        w: 'undefined b c d',
+        x: 'undefined b c d e',
+        y: 'undefined b c d e f',
+        z: 'undefined b c d e f g',
+      };
 
-    const source = e1.pipe(scan((acc: any, x: string) => acc + ' ' + x, undefined));
+      const source = e1.pipe(scan((acc: any, x: string) => acc + ' ' + x, undefined));
 
-    expectObservable(source).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should scan without seed', () => {
-    const e1 = hot('--a--^--b--c--d--|');
-    const e1subs =      '^           !';
-    const expected =    '---x--y--z--|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--d--|');
+      const e1subs = '     ^-----------!';
+      const expected = '   ---x--y--z--|';
 
-    const values = {
-      x: 'b',
-      y: 'bc',
-      z: 'bcd'
-    };
+      const values = {
+        x: 'b',
+        y: 'bc',
+        z: 'bcd',
+      };
 
-    const source = e1.pipe(scan((acc: any, x: string) => acc + x));
+      const source = e1.pipe(scan((acc: any, x: string) => acc + x));
 
-    expectObservable(source).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle errors', () => {
-    const e1 = hot('--a--^--b--c--d--#');
-    const e1subs =      '^           !';
-    const expected =    '---u--v--w--#';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--d--#');
+      const e1subs = '     ^-----------!';
+      const expected = '   ---u--v--w--#';
 
-    const values = {
-      u: ['b'],
-      v: ['b', 'c'],
-      w: ['b', 'c', 'd']
-    };
+      const values = {
+        u: ['b'],
+        v: ['b', 'c'],
+        w: ['b', 'c', 'd'],
+      };
 
-    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
+      const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
-    expectObservable(source).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should handle errors in the projection function', () => {
-    const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const e1subs =      '^        !            ';
-    const expected =    '---u--v--#            ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--d--e--f--g--|');
+      const e1subs = '     ^--------!            ';
+      const expected = '   ---u--v--#            ';
 
-    const values = {
-      u: ['b'],
-      v: ['b', 'c'],
-      w: ['b', 'c', 'd'],
-      x: ['b', 'c', 'd', 'e'],
-      y: ['b', 'c', 'd', 'e', 'f'],
-      z: ['b', 'c', 'd', 'e', 'f', 'g']
-    };
+      const values = {
+        u: ['b'],
+        v: ['b', 'c'],
+        w: ['b', 'c', 'd'],
+        x: ['b', 'c', 'd', 'e'],
+        y: ['b', 'c', 'd', 'e', 'f'],
+        z: ['b', 'c', 'd', 'e', 'f', 'g'],
+      };
 
-    const source = e1.pipe(scan((acc, x) => {
-      if (x === 'd') {
-        throw 'bad!';
-      }
-      return acc.concat(x);
-    }, [] as string[]));
+      const source = e1.pipe(
+        scan((acc, x) => {
+          if (x === 'd') {
+            throw 'bad!';
+          }
+          return acc.concat(x);
+        }, [] as string[])
+      );
 
-    expectObservable(source).toBe(expected, values, 'bad!');
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected, values, 'bad!');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('handle empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '|   ';
 
-    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
+      const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('handle never', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
+      const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('handle throw', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
+      const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const unsub =       '              !       ';
-    const e1subs =      '^             !       ';
-    const expected =    '---u--v--w--x--       ';
-    const values = {
-      u: ['b'],
-      v: ['b', 'c'],
-      w: ['b', 'c', 'd'],
-      x: ['b', 'c', 'd', 'e'],
-      y: ['b', 'c', 'd', 'e', 'f'],
-      z: ['b', 'c', 'd', 'e', 'f', 'g']
-    };
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--d--e--f--g--|');
+      const unsub = '      --------------!       ';
+      const e1subs = '     ^-------------!       ';
+      const expected = '   ---u--v--w--x--       ';
+      const values = {
+        u: ['b'],
+        v: ['b', 'c'],
+        w: ['b', 'c', 'd'],
+        x: ['b', 'c', 'd', 'e'],
+        y: ['b', 'c', 'd', 'e', 'f'],
+        z: ['b', 'c', 'd', 'e', 'f', 'g'],
+      };
 
-    const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
+      const source = e1.pipe(scan((acc, x) => acc.concat(x), [] as string[]));
 
-    expectObservable(source, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 = hot('--a--^--b--c--d--e--f--g--|');
-    const e1subs =      '^             !       ';
-    const expected =    '---u--v--w--x--       ';
-    const unsub =       '              !       ';
-    const values = {
-      u: ['b'],
-      v: ['b', 'c'],
-      w: ['b', 'c', 'd'],
-      x: ['b', 'c', 'd', 'e'],
-      y: ['b', 'c', 'd', 'e', 'f'],
-      z: ['b', 'c', 'd', 'e', 'f', 'g']
-    };
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--d--e--f--g--|');
+      const e1subs = '     ^-------------!       ';
+      const expected = '   ---u--v--w--x--       ';
+      const unsub = '      --------------!       ';
+      const values = {
+        u: ['b'],
+        v: ['b', 'c'],
+        w: ['b', 'c', 'd'],
+        x: ['b', 'c', 'd', 'e'],
+        y: ['b', 'c', 'd', 'e', 'f'],
+        z: ['b', 'c', 'd', 'e', 'f', 'g'],
+      };
 
-    const source = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      scan((acc, x) => acc.concat(x), [] as string[]),
-      mergeMap((x: string[]) => of(x))
-    );
+      const source = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        scan((acc, x) => acc.concat(x), [] as string[]),
+        mergeMap((x: string[]) => of(x))
+      );
 
-    expectObservable(source, unsub).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should pass current index to accumulator', () => {
-    const values = {
-      a: 1, b: 3, c: 5,
-      x: 1, y: 4, z: 9
-    };
-    let idx = [0, 1, 2];
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      // prettier-ignore
+      const values = {
+        a: 1, b: 3, c: 5,
+        x: 1, y: 4, z: 9,
+      };
+      let idx = [0, 1, 2];
 
-    const e1 =     hot('--a--b--c--|', values);
-    const e1subs =     '^          !';
-    const expected =   '--x--y--z--|';
+      const e1 = hot('  --a--b--c--|', values);
+      const e1subs = '  ^----------!';
+      const expected = '--x--y--z--|';
 
-    const scanFunction = (o: number, value: number, index: number) => {
-      expect(index).to.equal(idx.shift());
-      return o + value;
-    };
+      const scanFunction = (o: number, value: number, index: number) => {
+        expect(index).to.equal(idx.shift());
+        return o + value;
+      };
 
-    const scanObs = e1.pipe(
-      scan(scanFunction, 0),
-      finalize(() => {
-        expect(idx).to.be.empty;
-      })
-    );
+      const scanObs = e1.pipe(
+        scan(scanFunction, 0),
+        finalize(() => {
+          expect(idx).to.be.empty;
+        })
+      );
 
-    expectObservable(scanObs).toBe(expected, values);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(scanObs).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -246,10 +284,14 @@ describe('scan operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      scan((acc, value: number) => value, 0),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable
+      .pipe(
+        scan((_acc, value: number) => value, 0),
+        take(3)
+      )
+      .subscribe(() => {
+        /* noop */
+      });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `scan` tests to run mode.

**Related issue (if exists):**
None
