### PR TITLE
refactor: add `createOperatorSubscriber` abstraction

### DIFF
--- a/src/internal/observable/ConnectableObservable.ts
+++ b/src/internal/observable/ConnectableObservable.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { Subscription } from '../Subscription';
 import { refCount as higherOrderRefCount } from '../operators/refCount';
-import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { createOperatorSubscriber } from '../operators/OperatorSubscriber';
 import { hasLift } from '../util/lift';
 
 /**
@@ -70,7 +70,7 @@ export class ConnectableObservable<T> extends Observable<T> {
       const subject = this.getSubject();
       connection.add(
         this.source.subscribe(
-          new OperatorSubscriber(
+          createOperatorSubscriber(
             subject as any,
             undefined,
             () => {

--- a/src/internal/observable/combineLatest.ts
+++ b/src/internal/observable/combineLatest.ts
@@ -8,7 +8,7 @@ import { Subscription } from '../Subscription';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { popResultSelector, popScheduler } from '../util/args';
 import { createObject } from '../util/createObject';
-import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { createOperatorSubscriber } from '../operators/OperatorSubscriber';
 import { AnyCatcher } from '../AnyCatcher';
 import { executeSchedule } from '../util/executeSchedule';
 
@@ -256,7 +256,7 @@ export function combineLatestInit(
               const source = from(observables[i], scheduler as any);
               let hasFirstValue = false;
               source.subscribe(
-                new OperatorSubscriber(
+                createOperatorSubscriber(
                   subscriber,
                   (value) => {
                     // When we get a value, record it in our set of values.

--- a/src/internal/observable/dom/fetch.ts
+++ b/src/internal/observable/dom/fetch.ts
@@ -1,4 +1,4 @@
-import { OperatorSubscriber } from '../../operators/OperatorSubscriber';
+import { createOperatorSubscriber } from '../../operators/OperatorSubscriber';
 import { Observable } from '../../Observable';
 import { innerFrom } from '../../observable/innerFrom';
 import { ObservableInput } from '../../types';
@@ -151,7 +151,7 @@ export function fromFetch<T>(
           // Note that any error that comes from our selector will be
           // sent to the promise `catch` below and handled.
           innerFrom(selector(response)).subscribe(
-            new OperatorSubscriber(
+            createOperatorSubscriber(
               subscriber,
               // Values are passed through to the subscriber
               undefined,

--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -3,7 +3,7 @@ import { ObservedValueOf, ObservableInputTuple, ObservableInput } from '../types
 import { argsArgArrayOrObject } from '../util/argsArgArrayOrObject';
 import { innerFrom } from './innerFrom';
 import { popResultSelector } from '../util/args';
-import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { createOperatorSubscriber } from '../operators/OperatorSubscriber';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { createObject } from '../util/createObject';
 import { AnyCatcher } from '../AnyCatcher';
@@ -159,7 +159,7 @@ export function forkJoin(...args: any[]): Observable<any> {
     for (let sourceIndex = 0; sourceIndex < length; sourceIndex++) {
       let hasValue = false;
       innerFrom(sources[sourceIndex]).subscribe(
-        new OperatorSubscriber(
+        createOperatorSubscriber(
           subscriber,
           (value) => {
             if (!hasValue) {

--- a/src/internal/observable/race.ts
+++ b/src/internal/observable/race.ts
@@ -3,7 +3,7 @@ import { innerFrom } from './innerFrom';
 import { Subscription } from '../Subscription';
 import { ObservableInput, ObservableInputTuple } from '../types';
 import { argsOrArgArray } from '../util/argsOrArgArray';
-import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { createOperatorSubscriber } from '../operators/OperatorSubscriber';
 import { Subscriber } from '../Subscriber';
 
 export function race<T extends readonly unknown[]>(inputs: [...ObservableInputTuple<T>]): Observable<T[number]>;
@@ -70,7 +70,7 @@ export function raceInit<T>(sources: ObservableInput<T>[]) {
     for (let i = 0; subscriptions && !subscriber.closed && i < sources.length; i++) {
       subscriptions.push(
         innerFrom(sources[i] as ObservableInput<T>).subscribe(
-          new OperatorSubscriber(subscriber, (value) => {
+          createOperatorSubscriber(subscriber, (value) => {
             if (subscriptions) {
               // We're still racing, but we won! So unsubscribe
               // all other subscriptions that we have, except this one.

--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -3,7 +3,7 @@ import { ObservableInputTuple } from '../types';
 import { innerFrom } from './innerFrom';
 import { argsOrArgArray } from '../util/argsOrArgArray';
 import { EMPTY } from './empty';
-import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { createOperatorSubscriber } from '../operators/OperatorSubscriber';
 import { popResultSelector } from '../util/args';
 
 export function zip<A extends readonly unknown[]>(sources: [...ObservableInputTuple<A>]): Observable<A>;
@@ -74,7 +74,7 @@ export function zip(...args: unknown[]): Observable<unknown> {
         // access the related buffers and completion properties
         for (let sourceIndex = 0; !subscriber.closed && sourceIndex < sources.length; sourceIndex++) {
           innerFrom(sources[sourceIndex]).subscribe(
-            new OperatorSubscriber(
+            createOperatorSubscriber(
               subscriber,
               (value) => {
                 buffers[sourceIndex].push(value);

--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -1,6 +1,28 @@
 import { Subscriber } from '../Subscriber';
 
 /**
+ * Creates an instance of an `OperatorSubscriber`.
+ * @param destination The downstream subscriber.
+ * @param onNext Handles next values, only called if this subscriber is not stopped or closed. Any
+ * error that occurs in this function is caught and sent to the `error` method of this subscriber.
+ * @param onError Handles errors from the subscription, any errors that occur in this handler are caught
+ * and send to the `destination` error handler.
+ * @param onComplete Handles completion notification from the subscription. Any errors that occur in
+ * this handler are sent to the `destination` error handler.
+ * @param onFinalize Additional teardown logic here. This will only be called on teardown if the
+ * subscriber itself is not already closed. This is called after all other teardown logic is executed.
+ */
+export function createOperatorSubscriber<T>(
+  destination: Subscriber<any>,
+  onNext?: (value: T) => void,
+  onComplete?: () => void,
+  onError?: (err: any) => void,
+  onFinalize?: () => void
+): Subscriber<T> {
+  return new OperatorSubscriber(destination, onNext, onComplete, onError, onFinalize);
+}
+
+/**
  * A generic helper for allowing operators to be created with a Subscriber and
  * use closures to capture necessary state from the operator function itself.
  */

