### PR TITLE
Add clearBuffer method to ReplaySubject

### DIFF
--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -65,6 +65,12 @@ export class ReplaySubject<T> extends Subject<T> {
     super.next(value);
   }
 
+  public clearBuffer() {
+    // clears the event buffer so that new subscribers do not receive events which have been 
+    // added to the buffer before this method was called.
+    this._events = [];
+  }
+  
   /** @internal */
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
     this._throwIfClosed();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Adds a `clearBuffer()` method on `ReplaySubject`.  This allows consumers to clear the buffer of events which have already been delivered to the `ReplaySubject`.

This addresses an edge case where a developer may want to avoid disrupting existing subscriptions to a `ReplaySubject` and prevent new subscribers from receiving the whole history before a point in time (while maintaining the behavior which facilitates new subscribers to receive history)

This _should be_ a preferred solution over the various proposed workarounds at:

- https://stackoverflow.com/questions/58812252/angular-8-replaysubject-clear-delete-history-and-cache
- https://stackoverflow.com/questions/51145664/resetting-replaysubject-in-rxjs-6

An alternative workaround may be to extend `ReplaySubject` as `ClearableReplaySubject` and adjust the visibility modifier on the `events[]` from `private` to `protected` so that this method can be implemented on the child class

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
