### PR TITLE
fix(isArrayLike): function will now return false when a string is given

### DIFF
--- a/spec/util/isArrayLike-spec.ts
+++ b/spec/util/isArrayLike-spec.ts
@@ -1,0 +1,38 @@
+import { expect } from 'chai';
+import { isArrayLike } from 'rxjs/internal/util/isArrayLike';
+
+describe('isArrayLike', () => {
+  it('should return true for new Array', () => {
+    const a = new Array();
+    expect(isArrayLike(a)).to.be.true;
+    expect(isArrayLike([])).to.be.true;
+  });
+
+  it('should return false for a function', () => {
+    expect(isArrayLike(() => {
+      // noop
+    })).to.be.false;
+  });
+
+  it('should return false for a string', () => {
+    expect(isArrayLike('1')).to.be.false;
+  });
+
+  it('should return false for null', () => {
+    expect(isArrayLike(null)).to.be.false;
+  });
+
+  it('should return false for undefined', () => {
+    expect(isArrayLike(undefined)).to.be.false;
+  });
+
+  it('should return false for boolean', () => {
+    expect(isArrayLike(true)).to.be.false;
+    expect(isArrayLike(false)).to.be.false;
+  });
+
+  it('should return false for an object where property length is NOT of type number', () => {
+    const o = {length: "foo"};
+    expect(isArrayLike(o)).to.be.false;
+  });
+});

--- a/src/internal/util/isArrayLike.ts
+++ b/src/internal/util/isArrayLike.ts
@@ -1,1 +1,2 @@
-export const isArrayLike = (<T>(x: any): x is ArrayLike<T> => x && typeof x.length === 'number' && typeof x !== 'function');
+export const isArrayLike = <T>(x: any): x is ArrayLike<T> =>
+  Boolean(x && typeof x.length === 'number' && typeof x !== 'function' && typeof x !== 'string');


### PR DESCRIPTION
**Description:**

For now `isArrayLike` returns true when a `string` is given since a `string` has a `length` property of type `number`. This fix prevents the function from returning `true` in this case.

This PR also adds a test for `isArrayLike`.

**Related issue (if exists):**

#6474 
