### PR TITLE
chore: fix heritage links

### DIFF
--- a/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
@@ -2,10 +2,10 @@
 
 {%- macro renderHeritage(exportDoc) -%}
   {%- if exportDoc.extendsClauses.length %} extends {% for clause in exportDoc.extendsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text $}</a>{% if not loop.last %}, {% endif -%}
+  {% if clause.doc.path %}<a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% else %}{$ clause.text | escape $}{% endif %}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
   {%- if exportDoc.implementsClauses.length %} implements {% for clause in exportDoc.implementsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text $}</a>{% if not loop.last %}, {% endif -%}
+  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
**Description:**
This PR fixes the issue with the docs rendering. Please see more details in this issue: #6427

One note: I took `{% if clause.doc.path %}` section from Angular docs to check if the doc has the `path` - if it has it, then render the `<a>` tag; otherwise, render only `text`.

**Related issue (if exists):**
Closes #6427
Related angular/angular#43956
Related  ngrx/platform#3262