### PR TITLE
buckets and splitBy operators

### DIFF
--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -251,6 +251,10 @@ export declare function skipWhile<T>(predicate: BooleanConstructor): OperatorFun
 export declare function skipWhile<T>(predicate: (value: T, index: number) => true): OperatorFunction<T, never>;
 export declare function skipWhile<T>(predicate: (value: T, index: number) => boolean): MonoTypeOperatorFunction<T>;
 
+export declare function splitBy<T, U extends T>(predicate: (value: T) => value is U, options?: SplitByOptions<T>): OperatorFunction<T, [Observable<U>, Observable<Exclude<T, U>>]>;
+export declare function splitBy<T>(predicate: BooleanConstructor, options?: SplitByOptions<T>): OperatorFunction<T, [Observable<TruthyTypesOf<T>>, Observable<Exclude<T, TruthyTypesOf<T>>>]>;
+export declare function splitBy<T>(predicate: (value: T) => boolean, options?: SplitByOptions<T>): OperatorFunction<T, [Observable<T>, Observable<T>]>;
+
 export declare function startWith<T>(value: null): OperatorFunction<T, T | null>;
 export declare function startWith<T>(value: undefined): OperatorFunction<T, T | undefined>;
 export declare function startWith<T, A extends readonly unknown[] = T[]>(...valuesAndScheduler: [...A, SchedulerLike]): OperatorFunction<T, T | ValueFromArray<A>>;

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -2,6 +2,8 @@ export declare function audit<T>(durationSelector: (value: T) => ObservableInput
 
 export declare function auditTime<T>(duration: number, scheduler?: SchedulerLike): MonoTypeOperatorFunction<T>;
 
+export declare function buckets<T>(bucketCount: number, options?: BucketsOptions<T>): OperatorFunction<T, Observable<T>[]>;
+
 export declare function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]>;
 
 export declare function bufferCount<T>(bufferSize: number, startBufferEvery?: number | null): OperatorFunction<T, T[]>;

--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -147,6 +147,7 @@ These are Observable creation operators that also have join functionality -- emi
 
 ### Transformation Operators
 
+- [`buckets`](/api/operators/buckets)
 - [`buffer`](/api/operators/buffer)
 - [`bufferCount`](/api/operators/bufferCount)
 - [`bufferTime`](/api/operators/bufferTime)

--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -168,6 +168,7 @@ These are Observable creation operators that also have join functionality -- emi
 - [`partition`](/api/operators/partition)
 - [`pluck`](/api/operators/pluck)
 - [`scan`](/api/operators/scan)
+- [`splitBy`](/api/operators/splitBy)
 - [`switchScan`](/api/operators/switchScan)
 - [`switchMap`](/api/operators/switchMap)
 - [`switchMapTo`](/api/operators/switchMapTo)

