### PR TITLE
fix: when crossDomain is using default the X-Requested-With header is no longer added incorrectly

### DIFF
--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -103,7 +103,6 @@ describe('ajax', () => {
       'content-type': 'kenny/loggins',
       'fly-into-the': 'Dangah Zone!',
       'take-a-ride-into-the': 'Danger ZoooOoone!',
-      'x-requested-with': 'XMLHttpRequest',
     });
     // Did not mutate the headers passed
     expect(obj.headers).to.deep.equal({
@@ -129,6 +128,7 @@ describe('ajax', () => {
         url: '/some/path',
         xsrfCookieName: 'foo',
         xsrfHeaderName: 'Custom-Header-Name',
+        crossDomain: false,
       };
 
       ajax(obj).subscribe();
@@ -188,10 +188,31 @@ describe('ajax', () => {
       const request = MockXMLHttpRequest.mostRecent;
 
       expect(request.url).to.equal('/some/page');
-      expect(request.requestHeaders).to.deep.equal({
-        'x-requested-with': 'XMLHttpRequest',
-      });
+      expect(request.requestHeaders).to.deep.equal({});
     });
+  });
+
+  it('should not set the X-Requested-With if crossDomain is true', () => {
+    ajax({
+      url: '/test/monkey',
+      method: 'GET',
+      crossDomain: true,
+    }).subscribe();
+
+    const request = MockXMLHttpRequest.mostRecent;
+
+    expect(request.requestHeaders).to.not.have.key('x-requested-with');
+  });
+
+  it('should not set the X-Requested-With if crossDomain is not present (it defaults to true)', () => {
+    ajax({
+      url: '/test/monkey',
+      method: 'GET',
+    }).subscribe();
+
+    const request = MockXMLHttpRequest.mostRecent;
+
+    expect(request.requestHeaders).to.not.have.key('x-requested-with');
   });
 
   it('should set the X-Requested-With if crossDomain is false', () => {
@@ -590,9 +611,7 @@ describe('ajax', () => {
 
       expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
       expect(MockXMLHttpRequest.mostRecent.data).to.equal(body);
-      expect(MockXMLHttpRequest.mostRecent.requestHeaders).to.deep.equal({
-        'x-requested-with': 'XMLHttpRequest',
-      });
+      expect(MockXMLHttpRequest.mostRecent.requestHeaders).to.deep.equal({});
     });
 
     it('should send the URLSearchParams straight through to the body', () => {
@@ -789,7 +808,6 @@ describe('ajax', () => {
       expect(request.url).to.equal('/flibbertyJibbet');
       expect(request.requestHeaders).to.deep.equal({
         'content-type': 'application/json;charset=utf-8',
-        'x-requested-with': 'XMLHttpRequest',
       });
 
       request.respondWith({
@@ -820,9 +838,7 @@ describe('ajax', () => {
 
       expect(request.method).to.equal('POST');
       expect(request.url).to.equal('/flibbertyJibbet');
-      expect(request.requestHeaders).to.deep.equal({
-        'x-requested-with': 'XMLHttpRequest',
-      });
+      expect(request.requestHeaders).to.deep.equal({});
 
       request.respondWith({
         status: 204,
@@ -913,7 +929,6 @@ describe('ajax', () => {
       expect(request.url).to.equal('/flibbertyJibbet');
       expect(request.requestHeaders).to.deep.equal({
         'content-type': 'application/json;charset=utf-8',
-        'x-requested-with': 'XMLHttpRequest',
       });
 
       request.respondWith({
@@ -1026,9 +1041,7 @@ describe('ajax', () => {
         async: true,
         body: undefined,
         crossDomain: true,
-        headers: {
-          'x-requested-with': 'XMLHttpRequest',
-        },
+        headers: {},
         includeDownloadProgress: true,
         method: 'GET',
         responseType: 'json',
@@ -1154,9 +1167,7 @@ describe('ajax', () => {
         async: true,
         body: undefined,
         crossDomain: true,
-        headers: {
-          'x-requested-with': 'XMLHttpRequest',
-        },
+        headers: {},
         includeUploadProgress: true,
         includeDownloadProgress: true,
         method: 'GET',

--- a/src/internal/ajax/ajax.ts
+++ b/src/internal/ajax/ajax.ts
@@ -279,7 +279,20 @@ export function fromAjax<T>(config: AjaxConfig): Observable<AjaxResponse<T>> {
     // Here we're pulling off each of the configuration arguments
     // that we don't want to add to the request information we're
     // passing around.
-    const { queryParams, body: configuredBody, headers: configuredHeaders, ...remainingConfig } = config;
+    const configWithDefaults = {
+      // Default values
+      async: true,
+      crossDomain: true,
+      withCredentials: false,
+      method: 'GET',
+      timeout: 0,
+      responseType: 'json' as XMLHttpRequestResponseType,
+
+      // Override with passed user values
+      ...config,
+    };
+
+    const { queryParams, body: configuredBody, headers: configuredHeaders, ...remainingConfig } = configWithDefaults;
 
     let { url } = remainingConfig;
     if (!url) {
@@ -334,7 +347,7 @@ export function fromAjax<T>(config: AjaxConfig): Observable<AjaxResponse<T>> {
     // None of this is necessary, it's only being set because it's "the thing libraries do"
     // Starting back as far as JQuery, and continuing with other libraries such as Angular 1,
     // Axios, et al.
-    if (!config.crossDomain && !('x-requested-with' in headers)) {
+    if (!configWithDefaults.crossDomain && !('x-requested-with' in headers)) {
       headers['x-requested-with'] = 'XMLHttpRequest';
     }
 
@@ -353,16 +366,8 @@ export function fromAjax<T>(config: AjaxConfig): Observable<AjaxResponse<T>> {
     const body = extractContentTypeAndMaybeSerializeBody(configuredBody, headers);
 
     const _request: AjaxRequest = {
-      // Default values
-      async: true,
-      crossDomain: true,
-      withCredentials: false,
-      method: 'GET',
-      timeout: 0,
-      responseType: 'json' as XMLHttpRequestResponseType,
-
-      // Override with passed user values
-      ...remainingConfig,
+      // Take the final configuration
+      ...configWithDefaults,
 
       // Set values we ensured above
       url,


### PR DESCRIPTION
**Description:**

When this header is added incorrectly, it triggers preflight requests. This caused a breaking change from rxjs 6.x with any backend request URL that does not support preflight requests (OPTIONS method). See the #6663 for more details.

Issue traces back to https://github.com/ReactiveX/rxjs/commit/0d66ba458f07fba51cfc73440d01ef453c24cda7 which is really strange as it seems to change tests; likely just an accidental change. As an example just because I know I changed a lot of tests here to fix them... If you look at https://github.com/ReactiveX/rxjs/commit/0d66ba458f07fba51cfc73440d01ef453c24cda7#diff-0f6e5e92622cfbc19d5344e07b65569c748bce03635ad9be2ffb87321b12d228R96 you can see that the original test changes because now it expects a header in the request the original did not expect. So possibly it was thought that the header was being set but not checked - but actually due to deep equals it was already correct and the header was not meant to be set. There's likely other commits that further embedded the bad behaviour into the tests. For example the upload/download progress the check on the request object shows `crossDomain: true` but then it shows the header is also verified to be there even though when `true` it should never be there.

Some other changes I did to tests are a result of a feature that was built after the broken behaviour was introduced, and that's this feature: https://github.com/ReactiveX/rxjs/commit/1a2c2e49482a460778ea92c7f6a92e58cc3e87bb

**BREAKING CHANGE: (I don't believe it is)**

This fixes a breaking change from v6->v7. I do not believe this fix itself would break any v7 code as it should only mean code that was preflighting when it wasn't in v6 no longer preflights again. Unless some code is explicitly written that relies on the preflight this shouldn't cause any impact.

**Related issue (if exists):**

Fixes #6663
