### PR TITLE
test(single): correct misleading test description

### DIFF
--- a/spec/operators/single-spec.ts
+++ b/spec/operators/single-spec.ts
@@ -150,7 +150,7 @@ describe('single operator', () => {
     });
   });
 
-  it('should return undefined from predicate if observable does not contain matching element', () => {
+  it('should raise error from predicate if observable does not contain matching element', () => {
     rxTest.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--b--c--|');
       const e1subs = '  ^----------!';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR corrects a misleading test description. `undefined` is not returned/emitted; an error is emitted.

**Related issue (if exists):** Nope