### PR TITLE
feat(operators): combineAll operator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rxjs",
-  "version": "7.5.2",
+  "version": "7.6.0",
   "description": "Reactive Extensions for modern JavaScript",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm5/index.js",

--- a/spec/operators/combine-spec.ts
+++ b/spec/operators/combine-spec.ts
@@ -1,0 +1,558 @@
+import { expect } from 'chai';
+import { queueScheduler as rxQueueScheduler, of, scheduled } from 'rxjs';
+import { combineAll, map, mergeMap } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+const queueScheduler = rxQueueScheduler;
+
+/** @test {combineAll} */
+describe('combineAll operator', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should return EMPTY if passed an empty array as the only argument', () => {
+    const results: string[] = [];
+    scheduled([], rxTestScheduler)
+      .pipe(combineAll())
+      .subscribe({
+        next: () => {
+          throw new Error('should not emit');
+        },
+        complete: () => {
+          results.push('done');
+          expect(results).to.deep.equal(['done']);
+        }
+      });
+  });
+
+  it('should combine the provided observables', () => {
+    rxTestScheduler.run(({ hot, expectObservable }) => {
+      const firstSource = hot(' ----a----b----c----|');
+      const secondSource = hot('--d--e--f--g--|');
+      const expected = '        ----uv--wx-y--z----|';
+
+      const combined = scheduled([firstSource, secondSource], rxTestScheduler)
+        .pipe(combineAll((a, b) => '' + a + b));
+
+      expectObservable(combined).toBe(expected, { u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg' });
+    });
+  });
+
+  it('should combine an immediately-scheduled source with an immediately-scheduled second', (done) => {
+    const a = of(1, 2, 3, queueScheduler);
+    const b = of(4, 5, 6, 7, 8, queueScheduler);
+    const r = [
+      [1, 4],
+      [2, 4],
+      [2, 5],
+      [3, 5],
+      [3, 6],
+      [3, 7],
+      [3, 8],
+    ];
+
+    const actual: [number, number][] = [];
+    //type definition need to be updated
+    scheduled([a, b], queueScheduler)
+      .pipe(combineAll())
+      .subscribe(
+        // @ts-ignore
+        (vals: [number, number]) => {
+          actual.push(vals);
+        },
+        () => {
+          done(new Error('should not be called'));
+        },
+        () => {
+          expect(actual).to.deep.equal(r);
+          done();
+        }
+      );
+  });
+
+  it('should accept array of observables', () => {
+    rxTestScheduler.run(({ hot, expectObservable }) => {
+      const firstSource = hot(' ----a----b----c----|');
+      const secondSource = hot('--d--e--f--g--|');
+      const expected = '        ----uv--wx-y--z----|';
+
+      const combined = scheduled([firstSource, secondSource], rxTestScheduler)
+        .pipe(combineAll((a: string, b: string) => '' + a + b));
+
+      expectObservable(combined).toBe(expected, { u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg' });
+    });
+  });
+
+  it('should work with two nevers', () => {
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const e2 = cold(' -');
+      const e2subs = '  ^';
+      const expected = '-';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with never and empty', () => {
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const e2 = cold(' |');
+      const e2subs = '  (^!)';
+      const expected = '-';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with empty and never', () => {
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |');
+      const e1subs = '  (^!)';
+      const e2 = cold(' -');
+      const e2subs = '  ^';
+      const expected = '-';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with empty and empty', () => {
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |');
+      const e1subs = '  (^!)';
+      const e2 = cold(' |');
+      const e2subs = '  (^!)';
+      const expected = '|';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with hot-empty and hot-single', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const values = {
+        a: 1,
+        b: 2,
+        c: 3,
+        r: 1 + 3, //a + c
+      };
+      const e1 = hot('-a-^-|', values);
+      const e1subs = '   ^-!';
+      const e2 = hot('-b-^-c-|', values);
+      const e2subs = '   ^---!';
+      const expected = ' ----|';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with hot-single and hot-empty', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const values = {
+        a: 1,
+        b: 2,
+        c: 3,
+      };
+      const e1 = hot('-a-^-|', values);
+      const e1subs = '   ^-!';
+      const e2 = hot('-b-^-c-|', values);
+      const e2subs = '   ^---!';
+      const expected = ' ----|';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with hot-single and never', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const values = {
+        a: 1,
+      };
+      const e1 = hot('-a-^-|', values);
+      const e1subs = '   ^-!';
+      const e2 = hot('------', values); //never
+      const e2subs = '   ^  ';
+      const expected = ' -'; //never
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with never and hot-single', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const values = {
+        a: 1,
+        b: 2,
+      };
+      const e1 = hot('--------', values); //never
+      const e1subs = '   ^----';
+      const e2 = hot('-a-^-b-|', values);
+      const e2subs = '   ^---!';
+      const expected = ' -----'; //never
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with hot and hot', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--|', { a: 'a', b: 'b', c: 'c' });
+      const e1subs = '     ^--------!';
+      const e2 = hot('---e-^---f--g--|', { e: 'e', f: 'f', g: 'g' });
+      const e2subs = '     ^---------!';
+      const expected = '   ----x-yz--|';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with empty and error', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ----------|'); //empty
+      const e1subs = '  ^-----!';
+      const e2 = hot('  ------#', undefined, 'shazbot!'); //error
+      const e2subs = '  ^-----!';
+      const expected = '------#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'shazbot!');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with error and empty', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--^---#', undefined, 'too bad, honk'); //error
+      const e1subs = '  ^---!';
+      const e2 = hot('--^--------|'); //empty
+      const e2subs = '  ^---!';
+      const expected = '----#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'too bad, honk');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with hot and throw', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('-a-^--b--c--|', { a: 1, b: 2, c: 3 });
+      const e1subs = '   ^-!';
+      const e2 = hot('---^-#', undefined, 'bazinga');
+      const e2subs = '   ^-!';
+      const expected = ' --#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: number, y: string) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'bazinga');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with throw and hot', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^-#', undefined, 'bazinga');
+      const e1subs = '   ^-!';
+      const e2 = hot('-a-^--b--c--|', { a: 1, b: 2, c: 3 });
+      const e2subs = '   ^-!';
+      const expected = ' --#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: string, y: number) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'bazinga');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with throw and throw', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^----#', undefined, 'jenga');
+      const e1subs = '   ^-!';
+      const e2 = hot('---^-#', undefined, 'bazinga');
+      const e2subs = '   ^-!';
+      const expected = ' --#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'bazinga');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with error and throw', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('-a-^--b--#', { a: 1, b: 2 }, 'wokka wokka');
+      const e1subs = '   ^-!';
+      const e2 = hot('---^-#', undefined, 'flurp');
+      const e2subs = '   ^-!';
+      const expected = ' --#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: number|string, y: string) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'flurp');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with throw and error', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^-#', undefined, 'flurp');
+      const e1subs = '   ^-!';
+      const e2 = hot('-a-^--b--#', { a: 1, b: 2 }, 'wokka wokka');
+      const e2subs = '   ^-!';
+      const expected = ' --#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: string, y: number|string) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'flurp');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with never and throw', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^-----------');
+      const e1subs = '   ^-----!';
+      const e2 = hot('---^-----#', undefined, 'wokka wokka');
+      const e2subs = '   ^-----!';
+      const expected = ' ------#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'wokka wokka');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with throw and never', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^----#', undefined, 'wokka wokka');
+      const e1subs = '   ^----!';
+      const e2 = hot('---^-----------');
+      const e2subs = '   ^----!';
+      const expected = ' -----#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'wokka wokka');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with some and throw', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^----a---b--|', { a: 1, b: 2 });
+      const e1subs = '   ^--!';
+      const e2 = hot('---^--#', undefined, 'wokka wokka');
+      const e2subs = '   ^--!';
+      const expected = ' ---#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: number, y: string) => x + y));
+
+      expectObservable(result).toBe(expected, { a: 1, b: 2 }, 'wokka wokka');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should work with throw and some', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('---^--#', undefined, 'wokka wokka');
+      const e1subs = '   ^--!';
+      const e2 = hot('---^----a---b--|', { a: 1, b: 2 });
+      const e2subs = '   ^--!';
+      const expected = ' ---#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: string, y: number) => x + y));
+
+      expectObservable(result).toBe(expected, { a: 1, b: 2 }, 'wokka wokka');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should handle throw after complete left', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot(' --a--^--b---|', { a: 1, b: 2 });
+      const leftSubs = '      ^------!';
+      const e2 = hot('-----^--------#', undefined, 'bad things');
+      const rightSubs = '     ^--------!';
+      const expected = '      ---------#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: number, y: string) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'bad things');
+      expectSubscriptions(e1.subscriptions).toBe(leftSubs);
+      expectSubscriptions(e2.subscriptions).toBe(rightSubs);
+    });
+  });
+
+  it('should handle throw after complete right', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot(' -----^--------#', undefined, 'bad things');
+      const leftSubs = '      ^--------!';
+      const e2 = hot('--a--^--b---|', { a: 1, b: 2 });
+      const rightSubs = '     ^------!';
+      const expected = '      ---------#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x: string, y: number) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'bad things');
+      expectSubscriptions(e1.subscriptions).toBe(leftSubs);
+      expectSubscriptions(e2.subscriptions).toBe(rightSubs);
+    });
+  });
+
+  it('should handle interleaved with tail', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('-a--^--b---c---|', { a: 'a', b: 'b', c: 'c' });
+      const e1subs = '    ^----------!';
+      const e2 = hot('--d-^----e---f--|', { d: 'd', e: 'e', f: 'f' });
+      const e2subs = '    ^-----------!';
+      const expected = '  -----x-y-z--|';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, { x: 'be', y: 'ce', z: 'cf' });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should handle two consecutive hot observables', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c--|', { a: 'a', b: 'b', c: 'c' });
+      const e1subs = '     ^--------!';
+      const e2 = hot('-----^----------d---e--f-|', { d: 'd', e: 'e', f: 'f' });
+      const e2subs = '     ^-------------------!';
+      const expected = '   -----------(bc)y--z-|';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, { b: 'bd', c: 'cd', y: 'ce', z: 'cf' });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should handle two consecutive hot observables with error left', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot(' --a--^--b--c--#', { a: 'a', b: 'b', c: 'c' }, 'jenga');
+      const leftSubs = '      ^--------!';
+      const e2 = hot('-----^----------d--e--f--|', { d: 'd', e: 'e', f: 'f' });
+      const rightSubs = '     ^--------!';
+      const expected = '      ---------#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, null, 'jenga');
+      expectSubscriptions(e1.subscriptions).toBe(leftSubs);
+      expectSubscriptions(e2.subscriptions).toBe(rightSubs);
+    });
+  });
+
+  it('should handle two consecutive hot observables with error right', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot(' --a--^--b--c--|', { a: 'a', b: 'b', c: 'c' });
+      const leftSubs = '      ^--------!';
+      const e2 = hot('-----^----------d---e--f-#', { d: 'd', e: 'e', f: 'f' }, 'dun dun dun');
+      const rightSubs = '     ^-------------------!';
+      const expected = '      -----------(ax)y--z-#';
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result).toBe(expected, { a: 'bd', x: 'cd', y: 'ce', z: 'cf' }, 'dun dun dun');
+      expectSubscriptions(e1.subscriptions).toBe(leftSubs);
+      expectSubscriptions(e2.subscriptions).toBe(rightSubs);
+    });
+  });
+
+  it('should handle selector throwing', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--|', { a: 1, b: 2 });
+      const e1subs = '     ^--!';
+      const e2 = hot('--c--^--d--|', { c: 3, d: 4 });
+      const e2subs = '     ^--!';
+      const expected = '   ---#';
+
+      const result = scheduled([e1, e2], rxTestScheduler)
+        .pipe(combineAll((x, y) => { throw 'ha ha ' + x + ', ' + y; }));
+
+      expectObservable(result).toBe(expected, null, 'ha ha 2, 4');
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+
+  it('should allow unsubscribing early and explicitly', () => {
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('--a--^--b--c---d-| ');
+      const e1subs = '     ^--------!    ';
+      const e2 = hot('---e-^---f--g---h-|');
+      const e2subs = '     ^--------!    ';
+      const expected = '   ----x-yz--    ';
+      const unsub = '      ---------!    ';
+      const values = { x: 'bf', y: 'cf', z: 'cg' };
+
+      const result = scheduled([e1, e2], rxTestScheduler).pipe(combineAll((x, y) => x + y));
+
+      expectObservable(result, unsub).toBe(expected, values);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
+  });
+});

