### PR TITLE
docs: fix UMD link

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ range(1, 200)
 
 For CDN, you can use [unpkg](https://unpkg.com/):
 
-https://unpkg.com/rxjs/bundles/rxjs.umd.min.js
+https://unpkg.com/rxjs/dist/bundles/rxjs.umd.min.js
 
 The global namespace for rxjs is `rxjs`:
 


### PR DESCRIPTION
**Description:**

Fixes UMD link in README to not 404 anymore