--- a/spec-dtslint/operators/buckets-spec.ts
+++ b/spec-dtslint/operators/buckets-spec.ts
@@ -1,0 +1,34 @@
+import { of, BehaviorSubject, Subject, GroupedObservable } from 'rxjs';
+import { buckets, groupBy, mergeMap } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(buckets(3)); // $ExpectType Observable<Observable<number>[]>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(buckets()); // $ExpectError
+  const p = of(1, 2, 3).pipe(buckets(false)); // $ExpectError
+});
+
+it('should support a hash function', () => {
+  const o = of(1, 2, 3).pipe(buckets(3, { hashFn: (value) => value + 1 })); // $ExpectType Observable<Observable<number>[]>
+  const p = of('foo', 'bar').pipe(buckets(3, { hashFn: (value) => value.length })); // $ExpectType Observable<Observable<string>[]>
+});
+
+it('should enforce type of hash function', () => {
+  const o = of(1, 2, 3).pipe(buckets(3, { hashFn: null })); // $ExpectError
+  const p = of(1, 2, 3).pipe(buckets(3, { hashFn: (value) => Number(value === '1') })); // $ExpectError
+  const q = of(1, 2, 3).pipe(buckets(3, { hashFn: (value) => String(value) })); // $ExpectError
+});
+
+it('should support a connector factory', () => {
+  const o = of(1, 2, 3).pipe(buckets(3, { connector: (bucketIndex) => bucketIndex === 0 ? new BehaviorSubject(3) : new Subject() })); // $ExpectType Observable<Observable<number>[]>
+  const p = of('foo', 'bar').pipe(buckets(3, { connector: (bucketIndex) => new BehaviorSubject(String(bucketIndex)) })); // $ExpectType Observable<Observable<string>[]>
+});
+
+it('should enforce type of connector factory', () => {
+  const o = of(1, 2, 3).pipe(buckets(3, { connector: null })); // $ExpectError
+  const p = of(1, 2, 3).pipe(buckets(3, { connector: (bucketIndex) => new Error(String(bucketIndex)) })); // $ExpectError
+  const q = of(1, 2, 3).pipe(buckets(3, { connector: (bucketIndex) => new BehaviorSubject(Number(bucketIndex === '1')) })); // $ExpectError
+  const r = of(1, 2, 3).pipe(buckets(3, { connector: (bucketIndex) => new BehaviorSubject(bucketIndex === 0 ? 'bar' : 'baz') })); // $ExpectError
+});

--- a/spec-dtslint/operators/splitBy-spec.ts
+++ b/spec-dtslint/operators/splitBy-spec.ts
@@ -1,0 +1,64 @@
+import { Observable, of } from 'rxjs';
+import { map, splitBy } from 'rxjs/operators';
+
+it('should support a predicate', () => {
+  const o = of(1, 2, 3).pipe(splitBy((value) => value === 3)); // $ExpectType Observable<[Observable<number>, Observable<number>]>
+});
+
+it('should support a user-defined type guard as predicate', () => {
+  const o = of(1, 'a', []).pipe(splitBy((value): value is number => typeof value === 'number')); // $ExpectType Observable<[Observable<number>, Observable<string | never[]>]>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(splitBy()); // $ExpectError
+});
+
+it('should enforce predicate types', () => {
+  const o = of(1, 2, 3).pipe(splitBy((value) => value === '3')); // $ExpectError
+});
+
+it('should enforce user-defined type guard types', () => {
+  const o = of(1, 2, 3).pipe(splitBy((value): value is string => value === 'string')); // $ExpectError
+});
+
+it('should support Boolean as a predicate', () => {
+  const o = of(1, 2, 3).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<number>, Observable<never>]>
+  const p = of(1, null, undefined).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<number>, Observable<null | undefined>]>
+  const q = of(null, undefined).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<never>, Observable<null | undefined>]>
+  const r = of(true).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<true>, Observable<false>]>
+  const s = of(false as const).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<never>, Observable<false>]>
+  const t = of(0 as const, -0 as const, 1 as const).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<1>, Observable<0>]>
+  const u = of(0 as const, -0 as const).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<never>, Observable<0>]>
+  const v = of('' as const, "foo" as const, "bar" as const).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<"foo" | "bar">, Observable<"">]>
+  const w = of('' as const).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<never>, Observable<"">]>
+  // Intentionally weird looking test... `false` is `boolean`, which is `true | false`.
+  const x = of(false, false, false, false).pipe(splitBy(Boolean)); // $ExpectType Observable<[Observable<true>, Observable<false>]>
+});
+
+// FIXME this one is wrong, the type should be Observable<[Observable<string>, Observable<string | null>]>
+it('should support inference from a return type with Boolean as a predicate', () => {
+  interface I {
+    a: string | null;
+  }
+
+  const i$: Observable<I> = of();
+  const s$ = i$.pipe(map(i => i.a), splitBy(Boolean)); // $ExpectType Observable<[Observable<string>, Observable<null>]>
+});
+
+it('should support inference from a generic return type of the predicate', () => {
+  function isDefined<T>() {
+    return (value: T | undefined | null): value is T => {
+      return value !== undefined && value !== null;
+    };
+  }
+
+  const o$ = of(1, null, { foo: 'bar' }, true, undefined, 'Nick Cage').pipe(splitBy(isDefined())); // $ExpectType Observable<[Observable<string | number | boolean | { foo: string; }>, Observable<null | undefined>]>
+});
+
+it('should support inference from a predicate that returns any', () => {
+  function isTruthy(value: number): any {
+    return !!value;
+  }
+
+  const o$ = of(1).pipe(splitBy(isTruthy)); // $ExpectType Observable<[Observable<number>, Observable<number>]>
+});

