### PR TITLE
docs: add es2015 code usage notes in installation guide

### DIFF
--- a/docs_app/content/guide/installation.md
+++ b/docs_app/content/guide/installation.md
@@ -2,11 +2,22 @@
 
 Here are different ways you can install RxJS:
 
-## ES6 via npm
+## ES2015 via npm
 
 ```js
 npm install rxjs
 ```
+
+By default, RxJS 7.x will provide different variants of the code based on the consumer:
+* When RxJS 7.x is used on Node.js regardless of whether it is consumed via `require` or `import`, CommonJS code targetting ES5 will be provided for execution.
+* When RxJS 7.4+ is used via a bundler targeting a browser (or other non-Node.js platform) ES module code targetting ES5 will be provided by default with the option to use ES2015 code.
+7.x versions prior to 7.4.0 will only provide ES5 code.
+
+If the target browsers for a project support ES2015+ or the bundle process supports down-leveling to ES5 then the bundler can optionally be configured to allow the ES2015 RxJS code to be used instead.
+You can enable support for using the ES2015 RxJS code by configuring a bundler to use the `es2015` custom export condition during module resolution.
+Configuring a bundler to use the `es2015` custom export condition is specific to each bundler.
+If you are interested in using this option, please consult the documentation of your bundler for additional information.
+However, some general information can be found here: https://webpack.js.org/guides/package-exports/#conditions-custom
 
 To import only what you need:
 


### PR DESCRIPTION
Documentation to describe how to leverage the ES2015 export condition feature in 7.4.0 and introduced via https://github.com/ReactiveX/rxjs/commit/268777bc3a4fd0cf76882683b51809771741ddc3 has been added to the installation guide.

Related PR: https://github.com/ReactiveX/rxjs/pull/6614