### PR TITLE
chore: update pluck tests to run mode

### DIFF
--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -1,209 +1,261 @@
+/** @prettier */
 import { expect } from 'chai';
-import { cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
 import { pluck, map, tap, mergeMap } from 'rxjs/operators';
 import { of } from 'rxjs';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {pluck} */
-describe('pluck operator', () => {
+describe('pluck', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should dematerialize an Observable', () => {
-    const values = {
-      a: '{v:1}',
-      b: '{v:2}',
-      c: '{v:3}'
-    };
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = {
+        a: '{v:1}',
+        b: '{v:2}',
+        c: '{v:3}',
+      };
 
-    const e1 =  cold('--a--b--c--|', values);
-    const expected = '--x--y--z--|';
+      const e1 = cold(' --a--b--c--|', inputs);
+      const e1subs = '  ^----------!';
+      const expected = '--x--y--z--|';
 
-    const result = e1.pipe(
-      map((x: string) => ({v: x.charAt(3)})),
-      pluck('v')
-    );
+      const result = e1.pipe(
+        map((x) => ({ v: x.charAt(3) })),
+        pluck('v')
+      );
 
-    expectObservable(result).toBe(expected, {x: '1', y: '2', z: '3'});
+      expectObservable(result).toBe(expected, { x: '1', y: '2', z: '3' });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work for one array', () => {
-    const a =   cold('--x--|', {x: ['abc']});
-    const asubs =    '^    !';
-    const expected = '--y--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = { x: ['abc'] };
+      const e1 = cold(' --x--|', inputs);
+      const e1subs = '  ^----!';
+      const expected = '--y--|';
 
-    const r = a.pipe(pluck(0));
-    expectObservable(r).toBe(expected, {y: 'abc'});
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck(0));
+
+      expectObservable(result).toBe(expected, { y: 'abc' });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work for one object', () => {
-    const a =   cold('--x--|', {x: {prop: 42}});
-    const asubs =    '^    !';
-    const expected = '--y--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = { x: { prop: 42 } };
+      const e1 = cold(' --x--|', inputs);
+      const e1subs = '  ^----!';
+      const expected = '--y--|';
 
-    const r = a.pipe(pluck('prop'));
-    expectObservable(r).toBe(expected, {y: 42});
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('prop'));
+
+      expectObservable(result).toBe(expected, { y: 42 });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work for multiple objects', () => {
-    const inputs = {
-      a: {prop: '1'},
-      b: {prop: '2'},
-      c: {prop: '3'},
-      d: {prop: '4'},
-      e: {prop: '5'},
-    };
-    const a =   cold('--a-b--c-d---e-|', inputs);
-    const asubs =    '^              !';
-    const expected = '--1-2--3-4---5-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = {
+        a: { prop: '1' },
+        b: { prop: '2' },
+        c: { prop: '3' },
+        d: { prop: '4' },
+        e: { prop: '5' },
+      };
+      const e1 = cold(' --a-b--c-d---e-|', inputs);
+      const e1subs = '  ^--------------!';
+      const expected = '--1-2--3-4---5-|';
 
-    const r = a.pipe(pluck('prop'));
-    expectObservable(r).toBe(expected);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('prop'));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with deep nested properties', () => {
-    const inputs = {
-      a: {a: {b: {c: '1'}}},
-      b: {a: {b: {c: '2'}}},
-      c: {a: {b: {c: '3'}}},
-      d: {a: {b: {c: '4'}}},
-      e: {a: {b: {c: '5'}}},
-    };
-    const a =   cold('--a-b--c-d---e-|', inputs);
-    const asubs =    '^              !';
-    const expected = '--1-2--3-4---5-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = {
+        a: { a: { b: { c: '1' } } },
+        b: { a: { b: { c: '2' } } },
+        c: { a: { b: { c: '3' } } },
+        d: { a: { b: { c: '4' } } },
+        e: { a: { b: { c: '5' } } },
+      };
+      const e1 = cold(' --a-b--c-d---e-|', inputs);
+      const e1subs = '  ^--------------!';
+      const expected = '--1-2--3-4---5-|';
 
