### PR TITLE
docs: add deprecation notes to documentation pages

### DIFF
--- a/docs_app/src/styles/2-modules/_api-pages.scss
+++ b/docs_app/src/styles/2-modules/_api-pages.scss
@@ -106,3 +106,8 @@
     color: $pink;
   }
 }
+
+
+.deprecated-api-item {
+  text-decoration: line-through;
+}

--- a/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
@@ -11,15 +11,15 @@
 
 {%- macro renderMembers(doc) -%}
   {%- for member in doc.staticProperties %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
   {% for member in doc.staticMethods %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
   {% if doc.constructorDoc and not doc.constructorDoc.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ doc.constructorDoc.anchor | urlencode $}">{$ renderMemberSyntax(doc.constructorDoc, 1) $}</a>{% endif -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ doc.constructorDoc.anchor | urlencode $}">{$ renderMemberSyntax(doc.constructorDoc, 1) $}</a>{% endif -%}
   {% for member in doc.properties %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
   {% for member in doc.methods %}{% if not member.internal %}
-  <a class="code-anchor" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
+  <a class="code-anchor{% if member.deprecated %} deprecated-api-item{% endif %}" href="{$ doc.path $}#{$ member.anchor | urlencode $}">{$ renderMemberSyntax(member, 1) $}</a>{% endif %}{% endfor -%}
 
   {%- for ancestor in doc.extendsClauses %}{% if ancestor.doc %}
 
@@ -39,11 +39,16 @@
 
 {%- macro renderOverloadInfo(overload, cssClass, method) -%}
 
-<code-example language="ts" hideCopy="true" class="no-box api-heading">{$ renderMemberSyntax(overload) $}</code-example>
+<code-example language="ts" hideCopy="true" class="no-box api-heading{% if overload.deprecated %} deprecated-api-item{% endif %}">{$ renderMemberSyntax(overload) $}</code-example>
 
 {% if overload.shortDescription and (overload.shortDescription != method.shortDescription) %}
 <div class="short-description">
   {$ overload.shortDescription | marked $}
+</div>{% endif %}
+{% if overload.deprecated !== undefined %}
+<div class="deprecated">
+  <h4>Deprecation Notes</h4>
+  {$ overload.deprecated | marked $}
 </div>{% endif %}
 
 <h4 class="no-anchor">Parameters</h4>
@@ -147,7 +152,7 @@
     <tbody>
     {% for property in nonInternalProperties %}
       <tr class="{$ propertyClass $}">
-        <td><a id="{$ property.anchor $}"></a>{$ property.name $}</td>
+        <td><a id="{$ property.anchor $}"></a><code class="{% if property.deprecated %} deprecated-api-item{% endif %}">{$ property.name $}</code></td>
         <td><label class="property-type-label"><code>{$ property.type | escape $}</code></label></td>
         <td>
           {%- if (property.isGetAccessor or property.isReadonly) and not property.isSetAccessor %}<span class='read-only-property'>Read-only.</span>{% endif %}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR adds deprecation notes to the documentation for single method and function overrides. Additionally a strikethrough is also added to the method signature. The source of the changes was the angular.io project, although only the pieces necessary for the deprecations where included.

There are still some places that are a little odd:
* if all function overloads are deprecated, the deprecation note is shown for the function and all of its overloads
* if all function overloads are marked as deprecated the function is *not* marked with a deprecated badge
* the deprecation notes contain literal links to http://rxjs.dev/... Their purpose is probalby to accomodate IDEs to show the correct link

I am planing on working on some of the issues above in follow up PRs to keep this one simple as I think that this PR already adds value to the documentation.

**Examples:**
`toPromise` method
![grafik](https://user-images.githubusercontent.com/1596276/117467175-bd6b3c00-af53-11eb-91d0-c5331bee0ff7.png)
![grafik](https://user-images.githubusercontent.com/1596276/117467252-ce1bb200-af53-11eb-90d2-ac9276b1eaeb.png)

`pluck` function
![grafik](https://user-images.githubusercontent.com/1596276/117467396-f0153480-af53-11eb-9e63-d20d77ed85a6.png)
![grafik](https://user-images.githubusercontent.com/1596276/117467463-00c5aa80-af54-11eb-9a32-eb415ae9556b.png)

`publishReplay` function
![grafik](https://user-images.githubusercontent.com/1596276/117467583-1c30b580-af54-11eb-83e1-37dd0db60deb.png)
![grafik](https://user-images.githubusercontent.com/1596276/117467636-28b50e00-af54-11eb-9c9f-5dc5d8cc3a54.png)


**Related issue (if exists):**
#5404