### PR TITLE
chore: fixing deprecated subscribe and tap calls

### DIFF
--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -30,11 +30,9 @@ describe('Observable', () => {
     });
 
     source.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(1);
-      },
-      null,
-      done
+      }, complete: done }
     );
   });
 
@@ -211,15 +209,13 @@ describe('Observable', () => {
       let mutatedByComplete = false;
 
       source.subscribe(
-        (x) => {
+        { next: (x) => {
           nexted = x;
           mutatedByNext = true;
-        },
-        null,
-        () => {
+        }, complete: () => {
           completed = true;
           mutatedByComplete = true;
-        }
+        } }
       );
 
       expect(mutatedByNext).to.be.true;
@@ -382,14 +378,13 @@ describe('Observable', () => {
       })
         .pipe(tap(() => (times += 1)))
         .subscribe(
-          function () {
+          { next: function () {
             if (times === 2) {
               subscription.unsubscribe();
             }
-          },
-          function () {
+          }, error: function () {
             errorCalled = true;
-          }
+          } }
         );
     });
 
@@ -415,15 +410,13 @@ describe('Observable', () => {
       })
         .pipe(tap(() => (times += 1)))
         .subscribe(
-          function () {
+          { next: function () {
             if (times === 2) {
               subscription.unsubscribe();
             }
-          },
-          null,
-          function () {
+          }, complete: function () {
             completeCalled = true;
-          }
+          } }
         );
     });
 
@@ -847,11 +840,9 @@ describe('Observable', () => {
           map((x) => x + '!!!')
         )
         .subscribe(
-          (x) => {
+          { next: (x) => {
             expect(x).to.equal('testtest!!!');
-          },
-          null,
-          done
+          }, complete: done }
         );
     });
 
@@ -1006,15 +997,13 @@ describe('Observable.lift', () => {
     const expected = [10, 20, 30];
 
     result.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -1035,15 +1024,13 @@ describe('Observable.lift', () => {
     const expected = [10, 20, 30];
 
     result.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -1065,15 +1052,13 @@ describe('Observable.lift', () => {
     const expected = [10, 20, 30];
 
     result.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -1095,15 +1080,13 @@ describe('Observable.lift', () => {
     const expected = [30];
 
     result.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -1124,15 +1107,13 @@ describe('Observable.lift', () => {
     const expected = [0, 10, 20, 30];
 
     result.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -1308,15 +1289,13 @@ describe('Observable.lift', () => {
     const expected = [10, 20, 30];
 
     result.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -1458,13 +1437,11 @@ describe('Observable.lift', () => {
     const expected = [2];
 
     result.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         expect(log).to.deep.equal([
           'next 10', // map
           'next 20', // map
@@ -1474,7 +1451,7 @@ describe('Observable.lift', () => {
           'next 2', // count
         ]);
         done();
-      }
+      } }
     );
   });
 });

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -16,11 +16,9 @@ describe('Subject', () => {
   it('should allow next with undefined or any when created with no type', (done) => {
     const subject = new Subject();
     subject.subscribe(
-      (x) => {
+      { next: (x) => {
         expect(x).to.be.a('undefined');
-      },
-      null,
-      done
+      }, complete: done }
     );
 
     const data: any = undefined;
@@ -32,11 +30,9 @@ describe('Subject', () => {
   it('should allow empty next when created with void type', (done) => {
     const subject = new Subject<void>();
     subject.subscribe(
-      (x) => {
+      { next: (x) => {
         expect(x).to.be.a('undefined');
-      },
-      null,
-      done
+      }, complete: done }
     );
 
     subject.next();
@@ -48,11 +44,9 @@ describe('Subject', () => {
     const expected = ['foo', 'bar'];
 
     subject.subscribe(
-      (x: string) => {
+      { next: (x: string) => {
         expect(x).to.equal(expected.shift());
-      },
-      null,
-      done
+      }, complete: done }
     );
 
     subject.next('foo');
@@ -72,11 +66,9 @@ describe('Subject', () => {
     });
 
     subject.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected[j++]);
-      },
-      null,
-      done
+      }, complete: done }
     );
 
     expect(subject.observers.length).to.equal(2);
@@ -97,29 +89,25 @@ describe('Subject', () => {
     subject.next(4);
 
     const subscription1 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results1.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results1.push('E');
-      },
-      () => {
+      }, complete: () => {
         results1.push('C');
-      }
+      } }
     );
 
     subject.next(5);
 
     const subscription2 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results2.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results2.push('E');
-      },
-      () => {
+      }, complete: () => {
         results2.push('C');
-      }
+      } }
     );
 
     subject.next(6);
@@ -135,15 +123,13 @@ describe('Subject', () => {
     subject.next(10);
 
     const subscription3 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results3.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results3.push('E');
-      },
-      () => {
+      }, complete: () => {
         results3.push('C');
-      }
+      } }
     );
 
     subject.next(11);
@@ -167,29 +153,25 @@ describe('Subject', () => {
     subject.next(4);
 
     const subscription1 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results1.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results1.push('E');
-      },
-      () => {
+      }, complete: () => {
         results1.push('C');
-      }
+      } }
     );
 
     subject.next(5);
 
     const subscription2 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results2.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results2.push('E');
-      },
-      () => {
+      }, complete: () => {
         results2.push('C');
-      }
+      } }
     );
 
     subject.next(6);
@@ -202,15 +184,13 @@ describe('Subject', () => {
     subscription2.unsubscribe();
 
     const subscription3 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results3.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results3.push('E');
-      },
-      () => {
+      }, complete: () => {
         results3.push('C');
-      }
+      } }
     );
 
     subscription3.unsubscribe();
@@ -232,29 +212,25 @@ describe('Subject', () => {
     subject.next(4);
 
     const subscription1 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results1.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results1.push('E');
-      },
-      () => {
+      }, complete: () => {
         results1.push('C');
-      }
+      } }
     );
 
     subject.next(5);
 
     const subscription2 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results2.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results2.push('E');
-      },
-      () => {
+      }, complete: () => {
         results2.push('C');
-      }
+      } }
     );
 
     subject.next(6);
@@ -267,15 +243,13 @@ describe('Subject', () => {
     subscription2.unsubscribe();
 
     const subscription3 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results3.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results3.push('E');
-      },
-      () => {
+      }, complete: () => {
         results3.push('C');
-      }
+      } }
     );
 
     subscription3.unsubscribe();
@@ -292,27 +266,23 @@ describe('Subject', () => {
     const results3: (number | string)[] = [];
 
     const subscription1 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results1.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results1.push('E');
-      },
-      () => {
+      }, complete: () => {
         results1.push('C');
-      }
+      } }
     );
 
     const subscription2 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results2.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results2.push('E');
-      },
-      () => {
+      }, complete: () => {
         results2.push('C');
-      }
+      } }
     );
 
     subscription1.unsubscribe();
@@ -322,15 +292,13 @@ describe('Subject', () => {
     subscription2.unsubscribe();
 
     const subscription3 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results3.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results3.push('E');
-      },
-      () => {
+      }, complete: () => {
         results3.push('C');
-      }
+      } }
     );
 
     subscription3.unsubscribe();
@@ -347,30 +315,26 @@ describe('Subject', () => {
     const results3: (number | string)[] = [];
 
     const subscription1 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results1.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results1.push('E');
-      },
-      () => {
+      }, complete: () => {
         results1.push('C');
-      }
+      } }
     );
 
     subject.next(1);
     subject.next(2);
 
     const subscription2 = subject.subscribe(
-      function (x) {
+      { next: function (x) {
         results2.push(x);
-      },
-      function (e) {
+      }, error: function (e) {
         results2.push('E');
-      },
-      () => {
+      }, complete: () => {
         results2.push('C');
-      }
+      } }
     );
 
     subject.next(3);
