### PR TITLE
fix(Subscription): null _parentage on unsubscribe

### DIFF
--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -56,6 +56,7 @@ export class Subscription implements SubscriptionLike {
 
       // Remove this from it's parents.
       const { _parentage } = this;
+      this._parentage = null;
       if (Array.isArray(_parentage)) {
         for (const parent of _parentage) {
           parent.remove(this);

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -56,13 +56,15 @@ export class Subscription implements SubscriptionLike {
 
       // Remove this from it's parents.
       const { _parentage } = this;
-      this._parentage = null;
-      if (Array.isArray(_parentage)) {
-        for (const parent of _parentage) {
-          parent.remove(this);
+      if (_parentage) {
+        this._parentage = null;
+        if (Array.isArray(_parentage)) {
+          for (const parent of _parentage) {
+            parent.remove(this);
+          }
+        } else {
+          _parentage.remove(this);
         }
-      } else {
-        _parentage?.remove(this);
       }
 
       const { initialTeardown } = this;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixed the bug reported in #6351 by nulling `this._parentage` before the array is iterated. This was an oversight. It should have been nulled as is `this._teardowns`, immediately after it is destructured:

https://github.com/ReactiveX/rxjs/blob/7b30546717ab8bb271217064318ef9e0c0c40ecc/src/internal/Subscription.ts#L76-L78

If `this._parentage` is not nulled, it's mutated as it's iterated and parents can be left holding onto child subscriptions that have been closed.

The PR also adds - in a separate commit - an `if` statement around the handling of `_parentage`, so that the implementation is more like what's done with `_teardowns`. If there's some reason for not using the `if` statement, we can just revert that commit.

**Related issue (if exists):** #6351