--- a/src/internal/observable/combine.ts
+++ b/src/internal/observable/combine.ts
@@ -1,0 +1,267 @@
+import { Observable } from '../Observable';
+import { ObservableInput, SchedulerLike, ObservedValueOf, ObservableInputTuple } from '../types';
+import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
+import { Subscriber } from '../Subscriber';
+import { from } from './from';
+import { identity } from '../util/identity';
+import { Tetris } from '../util/tetris';
+import { Subscription } from '../Subscription';
+import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
+import { popResultSelector, popScheduler } from '../util/args';
+import { createObject } from '../util/createObject';
+import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { AnyCatcher } from '../AnyCatcher';
+import { executeSchedule } from '../util/executeSchedule';
+
+// combine(any)
+// We put this first because we need to catch cases where the user has supplied
+// _exactly `any`_ as the argument. Since `any` literally matches _anything_,
+// we don't want it to randomly hit one of the other type signatures below,
+// as we have no idea at build-time what type we should be returning when given an any.
+
+/**
+ * You have passed `any` here, we can't figure out if it is
+ * an array or an object, so you're getting `unknown`. Use better types.
+ * @param arg Something typed as `any`
+ */
+export function combine<T extends AnyCatcher>(arg: T): Observable<unknown>;
+
+// combine([a, b, c])
+export function combine(sources: []): Observable<never>;
+export function combine<A extends readonly unknown[]>(sources: readonly [...ObservableInputTuple<A>]): Observable<A>;
+
+export function combine<A extends readonly unknown[], R>(
+  sources: readonly [...ObservableInputTuple<A>],
+  resultSelector: (...values: A) => R
+): Observable<R>;
+
+// combine({a, b, c})
+export function combine(sourcesObject: { [K in any]: never }): Observable<never>;
+export function combine<T extends Record<string, ObservableInput<any>>>(
+  sourcesObject: T
+): Observable<{ [K in keyof T]: ObservedValueOf<T[K]> }>;
+
+/**
+ * Combines multiple Observables to create an Observable whose values are
+ * calculated from the time of subscription to its input Observables.
+ *
+ * <span class="informal">Whenever any input Observable emits a value, it
+ * computes a formula using the values from all the inputs, then emits
+ * the output of that formula.</span>
+ *
+ * ![](combine.png)
+ *
+ * `combine` combines the values from all the Observables passed in the
+ * observables array. This is done by subscribing to each Observable in order and,
+ * whenever any Observable emits, collecting an array of values from each Observable. So if you pass `n` Observables
+ * to this operator, the returned Observable will always emit an array of `n` values, in an order
+ * corresponding to the order of the passed Observables (the value from the first Observable
+ * will be at index 0 of the array and so on).
+ *
+ * Static version of `combine` accepts an array of Observables. Note that an array of
+ * Observables is a good choice, if you don't know beforehand how many Observables
+ * you will combine. Passing an empty array will result in an Observable that
+ * completes immediately.
+ *
+ * To ensure the output array always has the same length, `combine` will
+ * actually wait for all input Observables to emit at least once,
+ * before it starts emitting results. If some Observable does not emit a value but
+ * completes, resulting Observable will complete at the same moment without
+ * emitting anything, since it will now be impossible to include a value from the
+ * completed Observable in the resulting array. Also, if some input Observable does
+ * not emit any value and never completes, `combine` will also never emit
+ * and never complete, since, again, it will wait for all streams to emit some
+ * value.
+ *
+ * If at least one Observable was passed to `combine` and all passed Observables
+ * emitted something, the resulting Observable will complete when all combined
+ * streams complete. So even if some Observable completes, the result of
+ * `combine` will still emit values when other Observables do. In case
+ * of a completed Observable, its value from now on will always be the last
+ * emitted value. On the other hand, if any Observable errors, `combine`
+ * will error immediately as well, and all other Observables will be unsubscribed.
+ *
+ * ## Examples
+ *
+ * Combine two timer Observables
+ *
+ * ```ts
+ * import { timer, combine } from 'rxjs';
+ *
+ * const firstTimer = timer(0, 1000); // emit 0, 1, 2... after every second, starting from now
+ * const secondTimer = timer(500, 1000); // emit 0, 1, 2... after every second, starting 0,5s from now
+ * const combinedTimers = combine([firstTimer, secondTimer]);
+ * combinedTimers.subscribe(value => console.log(value));
+ * // Logs
+ * // [0, 0] after 0.5s
+ * // [1, 0] after 1s
+ * // [1, 1] after 1.5s
+ * // [2, 1] after 2s
+ * ```
+ *
+ * Combine a dictionary of Observables
+ *
+ * ```ts
+ * import { of, delay, startWith, combine } from 'rxjs';
+ *
+ * const observables = {
+ *   a: of(1).pipe(delay(1000), startWith(0)),
+ *   b: of(5).pipe(delay(5000), startWith(0)),
+ *   c: of(10).pipe(delay(10000), startWith(0))
+ * };
+ * const combined = combine(observables);
+ * combined.subscribe(value => console.log(value));
+ * // Logs
+ * // { a: 0, b: 0, c: 0 } immediately
+ * // { a: 1, b: 0, c: 0 } after 1s
+ * // { a: 1, b: 5, c: 0 } after 5s
+ * // { a: 1, b: 5, c: 10 } after 10s
+ * ```
+ *
+ * Combine an array of Observables
+ *
+ * ```ts
+ * import { of, delay, startWith, combine } from 'rxjs';
+ *
+ * const observables = [1, 5, 10].map(
+ *   n => of(n).pipe(
+ *     delay(n * 1000), // emit 0 and then emit n after n seconds
+ *     startWith(0)
+ *   )
+ * );
+ * const combined = combine(observables);
+ * combined.subscribe(value => console.log(value));
+ * // Logs
+ * // [0, 0, 0] immediately
+ * // [1, 0, 0] after 1s
+ * // [1, 5, 0] after 5s
+ * // [1, 5, 10] after 10s
+ * ```
+ *
+ * Use map operator to dynamically calculate the Body-Mass Index
+ *
+ * ```ts
+ * import { of, combine, map } from 'rxjs';
+ *
+ * const weight = of(70, 72, 76, 79, 75);
+ * const height = of(1.76, 1.77, 1.78);
+ * const bmi = combine([weight, height]).pipe(
+ *   map(([w, h]) => w / (h * h)),
+ * );
+ * bmi.subscribe(x => console.log('BMI is ' + x));
+ *
+ * // With output to console:
+ * // BMI is 24.212293388429753
+ * // BMI is 23.93948099205209
+ * // BMI is 23.671253629592222
+ * ```
+ *
+ * @see {@link combineAll}
+ * @see {@link merge}
+ * @see {@link withLatestFrom}
+ *
+ * @param {ObservableInput} [observables] An array of input Observables to combine with each other.
+ * An array of Observables must be given as the first argument.
+ * @param {function} [project] An optional function to project the values from
+ * the combined values into a new value on the output Observable.
+ * @param {SchedulerLike} [scheduler=null] The {@link SchedulerLike} to use for subscribing to
+ * each input Observable.
+ * @return {Observable} An Observable of projected values from the most recent
+ * values from each input Observable, or an array of the most recent values from
+ * each input Observable.
+ */
+export function combine<O extends ObservableInput<any>, R>(...args: any[]): Observable<R> | Observable<ObservedValueOf<O>[]> {
+  const scheduler = popScheduler(args);
+  const resultSelector = popResultSelector(args);
+
+  const { args: observables, keys } = argsArgArrayOrObject(args);
+
+  if (observables.length === 0) {
+    // If no observables are passed, or someone has passed an ampty array
+    // of observables, or even an empty object POJO, we need to just
+    // complete (EMPTY), but we have to honor the scheduler provided if any.
+    return from([], scheduler as any);
+  }
+
+  const result = new Observable<ObservedValueOf<O>[]>(
+    combineInit(
+      observables as ObservableInput<ObservedValueOf<O>>[],
+      scheduler,
+      keys
+        ? // A handler for scrubbing the array of args into a dictionary.
+          (values) => createObject(keys, values)
+        : // A passthrough to just return the array
+          identity
+    )
+  );
+
+  return resultSelector ? (result.pipe(mapOneOrManyArgs(resultSelector)) as Observable<R>) : result;
+}
+
+export function combineInit(
+  observables: ObservableInput<any>[],
+  scheduler?: SchedulerLike,
+  valueTransform: (values: any[]) => any = identity
+) {
+  return (subscriber: Subscriber<any>) => {
+    // The outer subscription. We're capturing this in a function
+    // because we may have to schedule it.
+    maybeSchedule(
+      scheduler,
+      () => {
+        const { length } = observables;
+        // A store for the values each observable has emitted so far. We match observable to value on index.
+        const tetris = new Tetris(length);
+        // The number of currently active subscriptions, as they complete, we decrement this number to see if
+        // we are all done combining values, so we can complete the result.
+        let active = length;
+        // The loop to kick off subscription. We're keying everything on index `i` to relate the observables passed
+        // in to the slot in the output array or the key in the array of keys in the output dictionary.
+        for (let i = 0; i < length; i++) {
+          maybeSchedule(
+            scheduler,
+            () => {
+              const source = from(observables[i], scheduler as any);
+              source.subscribe(
+                new OperatorSubscriber(
+                  subscriber,
+                  (value) => {
+                    // When we get a value, record it in our set of values.
+                    tetris.pushToColumn(i, value);
+                    while (tetris.hasNext()) {
+                      const next = tetris.getNext();
+                      // We're not waiting for any more
+                      // first values, so we can emit!
+                      subscriber.next(valueTransform(next));
+                    }
+                  },
+                  () => {
+                    if (!--active) {
+                      // We only complete the result if we have no more active
+                      // inner observables.
+                      subscriber.complete();
+                    }
+                  }
+                )
+              );
+            },
+            subscriber
+          );
+        }
+      },
+      subscriber
+    );
+  };
+}
+
+/**
+ * A small utility to handle the couple of locations where we want to schedule if a scheduler was provided,
+ * but we don't if there was no scheduler.
+ */
+function maybeSchedule(scheduler: SchedulerLike | undefined, execute: () => void, subscription: Subscription) {
+  if (scheduler) {
+    executeSchedule(subscription, scheduler, execute);
+  } else {
+    execute();
+  }
+}

