### PR TITLE
feat(tap): Removed deprecated `tap(fn, fn, fn)` call pattern.

### DIFF
--- a/api_guard/dist/types/index.d.ts
+++ b/api_guard/dist/types/index.d.ts
@@ -706,9 +706,7 @@ export declare function takeWhile<T, S extends T>(predicate: (value: T, index: n
 export declare function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S, inclusive: false): OperatorFunction<T, S>;
 export declare function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive?: boolean): MonoTypeOperatorFunction<T>;
 
-export declare function tap<T>(observer?: Partial<TapObserver<T>>): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): MonoTypeOperatorFunction<T>;
+export declare function tap<T>(observerOrNext?: Partial<TapObserver<T>> | ((value: T) => void) | null): MonoTypeOperatorFunction<T>;
 
 export declare type TeardownLogic = Subscription | Unsubscribable | (() => void) | void;
 

--- a/api_guard/dist/types/operators/index.d.ts
+++ b/api_guard/dist/types/operators/index.d.ts
@@ -319,9 +319,7 @@ export declare function takeWhile<T, S extends T>(predicate: (value: T, index: n
 export declare function takeWhile<T, S extends T>(predicate: (value: T, index: number) => value is S, inclusive: false): OperatorFunction<T, S>;
 export declare function takeWhile<T>(predicate: (value: T, index: number) => boolean, inclusive?: boolean): MonoTypeOperatorFunction<T>;
 
-export declare function tap<T>(observer?: Partial<TapObserver<T>>): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
-export declare function tap<T>(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): MonoTypeOperatorFunction<T>;
+export declare function tap<T>(observerOrNext?: Partial<TapObserver<T>> | ((value: T) => void) | null): MonoTypeOperatorFunction<T>;
 
 export declare function throttle<T>(durationSelector: (value: T) => ObservableInput<any>, config?: ThrottleConfig): MonoTypeOperatorFunction<T>;
 

--- a/spec-dtslint/operators/tap-spec.ts
+++ b/spec-dtslint/operators/tap-spec.ts
@@ -29,10 +29,4 @@ it('should deprecate the multi-argument usage', () => {
   o.pipe(tap({ error, complete })); // $ExpectNoDeprecation
   o.pipe(tap({ complete })); // $ExpectNoDeprecation
   o.pipe(tap(next)); // $ExpectNoDeprecation
-  o.pipe(tap(null, error)); // $ExpectDeprecation
-  o.pipe(tap(undefined, error)); // $ExpectDeprecation
-  o.pipe(tap(null, error, complete)); // $ExpectDeprecation
-  o.pipe(tap(undefined, error, complete)); // $ExpectDeprecation
-  o.pipe(tap(null, null, complete)); // $ExpectDeprecation
-  o.pipe(tap(undefined, undefined, complete)); // $ExpectDeprecation
 });

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -10,15 +10,6 @@ export interface TapObserver<T> extends Observer<T> {
   finalize: () => void;
 }
 
-export function tap<T>(observer?: Partial<TapObserver<T>>): MonoTypeOperatorFunction<T>;
-export function tap<T>(next: (value: T) => void): MonoTypeOperatorFunction<T>;
-/** @deprecated Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments */
-export function tap<T>(
-  next?: ((value: T) => void) | null,
-  error?: ((error: any) => void) | null,
-  complete?: (() => void) | null
-): MonoTypeOperatorFunction<T>;
-
 /**
  * Used to perform side-effects for notifications from the source observable
  *
@@ -104,19 +95,11 @@ export function tap<T>(
  * @return A function that returns an Observable identical to the source, but
  * runs the specified Observer or callback(s) for each item.
  */
-export function tap<T>(
-  observerOrNext?: Partial<TapObserver<T>> | ((value: T) => void) | null,
-  error?: ((e: any) => void) | null,
-  complete?: (() => void) | null
-): MonoTypeOperatorFunction<T> {
+export function tap<T>(observerOrNext?: Partial<TapObserver<T>> | ((value: T) => void) | null): MonoTypeOperatorFunction<T> {
   // We have to check to see not only if next is a function,
   // but if error or complete were passed. This is because someone
   // could technically call tap like `tap(null, fn)` or `tap(null, null, fn)`.
-  const tapObserver =
-    isFunction(observerOrNext) || error || complete
-      ? // tslint:disable-next-line: no-object-literal-type-assertion
-        ({ next: observerOrNext as Exclude<typeof observerOrNext, Partial<TapObserver<T>>>, error, complete } as Partial<TapObserver<T>>)
-      : observerOrNext;
+  const tapObserver = isFunction(observerOrNext) ? { next: observerOrNext } : observerOrNext;
 
   return tapObserver
     ? operate((source, subscriber) => {


### PR DESCRIPTION
BREAKING CHANGE: `tap(fn, fn, fn)` call pattern is no longer available. Use named arguments (observers) instead: `tap({ complete: fn, error: fn, next: fn })`.
