### PR TITLE
Chore/config handler spies test helpers

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -577,7 +577,7 @@ describe('Observable', () => {
           });
       });
     });
-    
+
     it('should teardown even with a synchronous thrown error', () => {
       let called = false;
       const badObservable = new Observable((subscriber) => {
@@ -595,7 +595,7 @@ describe('Observable', () => {
       expect(called).to.be.true;
     });
 
-    
+
     it('should handle empty string sync errors', () => {
       const badObservable = new Observable(() => {
         throw '';
@@ -610,7 +610,7 @@ describe('Observable', () => {
       });
       expect(caught).to.be.true;
     });
-      
+
 
     describe('if config.useDeprecatedSynchronousErrorHandling === true', () => {
       beforeEach(() => {
@@ -705,7 +705,7 @@ describe('Observable', () => {
         expect(called).to.be.true;
       });
 
-      
+
       it('should handle empty string sync errors', () => {
         const badObservable = new Observable(() => {
           throw '';
@@ -738,7 +738,7 @@ describe('Observable', () => {
         }
         expect(called).to.be.true;
       });
-      
+
       it('should execute finalize even with a sync thrown error', () => {
         let called = false;
         const badObservable = new Observable(() => {
@@ -756,7 +756,7 @@ describe('Observable', () => {
         }
         expect(called).to.be.true;
       });
-      
+
       it('should execute finalize in order even with a sync error', () => {
         const results: any[] = [];
         const badObservable = new Observable((subscriber) => {
@@ -799,7 +799,7 @@ describe('Observable', () => {
         expect(results).to.deep.equal([1, 2]);
       });
 
-      // https://github.com/ReactiveX/rxjs/issues/6271      
+      // https://github.com/ReactiveX/rxjs/issues/6271
       it('should not have a run-time error if no errors are thrown and there are operators', () => {
         expect(() => {
           of(1, 2, 3).pipe(
@@ -859,24 +859,6 @@ describe('Observable', () => {
       const source = of('test');
       const result = source.pipe();
       expect(result).to.equal(source);
-    });
-  });
-
-  it('should not swallow internal errors', (done) => {
-    config.onStoppedNotification = (notification) => {
-      expect(notification.kind).to.equal('E');
-      expect(notification).to.have.property('error', 'bad');
-      config.onStoppedNotification = null;
-      done();
-    };
-
-    new Observable(subscriber => {
-      subscriber.error('test');
-      throw 'bad';
-    }).subscribe({
-      error: err => {
-        expect(err).to.equal('test');
-      }
     });
   });
 
@@ -1047,7 +1029,7 @@ describe('Observable.lift', () => {
     );
   });
 
-  
+
   it('should compose through publish and refCount', (done) => {
     const result = new MyCustomObservable<number>((observer) => {
       observer.next(1);
@@ -1077,7 +1059,7 @@ describe('Observable.lift', () => {
     );
   });
 
-  
+
   it('should compose through publishLast and refCount', (done) => {
     const result = new MyCustomObservable<number>((observer) => {
       observer.next(1);
@@ -1138,7 +1120,7 @@ describe('Observable.lift', () => {
 
   it('should composes Subjects in the simple case', () => {
     const subject = new Subject<number>();
-    
+
     const result = subject.pipe(
       map((x) => 10 * x)
     ) as any as Subject<number>; // Yes, this is correct. (but you're advised not to do this)
@@ -1151,7 +1133,7 @@ describe('Observable.lift', () => {
     result.next(10);
     result.next(20);
     result.next(30);
-    
+
     expect(emitted).to.deep.equal([100, 200, 300]);
   });
 
@@ -1161,7 +1143,7 @@ describe('Observable.lift', () => {
    */
   it('should demonstrate the horrors of sharing and lifting the Subject through', () => {
     const subject = new Subject<number>();
-    
+
     const shared = subject.pipe(
       share()
     );
@@ -1177,15 +1159,15 @@ describe('Observable.lift', () => {
 
     const emitted1: any[] = [];
     result1.subscribe(value => emitted1.push(value));
-    
+
     const emitted2: any[] = [];
     result2.subscribe(value => emitted2.push(value));
 
     // THIS IS HORRIBLE DON'T DO THIS.
     result1.next(10);
     result2.next(20); // Yuck
-    result1.next(30); 
-    
+    result1.next(30);
+
     expect(emitted1).to.deep.equal([100, 200, 300]);
     expect(emitted2).to.deep.equal([0, 10, 20]);
   });
@@ -1196,17 +1178,17 @@ describe('Observable.lift', () => {
    * probably should have never tried to compose through the Subject's observer methods.
    * If you're a user and you're reading this... NEVER try to use this feature, it's likely
    * to go away at some point.
-   * 
+   *
    * The problem is that you can have the Subject parts, or you can have the ConnectableObservable parts,
    * but you can't have both.
-   * 
+   *
    * NOTE: We can remove this in version 8 or 9, because we're getting rid of operators that
    * return `ConnectableObservable`. :tada:
    */
   describe.skip('The lift through Connectable gaff', () => {
     it('should compose through multicast and refCount, even if it is a Subject', () => {
       const subject = new Subject<number>();
-      
+
       const result = subject.pipe(
         multicast(() => new Subject<number>()),
         refCount(),
@@ -1221,13 +1203,13 @@ describe('Observable.lift', () => {
       result.next(10);
       result.next(20);
       result.next(30);
-      
+
       expect(emitted).to.deep.equal([100, 200, 300]);
     });
-    
+
     it('should compose through publish and refCount, even if it is a Subject', () => {
       const subject = new Subject<number>();
-      
+
       const result = subject.pipe(
         publish(),
         refCount(),
@@ -1242,14 +1224,14 @@ describe('Observable.lift', () => {
       result.next(10);
       result.next(20);
       result.next(30);
-      
+
       expect(emitted).to.deep.equal([100, 200, 300]);
     });
 
-    
+
     it('should compose through publishLast and refCount, even if it is a Subject', () => {
       const subject = new Subject<number>();
-      
+
       const result = subject.pipe(
         publishLast(),
         refCount(),
@@ -1264,13 +1246,13 @@ describe('Observable.lift', () => {
       result.next(10);
       result.next(20);
       result.next(30);
-      
+
       expect(emitted).to.deep.equal([100, 200, 300]);
     });
 
     it('should compose through publishBehavior and refCount, even if it is a Subject', () => {
       const subject = new Subject<number>();
-      
+
       const result = subject.pipe(
         publishBehavior(0),
         refCount(),
@@ -1285,7 +1267,7 @@ describe('Observable.lift', () => {
       result.next(10);
       result.next(20);
       result.next(30);
-      
+
       expect(emitted).to.deep.equal([0, 100, 200, 300]);
     });
   });

--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -1,6 +1,8 @@
-import { of, asyncScheduler, Observable, scheduled, ObservableInput } from 'rxjs';
-import { observable } from 'rxjs/internal/symbol/observable';
+/** @prettier */
+
+import { asyncScheduler, config, Observable, observable, ObservableInput, Observer, of, scheduled } from 'rxjs';
 import { iterator } from 'rxjs/internal/symbol/iterator';
+import { SinonSpy, spy } from 'sinon';
 
 if (process && process.on) {
   /**
@@ -9,21 +11,72 @@ if (process && process.on) {
    * it handles the rejected promise where it does not notice
    * that the test failed.
    */
-  process.on('unhandledRejection', err => {
+  process.on('unhandledRejection', (err) => {
     console.error(err);
     process.exit(1);
   });
 }
 
+export interface ConfigHandlerSpies {
+  onUnhandledError: SinonSpy;
+  onStoppedNotification: SinonSpy;
+  uninstallHandlers: () => void;
+  done: Mocha.Done;
+}
+
+export function withConfigHandlerSpies(fn: (this: Mocha.Context, spies: ConfigHandlerSpies) => void): Mocha.Func {
+  return function (mochaDone) {
+    const prevOnUnhandledError = config.onUnhandledError;
+    const prevOnStoppedNotification = config.onStoppedNotification;
+
+    const onUnhandledError = spy();
+    const onStoppedNotification = spy();
+
+    let handlersUninstalled = false;
+    const uninstallHandlers = () => {
+      if (handlersUninstalled) {
+        return;
+      }
+      handlersUninstalled = true;
+      config.onUnhandledError = prevOnUnhandledError;
+      config.onStoppedNotification = prevOnStoppedNotification;
+    };
+
+    const done = () => {
+      uninstallHandlers();
+      mochaDone();
+    };
+
+    config.onUnhandledError = onUnhandledError;
+    config.onStoppedNotification = onStoppedNotification;
+
+    fn.call(this, { onUnhandledError, onStoppedNotification, uninstallHandlers, done });
+  };
+}
+
+export interface SpiedObserver<T extends 'next' | 'error' | 'complete'> extends Observer<any> {
+  next: 'next' extends T ? SinonSpy : never;
+  error: 'error' extends T ? SinonSpy : never;
+  complete: 'complete' extends T ? SinonSpy : never;
+}
+
+export function createSpiedObserver<T extends 'next' | 'error' | 'complete'>(...kinds: T[]): SpiedObserver<T> {
+  return (Object.fromEntries(
+    (kinds.length > 0 ? kinds : ['next', 'error', 'complete']).map((key) => [key, spy()])
+  ) as unknown) as SpiedObserver<T>;
+}
+
 export function lowerCaseO<T>(...args: Array<any>): Observable<T> {
   const o: any = {
     subscribe(observer: any) {
-      args.forEach(v => observer.next(v));
+      args.forEach((v) => observer.next(v));
       observer.complete();
       return {
-        unsubscribe() { /* do nothing */ }
+        unsubscribe() {
+          /* do nothing */
+        },
       };
-    }
+    },
   };
 
   o[observable] = function (this: any) {
@@ -33,28 +86,26 @@ export function lowerCaseO<T>(...args: Array<any>): Observable<T> {
   return <any>o;
 }
 
-export const createObservableInputs = <T>(value: T) => of(
-  of(value),
-  scheduled([value], asyncScheduler),
-  [value],
-  Promise.resolve(value),
-  {
-    [iterator]: () => {
-      const iteratorResults = [
-        { value, done: false },
-        { done: true }
-      ];
-      return {
-        next: () => {
-          return iteratorResults.shift();
-        }
-      };
-    }
-  } as any as Iterable<T>,
-  {
-    [observable]: () => of(value)
-  } as any
-) as Observable<ObservableInput<T>>;
+export const createObservableInputs = <T>(value: T) =>
+  of(
+    of(value),
+    scheduled([value], asyncScheduler),
+    [value],
+    Promise.resolve(value),
+    ({
+      [iterator]: () => {
+        const iteratorResults = [{ value, done: false }, { done: true }];
+        return {
+          next: () => {
+            return iteratorResults.shift();
+          },
+        };
+      },
+    } as any) as Iterable<T>,
+    {
+      [observable]: () => of(value),
+    } as any
+  ) as Observable<ObservableInput<T>>;
 
 /**
  * Used to signify no subscriptions took place to `expectSubscriptions` assertions.

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -219,6 +219,8 @@ function defaultErrorHandler(err: any) {
  * @param subscriber The stopped subscriber
  */
 function handleStoppedNotification(notification: ObservableNotification<any>, subscriber: Subscriber<any>) {
+  // grab a local reference here, to ensure the async call uses the handler that
+  // was active when the notification was stopped
   const { onStoppedNotification } = config;
   onStoppedNotification && timeoutProvider.setTimeout(() => onStoppedNotification(notification, subscriber));
 }

--- a/src/internal/util/reportUnhandledError.ts
+++ b/src/internal/util/reportUnhandledError.ts
@@ -11,8 +11,11 @@ import { timeoutProvider } from '../scheduler/timeoutProvider';
  * @param err the error to report
  */
 export function reportUnhandledError(err: any) {
+  // grab a local reference here, to ensure the async call uses the handler that
+  // was active when the error was reported
+  const { onUnhandledError } = config;
+
   timeoutProvider.setTimeout(() => {
-    const { onUnhandledError } = config;
     if (onUnhandledError) {
       // Execute the user-configured error handler.
       onUnhandledError(err);


### PR DESCRIPTION
**Description:**

I introduced a helper function in https://github.com/ReactiveX/rxjs/pull/6169/files#diff-9e451a38948f76e3294d51d3a213e0e9d0170c3d327a871e1435a457a8268125R28 to more easily test the global config handlers.

With this PR I want to extract it into a general helper function in `helpers/test-helper` and convert existing config tests (or other tests involving the global config handlers) to use the helper. This also makes the config tests more readable imho, because the code order now matches the execution order.

I also removed a duplicated test in `Observable-spec.ts` which had the same test code as one of the config-spec tests.

**BREAKING CHANGE:**
While implementing the helper and converting the config-spec tests, I noticed a small discrepancy between how `onUnhandledError` and `onStoppedNotification` are handled. In the last commit, I adjusted `onUnhandledError` handling to match that of `onStoppedNotification` and added appropriate tests. this might be considered a BC break in the following case:
```ts
// current behavior
config.onUnhandledError = () => console.log('I am not called.');

new Observable((subscriber) => {
  subscriber.error('bad');
}).subscribe();

config.onUnhandledError = () => console.log('But I am!');

// behavior after the change
config.onUnhandledError = () => console.log('I am called!');

new Observable((subscriber) => {
  subscriber.error('bad');
}).subscribe();

config.onUnhandledError = () => console.log('But I am not.');
```

