### PR TITLE
fix(share): propagate closed to firehose sources

### DIFF
--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -821,47 +821,4 @@ describe('multicast', () => {
         );
     });
   });
-
-  // TODO: fix firehose unsubscription
-  // AFAICT, it's not possible for multicast observables to support ASAP
-  // unsubscription from synchronous firehose sources. The problem is that the
-  // chaining of the closed 'signal' is broken by the subject. For example,
-  // here:
-  //
-  // https://github.com/ReactiveX/rxjs/blob/2d5e4d5bd7b684a912485e1c1583ba3d41c8308e/src/internal/operators/multicast.ts#L53
-  //
-  // The subject is passed to subscribe. However, in the subscribe
-  // implementation a SafeSubscriber is created with the subject as the
-  // observer:
-  //
-  // https://github.com/ReactiveX/rxjs/blob/2d5e4d5bd7b684a912485e1c1583ba3d41c8308e/src/internal/Observable.ts#L210
-  //
-  // That breaks the chaining of closed - i.e. even if the unsubscribe is
-  // called on the subject, closing it, the SafeSubscriber's closed property
-  // won't reflect that.
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
-    const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>((subscriber) => {
-      // This will check to see if the subscriber was closed on each loop
-      // when the unsubscribe hits (from the `take`), it should be closed
-      for (let i = 0; !subscriber.closed && i < 10; i++) {
-        sideEffects.push(i);
-        subscriber.next(i);
-      }
-    });
-
-    synchronousObservable
-      .pipe(
-        multicast(
-          () => new Subject<number>(),
-          (source) => source
-        ),
-        take(3)
-      )
-      .subscribe(() => {
-        /* noop */
-      });
-
-    expect(sideEffects).to.deep.equal([0, 1, 2]);
-  });
 });

--- a/spec/operators/refCount-spec.ts
+++ b/spec/operators/refCount-spec.ts
@@ -114,25 +114,4 @@ describe('refCount', () => {
     expect(arr[0]).to.equal('the number one');
     expect(arr[1]).to.equal('the number two');
   });
-
-  // TODO: fix firehose unsubscription
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
-    const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
-      // This will check to see if the subscriber was closed on each loop
-      // when the unsubscribe hits (from the `take`), it should be closed
-      for (let i = 0; !subscriber.closed && i < 10; i++) {
-        sideEffects.push(i);
-        subscriber.next(i);
-      }
-    });
-
-    synchronousObservable.pipe(
-      multicast(() => new Subject<number>()),
-      refCount(),
-      take(3),
-    ).subscribe(() => { /* noop */ });
-
-    expect(sideEffects).to.deep.equal([0, 1, 2]);
-  });
 });

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -427,8 +427,7 @@ describe('share', () => {
       });
     });
 
-    // TODO: fix firehose unsubscription
-    it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
+    it('should stop listening to a synchronous observable when unsubscribed', () => {
       const sideEffects: number[] = [];
       const synchronousObservable = new Observable<number>((subscriber) => {
         // This will check to see if the subscriber was closed on each loop

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -347,25 +347,6 @@ describe('shareReplay', () => {
     });
   });
 
-  // TODO: fix firehose unsubscription
-  it.skip('should stop listening to a synchronous observable when unsubscribed', () => {
-    const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>((subscriber) => {
-      // This will check to see if the subscriber was closed on each loop
-      // when the unsubscribe hits (from the `take`), it should be closed
-      for (let i = 0; !subscriber.closed && i < 10; i++) {
-        sideEffects.push(i);
-        subscriber.next(i);
-      }
-    });
-
-    synchronousObservable.pipe(shareReplay(), take(3)).subscribe(() => {
-      /* noop */
-    });
-
-    expect(sideEffects).to.deep.equal([0, 1, 2]);
-  });
-
   const FinalizationRegistry = (global as any).FinalizationRegistry;
   if (FinalizationRegistry) {
     it('should not leak the subscriber for sync sources', (done) => {

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -112,10 +112,6 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
     // Create the subject if we don't have one yet.
     subject = subject ?? connector();
 
-    // The following line adds the subscription to the subscriber passed.
-    // Basically, `subscriber === subject.subscribe(subscriber)` is `true`.
-    subject.subscribe(subscriber);
-
     // Add the teardown directly to the subscriber - instead of returning it -
     // so that the handling of the subscriber's unsubscription will be wired
     // up _before_ the subscription to the source occurs. This is done so that
@@ -135,6 +131,10 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
         conn?.unsubscribe();
       }
     });
+
+    // The following line adds the subscription to the subscriber passed.
+    // Basically, `subscriber === subject.subscribe(subscriber)` is `true`.
+    subject.subscribe(subscriber);
 
     if (!connection) {
       // We need to create a subscriber here - rather than pass an observer and

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -115,6 +115,12 @@ export function share<T>(options?: ShareConfig<T>): OperatorFunction<T, T> {
     // The following line adds the subscription to the subscriber passed.
     // Basically, `subscriber === subject.subscribe(subscriber)` is `true`.
     subject.subscribe(subscriber);
+
+    // Add the teardown directly to the subscriber - instead of returning it -
+    // so that the handling of the subscriber's unsubscription will be wired
+    // up _before_ the subscription to the source occurs. This is done so that
+    // the assignment to the source connection's `closed` property will be seen
+    // by synchronous firehose sources.
     subscriber.add(() => {
       refCount--;
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR fixes `share` so that it wires up the teardown _before_ subscribing to the source - ensuring the assignment to the subscriber's `closed` property is propagated to the firehose source.

The skipped firehose test has been enabled and the firehose tests that related to now-deprecated operators have been removed.

**Related issue (if exists):** #5834 (I've closed this because it related to the now-deprecated APIs)