### PR TITLE
fix(debounceTime): handle synchronous schedulers

### DIFF
--- a/spec/operators/debounceTime-spec.ts
+++ b/spec/operators/debounceTime-spec.ts
@@ -1,6 +1,6 @@
 /** @prettier */
 import { expect } from 'chai';
-import { NEVER, of, Subject } from 'rxjs';
+import { NEVER, of, Subject, queueScheduler } from 'rxjs';
 import { AnimationFrameAction } from 'rxjs/internal/scheduler/AnimationFrameAction';
 import { AnimationFrameScheduler } from 'rxjs/internal/scheduler/AnimationFrameScheduler';
 import { debounceTime, mergeMap, startWith } from 'rxjs/operators';
@@ -239,5 +239,15 @@ describe('debounceTime', () => {
 
     expect(scheduler._scheduled).to.not.exist;
     expect(scheduler.actions).to.be.empty;
+  });
+
+  it('should work synchronously with queueScheduler', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const a = cold('a');
+      const expected = 'a';
+
+      const result = a.pipe(debounceTime(0, queueScheduler));
+      expectObservable(result).toBe(expected);
+    });
   });
 });

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -103,8 +103,7 @@ export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = asyn
           // Only set up a task if it's not already up
           if (!activeTask) {
             // Set activeTask as intermediary Subscription to handle synchronous schedulers
-            // https://github.com/ReactiveX/rxjs/pull/6826
-            subscriber.add(activeTask = new Subscription());
+            subscriber.add((activeTask = new Subscription()));
             activeTask.add(scheduler.schedule(emitWhenIdle, dueTime));
           }
         },

--- a/src/internal/operators/debounceTime.ts
+++ b/src/internal/operators/debounceTime.ts
@@ -67,11 +67,28 @@ export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = asyn
     let lastValue: T | null = null;
     let lastTime: number | null = null;
 
+    // Flags for managing state for synchronous schedulers
+    let possibleSynchronousEmitInProgress = false;
+    let activeTaskNeedsCleanup = false;
+
     const emit = () => {
+      // If we have a synchronous scheduler, scheduler.schedule() won't return
+      // before emit is called, so activeTask won't be set here even though we
+      // have a value ready to go. So we use some flags to maintain the same
+      // behavior between sync/async schedulers.
+      const shouldEmit = activeTask || possibleSynchronousEmitInProgress;
+
       if (activeTask) {
-        // We have a value! Free up memory first, then emit the value.
         activeTask.unsubscribe();
         activeTask = null;
+      }
+
+      if (possibleSynchronousEmitInProgress) {
+        possibleSynchronousEmitInProgress = false;
+        activeTaskNeedsCleanup = true;
+      }
+
+      if (shouldEmit) {
         const value = lastValue!;
         lastValue = null;
         subscriber.next(value);
@@ -102,8 +119,19 @@ export function debounceTime<T>(dueTime: number, scheduler: SchedulerLike = asyn
 
           // Only set up a task if it's not already up
           if (!activeTask) {
+            possibleSynchronousEmitInProgress = true;
             activeTask = scheduler.schedule(emitWhenIdle, dueTime);
-            subscriber.add(activeTask);
+            possibleSynchronousEmitInProgress = false;
+
+            // A synchronous scheduler may have already processed this task. If
+            // so the cleanup flag is set above so we know to do so immediately.
+            if (activeTaskNeedsCleanup) {
+              activeTaskNeedsCleanup = false;
+              activeTask.unsubscribe();
+              activeTask = null;
+            } else {
+              subscriber.add(activeTask);
+            }
           }
         },
         () => {


### PR DESCRIPTION
**Description:**

Using `debounceTime(0, queueScheduler)` was not emitting any values. `scheduler.schedule()` emits immediately but logic in `debounceTime` was expecting it to always return before emitting.

**Related issue (if exists):**

Fixes https://github.com/ReactiveX/rxjs/issues/6764
