### PR TITLE
build(package): support internal subpath import

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -106,6 +106,10 @@
         "hot": true,
         "cold": true
     },
+    "parserOptions": {
+        "sourceType": "module",
+        "ecmaVersion": 2015
+    },
     "env": {
         "browser": true,
         "node": true,

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ spec-build/
 npm-debug.log
 .DS_STORE
 *.tgz
+.eslintcache
 
 integration/import/**/rx.json
 integration/import/**/operators.json

--- a/integration/import/fixtures/commonjs/index.js
+++ b/integration/import/fixtures/commonjs/index.js
@@ -6,8 +6,11 @@ const operators = require('rxjs/operators');
 const rxSnapshot = require('./rx.json');
 const operatorsSnapshot = require('./operators.json');
 
+const coldObservalbe = require('rxjs/internal/testing/ColdObservable');
+
 assert.ok(rx, 'main export should exists');
 assert.ok(operators, 'operator export should exists');
+assert.ok(coldObservalbe, 'internal can be imported');
 
 assert.deepStrictEqual(Object.keys(rx).sort(), rxSnapshot.sort(), 'main export should include exports');
 assert.deepStrictEqual(Object.keys(operators).sort(), operatorsSnapshot.sort(), 'operator export should include exports');

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
   "types": "index.d.ts",
   "typesVersions": {
     ">=4.2": {
-      "*": ["dist/types/*"]
+      "*": [
+        "dist/types/*"
+      ]
     }
   },
   "sideEffects": false,
@@ -36,6 +38,10 @@
     "./webSocket": {
       "node": "./dist/cjs/webSocket/index.js",
       "default": "./dist/esm5/webSocket/index.js"
+    },
+    "./internal/*": {
+      "node": "./dist/cjs/internal/*.js",
+      "default": "./dist/esm5/internal/*.js"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR re-enables subpath import under `internal` in v7. 

Previously subpath import was not restricted in v6. With change of import maps node.js only allows explicitly exposed subpath import, ends up any subpath import to `internal` is prohibited. This is not a breaking change techinically - we never officially supported internal subpath and never will. But for some cases, user have usecases with `at your own risk` and this PR will allow it again.

**Related issue (if exists):**
