### PR TITLE
feat(Observable.create): removed

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -435,7 +435,6 @@ export declare class Observable<T> implements Subscribable<T> {
     subscribe(observer?: Partial<Observer<T>>): Subscription;
     subscribe(next: (value: T) => void): Subscription;
     subscribe(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): Subscription;
-    static create: (...args: any[]) => any;
 }
 
 export declare type ObservableInput<T> = Observable<T> | InteropObservable<T> | AsyncIterable<T> | PromiseLike<T> | ArrayLike<T> | Iterable<T> | ReadableStreamLike<T>;
@@ -714,7 +713,7 @@ export declare function tap<T>(next?: ((value: T) => void) | null, error?: ((err
 
 export declare type TeardownLogic = Subscription | Unsubscribable | (() => void) | void;
 
-export declare function throttle<T>(durationSelector: (value: T) => ObservableInput<any>, { leading, trailing }?: ThrottleConfig): MonoTypeOperatorFunction<T>;
+export declare function throttle<T>(durationSelector: (value: T) => ObservableInput<any>, config?: ThrottleConfig): MonoTypeOperatorFunction<T>;
 
 export declare function throttleTime<T>(duration: number, scheduler?: SchedulerLike, config?: import("./throttle").ThrottleConfig): MonoTypeOperatorFunction<T>;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -237,7 +237,8 @@ export declare function retry<T>(count?: number): MonoTypeOperatorFunction<T>;
 export declare function retry<T>(config: RetryConfig): MonoTypeOperatorFunction<T>;
 
 export interface RetryConfig {
-    count: number;
+    count?: number;
+    delay?: number | ((error: any, retryCount: number) => ObservableInput<any>);
     resetOnSuccess?: boolean;
 }
 

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -673,41 +673,6 @@ describe('Observable', () => {
   });
 });
 
-/** @test {Observable} */
-describe('Observable.create', () => {
-  it('should create an Observable', () => {
-    const result = Observable.create(() => {
-      //noop
-    });
-    expect(result instanceof Observable).to.be.true;
-  });
-
-  it('should provide an observer to the function', () => {
-    let called = false;
-    const result = Observable.create((observer: Observer<any>) => {
-      called = true;
-      expectFullObserver(observer);
-      observer.complete();
-    });
-
-    expect(called).to.be.false;
-    result.subscribe(() => {
-      //noop
-    });
-    expect(called).to.be.true;
-  });
-
-  it('should send errors thrown in the passed function down the error path', (done) => {
-    Observable.create(() => {
-      throw new Error('this should be handled');
-    }).subscribe({
-      error(err: Error) {
-        expect(err).to.exist.and.be.instanceof(Error).and.have.property('message', 'this should be handled');
-        done();
-      },
-    });
-  });
-});
 
 /** @test {Observable} */
 describe('Observable.lift', () => {

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -39,21 +39,6 @@ export class Observable<T> implements Subscribable<T> {
     }
   }
 
-  // HACK: Since TypeScript inherits static properties too, we have to
-  // fight against TypeScript here so Subject can have a different static create signature
-  /**
-   * Creates a new Observable by calling the Observable constructor
-   * @owner Observable
-   * @method create
-   * @param {Function} subscribe? the subscriber function to be passed to the Observable constructor
-   * @return {Observable} a new observable
-   * @nocollapse
-   * @deprecated Use `new Observable()` instead. Will be removed in v8.
-   */
-  static create: (...args: any[]) => any = <T>(subscribe?: (subscriber: Subscriber<T>) => TeardownLogic) => {
-    return new Observable<T>(subscribe);
-  };
-
   /**
    * Creates a new Observable, with this Observable instance as the source, and the passed
    * operator defined as the new observable's operator.


### PR DESCRIPTION
BREAKING CHANGE: `Observable.create` has been removed. Use `new Observable` instead.
