### PR TITLE
fix: Observable teardowns now properly called if `useDeprecatedSynchronousErrorHandling` is `true`.

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -810,6 +810,24 @@ describe('Observable', () => {
         }).not.to.throw();
       });
 
+      it('should call teardown if sync unsubscribed', () => {
+        let called = false;
+        const observable = new Observable(() => () => (called = true));
+        const subscription = observable.subscribe();
+        subscription.unsubscribe();
+
+        expect(called).to.be.true;
+      });
+
+      it('should call registered teardowns if sync unsubscribed', () => {
+        let called = false;
+        const observable = new Observable((subscriber) => subscriber.add(() => called = true));
+        const subscription = observable.subscribe();
+        subscription.unsubscribe();
+
+        expect(called).to.be.true;
+      });
+
       afterEach(() => {
         config.useDeprecatedSynchronousErrorHandling = false;
       });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -252,7 +252,7 @@ export class Observable<T> implements Subscribable<T> {
       subscriber.add(operator.call(subscriber, this.source));
     } else {
       try {
-        this._subscribe(subscriber);
+        subscriber.add(this._subscribe(subscriber));
       } catch (err) {
         localSubscriber.__syncError = err;
       }


### PR DESCRIPTION
Resolves an issue where teardowns returned by the Observable initializer were not being registered with the subscriber.

Fixes #6364


cc @leggechr 