### PR TITLE
docs: add operator flag to operator functions

### DIFF
--- a/docs_app/src/styles/2-modules/_label.scss
+++ b/docs_app/src/styles/2-modules/_label.scss
@@ -56,6 +56,10 @@ label.raised, .api-header label {
             &.impure-pipe {
                 background-color: $brightred;
             }
+
+            &.operator {
+                background-color: $brightred;
+            }
         }
 
         &.api-type-label {

--- a/docs_app/tools/transforms/angular-base-package/index.js
+++ b/docs_app/tools/transforms/angular-base-package/index.js
@@ -36,6 +36,7 @@ module.exports = new Package('angular-base', [
   .processor(require('./processors/fixInternalDocumentLinks'))
   .processor(require('./processors/copyContentAssets'))
   .processor(require('./processors/renderLinkInfo'))
+  .processor(require('./processors/checkOperator'))
 
   // overrides base packageInfo and returns the one for the 'angular/angular' repo.
   .factory('packageInfo', function () {

--- a/docs_app/tools/transforms/angular-base-package/processors/checkOperator.js
+++ b/docs_app/tools/transforms/angular-base-package/processors/checkOperator.js
@@ -1,0 +1,11 @@
+module.exports = function checkOperator() {
+  return {
+    $runAfter: ['generateApiListDoc'],
+    $runBefore: ['renderDocsProcessor'],
+    $process(docs) {
+      docs.forEach((doc) => {
+        doc.isOperator = !!(doc.originalModule && doc.originalModule.startsWith('internal/operators'));
+      });
+    },
+  };
+};

--- a/docs_app/tools/transforms/templates/api/base.template.html
+++ b/docs_app/tools/transforms/templates/api/base.template.html
@@ -26,6 +26,7 @@
     {% if doc.experimental !== undefined %}<label class="api-status-label experimental">experimental</label>{% endif %}
     {% if doc.stable !== undefined %}<label class="api-status-label stable">stable</label>{% endif %}
     {% if doc.pipeOptions.pure === 'false' %}<label class="api-status-label impure-pipe">impure</label>{% endif %}
+    {% if doc.isOperator %}<label class="api-status-label operator">operator</label>{% endif %}
   </header>
   <aio-toc class="embedded"></aio-toc>
 


### PR DESCRIPTION
**Description:**
This PR adds a label to all functions that are considered as operator functions. That is, any function that is exported from `src/internal/operators` will have this label.

The processor that was created to determine if a document `isOperator` determines this by checking if a document has `originalModule` and if `originalModule` starts with `'internal/operators'`. This means that any exported function that is not operator that may in future come from `'internal/operators'` will be marked as an operator - for now, there are no such functions. But if some util (non-operator) function gets exported in future from `'internal/operators'`, it should be moved to another place so that it doesn't get marked as operator.

This is a handy addition, especially after RxJS v7.2.0 since operators are exported from `'rxjs'` and many operators are now displayed on two pages (for example: http://rxjs.dev/api/operators/map and http://rxjs.dev/api/index/function/map).

Some examples how this looks like (please notice URL):

![image](https://user-images.githubusercontent.com/28087049/129411532-4b01c879-81b3-4d8a-805d-b66857a3ccdc.png)

![image](https://user-images.githubusercontent.com/28087049/129411578-6d701e40-4c50-4853-a081-de6cc8bb0be1.png)

![image](https://user-images.githubusercontent.com/28087049/129411657-ebe13b62-d20a-4ed7-9415-6a6930657e46.png)

`zip` creation function, exported from `'rxjs'`:
![image](https://user-images.githubusercontent.com/28087049/129411720-82a97bd6-aeb3-41a4-bcf4-29522df4c457.png)

Deprecated `zip` operator, exported from `'rxjs/operators'`:
![image](https://user-images.githubusercontent.com/28087049/129411797-b844e39a-9a3b-4490-a598-9d9ed623ef56.png)

Note: almost all (if not all) [processors](https://github.com/ReactiveX/rxjs/tree/5d0e41ee46337f56dba6d9a1ef938002b261ccac/docs_app/tools/transforms/angular-base-package/processors) come with a `.spec.js` file. I didn't add one with this PR as so many tests actually fail when [tests are run](https://github.com/ReactiveX/rxjs/blob/5d0e41ee46337f56dba6d9a1ef938002b261ccac/docs_app/package.json#L30). For this reason, I don't think those tests are really essential. If they ever become essential, I will write some.

**Related issue (if exists):**
Somewhat #6544.