--- a/src/internal/operators/combineAll.ts
+++ b/src/internal/operators/combineAll.ts
@@ -1,6 +1,52 @@
-import { combineLatestAll } from './combineLatestAll';
+import { OperatorFunction, ObservableInput } from '../types';
+import { joinAllInternals } from './joinAllInternals';
+import { combine } from '../observable/combine';
+
+export function combineAll<T>(): OperatorFunction<ObservableInput<T>, T[]>;
+export function combineAll<T>(): OperatorFunction<any, T[]>;
+export function combineAll<T, R>(project: (...values: T[]) => R): OperatorFunction<ObservableInput<T>, R>;
+export function combineAll<R>(project: (...values: Array<any>) => R): OperatorFunction<any, R>;
 
 /**
- * @deprecated Renamed to {@link combineLatestAll}. Will be removed in v8.
+ * Flattens an Observable-of-Observables by applying {@link combine} when the Observable-of-Observables completes.
+ *
+ * ![](combineAll.png)
+ *
+ * `combineAll` takes an Observable of Observables, and collects all Observables from it. Once the outer Observable completes,
+ * it subscribes to all collected Observables and combines their values using the {@link combineLatest} strategy, such that:
+ *
+ * * Every time an inner Observable emits, the output Observable emits
+ * * When the returned observable emits, it emits all of the latest values by:
+ *    * If a `project` function is provided, it is called with each recent value from each inner Observable in whatever order they
+ *      arrived, and the result of the `project` function is what is emitted by the output Observable.
+ *    * If there is no `project` function, an array of all the most recent values is emitted by the output Observable.
+ *
+ * ## Example
+ *
+ * Map two click events to a finite interval Observable, then apply `combineAll`
+ *
+ * ```ts
+ * import { fromEvent, map, interval, take, combineAll } from 'rxjs';
+ *
+ * const clicks = fromEvent(document, 'click');
+ * const higherOrder = clicks.pipe(
+ *   map(() => interval(Math.random() * 2000).pipe(take(3))),
+ *   take(2)
+ * );
+ * const result = higherOrder.pipe(combineAll());
+ *
+ * result.subscribe(x => console.log(x));
+ * ```
+ *
+ * @see {@link combineLatest}
+ * @see {@link combineLatestWith}
+ * @see {@link mergeAll}
+ *
+ * @param project optional function to map the most recent values from each inner Observable into a new result.
+ * Takes each of the most recent values from each collected inner Observable as arguments, in order.
+ * @return A function that returns an Observable that flattens Observables
+ * emitted by the source Observable.
  */
