### PR TITLE
chore: remove Node v11 from CI

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [ '11', '12', '13', '14', '15' ]
+        node: [ '12', '13', '14', '15' ]
 
     name: Node ${{ matrix.node }} build
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR removes Node v11 from the CI configuration. Node v12 is no longer active LTS - it's now maintenance - so IMO a version that's older than that and wasn't an LTS version isn't something we need to continue to support. And it doesn't support `globalThis`, so it's annoying.

**Related issue (if exists):** Nope