### PR TITLE
Removing deprecated empty and never functions

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -170,8 +170,6 @@ export declare function distinctUntilKeyChanged<T, K extends keyof T>(key: K, co
 
 export declare function elementAt<T, D = T>(index: number, defaultValue?: D): OperatorFunction<T, T | D>;
 
-export declare function empty(scheduler?: SchedulerLike): Observable<never>;
-
 export declare const EMPTY: Observable<never>;
 
 export interface EmptyError extends Error {
@@ -371,8 +369,6 @@ export declare function multicast<T>(subject: Subject<T>): UnaryFunction<Observa
 export declare function multicast<T, O extends ObservableInput<any>>(subject: Subject<T>, selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
 export declare function multicast<T>(subjectFactory: () => Subject<T>): UnaryFunction<Observable<T>, ConnectableObservable<T>>;
 export declare function multicast<T, O extends ObservableInput<any>>(subjectFactory: () => Subject<T>, selector: (shared: Observable<T>) => O): OperatorFunction<T, ObservedValueOf<O>>;
-
-export declare function never(): Observable<never>;
 
 export declare const NEVER: Observable<never>;
 

--- a/spec-dtslint/observables/empty-spec.ts
+++ b/spec-dtslint/observables/empty-spec.ts
@@ -1,12 +1,4 @@
-import { empty, animationFrameScheduler, EMPTY } from 'rxjs';
-
-it('should infer correctly with no parameter', () => {
-  const a = empty(); // $ExpectType Observable<never>
-});
-
-it('should support scheduler parameter', () => {
-  const a = empty(animationFrameScheduler); // $ExpectType Observable<never>
-});
+import { EMPTY } from 'rxjs';
 
 it('should always infer empty observable', () => {
   // Empty Observable that replace empty static function 

--- a/spec-dtslint/observables/never-spec.ts
+++ b/spec-dtslint/observables/never-spec.ts
@@ -1,9 +1,5 @@
-import { never } from 'rxjs';
+import { NEVER } from 'rxjs';
 
-it('should not support any parameter', () => {
-  const a = never(1); // $ExpectError
-});
-
-it('should infer never', () => {
-  const a = never(); // $ExpectType Observable<never>
+it('should be of type Observable<never>', () => {
+  const a = NEVER; // $ExpectType Observable<never>
 });

--- a/spec/Observable-spec.ts
+++ b/spec/Observable-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { Observer, TeardownLogic } from '../src/internal/types';
-import { Observable, config, Subscription, noop, Subscriber, Operator, NEVER, Subject, of, throwError, empty } from 'rxjs';
+import { Observable, config, Subscription, noop, Subscriber, Operator, NEVER, Subject, of, throwError, EMPTY } from 'rxjs';
 import { map, multicast, refCount, filter, count, tap, combineLatest, concat, merge, race, zip, catchError, concatMap, switchMap, publish, publishLast, publishBehavior, share, finalize} from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from './helpers/observableMatcher';
@@ -224,7 +224,7 @@ describe('Observable', () => {
 
       expect(unsubscribeCalled).to.be.false;
 
-      empty().subscribe();
+      EMPTY.subscribe();
 
       expect(unsubscribeCalled).to.be.false;
     });
@@ -247,7 +247,7 @@ describe('Observable', () => {
 
       expect(unsubscribeCalled).to.be.false;
 
-      empty().subscribe(observer);
+      EMPTY.subscribe(observer);
 
       expect(unsubscribeCalled).to.be.false;
     });
@@ -451,13 +451,13 @@ describe('Observable', () => {
             },
           };
 
-          empty().subscribe(o);
+          EMPTY.subscribe(o);
         }
       );
 
       it('should accept an anonymous observer with no functions at all', () => {
         expect(() => {
-          empty().subscribe(<any>{});
+          EMPTY.subscribe(<any>{});
         }).not.to.throw();
       });
 

--- a/spec/index-spec.ts
+++ b/spec/index-spec.ts
@@ -60,7 +60,6 @@ describe('index', () => {
     expect(index.combineLatest).to.exist;
     expect(index.concat).to.exist;
     expect(index.defer).to.exist;
-    expect(index.empty).to.exist;
     expect(index.forkJoin).to.exist;
     expect(index.from).to.exist;
     expect(index.fromEvent).to.exist;

--- a/spec/observables/empty-spec.ts
+++ b/spec/observables/empty-spec.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { expect } from 'chai';
-import { empty, EMPTY } from 'rxjs';
+import { EMPTY } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
@@ -12,49 +12,20 @@ describe('empty', () => {
     rxTestScheduler = new TestScheduler(observableMatcher);
   });
 
-  it('should return EMPTY', () => {
-    expect(empty()).to.equal(EMPTY);
-  });
-
-  it('should create a cold observable with only complete', () => {
+  it('should only complete', () => {
     rxTestScheduler.run(({ expectObservable }) => {
       const expected = '|';
-      const e1 = empty();
-      expectObservable(e1).toBe(expected);
+      expectObservable(EMPTY).toBe(expected);
     });
   });
 
-  it('should return the same instance EMPTY', () => {
-    const s1 = empty();
-    const s2 = empty();
-    expect(s1).to.equal(s2);
-  });
-
-  it('should be synchronous by default', () => {
-    const source = empty();
+  it('should be synchronous', () => {
     let hit = false;
-    source.subscribe({
+    EMPTY.subscribe({
       complete() {
         hit = true;
       },
     });
-    expect(hit).to.be.true;
-  });
-
-  it('should equal EMPTY', () => {
-    expect(empty()).to.equal(EMPTY);
-  });
-
-  it('should take a scheduler', () => {
-    const source = empty(rxTestScheduler);
-    let hit = false;
-    source.subscribe({
-      complete() {
-        hit = true;
-      },
-    });
-    expect(hit).to.be.false;
-    rxTestScheduler.flush();
     expect(hit).to.be.true;
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -67,7 +67,6 @@ export { combineLatest } from './internal/observable/combineLatest';
 export { concat } from './internal/observable/concat';
 export { connectable } from './internal/observable/connectable';
 export { defer } from './internal/observable/defer';
-export { empty } from './internal/observable/empty';
 export { forkJoin } from './internal/observable/forkJoin';
 export { from } from './internal/observable/from';
 export { fromEvent } from './internal/observable/fromEvent';

--- a/src/index.ts
+++ b/src/index.ts
@@ -75,7 +75,6 @@ export { generate } from './internal/observable/generate';
 export { iif } from './internal/observable/iif';
 export { interval } from './internal/observable/interval';
 export { merge } from './internal/observable/merge';
-export { never } from './internal/observable/never';
 export { of } from './internal/observable/of';
 export { onErrorResumeNext } from './internal/observable/onErrorResumeNext';
 export { pairs } from './internal/observable/pairs';

--- a/src/internal/observable/empty.ts
+++ b/src/internal/observable/empty.ts
@@ -1,5 +1,4 @@
 import { Observable } from '../Observable';
-import { SchedulerLike } from '../types';
 
 /**
  * A simple Observable that emits no items to the Observer and immediately
@@ -64,16 +63,3 @@ import { SchedulerLike } from '../types';
  * @see {@link throwError}
  */
 export const EMPTY = new Observable<never>((subscriber) => subscriber.complete());
-
-/**
- * @param scheduler A {@link SchedulerLike} to use for scheduling
- * the emission of the complete notification.
- * @deprecated Replaced with the {@link EMPTY} constant or {@link scheduled} (e.g. `scheduled([], scheduler)`). Will be removed in v8.
- */
-export function empty(scheduler?: SchedulerLike) {
-  return scheduler ? emptyScheduled(scheduler) : EMPTY;
-}
-
-function emptyScheduled(scheduler: SchedulerLike) {
-  return new Observable<never>((subscriber) => scheduler.schedule(() => subscriber.complete()));
-}

--- a/src/internal/observable/never.ts
+++ b/src/internal/observable/never.ts
@@ -35,10 +35,3 @@ import { noop } from '../util/noop';
  * @see {@link throwError}
  */
 export const NEVER = new Observable<never>(noop);
-
-/**
- * @deprecated Replaced with the {@link NEVER} constant. Will be removed in v8.
- */
-export function never() {
-  return NEVER;
-}


### PR DESCRIPTION
Just removing `empty()` and `never()` finally. (version 8 only)