### PR TITLE
Remove more deprecated subscribes in tests

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -442,17 +442,16 @@ describe('Subject', () => {
       },
     };
 
-    const sub = Subject.create(destination, source);
+    const sub: Subject<any> = Subject.create(destination, source);
 
-    sub.subscribe(
-      function (x: number) {
+    sub.subscribe({
+      next: function (x: number) {
         output.push(x);
       },
-      null,
-      () => {
+      complete: () => {
         outputComplete = true;
       }
-    );
+    });
 
     sub.next('a');
     sub.next('b');
@@ -492,17 +491,16 @@ describe('Subject', () => {
       },
     };
 
-    const sub = Subject.create(destination, source);
+    const sub: Subject<any> = Subject.create(destination, source);
 
-    sub.subscribe(
-      function (x: number) {
+    sub.subscribe({
+      next: function (x: number) {
         output.push(x);
       },
-      null,
-      () => {
+      complete: () => {
         outputComplete = true;
       }
-    );
+    });
 
     sub.next('a');
     sub.next('b');

--- a/spec/operators/min-spec.ts
+++ b/spec/operators/min-spec.ts
@@ -91,45 +91,45 @@ describe('min', () => {
   });
 
   it('should min a range() source observable', (done) => {
-    (<any>range(1, 10000)).pipe(min()).subscribe(
-      (value: number) => {
-        expect(value).to.equal(1);
-      },
-      (x: any) => {
-        done(new Error('should not be called'));
-      },
-      () => {
-        done();
-      }
-    );
+    range(1, 10000)
+      .pipe(min())
+      .subscribe({
+        next: (value) => {
+          expect(value).to.equal(1);
+        },
+        error: () => {
+          done(new Error('should not be called'));
+        },
+        complete: done,
+      });
   });
 
   it('should min a range().skip(1) source observable', (done) => {
-    (<any>range(1, 10)).pipe(skip(1), min()).subscribe(
-      (value: number) => {
-        expect(value).to.equal(2);
-      },
-      (x: any) => {
-        done(new Error('should not be called'));
-      },
-      () => {
-        done();
-      }
-    );
+    range(1, 10)
+      .pipe(skip(1), min())
+      .subscribe({
+        next: (value) => {
+          expect(value).to.equal(2);
+        },
+        error: () => {
+          done(new Error('should not be called'));
+        },
+        complete: done,
+      });
   });
 
   it('should min a range().take(1) source observable', (done) => {
-    (<any>range(1, 10)).pipe(take(1), min()).subscribe(
-      (value: number) => {
-        expect(value).to.equal(1);
-      },
-      (x: any) => {
-        done(new Error('should not be called'));
-      },
-      () => {
-        done();
-      }
-    );
+    range(1, 10)
+      .pipe(take(1), min())
+      .subscribe({
+        next: (value) => {
+          expect(value).to.equal(1);
+        },
+        error: () => {
+          done(new Error('should not be called'));
+        },
+        complete: done,
+      });
   });
 
   it('should work with error', () => {


### PR DESCRIPTION
Looks like a few were missed because of `any`. Ugh.

(This change is also already in #6757)