### PR TITLE
chore(docs): update multicasting in deprecations

### DIFF
--- a/docs_app/content/deprecations/multicasting.md
+++ b/docs_app/content/deprecations/multicasting.md
@@ -66,7 +66,8 @@ const tick$ = new ConnectableObservable(
 
 <!-- prettier-ignore -->
 ```ts
-import { share, Subject, timer } from 'rxjs';
+import { Subject, timer } from 'rxjs';
+import { share } from 'rxjs/operators';
 // suggested refactor
 const tick$ = timer(1_000).pipe(
   share({ connector: () => new Subject() })


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The `share` operator should be imported from 'rxjs/operators'

**Related issue (if exists):**

none
