### PR TITLE
feat(tap): Adds subscribe, unsubscribe, finalize handlers

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -708,7 +708,7 @@ export declare function takeWhile<T, S extends T>(predicate: (value: T, index: n
 export declare function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S, inclusive: false): OperatorFunction<T, S>;
 export declare function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive?: boolean): MonoTypeOperatorFunction<T>;
 
-export declare function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
+export declare function tap<T>(observer?: Partial<TapObserver<T>>): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): MonoTypeOperatorFunction<T>;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -283,7 +283,7 @@ export declare function takeWhile<T, S extends T>(predicate: (value: T, index: n
 export declare function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S, inclusive: false): OperatorFunction<T, S>;
 export declare function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive?: boolean): MonoTypeOperatorFunction<T>;
 
-export declare function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
+export declare function tap<T>(observer?: Partial<TapObserver<T>>): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
 export declare function tap<T>(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): MonoTypeOperatorFunction<T>;
 

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -125,7 +125,6 @@ export function tap<T>(
         ({ next: observerOrNext as Exclude<typeof observerOrNext, Partial<TapObserver<T>>>, error, complete } as Partial<TapObserver<T>>)
       : observerOrNext;
 
-  // TODO: Use `operate` function once this PR lands: https://github.com/ReactiveX/rxjs/pull/5742
   return tapObserver
     ? operate((source, subscriber) => {
         tapObserver.subscribe?.();

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -4,7 +4,13 @@ import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 
-export function tap<T>(observer?: Partial<Observer<T>>): MonoTypeOperatorFunction<T>;
+export interface TapObserver<T> extends Observer<T> {
+  subscribe: () => void;
+  unsubscribe: () => void;
+  finalize: () => void;
+}
+
+export function tap<T>(observer?: Partial<TapObserver<T>>): MonoTypeOperatorFunction<T>;
 export function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
 /** @deprecated Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments */
 export function tap<T>(
@@ -106,7 +112,7 @@ export function tap<T>(
  * runs the specified Observer or callback(s) for each item.
  */
 export function tap<T>(
-  observerOrNext?: Partial<Observer<T>> | ((value: T) => void) | null,
+  observerOrNext?: Partial<TapObserver<T>> | ((value: T) => void) | null,
   error?: ((e: any) => void) | null,
   complete?: (() => void) | null
 ): MonoTypeOperatorFunction<T> {
@@ -114,11 +120,16 @@ export function tap<T>(
   // but if error or complete were passed. This is because someone
   // could technically call tap like `tap(null, fn)` or `tap(null, null, fn)`.
   const tapObserver =
-    isFunction(observerOrNext) || error || complete ? { next: observerOrNext as (value: T) => void, error, complete } : observerOrNext;
+    isFunction(observerOrNext) || error || complete
+      ? // tslint:disable-next-line: no-object-literal-type-assertion
+        ({ next: observerOrNext as Exclude<typeof observerOrNext, Partial<TapObserver<T>>>, error, complete } as Partial<TapObserver<T>>)
+      : observerOrNext;
 
   // TODO: Use `operate` function once this PR lands: https://github.com/ReactiveX/rxjs/pull/5742
   return tapObserver
     ? operate((source, subscriber) => {
+        tapObserver.subscribe?.();
+        let isUnsub = true;
         source.subscribe(
           new OperatorSubscriber(
             subscriber,
@@ -127,12 +138,20 @@ export function tap<T>(
               subscriber.next(value);
             },
             () => {
+              isUnsub = false;
               tapObserver.complete?.();
               subscriber.complete();
             },
             (err) => {
+              isUnsub = false;
               tapObserver.error?.(err);
               subscriber.error(err);
+            },
+            () => {
+              if (isUnsub) {
+                tapObserver.unsubscribe?.();
+              }
+              tapObserver.finalize?.();
             }
           )
         );


### PR DESCRIPTION
This adds a common request/task for RxJS users, which are three new handlers:

- `subscribe`: fires on subscription to the source
- `unsubscribe`: fires when the subscription to the result is unsubscribed from, but NOT if the source completes or errors
- `finalize`: always fires on finalization, (basically equivalent to `finalize`)

This is useful for situations where you'd like to know that your consumer has decided to unsubscribe (and you're not terminating because of a complete or an error).

```ts
let subject = new Subject();

const sub1 = subject.pipe(
   tap({ 
      subscribe: () => console.log('subscribed'),
      complete: () => console.log('complete'),
      unsubscribe: () => console.log('unsubbed'),
      finalize: () => console.log('finalize')
   })
).subscribe();
// logs "subscribed"

sub1.unsubscribe();
// logs "unsubbed"
// logs "finalized"

const sub1 = subject.pipe(
   tap({ 
      complete: () => console.log('complete'),
      unsubscribe: () => console.log('unsubbed')
   })
).subscribe();
// logs "subscribed"

subject.complete();
// logs "complete"
// logs "finalized"
```

See included tests for more information.