### PR TITLE
docs(operators.md): fix broken "anatomy of a marble diagram" link

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -105,7 +105,7 @@ To explain how operators work, textual descriptions are often not enough. Many o
 
 Below you can see the anatomy of a marble diagram.
 
-<img src="../../assets/images/guide/marble-diagram-anatomy.svg">
+<img src="assets/images/guide/marble-diagram-anatomy.svg">
 
 Throughout this documentation site, we extensively use marble diagrams to explain how operators work. They may be really useful in other contexts too, like on a whiteboard or even in our unit tests (as ASCII diagrams).
 


### PR DESCRIPTION
This is like 4th or 5th PR fixing similar issue. I'm reverting this now to how it was added by the original PR (#4151).

**Related issue (if exists):**
Closes #6534