### PR TITLE
fix(pkg): add `require` export condition

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,36 +17,43 @@
   "exports": {
     ".": {
       "node": "./dist/cjs/index.js",
+      "require": "./dist/cjs/index.js",
       "es2015": "./dist/esm/index.js",
       "default": "./dist/esm5/index.js"
     },
     "./ajax": {
       "node": "./dist/cjs/ajax/index.js",
+      "require": "./dist/cjs/ajax/index.js",
       "es2015": "./dist/esm/ajax/index.js",
       "default": "./dist/esm5/ajax/index.js"
     },
     "./fetch": {
       "node": "./dist/cjs/fetch/index.js",
+      "require": "./dist/cjs/fetch/index.js",
       "es2015": "./dist/esm/fetch/index.js",
       "default": "./dist/esm5/fetch/index.js"
     },
     "./operators": {
       "node": "./dist/cjs/operators/index.js",
+      "require": "./dist/cjs/operators/index.js",
       "es2015": "./dist/esm/operators/index.js",
       "default": "./dist/esm5/operators/index.js"
     },
     "./testing": {
       "node": "./dist/cjs/testing/index.js",
+      "require": "./dist/cjs/testing/index.js",
       "es2015": "./dist/esm/testing/index.js",
       "default": "./dist/esm5/testing/index.js"
     },
     "./webSocket": {
       "node": "./dist/cjs/webSocket/index.js",
+      "require": "./dist/cjs/webSocket/index.js",
       "es2015": "./dist/esm/webSocket/index.js",
       "default": "./dist/esm5/webSocket/index.js"
     },
     "./internal/*": {
       "node": "./dist/cjs/internal/*.js",
+      "require": "./dist/cjs/internal/*.js",
       "es2015": "./dist/esm/internal/*.js",
       "default": "./dist/esm5/internal/*.js"
     },


### PR DESCRIPTION
**Description:**

If using the upcoming `jest@28` with support for `exports` and running tests in JSDOM, this module will fail to load unless the user also uses ESM. The JSDOM env supplies `browser` condition, and either `import` or `require` (plus `default`). But since this module only has the `node` condition, it goes all the way to `default`, which is ESM, resulting in a syntax error.

Can probably just replace `node` with `require`, but that's possibly a breaking change for node users who use native ESM and the code is different in browsers vs a node env?

(I've never used rxjs, so I don't have the answer to the last question. I just noticed Jest's integration test with Angular failing after adding `exports` support 🙂)

**Related issue (if exists):**

N/A
