### PR TITLE
docs(distinctUntilChanged): fix docs rendering

### DIFF
--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -3,9 +3,18 @@ import { identity } from '../util/identity';
 import { operate } from '../util/lift';
 import { OperatorSubscriber } from './OperatorSubscriber';
 
+export function distinctUntilChanged<T>(comparator?: (previous: T, current: T) => boolean): MonoTypeOperatorFunction<T>;
+export function distinctUntilChanged<T, K>(
+  comparator: (previous: K, current: K) => boolean,
+  keySelector: (value: T) => K
+): MonoTypeOperatorFunction<T>;
+
 /**
  * Returns a result {@link Observable} that emits all values pushed by the source observable if they
  * are distinct in comparison to the last value the result observable emitted.
+ *
+ * When provided without parameters or with the first parameter (`{@link distinctUntilChanged#comparator comparator}`),
+ * it behaves like this:
  *
  * 1. It will always emit the first value from the source.
  * 2. For all subsequent values pushed by the source, they will be compared to the previously emitted values
@@ -13,9 +22,19 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * 3. If the value pushed by the source is determined to be unequal by this check, that value is emitted and
  *    becomes the new "previously emitted value" internally.
  *
+ * When the second parameter (`{@link distinctUntilChanged#keySelector keySelector}`) is provided, the behavior
+ * changes:
+ *
+ * 1. It will always emit the first value from the source.
+ * 2. The `keySelector` will be run against all values, including the first value.
+ * 3. For all values after the first, the selected key will be compared against the key selected from
+ *    the previously emitted value using the `comparator`.
+ * 4. If the keys are determined to be unequal by this check, the value (not the key), is emitted
+ *    and the selected key from that value is saved for future comparisons against other keys.
+ *
  * ## Examples
  *
- * A very basic example with no `comparator`. Note that `1` is emitted more than once,
+ * A very basic example with no `{@link distinctUntilChanged#comparator comparator}`. Note that `1` is emitted more than once,
  * because it's distinct in comparison to the _previously emitted_ value,
  * not in comparison to _all other emitted values_.
  *
@@ -28,7 +47,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * // Logs: 1, 2, 1, 3
  * ```
  *
- * With a `comparator`, you can do custom comparisons. Let's say
+ * With a `{@link distinctUntilChanged#comparator comparator}`, you can do custom comparisons. Let's say
  * you only want to emit a value when all of its components have
  * changed:
  *
@@ -58,7 +77,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * // { engineVersion: '2.0.0', transmissionVersion: '1.5.0' }
  * ```
  *
- * You can also provide a custom `comparator` to check that emitted
+ * You can also provide a custom `{@link distinctUntilChanged#comparator comparator}` to check that emitted
  * changes are only in one direction. Let's say you only want to get
  * the next record temperature:
  *
@@ -80,28 +99,8 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  * // Logs: 30, 31, 34, 35
  * ```
  *
- * @param comparator A function used to compare the previous and current values for
- * equality. Defaults to a `===` check.
- * @return A function that returns an Observable that emits items from the
- * source Observable with distinct values.
- */
-export function distinctUntilChanged<T>(comparator?: (previous: T, current: T) => boolean): MonoTypeOperatorFunction<T>;
-
-/**
- * Returns a result {@link Observable} that emits all values pushed by the source observable if they
- * are distinct in comparison to the last value the result observable emitted.
- *
- * 1. It will always emit the first value from the source.
- * 2. The `keySelector` will be run against all values, including the first value.
- * 3. For all values after the first, the selected key will be compared against the key selected from
- *    the previously emitted value using the `comparator`.
- * 4. If the keys are determined to be unequal by this check, the value (not the key), is emitted
- *    and the selected key from that value is saved for future comparisons against other keys.
- *
- * ## Example
- *
  * Selecting update events only when the `updatedBy` field shows
- * the account changed hands...
+ * the account changed hands.
  *
  * ```ts
  * import { of, distinctUntilChanged } from 'rxjs';
@@ -127,17 +126,16 @@ export function distinctUntilChanged<T>(comparator?: (previous: T, current: T) =
  * // { updatedBy: 'blesh', data: Array[0] }
  * ```
  *
+ * @see {@link distinct}
+ * @see {@link distinctUntilKeyChanged}
+ *
  * @param comparator A function used to compare the previous and current keys for
  * equality. Defaults to a `===` check.
  * @param keySelector Used to select a key value to be passed to the `comparator`.
+ *
  * @return A function that returns an Observable that emits items from the
  * source Observable with distinct values.
  */
-export function distinctUntilChanged<T, K>(
-  comparator: (previous: K, current: K) => boolean,
-  keySelector: (value: T) => K
-): MonoTypeOperatorFunction<T>;
-
 export function distinctUntilChanged<T, K>(
   comparator?: (previous: K, current: K) => boolean,
   keySelector: (value: T) => K = identity as (value: T) => K


### PR DESCRIPTION
**Description:**
Please check the related issue for more info. This is how the page looks like with this fix (sorry for the large image):

![image](https://user-images.githubusercontent.com/28087049/149143306-72be1622-ab73-4c2a-8b09-dd0c27e58690.png)

One note: I'm not an expert, but it looks like that having multiple JSDocs comments on the same function overload (for two or more overloads) don't really work with the docs rendering scripts. Maybe there is an option to turn it on, but for now, all documentation should be contained in one JSDocs comment (`/** here */`) instead of having it in multiple comments (for example, one for each overload).

**Related issue (if exists):**
Closes #6660