### PR TITLE
fix: Expose `Connectable`, return type of `connectable`

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -112,7 +112,11 @@ export declare const config: GlobalConfig;
 
 export declare function connect<T, O extends ObservableInput<unknown>>(selector: (shared: Observable<T>) => O, config?: ConnectConfig<T>): OperatorFunction<T, ObservedValueOf<O>>;
 
-export declare function connectable<T>(source: ObservableInput<T>, config?: ConnectableConfig<T>): ConnectableObservableLike<T>;
+export declare function connectable<T>(source: ObservableInput<T>, config?: ConnectableConfig<T>): Connectable<T>;
+
+export interface Connectable<T> extends Observable<T> {
+    connect(): Subscription;
+}
 
 export declare class ConnectableObservable<T> extends Observable<T> {
     protected _connection: Subscription | null;

--- a/src/internal/observable/connectable.ts
+++ b/src/internal/observable/connectable.ts
@@ -1,22 +1,8 @@
-import { ObservableInput, SubjectLike } from '../types';
+import { Connectable, ObservableInput, SubjectLike } from '../types';
 import { Subject } from '../Subject';
 import { Subscription } from '../Subscription';
 import { Observable } from '../Observable';
 import { defer } from './defer';
-
-/**
- * An observable with a `connect` method that is used to create a subscription
- * to an underlying source, connecting it with all consumers via a multicast.
- */
-export interface ConnectableObservableLike<T> extends Observable<T> {
-  /**
-   * (Idempotent) Calling this method will connect the underlying source observable to all subscribed consumers
-   * through an underlying {@link Subject}.
-   * @returns A subscription, that when unsubscribed, will "disconnect" the source from the connector subject,
-   * severing notifications to all consumers.
-   */
-  connect(): Subscription;
-}
 
 export interface ConnectableConfig<T> {
   /**
@@ -51,7 +37,7 @@ const DEFAULT_CONFIG: ConnectableConfig<unknown> = {
  * @returns A "connectable" observable, that has a `connect()` method, that you must call to
  * connect the source to all consumers through the subject provided as the connector.
  */
-export function connectable<T>(source: ObservableInput<T>, config: ConnectableConfig<T> = DEFAULT_CONFIG): ConnectableObservableLike<T> {
+export function connectable<T>(source: ObservableInput<T>, config: ConnectableConfig<T> = DEFAULT_CONFIG): Connectable<T> {
   // The subscription representing the connection.
   let connection: Subscription | null = null;
   const { connector, resetOnDisconnect = true } = config;

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -308,3 +308,17 @@ interface ReadableStreamDefaultReaderLike<T> {
 export interface ReadableStreamLike<T> {
   getReader(): ReadableStreamDefaultReaderLike<T>;
 }
+
+/**
+ * An observable with a `connect` method that is used to create a subscription
+ * to an underlying source, connecting it with all consumers via a multicast.
+ */
+export interface Connectable<T> extends Observable<T> {
+  /**
+   * (Idempotent) Calling this method will connect the underlying source observable to all subscribed consumers
+   * through an underlying {@link Subject}.
+   * @returns A subscription, that when unsubscribed, will "disconnect" the source from the connector subject,
+   * severing notifications to all consumers.
+   */
+  connect(): Subscription;
+}


### PR DESCRIPTION
Renames previously unexposed return type of `connectable` from `ConnectableObservableLike` to `Connectable`. Moves it to `types.ts`, from which we export everything.

Resolves #6529