### PR TITLE
chore(retry): convert retry tests to run mode

### DIFF
--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -33,7 +33,7 @@ describe('retry', () => {
   it('should retry a number of times, without error, then complete', (done) => {
     let errors = 0;
     const retries = 2;
-    Observable.create((observer: Observer<number>) => {
+    new Observable((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })
@@ -61,7 +61,7 @@ describe('retry', () => {
   it('should retry a number of times, then call error handler', (done) => {
     let errors = 0;
     const retries = 2;
-    Observable.create((observer: Observer<number>) => {
+    new Observable((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })
@@ -89,7 +89,7 @@ describe('retry', () => {
   it('should retry a number of times, then call error handler (with resetOnSuccess)', (done) => {
     let errors = 0;
     const retries = 2;
-    Observable.create((observer: Observer<number>) => {
+    new Observable((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })
@@ -198,7 +198,7 @@ describe('retry', () => {
   it('should retry until successful completion', (done) => {
     let errors = 0;
     const retries = 10;
-    Observable.create((observer: Observer<number>) => {
+    new Observable((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
     })

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -1,21 +1,33 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { retry, map, take, mergeMap, concat, multicast, refCount } from 'rxjs/operators';
 import { Observable, Observer, defer, range, of, throwError, Subject } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {retry} */
-describe('retry operator', () => {
+describe('retry', () => {
+  let rxTest: TestScheduler;
+
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
   it('should handle a basic source that emits next then errors, count=3', () => {
-    const source = cold('--1-2-3-#');
-    const subs =       ['^       !                ',
-                      '        ^       !        ',
-                      '                ^       !'];
-    const expected =    '--1-2-3---1-2-3---1-2-3-#';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2-3-#');
+      const subs = [
+        '                  ^-------!                ',
+        '                  --------^-------!        ',
+        '                  ----------------^-------!',
+      ];
+      const expected = '   --1-2-3---1-2-3---1-2-3-#';
 
-    const result = source.pipe(retry(2));
+      const result = source.pipe(retry(2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should retry a number of times, without error, then complete', (done) => {
@@ -24,22 +36,26 @@ describe('retry operator', () => {
     Observable.create((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
-    }).pipe(
-      map((x: any) => {
-        if (++errors < retries) {
-          throw 'bad';
-        }
-        errors = 0;
-        return x;
-      }),
-      retry(retries)
-    ).subscribe(
+    })
+      .pipe(
+        map((x: any) => {
+          if (++errors < retries) {
+            throw 'bad';
+          }
+          errors = 0;
+          return x;
+        }),
+        retry(retries)
+      )
+      .subscribe(
         (x: number) => {
           expect(x).to.equal(42);
         },
         (err: any) => {
           expect('this was called').to.be.true;
-        }, done);
+        },
+        done
+      );
   });
 
   it('should retry a number of times, then call error handler', (done) => {
@@ -48,22 +64,26 @@ describe('retry operator', () => {
     Observable.create((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
-    }).pipe(
-      map((x: any) => {
-        errors += 1;
-        throw 'bad';
-      }),
-      retry(retries - 1)
-    ).subscribe(
+    })
+      .pipe(
+        map((x: any) => {
+          errors += 1;
+          throw 'bad';
+        }),
+        retry(retries - 1)
+      )
+      .subscribe(
         (x: number) => {
           done("shouldn't next");
         },
         (err: any) => {
           expect(errors).to.equal(2);
           done();
-        }, () => {
+        },
+        () => {
           done("shouldn't complete");
-        });
+        }
+      );
   });
 
   it('should retry a number of times, then call error handler (with resetOnSuccess)', (done) => {
@@ -72,95 +92,107 @@ describe('retry operator', () => {
     Observable.create((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
-    }).pipe(
-      map((x: any) => {
-        errors += 1;
-        throw 'bad';
-      }),
-      retry({count: retries - 1, resetOnSuccess: true})
-    ).subscribe(
-      (x: number) => {
-        done("shouldn't next");
-      },
-      (err: any) => {
-        expect(errors).to.equal(2);
-        done();
-      }, () => {
-        done("shouldn't complete");
-      });
+    })
+      .pipe(
+        map((x: any) => {
+          errors += 1;
+          throw 'bad';
+        }),
+        retry({ count: retries - 1, resetOnSuccess: true })
+      )
+      .subscribe(
+        (x: number) => {
+          done("shouldn't next");
+        },
+        (err: any) => {
+          expect(errors).to.equal(2);
+          done();
+        },
+        () => {
+          done("shouldn't complete");
+        }
+      );
   });
 
   it('should retry a number of times, then call next handler without error, then retry and complete', (done) => {
     let index = 0;
     let errors = 0;
     const retries = 2;
-    defer(() => range(0, 4 - index)).pipe(
-      mergeMap(() => {
-        index++;
-        if (index === 1 || index === 3) {
-          errors++;
-          return throwError(() => ('bad'));
-        } else {
-          return of(42);
+    defer(() => range(0, 4 - index))
+      .pipe(
+        mergeMap(() => {
+          index++;
+          if (index === 1 || index === 3) {
+            errors++;
+            return throwError(() => 'bad');
+          } else {
+            return of(42);
+          }
+        }),
+        retry({ count: retries - 1, resetOnSuccess: true })
+      )
+      .subscribe(
+        (x: number) => {
+          expect(x).to.equal(42);
+        },
+        (err: any) => {
+          done("shouldn't error");
+        },
+        () => {
+          expect(errors).to.equal(retries);
+          done();
         }
-      }),
-      retry({count: retries - 1, resetOnSuccess: true})
-    ).subscribe(
-      (x: number) => {
-        expect(x).to.equal(42);
-      },
-      (err: any) => {
-        done("shouldn't error");
-      }, () => {
-        expect(errors).to.equal(retries);
-        done();
-      });
+      );
   });
 
   it('should always teardown before starting the next cycle, even when synchronous', () => {
     const results: any[] = [];
-    const source = new Observable<number>(subscriber => {
+    const source = new Observable<number>((subscriber) => {
       subscriber.next(1);
       subscriber.next(2);
       subscriber.error('bad');
       return () => {
         results.push('teardown');
-      }
+      };
     });
     const subscription = source.pipe(retry(3)).subscribe({
-      next: value => results.push(value),
-      error: (err) => results.push(err)
+      next: (value) => results.push(value),
+      error: (err) => results.push(err),
     });
 
     expect(subscription.closed).to.be.true;
-    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'bad', 'teardown'])
+    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'bad', 'teardown']);
   });
 
   it('should retry a number of times, then call next handler without error, then retry and error', (done) => {
     let index = 0;
     let errors = 0;
     const retries = 2;
-    defer(() => range(0, 4 - index)).pipe(
-      mergeMap(() => {
-        index++;
-        if (index === 1 || index === 3) {
-          errors++;
-          return throwError(() => ('bad'));
-        } else {
-          return of(42);
+    defer(() => range(0, 4 - index))
+      .pipe(
+        mergeMap(() => {
+          index++;
+          if (index === 1 || index === 3) {
+            errors++;
+            return throwError(() => 'bad');
+          } else {
+            return of(42);
+          }
+        }),
+        retry({ count: retries - 1, resetOnSuccess: false })
+      )
+      .subscribe(
+        (x: number) => {
+          expect(x).to.equal(42);
+        },
+        (err: any) => {
+          expect(errors).to.equal(retries);
+          done();
+        },
+        () => {
+          done("shouldn't complete");
         }
-      }),
-      retry({count: retries - 1, resetOnSuccess: false})
-    ).subscribe(
-      (x: number) => {
-        expect(x).to.equal(42);
-      },
-      (err: any) => {
-        expect(errors).to.equal(retries);
-        done();
-      }, () => {
-        done("shouldn't complete");
-      });
+      );
   });
 
   it('should retry until successful completion', (done) => {
@@ -169,148 +201,187 @@ describe('retry operator', () => {
     Observable.create((observer: Observer<number>) => {
       observer.next(42);
       observer.complete();
-    }).pipe(
-      map((x: any) => {
-        if (++errors < retries) {
-          throw 'bad';
-        }
-        errors = 0;
-        return x;
-      }),
-      retry(),
-      take(retries)
-    ).subscribe(
+    })
+      .pipe(
+        map((x: any) => {
+          if (++errors < retries) {
+            throw 'bad';
+          }
+          errors = 0;
+          return x;
+        }),
+        retry(),
+        take(retries)
+      )
+      .subscribe(
         (x: number) => {
           expect(x).to.equal(42);
         },
         (err: any) => {
           expect('this was called').to.be.true;
-        }, done);
+        },
+        done
+      );
   });
 
   it('should handle an empty source', () => {
-    const source = cold('|');
-    const subs =        '(^!)';
-    const expected =    '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('|  ');
+      const subs = '      (^!)';
+      const expected = '   |  ';
 
-    const result = source.pipe(retry());
+      const result = source.pipe(retry());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should handle a never source', () => {
-    const source = cold('-');
-    const subs =        '^';
-    const expected =    '-';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('-');
+      const subs = '       ^';
+      const expected = '   -';
 
-    const result = source.pipe(retry());
+      const result = source.pipe(retry());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should return a never observable given an async just-throw source and no count', () => {
-    const source = cold('-#'); // important that it's not a sync error
-    const unsub =       '                                     !';
-    const expected =    '--------------------------------------';
+    rxTest.run(({ cold, expectObservable }) => {
+      const source = cold('-#                                    '); // important that it's not a sync error
+      const unsub = '     -------------------------------------!';
+      const expected = '  --------------------------------------';
 
-    const result = source.pipe(retry());
+      const result = source.pipe(retry());
 
-    expectObservable(result, unsub).toBe(expected);
+      expectObservable(result, unsub).toBe(expected);
+    });
   });
 
   it('should handle a basic source that emits next then completes', () => {
-    const source = hot('--1--2--^--3--4--5---|');
-    const subs =               '^            !';
-    const expected =           '---3--4--5---|';
+    rxTest.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--1--2--^--3--4--5---|');
+      const subs = '              ^------------!';
+      const expected = '          ---3--4--5---|';
 
-    const result = source.pipe(retry());
+      const result = source.pipe(retry());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should handle a basic source that emits next but does not complete', () => {
-    const source = hot('--1--2--^--3--4--5---');
-    const subs =               '^            ';
-    const expected =           '---3--4--5---';
+    rxTest.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('--1--2--^--3--4--5---');
+      const subs = '              ^------------';
+      const expected = '          ---3--4--5---';
 
-    const result = source.pipe(retry());
+      const result = source.pipe(retry());
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should handle a basic source that emits next then errors, no count', () => {
-    const source = cold('--1-2-3-#');
-    const unsub =       '                                     !';
-    const subs =       ['^       !                             ',
-                      '        ^       !                     ',
-                      '                ^       !             ',
-                      '                        ^       !     ',
-                      '                                ^    !'];
-    const expected =    '--1-2-3---1-2-3---1-2-3---1-2-3---1-2-';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2-3-#                             ');
+      //                           --1-2-3-#
+      //                                   --1-2-3-#
+      //                                           --1-2-3-#
+      //                                                   --1-2-3-#
+      const unsub = '      -------------------------------------!';
+      const subs = [
+        '                  ^-------!                             ',
+        '                  --------^-------!                     ',
+        '                  ----------------^-------!             ',
+        '                  ------------------------^-------!     ',
+        '                  --------------------------------^----!',
+      ];
+      const expected = '   --1-2-3---1-2-3---1-2-3---1-2-3---1-2-';
 
-    const result = source.pipe(retry());
+      const result = source.pipe(retry());
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
-  it('should handle a source which eventually throws, count=3, and result is ' +
-  'unsubscribed early', () => {
-    const source = cold('--1-2-3-#');
-    const unsub =       '             !           ';
-    const subs =       ['^       !                ',
-                      '        ^    !           '];
-    const expected =    '--1-2-3---1-2-';
+  it('should handle a source which eventually throws, count=3, and result is unsubscribed early', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2-3-#     ');
+      //                           --1-2-3-#
+      const unsub = '      -------------!';
+      // prettier-ignore
+      const subs = [
+        '                  ^-------!     ', 
+        '                  --------^----!',
+      ];
+      const expected = '   --1-2-3---1-2-';
 
-    const result = source.pipe(retry(3));
+      const result = source.pipe(retry(3));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
-    const source = cold('--1-2-3-#');
-    const subs =       ['^       !                ',
-                      '        ^    !           '];
-    const expected =    '--1-2-3---1-2-';
-    const unsub =       '             !           ';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2-3-#     ');
+      //                           --1-2-3-#
+      // prettier-ignore
+      const subs = [
+        '                  ^-------!     ',
+        '                  --------^----!',
+      ];
+      const expected = '   --1-2-3---1-2-';
+      const unsub = '      -------------!';
 
-    const result = source.pipe(
-      mergeMap((x: string) => of(x)),
-      retry(100),
-      mergeMap((x: string) => of(x))
-    );
+      const result = source.pipe(
+        mergeMap((x: string) => of(x)),
+        retry(100),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
   it('should retry a synchronous source (multicasted and refCounted) multiple times', (done) => {
     const expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
 
-    of(1, 2, 3).pipe(
-      concat(throwError(() => ('bad!'))),
-      multicast(() => new Subject<number>()),
-      refCount(),
-      retry(4)
-    ).subscribe(
-        (x: number) => { expect(x).to.equal(expected.shift()); },
+    of(1, 2, 3)
+      .pipe(
+        concat(throwError(() => 'bad!')),
+        multicast(() => new Subject<number>()),
+        refCount(),
+        retry(4)
+      )
+      .subscribe(
+        (x: number) => {
+          expect(x).to.equal(expected.shift());
+        },
         (err: any) => {
           expect(err).to.equal('bad!');
           expect(expected.length).to.equal(0);
           done();
-        }, () => {
+        },
+        () => {
           done(new Error('should not be called'));
-        });
+        }
+      );
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -319,24 +390,25 @@ describe('retry operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      retry(1),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(retry(1), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });
 
   it('should not alter the source when the number of retries is smaller than 1', () => {
-    const source = cold('--1-2-3-#');
-    const subs =       ['^       !'];
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2-3-# ');
+      const subs = ['      ^-------! '];
 
-    const expected =    '--1-2-3-#';
-    const unsub =       '         !';
+      const expected = '   --1-2-3-# ';
+      const unsub = '      ---------!';
 
-    const result = source.pipe(retry(0));
+      const result = source.pipe(retry(0));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
-  })
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
+  });
 });

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -66,7 +66,7 @@ describe('retry', () => {
       observer.complete();
     })
       .pipe(
-        map((x: any) => {
+        map(() => {
           errors += 1;
           throw 'bad';
         }),
@@ -94,7 +94,7 @@ describe('retry', () => {
       observer.complete();
     })
       .pipe(
-        map((x: any) => {
+        map(() => {
           errors += 1;
           throw 'bad';
         }),

--- a/spec/operators/retry-spec.ts
+++ b/spec/operators/retry-spec.ts
@@ -47,15 +47,15 @@ describe('retry', () => {
         }),
         retry(retries)
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next(x: number) {
           expect(x).to.equal(42);
         },
-        (err: any) => {
+        error() {
           expect('this was called').to.be.true;
         },
-        done
-      );
+        complete: done,
+      });
   });
 
   it('should retry a number of times, then call error handler', (done) => {
@@ -72,18 +72,18 @@ describe('retry', () => {
         }),
         retry(retries - 1)
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next() {
           done("shouldn't next");
         },
-        (err: any) => {
+        error() {
           expect(errors).to.equal(2);
           done();
         },
-        () => {
+        complete() {
           done("shouldn't complete");
-        }
-      );
+        },
+      });
   });
 
   it('should retry a number of times, then call error handler (with resetOnSuccess)', (done) => {
@@ -100,18 +100,18 @@ describe('retry', () => {
         }),
         retry({ count: retries - 1, resetOnSuccess: true })
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next() {
           done("shouldn't next");
         },
-        (err: any) => {
+        error() {
           expect(errors).to.equal(2);
           done();
         },
-        () => {
+        complete() {
           done("shouldn't complete");
-        }
-      );
+        },
+      });
   });
 
   it('should retry a number of times, then call next handler without error, then retry and complete', (done) => {
@@ -131,18 +131,18 @@ describe('retry', () => {
         }),
         retry({ count: retries - 1, resetOnSuccess: true })
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next(x: number) {
           expect(x).to.equal(42);
         },
-        (err: any) => {
+        error() {
           done("shouldn't error");
         },
-        () => {
+        complete() {
           expect(errors).to.equal(retries);
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should always teardown before starting the next cycle, even when synchronous', () => {
@@ -181,18 +181,18 @@ describe('retry', () => {
         }),
         retry({ count: retries - 1, resetOnSuccess: false })
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next(x: number) {
           expect(x).to.equal(42);
         },
-        (err: any) => {
+        error() {
           expect(errors).to.equal(retries);
           done();
         },
-        () => {
+        complete() {
           done("shouldn't complete");
-        }
-      );
+        },
+      });
   });
 
   it('should retry until successful completion', (done) => {
@@ -213,15 +213,15 @@ describe('retry', () => {
         retry(),
         take(retries)
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next(x: number) {
           expect(x).to.equal(42);
         },
-        (err: any) => {
+        error() {
           expect('this was called').to.be.true;
         },
-        done
-      );
+        complete: done,
+      });
   });
 
   it('should handle an empty source', () => {
@@ -364,19 +364,19 @@ describe('retry', () => {
         refCount(),
         retry(4)
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next(x: number) {
           expect(x).to.equal(expected.shift());
         },
-        (err: any) => {
+        error(err: any) {
           expect(err).to.equal('bad!');
           expect(expected.length).to.equal(0);
           done();
         },
-        () => {
+        complete() {
           done(new Error('should not be called'));
-        }
-      );
+        },
+      });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `retry` tests to run mode. It also replaces deprecated `subscribe` and `Observable.create` signatures in the test file and removes some unused parameters.

**Related issue (if exists):**
None
