### PR TITLE
Docs: remove broken MDN link in Overview guide

### DIFF
--- a/docs_app/content/guide/overview.md
+++ b/docs_app/content/guide/overview.md
@@ -1,6 +1,6 @@
 # Introduction
 
-RxJS is a library for composing asynchronous and event-based programs by using observable sequences. It provides one core type, the [Observable](./guide/observable), satellite types (Observer, Schedulers, Subjects) and operators inspired by [Array#extras](https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/1.6) (map, filter, reduce, every, etc) to allow handling asynchronous events as collections.
+RxJS is a library for composing asynchronous and event-based programs by using observable sequences. It provides one core type, the [Observable](./guide/observable), satellite types (Observer, Schedulers, Subjects) and operators inspired by `Array` methods (`map`, `filter`, `reduce`, `every`, etc) to allow handling asynchronous events as collections.
 
 <span class="informal">Think of RxJS as Lodash for events.</span>
 


### PR DESCRIPTION
**Description:**

Noticed that the Overview had a broken MDN link (seems like it [broke some time in ~2020](https://web.archive.org/web/2020*/https://developer.mozilla.org/en-US/docs/Web/JavaScript/New_in_JavaScript/1.6)). There's not really an authoritative good alternative link but also I feel like we no longer need to introduce these ECMAScript 2015 concepts with a source.