-    const r = a.pipe(pluck('a', 'b', 'c'));
-    expectObservable(r).toBe(expected);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('a', 'b', 'c'));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should work with edge cases of deep nested properties', () => {
-    const inputs = {
-      a: {a: {b: {c: 1}}},
-      b: {a: {b: 2}},
-      c: {a: {c: {c: 3}}},
-      d: {},
-      e: {a: {b: {c: 5}}},
-    };
-    const a =   cold('--a-b--c-d---e-|', inputs);
-    const asubs =    '^              !';
-    const expected = '--r-x--y-z---w-|';
-    const values: { [key: string]: number | undefined } = {r: 1, x: undefined, y: undefined, z: undefined, w: 5};
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = {
+        a: { i: { j: { k: 1 } } },
+        b: { i: { j: 2 } },
+        c: { i: { k: { k: 3 } } },
+        d: {},
+        e: { i: { j: { k: 5 } } },
+      };
+      const e1 = cold(' --a-b--c-d---e-|', inputs);
+      const e1subs = '  ^--------------!';
+      const expected = '--v-w--x-y---z-|';
+      const values: { [key: string]: number | undefined } = { v: 1, w: undefined, x: undefined, y: undefined, z: 5 };
 
-    const r = a.pipe(pluck('a', 'b', 'c'));
-    expectObservable(r).toBe(expected, values);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('i', 'j', 'k'));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should throw an error if not property is passed', () => {
     expect(() => {
-      of({prop: 1}, {prop: 2}).pipe(pluck());
+      of({ prop: 1 }, { prop: 2 }).pipe(pluck());
     }).to.throw(Error, 'list of properties cannot be empty.');
   });
 
   it('should propagate errors from observable that emits only errors', () => {
-    const a =   cold('#');
-    const asubs =    '(^!)';
-    const expected = '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    const r = a.pipe(pluck('whatever'));
-    expectObservable(r).toBe(expected);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('whatever'));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should propagate errors from observable that emit values', () => {
-    const a =   cold('--a--b--#', {a: {prop: '1'}, b: {prop: '2'}}, 'too bad');
-    const asubs =    '^       !';
-    const expected = '--1--2--#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = { a: { prop: '1' }, b: { prop: '2' } };
+      const e1 = cold(' --a--b--#', inputs, 'too bad');
+      const e1subs = '  ^-------!';
+      const expected = '--1--2--#';
 
-    const r = a.pipe(pluck('prop'));
-    expectObservable(r).toBe(expected, undefined, 'too bad');
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('prop'));
+
+      expectObservable(result).toBe(expected, undefined, 'too bad');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not pluck an empty observable', () => {
-    const a =   cold('|');
-    const asubs =    '(^!)';
-    const expected = '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '|   ';
 
-    const invoked = 0;
-    const r = a.pipe(
-      pluck('whatever'),
-      tap(null, null, () => {
-        expect(invoked).to.equal(0);
-      })
-    );
+      const invoked = 0;
+      const result = e1.pipe(
+        pluck('whatever'),
+        tap(null, null, () => {
+          expect(invoked).to.equal(0);
+        })
+      );
 
-    expectObservable(r).toBe(expected);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should allow unsubscribing explicitly and early', () => {
-    const a =   cold('--a--b--c--|', {a: {prop: '1'}, b: {prop: '2'}});
-    const unsub =    '      !     ';
-    const asubs =    '^     !     ';
-    const expected = '--1--2-     ';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--c--|', { a: { prop: '1' }, b: { prop: '2' } });
+      const e1subs = '  ^-----!     ';
+      const expected = '--1--2-     ';
+      const unsub = '   ------!     ';
 
-    const r = a.pipe(pluck('prop'));
-    expectObservable(r, unsub).toBe(expected);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('prop'));
+
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should pluck twice', () => {
-    const inputs = {
-      a: {a: {b: {c: '1'}}},
-      b: {a: {b: {c: '2'}}},
-      c: {a: {b: {c: '3'}}},
-      d: {a: {b: {c: '4'}}},
-      e: {a: {b: {c: '5'}}},
-    };
-    const a =   cold('--a-b--c-d---e-|', inputs);
-    const asubs =    '^              !';
-    const expected = '--1-2--3-4---5-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = {
+        a: { a: { b: { c: '1' } } },
+        b: { a: { b: { c: '2' } } },
+        c: { a: { b: { c: '3' } } },
+        d: { a: { b: { c: '4' } } },
+        e: { a: { b: { c: '5' } } },
+      };
+      const e1 = cold(' --a-b--c-d---e-|', inputs);
+      const e1subs = '  ^--------------!';
+      const expected = '--1-2--3-4---5-|';
 
