### PR TITLE
feat(repeat): now has configurable delay

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -559,7 +559,7 @@ export declare function reduce<V, A, S = A>(accumulator: (acc: A | S, value: V, 
 
 export declare function refCount<T>(): MonoTypeOperatorFunction<T>;
 
-export declare function repeat<T>(count?: number): MonoTypeOperatorFunction<T>;
+export declare function repeat<T>(countOrConfig?: number | RepeatConfig): MonoTypeOperatorFunction<T>;
 
 export declare function repeatWhen<T>(notifier: (notifications: Observable<void>) => Observable<any>): MonoTypeOperatorFunction<T>;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -213,7 +213,7 @@ export declare function reduce<V, A, S = A>(accumulator: (acc: A | S, value: V, 
 
 export declare function refCount<T>(): MonoTypeOperatorFunction<T>;
 
-export declare function repeat<T>(count?: number): MonoTypeOperatorFunction<T>;
+export declare function repeat<T>(countOrConfig?: number | RepeatConfig): MonoTypeOperatorFunction<T>;
 
 export declare function repeatWhen<T>(notifier: (notifications: Observable<void>) => Observable<any>): MonoTypeOperatorFunction<T>;
 

--- a/spec/operators/repeat-spec.ts
+++ b/spec/operators/repeat-spec.ts
@@ -128,10 +128,9 @@ describe('repeat operator', () => {
   it('should consider negative count as no repeat, and return EMPTY', () => {
     rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
       const e1 = cold('--a--b--|                                    ');
-      const unsub = '                                            !';
       const expected = '|';
 
-      expectObservable(e1.pipe(repeat(-1)), unsub).toBe(expected);
+      expectObservable(e1.pipe(repeat(-1))).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe([]);
     });
   });

--- a/spec/operators/repeat-spec.ts
+++ b/spec/operators/repeat-spec.ts
@@ -1,115 +1,146 @@
+/** @prettier */
 import { expect } from 'chai';
-import { cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { repeat, mergeMap, map, multicast, refCount, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { of, Subject, Observable } from 'rxjs';
-
-declare const rxTestScheduler: TestScheduler;
+import { of, Subject, Observable, timer } from 'rxjs';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {repeat} */
 describe('repeat operator', () => {
-  it('should resubscribe count number of times', () => {
-    const e1 =   cold('--a--b--|                ');
-    const subs =     ['^       !                ',
-                    '        ^       !        ',
-                    '                ^       !'];
-    const expected =  '--a--b----a--b----a--b--|';
+  let rxTest: TestScheduler;
 
-    expectObservable(e1.pipe(repeat(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+  beforeEach(() => {
+    rxTest = new TestScheduler(observableMatcher);
+  });
+
+  it('should resubscribe count number of times', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|                ');
+      const subs = [
+        '               ^-------!                ', //
+        '               --------^-------!        ',
+        '               ----------------^-------!',
+      ];
+      const expected = '--a--b----a--b----a--b--|';
+
+      expectObservable(e1.pipe(repeat(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should resubscribe multiple times', () => {
-    const e1 =   cold('--a--b--|                        ');
-    const subs =     ['^       !                        ',
-                    '        ^       !                ',
-                    '                ^       !        ',
-                    '                        ^       !'];
-    const expected =  '--a--b----a--b----a--b----a--b--|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|                        ');
+      const subs = [
+        '               ^-------!                        ',
+        '               --------^-------!                ',
+        '               ----------------^-------!        ',
+        '               ------------------------^-------!',
+      ];
+      const expected = '--a--b----a--b----a--b----a--b--|';
 
-    expectObservable(e1.pipe(repeat(2), repeat(2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(2), repeat(2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should complete without emit when count is zero', () => {
-    const e1 =  cold('--a--b--|');
-    const subs: string[] = [];
-    const expected = '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('--a--b--|');
+      const subs: string[] = [];
+      const expected = '|';
 
-    expectObservable(e1.pipe(repeat(0))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should emit source once when count is one', () => {
-    const e1 =  cold('--a--b--|');
-    const subs =     '^       !';
-    const expected = '--a--b--|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|');
+      const subs = '    ^-------!';
+      const expected = '--a--b--|';
 
-    expectObservable(e1.pipe(repeat(1))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(1))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should repeat until gets unsubscribed', () => {
-    const e1 =  cold('--a--b--|      ');
-    const subs =    ['^       !      ',
-                   '        ^     !'];
-    const unsub =    '              !';
-    const expected = '--a--b----a--b-';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|      ');
+      const subs = [
+        '               ^-------!      ', //
+        '               --------^------!',
+      ];
+      const unsub = '   ---------------!';
+      const expected = '--a--b----a--b-';
 
-    expectObservable(e1.pipe(repeat(10)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(10)), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should be able to repeat indefinitely until unsubscribed', () => {
-    const e1 =  cold('--a--b--|                                    ');
-    const subs =    ['^       !                                    ',
-                   '        ^       !                            ',
-                   '                ^       !                    ',
-                   '                        ^       !            ',
-                   '                                ^       !    ',
-                   '                                        ^   !'];
-    const unsub =    '                                            !';
-    const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|                                    ');
+      const subs = [
+        '               ^-------!                                    ',
+        '               --------^-------!                            ',
+        '               ----------------^-------!                    ',
+        '               ------------------------^-------!            ',
+        '               --------------------------------^-------!    ',
+        '               ----------------------------------------^---!',
+      ];
+      const unsub = '   --------------------------------------------!';
+      const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
 
-    expectObservable(e1.pipe(repeat()), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat()), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {
-    const e1 =  cold('--a--b--|                                    ');
-    const subs =    ['^       !                                    ',
-                   '        ^       !                            ',
-                   '                ^       !                    ',
-                   '                        ^       !            ',
-                   '                                ^       !    ',
-                   '                                        ^   !'];
-    const unsub =    '                                            !';
-    const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|                                    ');
+      const subs = [
+        '               ^-------!                                    ',
+        '               --------^-------!                            ',
+        '               ----------------^-------!                    ',
+        '               ------------------------^-------!            ',
+        '               --------------------------------^-------!    ',
+        '               ----------------------------------------^---!',
+      ];
+      const unsub = '   --------------------------------------------!';
+      const expected = '--a--b----a--b----a--b----a--b----a--b----a--';
 
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      repeat(),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        repeat(),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should consider negative count as no repeat, and return EMPTY', () => {
-    const e1 =  cold('--a--b--|                                    ');
-    const unsub =    '                                            !';
-    const expected = '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('--a--b--|                                    ');
+      const unsub = '                                            !';
+      const expected = '|';
 
-    expectObservable(e1.pipe(repeat(-1)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe([]);
+      expectObservable(e1.pipe(repeat(-1)), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe([]);
+    });
   });
 
   it('should always teardown before starting the next cycle', async () => {
     const results: any[] = [];
-    const source = new Observable<number>(subscriber => {
+    const source = new Observable<number>((subscriber) => {
       Promise.resolve().then(() => {
-        subscriber.next(1)
+        subscriber.next(1);
         Promise.resolve().then(() => {
           subscriber.next(2);
           Promise.resolve().then(() => {
@@ -119,171 +150,205 @@ describe('repeat operator', () => {
       });
       return () => {
         results.push('teardown');
-      }
+      };
     });
 
-    await source.pipe(repeat(3)).forEach(value => results.push(value));
-  
-    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'teardown'])
+    await source.pipe(repeat(3)).forEach((value) => results.push(value));
+
+    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'teardown']);
   });
 
   it('should always teardown before starting the next cycle, even when synchronous', () => {
     const results: any[] = [];
-    const source = new Observable<number>(subscriber => {
+    const source = new Observable<number>((subscriber) => {
       subscriber.next(1);
       subscriber.next(2);
       subscriber.complete();
       return () => {
         results.push('teardown');
-      }
+      };
     });
     const subscription = source.pipe(repeat(3)).subscribe({
-      next: value => results.push(value),
-      complete: () => results.push('complete')
+      next: (value) => results.push(value),
+      complete: () => results.push('complete'),
     });
 
     expect(subscription.closed).to.be.true;
-    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'complete', 'teardown'])
+    expect(results).to.deep.equal([1, 2, 'teardown', 1, 2, 'teardown', 1, 2, 'complete', 'teardown']);
   });
 
   it('should not complete when source never completes', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('-');
+      const e1subs = '^';
+      const expected = '-';
 
-    expectObservable(e1.pipe(repeat(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(repeat(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should not complete when source does not completes', () => {
-    const e1 =  cold('-');
-    const unsub =    '                              !';
-    const subs =     '^                             !';
-    const expected = '-';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('-');
+      const unsub = '------------------------------!';
+      const subs = ' ^-----------------------------!';
+      const expected = '-';
 
-    expectObservable(e1.pipe(repeat(3)), unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(3)), unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should complete immediately when source does not complete without emit but count is zero', () => {
-    const e1 =  cold('-');
-    const subs: string[] = [];
-    const expected = '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('-');
+      const subs: string[] = [];
+      const expected = '|';
 
-    expectObservable(e1.pipe(repeat(0))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should complete immediately when source does not complete but count is zero', () => {
-    const e1 =   cold('--a--b--');
-    const subs: string[] = [];
-    const expected = '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('--a--b--');
+      const subs: string[] = [];
+      const expected = '|';
 
-    expectObservable(e1.pipe(repeat(0))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should emit source once and does not complete when source emits but does not complete', () => {
-    const e1 =   cold('--a--b--');
-    const subs =     ['^       '];
-    const expected =  '--a--b--';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--');
+      const subs = ['   ^-------'];
+      const expected = '--a--b--';
 
-    expectObservable(e1.pipe(repeat(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should complete when source is empty', () => {
-    const e1 =  cold('|');
-    const e1subs =  ['(^!)', '(^!)', '(^!)'];
-    const expected = '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('|');
+      const e1subs = ['(^!)', '(^!)', '(^!)'];
+      const expected = '|';
 
-    expectObservable(e1.pipe(repeat(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(repeat(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should complete when source does not emit', () => {
-    const e1 =  cold('----|        ');
-    const subs =    ['^   !        ',
-                   '    ^   !    ',
-                   '        ^   !'];
-    const expected = '------------|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('----|        ');
+      const subs = [
+        '              ^---!        ', //
+        '              ----^---!    ',
+        '              --------^---!',
+      ];
+      const expected = '------------|';
 
-    expectObservable(e1.pipe(repeat(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should complete immediately when source does not emit but count is zero', () => {
-    const e1 =  cold('----|');
-    const subs: string[] = [];
-    const expected = '|';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('----|');
+      const subs: string[] = [];
+      const expected = '|';
 
-    expectObservable(e1.pipe(repeat(0))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(0))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should raise error when source raises error', () => {
-    const e1 =  cold('--a--b--#');
-    const subs =     '^       !';
-    const expected = '--a--b--#';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--#');
+      const subs = '    ^-------!';
+      const expected = '--a--b--#';
 
-    expectObservable(e1.pipe(repeat(2))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(subs);
+      expectObservable(e1.pipe(repeat(2))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 
   it('should raises error if source throws', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('#');
+      const e1subs = '(^!)';
+      const expected = '#';
 
-    expectObservable(e1.pipe(repeat(3))).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(repeat(3))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raises error if source throws when repeating infinitely', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('#');
+      const e1subs = '(^!)';
+      const expected = '#';
 
-    expectObservable(e1.pipe(repeat())).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(e1.pipe(repeat())).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should raise error after first emit succeed', () => {
-    let repeated = false;
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      let repeated = false;
 
-    const e1 = cold('--a--|').pipe(map((x: string) => {
-      if (repeated) {
-        throw 'error';
-      } else {
-        repeated = true;
-        return x;
-      }
-    }));
-    const expected = '--a----#';
+      const e1 = cold('--a--|').pipe(
+        map((x: string) => {
+          if (repeated) {
+            throw 'error';
+          } else {
+            repeated = true;
+            return x;
+          }
+        })
+      );
+      const expected = '--a----#';
 
-    expectObservable(e1.pipe(repeat(2))).toBe(expected);
+      expectObservable(e1.pipe(repeat(2))).toBe(expected);
+    });
   });
 
   it('should repeat a synchronous source (multicasted and refCounted) multiple times', (done) => {
     const expected = [1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3, 1, 2, 3];
 
-    of(1, 2, 3).pipe(
-      multicast(() => new Subject<number>()),
-      refCount(),
-      repeat(5)
-    ).subscribe(
-        (x: number) => { expect(x).to.equal(expected.shift()); },
+    of(1, 2, 3)
+      .pipe(
+        multicast(() => new Subject<number>()),
+        refCount(),
+        repeat(5)
+      )
+      .subscribe(
+        (x: number) => {
+          expect(x).to.equal(expected.shift());
+        },
         (x) => {
           done(new Error('should not be called'));
-        }, () => {
+        },
+        () => {
           expect(expected.length).to.equal(0);
           done();
-        });
+        }
+      );
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -292,11 +357,98 @@ describe('repeat operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      repeat(),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(repeat(), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
+  });
+
+  it('should allow count configuration', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|                ');
+      const subs = [
+        '               ^-------!                ', //
+        '               --------^-------!        ',
+        '               ----------------^-------!',
+      ];
+      const expected = '--a--b----a--b----a--b--|';
+
+      expectObservable(e1.pipe(repeat({ count: 3 }))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should allow delay time configuration', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' --a--b--|                ');
+      const delay = 3; //       ---|       ---|
+      const subs = [
+        '               ^-------!                ', //
+        '               -----------^-------!        ',
+        '               ----------------------^-------!',
+      ];
+      const expected = '--a--b-------a--b-------a--b--|';
+
+      expectObservable(e1.pipe(repeat({ count: 3, delay }))).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should allow delay function configuration', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const expectedCounts = [1, 2, 3];
+
+      const e1 = cold(' --a--b--|                ');
+      const delay = 3; //       ---|       ---|
+      const subs = [
+        '               ^-------!                ', //
+        '               -----------^-------!        ',
+        '               ----------------------^-------!',
+      ];
+      const expected = '--a--b-------a--b-------a--b--|';
+
+      expectObservable(
+        e1.pipe(
+          repeat({
+            count: 3,
+            delay: (count) => {
+              expect(count).to.equal(expectedCounts.shift());
+              return timer(delay);
+            },
+          })
+        )
+      ).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
+  });
+
+  it('should handle delay function throwing', () => {
+    rxTest.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const expectedCounts = [1, 2, 3];
+
+      const e1 = cold(' --a--b--|                ');
+      const delay = 3; //       ---|       ---|
+      const subs = [
+        '               ^-------!                ', //
+        '               -----------^-------!        ',
+      ];
+      const expected = '--a--b-------a--b--#';
+
+      expectObservable(
+        e1.pipe(
+          repeat({
+            count: 3,
+            delay: (count) => {
+              if (count === 2) {
+                throw 'bad';
+              }
+              return timer(delay);
+            },
+          })
+        )
+      ).toBe(expected, undefined, 'bad');
+      expectSubscriptions(e1.subscriptions).toBe(subs);
+    });
   });
 });


### PR DESCRIPTION
Adds a feature to `repeat` to match the configurable API of `retry`.
`repeat` can now be used in a similar manner to `repeatWhen`, only
perhaps in a more developer-friendly way.

- Also updates `repeat` tests to use run mode.
