### PR TITLE
Feature: Add getValue() in ReplaySubject to get the last emitted value

### DIFF
--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -37,6 +37,7 @@ import { dateTimestampProvider } from './scheduler/dateTimestampProvider';
 export class ReplaySubject<T> extends Subject<T> {
   private _buffer: (T | number)[] = [];
   private _infiniteTimeWindow = true;
+  private _lastValue: T | null = null;
 
   /**
    * @param bufferSize The size of the buffer to replay on subscription
@@ -55,6 +56,14 @@ export class ReplaySubject<T> extends Subject<T> {
     this._windowTime = Math.max(1, _windowTime);
   }
 
+  get value(): T | null {
+    return this.getValue();
+  }
+
+  getValue(): T | null {
+    return this._lastValue;
+  }
+
   next(value: T): void {
     const { isStopped, _buffer, _infiniteTimeWindow, _timestampProvider, _windowTime } = this;
     if (!isStopped) {
@@ -62,7 +71,7 @@ export class ReplaySubject<T> extends Subject<T> {
       !_infiniteTimeWindow && _buffer.push(_timestampProvider.now() + _windowTime);
     }
     this._trimBuffer();
-    super.next(value);
+    super.next((this._lastValue = value));
   }
 
   /** @internal */


### PR DESCRIPTION
*I'm a first-time contributor (not a consumer) to RxJS. Pardon my lack of understanding.*

**Description:**

Just like `BehaviorSubject`, this PR will add a method `getValue()` in `ReplaySubject` so that the owner can always get the last emitted value (if not, returns `null`). This change makes the `ReplaySubject` usable like a state (maybe this can be a different *Subject class itself).

Once this MR is approved, I'll update the documentation.