--- a/spec/operators/buckets-spec.ts
+++ b/spec/operators/buckets-spec.ts
@@ -1,0 +1,153 @@
+/** @prettier */
+import { buckets, map, mergeAll } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+describe('buckets()', () => {
+  let rxTest: TestScheduler;
+
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
+  const lettersIntoBuckets = (bucketCount: number) =>
+    buckets(bucketCount, { hashFn: (value: string) => value.charCodeAt(0) - 'a'.charCodeAt(0) });
+
+  it('should bucket values', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' --a-b-c-a-b-c-|');
+      const x = cold('      --a-----a-----|');
+      const y = cold('      ----b-----b---|');
+      const z = cold('      ------c-----c-|');
+      const expected = '    (xyz)---------|';
+
+      const bucketed = source.pipe(lettersIntoBuckets(3), mergeAll());
+
+      expectObservable(bucketed).toBe(expected, { x, y, z });
+    });
+  });
+
+  it('should forward errors for non-empty sources', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' --a-b--#');
+      const x = cold('      --a----#');
+      const y = cold('      ----b--#');
+      const z = cold('      -------#');
+      const expected = '    (xyz)--#';
+
+      const bucketed = source.pipe(lettersIntoBuckets(3), mergeAll());
+
+      expectObservable(bucketed).toBe(expected, { x, y, z });
+    });
+  });
+
+  it('should forward errors for empty sources', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' #');
+      const x = cold('      #');
+      const y = cold('      #');
+      const z = cold('      #');
+      const expected = '    (xyz#)';
+
+      const bucketed = source.pipe(lettersIntoBuckets(3), mergeAll());
+
+      expectObservable(bucketed).toBe(expected, { x, y, z });
+    });
+  });
+
+  it('should forward completions for empty sources', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' |     ');
+      const x = cold('      |     ');
+      const y = cold('      |     ');
+      const z = cold('      |     ');
+      const expected = '    (xyz|)';
+
+      const bucketed = source.pipe(lettersIntoBuckets(3), mergeAll());
+
+      expectObservable(bucketed).toBe(expected, { x, y, z });
+    });
+  });
+
+  it('should handle hash values that exceed the count', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' --a----|');
+      const x = cold('      -------|');
+      const y = cold('      --a----|');
+      const z = cold('      -------|');
+      const expected = '    (xyz)--|';
+
+      const bucketed = source.pipe(buckets(3, { hashFn: () => 4 }), mergeAll());
+
+      expectObservable(bucketed).toBe(expected, { x, y, z });
+    });
+  });
+
+  it('should handle negative hash values', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' --a----|');
+      const x = cold('      -------|');
+      const y = cold('      --a----|');
+      const z = cold('      -------|');
+      const expected = '    (xyz)--|';
+
+      const bucketed = source.pipe(buckets(3, { hashFn: () => -1 }), mergeAll());
+
+      expectObservable(bucketed).toBe(expected, { x, y, z });
+    });
+  });
+
+  it('should handle floating-point hash values', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' --a----|');
+      const x = cold('      -------|');
+      const y = cold('      --a----|');
+      const z = cold('      -------|');
+      const expected = '    (xyz)--|';
+
+      const bucketed = source.pipe(buckets(3, { hashFn: () => 1.5 }), mergeAll());
+
+      expectObservable(bucketed).toBe(expected, { x, y, z });
+    });
+  });
+
+  it('should forward errors thrown from the hash selector', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const error = new Error('Kaboom!');
+      const source = cold(' ------a-|');
+      const x = cold('      ------#  ', undefined, error);
+      const y = cold('      ------#  ', undefined, error);
+      const z = cold('      ------#  ', undefined, error);
+      const expected = '    (xyz)-#  ';
+
+      const bucketed = source.pipe(
+        buckets(3, {
+          hashFn: () => {
+            throw error;
+          },
+        }),
+        mergeAll()
+      );
+      expectObservable(bucketed).toBe(expected, { x, y, z }, error);
+    });
+  });
+
+  it('should not subscribe to the source, if an error is thrown synchronously from downstream', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const error = new Error('Kaboom!');
+      const source = cold(' ------a-|');
+      const sourceSubs = '           ';
+      const expected = '    #        ';
+
+      const bucketed = source.pipe(
+        buckets(3),
+        map(() => {
+          throw error;
+        })
+      );
+
+      expectObservable(bucketed).toBe(expected, undefined, error);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
+  });
+});

