### PR TITLE
fix: remove broken types reference in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,6 @@
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm5/index.js",
   "es2015": "./dist/esm/index.js",
-  "types": "index.d.ts",
   "typesVersions": {
     ">=4.2": {
       "*": [


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The `types` field in `package.json` references a type definition file that does not exist. This causes `eslint-plugin-import` to fail when it tries to resolve the reference: 

![image](https://user-images.githubusercontent.com/2001071/152250423-4d4dbce4-8984-4c4c-80db-b081ed982cf9.png)

`example.ts` looks like this:

```typescript
import { BehaviorSubject } from "rxjs";

const a = new BehaviorSubject(1);
console.log(a.getValue());
```

TypeScript successfully resolves the package, but `eslint-plugin-import` does not (I'm using the latest version of this package). Removing the broken `types` reference fixes the issue.
