### PR TITLE
docs(operators): single

### DIFF
--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -73,7 +73,7 @@ export function single<T>(predicate?: (value: T, index: number, source: Observab
  *   single(x => x.name.startsWith('B'))
  * )
  * .subscribe(x => console.log(x));
- * // Error emitted: NotFoundError('No values match')
+ * // Emits undefined
  * ```
  *
  * @see {@link first}


### PR DESCRIPTION
mismatch in result

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Mistake in docs
https://rxjs.dev/api/operators/single

