### PR TITLE
docs(operators): sequenceEqual

### DIFF
--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -26,7 +26,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * import { from, fromEvent } from 'rxjs';
  * import { sequenceEqual, bufferCount, mergeMap, map } from 'rxjs/operators';
  *
- * const codes = innerFrom([
+ * const codes = from([
  *   'ArrowUp',
  *   'ArrowUp',
  *   'ArrowDown',
@@ -44,7 +44,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * const matches = keys.pipe(
  *   bufferCount(11, 1),
  *   mergeMap(
- *     last11 => innerFrom(last11).pipe(sequenceEqual(codes)),
+ *     last11 => from(last11).pipe(sequenceEqual(codes)),
  *   ),
  * );
  * matches.subscribe(matched => console.log('Successful cheat at Contra? ', matched));


### PR DESCRIPTION
probably a mistake, because not 'rxjs' nor 'rxjs/operators' has `innerFrom` exported
