### PR TITLE
feat: Allow operators to operate on any Subscribable without lift

### DIFF
--- a/spec/operators/non-lifted-spec.ts
+++ b/spec/operators/non-lifted-spec.ts
@@ -1,0 +1,79 @@
+/** @prettier */
+import { expect } from 'chai';
+import { Observer, pipe, Subject, Unsubscribable, map, filter, take } from 'rxjs';
+
+/**
+ * An observable that does not have lift.
+ */
+class PrimitiveObservableFixture<T> {
+  subscriptionCount = 0;
+  unsubscriptionCount = 0;
+  private _subject = new Subject<T>();
+
+  next(value: T) {
+    this._subject.next(value);
+  }
+
+  error(error: any) {
+    this._subject.error(error);
+  }
+
+  complete() {
+    this._subject.complete();
+  }
+
+  subscribe(observer: Observer<T>): Unsubscribable {
+    this.subscriptionCount++;
+    const sub = this._subject.subscribe(observer);
+    return {
+      unsubscribe: () => {
+        sub.unsubscribe();
+        this.unsubscriptionCount++;
+      },
+    };
+  }
+}
+
+describe('operating on non-lifted observables', () => {
+  it('should work in a general sense', () => {
+    const source = new PrimitiveObservableFixture<number>();
+
+    const result = pipe(
+      filter((x: number) => x > 0),
+      map((x) => x + x),
+      take(3)
+    )(source);
+
+    const results: any[] = [];
+
+    const subs = result.subscribe({
+      next: (value) => results.push(value),
+      complete: () => {
+        results.push('done');
+      },
+    });
+
+    expect(source.subscriptionCount).to.equal(1);
+    expect(source.unsubscriptionCount).to.equal(0);
+
+    source.next(-1);
+    source.next(0);
+    expect(results).to.deep.equal([]);
+
+    source.next(1);
+    expect(results).to.deep.equal([2]);
+
+    source.next(2);
+    expect(results).to.deep.equal([2, 4]);
+
+    source.next(3);
+    expect(results).to.deep.equal([2, 4, 6, 'done']);
+    expect(source.unsubscriptionCount).to.equal(1);
+    expect(source.subscriptionCount).to.equal(1);
+
+    source.next(4);
+    expect(results).to.deep.equal([2, 4, 6, 'done']);
+
+    subs.unsubscribe();
+  });
+});

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -20,7 +20,7 @@ export interface UnaryFunction<T, R> {
   (source: T): R;
 }
 
-export interface OperatorFunction<T, R> extends UnaryFunction<Observable<T>, Observable<R>> {}
+export interface OperatorFunction<T, R> extends UnaryFunction<Subscribable<T>, Subscribable<R>> {}
 
 export type FactoryOrValue<T> = T | (() => T);
 


### PR DESCRIPTION
* Adds a code path for operating on a Subscribable without lift.
* Loosens the type of `OperatorFunction` and therefore `MonoTypeOperatorFunction` to go from `Subscribable<In>` to `Subscribable<Out>`.

This is done in preparation for splitting `Observable` into its own package, where `lift` doesn't really need to exist in the public API.

Related #6803 #6786