@@ -383,12 +347,11 @@ describe('Subject', () => {
 
     expect(() => {
       subject.subscribe(
-        function (x) {
+        { next: function (x) {
           results3.push(x);
-        },
-        function (err) {
+        }, error: function (err) {
           expect(false).to.equal('should not throw error: ' + err.toString());
-        }
+        } }
       );
     }).to.throw(ObjectUnsubscribedError);
 
@@ -560,15 +523,13 @@ describe('Subject', () => {
     const expected = [1, 2, 3, 4, 5];
 
     subject.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      (x) => {
+      }, error: (x) => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
 
     source.subscribe(subject);
@@ -581,15 +542,13 @@ describe('Subject', () => {
     const expected = [1, 2, 3];
 
     subject.subscribe(
-      function (x) {
+      { next: function (x) {
         expect(x).to.equal(expected.shift());
-      },
-      (x) => {
+      }, error: (x) => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
 
     source.subscribe(subject);
@@ -616,9 +575,7 @@ describe('Subject', () => {
     const subject = new Subject<string>();
     const results: string[] = [];
     subject.subscribe(
-      (x) => results.push(x),
-      null,
-      () => results.push('C')
+      { next: (x) => results.push(x), complete: () => results.push('C') }
     );
     subject.next('a');
     subject.complete();
@@ -631,8 +588,7 @@ describe('Subject', () => {
     const subject = new Subject<string>();
     const results: string[] = [];
     subject.subscribe(
-      (x) => results.push(x),
-      (err) => results.push(err)
+      { next: (x) => results.push(x), error: (err) => results.push(err) }
     );
     subject.next('a');
     subject.error(error);
@@ -696,9 +652,7 @@ describe('Subject', () => {
       const observable = subject.asObservable();
 
       observable.subscribe(
-        (x) => results.push(x),
-        null,
-        () => results.push('done')
+        { next: (x) => results.push(x), complete: () => results.push('done') }
       );
 
       expect(results).to.deep.equal([42, 'done']);

--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -16,11 +16,11 @@ describe('bindCallback', () => {
       const results: Array<string|number> = [];
 
       boundCallback()
-        .subscribe((x: any) => {
+        .subscribe({ next: (x: any) => {
           results.push(typeof x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       expect(results).to.deep.equal(['undefined', 'done']);
     });
@@ -75,11 +75,11 @@ describe('bindCallback', () => {
       const results: Array<string|number> = [];
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       expect(results).to.deep.equal([42, 'done']);
     });
@@ -94,9 +94,7 @@ describe('bindCallback', () => {
 
       boundCallback.apply({datum: 5})
         .subscribe(
-          (x: number) => results.push(x),
-          null,
-          () => results.push('done')
+          { next: (x: number) => results.push(x), complete: () => results.push('done') }
         );
 
       expect(results).to.deep.equal([5, 'done']);
@@ -114,7 +112,7 @@ describe('bindCallback', () => {
         }, 0);
       }
       const subscription = bindCallback(callback)(42)
-        .subscribe(nextSpy, throwSpy, completeSpy);
+        .subscribe({ next: nextSpy, error: throwSpy, complete: completeSpy });
       subscription.unsubscribe();
 
       setTimeout(() => {
@@ -135,17 +133,17 @@ describe('bindCallback', () => {
       const results: Array<string|number> = [];
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
       boundCallback(54)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       expect(results).to.deep.equal([42, 'done', 54, 'done']);
     });
@@ -160,11 +158,11 @@ describe('bindCallback', () => {
       const results: Array<string|number> = [];
 
       boundCallback()
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(typeof x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       rxTestScheduler.flush();
 
@@ -179,11 +177,11 @@ describe('bindCallback', () => {
       const results: Array<string|number> = [];
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       rxTestScheduler.flush();
 
@@ -200,9 +198,7 @@ describe('bindCallback', () => {
 
       boundCallback.apply({ datum: 5 })
         .subscribe(
-          (x: number) => results.push(x),
-          null,
-          () => results.push('done')
+          { next: (x: number) => results.push(x), complete: () => results.push('done') }
         );
 
       rxTestScheduler.flush();
@@ -218,13 +214,13 @@ describe('bindCallback', () => {
       const boundCallback = bindCallback(callback, rxTestScheduler);
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           throw new Error('should not next');
-        }, (err: any) => {
+        }, error: (err: any) => {
           expect(err).to.equal(expected);
-        }, () => {
+        }, complete: () => {
           throw new Error('should not complete');
-        });
+        } });
 
       rxTestScheduler.flush();
     });
@@ -237,11 +233,11 @@ describe('bindCallback', () => {
     const results: Array<string|number[]> = [];
 
     boundCallback(42)
-      .subscribe(x => {
+      .subscribe({ next: x => {
         results.push(x);
-      }, null, () => {
+      }, complete: () => {
         results.push('done');
-      });
+      } });
 
     rxTestScheduler.flush();
 
@@ -260,17 +256,17 @@ describe('bindCallback', () => {
 
     const source = boundCallback(42);
 
-    source.subscribe(x => {
+    source.subscribe({ next: x => {
       results1.push(x);
-    }, null, () => {
+    }, complete: () => {
       results1.push('done');
-    });
+    } });
 
-    source.subscribe(x => {
+    source.subscribe({ next: x => {
       results2.push(x);
-    }, null, () => {
+    }, complete: () => {
       results2.push('done');
-    });
+    } });
 
     rxTestScheduler.flush();
 
@@ -290,11 +286,11 @@ describe('bindCallback', () => {
 
     const source = boundCallback(42);
 
-    const subscription = source.subscribe((x: any) => {
+    const subscription = source.subscribe({ next: (x: any) => {
       results1.push(x);
-    }, null, () => {
+    }, complete: () => {
       results1.push('done');
-    });
+    } });
 
     subscription.unsubscribe();
 

--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -17,11 +17,11 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback()
-        .subscribe((x: any) => {
+        .subscribe({ next: (x: any) => {
           results.push(typeof x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       expect(results).to.deep.equal(['undefined', 'done']);
     });
@@ -35,11 +35,11 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback()
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       expect(results).to.deep.equal([43, 'done']);
     });
@@ -52,11 +52,11 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       expect(results).to.deep.equal([42, 'done']);
     });
@@ -70,9 +70,7 @@ describe('bindNodeCallback', () => {
 
       boundCallback.call({datum: 42})
         .subscribe(
-          (x: number) => results.push(x),
-          null,
-          () => results.push('done')
+          { next: (x: number) => results.push(x), complete: () => results.push('done') }
         );
 
       expect(results).to.deep.equal([42, 'done']);
@@ -89,13 +87,13 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback()
-        .subscribe(() => {
+        .subscribe({ next: () => {
           throw new Error('should not next');
-        }, (err: any) => {
+        }, error: (err: any) => {
           results.push(err);
-        }, () => {
+        }, complete: () => {
           throw new Error('should not complete');
-        });
+        } });
 
       expect(results).to.deep.equal([error]);
     });
@@ -112,7 +110,7 @@ describe('bindNodeCallback', () => {
         }, 0);
       }
       const subscription = bindNodeCallback(callback)(42)
-        .subscribe(nextSpy, throwSpy, completeSpy);
+        .subscribe({ next: nextSpy, error: throwSpy, complete: completeSpy });
       subscription.unsubscribe();
 
       setTimeout(() => {
@@ -133,17 +131,17 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
       boundCallback(54)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       expect(results).to.deep.equal([42, 'done', 54, 'done']);
     });
@@ -159,11 +157,11 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback()
-        .subscribe((x: any) => {
+        .subscribe({ next: (x: any) => {
           results.push(typeof x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       rxTestScheduler.flush();
 
@@ -178,11 +176,11 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           results.push(x);
-        }, null, () => {
+        }, complete: () => {
           results.push('done');
-        });
+        } });
 
       rxTestScheduler.flush();
 
@@ -198,9 +196,7 @@ describe('bindNodeCallback', () => {
 
       boundCallback.call({datum: 42})
         .subscribe(
-          (x: number) => results.push(x),
-          null,
-          () => results.push('done')
+          { next: (x: number) => results.push(x), complete: () => results.push('done') }
         );
 
       rxTestScheduler.flush();
@@ -216,13 +212,13 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback, rxTestScheduler);
 
       boundCallback(42)
-        .subscribe(x => {
+        .subscribe({ next: x => {
           throw new Error('should not next');
-        }, (err: any) => {
+        }, error: (err: any) => {
           expect(err).to.equal(expected);
-        }, () => {
+        }, complete: () => {
           throw new Error('should not complete');
-        });
+        } });
 
       rxTestScheduler.flush();
     });
@@ -238,13 +234,13 @@ describe('bindNodeCallback', () => {
       const results: Array<number | string> = [];
 
       boundCallback()
-        .subscribe(() => {
+        .subscribe({ next: () => {
           throw new Error('should not next');
-        }, (err: any) => {
+        }, error: (err: any) => {
           results.push(err);
-        }, () => {
+        }, complete: () => {
           throw new Error('should not complete');
-        });
+        } });
 
       rxTestScheduler.flush();
 
@@ -260,11 +256,11 @@ describe('bindNodeCallback', () => {
     const results: Array<number[] | string> = [];
 
     boundCallback(42)
-      .subscribe(x => {
+      .subscribe({ next: x => {
         results.push(x);
-      }, null, () => {
+      }, complete: () => {
         results.push('done');
-      });
+      } });
 
     rxTestScheduler.flush();
 
@@ -283,17 +279,17 @@ describe('bindNodeCallback', () => {
 
     const source = boundCallback(42);
 
-    source.subscribe(x => {
+    source.subscribe({ next: x => {
       results1.push(x);
-    }, null, () => {
+    }, complete: () => {
       results1.push('done');
-    });
+    } });
 
-    source.subscribe(x => {
+    source.subscribe({ next: x => {
       results2.push(x);
-    }, null, () => {
+    }, complete: () => {
       results2.push('done');
-    });
+    } });
 
     rxTestScheduler.flush();
 
@@ -351,11 +347,11 @@ describe('bindNodeCallback', () => {
 
     const source = boundCallback(42);
 
-    const subscription = source.subscribe((x: any) => {
+    const subscription = source.subscribe({ next: (x: any) => {
       results1.push(x);
-    }, null, () => {
+    }, complete: () => {
       results1.push('done');
-    });
+    } });
 
     subscription.unsubscribe();
 

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -86,16 +86,14 @@ describe('static combineLatest', () => {
     const actual: [number, number][] = [];
     //type definition need to be updated
     combineLatest(a, b, queueScheduler).subscribe(
-      (vals) => {
+      { next: (vals) => {
         actual.push(vals);
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         expect(actual).to.deep.equal(r);
         done();
-      }
+      } }
     );
   });
 

--- a/spec/observables/concat-spec.ts
+++ b/spec/observables/concat-spec.ts
@@ -394,13 +394,12 @@ describe('static concat', () => {
     const b = of(4, 5, 6, 7, 8, queueScheduler);
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
 
-    concat(a, b, queueScheduler).subscribe(
-      (vals) => {
+    concat(a, b, queueScheduler).subscribe({
+      next: (vals) => {
         expect(vals).to.equal(r.shift());
       },
-      null,
-      done
-    );
+      complete: done,
+    });
   });
 
   it("should use the scheduler even when one Observable is concat'd", (done) => {

--- a/spec/observables/defer-spec.ts
+++ b/spec/observables/defer-spec.ts
@@ -55,15 +55,15 @@ describe('defer', () => {
       });
     });
 
-    e1.subscribe(
-      (x: number) => {
+    e1.subscribe({
+      next: (x: number) => {
         expect(x).to.equal(expected);
         done();
       },
-      (x: any) => {
+      error: (x: any) => {
         done(new Error('should not be called'));
-      }
-    );
+      },
+    });
   });
 
   it('should accept factory returns promise rejects', (done) => {
@@ -74,18 +74,18 @@ describe('defer', () => {
       });
     });
 
-    e1.subscribe(
-      (x: number) => {
+    e1.subscribe({
+      next: (x: number) => {
         done(new Error('should not be called'));
       },
-      (x: any) => {
+      error: (x: any) => {
         expect(x).to.equal(expected);
         done();
       },
-      () => {
+      complete: () => {
         done(new Error('should not be called'));
-      }
-    );
+      },
+    });
   });
 
   it('should create an observable from error', () => {

--- a/spec/observables/dom/ajax-spec.ts
+++ b/spec/observables/dom/ajax-spec.ts
@@ -52,7 +52,7 @@ describe('ajax', () => {
       method: '',
     };
 
-    ajax(obj).subscribe(null, (err) => expect(err).to.exist);
+    ajax(obj).subscribe({ error: (err) => expect(err).to.exist });
   });
 
   it('should create XMLHttpRequest for CORS', () => {
@@ -231,17 +231,17 @@ describe('ajax', () => {
       createXHR: () => {
         throw new Error('wokka wokka');
       },
-    }).subscribe(
-      () => {
+    }).subscribe({
+      next: () => {
         throw new Error('should not next');
       },
-      (err: any) => {
+      error: (err: any) => {
         error = err;
       },
-      () => {
+      complete: () => {
         throw new Error('should not complete');
-      }
-    );
+      },
+    });
 
     expect(error).to.be.an('error', 'wokka wokka');
   });
@@ -260,18 +260,18 @@ describe('ajax', () => {
         };
         return ret as any;
       },
-    }).subscribe(
-      () => {
+    }).subscribe({
+      next: () => {
         done(new Error('should not be called'));
       },
-      (e: Error) => {
+      error: (e: Error) => {
         expect(e).to.be.equal(expected);
         done();
       },
-      () => {
+      complete: () => {
         done(new Error('should not be called'));
-      }
-    );
+      },
+    });
   });
 
   it('should succeed on 200', () => {
@@ -282,15 +282,14 @@ describe('ajax', () => {
     ajax({
       url: '/flibbertyJibbet',
       method: '',
-    }).subscribe(
-      (x: any) => {
+    }).subscribe({
+      next: (x: any) => {
         result = x;
       },
-      null,
-      () => {
+      complete: () => {
         complete = true;
-      }
-    );
+      },
+    });
 
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
 
@@ -314,17 +313,17 @@ describe('ajax', () => {
     // No `response` property on the object (for older IE).
     MockXMLHttpRequest.noResponseProp = true;
 
-    ajax(obj).subscribe(
-      () => {
+    ajax(obj).subscribe({
+      next: () => {
         throw new Error('should not next');
       },
-      (err: any) => {
+      error: (err: any) => {
         error = err;
       },
-      () => {
+      complete: () => {
         throw new Error('should not complete');
-      }
-    );
+      },
+    });
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 207,
@@ -343,17 +342,17 @@ describe('ajax', () => {
       method: '',
     };
 
-    ajax(obj).subscribe(
-      () => {
+    ajax(obj).subscribe({
+      next: () => {
         throw new Error('should not next');
       },
-      (err: any) => {
+      error: (err: any) => {
         error = err;
       },
-      () => {
+      complete: () => {
         throw new Error('should not complete');
-      }
-    );
+      },
+    });
 
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
 
@@ -377,15 +376,14 @@ describe('ajax', () => {
       method: '',
     };
 
-    ajax(obj).subscribe(
-      (x: any) => {
+    ajax(obj).subscribe({
+      next: (x: any) => {
         result = x;
       },
-      null,
-      () => {
+      complete: () => {
         complete = true;
-      }
-    );
+      },
+    });
 
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
 
@@ -407,17 +405,17 @@ describe('ajax', () => {
       method: '',
     };
 
-    ajax(obj).subscribe(
-      () => {
+    ajax(obj).subscribe({
+      next: () => {
         throw new Error('should not next');
       },
-      (err: any) => {
+      error: (err: any) => {
         error = err;
       },
-      () => {
+      complete: () => {
         throw new Error('should not complete');
-      }
-    );
+      },
+    });
 
     MockXMLHttpRequest.mostRecent.respondWith({
       status: 404,
@@ -434,16 +432,16 @@ describe('ajax', () => {
   it('should succeed no settings', () => {
     const expected = JSON.stringify({ foo: 'bar' });
 
-    ajax('/flibbertyJibbet').subscribe(
-      (x: any) => {
+    ajax('/flibbertyJibbet').subscribe({
+      next: (x: any) => {
         expect(x.status).to.equal(200);
         expect(x.xhr.method).to.equal('GET');
         expect(x.xhr.responseText).to.equal(expected);
       },
-      () => {
+      error: () => {
         throw 'should not have been called';
-      }
-    );
+      },
+    });
 
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
     MockXMLHttpRequest.mostRecent.respondWith({
@@ -455,19 +453,19 @@ describe('ajax', () => {
   it('should fail no settings', () => {
     const expected = JSON.stringify({ foo: 'bar' });
 
-    ajax('/flibbertyJibbet').subscribe(
-      () => {
+    ajax('/flibbertyJibbet').subscribe({
+      next: () => {
         throw 'should not have been called';
       },
-      (x: any) => {
+      error: (x: any) => {
         expect(x.status).to.equal(500);
         expect(x.xhr.method).to.equal('GET');
         expect(x.xhr.responseText).to.equal(expected);
       },
-      () => {
+      complete: () => {
         throw 'should not have been called';
-      }
-    );
+      },
+    });
 
     expect(MockXMLHttpRequest.mostRecent.url).to.equal('/flibbertyJibbet');
     MockXMLHttpRequest.mostRecent.respondWith({
@@ -483,18 +481,18 @@ describe('ajax', () => {
       timeout: 10,
     };
 
-    ajax(obj).subscribe(
-      (x: any) => {
+    ajax(obj).subscribe({
+      next: (x: any) => {
         expect(x.status).to.equal(200);
         expect(x.xhr.method).to.equal('GET');
         expect(x.xhr.async).to.equal(true);
         expect(x.xhr.timeout).to.equal(10);
         expect(x.xhr.responseType).to.equal('text');
       },
-      () => {
+      error: () => {
         throw 'should not have been called';
-      }
-    );
+      },
+    });
 
     const request = MockXMLHttpRequest.mostRecent;
 
@@ -515,18 +513,18 @@ describe('ajax', () => {
       timeout: 10,
     };
 
-    ajax(obj).subscribe(
-      () => {
+    ajax(obj).subscribe({
+      next: () => {
         throw 'should not have been called';
       },
-      (e) => {
+      error: (e) => {
         expect(e.status).to.equal(0);
         expect(e.xhr.method).to.equal('GET');
         expect(e.xhr.async).to.equal(true);
         expect(e.xhr.timeout).to.equal(10);
         expect(e.xhr.responseType).to.equal('text');
-      }
-    );
+      },
+    });
 
     const request = MockXMLHttpRequest.mostRecent;
 
@@ -664,18 +662,18 @@ describe('ajax', () => {
         },
       };
 
-      ajax(obj).subscribe(
-        () => {
+      ajax(obj).subscribe({
+        next: () => {
           done(new Error('should not be called'));
         },
-        (e: Error) => {
+        error: (e: Error) => {
           expect(e).to.be.equal(expected);
           done();
         },
-        () => {
+        complete: () => {
           done(new Error('should not be called'));
-        }
-      );
+        },
+      });
     });
   });
 
@@ -685,15 +683,14 @@ describe('ajax', () => {
       let result;
       let complete = false;
 
-      ajax.get('/flibbertyJibbet').subscribe(
-        (x) => {
+      ajax.get('/flibbertyJibbet').subscribe({
+        next: (x) => {
           result = x.response;
         },
-        null,
-        () => {
+        complete: () => {
           complete = true;
-        }
-      );
+        },
+      });
 
       const request = MockXMLHttpRequest.mostRecent;
 
@@ -712,15 +709,14 @@ describe('ajax', () => {
       let result;
       let complete = false;
 
-      ajax.get('/flibbertyJibbet').subscribe(
-        (x) => {
+      ajax.get('/flibbertyJibbet').subscribe({
+        next: (x) => {
           result = x.response;
         },
-        null,
-        () => {
+        complete: () => {
           complete = true;
-        }
-      );
+        },
+      });
 
       const request = MockXMLHttpRequest.mostRecent;
 
@@ -743,15 +739,14 @@ describe('ajax', () => {
       let result;
       let complete = false;
 
-      ajax.getJSON('/flibbertyJibbet').subscribe(
-        (x) => {
+      ajax.getJSON('/flibbertyJibbet').subscribe({
+        next: (x) => {
           result = x;
         },
-        null,
-        () => {
+        complete: () => {
           complete = true;
-        }
-      );
+        },
+      });
 
       const request = MockXMLHttpRequest.mostRecent;
 
@@ -773,15 +768,14 @@ describe('ajax', () => {
       let result: AjaxResponse<any>;
       let complete = false;
 
-      ajax.post('/flibbertyJibbet', expected).subscribe(
-        (x) => {
+      ajax.post('/flibbertyJibbet', expected).subscribe({
+        next: (x) => {
           result = x;
         },
-        null,
-        () => {
+        complete: () => {
           complete = true;
-        }
-      );
+        },
+      });
 
       const request = MockXMLHttpRequest.mostRecent;
 
@@ -806,15 +800,14 @@ describe('ajax', () => {
       let result: AjaxResponse<any>;
       let complete = false;
 
-      ajax.post('/flibbertyJibbet', undefined).subscribe(
-        (x) => {
+      ajax.post('/flibbertyJibbet', undefined).subscribe({
+        next: (x) => {
           result = x;
         },
-        null,
-        () => {
+        complete: () => {
           complete = true;
-        }
-      );
+        },
+      });
 
       const request = MockXMLHttpRequest.mostRecent;
 
@@ -897,15 +890,14 @@ describe('ajax', () => {
       let result: AjaxResponse<any>;
       let complete = false;
 
-      ajax.patch('/flibbertyJibbet', expected).subscribe(
-        (x) => {
+      ajax.patch('/flibbertyJibbet', expected).subscribe({
+        next: (x) => {
           result = x;
         },
-        null,
-        () => {
+        complete: () => {
           complete = true;
-        }
-      );
+        },
+      });
 
       const request = MockXMLHttpRequest.mostRecent;
 

--- a/spec/observables/dom/webSocket-spec.ts
+++ b/spec/observables/dom/webSocket-spec.ts
@@ -403,11 +403,11 @@ describe('webSocket', () => {
         }
       });
 
-      subject.subscribe((x: any) => {
+      subject.subscribe({ next: (x: any) => {
         expect(x).to.equal('this should not happen');
-      }, (err: any) => {
+      }, error: (err: any) => {
         expect(err).to.be.an('error', 'I am a bad error');
-      });
+      } });
 
       const socket = MockWebSocket.lastSocket;
       socket.open();
@@ -468,9 +468,9 @@ describe('webSocket', () => {
       socket.triggerClose(expected[0]);
       expect(closes.length).to.equal(1);
 
-      subject.subscribe(null, function (err) {
+      subject.subscribe({ error: function (err) {
         expect(err).to.equal(expected[1]);
-      });
+      } });
 
       socket = MockWebSocket.lastSocket;
       socket.open();
@@ -492,11 +492,11 @@ describe('webSocket', () => {
         }
       });
 
-      subject.subscribe((x: any) => {
+      subject.subscribe({ next: (x: any) => {
         expect(x).to.equal('this should not happen');
-      }, (err: any) => {
+      }, error: (err: any) => {
         expect(err).to.be.an('error', 'connection refused');
-      });
+      } });
 
       subject.unsubscribe();
     });
@@ -640,9 +640,7 @@ describe('webSocket', () => {
         takeWhile((req: any) => !req.complete)
       )
       .subscribe(
-        () => results.push('A next'),
-        (e) => results.push('A error ' + e),
-        () => results.push('A complete')
+        { next: () => results.push('A next'), error: (e) => results.push('A error ' + e), complete: () => results.push('A complete') }
       );
 
       socketSubject.multiplex(
@@ -650,9 +648,7 @@ describe('webSocket', () => {
         () => results.push('B unsub'),
         (req: any) => req.id === 'B')
         .subscribe(
-          () => results.push('B next'),
-          (e) => results.push('B error ' + e),
-          () => results.push('B complete')
+          { next: () => results.push('B next'), error: (e) => results.push('B error ' + e), complete: () => results.push('B complete') }
         );
 
       // Setup socket and send messages
@@ -696,9 +692,7 @@ describe('webSocket', () => {
       ).pipe(
         takeWhile(req => !req.complete)
       ).subscribe(
-        () => results.push('A next'),
-        (e) => results.push('A error ' + e),
-        () => results.push('A complete')
+        { next: () => results.push('A next'), error: (e) => results.push('A error ' + e), complete: () => results.push('A complete') }
       );
 
       socketSubject.multiplex(
@@ -708,9 +702,7 @@ describe('webSocket', () => {
       ).pipe(
         takeWhile(req => !req.complete)
       ).subscribe(
-        () => results.push('B next'),
-        (e) => results.push('B error ' + e),
-        () => results.push('B complete')
+        { next: () => results.push('B next'), error: (e) => results.push('B error ' + e), complete: () => results.push('B complete') }
       );
 
       // Setup socket and send messages

--- a/spec/observables/from-promise-spec.ts
+++ b/spec/observables/from-promise-spec.ts
@@ -10,26 +10,24 @@ describe('from (fromPromise)', () => {
     const promise = Promise.resolve(42);
     from(promise)
       .subscribe(
-        (x) => { expect(x).to.equal(42); },
-        (x) => {
+        { next: (x) => { expect(x).to.equal(42); }, error: (x) => {
           done(new Error('should not be called'));
-        }, () => {
+        }, complete: () => {
           done();
-        });
+        } });
   });
 
   it('should raise error from a rejected promise', (done) => {
     const promise = Promise.reject('bad');
     from(promise)
-      .subscribe((x) => {
+      .subscribe({ next: (x) => {
           done(new Error('should not be called'));
-        },
-        (e) => {
+        }, error: (e) => {
           expect(e).to.equal('bad');
           done();
-        }, () => {
+        }, complete: () => {
          done(new Error('should not be called'));
-       });
+       } });
   });
 
   it('should share the underlying promise with multiple subscribers', (done) => {
@@ -38,19 +36,17 @@ describe('from (fromPromise)', () => {
 
     observable
       .subscribe(
-        (x) => { expect(x).to.equal(42); },
-        (x) => {
+        { next: (x) => { expect(x).to.equal(42); }, error: (x) => {
           done(new Error('should not be called'));
-        }, undefined);
+        } });
     setTimeout(() => {
       observable
         .subscribe(
-          (x) => { expect(x).to.equal(42); },
-          (x) => {
+          { next: (x) => { expect(x).to.equal(42); }, error: (x) => {
             done(new Error('should not be called'));
-          }, () => {
+          }, complete: () => {
             done();
-          });
+          } });
     });
   });
 
@@ -60,12 +56,11 @@ describe('from (fromPromise)', () => {
       expect(x).to.equal(42);
       from(promise)
         .subscribe(
-          (y) => { expect(y).to.equal(42); },
-          (x) => {
+          { next: (y) => { expect(y).to.equal(42); }, error: (x) => {
             done(new Error('should not be called'));
-          }, () => {
+          }, complete: () => {
             done();
-          });
+          } });
     }, () => {
       done(new Error('should not be called'));
     });
@@ -84,37 +79,34 @@ describe('from (fromPromise)', () => {
     const promise = new CustomPromise(Promise.resolve(42));
     from(promise)
       .subscribe(
-        (x) => { expect(x).to.equal(42); },
-        () => {
+        { next: (x) => { expect(x).to.equal(42); }, error: () => {
           done(new Error('should not be called'));
-        }, () => {
+        }, complete: () => {
           done();
-        });
+        } });
   });
 
   it('should emit a value from a resolved promise on a separate scheduler', (done) => {
     const promise = Promise.resolve(42);
     from(promise, asapScheduler)
       .subscribe(
-        (x) => { expect(x).to.equal(42); },
-        (x) => {
+        { next: (x) => { expect(x).to.equal(42); }, error: (x) => {
           done(new Error('should not be called'));
-        }, () => {
+        }, complete: () => {
           done();
-        });
+        } });
   });
 
   it('should raise error from a rejected promise on a separate scheduler', (done) => {
     const promise = Promise.reject('bad');
     from(promise, asapScheduler)
       .subscribe(
-        (x) => { done(new Error('should not be called')); },
-        (e) => {
+        { next: (x) => { done(new Error('should not be called')); }, error: (e) => {
           expect(e).to.equal('bad');
           done();
-        }, () => {
+        }, complete: () => {
           done(new Error('should not be called'));
-        });
+        } });
   });
 
   it('should share the underlying promise with multiple subscribers on a separate scheduler', (done) => {
@@ -123,20 +115,17 @@ describe('from (fromPromise)', () => {
 
     observable
       .subscribe(
-        (x) => { expect(x).to.equal(42); },
-        (x) => {
+        { next: (x) => { expect(x).to.equal(42); }, error: (x) => {
           done(new Error('should not be called'));
-        },
-        undefined);
+        } });
     setTimeout(() => {
       observable
         .subscribe(
-          (x) => { expect(x).to.equal(42); },
-          (x) => {
+          { next: (x) => { expect(x).to.equal(42); }, error: (x) => {
             done(new Error('should not be called'));
-          }, () => {
+          }, complete: () => {
             done();
-          });
+          } });
     });
   });
 
@@ -146,7 +135,7 @@ describe('from (fromPromise)', () => {
     const completeSpy = sinon.spy();
     const promise = Promise.resolve(42);
     const subscription = from(promise)
-      .subscribe(nextSpy, throwSpy, completeSpy);
+      .subscribe({ next: nextSpy, error: throwSpy, complete: completeSpy });
     subscription.unsubscribe();
 
     setTimeout(() => {

--- a/spec/observables/from-spec.ts
+++ b/spec/observables/from-spec.ts
@@ -257,34 +257,30 @@ describe('from', () => {
       let nextInvoked = false;
       from(source.createValue())
         .subscribe(
-          (x) => {
+          { next: (x) => {
             nextInvoked = true;
             expect(x).to.equal('x');
-          },
-          (x) => {
+          }, error: (x) => {
             done(new Error('should not be called'));
-          },
-          () => {
+          }, complete: () => {
             expect(nextInvoked).to.equal(true);
             done();
-          }
+          } }
         );
     });
     it(`should accept ${source.name} and scheduler`, (done) => {
       let nextInvoked = false;
       from(source.createValue(), asyncScheduler)
         .subscribe(
-          (x) => {
+          { next: (x) => {
             nextInvoked = true;
             expect(x).to.equal('x');
-          },
-          (x) => {
+          }, error: (x) => {
             done(new Error('should not be called'));
-          },
-          () => {
+          }, complete: () => {
             expect(nextInvoked).to.equal(true);
             done();
-          }
+          } }
         );
       expect(nextInvoked).to.equal(false);
     });
@@ -296,17 +292,15 @@ describe('from', () => {
       let nextInvoked = false;
 
       from((handler as any)).pipe(first()).subscribe(
-        (x) => {
+        { next: (x) => {
           nextInvoked = true;
           expect(x).to.equal('x');
-        },
-        (x) => {
+        }, error: (x) => {
           done(new Error('should not be called'));
-        },
-        () => {
+        }, complete: () => {
           expect(nextInvoked).to.equal(true);
           done();
-        }
+        } }
       );
       handler('x');
     });

--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -229,13 +229,13 @@ describe('fromEvent', () => {
     };
 
     fromEvent(obj, 'click').pipe(take(1))
-      .subscribe((e: any) => {
+      .subscribe({ next: (e: any) => {
         expect(e).to.equal('test');
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
 
     send('test');
   });
@@ -256,13 +256,13 @@ describe('fromEvent', () => {
     }
 
     fromEvent(obj, 'click', selector).pipe(take(1))
-      .subscribe((e: any) => {
+      .subscribe({ next: (e: any) => {
         expect(e).to.equal('test!');
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
 
     send('test');
   });
@@ -283,13 +283,13 @@ describe('fromEvent', () => {
     }
 
     fromEvent(obj, 'click', selector).pipe(take(1))
-      .subscribe((e: any) => {
+      .subscribe({ next: (e: any) => {
         expect(e).not.exist;
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
 
     send();
   });
@@ -310,13 +310,13 @@ describe('fromEvent', () => {
     }
 
     fromEvent(obj, 'click', selector).pipe(take(1))
-      .subscribe((e: any) => {
+      .subscribe({ next: (e: any) => {
         expect(e).to.equal('no arguments');
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
 
     send();
   });
@@ -337,13 +337,13 @@ describe('fromEvent', () => {
     }
 
     fromEvent(obj, 'click', selector).pipe(take(1))
-      .subscribe((e: any) => {
+      .subscribe({ next: (e: any) => {
         expect(e).to.deep.equal([1, 2, 3]);
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
 
     send(1, 2, 3);
   });
@@ -360,13 +360,13 @@ describe('fromEvent', () => {
     };
 
     fromEvent(obj, 'click').pipe(take(1))
-      .subscribe((e: any) => {
+      .subscribe({ next: (e: any) => {
         expect(e).to.deep.equal([1, 2, 3]);
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
 
     send(1, 2, 3);
   });

--- a/spec/observables/fromEventPattern-spec.ts
+++ b/spec/observables/fromEventPattern-spec.ts
@@ -63,11 +63,10 @@ describe('fromEventPattern', () => {
     fromEventPattern((h: any) => {
       throw 'bad';
     }, noop).subscribe(
-      () => done(new Error('should not be called')),
-      (err: any) => {
+      { next: () => done(new Error('should not be called')), error: (err: any) => {
         expect(err).to.equal('bad');
         done();
-      }, () => done(new Error('should not be called')));
+      }, complete: () => done(new Error('should not be called')) });
   });
 
   it('should accept a selector that maps outgoing values', (done) => {
@@ -89,13 +88,13 @@ describe('fromEventPattern', () => {
     };
 
     fromEventPattern(addHandler, removeHandler, selector).pipe(take(1))
-      .subscribe((x: any) => {
+      .subscribe({ next: (x: any) => {
         expect(x).to.equal('testme!');
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
 
     trigger('test', 'me');
   });
@@ -119,14 +118,14 @@ describe('fromEventPattern', () => {
     };
 
     fromEventPattern(addHandler, removeHandler, selector)
-      .subscribe((x: any) => {
+      .subscribe({ next: (x: any) => {
         done(new Error('should not be called'));
-      }, (err: any) => {
+      }, error: (err: any) => {
         expect(err).to.equal('bad');
         done();
-      }, () => {
+      }, complete: () => {
         done(new Error('should not be called'));
-      });
+      } });
 
     trigger('test');
   });

--- a/spec/observables/if-spec.ts
+++ b/spec/observables/if-spec.ts
@@ -38,13 +38,13 @@ describe('iif', () => {
     const expected = 42;
     const e1 = iif(() => true, new Promise((resolve: any) => { resolve(expected); }), of());
 
-    e1.subscribe(x => {
+    e1.subscribe({ next: x => {
       expect(x).to.equal(expected);
-    }, (x) => {
+    }, error: (x) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done();
-    });
+    } });
   });
 
   it('should accept resolved promise as elseSource', (done) => {
@@ -53,13 +53,13 @@ describe('iif', () => {
       of('a'),
       new Promise((resolve: any) => { resolve(expected); }));
 
-    e1.subscribe(x => {
+    e1.subscribe({ next: x => {
       expect(x).to.equal(expected);
-    }, (x) => {
+    }, error: (x) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done();
-    });
+    } });
   });
 
   it('should accept rejected promise as elseSource', (done) => {
@@ -68,27 +68,27 @@ describe('iif', () => {
       of('a'),
       new Promise((resolve: any, reject: any) => { reject(expected); }));
 
-    e1.subscribe(x => {
+    e1.subscribe({ next: x => {
       done(new Error('should not be called'));
-    }, (x) => {
+    }, error: (x) => {
       expect(x).to.equal(expected);
       done();
-    }, () => {
+    }, complete: () => {
       done(new Error('should not be called'));
-    });
+    } });
   });
 
   it('should accept rejected promise as thenSource', (done) => {
     const expected = 42;
     const e1 = iif(() => true, new Promise((resolve: any, reject: any) => { reject(expected); }), of());
 
-    e1.subscribe(x => {
+    e1.subscribe({ next: x => {
       done(new Error('should not be called'));
-    }, (x) => {
+    }, error: (x) => {
       expect(x).to.equal(expected);
       done();
-    }, () => {
+    }, complete: () => {
       done(new Error('should not be called'));
-    });
+    } });
   });
 });

--- a/spec/observables/interval-spec.ts
+++ b/spec/observables/interval-spec.ts
@@ -47,18 +47,18 @@ describe('interval', () => {
     const values: number[] = [];
     const expected = [0, 1, 2, 3, 4, 5, 6];
     const e1 = interval(5);
-    const subscription = e1.subscribe((x: number) => {
+    const subscription = e1.subscribe({ next: (x: number) => {
       values.push(x);
       if (x === 6) {
         subscription.unsubscribe();
         expect(values).to.deep.equal(expected);
         done();
       }
-    }, (err: any) => {
+    }, error: (err: any) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done(new Error('should not be called'));
-    });
+    } });
   });
 
   it('should create an observable emitting periodically with the AsapScheduler', (done) => {

--- a/spec/observables/of-spec.ts
+++ b/spec/observables/of-spec.ts
@@ -23,26 +23,26 @@ describe('of', () => {
     let i = 0;
 
    of(1, 'a', x)
-      .subscribe((y: any) => {
+      .subscribe({ next: (y: any) => {
         expect(y).to.equal(expected[i++]);
-      }, (x) => {
+      }, error: (x) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
   });
 
   it('should emit one value', (done) => {
     let calls = 0;
 
-    of(42).subscribe((x: number) => {
+    of(42).subscribe({ next: (x: number) => {
       expect(++calls).to.equal(1);
       expect(x).to.equal(42);
-  }, (err: any) => {
+  }, error: (err: any) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done();
-    });
+    } });
   });
 
   it('should handle an Observable as the only value', () => {

--- a/spec/observables/pairs-spec.ts
+++ b/spec/observables/pairs-spec.ts
@@ -24,14 +24,14 @@ describe('pairs', () => {
       ['c', 3]
     ];
 
-    pairs({a: 1, b: 2, c: 3}).subscribe(x => {
+    pairs({a: 1, b: 2, c: 3}).subscribe({ next: x => {
       expect(x).to.deep.equal(expected.shift());
-    }, x => {
+    }, error: x => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       expect(expected).to.be.empty;
       done();
-    });
+    } });
   });
 
   it('should work with empty object', () => {

--- a/spec/observables/race-spec.ts
+++ b/spec/observables/race-spec.ts
@@ -208,8 +208,8 @@ describe('static race', () => {
 
   it('should support a single ObservableInput argument', (done) => {
     const source = race(Promise.resolve(42));
-    source.subscribe(value => {
+    source.subscribe({ next: value => {
       expect(value).to.equal(42);
-    }, done, done);
+    }, error: done, complete: done });
   });
 });

--- a/spec/observables/range-spec.ts
+++ b/spec/observables/range-spec.ts
@@ -58,16 +58,16 @@ describe('range', () => {
 
     const source = range(12, 4, asap);
 
-    source.subscribe(function (x) {
+    source.subscribe({ next: function (x) {
       expect(asap.schedule).have.been.called;
       const exp = expected.shift();
       expect(x).to.equal(exp);
-    }, function (x) {
+    }, error: function (x) {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       (<any>asap.schedule).restore();
       done();
-    });
+    } });
 
   });
 

--- a/spec/observables/throwError-spec.ts
+++ b/spec/observables/throwError-spec.ts
@@ -22,16 +22,16 @@ describe('throwError', () => {
 
   it('should emit one value', (done) => {
     let calls = 0;
-    throwError(() => 'bad').subscribe(
-      () => {
+    throwError(() => 'bad').subscribe({
+      next: () => {
         done(new Error('should not be called'));
       },
-      (err) => {
+      error: (err) => {
         expect(++calls).to.equal(1);
         expect(err).to.equal('bad');
         done();
-      }
-    );
+      },
+    });
   });
 
   it('should accept scheduler', () => {

--- a/spec/observables/using-spec.ts
+++ b/spec/observables/using-spec.ts
@@ -28,13 +28,13 @@ describe('using', () => {
       () => new Subscription(() => disposed = true),
       (resource) => new Promise((resolve: any) => { resolve(expected); }));
 
-    e1.subscribe(x => {
+    e1.subscribe({ next: x => {
       expect(x).to.equal(expected);
-    }, (x) => {
+    }, error: (x) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done();
-    });
+    } });
   });
 
   it('should accept factory returns promise rejects', (done) => {
@@ -45,14 +45,14 @@ describe('using', () => {
       () => new Subscription(() => disposed = true),
       (resource) => new Promise((resolve: any, reject: any) => { reject(expected); }));
 
-    e1.subscribe(x => {
+    e1.subscribe({ next: x => {
       done(new Error('should not be called'));
-    }, (x) => {
+    }, error: (x) => {
       expect(x).to.equal(expected);
       done();
-    }, () => {
+    }, complete: () => {
       done(new Error('should not be called'));
-    });
+    } });
   });
 
   it('should raise error when resource factory throws', (done) => {
@@ -68,14 +68,14 @@ describe('using', () => {
       }
     );
 
-    source.subscribe((x) => {
+    source.subscribe({ next: (x) => {
       done(new Error('should not be called'));
-    }, (x) => {
+    }, error: (x) => {
       expect(x).to.equal(expectedError);
       done();
-    }, () => {
+    }, complete: () => {
       done(new Error('should not be called'));
-    });
+    } });
   });
 
   it('should raise error when observable factory throws', (done) => {
@@ -89,13 +89,13 @@ describe('using', () => {
       }
     );
 
-    source.subscribe((x) => {
+    source.subscribe({ next: (x) => {
       done(new Error('should not be called'));
-    }, (x) => {
+    }, error: (x) => {
       expect(x).to.equal(error);
       done();
-    }, () => {
+    }, complete: () => {
       done(new Error('should not be called'));
-    });
+    } });
   });
 });

--- a/spec/observables/zip-spec.ts
+++ b/spec/observables/zip-spec.ts
@@ -26,9 +26,9 @@ describe('static zip', () => {
     zip(
       from(['a', 'b', 'c']),
       from([1, 2, 3]), (a: string, b: number) => a + b)
-        .subscribe((x: string) => {
+        .subscribe({ next: (x: string) => {
           expect(x).to.equal(expected[i++]);
-        }, null, done);
+        }, complete: done });
   });
 
   it('should end once one observable completes and its buffer is empty', () => {
@@ -524,9 +524,9 @@ describe('static zip', () => {
     const r = [[1, 4], [2, 5], [3, 6]];
     let i = 0;
 
-    zip(a, b).subscribe((vals: Array<number>) => {
+    zip(a, b).subscribe({ next: (vals: Array<number>) => {
       expect(vals).to.deep.equal(r[i++]);
-    }, null, done);
+    }, complete: done });
   });
 
   it('should be able to zip all iterables', () => {

--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -398,15 +398,13 @@ describe('audit operator', () => {
     e1.pipe(
       audit(() => Promise.resolve(42))
     ).subscribe(
-      (x: number) => {
-        expect(x).to.equal(expected.shift()); },
-      () => {
+      { next: (x: number) => {
+        expect(x).to.equal(expected.shift()); }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         expect(expected.length).to.equal(0);
         done();
-      }
+      } }
     );
   });
 
@@ -424,16 +422,14 @@ describe('audit operator', () => {
         }
       })
     ).subscribe(
-      (x: number) => {
-        expect(x).to.equal(expected.shift()); },
-      (err: any) => {
+      { next: (x: number) => {
+        expect(x).to.equal(expected.shift()); }, error: (err: any) => {
         expect(err).to.be.an('error', 'error');
         expect(expected.length).to.equal(0);
         done();
-      },
-      () => {
+      }, complete: () => {
         done(new Error('should not be called'));
-      }
+      } }
     );
   });
 

--- a/spec/operators/bufferToggle-spec.ts
+++ b/spec/operators/bufferToggle-spec.ts
@@ -430,14 +430,14 @@ describe('bufferToggle operator', () => {
       bufferToggle(new Promise((resolve: any) => { resolve(42); }), () => {
         return timer(50);
       })
-    ).subscribe((x) => {
+    ).subscribe({ next: (x) => {
       expect(x).to.deep.equal(expected.shift());
-    }, (x) => {
+    }, error: (x) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       expect(expected.length).to.be.equal(0);
       done();
-    });
+    } });
   });
 
   it('should accept openings rejected promise', (done) => {
@@ -453,14 +453,14 @@ describe('bufferToggle operator', () => {
       bufferToggle(new Promise((resolve: any, reject: any) => { reject(expected); }), () => {
         return timer(50);
       })
-    ).subscribe((x) => {
+    ).subscribe({ next: (x) => {
       done(new Error('should not be called'));
-    }, (x) => {
+    }, error: (x) => {
       expect(x).to.equal(expected);
       done();
-    }, () => {
+    }, complete: () => {
       done(new Error('should not be called'));
-    });
+    } });
   });
 
   it('should accept closing selector that returns a resolved promise', (done) => {
@@ -472,14 +472,14 @@ describe('bufferToggle operator', () => {
     const expected = [[1]];
 
     e1.pipe(bufferToggle(of(10), () => new Promise((resolve: any) => { resolve(42); })))
-      .subscribe((x) => {
+      .subscribe({ next: (x) => {
         expect(x).to.deep.equal(expected.shift());
-      }, () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         expect(expected.length).to.be.equal(0);
         done();
-      });
+      } });
   });
 
   it('should accept closing selector that returns a rejected promise', (done) => {
@@ -492,14 +492,14 @@ describe('bufferToggle operator', () => {
     const expected = 42;
 
     e1.pipe(bufferToggle(of(10), () => new Promise((resolve: any, reject: any) => { reject(expected); })))
-      .subscribe((x) => {
+      .subscribe({ next: (x) => {
         done(new Error('should not be called'));
-      }, (x) => {
+      }, error: (x) => {
         expect(x).to.equal(expected);
         done();
-      }, () => {
+      }, complete: () => {
         done(new Error('should not be called'));
-      });
+      } });
   });
 
   it('should handle empty closing observable', () => {

--- a/spec/operators/bufferWhen-spec.ts
+++ b/spec/operators/bufferWhen-spec.ts
@@ -369,14 +369,14 @@ describe('bufferWhen operator', () => {
     source.pipe(
       bufferWhen(() => closing),
       takeWhile((val: any, index: number) => index < TOO_MANY_INVOCATIONS)
-    ).subscribe((val: any) => {
+    ).subscribe({ next: (val: any) => {
       expect(Array.isArray(val)).to.be.true;
       expect(val.length).to.equal(0);
-    }, (err: any) => {
+    }, error: (err: any) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done();
-    });
+    } });
   });
 
   it('should handle inner throw', () => {

--- a/spec/operators/catchError-spec.ts
+++ b/spec/operators/catchError-spec.ts
@@ -344,13 +344,13 @@ describe('catchError operator', () => {
         expect(err).to.equal('bad');
         return EMPTY;
       })
-    ).subscribe(() => {
+    ).subscribe({ next: () => {
     //noop
-    }, (err: any) => {
+    }, error: (err: any) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done();
-    });
+    } });
   });
 
   it('should accept selector returns any ObservableInput', (done) => {
@@ -360,13 +360,13 @@ describe('catchError operator', () => {
       mergeMap(input =>
         throwError(() => ('bad')).pipe(catchError(err => input))
       )
-    ).subscribe(x => {
+    ).subscribe({ next: x => {
       expect(x).to.be.equal(42);
-    }, (err: any) => {
+    }, error: (err: any) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       done();
-    });
+    } });
   });
 
   it('should catch errors throw from within the constructor', () => {
@@ -412,7 +412,7 @@ describe('catchError operator', () => {
         catchError(err =>
           throwError(() => (thrownError))
         )
-      ).subscribe(subscribeSpy, errorSpy);
+      ).subscribe({ next: subscribeSpy, error: errorSpy });
 
       trueSetTimeout(() => {
         try {
@@ -448,12 +448,10 @@ describe('catchError operator', () => {
       catchError(err => sourceWithDelay)
     )
     .subscribe(
-      value => values.push(value),
-      err => done(err),
-      () => {
+      { next: value => values.push(value), error: err => done(err), complete: () => {
         expect(values).to.deep.equal(['delayed']);
         done();
-      }
+      } }
     );
   });
 

--- a/spec/operators/combineLatestAll-spec.ts
+++ b/spec/operators/combineLatestAll-spec.ts
@@ -520,12 +520,12 @@ describe('combineLatestAll operator', () => {
     const a = of(1, 2, 3);
     const b = of(4, 5, 6, 7, 8);
     const expected = [[3, 4], [3, 5], [3, 6], [3, 7], [3, 8]];
-    of(a, b).pipe(combineLatestAll()).subscribe((vals) => {
+    of(a, b).pipe(combineLatestAll()).subscribe({ next: (vals) => {
       expect(vals).to.deep.equal(expected.shift());
-    }, null, () => {
+    }, complete: () => {
       expect(expected.length).to.equal(0);
       done();
-    });
+    } });
   });
 
   it('should combine two immediately-scheduled observables', (done) => {
@@ -534,11 +534,11 @@ describe('combineLatestAll operator', () => {
     const r = [[1, 4], [2, 4], [2, 5], [3, 5], [3, 6], [3, 7], [3, 8]];
 
     of(a, b, queueScheduler).pipe(combineLatestAll())
-      .subscribe((vals) => {
+      .subscribe({ next: (vals) => {
         expect(vals).to.deep.equal(r.shift());
-    }, null, () => {
+    }, complete: () => {
       expect(r.length).to.equal(0);
       done();
-    });
+    } });
   });
 });

--- a/spec/operators/concat-legacy-spec.ts
+++ b/spec/operators/concat-legacy-spec.ts
@@ -33,17 +33,15 @@ describe('concat operator', () => {
     }).pipe(concat(of(2)));
 
     s1.subscribe(
-      x => {
+      { next: x => {
         results.push('Next: ' + x);
-      },
-      x => {
+      }, error: x => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         results.push('Completed');
         expect(results).to.deep.equal(['Next: 1', 'Next: 2', 'Completed']);
         done();
-      }
+      } }
     );
   });
 

--- a/spec/operators/concatAll-spec.ts
+++ b/spec/operators/concatAll-spec.ts
@@ -45,16 +45,14 @@ describe('concatAll operator', () => {
 
     const res: number[] = [];
     sources.pipe(concatAll()).subscribe(
-      x => {
+      { next: x => {
         res.push(x);
-      },
-      err => {
+      }, error: err => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         expect(res).to.deep.equal([0, 1, 2, 3]);
         done();
-      }
+      } }
     );
   });
 
@@ -112,17 +110,15 @@ describe('concatAll operator', () => {
 
     const res: number[] = [];
     sources.pipe(concatAll()).subscribe(
-      x => {
+      { next: x => {
         res.push(x);
-      },
-      err => {
+      }, error: err => {
         expect(res.length).to.equal(1);
         expect(err).to.equal(1);
         done();
-      },
-      () => {
+      }, complete: () => {
         done(new Error('should not be called'));
-      }
+      } }
     );
   });
 

--- a/spec/operators/concatMap-spec.ts
+++ b/spec/operators/concatMap-spec.ts
@@ -775,16 +775,14 @@ describe('Observable.prototype.concatMap', () => {
 
     const results: number[] = [];
     source.pipe(concatMap(project)).subscribe(
-      x => {
+      { next: x => {
         results.push(x);
-      },
-      err => {
+      }, error: err => {
         done(new Error('Subscriber error handler not supposed to be called.'));
-      },
-      () => {
+      }, complete: () => {
         expect(results).to.deep.equal([42, 42, 42, 42]);
         done();
-      }
+      } }
     );
   });
 
@@ -793,16 +791,14 @@ describe('Observable.prototype.concatMap', () => {
     const project = (value: any) => from(Promise.reject(42));
 
     source.pipe(concatMap(project)).subscribe(
-      x => {
+      { next: x => {
         done(new Error('Subscriber next handler not supposed to be called.'));
-      },
-      err => {
+      }, error: err => {
         expect(err).to.deep.equal(42);
         done();
-      },
-      () => {
+      }, complete: () => {
         done(new Error('Subscriber complete handler not supposed to be called.'));
-      }
+      } }
     );
   });
 
@@ -812,16 +808,14 @@ describe('Observable.prototype.concatMap', () => {
 
     const results: number[] = [];
     source.pipe(concatMap(project)).subscribe(
-      x => {
+      { next: x => {
         results.push(x);
-      },
-      err => {
+      }, error: err => {
         done(new Error('Subscriber error handler not supposed to be called.'));
-      },
-      () => {
+      }, complete: () => {
         expect(results).to.deep.equal([4, 4, 4, 4]);
         done();
-      }
+      } }
     );
   });
 
@@ -830,16 +824,14 @@ describe('Observable.prototype.concatMap', () => {
     const project = (value: number, index: number) => from(Promise.reject('' + value + '-' + index));
 
     source.pipe(concatMap(project)).subscribe(
-      x => {
+      { next: x => {
         done(new Error('Subscriber next handler not supposed to be called.'));
-      },
-      err => {
+      }, error: err => {
         expect(err).to.deep.equal('4-0');
         done();
-      },
-      () => {
+      }, complete: () => {
         done(new Error('Subscriber complete handler not supposed to be called.'));
-      }
+      } }
     );
   });
 

--- a/spec/operators/concatMapTo-spec.ts
+++ b/spec/operators/concatMapTo-spec.ts
@@ -384,32 +384,28 @@ describe('concatMapTo', () => {
 
     const results: number[] = [];
     source.pipe(concatMapTo(from(Promise.resolve(42)))).subscribe(
-      (x) => {
+      { next: (x) => {
         results.push(x);
-      },
-      (err) => {
+      }, error: (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
-      },
-      () => {
+      }, complete: () => {
         expect(results).to.deep.equal([42, 42, 42, 42]);
         done();
-      });
+      } });
   });
 
   it('should map values to constant rejected promises and concatenate', (done) => {
     const source = from([4, 3, 2, 1]);
 
     source.pipe(concatMapTo(from(Promise.reject(42)))).subscribe(
-      (x) => {
+      { next: (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
-      },
-      (err) => {
+      }, error: (err) => {
         expect(err).to.equal(42);
         done();
-      },
-      () => {
+      }, complete: () => {
         done(new Error('Subscriber complete handler not supposed to be called.'));
-      });
+      } });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {

--- a/spec/operators/concatWith-spec.ts
+++ b/spec/operators/concatWith-spec.ts
@@ -34,17 +34,15 @@ describe('concat operator', () => {
     }).pipe(concatWith(of(2)));
 
     s1.subscribe(
-      x => {
+      { next: x => {
         results.push('Next: ' + x);
-      },
-      x => {
+      }, error: x => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         results.push('Completed');
         expect(results).to.deep.equal(['Next: 1', 'Next: 2', 'Completed']);
         done();
-      }
+      } }
     );
   });
 

--- a/spec/operators/count-spec.ts
+++ b/spec/operators/count-spec.ts
@@ -93,49 +93,49 @@ describe('count', () => {
   it('should count a range() source observable', (done) => {
     range(1, 10)
       .pipe(count())
-      .subscribe(
-        (value: number) => {
+      .subscribe({
+        next: (value: number) => {
           expect(value).to.equal(10);
         },
-        (x) => {
+        error: (x) => {
           done(new Error('should not be called'));
         },
-        () => {
+        complete: () => {
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should count a range().skip(1) source observable', (done) => {
     range(1, 10)
       .pipe(skip(1), count())
-      .subscribe(
-        (value: number) => {
+      .subscribe({
+        next: (value: number) => {
           expect(value).to.equal(9);
         },
-        (x) => {
+        error: (x) => {
           done(new Error('should not be called'));
         },
-        () => {
+        complete: () => {
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should count a range().take(1) source observable', (done) => {
     range(1, 10)
       .pipe(take(1), count())
-      .subscribe(
-        (value: number) => {
+      .subscribe({
+        next: (value: number) => {
           expect(value).to.equal(1);
         },
-        (x) => {
+        error: (x) => {
           done(new Error('should not be called'));
         },
-        () => {
+        complete: () => {
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should work with error', () => {

--- a/spec/operators/debounce-spec.ts
+++ b/spec/operators/debounce-spec.ts
@@ -469,18 +469,18 @@ describe('debounce', () => {
           resolve(42);
         });
       })
-    ).subscribe(
-      (x: number) => {
+    ).subscribe({
+      next: (x: number) => {
         expect(x).to.equal(expected.shift());
       },
-      (x) => {
+      error: (x) => {
         done(new Error('should not be called'));
       },
-      () => {
+      complete: () => {
         expect(expected.length).to.equal(0);
         done();
-      }
-    );
+      },
+    });
   });
 
   it('should raises error when promise rejects', (done) => {
@@ -500,19 +500,19 @@ describe('debounce', () => {
           });
         }
       })
-    ).subscribe(
-      (x: number) => {
+    ).subscribe({
+      next: (x: number) => {
         expect(x).to.equal(expected.shift());
       },
-      (err: any) => {
+      error: (err: any) => {
         expect(err).to.be.an('error', 'error');
         expect(expected.length).to.equal(0);
         done();
       },
-      () => {
+      complete: () => {
         done(new Error('should not be called'));
-      }
-    );
+      },
+    });
   });
 
   it('should debounce correctly when synchronously reentered', () => {

--- a/spec/operators/delayWhen-spec.ts
+++ b/spec/operators/delayWhen-spec.ts
@@ -304,11 +304,7 @@ describe('delayWhen', () => {
 
     of(1)
       .pipe(delayWhen(() => of(2)))
-      .subscribe(
-        () => (next = true),
-        null,
-        () => (complete = true)
-      );
+      .subscribe({ next: () => (next = true), complete: () => (complete = true) });
 
     expect(next).to.be.true;
     expect(complete).to.be.true;
@@ -333,8 +329,10 @@ describe('delayWhen', () => {
 
       expectObservable(
         result.pipe(
-          tap(null, null, () => {
-            expect(indices).to.deep.equal([0, 1, 2]);
+          tap({
+            complete: () => {
+              expect(indices).to.deep.equal([0, 1, 2]);
+            },
           })
         )
       ).toBe(expected);

--- a/spec/operators/exhaustAll-spec.ts
+++ b/spec/operators/exhaustAll-spec.ts
@@ -240,33 +240,32 @@ describe('exhaust', () => {
 
     of(Promise.resolve(1), Promise.resolve(2), Promise.resolve(3))
       .pipe(exhaustAll())
-      .subscribe(
-        (x) => {
+      .subscribe({
+        next: (x) => {
           expect(x).to.equal(expected.shift());
         },
-        null,
-        () => {
+        complete: () => {
           expect(expected.length).to.equal(0);
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should handle an observable of promises, where one rejects', (done) => {
     of(Promise.reject(2), Promise.resolve(1))
       .pipe(exhaustAll())
-      .subscribe(
-        (x) => {
+      .subscribe({
+        next: (x) => {
           done(new Error('should not be called'));
         },
-        (err) => {
+        error: (err) => {
           expect(err).to.equal(2);
           done();
         },
-        () => {
+        complete: () => {
           done(new Error('should not be called'));
-        }
-      );
+        },
+      });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -393,16 +393,15 @@ describe('expand', () => {
           return Promise.resolve(x + x);
         })
       )
-      .subscribe(
-        (x) => {
+      .subscribe({
+        next: (x) => {
           expect(x).to.equal(expected.shift());
         },
-        null,
-        () => {
+        complete: () => {
           expect(expected.length).to.equal(0);
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should recursively flatten Arrays', (done) => {
@@ -416,16 +415,15 @@ describe('expand', () => {
           return [x + x];
         })
       )
-      .subscribe(
-        (x) => {
+      .subscribe({
+        next: (x) => {
           expect(x).to.equal(expected.shift());
         },
-        null,
-        () => {
+        complete: () => {
           expect(expected.length).to.equal(0);
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should recursively flatten lowercase-o observables', (done) => {
@@ -448,16 +446,15 @@ describe('expand', () => {
 
     of(1)
       .pipe(expand(project))
-      .subscribe(
-        (x) => {
+      .subscribe({
+        next: (x) => {
           expect(x).to.equal(expected.shift());
         },
-        null,
-        () => {
+        complete: () => {
           expect(expected.length).to.equal(0);
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should work when passing undefined for the optional arguments', () => {
@@ -496,7 +493,7 @@ describe('expand', () => {
         take(10),
         toArray()
       )
-      .subscribe((actual) => expect(actual).to.deep.equal(expected), done, done);
+      .subscribe({ next: (actual) => expect(actual).to.deep.equal(expected), error: done, complete: done });
   });
 
   it('should work with the AsyncScheduler', (done) => {
@@ -507,7 +504,7 @@ describe('expand', () => {
         take(10),
         toArray()
       )
-      .subscribe((actual) => expect(actual).to.deep.equal(expected), done, done);
+      .subscribe({ next: (actual) => expect(actual).to.deep.equal(expected), error: done, complete: done });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {

--- a/spec/operators/filter-spec.ts
+++ b/spec/operators/filter-spec.ts
@@ -154,8 +154,10 @@ describe('filter', () => {
 
       const result = e1.pipe(
         filter(predicate),
-        tap(null, null, () => {
-          expect(invoked).to.equal(7);
+        tap({
+          complete: () => {
+            expect(invoked).to.equal(7);
+          },
         })
       );
 
@@ -329,18 +331,18 @@ describe('filter', () => {
           throw 'bad';
         })
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next: (x: number) => {
           done(new Error('should not be called'));
         },
-        (err: any) => {
+        error: (err: any) => {
           expect(err).to.equal('bad');
           done();
         },
-        () => {
+        complete: () => {
           done(new Error('should not be called'));
-        }
-      );
+        },
+      });
   });
 
   it('should not break unsubscription chain when unsubscribed explicitly', () => {

--- a/spec/operators/finalize-spec.ts
+++ b/spec/operators/finalize-spec.ts
@@ -17,8 +17,10 @@ describe('finalize', () => {
           done();
         })
       )
-      .subscribe(null, null, () => {
-        completed = true;
+      .subscribe({
+        complete: () => {
+          completed = true;
+        },
       });
   });
 
@@ -37,8 +39,10 @@ describe('finalize', () => {
           done();
         })
       )
-      .subscribe(null, () => {
-        thrown = true;
+      .subscribe({
+        error: () => {
+          thrown = true;
+        },
       });
   });
 

--- a/spec/operators/groupBy-spec.ts
+++ b/spec/operators/groupBy-spec.ts
@@ -43,14 +43,14 @@ describe('groupBy operator', () => {
 
     of(1, 2, 3).pipe(
       groupBy((x) => x % 2)
-    ).subscribe((g: any) => {
+    ).subscribe({ next: (g: any) => {
         const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {
           expect(x).to.deep.equal(expectedGroup.values.shift());
         });
-      }, null, done);
+      }, complete: done });
   });
 
   it('should group values with an element selector', (done) => {
@@ -61,14 +61,14 @@ describe('groupBy operator', () => {
 
     of(1, 2, 3).pipe(
       groupBy((x) => x % 2, (x) => x + '!')
-    ).subscribe((g: any) => {
+    ).subscribe({ next: (g: any) => {
         const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {
           expect(x).to.deep.equal(expectedGroup.values.shift());
         });
-      }, null, done);
+      }, complete: done });
   });
 
   it('should group values with a duration selector', () => {
@@ -111,14 +111,14 @@ describe('groupBy operator', () => {
       // Ensure each inner group reaches the destination after the first event
       // has been next'd to the group
       delay(5)
-    ).subscribe((g: any) => {
+    ).subscribe({ next: (g: any) => {
         const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {
           expect(x).to.deep.equal(expectedGroup.values.shift());
         });
-      }, null, done);
+      }, complete: done });
   });
 
   it('should handle an empty Observable', () => {
@@ -666,13 +666,13 @@ describe('groupBy operator', () => {
     const expected = '----------------------------#';
 
     e1.pipe(groupBy((val: string) => val.toLowerCase().trim()))
-      .subscribe((group: any) => {
+      .subscribe({ next: (group: any) => {
         rxTestScheduler.schedule(() => {
           expectObservable(group).toBe(expected);
         }, 260);
-      }, () => {
+      }, error: () => {
         //noop
-      });
+      } });
     expectSubscriptions(e1.subscriptions).toBe(subs);
   });
 
@@ -1424,18 +1424,18 @@ describe('groupBy operator', () => {
     ];
 
     result
-      .subscribe((g: any) => {
+      .subscribe({ next: (g: any) => {
         const expectedGroup = expectedGroups.shift()!;
         expect(g.key).to.equal(expectedGroup.key);
 
         g.subscribe((x: any) => {
           expect(x).to.deep.equal(expectedGroup.values.shift());
         });
-      }, (x) => {
+      }, error: (x) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         done();
-      });
+      } });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {

--- a/spec/operators/max-spec.ts
+++ b/spec/operators/max-spec.ts
@@ -123,49 +123,49 @@ describe('max', () => {
   it('should max a range() source observable', (done) => {
     range(1, 10000)
       .pipe(max())
-      .subscribe(
-        (value: number) => {
+      .subscribe({
+        next: (value: number) => {
           expect(value).to.equal(10000);
         },
-        () => {
+        error: () => {
           done(new Error('should not be called'));
         },
-        () => {
+        complete: () => {
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should max a range().pipe(skip(1)) source observable', (done) => {
     range(1, 10)
       .pipe(skip(1), max())
-      .subscribe(
-        (value: number) => {
+      .subscribe({
+        next: (value: number) => {
           expect(value).to.equal(10);
         },
-        () => {
+        error: () => {
           done(new Error('should not be called'));
         },
-        () => {
+        complete: () => {
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should max a range().pipe(take(1)) source observable', (done) => {
     range(1, 10)
       .pipe(take(1), max())
-      .subscribe(
-        (value: number) => {
+      .subscribe({
+        next: (value: number) => {
           expect(value).to.equal(1);
         },
-        () => {
+        error: () => {
           done(new Error('should not be called'));
         },
-        () => {
+        complete: () => {
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should work with error', () => {

--- a/spec/operators/merge-legacy-spec.ts
+++ b/spec/operators/merge-legacy-spec.ts
@@ -9,15 +9,13 @@ describe('merge (legacy)', () => {
     const r = [1, 2, 4, 3, 5, 6, 7, 8];
 
     a.pipe(merge(b, queueScheduler)).subscribe(
-      val => {
+      { next: val => {
         expect(val).to.equal(r.shift());
-      },
-      x => {
+      }, error: x => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 });

--- a/spec/operators/mergeAll-spec.ts
+++ b/spec/operators/mergeAll-spec.ts
@@ -455,18 +455,18 @@ describe('mergeAll', () => {
     const expected = ['a', 'b', 'c', 'd'];
 
     const res: string[] = [];
-    e1.pipe(mergeAll()).subscribe(
-      (x) => {
+    e1.pipe(mergeAll()).subscribe({
+      next: (x) => {
         res.push(x);
       },
-      () => {
+      error: () => {
         done(new Error('should not be called'));
       },
-      () => {
+      complete: () => {
         expect(res).to.deep.equal(expected);
         done();
-      }
-    );
+      },
+    });
   });
 
   it('should raise error when promise rejects', (done) => {
@@ -487,19 +487,19 @@ describe('mergeAll', () => {
     ]);
 
     const res: string[] = [];
-    e1.pipe(mergeAll()).subscribe(
-      (x) => {
+    e1.pipe(mergeAll()).subscribe({
+      next: (x) => {
         res.push(x);
       },
-      (err) => {
+      error: (err) => {
         expect(res.length).to.equal(1);
         expect(err).to.equal('error');
         done();
       },
-      () => {
+      complete: () => {
         done(new Error('should not be called'));
-      }
-    );
+      },
+    });
   });
 
   it('should finalize generators when merged if the subscription ends', () => {
@@ -521,11 +521,7 @@ describe('mergeAll', () => {
     const iterableObservable = from<string>(iterable as any);
     of(iterableObservable)
       .pipe(mergeAll(), take(3))
-      .subscribe(
-        (x) => results.push(x),
-        null,
-        () => results.push('GOOSE!')
-      );
+      .subscribe({ next: (x) => results.push(x), complete: () => results.push('GOOSE!') });
 
     expect(results).to.deep.equal(['duck', 'duck', 'duck', 'GOOSE!']);
     expect(iterable.finalized).to.be.true;
@@ -538,13 +534,12 @@ describe('mergeAll', () => {
 
     of(a, b)
       .pipe(mergeAll())
-      .subscribe(
-        (val) => {
+      .subscribe({
+        next: (val) => {
           expect(val).to.equal(r.shift());
         },
-        null,
-        done
-      );
+        complete: done,
+      });
   });
 
   it('should merge two immediately-scheduled observables', (done) => {
@@ -554,13 +549,12 @@ describe('mergeAll', () => {
 
     of(a, b, queueScheduler)
       .pipe(mergeAll())
-      .subscribe(
-        (val) => {
+      .subscribe({
+        next: (val) => {
           expect(val).to.equal(r.shift());
         },
-        null,
-        done
-      );
+        complete: done,
+      });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {

--- a/spec/operators/mergeMap-spec.ts
+++ b/spec/operators/mergeMap-spec.ts
@@ -137,36 +137,36 @@ describe('mergeMap', () => {
     const project = () => from(Promise.resolve(42));
 
     const results: number[] = [];
-    source.pipe(mergeMap(project)).subscribe(
-      (x) => {
+    source.pipe(mergeMap(project)).subscribe({
+      next: (x) => {
         results.push(x);
       },
-      (err) => {
+      error: (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
-      () => {
+      complete: () => {
         expect(results).to.deep.equal([42, 42, 42, 42]);
         done();
-      }
-    );
+      },
+    });
   });
 
   it('should map values to constant rejected promises and merge', (done) => {
     const source = from([4, 3, 2, 1]);
     const project = () => from(Promise.reject<number>(42));
 
-    source.pipe(mergeMap(project)).subscribe(
-      (x) => {
+    source.pipe(mergeMap(project)).subscribe({
+      next: (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err) => {
+      error: (err) => {
         expect(err).to.equal(42);
         done();
       },
-      () => {
+      complete: () => {
         done(new Error('Subscriber complete handler not supposed to be called.'));
-      }
-    );
+      },
+    });
   });
 
   it('should map values to resolved promises and merge', (done) => {
@@ -174,36 +174,36 @@ describe('mergeMap', () => {
     const project = (value: number, index: number) => from(Promise.resolve(value + index));
 
     const results: number[] = [];
-    source.pipe(mergeMap(project)).subscribe(
-      (x) => {
+    source.pipe(mergeMap(project)).subscribe({
+      next: (x) => {
         results.push(x);
       },
-      (err) => {
+      error: (err) => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
-      () => {
+      complete: () => {
         expect(results).to.deep.equal([4, 4, 4, 4]);
         done();
-      }
-    );
+      },
+    });
   });
 
   it('should map values to rejected promises and merge', (done) => {
     const source = from([4, 3, 2, 1]);
     const project = (value: number, index: number) => from(Promise.reject<string>('' + value + '-' + index));
 
-    source.pipe(mergeMap(project)).subscribe(
-      (x) => {
+    source.pipe(mergeMap(project)).subscribe({
+      next: (x) => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err) => {
+      error: (err) => {
         expect(err).to.equal('4-0');
         done();
       },
-      () => {
+      complete: () => {
         done(new Error('Subscriber complete handler not supposed to be called.'));
-      }
-    );
+      },
+    });
   });
 
   it('should mergeMap many outer values to many inner values', () => {
@@ -869,16 +869,15 @@ describe('mergeMap', () => {
     const expected = ['1!', '2!', '3!', '4!'];
     let completed = false;
 
-    source.subscribe(
-      (x) => {
+    source.subscribe({
+      next: (x) => {
         expect(x).to.equal(expected.shift());
       },
-      null,
-      () => {
+      complete: () => {
         expect(expected.length).to.equal(0);
         completed = true;
-      }
-    );
+      },
+    });
 
     expect(completed).to.be.true;
   });
@@ -889,16 +888,15 @@ describe('mergeMap', () => {
     const expected = ['1!', '2!', '3!', '4!'];
     let completed = false;
 
-    source.subscribe(
-      (x) => {
+    source.subscribe({
+      next: (x) => {
         expect(x).to.equal(expected.shift());
       },
-      null,
-      () => {
+      complete: () => {
         expect(expected.length).to.equal(0);
         completed = true;
-      }
-    );
+      },
+    });
 
     expect(completed).to.be.true;
   });

--- a/spec/operators/mergeMapTo-spec.ts
+++ b/spec/operators/mergeMapTo-spec.ts
@@ -110,35 +110,35 @@ describe('mergeMapTo', () => {
     const source = from([4, 3, 2, 1]);
 
     const results: number[] = [];
-    source.pipe(mergeMapTo(from(Promise.resolve(42)))).subscribe(
-      (x) => {
+    source.pipe(mergeMapTo(from(Promise.resolve(42)))).subscribe({
+      next: (x) => {
         results.push(x);
       },
-      () => {
+      error: () => {
         done(new Error('Subscriber error handler not supposed to be called.'));
       },
-      () => {
+      complete: () => {
         expect(results).to.deep.equal([42, 42, 42, 42]);
         done();
-      }
-    );
+      },
+    });
   });
 
   it('should map values to constant rejected promises and merge', (done) => {
     const source = from([4, 3, 2, 1]);
 
-    source.pipe(mergeMapTo(from(Promise.reject(42)))).subscribe(
-      () => {
+    source.pipe(mergeMapTo(from(Promise.reject(42)))).subscribe({
+      next: () => {
         done(new Error('Subscriber next handler not supposed to be called.'));
       },
-      (err) => {
+      error: (err) => {
         expect(err).to.equal(42);
         done();
       },
-      () => {
+      complete: () => {
         done(new Error('Subscriber complete handler not supposed to be called.'));
-      }
-    );
+      },
+    });
   });
 
   it('should mergeMapTo many outer values to many inner values', () => {
@@ -422,16 +422,15 @@ describe('mergeMapTo', () => {
     const expected = ['!', '!', '!', '!'];
     let completed = false;
 
-    source.subscribe(
-      (x) => {
+    source.subscribe({
+      next: (x) => {
         expect(x).to.equal(expected.shift());
       },
-      null,
-      () => {
+      complete: () => {
         expect(expected.length).to.equal(0);
         completed = true;
-      }
-    );
+      },
+    });
 
     expect(completed).to.be.true;
   });
@@ -442,16 +441,15 @@ describe('mergeMapTo', () => {
     const expected = ['!', '!', '!', '!'];
     let completed = false;
 
-    source.subscribe(
-      (x) => {
+    source.subscribe({
+      next: (x) => {
         expect(x).to.equal(expected.shift());
       },
-      null,
-      () => {
+      complete: () => {
         expect(expected.length).to.equal(0);
         completed = true;
-      }
-    );
+      },
+    });
 
     expect(completed).to.be.true;
   });

--- a/spec/operators/mergeWith-spec.ts
+++ b/spec/operators/mergeWith-spec.ts
@@ -34,15 +34,13 @@ describe('merge operator', () => {
     const r = [1, 2, 3, 4, 5, 6, 7, 8];
 
     a.pipe(mergeWith(b)).subscribe(
-      val => {
+      { next: val => {
         expect(val).to.equal(r.shift());
-      },
-      () => {
+      }, error: () => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -314,11 +312,9 @@ describe('mergeAll operator', () => {
     of(a, b)
       .pipe(mergeAll())
       .subscribe(
-        val => {
+        { next: val => {
           expect(val).to.equal(r.shift());
-        },
-        null,
-        done
+        }, complete: done }
       );
   });
 
@@ -330,11 +326,9 @@ describe('mergeAll operator', () => {
     of(a, b, queueScheduler)
       .pipe(mergeAll())
       .subscribe(
-        val => {
+        { next: val => {
           expect(val).to.equal(r.shift());
-        },
-        null,
-        done
+        }, complete: done }
       );
   });
 

--- a/spec/operators/multicast-spec.ts
+++ b/spec/operators/multicast-spec.ts
@@ -33,17 +33,17 @@ describe('multicast', () => {
 
     const connectable = of(1, 2, 3, 4).pipe(multicast(new Subject<number>())) as ConnectableObservable<number>;
 
-    connectable.subscribe(
-      (x) => {
+    connectable.subscribe({
+      next: (x) => {
         expect(x).to.equal(expected.shift());
       },
-      () => {
+      error: () => {
         done(new Error('should not be called'));
       },
-      () => {
+      complete: () => {
         done();
-      }
-    );
+      },
+    });
 
     connectable.connect();
   });
@@ -75,7 +75,7 @@ describe('multicast', () => {
           },
         })
       )
-      .subscribe(null, done, done);
+      .subscribe({ error: done, complete: done });
   });
 
   it('should accept Subject factory functions', (done) => {
@@ -83,17 +83,17 @@ describe('multicast', () => {
 
     const connectable = of(1, 2, 3, 4).pipe(multicast(() => new Subject<number>())) as ConnectableObservable<number>;
 
-    connectable.subscribe(
-      (x) => {
+    connectable.subscribe({
+      next: (x) => {
         expect(x).to.equal(expected.shift());
       },
-      () => {
+      error: () => {
         done(new Error('should not be called'));
       },
-      () => {
+      complete: () => {
         done();
-      }
-    );
+      },
+    });
 
     connectable.connect();
   });
@@ -751,25 +751,23 @@ describe('multicast', () => {
 
       const source = of(1, 2, 3, 4).pipe(multicast(() => new Subject<number>())) as ConnectableObservable<number>;
 
-      source.subscribe(
-        (x) => {
+      source.subscribe({
+        next: (x) => {
           expect(x).to.equal(expected[i++]);
         },
-        null,
-        () => {
+        complete: () => {
           i = 0;
 
-          source.subscribe(
-            (x) => {
+          source.subscribe({
+            next: (x) => {
               expect(x).to.equal(expected[i++]);
             },
-            null,
-            done
-          );
+            complete: done,
+          });
 
           source.connect();
-        }
-      );
+        },
+      });
 
       source.connect();
     });
@@ -784,18 +782,18 @@ describe('multicast', () => {
 
       of('a', 'b', 'c')
         .pipe(switchMap((letter) => source.pipe(map((n) => String(letter + n)))))
-        .subscribe(
-          (x) => {
+        .subscribe({
+          next: (x) => {
             expect(x).to.equal(expected.shift());
           },
-          () => {
+          error: () => {
             done(new Error('should not be called'));
           },
-          () => {
+          complete: () => {
             expect(expected.length).to.equal(0);
             done();
-          }
-        );
+          },
+        });
     });
   });
 
@@ -807,18 +805,18 @@ describe('multicast', () => {
 
       of('a', 'b', 'c')
         .pipe(switchMap((letter) => source.pipe(map((n) => String(letter + n)))))
-        .subscribe(
-          (x) => {
+        .subscribe({
+          next: (x) => {
             expect(x).to.equal(expected.shift());
           },
-          () => {
+          error: () => {
             done(new Error('should not be called'));
           },
-          () => {
+          complete: () => {
             expect(expected.length).to.equal(0);
             done();
-          }
-        );
+          },
+        });
     });
   });
 });

--- a/spec/operators/onErrorResumeNext-spec.ts
+++ b/spec/operators/onErrorResumeNext-spec.ts
@@ -215,18 +215,18 @@ describe('onErrorResumeNext', () => {
       throwError(() => 'meh')
     );
 
-    source.pipe(onErrorResumeNext(Promise.resolve(2))).subscribe(
-      (x) => {
+    source.pipe(onErrorResumeNext(Promise.resolve(2))).subscribe({
+      next: (x) => {
         expect(expected.shift()).to.equal(x);
       },
-      () => {
+      error: () => {
         done(new Error('should not be called'));
       },
-      () => {
+      complete: () => {
         expect(expected).to.be.empty;
         done();
-      }
-    );
+      },
+    });
   });
 
   it('should skip invalid sources and move on', () => {

--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -257,14 +257,14 @@ describe('publish operator', () => {
     expect(results2).to.deep.equal([]);
     expect(subscriptions).to.equal(1);
 
-    connectable.subscribe((x) => {
+    connectable.subscribe({ next: (x) => {
       results2.push(x);
-    }, (x) => {
+    }, error: (x) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       expect(results2).to.deep.equal([]);
       done();
-    });
+    } });
   });
 
   it('should multicast an empty source', () => {

--- a/spec/operators/publishBehavior-spec.ts
+++ b/spec/operators/publishBehavior-spec.ts
@@ -241,14 +241,14 @@ describe('publishBehavior operator', () => {
     expect(results2).to.deep.equal([]);
     expect(subscriptions).to.equal(1);
 
-    connectable.subscribe(function (x) {
+    connectable.subscribe({ next: function (x) {
       results2.push(x);
-    }, (x) => {
+    }, error: (x) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       expect(results2).to.deep.equal([]);
       done();
-    });
+    } });
   });
 
   it('should multicast an empty source', () => {

--- a/spec/operators/publishReplay-spec.ts
+++ b/spec/operators/publishReplay-spec.ts
@@ -371,14 +371,14 @@ describe('publishReplay operator', () => {
     expect(results2).to.deep.equal([]);
     expect(subscriptions).to.equal(1);
 
-    connectable.subscribe((x) => {
+    connectable.subscribe({ next: (x) => {
       results2.push(x);
-    }, (x) => {
+    }, error: (x) => {
       done(new Error('should not be called'));
-    }, () => {
+    }, complete: () => {
       expect(results2).to.deep.equal([3, 4]);
       done();
-    });
+    } });
   });
 
   it('should multicast an empty source', () => {

--- a/spec/operators/race-legacy-spec.ts
+++ b/spec/operators/race-legacy-spec.ts
@@ -168,9 +168,9 @@ describe('race operator', () => {
     const e1 = of(true);
     const e2 = timer(200).pipe(map(_ => false));
 
-    e1.pipe(race(e2)).subscribe(x => {
+    e1.pipe(race(e2)).subscribe({ next: x => {
       expect(x).to.be.true;
-    }, done, done);
+    }, error: done, complete: done });
   });
 
   it('should ignore latter observables if a former one emits immediately', () => {

--- a/spec/operators/raceWith-spec.ts
+++ b/spec/operators/raceWith-spec.ts
@@ -154,9 +154,9 @@ describe('raceWith operator', () => {
     const e1 = of(true);
     const e2 = timer(200).pipe(map(_ => false));
 
-    e1.pipe(raceWith(e2)).subscribe(x => {
+    e1.pipe(raceWith(e2)).subscribe({ next: x => {
       expect(x).to.be.true;
-    }, done, done);
+    }, error: done, complete: done });
   });
 
   it('should ignore latter observables if a former one emits immediately', () => {

--- a/spec/operators/repeat-spec.ts
+++ b/spec/operators/repeat-spec.ts
@@ -331,18 +331,18 @@ describe('repeat operator', () => {
         refCount(),
         repeat(5)
       )
-      .subscribe(
-        (x: number) => {
+      .subscribe({
+        next: (x: number) => {
           expect(x).to.equal(expected.shift());
         },
-        (x) => {
+        error: (x) => {
           done(new Error('should not be called'));
         },
-        () => {
+        complete: () => {
           expect(expected.length).to.equal(0);
           done();
-        }
-      );
+        },
+      });
   });
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {

--- a/spec/operators/repeatWhen-spec.ts
+++ b/spec/operators/repeatWhen-spec.ts
@@ -50,13 +50,12 @@ describe('repeatWhen operator', () => {
           retried = true;
           return x;
       })))
-    ).subscribe((x: any) => {
+    ).subscribe({ next: (x: any) => {
         expect(x).to.equal(expected[i++]);
-      },
-      (err: any) => {
+      }, error: (err: any) => {
         expect(err).to.be.an('error', 'done');
         done();
-      });
+      } });
     } catch (err) {
       done(err);
     }
@@ -70,15 +69,15 @@ describe('repeatWhen operator', () => {
         return n;
       }),
       repeatWhen((notifications: any) => EMPTY)
-    ).subscribe((n: number) => {
+    ).subscribe({ next: (n: number) => {
         expect(n).to.equal(expected.shift());
         nexted.push(n);
-      }, (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         expect(nexted).to.deep.equal([1, 2]);
         done();
-      });
+      } });
   });
 
   it('should not error when applying an empty synchronous notifier', () => {
@@ -103,7 +102,7 @@ describe('repeatWhen operator', () => {
     };
     of(1, 2).pipe(
       repeatWhen((notifications: any) => EMPTY)
-    ).subscribe(undefined, err => errors.push(err));
+    ).subscribe({ error: err => errors.push(err) });
     Observable.prototype.subscribe = originalSubscribe;
     expect(errors).to.deep.equal([]);
   });
@@ -130,7 +129,7 @@ describe('repeatWhen operator', () => {
     };
     of(1, 2).pipe(
       repeatWhen((notifications: any) => of(1))
-    ).subscribe(undefined, err => errors.push(err));
+    ).subscribe({ error: err => errors.push(err) });
     Observable.prototype.subscribe = originalSubscribe;
     expect(errors).to.deep.equal([]);
   });

--- a/spec/operators/single-spec.ts
+++ b/spec/operators/single-spec.ts
@@ -176,9 +176,9 @@ describe('single operator', () => {
       expectObservable(
         e1.pipe(
           single(predicate),
-          tap(null, null, () => {
+          tap({ complete: () => {
             expect(indices).to.deep.equal([0, 1, 2]);
-          })
+          } })
         )
       ).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -342,7 +342,7 @@ describe('single operator', () => {
 
     synchronousObservable.pipe(
       single(),
-    ).subscribe(() => { /* noop */ }, () => { /* noop */ });
+    ).subscribe({ next: () => { /* noop */ }, error: () => { /* noop */ } });
 
     expect(sideEffects).to.deep.equal([0, 1]);
   });

--- a/spec/operators/takeWhile-spec.ts
+++ b/spec/operators/takeWhile-spec.ts
@@ -226,8 +226,10 @@ describe('takeWhile', () => {
 
       const result = e1.pipe(
         takeWhile(predicate),
-        tap(null, null, () => {
-          expect(invoked).to.equal(3);
+        tap({
+          complete: () => {
+            expect(invoked).to.equal(3);
+          },
         })
       );
       expectObservable(result).toBe(expected);

--- a/spec/operators/tap-spec.ts
+++ b/spec/operators/tap-spec.ts
@@ -47,8 +47,10 @@ describe('tap', () => {
     let err = null;
     throwError(() => 'bad')
       .pipe(
-        tap(null, function (x) {
-          err = x;
+        tap({
+          error: function (x) {
+            err = x;
+          },
         })
       )
       .subscribe({
@@ -107,8 +109,10 @@ describe('tap', () => {
     let errored = false;
     throwError(() => 'bad')
       .pipe(
-        tap(null, (err: any) => {
-          expect(err).to.equal('bad');
+        tap({
+          error: (err: any) => {
+            expect(err).to.equal('bad');
+          },
         })
       )
       .subscribe({

--- a/spec/operators/throttleTime-spec.ts
+++ b/spec/operators/throttleTime-spec.ts
@@ -31,13 +31,12 @@ describe('throttleTime operator', () => {
     it('should throttle events by 5 time units', (done) => {
       of(1, 2, 3)
         .pipe(throttleTime(5))
-        .subscribe(
-          (x: number) => {
+        .subscribe({
+          next: (x: number) => {
             expect(x).to.equal(1);
           },
-          null,
-          done
-        );
+          complete: done,
+        });
     });
 
     it('should throttle events multiple times', () => {

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -35,17 +35,17 @@ describe('timeout operator', () => {
       const t = time(' -----|');
       const result = e1.pipe(timeout(t, rxTestScheduler));
       let error: any;
-      result.subscribe(
-        () => {
+      result.subscribe({
+        next: () => {
           throw new Error('this should not next');
         },
-        (err) => {
+        error: (err) => {
           error = err;
         },
-        () => {
+        complete: () => {
           throw new Error('this should not complete');
-        }
-      );
+        },
+      });
       rxTestScheduler.flush();
       expect(error).to.be.an.instanceof(TimeoutError);
       expect(error).to.have.property('name', 'TimeoutError');
@@ -67,17 +67,17 @@ describe('timeout operator', () => {
 
       const result = e1.pipe(timeout(dueDate, rxTestScheduler));
       let error: any;
-      result.subscribe(
-        () => {
+      result.subscribe({
+        next: () => {
           throw new Error('this should not next');
         },
-        (err) => {
+        error: (err) => {
           error = err;
         },
-        () => {
+        complete: () => {
           throw new Error('this should not complete');
-        }
-      );
+        },
+      });
       rxTestScheduler.flush();
       expect(error).to.be.an.instanceof(TimeoutError);
       expect(error).to.have.property('name', 'TimeoutError');
@@ -210,17 +210,17 @@ describe('timeout operator', () => {
         const t = time(' -----|');
         const result = e1.pipe(timeout({ each: t }));
         let error: any;
-        result.subscribe(
-          () => {
+        result.subscribe({
+          next: () => {
             throw new Error('this should not next');
           },
-          (err) => {
+          error: (err) => {
             error = err;
           },
-          () => {
+          complete: () => {
             throw new Error('this should not complete');
-          }
-        );
+          },
+        });
         rxTestScheduler.flush();
         expect(error).to.be.an.instanceof(TimeoutError);
         expect(error).to.have.property('name', 'TimeoutError');
@@ -242,17 +242,17 @@ describe('timeout operator', () => {
 
         const result = e1.pipe(timeout({ first: dueDate }));
         let error: any;
-        result.subscribe(
-          () => {
+        result.subscribe({
+          next: () => {
             throw new Error('this should not next');
           },
-          (err) => {
+          error: (err) => {
             error = err;
           },
-          () => {
+          complete: () => {
             throw new Error('this should not complete');
-          }
-        );
+          },
+        });
         rxTestScheduler.flush();
         expect(error).to.be.an.instanceof(TimeoutError);
         expect(error).to.have.property('name', 'TimeoutError');
@@ -423,10 +423,12 @@ describe('timeout operator', () => {
         const innerSubs = '    -----^-----!  ';
         const expected = '     -----x-y-z-|  ';
 
-        const result = source.pipe(timeout({
-          each: t,
-          with: () => inner,
-        }));
+        const result = source.pipe(
+          timeout({
+            each: t,
+            with: () => inner,
+          })
+        );
 
         expectObservable(result).toBe(expected);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -444,10 +446,12 @@ describe('timeout operator', () => {
         const expected = '     ------------x--y--z--|';
 
         // The the current frame is zero.
-        const result = source.pipe(timeout({
-          first: new Date(t),
-          with: () => inner,
-        }));
+        const result = source.pipe(
+          timeout({
+            first: new Date(t),
+            with: () => inner,
+          })
+        );
 
         expectObservable(result).toBe(expected);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -464,9 +468,12 @@ describe('timeout operator', () => {
         const innerSubs = '   -----------^----!  ';
         const expected = '    ---a---b----x-y-|  ';
 
-        const result = source.pipe(timeout({
-          each: t,
-          with: () => inner, }));
+        const result = source.pipe(
+          timeout({
+            each: t,
+            with: () => inner,
+          })
+        );
 
         expectObservable(result).toBe(expected);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -504,7 +511,7 @@ describe('timeout operator', () => {
 
         const result = source.pipe(
           mergeMap((x) => of(x)),
-          timeout({ each: t, with: () => inner, }),
+          timeout({ each: t, with: () => inner }),
           mergeMap((x) => of(x))
         );
 
@@ -544,7 +551,7 @@ describe('timeout operator', () => {
         const innerSubs = '   ----------^--------!';
         const expected = '    --------------x----|';
 
-        const result = source.pipe(timeout({ each: t, with: () => inner, }));
+        const result = source.pipe(timeout({ each: t, with: () => inner }));
 
         expectObservable(result).toBe(expected);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -561,7 +568,7 @@ describe('timeout operator', () => {
         const innerSubs = '   ---------^-----------';
         const expected = '    --a--b---------------';
 
-        const result = source.pipe(timeout({ each: t, with: () => inner, }));
+        const result = source.pipe(timeout({ each: t, with: () => inner }));
 
         expectObservable(result).toBe(expected);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -578,7 +585,7 @@ describe('timeout operator', () => {
         const innerSubs = '   ----------^--------!';
         const expected = '    --------------x----|';
 
-        const result = source.pipe(timeout({ each: t, with: () => inner, }));
+        const result = source.pipe(timeout({ each: t, with: () => inner }));
 
         expectObservable(result).toBe(expected);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
@@ -688,7 +695,7 @@ describe('timeout operator', () => {
 
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
-    const synchronousObservable = new Observable<number>(subscriber => {
+    const synchronousObservable = new Observable<number>((subscriber) => {
       // This will check to see if the subscriber was closed on each loop
       // when the unsubscribe hits (from the `take`), it should be closed
       for (let i = 0; !subscriber.closed && i < 10; i++) {
@@ -697,10 +704,9 @@ describe('timeout operator', () => {
       }
     });
 
-    synchronousObservable.pipe(
-      timeout(0),
-      take(3),
-    ).subscribe(() => { /* noop */ });
+    synchronousObservable.pipe(timeout(0), take(3)).subscribe(() => {
+      /* noop */
+    });
 
     expect(sideEffects).to.deep.equal([0, 1, 2]);
   });

--- a/spec/schedulers/TestScheduler-spec.ts
+++ b/spec/schedulers/TestScheduler-spec.ts
@@ -224,11 +224,11 @@ describe('TestScheduler', () => {
       it('should create a cold observable', () => {
         const expected = [1, 2];
         const source = cold('-a-b-|', { a: 1, b: 2 });
-        source.subscribe((x: number) => {
+        source.subscribe({ next: (x: number) => {
           expect(x).to.equal(expected.shift());
-        }, null, () => {
+        }, complete: () => {
           expect(expected.length).to.equal(0);
-        });
+        } });
         expectObservable(source).toBe('-a-b-|', { a: 1, b: 2 });
       });
     });

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -63,9 +63,9 @@ describe('BehaviorSubject', () => {
     const expected = ['foo', 'bar'];
     let i = 0;
 
-    subject.subscribe((x: string) => {
+    subject.subscribe({ next: (x: string) => {
       expect(x).to.equal(expected[i++]);
-    }, null, done);
+    }, complete: done });
 
     subject.next('bar');
     subject.complete();
@@ -81,9 +81,9 @@ describe('BehaviorSubject', () => {
       expect(x).to.equal(expected[i++]);
     });
 
-    subject.subscribe((x: string) => {
+    subject.subscribe({ next: (x: string) => {
       expect(x).to.equal(expected[j++]);
-    }, null, done);
+    }, complete: done });
 
     expect(subject.observers.length).to.equal(2);
     subject.next('foo');
@@ -147,7 +147,7 @@ describe('BehaviorSubject', () => {
 
     expectObservable(hot(sourceTemplate).pipe(
       tap(
-      feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject
+      { next: feedNextIntoSubject, error: feedErrorIntoSubject, complete: feedCompleteIntoSubject }
       )
     )).toBe(sourceTemplate);
     expectObservable(subscriber1, unsub1).toBe(expected1);
@@ -169,7 +169,7 @@ describe('BehaviorSubject', () => {
 
     expectObservable(hot(sourceTemplate).pipe(
       tap(
-        feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject
+        { next: feedNextIntoSubject, error: feedErrorIntoSubject, complete: feedCompleteIntoSubject }
       )
     )).toBe(sourceTemplate);
     expectObservable(subscriber1).toBe(expected1);
@@ -181,14 +181,14 @@ describe('BehaviorSubject', () => {
     const expected = [0, 1, 2, 3, 4, 5];
 
     subject.subscribe(
-      (x: number) => {
+      { next: (x: number) => {
         expect(x).to.equal(expected.shift());
-      }, (x) => {
+      }, error: (x) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         expect(subject.value).to.equal(5);
         done();
-      });
+      } });
 
     source.subscribe(subject);
   });
@@ -203,14 +203,14 @@ describe('BehaviorSubject', () => {
     const expected = [0, 1, 2, 3, 4, 5];
 
     subject.subscribe(
-      (x: number) => {
+      { next: (x: number) => {
         expect(x).to.equal(expected.shift());
-      }, (x) => {
+      }, error: (x) => {
         done(new Error('should not be called'));
-      }, () => {
+      }, complete: () => {
         expect(subject.value).to.equal(5);
         done();
-      });
+      } });
 
       source.subscribe(asInteropSubject(subject));
   });

--- a/spec/subjects/ReplaySubject-spec.ts
+++ b/spec/subjects/ReplaySubject-spec.ts
@@ -40,18 +40,16 @@ describe('ReplaySubject', () => {
     subject.next(2);
     subject.next(3);
     subject.subscribe(
-      (x: number) => {
+      { next: (x: number) => {
         expect(x).to.equal(expects[i++]);
         if (i === 3) {
           subject.complete();
         }
-      },
-      (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -64,11 +62,9 @@ describe('ReplaySubject', () => {
     subject.next(3);
     subject.complete();
     subject.subscribe(
-      (x: number) => {
+      { next: (x: number) => {
         expect(x).to.equal(expects[i++]);
-      },
-      null,
-      done
+      }, complete: done }
     );
   });
 
@@ -81,13 +77,12 @@ describe('ReplaySubject', () => {
     subject.next(3);
     subject.error('fooey');
     subject.subscribe(
-      (x: number) => {
+      { next: (x: number) => {
         expect(x).to.equal(expects[i++]);
-      },
-      (err: any) => {
+      }, error: (err: any) => {
         expect(err).to.equal('fooey');
         done();
-      }
+      } }
     );
   });
 
@@ -99,18 +94,16 @@ describe('ReplaySubject', () => {
     subject.next(2);
     subject.next(3);
     subject.subscribe(
-      (x: number) => {
+      { next: (x: number) => {
         expect(x).to.equal(expects[i++]);
         if (i === 2) {
           subject.complete();
         }
-      },
-      (err: any) => {
+      }, error: (err: any) => {
         done(new Error('should not be called'));
-      },
-      () => {
+      }, complete: () => {
         done();
-      }
+      } }
     );
   });
 
@@ -138,7 +131,7 @@ describe('ReplaySubject', () => {
         const subscriber3 = hot('---------------------------(c|)    ').pipe(mergeMapTo(replaySubject));
         const expected3 = '      ---------------------------(78)9--|';
 
-        expectObservable(hot(sourceTemplate).pipe(tap(feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject))).toBe(
+        expectObservable(hot(sourceTemplate).pipe(tap({ next: feedNextIntoSubject, error: feedErrorIntoSubject, complete: feedCompleteIntoSubject }))).toBe(
           sourceTemplate
         );
         expectObservable(subscriber1, unsub1).toBe(expected1);
@@ -164,7 +157,7 @@ describe('ReplaySubject', () => {
         const subscriber1 = hot('---------------(a|) ').pipe(mergeMapTo(replaySubject));
         const expected1 = '      ---------------(34|)';
 
-        expectObservable(hot(sourceTemplate).pipe(tap(feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject))).toBe(
+        expectObservable(hot(sourceTemplate).pipe(tap({ next: feedNextIntoSubject, error: feedErrorIntoSubject, complete: feedCompleteIntoSubject }))).toBe(
           sourceTemplate
         );
         expectObservable(subscriber1).toBe(expected1);
@@ -183,29 +176,25 @@ describe('ReplaySubject', () => {
       subject.next(4);
 
       const subscription1 = subject.subscribe(
-        (x: number) => {
+        { next: (x: number) => {
           results1.push(x);
-        },
-        (err: any) => {
+        }, error: (err: any) => {
           results1.push('E');
-        },
-        () => {
+        }, complete: () => {
           results1.push('C');
-        }
+        } }
       );
 
       subject.next(5);
 
       const subscription2 = subject.subscribe(
-        (x: number) => {
+        { next: (x: number) => {
           results2.push(x);
-        },
-        (err: any) => {
+        }, error: (err: any) => {
           results2.push('E');
-        },
-        () => {
+        }, complete: () => {
           results2.push('C');
-        }
+        } }
       );
 
       subject.next(6);
@@ -221,15 +210,13 @@ describe('ReplaySubject', () => {
       subject.next(10);
 
       const subscription3 = subject.subscribe(
-        (x: number) => {
+        { next: (x: number) => {
           results3.push(x);
-        },
-        (err: any) => {
+        }, error: (err: any) => {
           results3.push('E');
-        },
-        () => {
+        }, complete: () => {
           results3.push('C');
-        }
+        } }
       );
 
       subject.next(11);
@@ -268,7 +255,7 @@ describe('ReplaySubject', () => {
         const subscriber3 = hot('---------------------------(c|)    ').pipe(mergeMapTo(replaySubject));
         const expected3 = '      ---------------------------(78)9--|';
 
-        expectObservable(hot(sourceTemplate).pipe(tap(feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject))).toBe(
+        expectObservable(hot(sourceTemplate).pipe(tap({ next: feedNextIntoSubject, error: feedErrorIntoSubject, complete: feedCompleteIntoSubject }))).toBe(
           sourceTemplate
         );
         expectObservable(subscriber1, unsub1).toBe(expected1);
@@ -294,7 +281,7 @@ describe('ReplaySubject', () => {
         const subscriber1 = hot('-------------(a|)').pipe(mergeMapTo(replaySubject));
         const expected1 = '      -------------(4|)';
 
-        expectObservable(hot(sourceTemplate).pipe(tap(feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject))).toBe(
+        expectObservable(hot(sourceTemplate).pipe(tap({ next: feedNextIntoSubject, error: feedErrorIntoSubject, complete: feedCompleteIntoSubject }))).toBe(
           sourceTemplate
         );
         expectObservable(subscriber1).toBe(expected1);
@@ -318,7 +305,7 @@ describe('ReplaySubject', () => {
         const subscriber1 = hot('----(a|)').pipe(mergeMapTo(replaySubject));
         const expected1 = '      ----(34)---|';
 
-        expectObservable(hot(sourceTemplate).pipe(tap(feedNextIntoSubject, feedErrorIntoSubject, feedCompleteIntoSubject))).toBe(
+        expectObservable(hot(sourceTemplate).pipe(tap({ next: feedNextIntoSubject, error: feedErrorIntoSubject, complete: feedCompleteIntoSubject }))).toBe(
           sourceTemplate
         );
         expectObservable(subscriber1).toBe(expected1);
@@ -332,9 +319,7 @@ describe('ReplaySubject', () => {
     let results: (number | string)[] = [];
 
     subject.subscribe(
-      (x) => results.push(x),
-      null,
-      () => results.push('done')
+      { next: (x) => results.push(x), complete: () => results.push('done') }
     );
 
     source.subscribe(subject);
@@ -344,9 +329,7 @@ describe('ReplaySubject', () => {
     results = [];
 
     subject.subscribe(
-      (x) => results.push(x),
-      null,
-      () => results.push('done')
+      { next: (x) => results.push(x), complete: () => results.push('done') }
     );
 
     expect(results).to.deep.equal([3, 4, 5, 'done']);


### PR DESCRIPTION
This was fixed in an automated way using a fixer that was added to @cartant's `eslint-plugin-rxjs`. Note that some of our test files weren't using prettier yet, so they're not formatted properly. That's okay. What I want to do is get these things updated so I can remove the deprecated call patterns for `tap` and `subscribe` in the 8.x branch and keep everything in sync.