### PR TITLE
feat(retry): Add configurable delay

### DIFF
--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -86,7 +86,7 @@ describe('retry', () => {
       });
   });
 
-  it('should retry a number of times, then call error handler (with resetOnFirstValue)', (done) => {
+  it('should retry a number of times, then call error handler (with resetOnSuccess)', (done) => {
     let errors = 0;
     const retries = 2;
     new Observable((observer: Observer<number>) => {
@@ -98,7 +98,7 @@ describe('retry', () => {
           errors += 1;
           throw 'bad';
         }),
-        retry({ count: retries - 1, resetOnFirstValue: true })
+        retry({ count: retries - 1, resetOnSuccess: true })
       )
       .subscribe({
         next() {
@@ -129,7 +129,7 @@ describe('retry', () => {
             return of(42);
           }
         }),
-        retry({ count: retries - 1, resetOnFirstValue: true })
+        retry({ count: retries - 1, resetOnSuccess: true })
       )
       .subscribe({
         next(x: number) {
@@ -179,7 +179,7 @@ describe('retry', () => {
             return of(42);
           }
         }),
-        retry({ count: retries - 1, resetOnFirstValue: false })
+        retry({ count: retries - 1, resetOnSuccess: false })
       )
       .subscribe({
         next(x: number) {

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -86,7 +86,7 @@ describe('retry', () => {
       });
   });
 
-  it('should retry a number of times, then call error handler (with resetOnSuccess)', (done) => {
+  it('should retry a number of times, then call error handler (with resetOnFirstValue)', (done) => {
     let errors = 0;
     const retries = 2;
     new Observable((observer: Observer<number>) => {
@@ -98,7 +98,7 @@ describe('retry', () => {
           errors += 1;
           throw 'bad';
         }),
-        retry({ count: retries - 1, resetOnSuccess: true })
+        retry({ count: retries - 1, resetOnFirstValue: true })
       )
       .subscribe({
         next() {
@@ -129,7 +129,7 @@ describe('retry', () => {
             return of(42);
           }
         }),
-        retry({ count: retries - 1, resetOnSuccess: true })
+        retry({ count: retries - 1, resetOnFirstValue: true })
       )
       .subscribe({
         next(x: number) {
@@ -179,7 +179,7 @@ describe('retry', () => {
             return of(42);
           }
         }),
-        retry({ count: retries - 1, resetOnSuccess: false })
+        retry({ count: retries - 1, resetOnFirstValue: false })
       )
       .subscribe({
         next(x: number) {

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -20,10 +20,10 @@ export interface RetryConfig {
    */
   delay?: number | ((error: any, retryCount: number) => ObservableInput<any>);
   /**
-   * Whether or not to reset the retry counter on success.
-   * Defaults to false.
+   * Whether or not to reset the retry counter when the retried subscription
+   * emits its first value.
    */
-  resetOnSuccess?: boolean;
+  resetOnFirstValue?: boolean;
 }
 
 /**
@@ -67,21 +67,22 @@ export interface RetryConfig {
  * // "Error!: Retried 2 times then quit!"
  * ```
  *
- * @param {number} count - Number of retry attempts before failing.
- * @param {boolean} resetOnSuccess - When set to `true` every successful emission will reset the error count
+ * @param count - Number of retry attempts before failing.
+ * @param resetOnSuccess - When set to `true` every successful emission will reset the error count
  * @return A function that returns an Observable that will resubscribe to the
  * source stream when the source stream errors, at most `count` times.
  */
 export function retry<T>(count?: number): MonoTypeOperatorFunction<T>;
 
 /**
- * A more configurable means of retrying a source.
+ * Returns an observable that mirrors the source observable unless it errors. If it errors, the source observable
+ * will be resubscribed to (or "retried") based on the configuration passed here. See documentation
+ * for {@link RetryConfig} for more details.
  *
- * If `delay` is provided as a `number`, after the source errors, the result will wait `delay` milliseconds,
- * then retry the source. If `delay` is a function, th
- * @param config The retry configuration
+ * @param config - The retry configuration
  */
 export function retry<T>(config: RetryConfig): MonoTypeOperatorFunction<T>;
+
 export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTypeOperatorFunction<T> {
   let config: RetryConfig;
   if (configOrCount && typeof configOrCount === 'object') {
@@ -91,7 +92,7 @@ export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTy
       count: configOrCount,
     };
   }
-  const { count = Infinity, delay, resetOnSuccess = false } = config;
+  const { count = Infinity, delay, resetOnFirstValue: resetOnSuccess = false } = config;
 
   return count <= 0
     ? identity

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -23,7 +23,7 @@ export interface RetryConfig {
    * Whether or not to reset the retry counter when the retried subscription
    * emits its first value.
    */
-  resetOnFirstValue?: boolean;
+  resetOnSuccess?: boolean;
 }
 
 /**
@@ -92,7 +92,7 @@ export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTy
       count: configOrCount,
     };
   }
-  const { count = Infinity, delay, resetOnFirstValue: resetOnSuccess = false } = config;
+  const { count = Infinity, delay, resetOnSuccess: resetOnSuccess = false } = config;
 
   return count <= 0
     ? identity


### PR DESCRIPTION
- Adds a `delay` configuration that allows the user to create simpler exponential backoff, simple retry delays, and/or other functionality.

Basically, this will allow a user to write an exponential backoff or simple delay more easily and intuitively than `retryWhen` could. In fact, we might want to deprecate `retryWhen` in favor of this, and also add this pattern to `repeat` (if we decide it's a good idea).

**Retry every 5 seconds, a maximum of 100 times:**

```ts
source.pipe(
  retry({
     // max retries (count is an unfortunate existing name)
     count: 100, 
     // retry 5 seconds after any error
     delay: 5000, // retry after 5 seconds
  })
)
```


**Exponential backoff example**:
```ts
source.pipe(
  retry({
    // max 100 retries
    count: 100,
    // backoff starting at 2 seconds, exponentially up to 1 minute.
    // retryCount starts a 1. 
    delay: (_err, retryCount) => timer(Math.min(60000, 1000 * (2 ** retryCount)))
  })
)
```

### Notes

Honestly, I'm okay even with adding configuration for the above backoff scenario, given it's such a common thing I've had to implement. Even if all we did was provide a helper function that was easy to tree shake like:  `retry({ delay: exponentialBackoff({ startDelay: 1000, maxDelay: 60000 }) })` or the like.