### PR TITLE
docs: remove typo in OperatorSubscriber.ts

### DIFF
--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -2,7 +2,7 @@ import { Subscriber } from '../Subscriber';
 
 /**
  * A generic helper for allowing operators to be created with a Subscriber and
- * use closures to capture neceessary state from the operator function itself.
+ * use closures to capture necessary state from the operator function itself.
  */
 export class OperatorSubscriber<T> extends Subscriber<T> {
   /**


### PR DESCRIPTION
No breaking change, no nothing, just getting rid of a small typo ;) 