### PR TITLE
fix: race condition with Interop Observables

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -415,7 +415,7 @@ export interface ObjectUnsubscribedError extends Error {
 
 export declare const ObjectUnsubscribedError: ObjectUnsubscribedErrorCtor;
 
-export declare const observable: string | symbol;
+export declare const observable: () => string | symbol;
 
 export declare class Observable<T> implements Subscribable<T> {
     operator: Operator<any, T> | undefined;

--- a/spec/helpers/interop-helper-spec.ts
+++ b/spec/helpers/interop-helper-spec.ts
@@ -7,7 +7,7 @@ describe('interop helper', () => {
   it('should simulate interop observables', () => {
     const observable: any = asInteropObservable(of(42));
     expect(observable).to.not.be.instanceOf(Observable);
-    expect(observable[symbolObservable]).to.be.a('function');
+    expect(observable[symbolObservable()]).to.be.a('function');
   });
 
   it('should simulate interop subscribers', () => {

--- a/spec/helpers/test-helper.ts
+++ b/spec/helpers/test-helper.ts
@@ -26,7 +26,7 @@ export function lowerCaseO<T>(...args: Array<any>): Observable<T> {
     }
   };
 
-  o[observable] = function (this: any) {
+  o[observable()] = function (this: any) {
     return this;
   };
 
@@ -52,7 +52,7 @@ export const createObservableInputs = <T>(value: T) => of(
     }
   } as any as Iterable<T>,
   {
-    [observable]: () => of(value)
+    [observable()]: () => of(value)
   } as any
 ) as Observable<ObservableInput<T>>;
 

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -166,7 +166,7 @@ describe('from', () => {
   });
 
   const fakervable = <T>(...values: T[]) => ({
-    [observable]: () => ({
+    [observable()]: () => ({
       subscribe: (observer: Observer<T>) => {
         for (const value of values) {
           observer.next(value);
@@ -178,7 +178,7 @@ describe('from', () => {
 
   const fakeArrayObservable = <T>(...values: T[]) => {
     let arr: any = ['bad array!'];
-    arr[observable] = () =>  {
+    arr[observable()] = () =>  {
       return {
         subscribe: (observer: Observer<T>) => {
           for (const value of values) {
@@ -292,7 +292,7 @@ describe('from', () => {
     it(`should accept a function that implements [Symbol.observable]`, (done) => {
       const subject = new Subject<any>();
       const handler: any = (arg: any) => subject.next(arg);
-      handler[observable] = () => subject;
+      handler[observable()] = () => subject;
       let nextInvoked = false;
 
       from((handler as any)).pipe(first()).subscribe(

--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -341,7 +341,7 @@ export class Observable<T> implements Subscribable<T> {
    * @method Symbol.observable
    * @return {Observable} this instance of the observable
    */
-  [Symbol_observable]() {
+  [Symbol_observable()]() {
     return this;
   }
 

--- a/src/internal/observable/innerFrom.ts
+++ b/src/internal/observable/innerFrom.ts
@@ -46,7 +46,7 @@ export function innerFrom<T>(input: ObservableInput<T>): Observable<T> {
  */
 export function fromInteropObservable<T>(obj: any) {
   return new Observable((subscriber: Subscriber<T>) => {
-    const obs = obj[Symbol_observable]();
+    const obs = obj[Symbol_observable()]();
     if (isFunction(obs.subscribe)) {
       return obs.subscribe(subscriber);
     }

--- a/src/internal/symbol/observable.ts
+++ b/src/internal/symbol/observable.ts
@@ -1,2 +1,2 @@
 /** Symbol.observable or a string "@@observable". Used for interop */
-export const observable: string | symbol = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();
+export const observable: () => string | symbol = () => (typeof Symbol === 'function' && Symbol.observable) || '@@observable';

--- a/src/internal/util/isInteropObservable.ts
+++ b/src/internal/util/isInteropObservable.ts
@@ -4,5 +4,5 @@ import { isFunction } from './isFunction';
 
 /** Identifies an input as being Observable (but not necessary an Rx Observable) */
 export function isInteropObservable(input: any): input is InteropObservable<any> {
-  return isFunction(input[Symbol_observable]);
+  return isFunction(input[Symbol_observable()]);
 }


### PR DESCRIPTION
**Description:**

I'm working on a library that exposes [Interop Observables](https://ncjamieson.com/how-to-use-interop-observables/) and I've noticed that in some situations, depending on which package gets imported first, the user gets the following error:

```bash
TypeError: You provided an invalid object where a stream was expected. You can provide an Observable, Promise, ReadableStream, Array, AsyncIterable, or Iterable.
```

After some debugging I found that the culprit is this line of code:

```ts
export const observable: string | symbol = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();
```

The problem with that code is that if it runs before the package(s) that are responsible for polyfilling `Symbol.observable` get evaluated, then it's already too late to polyfill `Symbol.observable`.

A simple solution would be to make that code lazy, so that if later on a package polyfills `Symbol.observable` then everything should work as it's expected:

```ts
export const observable: () => string | symbol = (() => typeof Symbol === 'function' && Symbol.observable) || '@@observable';
```

Which is the change that I'm proposing in this PR.