### PR TITLE
feat: `useDeprecatedNextContext` no longer available

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -278,7 +278,6 @@ export interface GlobalConfig {
     Promise?: PromiseConstructorLike;
     onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
     onUnhandledError: ((err: any) => void) | null;
-    useDeprecatedNextContext: boolean;
     useDeprecatedSynchronousErrorHandling: boolean;
 }
 

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -180,69 +180,6 @@ describe('Subscriber', () => {
     expect(consumer.valuesProcessed).not.to.equal(['new', 'new']);
   });
 
-  describe('deprecated next context mode', () => {
-    beforeEach(() => {
-      config.useDeprecatedNextContext = true;
-    });
-
-    afterEach(() => {
-      config.useDeprecatedNextContext = false;
-    });
-
-    it('should allow changing the context of `this` in a POJO subscriber', () => {
-      const results: any[] = [];
-
-      const source = new Observable<number>(subscriber => {
-        for (let i = 0; i < 10 && !subscriber.closed; i++) {
-          subscriber.next(i);
-        }
-        subscriber.complete();
-
-        return () => {
-          results.push('teardown');
-        }
-      });
-
-      source.subscribe({
-        next: function (this: any, value) {
-          expect(this.unsubscribe).to.be.a('function');
-          results.push(value);
-          if (value === 3) {
-            this.unsubscribe();
-          }
-        },
-        complete() {
-          throw new Error('should not be called');
-        }
-      });
-
-      expect(results).to.deep.equal([0, 1, 2, 3, 'teardown'])
-    });
-
-    it('should NOT break this context on next methods from unfortunate consumers', () => {
-      // This is a contrived class to illustrate that we can pass another
-      // object that is "observer shaped"
-      class CustomConsumer {
-        valuesProcessed: string[] = [];
-  
-        // In here, we access instance state and alter it.
-        next(value: string) {
-          if (value === 'reset') {
-            this.valuesProcessed = [];
-          } else {
-            this.valuesProcessed.push(value);
-          }
-        }
-      };
-  
-      const consumer = new CustomConsumer();
-  
-      of('old', 'old', 'reset', 'new', 'new').subscribe(consumer);
-  
-      expect(consumer.valuesProcessed).not.to.equal(['new', 'new']);
-    });
-  });
-
   const FinalizationRegistry = (global as any).FinalizationRegistry;
   if (FinalizationRegistry && global.gc) {
 

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -155,20 +155,9 @@ export class SafeSubscriber<T> extends Subscriber<T> {
       // going to put them all in a new destination with ensured methods
       // for `next`, `error`, and `complete`. That's part of what makes this
       // the "Safe" Subscriber.
-      ({ next, error, complete } = observerOrNext);
-      let context: any;
-      if (this && config.useDeprecatedNextContext) {
-        // This is a deprecated path that made `this.unsubscribe()` available in
-        // next handler functions passed to subscribe. This only exists behind a flag
-        // now, as it is *very* slow.
-        context = Object.create(observerOrNext);
-        context.unsubscribe = () => this.unsubscribe();
-      } else {
-        context = observerOrNext;
-      }
-      next = next?.bind(context);
-      error = error?.bind(context);
-      complete = complete?.bind(context);
+      next = observerOrNext.next?.bind(observerOrNext);
+      error = observerOrNext.error?.bind(observerOrNext);
+      complete = observerOrNext.complete?.bind(observerOrNext);
     }
 
     // Once we set the destination, the superclass `Subscriber` will

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -10,7 +10,6 @@ export const config: GlobalConfig = {
   onStoppedNotification: null,
   Promise: undefined,
   useDeprecatedSynchronousErrorHandling: false,
-  useDeprecatedNextContext: false,
 };
 
 /**
@@ -65,20 +64,4 @@ export interface GlobalConfig {
    * behaviors described above. Will be removed in v8.
    */
   useDeprecatedSynchronousErrorHandling: boolean;
-
-  /**
-   * If true, enables an as-of-yet undocumented feature from v5: The ability to access
-   * `unsubscribe()` via `this` context in `next` functions created in observers passed
-   * to `subscribe`.
-   *
-   * This is being removed because the performance was severely problematic, and it could also cause
-   * issues when types other than POJOs are passed to subscribe as subscribers, as they will likely have
-   * their `this` context overwritten.
-   *
-   * @deprecated As of version 8, RxJS will no longer support altering the
-   * context of next functions provided as part of an observer to Subscribe. Instead,
-   * you will have access to a subscription or a signal or token that will allow you to do things like
-   * unsubscribe and test closed status. Will be removed in v8.
-   */
-  useDeprecatedNextContext: boolean;
 }


### PR DESCRIPTION
BREAKING CHANGE: `useDeprecatedNextContext` is no longer available. No workaround.
