### PR TITLE
fix: Add types to the package export map

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,36 +16,43 @@
   "sideEffects": false,
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "node": "./dist/cjs/index.js",
       "es2015": "./dist/esm/index.js",
       "default": "./dist/esm5/index.js"
     },
     "./ajax": {
+      "types": "./dist/types/ajax/index.d.ts",
       "node": "./dist/cjs/ajax/index.js",
       "es2015": "./dist/esm/ajax/index.js",
       "default": "./dist/esm5/ajax/index.js"
     },
     "./fetch": {
+      "types": "./dist/types/fetch/index.d.ts",
       "node": "./dist/cjs/fetch/index.js",
       "es2015": "./dist/esm/fetch/index.js",
       "default": "./dist/esm5/fetch/index.js"
     },
     "./operators": {
+      "types": "./dist/types/operators/index.d.ts",
       "node": "./dist/cjs/operators/index.js",
       "es2015": "./dist/esm/operators/index.js",
       "default": "./dist/esm5/operators/index.js"
     },
     "./testing": {
+      "types": "./dist/types/testing/index.d.ts",
       "node": "./dist/cjs/testing/index.js",
       "es2015": "./dist/esm/testing/index.js",
       "default": "./dist/esm5/testing/index.js"
     },
     "./webSocket": {
+      "types": "./dist/types/webSocket/index.d.ts",
       "node": "./dist/cjs/webSocket/index.js",
       "es2015": "./dist/esm/webSocket/index.js",
       "default": "./dist/esm5/webSocket/index.js"
     },
     "./internal/*": {
+      "types": "./dist/types/internal/*.d.ts",
       "node": "./dist/cjs/internal/*.js",
       "es2015": "./dist/esm/internal/*.js",
       "default": "./dist/esm5/internal/*.js"


### PR DESCRIPTION
**Description:**

This commit adds `types` mapping for the package `exports`. It makes the package compatible with the upcoming `node12` module resolution in TypeScript 4.5.0.

**BREAKING CHANGE:** N/A

**Related issue (if exists):** #6641
