### PR TITLE
fix(WebSocketSubject): add different input and output types

### DIFF
--- a/api_guard/dist/types/webSocket/index.d.ts
+++ b/api_guard/dist/types/webSocket/index.d.ts
@@ -1,23 +1,27 @@
-export declare function webSocket<T>(urlConfigOrSource: string | WebSocketSubjectConfig<T>): WebSocketSubject<T>;
+export declare function webSocket<In, Out = In>(urlConfigOrSource: string | WebSocketSubjectConfig<In, Out>): WebSocketSubject<In, Out>;
 
-export declare class WebSocketSubject<T> extends AnonymousSubject<T> {
-    constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>);
-    lift<R>(operator: Operator<T, R>): WebSocketSubject<R>;
-    multiplex(subMsg: () => any, unsubMsg: () => any, messageFilter: (value: T) => boolean): Observable<T>;
+export declare class WebSocketSubject<In, Out = In> extends Observable<Out> implements Observer<In> {
+    destination?: Observer<In>;
+    constructor(urlConfigOrSource: string | WebSocketSubjectConfig<In, Out> | Observable<In>, destination?: Observer<In>);
+    complete(): void;
+    error(err: any): void;
+    lift<R>(operator: Operator<In, R>): WebSocketSubject<R>;
+    multiplex(subMsg: () => any, unsubMsg: () => any, messageFilter: (value: Out) => boolean): Observable<Out>;
+    next(value: In): void;
     unsubscribe(): void;
 }
 
-export interface WebSocketSubjectConfig<T> {
+export interface WebSocketSubjectConfig<In, Out = In> {
     WebSocketCtor?: {
         new (url: string, protocols?: string | string[]): WebSocket;
     };
     binaryType?: 'blob' | 'arraybuffer';
     closeObserver?: NextObserver<CloseEvent>;
     closingObserver?: NextObserver<void>;
-    deserializer?: (e: MessageEvent) => T;
+    deserializer?: (e: MessageEvent) => Out;
     openObserver?: NextObserver<Event>;
     protocol?: string | Array<string>;
-    resultSelector?: (e: MessageEvent) => T;
-    serializer?: (value: T) => WebSocketMessage;
+    resultSelector?: (e: MessageEvent) => Out;
+    serializer?: (value: In) => WebSocketMessage;
     url: string;
 }

--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -30,6 +30,40 @@ describe('webSocket', () => {
       teardownMockWebSocket();
     });
 
+    it('should send and receive messages <In, Out>', () => {
+      interface TestRequest {
+        action: string;
+      }
+
+      interface TestResponse {
+        result: string;
+      }
+
+      const request: TestRequest = {action: 'ping'};
+      const expectedResponse: TestResponse = {result: 'pong'};
+
+      let messageReceived = false;
+      const subject = webSocket<TestRequest, TestResponse>('ws://mysocket');
+
+      subject.next(request);
+
+      subject.subscribe((x: TestResponse) => {
+        expect(x.result).to.equal(expectedResponse.result);
+        messageReceived = true;
+      });
+
+      const socket = MockWebSocket.lastSocket;
+      expect(socket.url).to.equal('ws://mysocket');
+
+      socket.open();
+      expect(socket.lastMessageSent).to.equal(JSON.stringify(request));
+
+      socket.triggerMessage(JSON.stringify(expectedResponse));
+      expect(messageReceived).to.be.true;
+
+      subject.unsubscribe();
+    });
+
     it('should send and receive messages', () => {
       let messageReceived = false;
       const subject = webSocket<string>('ws://mysocket');

--- a/src/internal/observable/dom/webSocket.ts
+++ b/src/internal/observable/dom/webSocket.ts
@@ -151,6 +151,6 @@ import { WebSocketSubject, WebSocketSubjectConfig } from './WebSocketSubject';
  * configuration and additional Observers.
  * @return {WebSocketSubject} Subject which allows to both send and receive messages via WebSocket connection.
  */
-export function webSocket<T>(urlConfigOrSource: string | WebSocketSubjectConfig<T>): WebSocketSubject<T> {
-  return new WebSocketSubject<T>(urlConfigOrSource);
+export function webSocket<In, Out = In>(urlConfigOrSource: string | WebSocketSubjectConfig<In, Out>): WebSocketSubject<In, Out> {
+  return new WebSocketSubject<In, Out>(urlConfigOrSource);
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
add different input and output types to WebSocketSubject
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
#5381