--- a/spec/operators/splitBy-spec.ts
+++ b/spec/operators/splitBy-spec.ts
@@ -1,0 +1,27 @@
+/** @prettier */
+import { mergeMap, splitBy } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+describe('splitBy()', () => {
+  let rxTest: TestScheduler;
+
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
+  it('should split values', () => {
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold(' --a-b-c-a-b-c-|');
+      const x = cold('      --a-----a-----|');
+      const y = cold('      ----b-c---b-c-|');
+      const expected = '    (xy)----------|';
+
+      const split = source.pipe(
+        splitBy((value) => value === 'a'),
+        mergeMap((splits) => splits)
+      );
+      expectObservable(split).toBe(expected, { x, y });
+    });
+  });
+});

--- a/src/internal/operators/buckets.ts
+++ b/src/internal/operators/buckets.ts
@@ -1,0 +1,135 @@
+import { Observable } from '../Observable';
+import { Subject } from '../Subject';
+import { OperatorFunction } from '../types';
+import { operate } from '../util/lift';
+import { OperatorSubscriber } from './OperatorSubscriber';
+
+export interface BucketsOptions<T> {
+  /**
+   * The hash function used to partition the values into their buckets. The
+   * default hash function converts the values into numbers, if they are not
+   * already.
+   */
+  hashFn?: (value: T) => number;
+  /**
+   * The factory used to create the subject that will connect the source observable to
+   * multicast consumers.
+   */
+  connector?: (bucketIndex: number) => Subject<T>;
+}
+
+/**
+ * Maps a source observable into an observable that does a single immediate and
+ * synchronous emit that contains an array of multicasted ("hot") observables
+ * - the buckets - into which the source values are partitioned into according
+ * to a given hash function applied over each source value.
+ *
+ * This enables similar behavior to the {@link groupBy} operator with the
+ * difference that all possible groups are available immediately when using
+ * `buckets`.
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { interval } from 'rxjs';
+ * import { buckets, mergeMap, mapTo, mergeAll, groupBy } from 'rxjs/operators';
+ *
+ * interval(1000).pipe(
+ *   buckets(3),
+ *   mergeAll(),
+ *   mergeMap((bucket, index) => {
+ *     console.log(`bucket ${index} discovered`);
+ *
+ *     return bucket.pipe(mapTo(`in bucket ${index}`));
+ *   }),
+ * ).subscribe(console.log);
+ *
+ * // Result
+ * // "bucket 0 discovered"
+ * // "bucket 1 discovered"
+ * // "bucket 2 discovered"
+ * // "in bucket 0"
+ * // "in bucket 1"
+ * // "in bucket 2"
+ * // "in bucket 0"
+ * // "in bucket 1"
+ * // "in bucket 2"
+ * // "in bucket 0"
+ * // ...
+ *
+ * // groupBy is similar but different
+ *
+ * interval(1000).pipe(
+ *   groupBy((value) => value % 3),
+ *   mergeMap((group) => {
+ *     console.log(`group ${group.key} discovered`);
+ *
+ *     return group.pipe(mapTo(`in group ${group.key}`));
+ *   }),
+ * ).subscribe(console.log);
+ *
+ * // Result
+ * // "group 0 discovered"
+ * // "in group 0"
+ * // "group 1 discovered"
+ * // "in group 1"
+ * // "group 2 discovered"
+ * // "in group 2"
+ * // "in group 0"
+ * // "in group 1"
+ * // "in group 2"
+ * // "in group 0"
+ * // ...
+ *
+ * ```
+ *
+ * @param bucketCount The number of buckets
+ * @return A function that returns an Observable that does a single emit
+ *  containing the array of buckets
+ *
+ * @see {@link groupBy}
+ * @see {@link partition}
+ * @see {@link splitBy}
+ */
+export function buckets<T>(bucketCount: number, options: BucketsOptions<T> = {}): OperatorFunction<T, Observable<T>[]> {
+  const { hashFn = Number, connector = () => new Subject() } = options;
+
+  return operate((source, subscriber) => {
+    const { subjects, bucketFor, observables } = indexedBuckets(bucketCount, hashFn, connector);
+    const observers = [...subjects, subscriber];
+    const connection = new OperatorSubscriber<T>(
+      subscriber,
+      (value) => {
+        try {
+          bucketFor(value).next(value);
+        } catch (e) {
+          observers.forEach((observer) => observer.error(e));
+        }
+      },
+      () => void observers.forEach((observer) => observer.complete()),
+      (err) => void observers.forEach((observer) => observer.error(err))
+    );
+
+    subscriber.next(observables);
+
+    if (!connection.closed) {
+      source.subscribe(connection);
+    }
+  });
+}
+
+function indexedBuckets<T>(
+  bucketCount: number,
+  hashFn: (value: T) => number,
+  connector: (bucketIndex: number) => Subject<T>
+): {
+  subjects: Subject<T>[];
+  bucketFor: (value: T) => Subject<T>;
+  observables: Observable<T>[];
+} {
+  const subjects = new Array(bucketCount).fill(undefined).map((_, index) => connector(index));
+  const bucketFor = (value: T) => subjects[Math.abs(Math.floor(hashFn(value))) % bucketCount];
+  const observables = [...subjects];
+
+  return { subjects, bucketFor, observables };
+}

