### PR TITLE
docs: "timer" accepts milliseconds, not seconds

### DIFF
--- a/src/internal/observable/timer.ts
+++ b/src/internal/observable/timer.ts
@@ -80,7 +80,7 @@ import { isValidDate } from '../util/isDate';
  * should occur will be incorrect. In this case, it would be best to do your own calculations
  * ahead of time, and pass a `number` in as the `dueTime`.
  *
- * @param due If a `number`, the amount of time in seconds to wait before emitting.
+ * @param due If a `number`, the amount of time in milliseconds to wait before emitting.
  * If a `Date`, the exact time at which to emit.
  * @param scheduler The scheduler to use to schedule the delay. Defaults to {@link asyncScheduler}.
  */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** A minor mistake in the JSDoc description of the parameter threw me off when I was using a quick lookup of the parameter meaning in my IDE. The example and earlier explanation correctly stated milliseconds, but the parameter description was wrong.

**Related issue (if exists):** Didn't really look, just created a quick edit from the GitHub editor.
