### PR TITLE
docs(identity): add identity docs

### DIFF
--- a/src/internal/util/identity.ts
+++ b/src/internal/util/identity.ts
@@ -1,3 +1,29 @@
+/**
+ * This function takes one parameter and just returns it. Simply put,
+ * this is like `<T>(x: T): T => x`.
+ *
+ * ## Example
+ *
+ * This is useful in some cases when using things like `mergeMap`
+ *
+ * ```ts
+ * import { interval, take, map, range, mergeMap, identity } from 'rxjs';
+ *
+ * const source$ = interval(1000).pipe(take(5));
+ *
+ * const result$ = source$.pipe(
+ *   map(i => range(i)),
+ *   mergeMap(identity) // same as mergeMap(x => x)
+ * );
+ *
+ * result$.subscribe({
+ *   next: console.log
+ * });
+ * ```
+ *
+ * @param x Any value that is returned by this function
+ * @returns The value passed as the first parameter to this function
+ */
 export function identity<T>(x: T): T {
   return x;
 }

--- a/src/internal/util/identity.ts
+++ b/src/internal/util/identity.ts
@@ -2,7 +2,7 @@
  * This function takes one parameter and just returns it. Simply put,
  * this is like `<T>(x: T): T => x`.
  *
- * ## Example
+ * ## Examples
  *
  * This is useful in some cases when using things like `mergeMap`
  *
@@ -15,6 +15,22 @@
  *   map(i => range(i)),
  *   mergeMap(identity) // same as mergeMap(x => x)
  * );
+ *
+ * result$.subscribe({
+ *   next: console.log
+ * });
+ * ```
+ *
+ * Or when you want to selectively apply an operator
+ *
+ * ```ts
+ * import { interval, take, identity } from 'rxjs';
+ *
+ * const shouldLimit = () => Math.random() < 0.5;
+ *
+ * const source$ = interval(1000);
+ *
+ * const result$ = source$.pipe(shouldLimit() ? take(5) : identity);
  *
  * result$.subscribe({
  *   next: console.log


### PR DESCRIPTION
**Description:**
Now that #6734 is merged, accessing to `identity` page is much more likely since `<code>` tags contain references to it. It's time to document it.

<img width="1138" alt="image" src="https://user-images.githubusercontent.com/28087049/149017539-2969c0ce-43e0-4168-92c4-bae05d991f36.png">


**Related issue (if exists):**
None