### PR TITLE
docs(operators): clarify that `find` can emit `undefined`

### DIFF
--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -31,7 +31,8 @@ export function find<T>(predicate: (value: T, index: number, source: Observable<
  * `find` searches for the first item in the source Observable that matches the
  * specified condition embodied by the `predicate`, and returns the first
  * occurrence in the source. Unlike {@link first}, the `predicate` is required
- * in `find`, and does not emit an error if a valid value is not found.
+ * in `find`, and does not emit an error if a valid value is not found
+ * (emits `undefined` instead).
  *
  * ## Example
  * Find and emit the first click that happens on a DIV element


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:** Was bitten by this; I expected no emission to happen if nothing is found. Thought it would be good to explicitly state the edge case in the docs, since just “it won't throw” don't really say anything about what _will_ happen instead (nothing vs emits undefined).

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->
