### PR TITLE
refactor: import only what is being used from the lodash library

### DIFF
--- a/docs_app/tools/transforms/angular-api-package/processors/extractDecoratedClasses.js
+++ b/docs_app/tools/transforms/angular-api-package/processors/extractDecoratedClasses.js
@@ -1,7 +1,6 @@
-var _ = require('lodash');
+var forEach = require('lodash.forEach');
 
 module.exports = function extractDecoratedClassesProcessor(EXPORT_DOC_TYPES) {
-
   // Add the "directive" docType into those that can be exported from a module
   EXPORT_DOC_TYPES.push('directive', 'pipe');
 
@@ -9,13 +8,11 @@ module.exports = function extractDecoratedClassesProcessor(EXPORT_DOC_TYPES) {
     $runAfter: ['processing-docs'],
     $runBefore: ['docs-processed'],
     decoratorTypes: ['Directive', 'Component', 'Pipe'],
-    $process: function(docs) {
+    $process: function (docs) {
       var decoratorTypes = this.decoratorTypes;
 
-      _.forEach(docs, function(doc) {
-
-        _.forEach(doc.decorators, function(decorator) {
-
+      forEach(docs, function (doc) {
+        forEach(doc.decorators, function (decorator) {
           if (decoratorTypes.indexOf(decorator.name) !== -1) {
             doc.docType = decorator.name.toLowerCase();
             doc[doc.docType + 'Options'] = decorator.argumentInfo[0];
@@ -24,6 +21,6 @@ module.exports = function extractDecoratedClassesProcessor(EXPORT_DOC_TYPES) {
       });
 
       return docs;
-    }
+    },
   };
 };

--- a/docs_app/tools/transforms/angular-base-package/processors/checkUnbalancedBackTicks.js
+++ b/docs_app/tools/transforms/angular-base-package/processors/checkUnbalancedBackTicks.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var forEach = require('lodash.forEach');
 
 /**
  * @dgProcessor checkUnbalancedBackTicks
@@ -8,26 +8,23 @@ var _ = require('lodash');
  * source content.
  */
 module.exports = function checkUnbalancedBackTicks(log, createDocMessage) {
-
   var BACKTICK_REGEX = /^ *```/gm;
 
   return {
     // $runAfter: ['checkAnchorLinksProcessor'],
     $runAfter: ['inlineTagProcessor'],
     $runBefore: ['writeFilesProcessor'],
-    $process: function(docs) {
-      _.forEach(docs, function(doc) {
+    $process: function (docs) {
+      forEach(docs, function (doc) {
         if (doc.renderedContent) {
           var matches = doc.renderedContent.match(BACKTICK_REGEX);
           if (matches && matches.length % 2 !== 0) {
             doc.unbalancedBackTicks = true;
-            log.warn(createDocMessage(
-              'checkUnbalancedBackTicks processor: unbalanced backticks found in rendered content',
-              doc));
+            log.warn(createDocMessage('checkUnbalancedBackTicks processor: unbalanced backticks found in rendered content', doc));
             log.warn(doc.renderedContent);
           }
         }
       });
-    }
+    },
   };
 };

--- a/docs_app/tools/transforms/angular.io-package/processors/createOverviewDump.js
+++ b/docs_app/tools/transforms/angular.io-package/processors/createOverviewDump.js
@@ -1,24 +1,23 @@
-var _ = require('lodash');
+var forEach = require('lodash.forEach');
 
 module.exports = function createOverviewDump() {
-
   return {
     $runAfter: ['processing-docs'],
     $runBefore: ['docs-processed'],
-    $process: function(docs) {
+    $process: function (docs) {
       var overviewDoc = {
         id: 'overview-dump',
         aliases: ['overview-dump'],
         path: 'overview-dump',
         outputPath: 'overview-dump.html',
-        modules: []
+        modules: [],
       };
-      _.forEach(docs, function(doc) {
+      forEach(docs, function (doc) {
         if (doc.docType === 'module') {
           overviewDoc.modules.push(doc);
         }
       });
       docs.push(overviewDoc);
-    }
+    },
   };
 };

--- a/spec/support/mocha.sauce.runner.js
+++ b/spec/support/mocha.sauce.runner.js
@@ -1,16 +1,16 @@
-var _ = require('lodash');
+var forEach = require('lodash.forEach');
 var mochaSauce = require('mocha-in-sauce');
 
 var customLaunchers = {
   sl_chrome: {
     base: 'SauceLabs',
     browserName: 'chrome',
-    version: '46'
+    version: '46',
   },
   sl_chrome_beta: {
     base: 'SauceLabs',
     browserName: 'chrome',
-    version: 'beta'
+    version: 'beta',
   },
   /*
   sl_chrome_dev: {
@@ -21,7 +21,7 @@ var customLaunchers = {
   sl_firefox: {
     base: 'SauceLabs',
     browserName: 'firefox',
-    version: '44'
+    version: '44',
   },
   /*sl_firefox_beta: {
     base: 'SauceLabs',
@@ -37,92 +37,92 @@ var customLaunchers = {
     base: 'SauceLabs',
     browserName: 'safari',
     platform: 'OS X 10.9',
-    version: '7'
+    version: '7',
   },
   sl_safari8: {
     base: 'SauceLabs',
     browserName: 'safari',
     platform: 'OS X 10.10',
-    version: '8'
+    version: '8',
   },
   sl_safari9: {
     base: 'SauceLabs',
     browserName: 'safari',
     platform: 'OS X 10.11',
-    version: '9.0'
+    version: '9.0',
   },
   sl_ios8: {
     base: 'SauceLabs',
     browserName: 'iphone',
     platform: 'OS X 10.11',
-    version: '8.4'
+    version: '8.4',
   },
   sl_ios9: {
     base: 'SauceLabs',
     browserName: 'iphone',
     platform: 'OS X 10.11',
-    version: '9.1'
+    version: '9.1',
   },
   sl_ie9: {
     base: 'SauceLabs',
     browserName: 'internet explorer',
     platform: 'Windows 2008',
-    version: '9'
+    version: '9',
   },
   sl_ie10: {
     base: 'SauceLabs',
     browserName: 'internet explorer',
     platform: 'Windows 2012',
-    version: '10'
+    version: '10',
   },
   sl_ie11: {
     base: 'SauceLabs',
     browserName: 'internet explorer',
     platform: 'Windows 8.1',
-    version: '11'
+    version: '11',
   },
   sl_edge: {
     base: 'SauceLabs',
     browserName: 'MicrosoftEdge',
     platform: 'Windows 10',
-    version: '14.14393'
+    version: '14.14393',
   },
   sl_edge_13: {
     base: 'SauceLabs',
     browserName: 'MicrosoftEdge',
     platform: 'Windows 10',
-    version: '13.10586'
+    version: '13.10586',
   },
   sl_android_4_1: {
     base: 'SauceLabs',
     browserName: 'android',
     platform: 'Linux',
-    version: '4.1'
+    version: '4.1',
   },
   sl_android_4_2: {
     base: 'SauceLabs',
     browserName: 'android',
     platform: 'Linux',
-    version: '4.2'
+    version: '4.2',
   },
   sl_android_4_3: {
     base: 'SauceLabs',
     browserName: 'android',
     platform: 'Linux',
-    version: '4.3'
+    version: '4.3',
   },
   sl_android_4_4: {
     base: 'SauceLabs',
     browserName: 'android',
     platform: 'Linux',
-    version: '4.4'
+    version: '4.4',
   },
   sl_android5: {
     base: 'SauceLabs',
     browserName: 'android',
     platform: 'Linux',
-    version: '5.1'
-  }
+    version: '5.1',
+  },
 };
 
 var sauce = new mochaSauce({
@@ -134,13 +134,13 @@ var sauce = new mochaSauce({
   port: 4445,
   runSauceConnect: true, // run sauceConnect automatically
 
-  url: 'http://localhost:9876/spec/support/mocha-browser-runner.html'
+  url: 'http://localhost:9876/spec/support/mocha-browser-runner.html',
 });
 
 sauce.record(true, true);
 sauce.concurrency(1);
 
-_.each(customLaunchers, function (browser) {
+forEach(customLaunchers, function (browser) {
   sauce.browser(browser);
 });
 

--- a/spec/support/webpack.mocha.config.js
+++ b/spec/support/webpack.mocha.config.js
@@ -1,10 +1,11 @@
-var _ = require('lodash');
+var map = require('lodash.map');
 var path = require('path');
 var glob = require('glob');
 var webpack = require('webpack');
 
-var globPattern = 'spec-js/**/!(mocha.sauce.gruntfile|mocha.sauce.runner|webpack.mocha.config|painter|diagram-test-runner|polyfills|testScheduler-ui).js';
-var files = _.map(glob.sync(globPattern), function (x) {
+var globPattern =
+  'spec-js/**/!(mocha.sauce.gruntfile|mocha.sauce.runner|webpack.mocha.config|painter|diagram-test-runner|polyfills|testScheduler-ui).js';
+var files = map(glob.sync(globPattern), function (x) {
   return path.resolve('./', x);
 });
 
@@ -14,13 +15,13 @@ module.exports = {
   stats: {
     colors: true,
     assets: false,
-    chunks: false
+    chunks: false,
   },
 
   entry: {
     'browser.polyfills': './spec-js/helpers/polyfills.js',
     'browser.testscheduler': './spec-js/helpers/testScheduler-ui.js',
-    'browser.spec': files
+    'browser.spec': files,
   },
 
   output: {
@@ -28,8 +29,5 @@ module.exports = {
     filename: '[name].js',
   },
 
-  plugins: [
-    new webpack.optimize.CommonsChunkPlugin('browser.common.js'),
-    new webpack.IgnorePlugin(/^mocha$/)
-  ]
+  plugins: [new webpack.optimize.CommonsChunkPlugin('browser.common.js'), new webpack.IgnorePlugin(/^mocha$/)],
 };

--- a/tools/rollup-bundle.js
+++ b/tools/rollup-bundle.js
@@ -1,4 +1,4 @@
-var _ = require('lodash');
+var mapValues = require('lodash.mapValues');
 
 var rollup = require('rollup');
 var rollupAlias = require('rollup-plugin-alias');
@@ -13,38 +13,42 @@ module.exports = function rollupBundle(options) {
   var dest = options.dest;
   var sourcemapFullFile = dest + '.map';
 
-  rollup.rollup({
-    input: options.input,
-    plugins: [
-      rollupAlias(options.aliases),
-      rollupNodeResolve({
-        jsnext: true,
-      }),
-      rollupInject({
-        exclude: 'node_modules/**',
-        modules: _.mapValues(tslib, function (value, key) {
-          return ['tslib', key];
+  rollup
+    .rollup({
+      input: options.input,
+      plugins: [
+        rollupAlias(options.aliases),
+        rollupNodeResolve({
+          jsnext: true,
         }),
-      }),
-    ],
-  }).then(function (bundle) {
-    return bundle.generate({
-      format: 'umd',
-      name: 'rxjs',
-      amd: {
-        id: 'rxjs'
-      },
-      sourcemap: true,
-    });
-  }).then(function (result) {
-    // rollup doesn't add a sourceMappingURL
-    // https://github.com/rollup/rollup/issues/121
-    result.code = result.code + '\n//# sourceMappingURL=' + path.basename(sourcemapFullFile);
+        rollupInject({
+          exclude: 'node_modules/**',
+          modules: mapValues(tslib, function (value, key) {
+            return ['tslib', key];
+          }),
+        }),
+      ],
+    })
+    .then(function (bundle) {
+      return bundle.generate({
+        format: 'umd',
+        name: 'rxjs',
+        amd: {
+          id: 'rxjs',
+        },
+        sourcemap: true,
+      });
+    })
+    .then(function (result) {
+      // rollup doesn't add a sourceMappingURL
+      // https://github.com/rollup/rollup/issues/121
+      result.code = result.code + '\n//# sourceMappingURL=' + path.basename(sourcemapFullFile);
 
-    fs.writeFileSync(dest, result.code);
-    fs.writeFileSync(sourcemapFullFile, JSON.stringify(result.map));
-  }).catch(function (err) {
-    console.error(err);
-    process.exit(1);
-  });
+      fs.writeFileSync(dest, result.code);
+      fs.writeFileSync(sourcemapFullFile, JSON.stringify(result.map));
+    })
+    .catch(function (err) {
+      console.error(err);
+      process.exit(1);
+    });
 };


### PR DESCRIPTION
Hello,

**Description:**
I decided to rewrite the way you are using the _lodash_ import so that it only loads what is needed into each file.

Most of the changes have been made to files that are only used for project documentation, so there probably won't be any performance gains in the library (:sad-parrot-emoji:)...

