### PR TITLE
fix: fix types file path cannot be resolved

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm5/index.js",
   "es2015": "./dist/esm/index.js",
-  "types": "index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "typesVersions": {
     ">=4.2": {
       "*": [


### PR DESCRIPTION
will cause an error with [`eslint-import-resolver-typescript`](https://github.com/alexgorbatchev/eslint-import-resolver-typescript/blob/v2.5.0/src/index.ts#L125), due to missing types files.


![image](https://user-images.githubusercontent.com/15135943/135287425-1dfdea0a-e573-4df8-a452-2d8db217568d.png)


![image](https://user-images.githubusercontent.com/15135943/135285847-4202b574-0fbd-4704-9773-7582840ca5ca.png)
