### PR TITLE
feat: add generic type parameter to using for the resource

### DIFF
--- a/spec-dtslint/observables/using-spec.ts
+++ b/spec-dtslint/observables/using-spec.ts
@@ -1,4 +1,4 @@
-import { using } from 'rxjs';
+import { using, Subscription, of} from 'rxjs';
 import { a$, b$ } from '../helpers';
 
 it('should infer with a simple factory', () => {
@@ -7,4 +7,8 @@ it('should infer with a simple factory', () => {
 
 it('should infer with a factory that returns a union', () => {
   const o = using(() => {}, () => Math.random() < 0.5 ? a$ : b$); // $ExpectType Observable<A | B>
+});
+
+it('should infer resource types', () => {
+  const o = using(() => new Subscription(), (sub) => of(sub)); // $ExpectType Observable<Subscription>
 });

--- a/src/internal/observable/using.ts
+++ b/src/internal/observable/using.ts
@@ -31,9 +31,17 @@ import { EMPTY } from './empty';
  * @return {Observable<T>} An Observable that behaves the same as Observable returned by `observableFactory`, but
  * which - when completed, errored or unsubscribed - will also call `unsubscribe` on created resource object.
  */
+export function using<T extends ObservableInput<any>, R extends Unsubscribable = Unsubscribable>(
+  resourceFactory: () => R,
+  observableFactory: (resource: R) => T | void
+): Observable<ObservedValueOf<T>>;
 export function using<T extends ObservableInput<any>>(
-  resourceFactory: () => Unsubscribable | void,
-  observableFactory: (resource: Unsubscribable | void) => T | void
+  resourceFactory: () => void,
+  observableFactory: () => T | void
+): Observable<ObservedValueOf<T>>;
+export function using<T extends ObservableInput<any>, R extends Unsubscribable = Unsubscribable>(
+  resourceFactory: () => R | void,
+  observableFactory: (resource: R | void) => T | void
 ): Observable<ObservedValueOf<T>> {
   return new Observable<ObservedValueOf<T>>((subscriber) => {
     const resource = resourceFactory();


### PR DESCRIPTION
This overload alleviates the observableFactory from needing to cast its parameter to a more specific type.

**Description:**

Previously, a TypeScript user has to cast the resource to the appropriate type in order to do anything with it:

```
const o: Observable<MyResource> = using(
  () => new MyResource(),
  r => of(r as MyResource)   // t is `Unsubscribable | void`, so a cast is needed
)
```

Adding a type parameter for the resource lets TypeScript infer the type of `r` more precisely.

I asked in [discussion][1] about this and there didn't seem to be a good reason not to implement it.

**BREAKING CHANGE (maybe):** @cartant suggested this might be a breaking change. There's no functionality change, but there's a worry that it will cause existing code to no longer type-check. The existing signature is in place, so I think at _worst_ it will remove the `void` from the first parameter's type. That doesn't seem breaking to me, but the maintainers here have definitely seen more weird cases than I have.

**Related issue (if exists):**

* [Discussion][1]

[1]: https://github.com/ReactiveX/rxjs/discussions/6497