### PR TITLE
docs(operators): Rerun is changed to Return

### DIFF
--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -56,7 +56,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
  * // ... and so on
  * ```
  *
- * Return an interval Observable on every click event
+ * Restart an interval Observable on every click event
  * ```ts
  * import { fromEvent, interval } from 'rxjs';
  * import { switchMap } from 'rxjs/operators';

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -56,7 +56,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
  * // ... and so on
  * ```
  *
- * Rerun an interval Observable on every click event
+ * Return an interval Observable on every click event
  * ```ts
  * import { fromEvent, interval } from 'rxjs';
  * import { switchMap } from 'rxjs/operators';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** -

**Related issue (if exists):** -