### PR TITLE
chore: deprecate observable symbol export

### DIFF
--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,2 +1,7 @@
-/** Symbol.observable or a string "@@observable". Used for interop */
+/**
+ * Symbol.observable or a string "@@observable". Used for interop
+ *
+ * @deprecated We will no longer be exporting this symbol in upcoming versions of RxJS.
+ * Instead polyfill and use Symbol.observable directly *or* use https://www.npmjs.com/package/symbol-observable
+ */
 export const observable: string | symbol = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();


### PR DESCRIPTION
resolves #6489

