### PR TITLE
fix: scheduler unsubscription scenarios

### DIFF
--- a/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { animationFrameScheduler, Subscription, merge, animationFrames } from 'rxjs';
+import { animationFrameScheduler, Subscription, merge } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';

--- a/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -208,7 +208,7 @@ describe('Scheduler.animationFrame', () => {
       b.unsubscribe();
     });
     b = animationFrameScheduler.schedule(() => {
-      expect(stubFlush).to.have.callCount(1);
+      done(new Error('Unexpected execution of b'));
     });
   });
 
@@ -222,7 +222,9 @@ describe('Scheduler.animationFrame', () => {
 
     a = animationFrameScheduler.schedule(() => {
       expect(animationFrameScheduler.actions).to.have.length(1);
-      c = animationFrameScheduler.schedule(() => { /* stupid lint rule */ });
+      c = animationFrameScheduler.schedule(() => {
+        done(new Error('Unexpected execution of c'));
+      });
       expect(animationFrameScheduler.actions).to.have.length(2);
       // What we're testing here is that the unsubscription of action c effects
       // the cancellation of the animation frame in a scenario in which the
@@ -230,9 +232,10 @@ describe('Scheduler.animationFrame', () => {
       c.unsubscribe();
       expect(animationFrameScheduler.actions).to.have.length(1);
       expect(cancelAnimationFrameStub).to.have.callCount(1);
+    });
+    b = animationFrameScheduler.schedule(() => {
       sandbox.restore();
       done();
     });
-    b = animationFrameScheduler.schedule(() => { /* stupid lint rule */ });
   });
 });

--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -218,4 +218,50 @@ describe('Scheduler.asap', () => {
     }, 0, 0);
     scheduledIndices.push(0);
   });
+
+  it('should execute actions scheduled when flushing in a subsequent flush', (done) => {
+    const sandbox = sinon.createSandbox();
+    const stubFlush = (sandbox.stub(asapScheduler, 'flush')).callThrough();
+
+    let a: Subscription;
+    let b: Subscription;
+    let c: Subscription;
+
+    a = asapScheduler.schedule(() => {
+      expect(stubFlush).to.have.callCount(1);
+      c = asapScheduler.schedule(() => {
+        expect(stubFlush).to.have.callCount(2);
+        sandbox.restore();
+        done();
+      });
+    });
+    b = asapScheduler.schedule(() => {
+      expect(stubFlush).to.have.callCount(1);
+    });
+  });
+
+  it('should execute actions scheduled when flushing in a subsequent flush when some actions are unsubscribed', (done) => {
+    const sandbox = sinon.createSandbox();
+    const stubFlush = (sandbox.stub(asapScheduler, 'flush')).callThrough();
+
+    let a: Subscription;
+    let b: Subscription;
+    let c: Subscription;
+
+    a = asapScheduler.schedule(() => {
+      expect(stubFlush).to.have.callCount(1);
+      c = asapScheduler.schedule(() => {
+        expect(stubFlush).to.have.callCount(2);
+        sandbox.restore();
+        done();
+      });
+      b.unsubscribe();
+    });
+    b = asapScheduler.schedule(() => {
+      expect(stubFlush).to.have.callCount(1);
+    });
+  });
+
+  it.skip('should properly cancel an unnecessary flush', (done) => {
+  });
 });

--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -258,7 +258,7 @@ describe('Scheduler.asap', () => {
       b.unsubscribe();
     });
     b = asapScheduler.schedule(() => {
-      expect(stubFlush).to.have.callCount(1);
+      done(new Error('Unexpected execution of b'));
     });
   });
 
@@ -272,7 +272,9 @@ describe('Scheduler.asap', () => {
 
     a = asapScheduler.schedule(() => {
       expect(asapScheduler.actions).to.have.length(1);
-      c = asapScheduler.schedule(() => { /* stupid lint rule */ });
+      c = asapScheduler.schedule(() => {
+        done(new Error('Unexpected execution of c'));
+      });
       expect(asapScheduler.actions).to.have.length(2);
       // What we're testing here is that the unsubscription of action c effects
       // the cancellation of the microtask in a scenario in which the actions
@@ -280,9 +282,10 @@ describe('Scheduler.asap', () => {
       c.unsubscribe();
       expect(asapScheduler.actions).to.have.length(1);
       expect(clearImmediateStub).to.have.callCount(1);
+    });
+    b = asapScheduler.schedule(() => {
       sandbox.restore();
       done();
     });
-    b = asapScheduler.schedule(() => { /* stupid lint rule */ });
   });
 });

