### PR TITLE
feat(Subject): add isObserved() api

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -392,6 +392,7 @@ export declare class Subject<T> extends Observable<T> implements SubscriptionLik
     closed: boolean;
     hasError: boolean;
     isStopped: boolean;
+    get observed(): boolean;
     observers: Observer<T>[];
     thrownError: any;
     constructor();

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -430,29 +430,28 @@ describe('Subject', () => {
     done();
   });
 
-  it('should expose observed status', (done) => {
+  it('should expose observed status', () => {
     const subject = new Subject();
 
-    expect(subject.isObeserved()).to.equal(false);
+    expect(subject.observed()).to.equal(false);
 
     const sub1 = subject.subscribe(function (x) {
       //noop
     });
 
-    expect(subject.isObeserved()).to.equal(true);
+    expect(subject.observed()).to.equal(true);
 
     const sub2 = subject.subscribe(function (x) {
       //noop
     });
 
-    expect(subject.isObeserved()).to.equal(true);
+    expect(subject.observed()).to.equal(true);
     sub1.unsubscribe();
-    expect(subject.isObeserved()).to.equal(true);
+    expect(subject.observed()).to.equal(true);
     sub2.unsubscribe();
-    expect(subject.isObeserved()).to.equal(false);
+    expect(subject.observed()).to.equal(false);
     subject.unsubscribe();
-    expect(subject.isObeserved()).to.equal(false);
-    done();
+    expect(subject.observed()).to.equal(false);
   });
 
   it('should have a static create function that works', () => {

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -430,6 +430,31 @@ describe('Subject', () => {
     done();
   });
 
+  it('should expose observed status', (done) => {
+    const subject = new Subject();
+
+    expect(subject.isObeserved()).to.equal(false);
+
+    const sub1 = subject.subscribe(function (x) {
+      //noop
+    });
+
+    expect(subject.isObeserved()).to.equal(true);
+
+    const sub2 = subject.subscribe(function (x) {
+      //noop
+    });
+
+    expect(subject.isObeserved()).to.equal(true);
+    sub1.unsubscribe();
+    expect(subject.isObeserved()).to.equal(true);
+    sub2.unsubscribe();
+    expect(subject.isObeserved()).to.equal(false);
+    subject.unsubscribe();
+    expect(subject.isObeserved()).to.equal(false);
+    done();
+  });
+
   it('should have a static create function that works', () => {
     expect(Subject.create).to.be.a('function');
     const source = of(1, 2, 3, 4, 5);

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -433,25 +433,25 @@ describe('Subject', () => {
   it('should expose observed status', () => {
     const subject = new Subject();
 
-    expect(subject.observed()).to.equal(false);
+    expect(subject.observed).to.equal(false);
 
     const sub1 = subject.subscribe(function (x) {
       //noop
     });
 
-    expect(subject.observed()).to.equal(true);
+    expect(subject.observed).to.equal(true);
 
     const sub2 = subject.subscribe(function (x) {
       //noop
     });
 
-    expect(subject.observed()).to.equal(true);
+    expect(subject.observed).to.equal(true);
     sub1.unsubscribe();
-    expect(subject.observed()).to.equal(true);
+    expect(subject.observed).to.equal(true);
     sub2.unsubscribe();
-    expect(subject.observed()).to.equal(false);
+    expect(subject.observed).to.equal(false);
     subject.unsubscribe();
-    expect(subject.observed()).to.equal(false);
+    expect(subject.observed).to.equal(false);
   });
 
   it('should have a static create function that works', () => {

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -91,7 +91,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     this.observers = null!;
   }
 
-  isObeserved() {
+  observed() {
     return this.observers?.length > 0;
   }
 

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -91,6 +91,10 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     this.observers = null!;
   }
 
+  isObeserved() {
+    return this.observers?.length > 0;
+  }
+
   /** @internal */
   protected _trySubscribe(subscriber: Subscriber<T>): TeardownLogic {
     this._throwIfClosed();

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -91,7 +91,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     this.observers = null!;
   }
 
-  observed() {
+  get observed() {
     return this.observers?.length > 0;
   }
 


### PR DESCRIPTION
**Description:**

This PR adds an api `subject.isObserved()` to handle the common use case of the deprecated `subject.observers` member 

* https://stackoverflow.com/questions/44555615/rxjs-detect-when-observable-has-been-subscribed-to
* https://stackoverflow.com/questions/33441393/is-there-a-way-to-check-for-output-wire-up-from-within-a-component-in-angular-2

Relates to: #5967
