### PR TITLE
docs: remove googlebot noindex from index.html

### DIFF
--- a/docs_app/src/index.html
+++ b/docs_app/src/index.html
@@ -32,9 +32,7 @@
 
   <script>
     // Dynamically, pre-emptively, add `noindex`, which will be removed when the doc is ready and valid
-    var tag = document.createElement('meta'); tag.name = 'googlebot'; tag.content = 'noindex';
-    document.head.appendChild(tag);
-    tag = document.createElement('meta'); tag.name = 'robots'; tag.content = 'noindex';
+    var tag = document.createElement('meta'); tag.name = 'robots'; tag.content = 'noindex';
     document.head.appendChild(tag);
   </script>
 


### PR DESCRIPTION
**Description:**

The docs site has a meta tag that stops `googlebot` from indexing the site and this causes the site not to show up in google search results. I think was a bug as the `index.html` layout adds a `noindex` tag for both `googlebot` and `robots`, but the code that removes the `noindex` when the page is determined to be good only removes the `robots` tag but not the `googlebot` one: https://github.com/ReactiveX/rxjs/blob/6fa819beb91ba99dadd6262d6c13f7ddfd9470c5/docs_app/src/app/layout/doc-viewer/doc-viewer.component.ts#L163

/cc: @niklas-wortmann @benlesh 
