### PR TITLE
chore(sampleTime): convert sampleTime tests to run mode

### DIFF
--- a/spec/operators/sampleTime-spec.ts
+++ b/spec/operators/sampleTime-spec.ts
@@ -1,114 +1,150 @@
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+/** @prettier */
 import { sampleTime, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of } from 'rxjs';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {sampleTime} */
-describe('sampleTime operator', () => {
-  it('should get samples on a delay', () => {
-    const e1 =   hot('a---b-c---------d--e---f-g-h--|');
-    const e1subs =   '^                             !';
-    const expected = '-------c-------------e------h-|';
-    // timer          -------!------!------!------!--
+describe('sampleTime', () => {
+  let rxTest: TestScheduler;
 
-    expectObservable(e1.pipe(sampleTime(70, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
+  it('should get samples on a delay', () => {
+    rxTest.run(({ hot, expectObservable, expectSubscriptions, time }) => {
+      const e1 = hot('     a---b-c---------d--e---f-g-h--|');
+      const e1subs = '     ^-----------------------------!';
+      const expected = '   -------c-------------e------h-|';
+      // period            -------!------!------!------!--
+      const period = time('-------|                       ');
+
+      expectObservable(e1.pipe(sampleTime(period, rxTest))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should sample nothing if new value has not arrived', () => {
-    const e1 =   hot('----a-^--b----c--------------f----|');
-    const e1subs =         '^                           !';
-    const expected =       '-----------c----------------|';
-    // timer              -----------!----------!---------
+    rxTest.run(({ hot, expectObservable, expectSubscriptions, time }) => {
+      const e1 = hot('  ----a-^--b----c--------------f----|');
+      const e1subs = '        ^---------------------------!';
+      const expected = '      -----------c----------------|';
+      // period               -----------!----------!---------
+      const period = time('   -----------|                 ');
 
-    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should sample if new value has arrived, even if it is the same value', () => {
-    const e1 =   hot('----a-^--b----c----------c---f----|');
-    const e1subs =         '^                           !';
-    const expected =       '-----------c----------c-----|';
-    // timer              -----------!----------!---------
+    rxTest.run(({ hot, expectObservable, expectSubscriptions, time }) => {
+      const e1 = hot('----a-^--b----c----------c---f----|');
+      const e1subs = '      ^---------------------------!';
+      const expected = '    -----------c----------c-----|';
+      // period             -----------!----------!---------
+      const period = time(' -----------|                 ');
 
-    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should sample nothing if source has not nexted by time of sample', () => {
-    const e1 =   hot('----a-^-------------b-------------|');
-    const e1subs =         '^                           !';
-    const expected =       '----------------------b-----|';
-    // timer              -----------!----------!---------
+    rxTest.run(({ hot, expectObservable, expectSubscriptions, time }) => {
+      const e1 = hot('----a-^-------------b-------------|');
+      const e1subs = '      ^---------------------------!';
+      const expected = '    ----------------------b-----|';
+      // period             -----------!----------!---------
+      const period = time(' -----------|                 ');
 
-    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raise error if source raises error', () => {
-    const e1 =   hot('----a-^--b----c----d----#');
-    const e1subs =         '^                 !';
-    const expected =       '-----------c------#';
-    // timer              -----------!----------!---------
+    rxTest.run(({ hot, expectObservable, expectSubscriptions, time }) => {
+      const e1 = hot('----a-^--b----c----d----#');
+      const e1subs = '      ^-----------------!';
+      const expected = '    -----------c------#';
+      // period             -----------!----------!---------
+      const period = time(' -----------|       ');
 
-    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const e1 =   hot('----a-^--b----c----d----e----f----|');
-    const unsub =          '                !            ';
-    const e1subs =         '^               !            ';
-    const expected =       '-----------c-----            ';
-    // timer              -----------!----------!---------
+    rxTest.run(({ hot, expectObservable, expectSubscriptions, time }) => {
+      const e1 = hot('----a-^--b----c----d----e----f----|');
+      const unsub = '       ----------------!            ';
+      const e1subs = '      ^---------------!            ';
+      const expected = '    -----------c-----            ';
+      // period             -----------!----------!---------
+      const period = time(' -----------|                 ');
 
-    expectObservable(e1.pipe(sampleTime(110, rxTestScheduler)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest)), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const e1 =   hot('----a-^--b----c----d----e----f----|');
-    const e1subs =         '^               !            ';
-    // timer              -----------!----------!---------
-    const expected =       '-----------c-----            ';
-    const unsub =          '                !            ';
+    rxTest.run(({ hot, expectObservable, expectSubscriptions, time }) => {
+      const e1 = hot('----a-^--b----c----d----e----f----|');
+      const e1subs = '      ^---------------!            ';
+      // period             -----------!----------!---------
+      const period = time(' -----------|                 ');
+      const expected = '    -----------c-----            ';
+      const unsub = '       ----------------!            ';
 
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      sampleTime(110, rxTestScheduler),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        sampleTime(period, rxTest),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should completes if source does not emits', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions, time }) => {
+      const e1 = cold('    |     ');
+      const e1subs = '     (^!)  ';
+      const expected = '   |     ';
+      const period = time('-----|');
 
-    expectObservable(e1.pipe(sampleTime(60, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raise error if source throws immediately', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions, time }) => {
+      const e1 = cold('    #     ');
+      const e1subs = '     (^!)  ';
+      const expected = '   #     ';
+      const period = time('-----|');
 
-    expectObservable(e1.pipe(sampleTime(60, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
-  it('should not completes if source does not complete', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+  it('should not complete if source does not complete', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions, time }) => {
+      const e1 = cold('    --------');
+      const e1subs = '     ^------!';
+      const expected = '   --------';
+      const period = time('-----|  ');
+      const e1unsbs = '    -------!';
 
-    expectObservable(e1.pipe(sampleTime(60, rxTestScheduler))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(sampleTime(period, rxTest)), e1unsbs).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `sampleTime` tests to run mode.

I did encounter an issue with the `never` test. It seems that in run mode there is no maximum frame count, so I had to add an explicit unsubscription to the expectation.

**Related issue (if exists):**
None