### PR TITLE
refactor(sample): remove unnecessary variable declaration

### DIFF
--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -54,14 +54,19 @@ export function sample<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T
         lastValue = value;
       })
     );
-    const emit = () => {
-      if (hasValue) {
-        hasValue = false;
-        const value = lastValue!;
-        lastValue = null;
-        subscriber.next(value);
-      }
-    };
-    notifier.subscribe(new OperatorSubscriber(subscriber, emit, noop));
+    notifier.subscribe(
+      new OperatorSubscriber(
+        subscriber,
+        () => {
+          if (hasValue) {
+            hasValue = false;
+            const value = lastValue!;
+            lastValue = null;
+            subscriber.next(value);
+          }
+        },
+        noop
+      )
+    );
   });
 }


### PR DESCRIPTION
It did not really improve readability, and I could not see the benefit of keeping it.
