### PR TITLE
fix: fromEvent() type with resultSelector

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -138,7 +138,7 @@ export declare function from<O extends ObservableInput<any>>(input: O, scheduler
 export declare function fromEvent<T>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string): Observable<T>;
 export declare function fromEvent<T, R>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, resultSelector: (event: T) => R): Observable<R>;
 export declare function fromEvent<T>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, options: EventListenerOptions): Observable<T>;
-export declare function fromEvent<T, R>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, options: EventListenerOptions, resultSelector: (event: T) => R): Observable<T>;
+export declare function fromEvent<T, R>(target: HasEventTargetAddRemove<T> | ArrayLike<HasEventTargetAddRemove<T>>, eventName: string, options: EventListenerOptions, resultSelector: (event: T) => R): Observable<R>;
 export declare function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
 export declare function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<T>;
 export declare function fromEvent<R>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string, resultSelector: (...args: any[]) => R): Observable<R>;

--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -18,6 +18,14 @@ it('should support an event target source result selector', () => {
   const a = fromEvent(eventTargetSource, "click", () => "clunk"); // $ExpectType Observable<string>
 });
 
+it('should support an event target source with options', () => {
+    const a = fromEvent(eventTargetSource, "click", { once: true }); // $ExpectType Observable<Event>
+});
+
+it('should support an event target source with options and result selector', () => {
+    const a = fromEvent(eventTargetSource, "click", { once: true }, () => "clunk"); // $ExpectType Observable<string>
+});
+
 declare const documentSource: HTMLDocument;
 
 it('should support a document source', () => {
@@ -27,6 +35,14 @@ it('should support a document source', () => {
 
 it('should support a document source result selector', () => {
   const a = fromEvent(documentSource, "click", () => "clunk"); // $ExpectType Observable<string>
+});
+
+it('should support an document source with options', () => {
+    const a = fromEvent(documentSource, "click", { once: true }); // $ExpectType Observable<Event>
+});
+
+it('should support an document source with options and result selector', () => {
+    const a = fromEvent(documentSource, "click", { once: true }, () => "clunk"); // $ExpectType Observable<string>
 });
 
 // Pick the parts that will match NodeStyleEventEmitter. If this isn't done, it

--- a/spec-dtslint/observables/fromEvent-spec.ts
+++ b/spec-dtslint/observables/fromEvent-spec.ts
@@ -37,11 +37,11 @@ it('should support a document source result selector', () => {
   const a = fromEvent(documentSource, "click", () => "clunk"); // $ExpectType Observable<string>
 });
 
-it('should support an document source with options', () => {
+it('should support a document source with options', () => {
     const a = fromEvent(documentSource, "click", { once: true }); // $ExpectType Observable<Event>
 });
 
-it('should support an document source with options and result selector', () => {
+it('should support a document source with options and result selector', () => {
     const a = fromEvent(documentSource, "click", { once: true }, () => "clunk"); // $ExpectType Observable<string>
 });
 

--- a/src/internal/observable/fromEvent.ts
+++ b/src/internal/observable/fromEvent.ts
@@ -76,7 +76,7 @@ export function fromEvent<T, R>(
   eventName: string,
   options: EventListenerOptions,
   resultSelector: (event: T) => R
-): Observable<T>;
+): Observable<R>;
 
 export function fromEvent(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string): Observable<unknown>;
 /** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */


### PR DESCRIPTION
**Description:**

This PR simply fixes the return type of one overloaded form of `fromEvent()` that accepts a `resultSelector`.

With a `resultSelector: (event: T) => R`, `fromEvent<T, R>` should return a `Observable<R>`, instead of `Observable<T>`.

**Related issue (if exists):** N/A