-    const r = a.pipe(
-      pluck('a', 'b'),
-      pluck('c')
-    );
-    expectObservable(r).toBe(expected);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('a', 'b'), pluck('c'));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
-    const a =   cold('--a--b--c--|', {a: {prop: '1'}, b: {prop: '2'}});
-    const unsub =    '      !     ';
-    const asubs =    '^     !     ';
-    const expected = '--1--2-     ';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = { a: { prop: '1' }, b: { prop: '2' } };
+      const e1 = cold(' --a--b--c--|', inputs);
+      const e1subs = '  ^-----!     ';
+      const expected = '--1--2-     ';
+      const unsub = '   ------!     ';
 
-    const r = a.pipe(
-      mergeMap((x: { prop: string }) => of(x)),
-      pluck('prop'),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x) => of(x)),
+        pluck('prop'),
+        mergeMap((x) => of(x))
+      );
 
-    expectObservable(r, unsub).toBe(expected);
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should support symbols', () => {
-    const sym = Symbol('sym');
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const sym = Symbol('sym');
+      const inputs = { x: { [sym]: 'abc' } };
 
-    const a =   cold('--x--|', {x: {[sym]: 'abc'}});
-    const asubs =    '^    !';
-    const expected = '--y--|';
+      const e1 = cold(' --x--|', inputs);
+      const e1subs = '  ^----!';
+      const expected = '--y--|';
 
-    const r = a.pipe(pluck(sym));
-    expectObservable(r).toBe(expected, {y: 'abc'});
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck(sym));
+
+      expectObservable(result).toBe(expected, { y: 'abc' });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not break on null values', () => {
-    const a =   cold('--x--|', {x: null});
-    const asubs =    '^    !';
-    const expected = '--y--|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const inputs = { x: null };
+      const e1 = cold(' --x--|', inputs);
+      const e1subs = '  ^----!';
+      const expected = '--y--|';
 
-    const r = a.pipe(pluck('prop'));
-    expectObservable(r).toBe(expected, {y: undefined});
-    expectSubscriptions(a.subscriptions).toBe(asubs);
+      const result = e1.pipe(pluck('prop'));
+
+      expectObservable(result).toBe(expected, { y: undefined });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 });

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -1,8 +1,8 @@
 /** @prettier */
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
-import { pluck, map, mergeMap } from 'rxjs/operators';
-import { of } from 'rxjs';
+import { pluck, map, mergeMap, take } from 'rxjs/operators';
+import { of, Observable } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {pluck} */
@@ -251,5 +251,23 @@ describe('pluck', () => {
       expectObservable(result).toBe(expected, { y: undefined });
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
+  });
+
+  it('should stop listening to a synchronous observable when unsubscribed', () => {
+    const sideEffects: number[] = [];
+    const synchronousObservable = new Observable<number>((subscriber) => {
+      // This will check to see if the subscriber was closed on each loop
+      // when the unsubscribe hits (from the `take`), it should be closed
+      for (let i = 0; !subscriber.closed && i < 10; i++) {
+        sideEffects.push(i);
+        subscriber.next(i);
+      }
+    });
+
+    synchronousObservable.pipe(pluck('whatever'), take(3)).subscribe(() => {
+      /* noop */
+    });
+
+    expect(sideEffects).to.deep.equal([0, 1, 2]);
   });
 });

--- a/spec/operators/pluck-spec.ts
+++ b/spec/operators/pluck-spec.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
-import { pluck, map, tap, mergeMap } from 'rxjs/operators';
+import { pluck, map, mergeMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 
@@ -163,13 +163,7 @@ describe('pluck', () => {
       const e1subs = '  (^!)';
       const expected = '|   ';
 
-      const invoked = 0;
-      const result = e1.pipe(
-        pluck('whatever'),
-        tap(null, null, () => {
-          expect(invoked).to.equal(0);
-        })
-      );
+      const result = e1.pipe(pluck('whatever'));
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);


### PR DESCRIPTION
**Description:**
Updated `pluck` tests to use run mode.

There are two commits that I can exclude if needed (and possibly move to another PR), please let me know if I should.

The first one removes unused constant (its never been altered anywhere, it can be safely removed).

The second one adds firehose test for `pluck`, can this go with this PR or should I move it to another one?

**Related issue (if exists):**
None