### PR TITLE
test: add more test cases to isPromise spec

### DIFF
--- a/spec/util/isPromise-spec.ts
+++ b/spec/util/isPromise-spec.ts
@@ -34,5 +34,18 @@ describe('isPromise', () => {
   it('should return false for a string', () => {
     expect(isPromise('1')).to.be.false;
   });
-
+  
+  it('should return false for a boolean', () => {
+    expect(isPromise(false)).to.be.false;
+  });
+  
+  it('should return false for a symbol', () => {
+    expect(isPromise(Symbol('we-love-rxjs'))).to.be.false;
+  });
+  
+  it('should return false for objects', () => {
+    expect(isPromise({})).to.be.false;
+    expect(isPromise(new Object())).to.be.false;
+    expect(isPromise(Object.create({}))).to.be.false;
+  });
 });


### PR DESCRIPTION
Hello,

**Description:**
I'm just ensuring that some other data types, which aren't also of the "isPromise" type, don't generate false negatives.