### PR TITLE
refactor: clean unuse imports in several files

### DIFF
--- a/spec-dtslint/errors-spec.ts
+++ b/spec-dtslint/errors-spec.ts
@@ -1,4 +1,4 @@
-import { AjaxError, AjaxTimeoutError } from 'rxjs/ajax';
+import { AjaxError } from 'rxjs/ajax';
 import {
   ArgumentOutOfRangeError,
   EmptyError,

--- a/spec-dtslint/observables/bindCallback-spec.ts
+++ b/spec-dtslint/observables/bindCallback-spec.ts
@@ -1,6 +1,5 @@
 import { bindCallback } from 'rxjs';
 import { a,  b,  c,  d,  e,  f,  g, A, B, C, D, E, F, G } from '../helpers';
-import { SchedulerLike } from '../../src';
 
 describe('callbackFunc', () => {
   const f0 = (cb: () => void) => {

--- a/spec-dtslint/observables/empty-spec.ts
+++ b/spec-dtslint/observables/empty-spec.ts
@@ -1,4 +1,4 @@
-import { of, empty, animationFrameScheduler, EMPTY } from 'rxjs';
+import { empty, animationFrameScheduler, EMPTY } from 'rxjs';
 
 it('should infer correctly with no parameter', () => {
   const a = empty(); // $ExpectType Observable<never>

--- a/spec-dtslint/observables/race-spec.ts
+++ b/spec-dtslint/observables/race-spec.ts
@@ -1,4 +1,4 @@
-import { race, of, NEVER, EMPTY } from 'rxjs';
+import { race, NEVER, EMPTY } from 'rxjs';
 import { a$, b, b$, c, c$, d$, e$, f$ } from '../helpers';
 
 describe('race(a, b, c)', () => {

--- a/spec-dtslint/observables/zip-spec.ts
+++ b/spec-dtslint/observables/zip-spec.ts
@@ -1,4 +1,4 @@
-import { Observable, of, zip } from 'rxjs';
+import { of, zip } from 'rxjs';
 
 it('should support observables', () => {
   const a = of(1); // $ExpectType Observable<number>

--- a/spec-dtslint/operators/count-spec.ts
+++ b/spec-dtslint/operators/count-spec.ts
@@ -1,5 +1,5 @@
 import { of, Observable } from 'rxjs';
-import { count, buffer } from 'rxjs/operators';
+import { count } from 'rxjs/operators';
 
 it('should always infer number', () => {
   const o = of(1, 2, 3).pipe(count(x => x > 1)); // $ExpectType Observable<number>

--- a/spec-dtslint/operators/dematerialize-spec.ts
+++ b/spec-dtslint/operators/dematerialize-spec.ts
@@ -1,4 +1,4 @@
-import { of, Notification, Observable, ObservableNotification } from 'rxjs';
+import { of, Notification } from 'rxjs';
 import { dematerialize } from 'rxjs/operators';
 
 

--- a/spec-dtslint/operators/reduce-spec.ts
+++ b/spec-dtslint/operators/reduce-spec.ts
@@ -1,4 +1,4 @@
-import { of, OperatorFunction } from 'rxjs';
+import { of } from 'rxjs';
 import { reduce } from 'rxjs/operators';
 
 it('should enforce parameter', () => {

--- a/spec-dtslint/operators/scan-spec.ts
+++ b/spec-dtslint/operators/scan-spec.ts
@@ -1,4 +1,4 @@
-import { of, Observable } from 'rxjs';
+import { of } from 'rxjs';
 import { scan } from 'rxjs/operators';
 
 it('should enforce parameter', () => {

--- a/spec-dtslint/operators/zip-spec.ts
+++ b/spec-dtslint/operators/zip-spec.ts
@@ -1,4 +1,4 @@
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { zip } from 'rxjs/operators';
 
 it('should support observables', () => {

--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -1,7 +1,6 @@
 import { of, asyncScheduler, Observable, scheduled, ObservableInput } from 'rxjs';
 import { observable } from 'rxjs/internal/symbol/observable';
 import { iterator } from 'rxjs/internal/symbol/iterator';
-import { expect } from 'chai';
 
 if (process && process.on) {
   /**


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Raising this PR to clean files by removing unused imports from several files.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->
**Related issue (if exists):**
Noop