--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -39,9 +39,10 @@ describe('Scheduler.asap', () => {
 
   it('should cancel asap actions when delay > 0', () => {
     testScheduler.run(({ cold, expectObservable, flush, time }) => {
-      const setImmediateSpy = sinon.spy(immediateProvider, 'setImmediate');
-      const setSpy = sinon.spy(intervalProvider, 'setInterval');
-      const clearSpy = sinon.spy(intervalProvider, 'clearInterval');
+      const sandbox = sinon.createSandbox();
+      const setImmediateSpy = sandbox.spy(immediateProvider, 'setImmediate');
+      const setSpy = sandbox.spy(intervalProvider, 'setInterval');
+      const clearSpy = sandbox.spy(intervalProvider, 'clearInterval');
 
       const a = cold('  a            ');
       const ta = time(' ----|        ');
@@ -57,9 +58,7 @@ describe('Scheduler.asap', () => {
       expect(setImmediateSpy).to.have.not.been.called;
       expect(setSpy).to.have.been.calledOnce;
       expect(clearSpy).to.have.been.calledOnce;
-      setImmediateSpy.restore();
-      setSpy.restore();
-      clearSpy.restore();
+      sandbox.restore();
     });
   });
 
@@ -67,7 +66,7 @@ describe('Scheduler.asap', () => {
     const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sinon.stub(global, 'setInterval')).callThrough();
+    const stubSetInterval = (<any> sandbox.stub(global, 'setInterval')).callThrough();
     const period = 50;
     const state = { index: 0, period };
     type State = typeof state;
@@ -86,7 +85,6 @@ describe('Scheduler.asap', () => {
     fakeTimer.tick(period);
     expect(state).to.have.property('index', 2);
     expect(stubSetInterval).to.have.property('callCount', 1);
-    stubSetInterval.restore();
     sandbox.restore();
   });
 
@@ -94,7 +92,7 @@ describe('Scheduler.asap', () => {
     const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sinon.stub(global, 'setInterval')).callThrough();
+    const stubSetInterval = (<any> sandbox.stub(global, 'setInterval')).callThrough();
     const period = 50;
     const state = { index: 0, period };
     type State = typeof state;
@@ -114,7 +112,6 @@ describe('Scheduler.asap', () => {
     fakeTimer.tick(period);
     expect(state).to.have.property('index', 2);
     expect(stubSetInterval).to.have.property('callCount', 3);
-    stubSetInterval.restore();
     sandbox.restore();
   });
 

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -27,10 +27,10 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
-    // If the scheduler queue is empty, cancel the requested animation frame and
-    // set the scheduled flag to undefined so the next AnimationFrameAction will
-    // request its own.
-    if (scheduler.actions.length === 0) {
+    // If the scheduler queue has no remaining actions with the same async id,
+    // cancel the requested animation frame and set the scheduled flag to
+    // undefined so the next AnimationFrameAction will request its own.
+    if (!scheduler.actions.some((action) => action.id === id)) {
       animationFrameProvider.cancelAnimationFrame(id);
       scheduler._scheduled = undefined;
     }

--- a/src/internal/scheduler/AnimationFrameScheduler.ts
+++ b/src/internal/scheduler/AnimationFrameScheduler.ts
@@ -4,24 +4,32 @@ import { AsyncScheduler } from './AsyncScheduler';
 export class AnimationFrameScheduler extends AsyncScheduler {
   public flush(action?: AsyncAction<any>): void {
     this._active = true;
+    // The async id that effects a call to flush is stored in _scheduled.
+    // Before executing an action, it's necessary to check the action's async
+    // id to determine whether it's supposed to be executed in the current
+    // flush.
+    // Previous implementations of this method used a count to determine this,
+    // but that was unsound, as actions that are unsubscribed - i.e. cancelled -
+    // are removed from the actions array and that can shift actions that are
+    // scheduled to be executed in a subsequent flush into positions at which
+    // they are executed within the current flush.
+    const flushId = this._scheduled;
     this._scheduled = undefined;
 
     const { actions } = this;
     let error: any;
-    let index = -1;
     action = action || actions.shift()!;
-    const count = actions.length;
 
     do {
       if ((error = action.execute(action.state, action.delay))) {
         break;
       }
-    } while (++index < count && (action = actions.shift()));
+    } while ((action = actions[0]) && action.id === flushId && actions.shift());
 
     this._active = false;
 
     if (error) {
-      while (++index < count && (action = actions.shift())) {
+      while ((action = actions[0]) && action.id === flushId && actions.shift()) {
         action.unsubscribe();
       }
       throw error;

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -27,10 +27,10 @@ export class AsapAction<T> extends AsyncAction<T> {
     if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
-    // If the scheduler queue is empty, cancel the requested microtask and
-    // set the scheduled flag to undefined so the next AsapAction will schedule
-    // its own.
-    if (scheduler.actions.length === 0) {
+    // If the scheduler queue has no remaining actions with the same async id,
+    // cancel the requested microtask and set the scheduled flag to undefined
+    // so the next AsapAction will request its own.
+    if (!scheduler.actions.some((action) => action.id === id)) {
       immediateProvider.clearImmediate(id);
       scheduler._scheduled = undefined;
     }

--- a/src/internal/scheduler/AsapScheduler.ts
+++ b/src/internal/scheduler/AsapScheduler.ts
@@ -4,24 +4,32 @@ import { AsyncScheduler } from './AsyncScheduler';
 export class AsapScheduler extends AsyncScheduler {
   public flush(action?: AsyncAction<any>): void {
     this._active = true;
+    // The async id that effects a call to flush is stored in _scheduled.
+    // Before executing an action, it's necessary to check the action's async
+    // id to determine whether it's supposed to be executed in the current
+    // flush.
+    // Previous implementations of this method used a count to determine this,
+    // but that was unsound, as actions that are unsubscribed - i.e. cancelled -
+    // are removed from the actions array and that can shift actions that are
+    // scheduled to be executed in a subsequent flush into positions at which
+    // they are executed within the current flush.
+    const flushId = this._scheduled;
     this._scheduled = undefined;
 
     const { actions } = this;
     let error: any;
-    let index = -1;
     action = action || actions.shift()!;
-    const count = actions.length;
 
     do {
       if ((error = action.execute(action.state, action.delay))) {
         break;
       }
-    } while (++index < count && (action = actions.shift()));
+    } while ((action = actions[0]) && action.id === flushId && actions.shift());
 
     this._active = false;
 
     if (error) {
-      while (++index < count && (action = actions.shift())) {
+      while ((action = actions[0]) && action.id === flushId && actions.shift()) {
         action.unsubscribe();
       }
       throw error;


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR adds failing tests and fixes for the following scenarios:

- In the `AnimationFrameScheduler` and the `AsapScheduler`, it was possible for actions scheduled within a `flush` call - i.e. scheduled by actions executed with said `flush` call - to be themselves executed within the _same_ `flush` call. This would only occur if actions were unsubscribed, as that would 'move' the newly-scheduled actions to a lower index in the `actions` queue - rendering the `count`-based mechanism unreliable for determining which actions should be executed.
- In the `AnimationFrameAction` and the `AsapAction`, the cancellation of the animation frame and the clearing of the microtask depended upon whether or not the `actions` queue was empty. However, that's insufficient, as the `actions` queue can contain actions that are to be executed in separate `flush` calls. To determine whether cancellation is required, it's necessary to check that the `actions` queue has _no actions_ that share the _same_ async id.

Note that if the animation frame or microtask mentioned in the second scenario is not cancelled, `flush` is called with an empty `actions` queue and an error is effected:

```
TypeError: Cannot read properties of undefined (reading 'execute')
    at AsapScheduler.flush (node_modules/rxjs/src/internal/scheduler/AsapScheduler.ts:19:8
```

Version 6 is going to have the same problem - this has been a long-standing issue that has been hard to reproduce - so we should open another PR after this is merged to cherry-pick the change into that version.

**Related issue:** #6672 and #4690 and #2697