### PR TITLE
Fix/5487 reentrancy in take, takeWhile, and first

### DIFF
--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -715,11 +715,11 @@ describe('webSocket', () => {
       expect(results).to.deep.equal([
         'A next',
         'B next',
-        'A complete',
         'A unsub',
+        'A complete',
         'B next',
-        'B complete',
         'B unsub',
+        'B complete',
       ]);
     });
   });

--- a/spec/operators/delay-spec.ts
+++ b/spec/operators/delay-spec.ts
@@ -240,7 +240,6 @@ describe('delay', () => {
           return delayed;
         }),
         skip(1),
-        take(2),
         tap({
           next() {
             const [[subscriber]] = subscribeSpy.args;
@@ -249,7 +248,8 @@ describe('delay', () => {
           complete() {
             expect(counts).to.deep.equal([1, 1]);
           },
-        })
+        }),
+        take(2)
       );
 
       expectObservable(result).toBe(expected);

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -217,9 +217,7 @@ describe('take', () => {
     });
   });
 
-  // This is related to a PR with discussion here: https://github.com/ReactiveX/rxjs/pull/6396
-  // We can't fix this until version 8.
-  it.skip('should unsubscribe from the source when it reaches the limit before a recursive synchronous upstream error is notified', () => {
+  it('should unsubscribe from the source when it reaches the limit before a recursive synchronous upstream error is notified', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
       const subject = new Subject();
       const e1 = cold(' (a|)');
@@ -229,6 +227,23 @@ describe('take', () => {
       const result = merge(e1, subject).pipe(
         take(1),
         tap(() => subject.error('error'))
+      );
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
+  it('should unsubscribe from the source when it reaches the limit before a recursive synchronous upstream completion is notified', () => {
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const subject = new Subject();
+      const e1 = cold(' (a|)');
+      const e1subs = '  (^!)';
+      const expected = '(a|)';
+
+      const result = merge(e1, subject).pipe(
+        take(1),
+        tap(() => subject.complete())
       );
 
       expectObservable(result).toBe(expected);

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -52,20 +52,41 @@ export function take<T>(count: number): MonoTypeOperatorFunction<T> {
     : operate((source, subscriber) => {
         let seen = 0;
         source.subscribe(
-          createOperatorSubscriber(subscriber, (value) => {
-            // Increment the number of values we have seen,
-            // then check it against the allowed count to see
-            // if we are still letting values through.
-            if (++seen <= count) {
-              subscriber.next(value);
-              // If we have met or passed our allowed count,
-              // we need to complete. We have to do <= here,
-              // because re-entrant code will increment `seen` twice.
-              if (count <= seen) {
+          createOperatorSubscriber(
+            subscriber,
+            (value) => {
+              // Increment the number of values we have seen,
+              // then check it against the allowed count to see
+              // if we are still letting values through.
+              if (++seen <= count) {
+                subscriber.next(value);
+                // If we have met or passed our allowed count,
+                // we need to complete. We have to do <= here,
+                // because re-entrant code will increment `seen` twice.
+                if (count <= seen) {
+                  subscriber.complete();
+                }
+              }
+            },
+            () => {
+              // If seen === count or higher, then we've already taken all of
+              // the values we were supposed to, and the complete we're getting here
+              // is from reentrant code racing our `complete` above. We want to stop
+              // that here.
+              if (seen < count) {
                 subscriber.complete();
               }
+            },
+            (err) => {
+              // If seen === count or higher, then we've already taken all of
+              // the values we were supposed to, and the error we're getting here
+              // is from reentrant code racing our `complete` above. We want to stop
+              // that here.
+              if (seen < count) {
+                subscriber.error(err);
+              }
             }
-          })
+          )
         );
       });
 }

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -55,34 +55,18 @@ export function takeWhile<T>(predicate: (value: T, index: number) => boolean, in
 export function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive = false): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
     let index = 0;
-    // Whether or not we're still taking values.
-    let taking = true;
-    source.subscribe(
-      createOperatorSubscriber(
-        subscriber,
-        (value) => {
-          taking = predicate(value, index++);
-          if (taking || inclusive) {
-            // If we're still taking, Or if this was "inclusive", meaning
-            // we found the "last" value, then we send the value along.
-            subscriber.next(value);
-          }
-          if (!taking) {
-            // We're no longer taking values after calling the predicate above
-            // time to complete the result.
-            subscriber.complete();
-          }
-        },
-        undefined,
-        (err) => {
-          // If we're not currently taking values,
-          // then the code that has reached here is reentrant, and
-          // racing our `subscriber.complete()` above. We want to stop it.
-          if (taking) {
-            subscriber.error(err);
-          }
+    const operatorSubscriber = createOperatorSubscriber<T>(subscriber, (value) => {
+      if (predicate(value, index++)) {
+        subscriber.next(value);
+      } else {
+        operatorSubscriber.unsubscribe();
+        if (inclusive) {
+          subscriber.next(value);
         }
-      )
-    );
+        subscriber.complete();
+      }
+    });
+
+    source.subscribe(operatorSubscriber);
   });
 }


### PR DESCRIPTION
- fix(first/take): behave properly with reentrant errors and completions
    
    - Resolves an issue with both `first` and `take` where an error emitted by a reentrant source at the moment the last value it taken would result in superceding the expected emitted value and completion.
    - Resolves a similar issue where a reentrant completion would supercede the expected last value and completion

    Fixes #5487

- fix(takeWhile): reentrant errors and completions behave properly
    
    - Resolves an issue where a reentrant error notification would short circuit the completion.
    - Adds additional tests.

    Related #5487


- chore: Add reentrant error test for takeUntil