### PR TITLE
fix: make share, publish, et al. operator calls referentially transparent

### DIFF
--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -338,7 +338,7 @@ describe('publish operator', () => {
     done();
   });
 
-  it('should subscribe to its own source when using a shared pipeline', () => {
+  it('should be referentially-transparent', () => {
     const source1 = cold('-1-2-3-4-5-|');
     const source1Subs =  '^          !';
     const expected1 =    '-1-2-3-4-5-|';
@@ -346,10 +346,13 @@ describe('publish operator', () => {
     const source2Subs =  '^          !';
     const expected2 =    '-6-7-8-9-0-|';
 
+    // Calls to the _operator_ must be referentially-transparent.
     const sharedPipeLine = pipe(
       publish()
     );
 
+    // The non-referentially-transparent publishing occurs within the _operator function_
+    // returned by the _operator_ and that happens when the complete pipeline is composed.
     const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
     const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
 

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -347,14 +347,14 @@ describe('publish operator', () => {
     const expected2 =    '-6-7-8-9-0-|';
 
     // Calls to the _operator_ must be referentially-transparent.
-    const sharedPipeLine = pipe(
+    const partialPipeLine = pipe(
       publish()
     );
 
     // The non-referentially-transparent publishing occurs within the _operator function_
     // returned by the _operator_ and that happens when the complete pipeline is composed.
-    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
-    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published1 = source1.pipe(partialPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(partialPipeLine) as ConnectableObservable<any>;
 
     expectObservable(published1).toBe(expected1);
     expectSubscriptions(source1.subscriptions).toBe(source1Subs);

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -341,17 +341,17 @@ describe('publish operator', () => {
   it('should subscribe to its own source when using a shared pipeline', () => {
     const source1 = cold('-1-2-3-4-5-|');
     const source1Subs =  '^          !';
+    const expected1 =    '-1-2-3-4-5-|';
     const source2 = cold('-6-7-8-9-0-|');
-    const source2Subs =  '^          !'; 
+    const source2Subs =  '^          !';
+    const expected2 =    '-6-7-8-9-0-|';
 
     const sharedPipeLine = pipe(
-       publish()
-     );
+      publish()
+    );
 
     const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
     const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
-    const expected1 =    '-1-2-3-4-5-|';
-    const expected2 =    '-6-7-8-9-0-|';
 
     expectObservable(published1).toBe(expected1);
     expectSubscriptions(source1.subscriptions).toBe(source1Subs);

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { publishBehavior, mergeMapTo, tap, mergeMap, refCount, retry, repeat } from 'rxjs/operators';
-import { ConnectableObservable, of, Subscription, Observable } from 'rxjs';
+import { ConnectableObservable, of, Subscription, Observable, pipe } from 'rxjs';
 
 /** @test {publishBehavior} */
 describe('publishBehavior operator', () => {
@@ -343,5 +343,29 @@ describe('publishBehavior operator', () => {
 
     expect(results).to.deep.equal([]);
     done();
+  });
+
+  it('should subscribe to its own source when using a shared pipeline', () => {
+    const source1 = cold('-1-2-3-4-5-|');
+    const source1Subs =  '^          !';
+    const expected1 =    'x1-2-3-4-5-|';
+    const source2 = cold('-6-7-8-9-0-|');
+    const source2Subs =  '^          !'; 
+    const expected2 =    'x6-7-8-9-0-|';
+
+    const sharedPipeLine = pipe(
+      publishBehavior('x')
+    );
+
+    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+
+    expectObservable(published1).toBe(expected1);
+    expectSubscriptions(source1.subscriptions).toBe(source1Subs);
+    expectObservable(published2).toBe(expected2);
+    expectSubscriptions(source2.subscriptions).toBe(source2Subs);
+
+    published1.connect();
+    published2.connect();
   });
 });

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -345,7 +345,7 @@ describe('publishBehavior operator', () => {
     done();
   });
 
-  it('should subscribe to its own source when using a shared pipeline', () => {
+  it('should be referentially-transparent', () => {
     const source1 = cold('-1-2-3-4-5-|');
     const source1Subs =  '^          !';
     const expected1 =    'x1-2-3-4-5-|';
@@ -353,10 +353,13 @@ describe('publishBehavior operator', () => {
     const source2Subs =  '^          !'; 
     const expected2 =    'x6-7-8-9-0-|';
 
+    // Calls to the _operator_ must be referentially-transparent.
     const sharedPipeLine = pipe(
       publishBehavior('x')
     );
 
+    // The non-referentially-transparent publishing occurs within the _operator function_
+    // returned by the _operator_ and that happens when the complete pipeline is composed.
     const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
     const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
 

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -354,14 +354,14 @@ describe('publishBehavior operator', () => {
     const expected2 =    'x6-7-8-9-0-|';
 
     // Calls to the _operator_ must be referentially-transparent.
-    const sharedPipeLine = pipe(
+    const partialPipeLine = pipe(
       publishBehavior('x')
     );
 
     // The non-referentially-transparent publishing occurs within the _operator function_
     // returned by the _operator_ and that happens when the complete pipeline is composed.
-    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
-    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published1 = source1.pipe(partialPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(partialPipeLine) as ConnectableObservable<any>;
 
     expectObservable(published1).toBe(expected1);
     expectSubscriptions(source1.subscriptions).toBe(source1Subs);

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -262,7 +262,7 @@ describe('publishLast operator', () => {
     done();
   });
 
-  it('should subscribe to its own source when using a shared pipeline', () => {
+  it('should be referentially-transparent', () => {
     const source1 = cold('-1-2-3-4-5-|');
     const source1Subs =  '^          !';
     const expected1 =    '-----------(5|)';
@@ -270,10 +270,13 @@ describe('publishLast operator', () => {
     const source2Subs =  '^          !';
     const expected2 =    '-----------(0|)';
 
+    // Calls to the _operator_ must be referentially-transparent.
     const sharedPipeLine = pipe(
       publishLast()
     );
 
+    // The non-referentially-transparent publishing occurs within the _operator function_
+    // returned by the _operator_ and that happens when the complete pipeline is composed.
     const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
     const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
 

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -271,14 +271,14 @@ describe('publishLast operator', () => {
     const expected2 =    '-----------(0|)';
 
     // Calls to the _operator_ must be referentially-transparent.
-    const sharedPipeLine = pipe(
+    const partialPipeLine = pipe(
       publishLast()
     );
 
     // The non-referentially-transparent publishing occurs within the _operator function_
     // returned by the _operator_ and that happens when the complete pipeline is composed.
-    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
-    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published1 = source1.pipe(partialPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(partialPipeLine) as ConnectableObservable<any>;
 
     expectObservable(published1).toBe(expected1);
     expectSubscriptions(source1.subscriptions).toBe(source1Subs);

--- a/spec/operators/publishLast-spec.ts
+++ b/spec/operators/publishLast-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { publishLast, mergeMapTo, tap, mergeMap, refCount, retry } from 'rxjs/operators';
-import { ConnectableObservable, of, Subscription, Observable } from 'rxjs';
+import { ConnectableObservable, of, Subscription, Observable, pipe } from 'rxjs';
 
 /** @test {publishLast} */
 describe('publishLast operator', () => {
@@ -260,5 +260,29 @@ describe('publishLast operator', () => {
     expect(results2).to.deep.equal([4]);
     expect(subscriptions).to.equal(1);
     done();
+  });
+
+  it('should subscribe to its own source when using a shared pipeline', () => {
+    const source1 = cold('-1-2-3-4-5-|');
+    const source1Subs =  '^          !';
+    const expected1 =    '-----------(5|)';
+    const source2 = cold('-6-7-8-9-0-|');
+    const source2Subs =  '^          !';
+    const expected2 =    '-----------(0|)';
+
+    const sharedPipeLine = pipe(
+      publishLast()
+    );
+
+    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+
+    expectObservable(published1).toBe(expected1);
+    expectSubscriptions(source1.subscriptions).toBe(source1Subs);
+    expectObservable(published2).toBe(expected2);
+    expectSubscriptions(source2.subscriptions).toBe(source2Subs);
+
+    published1.connect();
+    published2.connect();
   });
 });

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -497,14 +497,14 @@ describe('publishReplay operator', () => {
     const expected2 =    '-6-7-8-9-0-|';
 
     // Calls to the _operator_ must be referentially-transparent.
-    const sharedPipeLine = pipe(
+    const partialPipeLine = pipe(
       publishReplay(1)
     );
 
     // The non-referentially-transparent publishing occurs within the _operator function_
     // returned by the _operator_ and that happens when the complete pipeline is composed.
-    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
-    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published1 = source1.pipe(partialPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(partialPipeLine) as ConnectableObservable<any>;
 
     expectObservable(published1).toBe(expected1);
     expectSubscriptions(source1.subscriptions).toBe(source1Subs);

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
-import { throwError, ConnectableObservable, EMPTY, NEVER, of, Observable, Subscription } from 'rxjs';
+import { throwError, ConnectableObservable, EMPTY, NEVER, of, Observable, Subscription, pipe } from 'rxjs';
 import { publishReplay, mergeMapTo, tap, mergeMap, refCount, retry, repeat, map } from 'rxjs/operators';
 
 /** @test {publishReplay} */
@@ -486,5 +486,29 @@ describe('publishReplay operator', () => {
 
     expectObservable(published).toBe(expected, undefined, error);
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+  });
+
+  it('should subscribe to its own source when using a shared pipeline', () => {
+    const source1 = cold('-1-2-3-4-5-|');
+    const source2 = cold('-6-7-8-9-0-|');
+    const expected1 =    '-1-2-3-4-5-|';
+    const expected2 =    '-6-7-8-9-0-|';
+    const source1Subs =  '^          !';
+    const source2Subs =  '^          !';
+
+    const sharedPipeLine = pipe(
+      publishReplay(1)
+     );
+
+    const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
+    const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
+
+    expectObservable(published1).toBe(expected1);
+    expectSubscriptions(source1.subscriptions).toBe(source1Subs);
+    expectObservable(published2).toBe(expected2);
+    expectSubscriptions(source2.subscriptions).toBe(source2Subs);
+
+    published1.connect();
+    published2.connect();
   });
 });

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -488,7 +488,7 @@ describe('publishReplay operator', () => {
     expectSubscriptions(source.subscriptions).toBe(sourceSubs);
   });
 
-  it('should subscribe to its own source when using a shared pipeline', () => {
+  it('should be referentially-transparent', () => {
     const source1 = cold('-1-2-3-4-5-|');
     const source1Subs =  '^          !';
     const expected1 =    '-1-2-3-4-5-|';
@@ -496,10 +496,13 @@ describe('publishReplay operator', () => {
     const source2Subs =  '^          !';
     const expected2 =    '-6-7-8-9-0-|';
 
+    // Calls to the _operator_ must be referentially-transparent.
     const sharedPipeLine = pipe(
       publishReplay(1)
     );
 
+    // The non-referentially-transparent publishing occurs within the _operator function_
+    // returned by the _operator_ and that happens when the complete pipeline is composed.
     const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
     const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;
 

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -490,15 +490,15 @@ describe('publishReplay operator', () => {
 
   it('should subscribe to its own source when using a shared pipeline', () => {
     const source1 = cold('-1-2-3-4-5-|');
-    const source2 = cold('-6-7-8-9-0-|');
-    const expected1 =    '-1-2-3-4-5-|';
-    const expected2 =    '-6-7-8-9-0-|';
     const source1Subs =  '^          !';
+    const expected1 =    '-1-2-3-4-5-|';
+    const source2 = cold('-6-7-8-9-0-|');
     const source2Subs =  '^          !';
+    const expected2 =    '-6-7-8-9-0-|';
 
     const sharedPipeLine = pipe(
       publishReplay(1)
-     );
+    );
 
     const published1 = source1.pipe(sharedPipeLine) as ConnectableObservable<any>;
     const published2 = source2.pipe(sharedPipeLine) as ConnectableObservable<any>;

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -630,12 +630,12 @@ describe('share', () => {
           const expected2 = '   -6-7-8-9-0-|';
 
           // Calls to the _operator_ must be referentially-transparent.
-          const sharedPipeLine = pipe(share({ resetOnRefCountZero }));
+          const partialPipeLine = pipe(share({ resetOnRefCountZero }));
 
           // The non-referentially-transparent sharing occurs within the _operator function_
           // returned by the _operator_ and that happens when the complete pipeline is composed.
-          const shared1 = source1.pipe(sharedPipeLine);
-          const shared2 = source2.pipe(sharedPipeLine);
+          const shared1 = source1.pipe(partialPipeLine);
+          const shared2 = source2.pipe(partialPipeLine);
 
           expectObservable(shared1).toBe(expected1);
           expectSubscriptions(source1.subscriptions).toBe(source1Subs);

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -620,7 +620,7 @@ describe('share', () => {
         });
       });
 
-      it('should subscribe to its own source when using a shared pipeline', () => {
+      it('should be referentially-transparent', () => {
         rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
           const source1 = cold('-1-2-3-4-5-|');
           const source1Subs = ' ^----------!';
@@ -629,8 +629,11 @@ describe('share', () => {
           const source2Subs = ' ^----------!';
           const expected2 = '   -6-7-8-9-0-|';
 
+          // Calls to the _operator_ must be referentially-transparent.
           const sharedPipeLine = pipe(share({ resetOnRefCountZero }));
 
+          // The non-referentially-transparent sharing occurs within the _operator function_
+          // returned by the _operator_ and that happens when the complete pipeline is composed.
           const shared1 = source1.pipe(sharedPipeLine);
           const shared2 = source2.pipe(sharedPipeLine);
 

--- a/spec/operators/share-spec.ts
+++ b/spec/operators/share-spec.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { expect } from 'chai';
-import { asapScheduler, concat, config, defer, EMPTY, NEVER, Observable, of, scheduled, Subject, throwError } from 'rxjs';
+import { asapScheduler, concat, config, defer, EMPTY, NEVER, Observable, of, scheduled, Subject, throwError, pipe } from 'rxjs';
 import {
   map,
   mergeMap,
@@ -617,6 +617,27 @@ describe('share', () => {
 
           expectObservable(result, subscription).toBe(expected);
           expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+        });
+      });
+
+      it('should subscribe to its own source when using a shared pipeline', () => {
+        rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+          const source1 = cold('-1-2-3-4-5-|');
+          const source1Subs = ' ^----------!';
+          const expected1 = '   -1-2-3-4-5-|';
+          const source2 = cold('-6-7-8-9-0-|');
+          const source2Subs = ' ^----------!';
+          const expected2 = '   -6-7-8-9-0-|';
+
+          const sharedPipeLine = pipe(share({ resetOnRefCountZero }));
+
+          const shared1 = source1.pipe(sharedPipeLine);
+          const shared2 = source2.pipe(sharedPipeLine);
+
+          expectObservable(shared1).toBe(expected1);
+          expectSubscriptions(source1.subscriptions).toBe(source1Subs);
+          expectObservable(shared2).toBe(expected2);
+          expectSubscriptions(source2.subscriptions).toBe(source2Subs);
         });
       });
     });

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -388,7 +388,7 @@ describe('shareReplay', () => {
     console.warn(`No support for FinalizationRegistry in Node ${process.version}`);
   }
 
-  it('should subscribe to its own source when using a shared pipeline', () => {
+  it('should be referentially-transparent', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
       const source1 = cold('-1-2-3-4-5-|');
       const source1Subs = ' ^----------!';
@@ -397,8 +397,11 @@ describe('shareReplay', () => {
       const source2Subs = ' ^----------!';
       const expected2 = '   -6-7-8-9-0-|';
 
+      // Calls to the _operator_ must be referentially-transparent.
       const sharedPipeLine = pipe(shareReplay({ refCount: false }));
 
+      // The non-referentially-transparent sharing occurs within the _operator function_
+      // returned by the _operator_ and that happens when the complete pipeline is composed.
       const shared1 = source1.pipe(sharedPipeLine);
       const shared2 = source2.pipe(sharedPipeLine);
 

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -398,12 +398,12 @@ describe('shareReplay', () => {
       const expected2 = '   -6-7-8-9-0-|';
 
       // Calls to the _operator_ must be referentially-transparent.
-      const sharedPipeLine = pipe(shareReplay({ refCount: false }));
+      const partialPipeLine = pipe(shareReplay({ refCount: false }));
 
       // The non-referentially-transparent sharing occurs within the _operator function_
       // returned by the _operator_ and that happens when the complete pipeline is composed.
-      const shared1 = source1.pipe(sharedPipeLine);
-      const shared2 = source2.pipe(sharedPipeLine);
+      const shared1 = source1.pipe(partialPipeLine);
+      const shared2 = source2.pipe(partialPipeLine);
 
       expectObservable(shared1).toBe(expected1);
       expectSubscriptions(source1.subscriptions).toBe(source1Subs);

--- a/src/internal/operators/publish.ts
+++ b/src/internal/operators/publish.ts
@@ -85,5 +85,5 @@ export function publish<T, O extends ObservableInput<any>>(selector: (shared: Ob
  * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publish<T, R>(selector?: OperatorFunction<T, R>): MonoTypeOperatorFunction<T> | OperatorFunction<T, R> {
-  return selector ? connect(selector) : multicast(new Subject<T>());
+  return selector ? (source) => connect(selector)(source) : (source) => multicast(new Subject<T>())(source);
 }

--- a/src/internal/operators/publishBehavior.ts
+++ b/src/internal/operators/publishBehavior.ts
@@ -18,7 +18,9 @@ import { UnaryFunction } from '../types';
  * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publishBehavior<T>(initialValue: T): UnaryFunction<Observable<T>, ConnectableObservable<T>> {
-  const subject = new BehaviorSubject<T>(initialValue);
   // Note that this has *never* supported the selector function.
-  return (source) => new ConnectableObservable(source, () => subject);
+  return (source) => {
+    const subject = new BehaviorSubject<T>(initialValue);
+    return new ConnectableObservable(source, () => subject);
+  };
 }

--- a/src/internal/operators/publishLast.ts
+++ b/src/internal/operators/publishLast.ts
@@ -67,7 +67,9 @@ import { UnaryFunction } from '../types';
  * Details: https://rxjs.dev/deprecations/multicasting
  */
 export function publishLast<T>(): UnaryFunction<Observable<T>, ConnectableObservable<T>> {
-  const subject = new AsyncSubject<T>();
   // Note that this has *never* supported a selector function like `publish` and `publishReplay`.
-  return (source) => new ConnectableObservable(source, () => subject);
+  return (source) => {
+    const subject = new AsyncSubject<T>();
+    return new ConnectableObservable(source, () => subject);
+  };
 }

--- a/src/internal/operators/publishReplay.ts
+++ b/src/internal/operators/publishReplay.ts
@@ -89,11 +89,8 @@ export function publishReplay<T, R>(
   if (selectorOrScheduler && !isFunction(selectorOrScheduler)) {
     timestampProvider = selectorOrScheduler;
   }
-
   const selector = isFunction(selectorOrScheduler) ? selectorOrScheduler : undefined;
-  const subject = new ReplaySubject<T>(bufferSize, windowTime, timestampProvider);
-
   // Note, we're passing `selector!` here, because at runtime, `undefined` is an acceptable argument
   // but it makes our TypeScript signature for `multicast` unhappy (as it should, because it's gross).
-  return (source: Observable<T>) => multicast(subject, selector!)(source);
+  return (source: Observable<T>) => multicast(new ReplaySubject<T>(bufferSize, windowTime, timestampProvider), selector!)(source);
 }

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -134,6 +134,7 @@ export function share<T>(options: ShareConfig<T>): MonoTypeOperatorFunction<T>;
  * @return A function that returns an Observable that mirrors the source.
  */
 export function share<T>(options: ShareConfig<T> = {}): MonoTypeOperatorFunction<T> {
+  const { connector = () => new Subject<T>(), resetOnError = true, resetOnComplete = true, resetOnRefCountZero = true } = options;
   // It's necessary to use a wrapper here, as the _operator_ must be
   // referentially transparent. Otherwise, it cannot be used in calls to the
   // static `pipe` function - to create a reusable pipeline.
@@ -143,8 +144,6 @@ export function share<T>(options: ShareConfig<T> = {}): MonoTypeOperatorFunction
   // _operator function_ is called when the complete pipeline is composed - not
   // when the static `pipe` function is called.
   return (wrapperSource) => {
-    const { connector = () => new Subject<T>(), resetOnError = true, resetOnComplete = true, resetOnRefCountZero = true } = options;
-
     let connection: SafeSubscriber<T> | null = null;
     let resetConnection: Subscription | null = null;
     let subject: SubjectLike<T> | null = null;

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -137,12 +137,13 @@ export function share<T>(options: ShareConfig<T> = {}): MonoTypeOperatorFunction
   const { connector = () => new Subject<T>(), resetOnError = true, resetOnComplete = true, resetOnRefCountZero = true } = options;
   // It's necessary to use a wrapper here, as the _operator_ must be
   // referentially transparent. Otherwise, it cannot be used in calls to the
-  // static `pipe` function - to create a reusable pipeline.
+  // static `pipe` function - to create a partial pipeline.
   //
   // The _operator function_ - the function returned by the _operator_ - will
   // not be referentially transparent - as it shares its source - but the
-  // _operator function_ is called when the complete pipeline is composed - not
-  // when the static `pipe` function is called.
+  // _operator function_ is called when the complete pipeline is composed via a
+  // call to a source observable's `pipe` method - not when the static `pipe`
+  // function is called.
   return (wrapperSource) => {
     let connection: SafeSubscriber<T> | null = null;
     let resetConnection: Subscription | null = null;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR incorporates the fixes and tests in #5585 and also fixes and tests the `share`, `shareReplay`, `publishBehavior` and `publishLast` operators.

The problem that is fixed can be described as follows:

- Calls to **operators** - like `share` - _must be referentially transparent_. Otherwise, those operators cannot be used in calls to the static `pipe` function (to create partial pipelines).
- It's the calls to the **operator functions** - the functions that are returned from **operator** calls - that _do not have to be referentially transparent_ (and can therefore implement the publishing and sharing). Those calls are made when the complete pipeline is composed via a call to a source observable's `pipe` method.

IMO, the changes are a bug fix, rather than a breaking change. The behaviour is changed. However, the behaviour prior to this change was not sensible and I cannot see how anyone could possibly be relying upon it. Any callers using a partial pipeline composed using the static `pipe` function and one of the affected operators would see wildly different behaviour - subscriptions to completely unexpected sources - depending upon the order in which subscriptions were made.

**Related issue (if exists):** #5411 #5585