--- a/src/internal/operators/splitBy.ts
+++ b/src/internal/operators/splitBy.ts
@@ -1,0 +1,107 @@
+import { Observable } from '../Observable';
+import { Subject } from '../Subject';
+import { OperatorFunction, TruthyTypesOf } from '../types';
+import { buckets } from './buckets';
+
+export interface SplitByOptions<T> {
+  /**
+   * The factory used to create the subject that will connect the source observable to
+   * multicast consumers.
+   */
+  connector?: (match: boolean) => Subject<T>;
+}
+
+export function splitBy<T, U extends T>(
+  predicate: (value: T) => value is U,
+  options?: SplitByOptions<T>
+): OperatorFunction<T, [Observable<U>, Observable<Exclude<T, U>>]>;
+export function splitBy<T>(
+  predicate: BooleanConstructor,
+  options?: SplitByOptions<T>
+): OperatorFunction<T, [Observable<TruthyTypesOf<T>>, Observable<Exclude<T, TruthyTypesOf<T>>>]>;
+export function splitBy<T>(
+  predicate: (value: T) => boolean,
+  options?: SplitByOptions<T>
+): OperatorFunction<T, [Observable<T>, Observable<T>]>;
+
+/**
+ * Maps a source observable into an observable that does a single immediate and
+ * synchronous emit that contains an array of two multicasted ("hot")
+ * observables into which the source values are partitioned into according to a
+ * given predicate applied over each source value. The values that match the
+ * predicate are piped into the first observable and the remaining, that do not
+ * match the predicate, into the second one.
+ *
+ * This enables similar behavior to the {@link groupBy} operator with the
+ * difference that both groups are available immediately when using `splitBy`.
+ *
+ * ## Example
+ *
+ * ```ts
+ * import { interval } from 'rxjs';
+ * import { splitBy, mergeMap, mapTo, mergeAll, groupBy } from 'rxjs/operators';
+ *
+ * interval(1000).pipe(
+ *   splitBy((value) => value % 2 === 0),
+ *   mergeAll(),
+ *   mergeMap((bucket, index) => {
+ *     const kind = index === 0 ? 'even' : 'odd';
+ *     console.log(`${kind} bucket discovered`);
+ *
+ *     return bucket.pipe(mapTo(kind));
+ *   }),
+ * ).subscribe(console.log);
+ *
+ * // Result
+ * // "even bucket discovered"
+ * // "odd bucket discovered"
+ * // "even"
+ * // "odd"
+ * // "even"
+ * // "odd"
+ * // "even"
+ * // ...
+ *
+ * // groupBy is similar but different
+ *
+ * interval(1000).pipe(
+ *   groupBy((value) => value % 2 === 0),
+ *   mergeMap((group) => {
+ *     const kind = group.key ? 'even' : 'odd';
+ *     console.log(`${kind} group discovered`);
+ *
+ *     return group.pipe(mapTo(kind));
+ *   }),
+ * ).subscribe(console.log);
+ *
+ * // Result
+ * // "even group discovered"
+ * // "even"
+ * // "odd group discovered"
+ * // "odd"
+ * // "even"
+ * // "odd"
+ * // "even"
+ * // ...
+ *
+ * ```
+ *
+ * @param predicate The predicate to partition by
+ * @return A function that returns an Observable that does a single emit
+ *  containing the two observables for matching and non-matching values
+ *
+ * @see {@link buckets}
+ * @see {@link groupBy}
+ * @see {@link partition}
+ */
+export function splitBy<T>(
+  predicate: (value: T) => boolean,
+  options: SplitByOptions<T> = {}
+): OperatorFunction<T, [Observable<T>, Observable<T>]> {
+  const { connector } = options;
+
+  return buckets(2, {
+    hashFn: (value) => Number(!predicate(value)),
+    connector: connector === undefined ? undefined : (bucketIndex) => connector(bucketIndex === 0),
+  }) as OperatorFunction<T, [Observable<T>, Observable<T>]>;
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -85,6 +85,7 @@ export { skip } from '../internal/operators/skip';
 export { skipLast } from '../internal/operators/skipLast';
 export { skipUntil } from '../internal/operators/skipUntil';
 export { skipWhile } from '../internal/operators/skipWhile';
+export { splitBy } from '../internal/operators/splitBy';
 export { startWith } from '../internal/operators/startWith';
 export { subscribeOn } from '../internal/operators/subscribeOn';
 export { switchAll } from '../internal/operators/switchAll';

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -1,6 +1,7 @@
 /* Operator exports */
 export { audit } from '../internal/operators/audit';
 export { auditTime } from '../internal/operators/auditTime';
+export { buckets } from '../internal/operators/buckets';
 export { buffer } from '../internal/operators/buffer';
 export { bufferCount } from '../internal/operators/bufferCount';
 export { bufferTime } from '../internal/operators/bufferTime';


### PR DESCRIPTION
- [x] Add the operator to Rx
- [x] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [x] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases -- *is the type test in splitBy-spec sufficient?*
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image -- *how to make the marble diagram?*
- [x] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [x] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).


**Description:**

Introduces 2 new operators `buckets` and `splitBy`.

`buckets` uses a hash function to partition values across multiple multicasted (hot) observables. This behaves similar to `groupBy`, but the groups are known immediately.

`splitBy` is the special case of `buckets` where the count of buckets is 2. This is similar to `partition`, but has a usage ergonomy more similar to `groupBy`.

implementation is based upon `bucketBy` and `splitBy` in `rxjs-etc` by @cartant 

**Related issue (if exists):** https://github.com/ReactiveX/rxjs/issues/3807 https://github.com/ReactiveX/rxjs/issues/4419 https://github.com/ReactiveX/rxjs/issues/5731 
