### PR TITLE
chore: fix TypeScript latest breakage in CI

### DIFF
--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -244,7 +244,7 @@ describe('Subscriber', () => {
   });
 
   const FinalizationRegistry = (global as any).FinalizationRegistry;
-  if (FinalizationRegistry) {
+  if (FinalizationRegistry && global.gc) {
 
     it('should not leak the destination', (done) => {
       let observer: Observer<number> | undefined = {

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -262,7 +262,7 @@ describe('Subscriber', () => {
       const subscription = of(42).subscribe(observer);
 
       observer = undefined;
-      global.gc();
+      global.gc?.();
     });
 
   } else {

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -382,7 +382,7 @@ describe('shareReplay', () => {
       shared.subscribe(callback);
 
       callback = undefined;
-      global.gc();
+      global.gc?.();
     });
   } else {
     console.warn(`No support for FinalizationRegistry in Node ${process.version}`);

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -366,7 +366,7 @@ describe('shareReplay', () => {
   });
 
   const FinalizationRegistry = (global as any).FinalizationRegistry;
-  if (FinalizationRegistry) {
+  if (FinalizationRegistry && global.gc) {
     it('should not leak the subscriber for sync sources', (done) => {
       let callback: (() => void) | undefined = () => {
         /* noop */

--- a/spec/schedulers/intervalProvider-spec.ts
+++ b/spec/schedulers/intervalProvider-spec.ts
@@ -15,10 +15,10 @@ describe('intervalProvider', () => {
     let setCalled = false;
     let clearCalled = false;
 
-    global.setInterval = () => {
+    global.setInterval = (() => {
       setCalled = true;
       return 0 as any;
-    };
+    }) as any; // TypeScript complains about a __promisify__ property
     global.clearInterval = () => {
       clearCalled = true;
     };


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

CI seems to be failing with the latest TypeScript and Node types. This PR should fix the failures.

**Related issue (if exists):** Nope