### PR TITLE
test: add thisArg deprecation tests

### DIFF
--- a/spec-dtslint/observables/partition-spec.ts
+++ b/spec-dtslint/observables/partition-spec.ts
@@ -46,3 +46,10 @@ it('should support this with predicate', () => {
     return val < limit;
   }, thisArg);
 });
+
+it('should deprecate thisArg usage', () => {
+  const a = partition(of(1, 2, 3), Boolean); // $ExpectNoDeprecation
+  const b = partition(of(1, 2, 3), Boolean, {}); // $ExpectDeprecation
+  const c = partition(of(1, 2, 3), (value) => Boolean(value)); // $ExpectNoDeprecation
+  const d = partition(of(1, 2, 3), (value) => Boolean(value), {}); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/every-spec.ts
+++ b/spec-dtslint/operators/every-spec.ts
@@ -52,3 +52,10 @@ it('should support this', () => {
     return val < limit;
   }, thisArg));
 });
+
+it('should deprecate thisArg usage', () => {
+  const a = of(1, 2, 3).pipe(every(Boolean)); // $ExpectNoDeprecation
+  const b = of(1, 2, 3).pipe(every(Boolean, {})); // $ExpectDeprecation
+  const c = of(1, 2, 3).pipe(every((value) => Boolean(value))); // $ExpectNoDeprecation
+  const d = of(1, 2, 3).pipe(every((value) => Boolean(value), {})); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/filter-spec.ts
+++ b/spec-dtslint/operators/filter-spec.ts
@@ -91,3 +91,10 @@ it('should support this', () => {
     return val < limit;
   }, thisArg));
 });
+
+it('should deprecate thisArg usage', () => {
+  const a = of(1, 2, 3).pipe(filter(Boolean)); // $ExpectNoDeprecation
+  const b = of(1, 2, 3).pipe(filter(Boolean, {})); // $ExpectDeprecation
+  const c = of(1, 2, 3).pipe(filter((value) => Boolean(value))); // $ExpectNoDeprecation
+  const d = of(1, 2, 3).pipe(filter((value) => Boolean(value), {})); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/find-spec.ts
+++ b/spec-dtslint/operators/find-spec.ts
@@ -41,3 +41,10 @@ it('should support this', () => {
     return val < wanted;
   }, thisArg));
 });
+
+it('should deprecate thisArg usage', () => {
+  const a = of(1, 2, 3).pipe(find(Boolean)); // $ExpectNoDeprecation
+  const b = of(1, 2, 3).pipe(find(Boolean, {})); // $ExpectDeprecation
+  const c = of(1, 2, 3).pipe(find((value) => Boolean(value))); // $ExpectNoDeprecation
+  const d = of(1, 2, 3).pipe(find((value) => Boolean(value), {})); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/findIndex-spec.ts
+++ b/spec-dtslint/operators/findIndex-spec.ts
@@ -50,3 +50,10 @@ it('should support this', () => {
     return val < wanted;
   }, thisArg));
 });
+
+it('should deprecate thisArg usage', () => {
+  const a = of(1, 2, 3).pipe(findIndex(Boolean)); // $ExpectNoDeprecation
+  const b = of(1, 2, 3).pipe(findIndex(Boolean, {})); // $ExpectDeprecation
+  const c = of(1, 2, 3).pipe(findIndex((value) => Boolean(value))); // $ExpectNoDeprecation
+  const d = of(1, 2, 3).pipe(findIndex((value) => Boolean(value), {})); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/map-spec.ts
+++ b/spec-dtslint/operators/map-spec.ts
@@ -33,3 +33,8 @@ it('should support this', () => {
     return val < limit ? val : limit;
   }, thisArg));
 });
+
+it('should deprecate thisArg usage', () => {
+  const a = of(1, 2, 3).pipe(map((value) => value)); // $ExpectNoDeprecation
+  const b = of(1, 2, 3).pipe(map((value) => value, {})); // $ExpectDeprecation
+});


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds dtslint tests for the `thisArg` deprecations that were added in #6361.

**Related issue (if exists):** #6361
