### PR TITLE
feat: removed `config.Promise` injection point.

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -275,7 +275,6 @@ export declare function generate<S>(options: GenerateBaseOptions<S>): Observable
 export declare function generate<T, S>(options: GenerateOptions<T, S>): Observable<T>;
 
 export interface GlobalConfig {
-    Promise?: PromiseConstructorLike;
     onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
     onUnhandledError: ((err: any) => void) | null;
     useDeprecatedNextContext: boolean;

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -86,25 +86,6 @@ describe('Observable', () => {
         );
     });
 
-    it('should allow Promise to be globally configured', async () => {
-      try {
-        let wasCalled = false;
-
-        config.Promise = function MyPromise(callback: any) {
-          wasCalled = true;
-          return new Promise<number>(callback);
-        } as any;
-
-        await of(42).forEach((x) => {
-          expect(x).to.equal(42);
-        })
-
-        expect(wasCalled).to.be.true;
-      } finally {
-        config.Promise = undefined;
-      }
-    });
-
     it('should reject promise if nextHandler throws', (done) => {
       const results: number[] = [];
 

--- a/spec/config-spec.ts
+++ b/spec/config-spec.ts
@@ -6,11 +6,6 @@ import { Observable } from 'rxjs';
 import { timeoutProvider } from 'rxjs/internal/scheduler/timeoutProvider';
 
 describe('config', () => {
-  it('should have a Promise property that defaults to nothing', () => {
-    expect(config).to.have.property('Promise');
-    expect(config.Promise).to.be.undefined;
-  });
-
   describe('onUnhandledError', () => {
     afterEach(() => {
       config.onUnhandledError = null;

--- a/spec/operators/toPromise-spec.ts
+++ b/spec/operators/toPromise-spec.ts
@@ -33,20 +33,4 @@ describe('Observable.toPromise', () => {
         }
       );
   });
-
-  it('should allow for global config via config.Promise', async () => {
-    try {
-      let wasCalled = false;
-      config.Promise = function MyPromise(callback: Function) {
-        wasCalled = true;
-        return new Promise(callback as any);
-      } as any;
-
-      const x = await of(42).toPromise();
-      expect(wasCalled).to.be.true;
-      expect(x).to.equal(42);
-    } finally {
-      config.Promise = undefined;
-    }
-  });
 });

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -7,7 +7,6 @@ import { isSubscription, Subscription } from './Subscription';
 import { TeardownLogic, OperatorFunction, Subscribable, Observer } from './types';
 import { observable as Symbol_observable } from './symbol/observable';
 import { pipeFromArray } from './util/pipe';
-import { config } from './config';
 import { isFunction } from './util/isFunction';
 import { errorContext } from './util/errorContext';
 

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -488,7 +488,7 @@ export class Observable<T> implements Subscribable<T> {
  * @param promiseCtor The optional promise constructor to passed by consuming code
  */
 function getPromiseCtor(promiseCtor: PromiseConstructorLike | undefined) {
-  return promiseCtor ?? config.Promise ?? Promise;
+  return promiseCtor ?? Promise;
 }
 
 function isObserver<T>(value: any): value is Observer<T> {

--- a/src/internal/config.ts
+++ b/src/internal/config.ts
@@ -8,7 +8,6 @@ import { ObservableNotification } from './types';
 export const config: GlobalConfig = {
   onUnhandledError: null,
   onStoppedNotification: null,
-  Promise: undefined,
   useDeprecatedSynchronousErrorHandling: false,
   useDeprecatedNextContext: false,
 };
@@ -41,16 +40,6 @@ export interface GlobalConfig {
    * behavior of the library.
    */
   onStoppedNotification: ((notification: ObservableNotification<any>, subscriber: Subscriber<any>) => void) | null;
-
-  /**
-   * The promise constructor used by default for {@link Observable#toPromise toPromise} and {@link Observable#forEach forEach}
-   * methods.
-   *
-   * @deprecated As of version 8, RxJS will no longer support this sort of injection of a
-   * Promise constructor. If you need a Promise implementation other than native promises,
-   * please polyfill/patch Promise as you see appropriate. Will be removed in v8.
-   */
-  Promise?: PromiseConstructorLike;
 
   /**
    * If true, turns on synchronous error rethrowing, which is a deprecated behavior


### PR DESCRIPTION
BREAKING CHANGE: `config.Promise` no longer exists. As a workaround, you will need to set a global Promise if one does not already exist in your environment.
