### PR TITLE
docs: fix typo in 'iif' comments

### DIFF
--- a/src/internal/observable/iif.ts
+++ b/src/internal/observable/iif.ts
@@ -5,7 +5,7 @@ import { ObservableInput } from '../types';
 /**
  * Checks a boolean at subscription time, and chooses between one of two observable sources
  *
- * `iif` excepts a function that returns a boolean (the `condition` function), and two sources,
+ * `iif` expects a function that returns a boolean (the `condition` function), and two sources,
  * the `trueResult` and the `falseResult`, and returns an Observable.
  *
  * At the moment of subscription, the `condition` function is called. If the result is `true`, the


### PR DESCRIPTION
Classical typo: 'excepts' instead of 'expects' ;-)

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

