### PR TITLE
docs: fix issues with H1 headers

### DIFF
--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -2,70 +2,70 @@
 
 This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x, presented in the order they can be found when diffing the TypeScript APIs in various module files.
 
-# module `rxjs`
+## module `rxjs`
 
-## Breaking changes
+### Breaking changes
 
-### AsyncSubject
+#### AsyncSubject
 
 - `_subscribe` method is no longer `public` and is now `protected`.
 - no longer has its own implementation of the `error` method inherited from `Subject`.
 
-### BehaviorSubject
+#### BehaviorSubject
 
 - `_subscribe` method is no longer `public` and is now `protected`.
 - `value` property is a getter `get value()` instead of `readonly value`, and can no longer be forcibly set.
 
-### bindCallback
+#### bindCallback
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### combineLatest
+#### combineLatest
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### concat
+#### concat
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### ConnectableObservable
+#### ConnectableObservable
 
 - `_isComplete` is no longer a property.
 - `_subscribe` method is no longer `public` and is now `protected`.
 
-### defer
+#### defer
 
 - Generic argument no longer extends `void`.
 - `defer` no longer allows factories to return void or undefined. All factories passed to `defer` must return a proper `ObservableInput`, such as `Observable`, `Promise`, et al. To get the same behavior as you may have relied on previously, `return EMPTY` or `return of()` from the factory.
 
-### forkJoin
+#### forkJoin
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### fromEvent
+#### fromEvent
 
 - The `fromEvent` signatures have been changed and there are now separate signatures for each type of target - DOM, Node, jQuery, etc. That means that an attempt to pass options - like `{ once: true }` - to a target that does not support an options argument will result in a TypeScript error.
 
-### GroupedObservable
+#### GroupedObservable
 
 - No longer publicly exposes `_subscribe`
 - `key` properly is `readonly`.
 - No longer publicly exposes `constructor`.
 
-### iif
+#### iif
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - `iif` will no longer allow result arguments that are `undefined`. This was a bad call pattern that was likely an error in most cases. If for some reason you are relying on this behavior, simply substitute `EMPTY` in place of the `undefined` argument. This ensures that the behavior was intentional and desired, rather than the result of an accidental `undefined` argument.
 
-### isObservable
+#### isObservable
 
 - No longer has a generic and returns `Observable<unknown>`, you must cast the result.
 
-### merge
+#### merge
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### Notification
+#### Notification
 
 - The `error` property is now `readonly`.
 - The `hasValue` property is now `readonly`.
@@ -73,7 +73,7 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 - The `value` property is now `readonly` and may be `undefined`.
 - `constructor` signature now only allows valid construction. For example `new Notification('C', 'some_value')` will be an error in TypeScript.
 
-### Observable
+#### Observable
 
 - `_isScalar` property removed.
 - `_subscribe` method is no longer `public` and is now marked `@internal`.
@@ -83,46 +83,46 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 - `static if` and `static throw` properties are no longer defined. They were unused in version 6.
 - `lift`, `source`, and `operator` properties are still **deprecated**, and should not be used. They are implementation details, and will very likely be renamed or missing in version 8.
 
-### of
+#### of
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### onErrorResumeNext
+#### onErrorResumeNext
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### pairs
+#### pairs
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - `pairs` will no longer function in IE without a polyfill for `Object.entries`. `pairs` itself is also deprecated in favor of users just using `from(Object.entries(obj))`.
 
-### partition
+#### partition
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### pipe
+#### pipe
 
 - Calls with `9` or more arguments will now return `(arg: A) => unknown` rather than `(arg: A) => {}`.
 
-### race
+#### race
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - `race` will no longer subscribe to subsequent observables if a provided source synchronously errors or completes. This means side effects that might have occurred during subscription in those rare cases will no longer occur.
 
-### ReplaySubject
+#### ReplaySubject
 
 - `_getNow` method has been removed.
 - `_subscribe` method is no longer `public` and is now `protected`.
 
-### Subscribable
+#### Subscribable
 
 - `subscribe` will accept `Partial<Observer<T>>` now. All overloads with functions as arguments have been removed. This is because `Subscribable` is intended to map to the basic observable contract from the TC39 proposal and the the return type of a call to `[Symbol.observable]()`.
 
-### SubscribableOrPromise
+#### SubscribableOrPromise
 
 - See notes on `Subscribable` above.
 
-### Subscriber
+#### Subscriber
 
 - `destination` property must now be a `Subscriber` or full `Observer`.
 - `syncErrorThrowable` property has been removed.
