### PR TITLE
fix(WebSocketSubject): handle slow WebSocket close

### DIFF
--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -336,7 +336,9 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     };
 
     socket.onclose = (e: CloseEvent) => {
-      this._resetState();
+      if (socket === this._socket) {
+        this._resetState();
+      }
       const { closeObserver } = this._config;
       if (closeObserver) {
         closeObserver.next(e);


### PR DESCRIPTION
**Description:**
The close event on WebSocket does not always occur immediately after running the close function. If the close event is occurs after a new WebSocket is opened, then the reset needs to be skipped. This checks to make sure the socket being reset is the one that matches the event.

The MockWebSocket class skipped the state between CLOSING and CLOSED. I removed the automatic closing so that the CLOSED state must be trigger manually. This caused many of the existing tests to expect CLOSING instead - I changed the codes instead of triggering close because it did not affect the tests.

I also changed the readyState codes to use an enum for clarity. If that is an unwanted change I can revert back to comments.


**Related issues:**
Closes #4650, #3935
