### PR TITLE
chore: remove deprecated subscribe use in library code

### DIFF
--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -234,8 +234,8 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
         observer.error(err);
       }
 
-      const subscription = self.subscribe(
-        (x) => {
+      const subscription = self.subscribe({
+        next: (x) => {
           try {
             if (messageFilter(x)) {
               observer.next(x);
@@ -244,9 +244,9 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
             observer.error(err);
           }
         },
-        (err) => observer.error(err),
-        () => observer.complete()
-      );
+        error: (err) => observer.error(err),
+        complete: () => observer.complete(),
+      });
 
       return () => {
         try {

--- a/src/internal/testing/TestScheduler.ts
+++ b/src/internal/testing/TestScheduler.ts
@@ -116,17 +116,17 @@ export class TestScheduler extends VirtualTimeScheduler {
 
   private materializeInnerObservable(observable: Observable<any>, outerFrame: number): TestMessage[] {
     const messages: TestMessage[] = [];
-    observable.subscribe(
-      (value) => {
+    observable.subscribe({
+      next: (value) => {
         messages.push({ frame: this.frame - outerFrame, notification: nextNotification(value) });
       },
-      (error) => {
+      error: (error) => {
         messages.push({ frame: this.frame - outerFrame, notification: errorNotification(error) });
       },
-      () => {
+      complete: () => {
         messages.push({ frame: this.frame - outerFrame, notification: COMPLETE_NOTIFICATION });
-      }
-    );
+      },
+    });
     return messages;
   }
 
@@ -139,19 +139,19 @@ export class TestScheduler extends VirtualTimeScheduler {
     let subscription: Subscription;
 
     this.schedule(() => {
-      subscription = observable.subscribe(
-        (x) => {
+      subscription = observable.subscribe({
+        next: (x) => {
           // Support Observable-of-Observables
           const value = x instanceof Observable ? this.materializeInnerObservable(x, this.frame) : x;
           actual.push({ frame: this.frame, notification: nextNotification(value) });
         },
-        (error) => {
+        error: (error) => {
           actual.push({ frame: this.frame, notification: errorNotification(error) });
         },
-        () => {
+        complete: () => {
           actual.push({ frame: this.frame, notification: COMPLETE_NOTIFICATION });
-        }
-      );
+        },
+      });
     }, subscriptionFrame);
 
     if (unsubscriptionFrame !== Infinity) {
@@ -170,19 +170,19 @@ export class TestScheduler extends VirtualTimeScheduler {
         flushTest.ready = true;
         flushTest.expected = [];
         this.schedule(() => {
-          subscription = other.subscribe(
-            (x) => {
+          subscription = other.subscribe({
+            next: (x) => {
               // Support Observable-of-Observables
               const value = x instanceof Observable ? this.materializeInnerObservable(x, this.frame) : x;
               flushTest.expected!.push({ frame: this.frame, notification: nextNotification(value) });
             },
-            (error) => {
+            error: (error) => {
               flushTest.expected!.push({ frame: this.frame, notification: errorNotification(error) });
             },
-            () => {
+            complete: () => {
               flushTest.expected!.push({ frame: this.frame, notification: COMPLETE_NOTIFICATION });
-            }
-          );
+            },
+          });
         }, subscriptionFrame);
       },
     };


### PR DESCRIPTION
Simply put, I'm replacing `subscribe(fn, fn, fn)` calls with `subscribe(observer)` calls. The process here was to comment out the deprecated signature and fix what was broken.