--- a/src/internal/operators/audit.ts
+++ b/src/internal/operators/audit.ts
@@ -3,7 +3,7 @@ import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/innerFrom';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Ignores source values for a duration determined by another Observable, then
@@ -75,14 +75,14 @@ export function audit<T>(durationSelector: (value: T) => ObservableInput<any>): 
     };
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           hasValue = true;
           lastValue = value;
           if (!durationSubscriber) {
             innerFrom(durationSelector(value)).subscribe(
-              (durationSubscriber = new OperatorSubscriber(subscriber, endDuration, cleanupDuration))
+              (durationSubscriber = createOperatorSubscriber(subscriber, endDuration, cleanupDuration))
             );
           }
         },

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { noop } from '../util/noop';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Buffers the source Observable values until `closingNotifier` emits.
@@ -48,7 +48,7 @@ export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T,
 
     // Subscribe to our source.
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => currentBuffer.push(value),
         () => {
@@ -60,7 +60,7 @@ export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T,
 
     // Subscribe to the closing notifier.
     closingNotifier.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         () => {
           // Start a new buffer and emit the previous one.

--- a/src/internal/operators/bufferCount.ts
+++ b/src/internal/operators/bufferCount.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { arrRemove } from '../util/arrRemove';
 
 /**
@@ -64,7 +64,7 @@ export function bufferCount<T>(bufferSize: number, startBufferEvery: number | nu
     let count = 0;
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           let toEmit: T[][] | null = null;

--- a/src/internal/operators/bufferTime.ts
+++ b/src/internal/operators/bufferTime.ts
@@ -1,7 +1,7 @@
 import { Subscription } from '../Subscription';
 import { OperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { arrRemove } from '../util/arrRemove';
 import { asyncScheduler } from '../scheduler/async';
 import { popScheduler } from '../util/args';
@@ -131,7 +131,7 @@ export function bufferTime<T>(bufferTimeSpan: number, ...otherArgs: any[]): Oper
 
     startBuffer();
 
-    const bufferTimeSubscriber = new OperatorSubscriber(
+    const bufferTimeSubscriber = createOperatorSubscriber(
       subscriber,
       (value: T) => {
         // Copy the records, so if we need to remove one we

--- a/src/internal/operators/bufferToggle.ts
+++ b/src/internal/operators/bufferToggle.ts
@@ -2,7 +2,7 @@ import { Subscription } from '../Subscription';
 import { OperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/innerFrom';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 import { arrRemove } from '../util/arrRemove';
 
@@ -58,7 +58,7 @@ export function bufferToggle<T, O>(
 
     // Subscribe to the openings notifier first
     innerFrom(openings).subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (openValue) => {
           const buffer: T[] = [];
@@ -74,14 +74,14 @@ export function bufferToggle<T, O>(
           };
 
           // The line below will add the subscription to the parent subscriber *and* the closing subscription.
-          closingSubscription.add(innerFrom(closingSelector(openValue)).subscribe(new OperatorSubscriber(subscriber, emitBuffer, noop)));
+          closingSubscription.add(innerFrom(closingSelector(openValue)).subscribe(createOperatorSubscriber(subscriber, emitBuffer, noop)));
         },
         noop
       )
     );
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           // Value from our source. Add it to all pending buffers.

--- a/src/internal/operators/bufferWhen.ts
+++ b/src/internal/operators/bufferWhen.ts
@@ -2,7 +2,7 @@ import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { noop } from '../util/noop';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 
 /**
@@ -66,7 +66,7 @@ export function bufferWhen<T>(closingSelector: () => ObservableInput<any>): Oper
       b && subscriber.next(b);
 
       // Get a new closing notifier and subscribe to it.
-      innerFrom(closingSelector()).subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openBuffer, noop)));
+      innerFrom(closingSelector()).subscribe((closingSubscriber = createOperatorSubscriber(subscriber, openBuffer, noop)));
     };
 
     // Start the first buffer.
@@ -74,7 +74,7 @@ export function bufferWhen<T>(closingSelector: () => ObservableInput<any>): Oper
 
     // Subscribe to our source.
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         // Add every new value to the current buffer.
         (value) => buffer?.push(value),

--- a/src/internal/operators/catchError.ts
+++ b/src/internal/operators/catchError.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { Subscription } from '../Subscription';
 import { innerFrom } from '../observable/innerFrom';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { operate } from '../util/lift';
 
 /* tslint:disable:max-line-length */
@@ -113,7 +113,7 @@ export function catchError<T, O extends ObservableInput<any>>(
     let handledResult: Observable<ObservedValueOf<O>>;
 
     innerSub = source.subscribe(
-      new OperatorSubscriber(subscriber, undefined, undefined, (err) => {
+      createOperatorSubscriber(subscriber, undefined, undefined, (err) => {
         handledResult = innerFrom(selector(err, catchError(selector)(source)));
         if (innerSub) {
           innerSub.unsubscribe();

--- a/src/internal/operators/debounce.ts
+++ b/src/internal/operators/debounce.ts
@@ -2,7 +2,7 @@ import { Subscriber } from '../Subscriber';
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { noop } from '../util/noop';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 
 /**
@@ -86,7 +86,7 @@ export function debounce<T>(durationSelector: (value: T) => ObservableInput<any>
     };
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value: T) => {
           // Cancel any pending debounce duration. We don't
@@ -97,7 +97,7 @@ export function debounce<T>(durationSelector: (value: T) => ObservableInput<any>
           lastValue = value;
           // Capture our duration subscriber, so we can unsubscribe it when we're notified
           // and we're going to emit the value.
-          durationSubscriber = new OperatorSubscriber(subscriber, emit, noop);
+          durationSubscriber = createOperatorSubscriber(subscriber, emit, noop);
           // Subscribe to the duration.
           innerFrom(durationSelector(value)).subscribe(durationSubscriber);
         },

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -2,7 +2,7 @@ import { asyncScheduler } from '../scheduler/async';
 import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction, SchedulerAction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Emits a notification from the source Observable only after a particular time span
@@ -94,7 +94,7 @@ export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = asyn
     }
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value: T) => {
           lastValue = value;

--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Emits a given value if the source Observable completes without emitting any
@@ -41,7 +41,7 @@ export function defaultIfEmpty<T, R>(defaultValue: R): OperatorFunction<T, T | R
   return operate((source, subscriber) => {
     let hasValue = false;
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           hasValue = true;

--- a/src/internal/operators/dematerialize.ts
+++ b/src/internal/operators/dematerialize.ts
@@ -1,7 +1,7 @@
 import { observeNotification } from '../Notification';
 import { OperatorFunction, ObservableNotification, ValueFromNotification } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Converts an Observable of {@link ObservableNotification} objects into the emissions
@@ -53,6 +53,6 @@ import { OperatorSubscriber } from './OperatorSubscriber';
  */
 export function dematerialize<N extends ObservableNotification<any>>(): OperatorFunction<N, ValueFromNotification<N>> {
   return operate((source, subscriber) => {
-    source.subscribe(new OperatorSubscriber(subscriber, (notification) => observeNotification(notification, subscriber)));
+    source.subscribe(createOperatorSubscriber(subscriber, (notification) => observeNotification(notification, subscriber)));
   });
 }

--- a/src/internal/operators/distinct.ts
+++ b/src/internal/operators/distinct.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 
 /**
@@ -65,7 +65,7 @@ export function distinct<T, K>(keySelector?: (value: T) => K, flushes?: Observab
   return operate((source, subscriber) => {
     const distinctKeys = new Set();
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
+      createOperatorSubscriber(subscriber, (value) => {
         const key = keySelector ? keySelector(value) : value;
         if (!distinctKeys.has(key)) {
           distinctKeys.add(key);
@@ -74,6 +74,6 @@ export function distinct<T, K>(keySelector?: (value: T) => K, flushes?: Observab
       })
     );
 
-    flushes?.subscribe(new OperatorSubscriber(subscriber, () => distinctKeys.clear(), noop));
+    flushes?.subscribe(createOperatorSubscriber(subscriber, () => distinctKeys.clear(), noop));
   });
 }

--- a/src/internal/operators/distinctUntilChanged.ts
+++ b/src/internal/operators/distinctUntilChanged.ts
@@ -1,7 +1,7 @@
 import { MonoTypeOperatorFunction } from '../types';
 import { identity } from '../util/identity';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Returns a result {@link Observable} that emits all values pushed by the source observable if they
@@ -155,7 +155,7 @@ export function distinctUntilChanged<T, K>(
     let first = true;
 
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
+      createOperatorSubscriber(subscriber, (value) => {
         // We always call the key selector.
         const currentKey = keySelector(value);
 

--- a/src/internal/operators/every.ts
+++ b/src/internal/operators/every.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { Falsy, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function every<T>(predicate: BooleanConstructor): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
 /** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
@@ -48,7 +48,7 @@ export function every<T>(
   return operate((source, subscriber) => {
     let index = 0;
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           if (!predicate.call(thisArg, value, index++, source)) {

--- a/src/internal/operators/exhaustAll.ts
+++ b/src/internal/operators/exhaustAll.ts
@@ -2,7 +2,7 @@ import { Subscription } from '../Subscription';
 import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/innerFrom';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Converts a higher-order Observable into a first-order Observable by dropping
@@ -53,12 +53,12 @@ export function exhaustAll<O extends ObservableInput<any>>(): OperatorFunction<O
     let isComplete = false;
     let innerSub: Subscription | null = null;
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (inner) => {
           if (!innerSub) {
             innerSub = innerFrom(inner).subscribe(
-              new OperatorSubscriber(subscriber, undefined, () => {
+              createOperatorSubscriber(subscriber, undefined, () => {
                 innerSub = null;
                 isComplete && subscriber.complete();
               })

--- a/src/internal/operators/exhaustMap.ts
+++ b/src/internal/operators/exhaustMap.ts
@@ -4,7 +4,7 @@ import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { map } from './map';
 import { innerFrom } from '../observable/innerFrom';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /* tslint:disable:max-line-length */
 export function exhaustMap<T, O extends ObservableInput<any>>(
@@ -80,11 +80,11 @@ export function exhaustMap<T, R, O extends ObservableInput<any>>(
     let innerSub: Subscriber<T> | null = null;
     let isComplete = false;
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (outerValue) => {
           if (!innerSub) {
-            innerSub = new OperatorSubscriber(subscriber, undefined, () => {
+            innerSub = createOperatorSubscriber(subscriber, undefined, () => {
               innerSub = null;
               isComplete && subscriber.complete();
             });

--- a/src/internal/operators/filter.ts
+++ b/src/internal/operators/filter.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction, MonoTypeOperatorFunction, TruthyTypesOf } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
 export function filter<T, S extends T, A>(predicate: (this: A, value: T, index: number) => value is S, thisArg: A): OperatorFunction<T, S>;
@@ -69,7 +69,7 @@ export function filter<T>(predicate: (value: T, index: number) => boolean, thisA
       // Call the predicate with the appropriate `this` context,
       // if the predicate returns `true`, then send the value
       // to the consumer.
-      new OperatorSubscriber(subscriber, (value) => predicate.call(thisArg, value, index++) && subscriber.next(value))
+      createOperatorSubscriber(subscriber, (value) => predicate.call(thisArg, value, index++) && subscriber.next(value))
     );
   });
 }

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { OperatorFunction, TruthyTypesOf } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function find<T>(predicate: BooleanConstructor): OperatorFunction<T, TruthyTypesOf<T>>;
 /** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
@@ -78,7 +78,7 @@ export function createFind<T>(
   return (source: Observable<T>, subscriber: Subscriber<any>) => {
     let index = 0;
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           const i = index++;

--- a/src/internal/operators/groupBy.ts
+++ b/src/internal/operators/groupBy.ts
@@ -3,7 +3,7 @@ import { innerFrom } from '../observable/innerFrom';
 import { Subject } from '../Subject';
 import { ObservableInput, Observer, OperatorFunction, SubjectLike } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber, OperatorSubscriber } from './OperatorSubscriber';
 
 export interface BasicGroupByOptions<K, T> {
   element?: undefined;
@@ -193,7 +193,7 @@ export function groupBy<T, K, R>(
             subscriber.next(grouped);
 
             if (duration) {
-              const durationSubscriber = new OperatorSubscriber(
+              const durationSubscriber = createOperatorSubscriber(
                 // Providing the group here ensures that it is disposed of -- via `unsubscribe` --
                 // wnen the duration subscription is torn down. That is important, because then
                 // if someone holds a handle to the grouped observable and tries to subscribe to it

--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 
 /**
@@ -40,6 +40,6 @@ import { noop } from '../util/noop';
  */
 export function ignoreElements(): OperatorFunction<unknown, never> {
   return operate((source, subscriber) => {
-    source.subscribe(new OperatorSubscriber(subscriber, noop));
+    source.subscribe(createOperatorSubscriber(subscriber, noop));
   });
 }

--- a/src/internal/operators/isEmpty.ts
+++ b/src/internal/operators/isEmpty.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Emits `false` if the input Observable emits any values, or emits `true` if the
@@ -66,7 +66,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function isEmpty<T>(): OperatorFunction<T, boolean> {
   return operate((source, subscriber) => {
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         () => {
           subscriber.next(false);

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function map<T, R>(project: (value: T, index: number) => R): OperatorFunction<T, R>;
 /** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
@@ -52,7 +52,7 @@ export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any
     // Subscribe to the source, all errors and completions are sent along
     // to the consumer.
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value: T) => {
+      createOperatorSubscriber(subscriber, (value: T) => {
         // Call the projection function with the appropriate this context,
         // and send the resulting value to the consumer.
         subscriber.next(project.call(thisArg, value, index++));

--- a/src/internal/operators/materialize.ts
+++ b/src/internal/operators/materialize.ts
@@ -1,7 +1,7 @@
 import { Notification } from '../Notification';
 import { OperatorFunction, ObservableNotification } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Represents all of the notifications from the source Observable as `next`
@@ -54,7 +54,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function materialize<T>(): OperatorFunction<T, Notification<T> & ObservableNotification<T>> {
   return operate((source, subscriber) => {
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           subscriber.next(Notification.createNext(value));

--- a/src/internal/operators/mergeInternals.ts
+++ b/src/internal/operators/mergeInternals.ts
@@ -3,7 +3,7 @@ import { innerFrom } from '../observable/innerFrom';
 import { Subscriber } from '../Subscriber';
 import { ObservableInput, SchedulerLike } from '../types';
 import { executeSchedule } from '../util/executeSchedule';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * A process embodying the general "merge" strategy. This is used in
@@ -69,7 +69,7 @@ export function mergeInternals<T, R>(
 
     // Start our inner subscription.
     innerFrom(project(value, index++)).subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (innerValue) => {
           // `mergeScan` has additional handling here. For example
@@ -134,7 +134,7 @@ export function mergeInternals<T, R>(
 
   // Subscribe to our source observable.
   source.subscribe(
-    new OperatorSubscriber(subscriber, outerNext, () => {
+    createOperatorSubscriber(subscriber, outerNext, () => {
       // Outer completed, make a note of it, and check to see if we can complete everything.
       isComplete = true;
       checkComplete();

--- a/src/internal/operators/observeOn.ts
+++ b/src/internal/operators/observeOn.ts
@@ -2,7 +2,7 @@
 import { MonoTypeOperatorFunction, SchedulerLike } from '../types';
 import { executeSchedule } from '../util/executeSchedule';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Re-emits all notifications from source Observable with specified scheduler.
@@ -59,7 +59,7 @@ import { OperatorSubscriber } from './OperatorSubscriber';
 export function observeOn<T>(scheduler: SchedulerLike, delay = 0): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => executeSchedule(subscriber, scheduler, () => subscriber.next(value), delay),
         () => executeSchedule(subscriber, scheduler, () => subscriber.complete(), delay),

--- a/src/internal/operators/onErrorResumeNext.ts
+++ b/src/internal/operators/onErrorResumeNext.ts
@@ -3,7 +3,7 @@ import { ObservableInputTuple, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/innerFrom';
 import { argsOrArgArray } from '../util/argsOrArgArray';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 
 export function onErrorResumeNext<T, A extends readonly unknown[]>(
@@ -111,7 +111,7 @@ export function onErrorResumeNext<T, A extends readonly unknown[]>(
           // The `closed` property of upstream Subscribers synchronously, that
           // would result in situation were we could not stop a synchronous firehose
           // with something like `take(3)`.
-          const innerSub = new OperatorSubscriber(subscriber, undefined, noop, noop);
+          const innerSub = createOperatorSubscriber(subscriber, undefined, noop, noop);
           nextSource.subscribe(innerSub);
           innerSub.add(subscribeNext);
         } else {

--- a/src/internal/operators/pairwise.ts
+++ b/src/internal/operators/pairwise.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Groups pairs of consecutive emissions together and emits them as an array of
@@ -50,7 +50,7 @@ export function pairwise<T>(): OperatorFunction<T, [T, T]> {
     let prev: T;
     let hasPrev = false;
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
+      createOperatorSubscriber(subscriber, (value) => {
         const p = prev;
         prev = value;
         hasPrev && subscriber.next([p, value]);

--- a/src/internal/operators/refCount.ts
+++ b/src/internal/operators/refCount.ts
@@ -2,7 +2,7 @@ import { ConnectableObservable } from '../observable/ConnectableObservable';
 import { Subscription } from '../Subscription';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Make a {@link ConnectableObservable} behave like a ordinary observable and automates the way
@@ -68,7 +68,7 @@ export function refCount<T>(): MonoTypeOperatorFunction<T> {
 
     (source as any)._refCount++;
 
-    const refCounter = new OperatorSubscriber(subscriber, undefined, undefined, undefined, () => {
+    const refCounter = createOperatorSubscriber(subscriber, undefined, undefined, undefined, () => {
       if (!source || (source as any)._refCount <= 0 || 0 < --(source as any)._refCount) {
         connection = null;
         return;

--- a/src/internal/operators/repeat.ts
+++ b/src/internal/operators/repeat.ts
@@ -2,7 +2,7 @@ import { Subscription } from '../Subscription';
 import { EMPTY } from '../observable/empty';
 import { operate } from '../util/lift';
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 import { timer } from '../observable/timer';
 
@@ -136,7 +136,7 @@ export function repeat<T>(countOrConfig?: number | RepeatConfig): MonoTypeOperat
           sourceSub = null;
           if (delay != null) {
             const notifier = typeof delay === 'number' ? timer(delay) : innerFrom(delay(soFar));
-            const notifierSubscriber = new OperatorSubscriber(subscriber, () => {
+            const notifierSubscriber = createOperatorSubscriber(subscriber, () => {
               notifierSubscriber.unsubscribe();
               subscribeToSource();
             });
@@ -149,7 +149,7 @@ export function repeat<T>(countOrConfig?: number | RepeatConfig): MonoTypeOperat
         const subscribeToSource = () => {
           let syncUnsub = false;
           sourceSub = source.subscribe(
-            new OperatorSubscriber(subscriber, undefined, () => {
+            createOperatorSubscriber(subscriber, undefined, () => {
               if (++soFar < count) {
                 if (sourceSub) {
                   resubscribe();

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -4,7 +4,7 @@ import { Subscription } from '../Subscription';
 
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Returns an Observable that mirrors the source Observable with the exception of a `complete`. If the source
@@ -61,7 +61,7 @@ export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Obs
         // If the call to `notifier` throws, it will be caught by the OperatorSubscriber
         // In the main subscription -- in `subscribeForRepeatWhen`.
         notifier(completions$).subscribe(
-          new OperatorSubscriber(
+          createOperatorSubscriber(
             subscriber,
             () => {
               if (innerSub) {
@@ -88,7 +88,7 @@ export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Obs
       isMainComplete = false;
 
       innerSub = source.subscribe(
-        new OperatorSubscriber(subscriber, undefined, () => {
+        createOperatorSubscriber(subscriber, undefined, () => {
           isMainComplete = true;
           // Check to see if we are complete, and complete if so.
           // If we are not complete. Get the subject. This calls the `notifier` function.

--- a/src/internal/operators/retry.ts
+++ b/src/internal/operators/retry.ts
@@ -1,7 +1,7 @@
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { Subscription } from '../Subscription';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 import { timer } from '../observable/timer';
 import { innerFrom } from '../observable/innerFrom';
@@ -98,7 +98,7 @@ export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTy
         const subscribeForRetry = () => {
           let syncUnsub = false;
           innerSub = source.subscribe(
-            new OperatorSubscriber(
+            createOperatorSubscriber(
               subscriber,
               (value) => {
                 // If we're resetting on success
@@ -127,7 +127,7 @@ export function retry<T>(configOrCount: number | RetryConfig = Infinity): MonoTy
                     // They gave us a number, use a timer, otherwise, it's a function,
                     // and we're going to call it to get a notifier.
                     const notifier = typeof delay === 'number' ? timer(delay) : innerFrom(delay(err, soFar));
-                    const notifierSubscriber = new OperatorSubscriber(
+                    const notifierSubscriber = createOperatorSubscriber(
                       subscriber,
                       () => {
                         // After we get the first notification, we

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -4,7 +4,7 @@ import { Subscription } from '../Subscription';
 
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Returns an Observable that mirrors the source Observable with the exception of an `error`. If the source Observable
@@ -68,11 +68,11 @@ export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<a
 
     const subscribeForRetryWhen = () => {
       innerSub = source.subscribe(
-        new OperatorSubscriber(subscriber, undefined, undefined, (err) => {
+        createOperatorSubscriber(subscriber, undefined, undefined, (err) => {
           if (!errors$) {
             errors$ = new Subject();
             notifier(errors$).subscribe(
-              new OperatorSubscriber(subscriber, () =>
+              createOperatorSubscriber(subscriber, () =>
                 // If we have an innerSub, this was an asynchronous call, kick off the retry.
                 // Otherwise, if we don't have an innerSub yet, that's because the inner subscription
                 // call hasn't even returned yet. We've arrived here synchronously.

--- a/src/internal/operators/sample.ts
+++ b/src/internal/operators/sample.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { noop } from '../util/noop';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Emits the most recently emitted value from the source Observable whenever
@@ -49,13 +49,13 @@ export function sample<T>(notifier: Observable<any>): MonoTypeOperatorFunction<T
     let hasValue = false;
     let lastValue: T | null = null;
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
+      createOperatorSubscriber(subscriber, (value) => {
         hasValue = true;
         lastValue = value;
       })
     );
     notifier.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         () => {
           if (hasValue) {

--- a/src/internal/operators/scanInternals.ts
+++ b/src/internal/operators/scanInternals.ts
@@ -1,6 +1,6 @@
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * A basic scan operation. This is used for `scan` and `reduce`.
@@ -32,7 +32,7 @@ export function scanInternals<V, A, S>(
 
     // Subscribe to our source. All errors and completions are passed through.
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           // Always increment the index.

--- a/src/internal/operators/sequenceEqual.ts
+++ b/src/internal/operators/sequenceEqual.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Compares all values of two observables in sequence using an optional comparator function
@@ -81,7 +81,7 @@ export function sequenceEqual<T>(
      * is used for both streams.
      */
     const createSubscriber = (selfState: SequenceState<T>, otherState: SequenceState<T>) => {
-      const sequenceEqualSubscriber = new OperatorSubscriber(
+      const sequenceEqualSubscriber = createOperatorSubscriber(
         subscriber,
         (a: T) => {
           const { buffer, complete } = otherState;

--- a/src/internal/operators/single.ts
+++ b/src/internal/operators/single.ts
@@ -5,7 +5,7 @@ import { MonoTypeOperatorFunction, OperatorFunction, TruthyTypesOf } from '../ty
 import { SequenceError } from '../util/SequenceError';
 import { NotFoundError } from '../util/NotFoundError';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function single<T>(predicate: BooleanConstructor): OperatorFunction<T, TruthyTypesOf<T>>;
 export function single<T>(predicate?: (value: T, index: number, source: Observable<T>) => boolean): MonoTypeOperatorFunction<T>;
@@ -93,7 +93,7 @@ export function single<T>(predicate?: (value: T, index: number, source: Observab
     let seenValue = false;
     let index = 0;
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           seenValue = true;

--- a/src/internal/operators/skipLast.ts
+++ b/src/internal/operators/skipLast.ts
@@ -1,7 +1,7 @@
 import { MonoTypeOperatorFunction } from '../types';
 import { identity } from '../util/identity';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Skip a specified number of values before the completion of an observable.
@@ -58,7 +58,7 @@ export function skipLast<T>(skipCount: number): MonoTypeOperatorFunction<T> {
         // the index of the current value when it arrives.
         let seen = 0;
         source.subscribe(
-          new OperatorSubscriber(subscriber, (value) => {
+          createOperatorSubscriber(subscriber, (value) => {
             // Get the index of the value we have right now
             // relative to all other values we've seen, then
             // increment `seen`. This ensures we've moved to

--- a/src/internal/operators/skipUntil.ts
+++ b/src/internal/operators/skipUntil.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 import { noop } from '../util/noop';
 
@@ -51,7 +51,7 @@ export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunctio
   return operate((source, subscriber) => {
     let taking = false;
 
-    const skipSubscriber = new OperatorSubscriber(
+    const skipSubscriber = createOperatorSubscriber(
       subscriber,
       () => {
         skipSubscriber?.unsubscribe();
@@ -62,6 +62,6 @@ export function skipUntil<T>(notifier: Observable<any>): MonoTypeOperatorFunctio
 
     innerFrom(notifier).subscribe(skipSubscriber);
 
-    source.subscribe(new OperatorSubscriber(subscriber, (value) => taking && subscriber.next(value)));
+    source.subscribe(createOperatorSubscriber(subscriber, (value) => taking && subscriber.next(value)));
   });
 }

--- a/src/internal/operators/skipWhile.ts
+++ b/src/internal/operators/skipWhile.ts
@@ -1,6 +1,6 @@
 import { Falsy, MonoTypeOperatorFunction, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function skipWhile<T>(predicate: BooleanConstructor): OperatorFunction<T, Extract<T, Falsy> extends never ? never : T>;
 export function skipWhile<T>(predicate: (value: T, index: number) => true): OperatorFunction<T, never>;
@@ -54,7 +54,7 @@ export function skipWhile<T>(predicate: (value: T, index: number) => boolean): M
     let taking = false;
     let index = 0;
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => (taking || (taking = !predicate(value, index++))) && subscriber.next(value))
+      createOperatorSubscriber(subscriber, (value) => (taking || (taking = !predicate(value, index++))) && subscriber.next(value))
     );
   });
 }

--- a/src/internal/operators/switchMap.ts
+++ b/src/internal/operators/switchMap.ts
@@ -2,7 +2,7 @@ import { Subscriber } from '../Subscriber';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { innerFrom } from '../observable/innerFrom';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /* tslint:disable:max-line-length */
 export function switchMap<T, O extends ObservableInput<any>>(
@@ -98,7 +98,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
     const checkComplete = () => isComplete && !innerSubscriber && subscriber.complete();
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           // Cancel the previous inner subscription if there was one
@@ -107,7 +107,7 @@ export function switchMap<T, R, O extends ObservableInput<any>>(
           const outerIndex = index++;
           // Start the next inner subscription
           innerFrom(project(value, outerIndex)).subscribe(
-            (innerSubscriber = new OperatorSubscriber(
+            (innerSubscriber = createOperatorSubscriber(
               subscriber,
               // When we get a new inner value, next it through. Note that this is
               // handling the deprecate result selector here. This is because with this architecture

--- a/src/internal/operators/take.ts
+++ b/src/internal/operators/take.ts
@@ -1,7 +1,7 @@
 import { MonoTypeOperatorFunction } from '../types';
 import { EMPTY } from '../observable/empty';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Emits only the first `count` values emitted by the source Observable.
@@ -52,7 +52,7 @@ export function take<T>(count: number): MonoTypeOperatorFunction<T> {
     : operate((source, subscriber) => {
         let seen = 0;
         source.subscribe(
-          new OperatorSubscriber(subscriber, (value) => {
+          createOperatorSubscriber(subscriber, (value) => {
             // Increment the number of values we have seen,
             // then check it against the allowed count to see
             // if we are still letting values through.

--- a/src/internal/operators/takeLast.ts
+++ b/src/internal/operators/takeLast.ts
@@ -1,7 +1,7 @@
 import { EMPTY } from '../observable/empty';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Waits for the source to complete, then emits the last N values from the source,
@@ -52,7 +52,7 @@ export function takeLast<T>(count: number): MonoTypeOperatorFunction<T> {
         // any more values.
         let buffer: T[] = [];
         source.subscribe(
-          new OperatorSubscriber(
+          createOperatorSubscriber(
             subscriber,
             (value) => {
               // Add the most recent value onto the end of our buffer.

--- a/src/internal/operators/takeUntil.ts
+++ b/src/internal/operators/takeUntil.ts
@@ -1,6 +1,6 @@
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 import { noop } from '../util/noop';
 
@@ -45,7 +45,7 @@ import { noop } from '../util/noop';
  */
 export function takeUntil<T>(notifier: ObservableInput<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {
-    innerFrom(notifier).subscribe(new OperatorSubscriber(subscriber, () => subscriber.complete(), noop));
+    innerFrom(notifier).subscribe(createOperatorSubscriber(subscriber, () => subscriber.complete(), noop));
     !subscriber.closed && source.subscribe(subscriber);
   });
 }

--- a/src/internal/operators/takeWhile.ts
+++ b/src/internal/operators/takeWhile.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction, MonoTypeOperatorFunction, TruthyTypesOf } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function takeWhile<T>(predicate: BooleanConstructor, inclusive: true): MonoTypeOperatorFunction<T>;
 export function takeWhile<T>(predicate: BooleanConstructor, inclusive: false): OperatorFunction<T, TruthyTypesOf<T>>;
@@ -56,7 +56,7 @@ export function takeWhile<T>(predicate: (value: T, index: number) => boolean, in
   return operate((source, subscriber) => {
     let index = 0;
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
+      createOperatorSubscriber(subscriber, (value) => {
         const result = predicate(value, index++);
         (result || inclusive) && subscriber.next(value);
         !result && subscriber.complete();

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -1,7 +1,7 @@
 import { MonoTypeOperatorFunction, Observer } from '../types';
 import { isFunction } from '../util/isFunction';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { identity } from '../util/identity';
 
 export interface TapObserver<T> extends Observer<T> {
@@ -123,7 +123,7 @@ export function tap<T>(
         tapObserver.subscribe?.();
         let isUnsub = true;
         source.subscribe(
-          new OperatorSubscriber(
+          createOperatorSubscriber(
             subscriber,
             (value) => {
               tapObserver.next?.(value);

--- a/src/internal/operators/throttle.ts
+++ b/src/internal/operators/throttle.ts
@@ -2,7 +2,7 @@ import { Subscription } from '../Subscription';
 
 import { MonoTypeOperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 
 export interface ThrottleConfig {
@@ -87,7 +87,7 @@ export function throttle<T>(
     };
 
     const startThrottle = (value: T) =>
-      (throttled = innerFrom(durationSelector(value)).subscribe(new OperatorSubscriber(subscriber, endThrottling, cleanupThrottling)));
+      (throttled = innerFrom(durationSelector(value)).subscribe(createOperatorSubscriber(subscriber, endThrottling, cleanupThrottling)));
 
     const send = () => {
       if (hasValue) {
@@ -104,7 +104,7 @@ export function throttle<T>(
     };
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         // Regarding the presence of throttled.closed in the following
         // conditions, if a synchronous duration selector is specified - weird,

--- a/src/internal/operators/throwIfEmpty.ts
+++ b/src/internal/operators/throwIfEmpty.ts
@@ -1,7 +1,7 @@
 import { EmptyError } from '../util/EmptyError';
 import { MonoTypeOperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * If the source observable completes without emitting a value, it will emit
@@ -43,7 +43,7 @@ export function throwIfEmpty<T>(errorFactory: () => any = defaultErrorFactory): 
   return operate((source, subscriber) => {
     let hasValue = false;
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => {
           hasValue = true;

--- a/src/internal/operators/timeInterval.ts
+++ b/src/internal/operators/timeInterval.ts
@@ -1,7 +1,7 @@
 import { asyncScheduler } from '../scheduler/async';
 import { SchedulerLike, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Emits an object containing the current value, and the time that has
@@ -46,7 +46,7 @@ export function timeInterval<T>(scheduler: SchedulerLike = asyncScheduler): Oper
   return operate((source, subscriber) => {
     let last = scheduler.now();
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
+      createOperatorSubscriber(subscriber, (value) => {
         const now = scheduler.now();
         const interval = now - last;
         last = now;

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -6,7 +6,7 @@ import { operate } from '../util/lift';
 import { Observable } from '../Observable';
 import { innerFrom } from '../observable/innerFrom';
 import { createErrorClass } from '../util/createErrorClass';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { executeSchedule } from '../util/executeSchedule';
 
 export interface TimeoutConfig<T, O extends ObservableInput<unknown> = ObservableInput<T>, M = unknown> {
@@ -309,11 +309,13 @@ export function timeout<T, O extends ObservableInput<any>, M>(
   // we destructure that into what we're going to use, setting important defaults as we do.
   // NOTE: The default for `scheduler` will be the `scheduler` argument if it exists, or
   // it will default to the `asyncScheduler`.
-  const { first, each, with: _with = timeoutErrorFactory, scheduler = schedulerArg ?? asyncScheduler, meta = null! } = (isValidDate(config)
-    ? { first: config }
-    : typeof config === 'number'
-    ? { each: config }
-    : config) as TimeoutConfig<T, O, M>;
+  const {
+    first,
+    each,
+    with: _with = timeoutErrorFactory,
+    scheduler = schedulerArg ?? asyncScheduler,
+    meta = null!,
+  } = (isValidDate(config) ? { first: config } : typeof config === 'number' ? { each: config } : config) as TimeoutConfig<T, O, M>;
 
   if (first == null && each == null) {
     // Ensure timeout was provided at runtime.
@@ -359,7 +361,7 @@ export function timeout<T, O extends ObservableInput<any>, M>(
     };
 
     originalSourceSubscription = source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value: T) => {
           // clear the timer so we can emit and start another one.

--- a/src/internal/operators/window.ts
+++ b/src/internal/operators/window.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { OperatorFunction } from '../types';
 import { Subject } from '../Subject';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 
 /**
@@ -61,7 +61,7 @@ export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T
 
     // Subscribe to our source
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => windowSubject?.next(value),
         () => {
@@ -74,7 +74,7 @@ export function window<T>(windowBoundaries: Observable<any>): OperatorFunction<T
 
     // Subscribe to the window boundaries.
     windowBoundaries.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         () => {
           windowSubject.complete();

--- a/src/internal/operators/windowCount.ts
+++ b/src/internal/operators/windowCount.ts
@@ -2,7 +2,7 @@ import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 
 /**
  * Branch out the source Observable values as a nested Observable with each
@@ -78,7 +78,7 @@ export function windowCount<T>(windowSize: number, startWindowEvery: number = 0)
     subscriber.next(windows[0].asObservable());
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value: T) => {
           // Emit the value through all current windows.

--- a/src/internal/operators/windowTime.ts
+++ b/src/internal/operators/windowTime.ts
@@ -4,7 +4,7 @@ import { Observable } from '../Observable';
 import { Subscription } from '../Subscription';
 import { Observer, OperatorFunction, SchedulerLike } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { arrRemove } from '../util/arrRemove';
 import { popScheduler } from '../util/args';
 import { executeSchedule } from '../util/executeSchedule';
@@ -173,7 +173,7 @@ export function windowTime<T>(windowTimeSpan: number, ...otherArgs: any[]): Oper
     };
 
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value: T) => {
           // Notify all windows of the value.

--- a/src/internal/operators/windowToggle.ts
+++ b/src/internal/operators/windowToggle.ts
@@ -4,7 +4,7 @@ import { Subscription } from '../Subscription';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { innerFrom } from '../observable/innerFrom';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { noop } from '../util/noop';
 import { arrRemove } from '../util/arrRemove';
 
@@ -70,7 +70,7 @@ export function windowToggle<T, O>(
     };
 
     innerFrom(openings).subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (openValue) => {
           const window = new Subject<T>();
@@ -92,7 +92,7 @@ export function windowToggle<T, O>(
 
           subscriber.next(window.asObservable());
 
-          closingSubscription.add(closingNotifier.subscribe(new OperatorSubscriber(subscriber, closeWindow, noop, handleError)));
+          closingSubscription.add(closingNotifier.subscribe(createOperatorSubscriber(subscriber, closeWindow, noop, handleError)));
         },
         noop
       )
@@ -100,7 +100,7 @@ export function windowToggle<T, O>(
 
     // Subcribe to the source to get things started.
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value: T) => {
           // Copy the windows array before we emit to

--- a/src/internal/operators/windowWhen.ts
+++ b/src/internal/operators/windowWhen.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { Subject } from '../Subject';
 import { ObservableInput, OperatorFunction } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 
 /**
@@ -95,7 +95,7 @@ export function windowWhen<T>(closingSelector: () => ObservableInput<any>): Oper
       // to capture the subscriber (aka Subscription)
       // so we can clean it up when we close the window
       // and open a new one.
-      closingNotifier.subscribe((closingSubscriber = new OperatorSubscriber(subscriber, openWindow, openWindow, handleError)));
+      closingNotifier.subscribe((closingSubscriber = createOperatorSubscriber(subscriber, openWindow, openWindow, handleError)));
     };
 
     // Start the first window.
@@ -103,7 +103,7 @@ export function windowWhen<T>(closingSelector: () => ObservableInput<any>): Oper
 
     // Subscribe to the source
     source.subscribe(
-      new OperatorSubscriber(
+      createOperatorSubscriber(
         subscriber,
         (value) => window!.next(value),
         () => {

--- a/src/internal/operators/withLatestFrom.ts
+++ b/src/internal/operators/withLatestFrom.ts
@@ -1,6 +1,6 @@
 import { OperatorFunction, ObservableInputTuple } from '../types';
 import { operate } from '../util/lift';
-import { OperatorSubscriber } from './OperatorSubscriber';
+import { createOperatorSubscriber } from './OperatorSubscriber';
 import { innerFrom } from '../observable/innerFrom';
 import { identity } from '../util/identity';
 import { noop } from '../util/noop';
@@ -75,7 +75,7 @@ export function withLatestFrom<T, R>(...inputs: any[]): OperatorFunction<T, R | 
     // a side-effect.
     for (let i = 0; i < len; i++) {
       innerFrom(inputs[i]).subscribe(
-        new OperatorSubscriber(
+        createOperatorSubscriber(
           subscriber,
           (value) => {
             otherValues[i] = value;
@@ -98,7 +98,7 @@ export function withLatestFrom<T, R>(...inputs: any[]): OperatorFunction<T, R | 
 
     // Source subscription
     source.subscribe(
-      new OperatorSubscriber(subscriber, (value) => {
+      createOperatorSubscriber(subscriber, (value) => {
         if (ready) {
           // We have at least one value from the other sources. Go ahead and emit.
           const values = [value, ...otherValues];


### PR DESCRIPTION
Simply hides the creation of `new OperatorSubscriber` in a function called `createOperatorSubscriber`.

This is part of a larger plan to:

1. Productize our internal means of creating operators so other folks can use it. (this is just the first step, I do not plan on exposing `createOperatorSubscriber` at this time). The idea is to move away from using classes all over our operators for both minification reasons and because then later, when we productize things, we don't have to export classes that people will try to subclass.
2. Make it easier to refactor the class underpinning our operators by abstracting it away

NOTE: This does not attempt to change anything about the special case in `groupBy`, which will require some thought.

Related: #6803