-export const combineAll = combineLatestAll;
+export function combineAll<R>(project?: (...values: Array<any>) => R) {
+  return joinAllInternals(combine, project);
+}

--- a/src/internal/util/tetris.ts
+++ b/src/internal/util/tetris.ts
@@ -1,0 +1,50 @@
+export class Tetris<T extends any> {
+  private readonly arrays: Array<Array<T>>;
+  private readonly lastEmissionIndices: Array<number>;
+
+  constructor(readonly columns: number = 2) {
+    this.arrays = new Array<Array<T>>();
+    this.lastEmissionIndices = new Array<number>(columns);
+    for (let i = 0; i < columns; i++) {
+      this.arrays[i] = new Array<T>();
+      this.lastEmissionIndices[i] = -1;
+    }
+  }
+
+  getNext(): Array<T> {
+    const next = new Array<T>();
+    if (!this.hasNext()) {
+      return [];
+    }
+    for (let column = 0; column < this.columns; column++) {
+      if (this._hasNewIn(column)) {
+        this.lastEmissionIndices[column] += 1;
+      }
+      next.push(this.arrays[column][this.lastEmissionIndices[column]]);
+    }
+    return next;
+  }
+
+  private _hasNewIn(column: number): boolean {
+    if (this.lastEmissionIndices[column] < this.arrays[column].length - 1) {
+      return true;
+    }
+    return false;
+  }
+
+  hasNext(): boolean {
+    let hasNext: boolean = false;
+    for (let column = 0; column < this.columns; column++) {
+      if (this.arrays[column].length === 0) {
+        return false;
+      }
+      hasNext = hasNext || this._hasNewIn(column);
+    }
+    return hasNext;
+  }
+
+  pushToColumn(column: number, value: T): Tetris<T> {
+    this.arrays[column].push(value);
+    return this;
+  }
+}

--- a/src/internal/util/tetris.ts
+++ b/src/internal/util/tetris.ts
@@ -18,6 +18,7 @@ export class Tetris<T extends any> {
     }
     for (let column = 0; column < this.columns; column++) {
       if (this._hasNewIn(column)) {
+        delete this.arrays[column][this.lastEmissionIndices[column]];
         this.lastEmissionIndices[column] += 1;
       }
       next.push(this.arrays[column][this.lastEmissionIndices[column]]);


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [x ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
An operator to combine values from source observables. The values emitted by early observers are saved until the last observer emits, following which all the previously saved values are emitted.

```
first$: ---a---b---c--
second$: ---------------d--
result$: [ad, bd, cd]
```