@@ -130,310 +130,310 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 - `syncErrorValue` property has been removed.
 - `_unsubscribeAndRecycle` method has been removed.
 
-### Subscription
+#### Subscription
 
 - `_parentOrParents` property has been removed.
 - `add` method returns `void` and no longer returns a `Subscription`. Returning `Subscription` was an old behavior from the early days of version 5. If you add a function to a subscription (i.e. `subscription.add(fn)`), you can remove that function directly by calling `remove` with the same function instance. (i.e. `subscription.remove(fn)`). Previously, you needed to get the returned `Subscription` object and pass _that_ to `remove`. In version 6 and lower, the `Subscription` returned by calling `add` with another `Subscription` was always the same subscription you passed in. (meaning `subscription.add(subs1).add(subs2)` was an antipattern and the same as `subscription.add(subs1); subs1.add(subs2);`.
 
-### VirtualAction
+#### VirtualAction
 
 - The static `sortActions` method has been removed.
 
-### zip
+#### zip
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - Zipping a single array will now have a different result. This is an extreme corner-case, because it is very unlikely that anyone would want to zip an array with nothing at all. The workaround would be to wrap the array in another array `zip([[1,2,3]])`. But again, that's pretty weird.
 
 ---
 
-## New Features
+### New Features
 
-### animationFrames
+#### animationFrames
 
 - A new method for creating a stream of animation frames. Each event will carry with it a high-resolution timestamp, and an elapsed time since observation was started.
 
-### config
+#### config
 
-#### onUnhandledError
+##### onUnhandledError
 
 - A handler for dealing with errors that make it all the way down to the "end" of the observation chain when there is no error handler in the observer. Useful for doing things like logging unhandled errors in RxJS observable chains.
 
-#### onStoppedNotification
+##### onStoppedNotification
 
 - A handler for edge cases where a subscriber within RxJS is notified after it has already "stopped", that is, a point in time where it has received an error or complete, but hasn't yet finalized. This is mostly useful for logging purposes.
 
-#### useDeprecatedNextContext
+##### useDeprecatedNextContext
 
 - In RxJS 6, a little used feature allowed users to access the `subscriber` directly as `this` within a call to the `next` handler. The problem with this is it incurred heavy performance penalties. That behavior has been changed (because it wasn't really documented and it was barely ever used) to not change the `this` context of any user-provided subscription handlers. If you need to get that feature back, you can switch it on with this flag. Note this behavior will be removed completely in version 8.
 
-### connectable
+#### connectable
 
 - This is the new means for creating a `ConnectableObservable`, and really is a replacement for non-selector usage of `multicast` and `publish` variants. Simply pass your source observable to `connectable` with the `Subject` you'd like to connect through.
 
-### firstValueFrom
+#### firstValueFrom
 
 - A better, more tree-shakable replacement for `toPromise()` (which is now deprecated). This function allows the user to convert any `Observable` in to a `Promise` that will resolve when the source observable emits its first value. If the source observable closes without emitting a value, the returned promise will reject with an `EmptyError`, or it will resolve with a configured `defaultValue`. For more information, see the [deprecation guide](/deprecations/to-promise).
 
-### lastValueFrom
+#### lastValueFrom
 
 - A better, more tree-shakable replacement for `toPromise()` (which is now deprecated). This function allows the user to convert any `Observable` in to a `Promise` that will resolve when the source observable emits the last value. If the source observable closes without emitting a value, the returned promise will reject with an `EmptyError`, or it will resolve with a configured `defaultValue`. For more information, see the [deprecation guide](/deprecations/to-promise).
 
-### ObservableInput
+#### ObservableInput
 
 - This is just a type, but it's important. This type defines the allowed types that can be passed to almost every API within RxJS that accepts an Observable. It has always accepted `Observable`, `Promise`, `Iterable`, and `ArrayLike`. Now it will also accept `AsyncIterable` and `ReadableStream`.
 
-#### AsyncIterable
+##### AsyncIterable
 
 - `AsyncIterables` such as those defined by `IxJS` or by async generators (`async function*`), may now be passed to any API that accepts an observable, and can be converted to an `Observable` directly using `from`.
 
-#### ReadableStream
+##### ReadableStream
 
 - `ReadableStream` such as those returned by `fetch`, et al, can be passed to any API that accepts an observable, and can be converted to `Observable` directly using `from`.
 
-### ReplaySubject
+#### ReplaySubject
 
 - A [bug was fixed](https://github.com/ReactiveX/rxjs/pull/5696) that prevented a completed or errored `ReplaySubject` from accumulating values in its buffer when resubscribed to another source. This breaks some uses - like [this StackOverflow answer](https://stackoverflow.com/a/54957061) - that depended upon the buggy behavior.
 
-### Subscription
+#### Subscription
 
 - Now allows adding and removing of functions directly via `add` and `remove` methods.
 
-### throwError
+#### throwError
 
 - Now accepts an `errorFactory` of `() => any` to defer the creation of the error until the time it will be emitted. It is recommended to use this method, as Errors created in most popular JavaScript runtimes will retain all values in the current scope for debugging purposes.
 
-# module `rxjs/operators`
+## module `rxjs/operators`
 
-## Breaking Changes
+### Breaking Changes
 
-### audit
+#### audit
 
 - The observable returned by the `audit` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
 - `audit` now emits the last value from the source when the source completes. Previously, `audit` would mirror the completion without emitting the value.
 
-### auditTime
+#### auditTime
 
 - `auditTime` now emits the last value from the source when the source completes, after the audit duration elapses. Previously, `auditTime` would mirror the completion without emitting the value and without waiting for the audit duration to elapse.
 
-### buffer
+#### buffer
 
 - `buffer` now subscribes to the source observable before it subscribes to the closing notifier. Previously, it subscribed to the closing notifier first.
 - Final buffered values will now always be emitted. To get the same behavior as the previous release, you can use `endWith` and `skipLast(1)`, like so: `source$.pipe(buffer(notifier$.pipe(endWith(true))), skipLast(1))`
 - `closingNotifier` completion no longer completes the result of `buffer`. If that is truly a desired behavior, then you should use `takeUntil`. Something like: `source$.pipe(buffer(notifier$), takeUntil(notifier$.pipe(ignoreElements(), endWith(true))))`, where `notifier$` is multicast, although there are many ways to compose this behavior.
 
-### bufferToggle
+#### bufferToggle
 
 - The observable returned by the `bufferToggle` operator's closing selector must emit a next notification to close the buffer. Complete notifications no longer close the buffer.
 
-### bufferWhen
+#### bufferWhen
 
 - The observable returned by the `bufferWhen` operator's closing selector must emit a next notification to close the buffer. Complete notifications no longer close the buffer.
 
-### combineLatest
+#### combineLatest
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### concat
+#### concat
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - Still deprecated, use the new `concatWith`.
 
-### concatAll
+#### concatAll
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### concatMapTo
+#### concatMapTo
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### count
+#### count
 
 - No longer passes `source` observable as a third argument to the predicate. That feature was rarely used, and of limited value. The workaround is to simply close over the source inside of the function if you need to access it in there.
 
-### debounce
+#### debounce
 
 - The observable returned by the `debounce` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
 
-### debounceTime
+#### debounceTime
 
 - The `debounceTime` implementation is more efficient and no longer schedules an action for each received next notification. However, because the implementation now uses the scheduler's concept of time, any tests using Jasmine's `clock` will need to ensure that [`jasmine.clock().mockDate()`](https://jasmine.github.io/api/edge/Clock.html#mockDate) is called after `jasmine.clock().install()` - because Jasmine does not mock `Date.now()` by default.
 
-### defaultIfEmpty
+#### defaultIfEmpty
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - `defaultIfEmpty` requires a value be passed. Will no longer convert `undefined` to `null` for no good reason.
 
-### delayWhen
+#### delayWhen
 
 - `delayWhen` will no longer emit if the duration selector simply completes without a value. Notifiers must notify with a value, not a completion.
 
-### endWith
+#### endWith
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### expand
+#### expand
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### finalize
+#### finalize
 
 - `finalize` will now unsubscribe from its source _before_ it calls its callback. That means that `finalize` callbacks will run in the order in which they occur in the pipeline: `source.pipe(finalize(() => console.log(1)), finalize(() => console.log(2)))` will log `1` and then `2`. Previously, callbacks were called in the reverse order.
 
-### map
+#### map
 
 - `thisArg` will now default to `undefined`. The previous default of `MapSubscriber` never made any sense. This will only affect code that calls map with a `function` and references `this` like so: `source.pipe(map(function () { console.log(this); }))`. There wasn't anything useful about doing this, so the breakage is expected to be very minimal. If anything we're no longer leaking an implementation detail.
 
-### merge
+#### merge
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - Still deprecated, use the new `mergeWith`.
 
-### mergeAll
+#### mergeAll
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### mergeScan
+#### mergeScan
 
 - `mergeScan` will no longer emit its inner state again upon completion.
 
-### pluck
+#### pluck
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### race
+#### race
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### reduce
+#### reduce
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### sample
+#### sample
 
 - The `sample` operator's notifier observable must emit a next notification to effect a sample. Complete notifications no longer effect a sample.
 
-### scan
+#### scan
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### single
+#### single
 
 - The `single` operator will now throw for scenarios where values coming in are either not present, or do not match the provided predicate. Error types have thrown have also been updated, please check documentation for changes.
 
-### skipLast
+#### skipLast
 
 - `skipLast` will no longer error when passed a negative number, rather it will simply return the source, as though `0` was passed.
 
-### startWith
+#### startWith
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### switchAll
+#### switchAll
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### switchMapTo
+#### switchMapTo
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### take
+#### take
 
 - `take` and will now throw runtime error for arguments that are negative or NaN, this includes non-TS calls like `take()`.
 
-### takeLast
+#### takeLast
 
 - `takeLast` now has runtime assertions that throw `TypeError`s for invalid arguments. Calling takeLast without arguments or with an argument that is `NaN` will throw a `TypeError`.
 
-### throttle
+#### throttle
 
 - The observable returned by the `throttle` operator's duration selector must emit a next notification to end the duration. Complete notifications no longer end the duration.
 
-### throwError
+#### throwError
 
 - In an extreme corner case for usage, `throwError` is no longer able to emit a function as an error directly. If you need to push a function as an error, you will have to use the factory function to return the function like so: `throwError(() => functionToEmit)`, in other words `throwError(() => () => console.log('called later'))`.
 
-### window
+#### window
 
 - The `windowBoundaries` observable no longer completes the result. It was only ever meant to notify of the window boundary. To get the same behavior as the old behavior, you would need to add an `endWith` and a `skipLast(1)` like so: `source$.pipe(window(notifier$.pipe(endWith(true))), skipLast(1))`.
 
-### windowToggle
+#### windowToggle
 
 - The observable returned by the `windowToggle` operator's closing selector must emit a next notification to close the window. Complete notifications no longer close the window.
 
-### withLatestFrom
+#### withLatestFrom
 
 - Generic signatures have changed. Do not explicitly pass generics.
 
-### zip
+#### zip
 
 - Generic signatures have changed. Do not explicitly pass generics.
 - Still deprecated, use the new `zipWith`.
 - `zip` operators will no longer iterate provided iterables "as needed", instead the iterables will be treated as push-streams just like they would be everywhere else in RxJS. This means that passing an endless iterable will result in the thread locking up, as it will endlessly try to read from that iterable. This puts us in-line with all other Rx implementations. To work around this, it is probably best to use `map` or some combination of `map` and `zip`. For example, `zip(source$, iterator)` could be `source$.pipe(map(value => [value, iterator.next().value]))`.
 
-## New Features
+### New Features
 
-### connect
+#### connect
 
 - New operator to cover the use cases of `publish` variants that use a `selector`. Wherein the selector allows the user to define multicast behavior prior to connection to the source observable for the multicast.
 
-### share
+#### share
 
 - Added functionality to allow complete configuration of what type of `Subject` is used to multicast, and when that subject is reset.
 
-### timeout
+#### timeout
 
 - Added more configuration options to `timeout`, so it could be used to timeout just if the first item doesn't arrive quickly enough, or it could be used as a timeout between each item. Users may also pass a `Date` object to define an absolute time for a timeout for the first time to arrive. Adds additional information to the timeout error, and the ability to pass along metadata with the timeout for identification purposes.
 
-### zipWith, concatWith, mergeWith, raceWith
+#### zipWith, concatWith, mergeWith, raceWith
 
 - Simply renamed versions of the operators `zip`, `concat`, `merge`, and `race`. So we can deprecate those old names and use the new names without collisions.
 
-# module `rxjs/ajax`
+## module `rxjs/ajax`
 
-## Breaking Changes
+### Breaking Changes
 
-### ajax
+#### ajax
 
 - `ajax` body serialization will now use default XHR behavior in all cases. If the body is a `Blob`, `ArrayBuffer`, any array buffer view (like a byte sequence, e.g. `Uint8Array`, etc), `FormData`, `URLSearchParams`, `string`, or `ReadableStream`, default handling is use. If the `body` is otherwise `typeof` `"object"`, then it will be converted to JSON via `JSON.stringify`, and the `Content-Type` header will be set to `application/json;charset=utf-8`. All other types will emit an error.
 - The `Content-Type` header passed to `ajax` configuration no longer has any effect on the serialization behavior of the AJAX request.
 - For TypeScript users, `AjaxRequest` is no longer the type that should be explicitly used to create an `ajax`. It is now `AjaxConfig`, although the two types are compatible, only `AjaxConfig` has `progressSubscriber` and `createXHR`.
 - Ajax implementation drops support for IE10 and lower. This puts us in-line with other implementations and helps clean up code in this area
 
-### AjaxRequest
+#### AjaxRequest
 
 - `AjaxRequest` is no longer used to type the configuration argument for calls to `ajax`. The new type is `AjaxConfig`. This was done to disambiguate two very similar types with different use cases. `AjaxRequest` is still there, but properties have changed, and it is used to show what final request information was send as part of an event response.
 
-## New Features
+### New Features
 
-### AjaxResponse
+#### AjaxResponse
 
 - Now includes `responseHeaders`.
 - Now includes event `type` and `total` numbers for examining upload and download progress (see `includeUploadProgress` and `includeDownloadProgress`).
 
-### includeUploadProgress
+#### includeUploadProgress
 
 - A flag to make a request that will include streaming upload progress events in the returned observable.
 
-### includeDownloadProgress
+#### includeDownloadProgress
 
 - A flag to make a request that will include streaming upload progress events in the returned observable.
 
-### queryParams
+#### queryParams
 
 - Configuration for setting query parameters in the URL of the request to be made.
 
-### XSRF (CSRF) additions:
+#### XSRF (CSRF) additions:
 
 - `xsrfCookieName` and `xsrfHeaderName` were added for cross-site request forgery prevention capabilities.
 
-# module `rxjs/fetch`
+## module `rxjs/fetch`
 
 No changes.
 
-# module `rxjs/testing`
+## module `rxjs/testing`
 
-## New Features
+### New Features
 
-### TestScheduler expectObservable().toEqual()
+#### TestScheduler expectObservable().toEqual()
 
 - A new means of comparing the equality of to observables. If all emissions are the same, and at the same time, then they are equal. This is primarily useful for refactoring operator chains and making sure that they are equivalent.

--- a/docs_app/content/deprecations/to-promise.md
+++ b/docs_app/content/deprecations/to-promise.md
@@ -4,7 +4,7 @@ The similarity between Observables and Promises is that both [collections](/guid
 time, but the difference is that Observables may produce none or more than one value, while Promises produce only one
 value when resolved successfully.
 
-# Issues
+## Issues
 
 For this reason, in RxJS 7, the return type of the Observable's [`toPromise()`](/api/index/class/Observable#toPromise)
 method has been fixed to better reflect the fact that Observables can yield zero values. This may be a **breaking
@@ -15,12 +15,12 @@ can produce multiple values over time. When converting to a Promise, you might w
 either the first value that has arrived or the last one. To fix all these issues, we decided to deprecate `toPromise()`,
 and to introduce the two new helper functions for conversion to Promises.
 
-# Use one of the two new functions
+## Use one of the two new functions
 
 As a replacement to the deprecated `toPromise()` method, you should use one of the two built in static conversion
 functions {@link firstValueFrom} or {@link lastValueFrom}.
 
-## `lastValueFrom`
+### `lastValueFrom`
 
 The `lastValueFrom` is almost exactly the same as `toPromise()` meaning that it will resolve with the last value that has
 arrived when the Observable completes, but with the difference in behavior when Observable completes without emitting a
@@ -28,7 +28,7 @@ single value. When Observable completes without emitting, `toPromise()` will suc
 the return type change), while the `lastValueFrom` will reject with the {@link EmptyError}. Thus, the return type of the
 `lastValueFrom` is `Promise<T>`, just like `toPromise()` had in RxJS 6.
 
-### Example
+#### Example
 
 ```ts
 import { interval, take, lastValueFrom } from 'rxjs';
@@ -45,14 +45,14 @@ execute();
 // "The final number is 9"
 ```
 
-## `firstValueFrom`
+### `firstValueFrom`
 
 However, you might want to take the first value as it arrives without waiting an Observable to complete, thus you can
 use `firstValueFrom`. The `firstValueFrom` will resolve a Promise with the first value that was emitted from the
 Observable and will immediately unsubscribe to retain resources. The `firstValueFrom` will also reject with an
 {@link EmptyError} if the Observable completes with no values emitted.
 
-### Example
+#### Example
 
 ```ts
 import { interval, firstValueFrom } from 'rxjs';
@@ -72,7 +72,7 @@ execute();
 <span class="informal">Both functions will return a Promise that rejects if the source Observable errors. The Promise
 will reject with the same error that the Observable has errored with.</span>
 
-# Use default value
+## Use default value
 
 If you don't want Promises created by `lastValueFrom` or `firstValueFrom` to reject with {@link EmptyError} if there
 were no emissions before completion, you can use the second parameter. The second parameter is expected to be an object
@@ -89,7 +89,7 @@ console.log(result);
 // 0
 ```
 
-# Warning
+## Warning
 
 Only use `lastValueFrom` function if you _know_ an Observable will eventually complete. The `firstValueFrom` function should
 be used if you _know_ an Observable will emit at least one value _or_ will eventually complete. If the source Observable

--- a/docs_app/content/guide/importing.md
+++ b/docs_app/content/guide/importing.md
@@ -8,7 +8,7 @@ the used RxJS version, but also depends on the used installation method.
 with RxJS version 6 where all pipeable operators could have been imported from `'rxjs/operators'`. For
 example, `import { map } from 'rxjs/operators'`.
 
-# New in RxJS v7.2.0
+## New in RxJS v7.2.0
 
 <span class="informal">**With RxJS v7.2.0, most operators have been moved to `{@link api#index 'rxjs'}`
 export site. This means that the preferred way to import operators is from `'rxjs'`, while
@@ -31,7 +31,7 @@ versions.
 
 Click {@link #how-to-migrate here to see} how to migrate.
 
-# Export sites
+## Export sites
 
 RxJS v7 exports 6 different locations out of which you can import what you need. Those are:
 
@@ -42,7 +42,7 @@ RxJS v7 exports 6 different locations out of which you can import what you need.
 - `{@link api#webSocket 'rxjs/webSocket'}` - for example: `import { webSocket } from 'rxjs/webSocket';`
 - `{@link api#testing 'rxjs/testing'}` - for example: `import { TestScheduler } from 'rxjs/testing';`
 
-## How to migrate?
+### How to migrate?
 
 While nothing has been removed from `'rxjs/operators'`, it is strongly recommended doing the operator
 imports from `'rxjs'`. Almost all operator function exports have been moved to `'rxjs'`, but only a
@@ -93,12 +93,12 @@ Depending on the preferred style, you can choose which one to follow, they are c
 Since a new way of importing operators is introduced with RxJS v7.2.0, instructions will be split to
 prior and after this version.
 
-## ES6 via npm
+### ES6 via npm
 
 If you've installed RxJS using {@link guide/installation#es6-via-npm ES6 via npm} and installed version
 is:
 
-### v7.2.0 or later
+#### v7.2.0 or later
 
 Import only what you need:
 
@@ -126,7 +126,7 @@ of(1, 2, 3).pipe(map((x) => x + '!!!')); // etc
 
 If you installed RxJS version:
 
-### v7.1.0 or older
+#### v7.1.0 or older
 
 Import only what you need:
 
@@ -155,12 +155,12 @@ const { map } = rxjs.operators;
 of(1, 2, 3).pipe(map((x) => x + '!!!')); // etc
 ```
 
-## CDN
+### CDN
 
 If you installed a library {@link guide/installation#cdn using CDN}, the global namespace for rxjs is
 `rxjs`.
 
-### v7.2.0 or later
+#### v7.2.0 or later
 
 ```js
 const { range, filter, map } = rxjs;
@@ -173,7 +173,7 @@ range(1, 200)
   .subscribe((x) => console.log(x));
 ```
 
-### v7.1.0 or older
+#### v7.1.0 or older
 
 ```js
 const { range } = rxjs;

--- a/docs_app/tools/transforms/angular-base-package/index.js
+++ b/docs_app/tools/transforms/angular-base-package/index.js
@@ -137,7 +137,7 @@ module.exports = new Package('angular-base', [
     postProcessHtml.plugins = [
       require('./post-processors/autolink-headings'),
       addImageDimensions,
-      // require('./post-processors/h1-checker'),
+      require('./post-processors/h1-checker'),
       autoLinkCode,
     ];
   })


### PR DESCRIPTION
**Description:**
This PR re-enables H1 checker post processor disabled in #6734 and fixes all issues with H1 headers by increasing every but first H1 to H2; every H2 to H3 and so on.

**Related issue (if exists):**
None.