### PR TITLE
docs: fix broken links in documentation

### DIFF
--- a/src/internal/Notification.ts
+++ b/src/internal/Notification.ts
@@ -44,7 +44,7 @@ export class Notification<T> {
    * Creates a "Next" notification object.
    * @param kind Always `'N'`
    * @param value The value to notify with if observed.
-   * @deprecated Internal implementation detail. Use {@link createNext} instead.
+   * @deprecated Internal implementation detail. Use {@link Notification#createNext createNext} instead.
    */
   constructor(kind: 'N', value?: T);
   /**
@@ -52,13 +52,13 @@ export class Notification<T> {
    * @param kind Always `'E'`
    * @param value Always `undefined`
    * @param error The error to notify with if observed.
-   * @deprecated Internal implementation detail. Use {@link createError} instead.
+   * @deprecated Internal implementation detail. Use {@link Notification#createError createError} instead.
    */
   constructor(kind: 'E', value: undefined, error: any);
   /**
    * Creates a "completion" notification object.
    * @param kind Always `'C'`
-   * @deprecated Internal implementation detail. Use {@link createComplete} instead.
+   * @deprecated Internal implementation detail. Use {@link Notification#createComplete createComplete} instead.
    */
   constructor(kind: 'C');
   constructor(public readonly kind: 'N' | 'E' | 'C', public readonly value?: T, public readonly error?: any) {
@@ -82,7 +82,7 @@ export class Notification<T> {
    * @param next A next handler
    * @param error An error handler
    * @param complete A complete handler
-   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
+   * @deprecated Replaced with {@link Notification#observe observe}. Will be removed in v8.
    */
   do(next: (value: T) => void, error: (err: any) => void, complete: () => void): void;
   /**
@@ -91,14 +91,14 @@ export class Notification<T> {
    * and no error is thrown, it will be a noop.
    * @param next A next handler
    * @param error An error handler
-   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
+   * @deprecated Replaced with {@link Notification#observe observe}. Will be removed in v8.
    */
   do(next: (value: T) => void, error: (err: any) => void): void;
   /**
    * Executes the next handler if the Notification is of `kind` `"N"`. Otherwise
    * this will not error, and it will be a noop.
    * @param next The next handler
-   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
+   * @deprecated Replaced with {@link Notification#observe observe}. Will be removed in v8.
    */
   do(next: (value: T) => void): void;
   do(nextHandler: (value: T) => void, errorHandler?: (err: any) => void, completeHandler?: () => void): void {
@@ -113,7 +113,7 @@ export class Notification<T> {
    * @param next A next handler
    * @param error An error handler
    * @param complete A complete handler
-   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
+   * @deprecated Replaced with {@link Notification#observe observe}. Will be removed in v8.
    */
   accept(next: (value: T) => void, error: (err: any) => void, complete: () => void): void;
   /**
@@ -122,14 +122,14 @@ export class Notification<T> {
    * and no error is thrown, it will be a noop.
    * @param next A next handler
    * @param error An error handler
-   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
+   * @deprecated Replaced with {@link Notification#observe observe}. Will be removed in v8.
    */
   accept(next: (value: T) => void, error: (err: any) => void): void;
   /**
    * Executes the next handler if the Notification is of `kind` `"N"`. Otherwise
    * this will not error, and it will be a noop.
    * @param next The next handler
-   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
+   * @deprecated Replaced with {@link Notification#observe observe}. Will be removed in v8.
    */
   accept(next: (value: T) => void): void;
 
@@ -138,7 +138,7 @@ export class Notification<T> {
    * If the handler is missing it will do nothing. Even if the notification is an error, if
    * there is no error handler on the observer, an error will not be thrown, it will noop.
    * @param observer The observer to notify.
-   * @deprecated Replaced with {@link Notification.prototype.observe}. Will be removed in v8.
+   * @deprecated Replaced with {@link Notification#observe observe}. Will be removed in v8.
    */
   accept(observer: PartialObserver<T>): void;
   accept(nextOrObserver: PartialObserver<T> | ((value: T) => void), error?: (err: any) => void, complete?: () => void) {

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -43,7 +43,7 @@ export interface GlobalConfig {
   onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
 
   /**
-   * The promise constructor used by default for {@link toPromise} and {@link forEach}
+   * The promise constructor used by default for {@link Observable#toPromise toPromise} and {@link Observable#forEach forEach}
    * methods.
    *
    * @deprecated As of version 8, RxJS will no longer support this sort of injection of a

--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -60,7 +60,7 @@ export class ConnectableObservable<T> extends Observable<T> {
   }
 
   /**
-   * @deprecated {@link ConnectableObservable} will be removed in v8. Use {@link connecatble} instead.
+   * @deprecated {@link ConnectableObservable} will be removed in v8. Use {@link connectable} instead.
    * Details: https://rxjs.dev/deprecations/multicasting
    */
   connect(): Subscription {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR fixes broken links within the documentation that are reported by the build of the documentation.

Two examples of the broken links can be found on the [Global Config](https://rxjs.dev/api/index/interface/GlobalConfig) documentation page.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None