### PR TITLE
Docs: multicast deprecation

### DIFF
--- a/src/internal/operators/multicast.ts
+++ b/src/internal/operators/multicast.ts
@@ -73,6 +73,12 @@ export function multicast<T, O extends ObservableInput<any>>(
   selector: (shared: Observable<T>) => O
 ): OperatorFunction<T, ObservedValueOf<O>>;
 
+/**
+ * @deprecated Will be removed in v8. Use the {@link connectable} observable, the {@link connect} operator or the
+ * {@link share} operator instead. See the overloads below for equivalent replacement examples of this operator's
+ * behaviors.
+ * Details: https://rxjs.dev/deprecations/multicasting
+ */
 export function multicast<T, R>(
   subjectOrSubjectFactory: Subject<T> | (() => Subject<T>),
   selector?: (source: Observable<T>) => Observable<R>

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -79,6 +79,10 @@ export function publish<T, O extends ObservableInput<any>>(selector: (shared: Ob
  * Subscribers to the given source will receive all notifications of the source from the time of the subscription on.
  * @return A function that returns a ConnectableObservable that upon connection
  * causes the source Observable to emit items to its Observers.
+ * @deprecated Will be removed in v8. Use the {@link connectable} observable, the {@link connect} operator or the
+ * {@link share} operator instead. See the overloads below for equivalent replacement examples of this operator's
+ * behaviors.
+ * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publish<T, R>(selector?: OperatorFunction<T, R>): MonoTypeOperatorFunction<T> | OperatorFunction<T, R> {
   return selector ? connect(selector) : multicast(new Subject<T>());

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -74,6 +74,12 @@ export function publishReplay<T, O extends ObservableInput<any>>(
   timestampProvider: TimestampProvider
 ): OperatorFunction<T, ObservedValueOf<O>>;
 
+/**
+ * @deprecated Will be removed in v8. Use the {@link connectable} observable, the {@link connect} operator or the
+ * {@link share} operator instead. See the overloads below for equivalent replacement examples of this operator's
+ * behaviors.
+ * Details: https://rxjs.dev/deprecations/multicasting
+ */
 export function publishReplay<T, R>(
   bufferSize?: number,
   windowTime?: number,


### PR DESCRIPTION
**Description:**
This adds deprecated tags to the primary signatures of deprecated multicast, publish & publishReplay, so they are properly marked as such in the [API reference](https://rxjs.dev/api).