### PR TITLE
docs: fix rendering parameters

### DIFF
--- a/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
@@ -52,7 +52,7 @@
 </div>{% endif %}
 
 <h4 class="no-anchor">Parameters</h4>
-{$ params.renderParameters(overload.parameterDocs, cssClass + '-parameters', cssClass + '-parameter') $}
+{$ params.renderParameters(overload.parameterDocs, cssClass + '-parameters', cssClass + '-parameter', true) $}
 
 {% if overload.type or overload.returns.type %}
 <h4 class="no-anchor">Returns</h4>

--- a/docs_app/tools/transforms/templates/api/lib/paramList.html
+++ b/docs_app/tools/transforms/templates/api/lib/paramList.html
@@ -17,7 +17,10 @@
   <tbody>
   {% for parameter in parameters %}
     <tr class="{$ parameterClass $}">
-      <td class="param-name"><a id="{$ parameter.anchor $}"></a>{$ parameter.name $}</td>
+      <td class="param-name">
+        <a id="{$ parameter.anchor or parameter.name $}"></a>
+        <code>{$ parameter.name $}</code>
+      </td>
       {% if showType %}<td class="param-type"><code>{$ parameter.type $}</code></td>{% endif %}
       <td class="param-description">
       {% marked %}


### PR DESCRIPTION
**Description:**
This PR fixes issue mentioned by [this comment](https://github.com/ReactiveX/rxjs/pull/6756#discussion_r783055893) so that it looks like this now:

![image](https://user-images.githubusercontent.com/28087049/149224832-49f7e84c-9869-4286-97f0-f80be518bf18.png)

It also turns on an option to render parameter types:

<img width="1096" alt="image" src="https://user-images.githubusercontent.com/28087049/149225316-adb2224c-b3c6-4f46-a7f7-81c154dfddbf.png">

**Related issue (if exists):**
None.