### PR TITLE
fix(forEach): properly unsubs after error in next handler

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -153,9 +153,9 @@ describe('Observable', () => {
           },
           (err) => {
             results.push(err);
-            // Since the consuming code can no longer interfere with the synchronous
-            // producer, the remaining results are nexted.
-            expect(results).to.deep.equal([1, 2, 3, 4, expected]);
+            // The error should unsubscribe from the source, meaning we 
+            // should not see the number 4.
+            expect(results).to.deep.equal([1, 2, 3, expected]);
           }
         );
     });


### PR DESCRIPTION
fixes #6676
