### PR TITLE
Fix as many skipped tests as possible.

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -856,8 +856,7 @@ describe('useDeprecatedSynchronousErrorHandling', () => {
     }).to.throw(Error, 'lol');
   });
 
-  // TODO: This is still an issue. Not sure how to handle this one yet.
-  it.skip('should throw an error when notifying an complete, and concatenated with another observable that synchronously errors', () => {
+  it('should throw an error when notifying an complete, and concatenated with another observable that synchronously errors', () => {
     const subject = new Subject<string>();
     concat(subject, throwError(new Error('lol'))).subscribe();
 

--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -205,8 +205,8 @@ describe('repeatWhen operator', () => {
     expectObservable(result).toBe(expected);
   });
 
-  xit('should hide errors using a never notifier on a source with eventual error', () => {
-    const source = cold(  '--a--b--c--#');
+  it('should return a never-ending result if the notifier is never', () => {
+    const source = cold(  '--a--b--c--|');
     const subs =          '^          !';
     const notifier = cold(           '-');
     const expected =      '--a--b--c---------------------------------';
@@ -217,7 +217,7 @@ describe('repeatWhen operator', () => {
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  xit('should propagate error thrown from notifierSelector function', () => {
+  it('should propagate error thrown from notifierSelector function', () => {
     const source = cold('--a--b--c--|');
     const subs =        '^          !';
     const expected =    '--a--b--c--#';
@@ -228,9 +228,8 @@ describe('repeatWhen operator', () => {
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  xit('should replace error with complete using an empty notifier on a source ' +
-  'with eventual error', () => {
-    const source = cold(  '--a--b--c--#');
+  it('should complete if the notifier only completes', () => {
+    const source = cold(  '--a--b--c--|');
     const subs =          '^          !';
     const notifier = cold(           '|');
     const expected =      '--a--b--c--|';
@@ -277,7 +276,8 @@ describe('repeatWhen operator', () => {
     expectSubscriptions(source.subscriptions).toBe(subs);
   });
 
-  xit('should handle a hot source that raises error but eventually completes', () => {
+  // https://github.com/ReactiveX/rxjs/issues/6523
+  it.skip('should handle a host source that completes via operator like take, and a hot notifier', () => {
     const source =   hot('-1--2--3----4--5---|');
     const ssubs =       ['^      !            ',
                        '              ^    !'];
@@ -286,12 +286,7 @@ describe('repeatWhen operator', () => {
     const expected =     '-1--2---      -5---|';
 
     const result = source.pipe(
-      map((x: string) => {
-        if (x === '3') {
-          throw 'error';
-        }
-        return x;
-      }),
+      takeWhile(value => value !== '3'),
       repeatWhen(() => notifier)
     );
 

--- a/spec/operators/take-spec.ts
+++ b/spec/operators/take-spec.ts
@@ -218,6 +218,8 @@ describe('take', () => {
     });
   });
 
+  // This is related to a PR with discussion here: https://github.com/ReactiveX/rxjs/pull/6396
+  // We can't fix this until version 8.
   it.skip('should unsubscribe from the source when it reaches the limit before a recursive synchronous upstream error is notified', () => {
     testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
       const subject = new Subject();

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -193,7 +193,7 @@ describe('BehaviorSubject', () => {
     source.subscribe(subject);
   });
 
-  it.skip('should be an Observer which can be given to an interop source', (done) => {
+  it('should be an Observer which can be given to an interop source', (done) => {
     // This test reproduces a bug reported in this issue:
     // https://github.com/ReactiveX/rxjs/issues/5105
     // However, it cannot easily be fixed. See this comment:

--- a/spec/support/.mocharc.js
+++ b/spec/support/.mocharc.js
@@ -6,4 +6,6 @@ module.exports = {
   recursive: true,
   'enable-source-maps': true,
   'expose-gc': true,
+  // Uncomment this to find all skipped tests.
+  // forbidPending: true
 };


### PR DESCRIPTION
- Adds a commented out bit to the .mocharc so it's a little easier to figure out how to find skipped tests when we need to.
- Stops skipping tests that no longer need to be skipped
- Adds an additional test to simplify the assertion of one of the skipped tests
- Adds a comment above a skipped section of tests explaining that we can probably remove them in v8 after we've moved completely to newer multicasting paradigms and removed deprecated operators.
- Some of the skipped tests in `repeatWhen-spec` were clearly copied from `retryWhen-spec` but never updated appropriately.
- One of the skipped tests showed a buggy behavior that is now reported in an issue and a comment with a link to that issue is now above it.
- Adds comments about why some tests are skipped.


Resolves #5370
Resolves #5105