### PR TITLE
chore(retryWhen): convert retryWhen tests to run mode 

### DIFF
--- a/spec/operators/retryWhen-spec.ts
+++ b/spec/operators/retryWhen-spec.ts
@@ -241,7 +241,7 @@ describe('retryWhen', () => {
     });
   });
 
-  it('should mirror a basic cold source with complete, given a never notifier', () => {
+  it('should mirror a basic cold source with complete, given an empty notifier', () => {
     rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
       const source = cold('  --a--b--c--|');
       const subs = '         ^----------!';
@@ -255,7 +255,7 @@ describe('retryWhen', () => {
     });
   });
 
-  it('should mirror a basic cold source with no termination, given a never notifier', () => {
+  it('should mirror a basic cold source with no termination, given an empty notifier', () => {
     rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
       const source = cold('  --a--b--c---');
       const subs = '         ^-----------';
@@ -269,7 +269,7 @@ describe('retryWhen', () => {
     });
   });
 
-  it('should mirror a basic hot source with complete, given a never notifier', () => {
+  it('should mirror a basic hot source with complete, given an empty notifier', () => {
     rxTest.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
       const source = hot('-a-^--b--c--|');
       const subs = '         ^--------!';

--- a/spec/operators/retryWhen-spec.ts
+++ b/spec/operators/retryWhen-spec.ts
@@ -1,359 +1,458 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { retryWhen, map, mergeMap, takeUntil, take } from 'rxjs/operators';
 import { of, EMPTY, Observable, throwError } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {retryWhen} */
-describe('retryWhen operator', () => {
+describe('retryWhen', () => {
+  let rxTest: TestScheduler;
+
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
   it('should handle a source with eventual error using a hot notifier', () => {
-    const source =  cold('-1--2--#');
-    const subs =        ['^      !                     ',
-                       '             ^      !        ',
-                       '                          ^ !'];
-    const notifier = hot('-------------r------------r-|');
-    const expected =     '-1--2---------1--2---------1|';
+    rxTest.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const source = cold(' -1--2--#                     ');
+      //                                 -1--2--#
+      //                                              -1--2--#
+      const subs = [
+        '                   ^------!                     ',
+        '                   -------------^------!        ',
+        '                   --------------------------^-!',
+      ];
+      const notifier = hot('-------------r------------r-|');
+      const expected = '    -1--2---------1--2---------1|';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should handle a source with eventual error using a hot notifier that raises error', () => {
-    const source = cold( '-1--2--#');
-    const subs =        ['^      !                    ',
-                       '           ^      !           ',
-                       '                   ^      !   '];
-    const notifier = hot('-----------r-------r---------#');
-    const expected =     '-1--2-------1--2----1--2-----#';
+    rxTest.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const source = cold(' -1--2--#                      ');
+      //                               -1--2--#
+      //                                       -1--2--#
+      const subs = [
+        '                   ^------!                      ',
+        '                   -----------^------!           ',
+        '                   -------------------^------!   ',
+      ];
+      const notifier = hot('-----------r-------r---------#');
+      const expected = '    -1--2-------1--2----1--2-----#';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should retry when notified via returned notifier on thrown error', (done) => {
     let retried = false;
     const expected = [1, 2, 1, 2];
     let i = 0;
-    of(1, 2, 3).pipe(
-      map((n: number) => {
-        if (n === 3) {
-          throw 'bad';
-        }
-        return n;
-      }),
-      retryWhen((errors: any) => errors.pipe(map((x: any) => {
-          expect(x).to.equal('bad');
-          if (retried) {
-            throw new Error('done');
+    of(1, 2, 3)
+      .pipe(
+        map((n: number) => {
+          if (n === 3) {
+            throw 'bad';
           }
-          retried = true;
-          return x;
-      })))
-    ).subscribe((x: any) => {
-        expect(x).to.equal(expected[i++]);
-      },
-      (err: any) => {
-        expect(err).to.be.an('error', 'done');
-        done();
-      });
+          return n;
+        }),
+        retryWhen((errors: any) =>
+          errors.pipe(
+            map((x: any) => {
+              expect(x).to.equal('bad');
+              if (retried) {
+                throw new Error('done');
+              }
+              retried = true;
+              return x;
+            })
+          )
+        )
+      )
+      .subscribe(
+        (x: any) => {
+          expect(x).to.equal(expected[i++]);
+        },
+        (err: any) => {
+          expect(err).to.be.an('error', 'done');
+          done();
+        }
+      );
   });
 
   it('should retry when notified and complete on returned completion', (done) => {
     const expected = [1, 2, 1, 2];
-    of(1, 2, 3).pipe(
-      map((n: number) => {
-        if (n === 3) {
-          throw 'bad';
+    of(1, 2, 3)
+      .pipe(
+        map((n: number) => {
+          if (n === 3) {
+            throw 'bad';
+          }
+          return n;
+        }),
+        retryWhen((errors: any) => EMPTY)
+      )
+      .subscribe(
+        (n: number) => {
+          expect(n).to.equal(expected.shift());
+        },
+        (err: any) => {
+          done(new Error('should not be called'));
+        },
+        () => {
+          done();
         }
-        return n;
-      }),
-      retryWhen((errors: any) => EMPTY)
-    ).subscribe((n: number) => {
-        expect(n).to.equal(expected.shift());
-      }, (err: any) => {
-        done(new Error('should not be called'));
-      }, () => {
-        done();
-      });
+      );
   });
 
   it('should apply an empty notifier on an empty source', () => {
-    const source = cold(  '|');
-    const subs =          '(^!)';
-    const notifier = cold('|');
-    const expected =      '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  |   ');
+      const subs = '         (^!)';
+      const notifier = cold('|   ');
+      const expected = '     |   ';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should apply a never notifier on an empty source', () => {
-    const source = cold(  '|');
-    const subs =          '(^!)';
-    const notifier = cold('-');
-    const expected =      '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  |   ');
+      const subs = '         (^!)';
+      const notifier = cold('-   ');
+      const expected = '     |   ';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should apply an empty notifier on a never source', () => {
-    const source = cold(  '-');
-    const unsub =         '                                         !';
-    const subs =          '^                                        !';
-    const notifier = cold('|');
-    const expected =      '-';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  ------------------------------------------');
+      const unsub = '        -----------------------------------------!';
+      const subs = '         ^----------------------------------------!';
+      const notifier = cold('|                                         ');
+      const expected = '     ------------------------------------------';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should apply a never notifier on a never source', () => {
-    const source = cold(  '-');
-    const unsub =         '                                         !';
-    const subs =          '^                                        !';
-    const notifier = cold('-');
-    const expected =      '-';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  -----------------------------------------');
+      const unsub = '        -----------------------------------------!';
+      const subs = '         ^----------------------------------------!';
+      const notifier = cold('------------------------------------------');
+      const expected = '     -----------------------------------------';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should return an empty observable given a just-throw source and empty notifier', () => {
-    const source = cold(  '#');
-    const notifier = cold('|');
-    const expected =      '|';
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold('  #');
+      const notifier = cold('|');
+      const expected = '     |';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
+      expectObservable(result).toBe(expected);
+    });
   });
 
   it('should return a never observable given a just-throw source and never notifier', () => {
-    const source = cold(  '#');
-    const notifier = cold('-');
-    const expected =      '-';
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold('  #');
+      const notifier = cold('-');
+      const expected = '     -';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
+      expectObservable(result).toBe(expected);
+    });
   });
 
   it('should hide errors using a never notifier on a source with eventual error', () => {
-    const source = cold(  '--a--b--c--#');
-    const subs =          '^          !';
-    const notifier = cold(           '-');
-    const expected =      '--a--b--c---------------------------------';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  --a--b--c--#                              ');
+      const subs = '         ^----------!                              ';
+      const notifier = cold('           -------------------------------');
+      const expected = '     --a--b--c---------------------------------';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should propagate error thrown from notifierSelector function', () => {
-    const source = cold('--a--b--c--#');
-    const subs =        '^          !';
-    const expected =    '--a--b--c--#';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--a--b--c--#');
+      const subs = '       ^----------!';
+      const expected = '   --a--b--c--#';
 
-    const result = source.pipe(retryWhen(<any>(() => { throw 'bad!'; })));
+      const result = source.pipe(
+        retryWhen(() => {
+          throw 'bad!';
+        })
+      );
 
-    expectObservable(result).toBe(expected, undefined, 'bad!');
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected, undefined, 'bad!');
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
-  it('should replace error with complete using an empty notifier on a source ' +
-  'with eventual error', () => {
-    const source = cold(  '--a--b--c--#');
-    const subs =          '^          !';
-    const notifier = cold(           '|');
-    const expected =      '--a--b--c--|';
+  it('should replace error with complete using an empty notifier on a source with eventual error', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  --a--b--c--#');
+      const subs = '         ^----------!';
+      const notifier = cold('           |');
+      const expected = '     --a--b--c--|';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should mirror a basic cold source with complete, given a never notifier', () => {
-    const source = cold(  '--a--b--c--|');
-    const subs =          '^          !';
-    const notifier = cold(           '|');
-    const expected =      '--a--b--c--|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  --a--b--c--|');
+      const subs = '         ^----------!';
+      const notifier = cold('           |');
+      const expected = '     --a--b--c--|';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should mirror a basic cold source with no termination, given a never notifier', () => {
-    const source = cold(  '--a--b--c---');
-    const subs =          '^           ';
-    const notifier = cold(           '|');
-    const expected =      '--a--b--c---';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('  --a--b--c---');
+      const subs = '         ^-----------';
+      const notifier = cold('           |');
+      const expected = '     --a--b--c---';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should mirror a basic hot source with complete, given a never notifier', () => {
-    const source = hot('-a-^--b--c--|');
-    const subs =          '^        !';
-    const notifier = cold(         '|');
-    const expected =      '---b--c--|';
+    rxTest.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('-a-^--b--c--|');
+      const subs = '         ^--------!';
+      const notifier = cold('         |');
+      const expected = '     ---b--c--|';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should handle a hot source that raises error but eventually completes', () => {
-    const source =   hot('-1--2--3----4--5---|');
-    const ssubs =       ['^      !            ',
-                       '              ^    !'];
-    const notifier = hot('--------------r--------r---r--r--r---|');
-    const nsubs =        '       ^           !';
-    const expected =     '-1--2---      -5---|';
+    rxTest.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('  -1--2--3----4--5---|                  ');
+      const ssubs = [
+        '                   ^------!                              ',
+        '                   --------------^----!                  ',
+      ];
+      const notifier = hot('--------------r--------r---r--r--r---|');
+      const nsubs = '       -------^-----------!                  ';
+      const expected = '    -1--2----------5---|                  ';
 
-    const result = source.pipe(
-      map((x: string) => {
-        if (x === '3') {
-          throw 'error';
-        }
-        return x;
-      }),
-      retryWhen(() => notifier)
-    );
+      const result = source.pipe(
+        map((x: string) => {
+          if (x === '3') {
+            throw 'error';
+          }
+          return x;
+        }),
+        retryWhen(() => notifier)
+      );
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(ssubs);
-    expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(ssubs);
+      expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+    });
   });
 
   it('should tear down resources when result is unsubscribed early', () => {
-    const source = cold( '-1--2--#');
-    const unsub =        '                    !       ';
-    const subs =        ['^      !                    ',
-                       '         ^      !           ',
-                       '                 ^  !       '];
-    const notifier = hot('---------r-------r---------#');
-    const nsubs =        '       ^            !       ';
-    const expected =     '-1--2-----1--2----1--       ';
+    rxTest.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const source = cold(' -1--2--#                    ');
+      //                             -1--2--#
+      //                                     -1--2--#
+      const unsub = '       --------------------!       ';
+      const subs = [
+        '                   ^------!                    ',
+        '                   ---------^------!           ',
+        '                   -----------------^--!       ',
+      ];
+      const notifier = hot('---------r-------r---------#');
+      const nsubs = '       -------^------------!       ';
+      const expected = '    -1--2-----1--2----1--       ';
 
-    const result = source.pipe(retryWhen((errors: any) => notifier));
+      const result = source.pipe(retryWhen(() => notifier));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
-    expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+      expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+    });
   });
 
   it('should not break unsubscription chains when unsubscribed explicitly', () => {
-    const source = cold( '-1--2--#');
-    const subs =        ['^      !                    ',
-                       '         ^      !           ',
-                       '                 ^  !       '];
-    const notifier = hot('---------r-------r-------r-#');
-    const nsubs =        '       ^            !       ';
-    const expected =     '-1--2-----1--2----1--       ';
-    const unsub =        '                    !       ';
+    rxTest.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const source = cold(' -1--2--#                    ');
+      //                             -1--2--#
+      //                                     -1--2--#
+      const subs = [
+        '                   ^------!                    ',
+        '                   ---------^------!           ',
+        '                   -----------------^--!       ',
+      ];
+      const notifier = hot('---------r-------r-------r-#');
+      const nsubs = '       -------^------------!       ';
+      const expected = '    -1--2-----1--2----1--       ';
+      const unsub = '       --------------------!       ';
 
-    const result = source.pipe(
-      mergeMap((x: string) => of(x)),
-      retryWhen((errors: any) => notifier),
-      mergeMap((x: string) => of(x))
-    );
+      const result = source.pipe(
+        mergeMap((x: string) => of(x)),
+        retryWhen(() => notifier),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
-    expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+      expectSubscriptions(notifier.subscriptions).toBe(nsubs);
+    });
   });
 
-  it('should handle a source with eventual error using a dynamic notifier ' +
-  'selector which eventually throws', () => {
-    const source = cold('-1--2--#');
-    const subs =       ['^      !              ',
-                      '       ^      !       ',
-                      '              ^      !'];
-    const expected =    '-1--2---1--2---1--2--#';
+  it('should handle a source with eventual error using a dynamic notifier selector which eventually throws', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('-1--2--#              ');
+      //                          -1--2--#
+      //                                 -1--2--#
+      const subs = [
+        '                  ^------!              ',
+        '                  -------^------!       ',
+        '                  --------------^------!',
+      ];
+      const expected = '   -1--2---1--2---1--2--#';
 
-    let invoked = 0;
-    const result = source.pipe(retryWhen((errors: any) =>
-      errors.pipe(map((err: any) => {
-        if (++invoked === 3) {
-          throw 'error';
-        } else {
-          return 'x';
-        }
-      }))));
+      let invoked = 0;
+      const result = source.pipe(
+        retryWhen((errors: any) =>
+          errors.pipe(
+            map(() => {
+              if (++invoked === 3) {
+                throw 'error';
+              } else {
+                return 'x';
+              }
+            })
+          )
+        )
+      );
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
-  it('should handle a source with eventual error using a dynamic notifier ' +
-  'selector which eventually completes', () => {
-    const source = cold('-1--2--#');
-    const subs =       ['^      !              ',
-                      '       ^      !       ',
-                      '              ^      !'];
-    const expected =    '-1--2---1--2---1--2--|';
+  it('should handle a source with eventual error using a dynamic notifier selector which eventually completes', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('-1--2--#              ');
+      //                          -1--2--#
+      //                                 -1--2--#
+      const subs = [
+        '                  ^------!              ',
+        '                  -------^------!       ',
+        '                  --------------^------!',
+      ];
+      const expected = '   -1--2---1--2---1--2--|';
 
-    let invoked = 0;
-    const result = source.pipe(retryWhen((errors: any) => errors.pipe(
-        map(() => 'x'),
-        takeUntil(
-          errors.pipe(mergeMap(() => {
-            if (++invoked < 3) {
-              return EMPTY;
-            } else {
-              return of('stop!');
-            }
-          }))
-      ))));
+      let invoked = 0;
+      const result = source.pipe(
+        retryWhen((errors: any) =>
+          errors.pipe(
+            map(() => 'x'),
+            takeUntil(
+              errors.pipe(
+                mergeMap(() => {
+                  if (++invoked < 3) {
+                    return EMPTY;
+                  } else {
+                    return of('stop!');
+                  }
+                })
+              )
+            )
+          )
+        )
+      );
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should always teardown before starting the next cycle, even when synchronous', () => {
     const results: any[] = [];
-    const source = new Observable<number>(subscriber => {
+    const source = new Observable<number>((subscriber) => {
       subscriber.next(1);
       subscriber.next(2);
       subscriber.error('bad');
       return () => {
         results.push('teardown');
-      }
+      };
     });
-    const subscription = source.pipe(retryWhen(errors$ => errors$.pipe(
-      mergeMap((err, i) => i < 3 ? of(true) : throwError(() => (err)))
-    ))).subscribe({
-      next: value => results.push(value),
-      error: (err) => results.push(err)
-    });
+    const subscription = source
+      .pipe(retryWhen((errors$) => errors$.pipe(mergeMap((err, i) => (i < 3 ? of(true) : throwError(() => err))))))
+      .subscribe({
+        next: (value) => results.push(value),
+        error: (err) => results.push(err),
+      });
 
     expect(subscription.closed).to.be.true;
-    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'bad', 'teardown'])
+    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'bad', 'teardown']);
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -362,10 +461,14 @@ describe('retryWhen operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      retryWhen(() => of(0)),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable
+      .pipe(
+        retryWhen(() => of(0)),
+        take(3)
+      )
+      .subscribe(() => {
+        /* noop */
+      });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });

--- a/spec/operators/retryWhen-spec.ts
+++ b/spec/operators/retryWhen-spec.ts
@@ -78,15 +78,15 @@ describe('retryWhen', () => {
           )
         )
       )
-      .subscribe(
-        (x: any) => {
+      .subscribe({
+        next(x: any) {
           expect(x).to.equal(expected[i++]);
         },
-        (err: any) => {
+        error(err: any) {
           expect(err).to.be.an('error', 'done');
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should retry when notified and complete on returned completion', (done) => {
@@ -99,19 +99,19 @@ describe('retryWhen', () => {
           }
           return n;
         }),
-        retryWhen((errors: any) => EMPTY)
+        retryWhen(() => EMPTY)
       )
-      .subscribe(
-        (n: number) => {
+      .subscribe({
+        next(n: number) {
           expect(n).to.equal(expected.shift());
         },
-        (err: any) => {
+        error() {
           done(new Error('should not be called'));
         },
-        () => {
+        complete() {
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should apply an empty notifier on an empty source', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `retryWhen` tests to run mode. It also updates the deprecated subscribe signatures within the spec file.

**Related issue (if exists):**
