### PR TITLE
fix(Schedulers): Throwing a falsy error in a scheduled function no longer results in strange error objects.

### DIFF
--- a/spec/schedulers/QueueScheduler-spec.ts
+++ b/spec/schedulers/QueueScheduler-spec.ts
@@ -63,7 +63,7 @@ describe('Scheduler.queue', () => {
     const actions: Subscription[] = [];
     let action2Exec = false;
     let action3Exec = false;
-    let errorValue = undefined;
+    let errorValue: any = undefined;
     try {
       queue.schedule(() => {
         actions.push(

--- a/spec/util/UnsubscriptionError-spec.ts
+++ b/spec/util/UnsubscriptionError-spec.ts
@@ -16,10 +16,13 @@ describe('UnsubscriptionError', () => {
     try {
       subscription.unsubscribe();
     } catch (err) {
-      expect(err instanceof UnsubscriptionError).to.equal(true);
-      expect(err.errors).to.deep.equal([err1, err2]);
-      expect(err.name).to.equal('UnsubscriptionError');
-      expect(err.stack).to.be.a('string');
+      if (err instanceof UnsubscriptionError) {
+        expect(err.errors).to.deep.equal([err1, err2]);
+        expect(err.name).to.equal('UnsubscriptionError');
+        expect(err.stack).to.be.a('string');
+      } else {
+        throw new TypeError('Invalid error type');
+      }
     }
   });
 });

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -119,7 +119,7 @@ export class AsyncAction<T> extends Action<T> {
       // HACK: Since code elsewhere is relying on the "truthiness" of the
       // return here, we can't have it return "" or 0 or false.
       // TODO: Clean this up when we refactor schedulers mid-version-8 or so.
-      errorValue = e ? e : new Error('Falsy action error');
+      errorValue = e ? e : new Error('Scheduled action threw falsy error');
     }
     if (errored) {
       this.unsubscribe();

--- a/src/internal/scheduler/AsyncAction.ts
+++ b/src/internal/scheduler/AsyncAction.ts
@@ -116,7 +116,10 @@ export class AsyncAction<T> extends Action<T> {
       this.work(state);
     } catch (e) {
       errored = true;
-      errorValue = (!!e && e) || new Error(e);
+      // HACK: Since code elsewhere is relying on the "truthiness" of the
+      // return here, we can't have it return "" or 0 or false.
+      // TODO: Clean this up when we refactor schedulers mid-version-8 or so.
+      errorValue = e ? e : new Error('Falsy action error');
     }
     if (errored) {
       this.unsubscribe();


### PR DESCRIPTION
Because TS 4.4 now infers `unknown` for `catch` blocks, we had to make some adjustments.

This also helped us catch a type problem where we were maybe creating `new Error(false)` or `new Error('')`, etc, in some cases.