### PR TITLE
docs: remove a link from keyword 'from' in code examples

### DIFF
--- a/docs_app/tools/transforms/angular-base-package/index.js
+++ b/docs_app/tools/transforms/angular-base-package/index.js
@@ -46,6 +46,7 @@ module.exports = new Package('angular-base', [
   .factory(require('./services/copyFolder'))
   .factory(require('./services/filterPipes'))
   .factory(require('./services/filterAmbiguousDirectiveAliases'))
+  .factory(require('./services/filterFromInImports'))
   .factory(require('./services/getImageDimensions'))
 
   .factory(require('./post-processors/add-image-dimensions'))
@@ -131,9 +132,10 @@ module.exports = new Package('angular-base', [
     computePathsProcessor.pathTemplates = [{ docTypes: ['example-region'], getOutputPath: function () {} }];
   })
 
-  .config(function (postProcessHtml, addImageDimensions, autoLinkCode, filterPipes, filterAmbiguousDirectiveAliases) {
+  .config(function (postProcessHtml, addImageDimensions, autoLinkCode, filterPipes, filterAmbiguousDirectiveAliases, filterFromInImports) {
     addImageDimensions.basePath = path.resolve(AIO_PATH, 'src');
     autoLinkCode.customFilters = [filterPipes, filterAmbiguousDirectiveAliases];
+    autoLinkCode.wordFilters = [filterFromInImports];
     postProcessHtml.plugins = [
       require('./post-processors/autolink-headings'),
       addImageDimensions,

--- a/docs_app/tools/transforms/angular-base-package/services/filterFromInImports.spec.js
+++ b/docs_app/tools/transforms/angular-base-package/services/filterFromInImports.spec.js
@@ -1,0 +1,22 @@
+const filterFromInImports = require('./filterFromInImports')();
+
+const words = ['import', ' { ', 'from', ' } ', 'from', ' \'', 'rxjs', '\';'];
+const words2 = [' } ', 'from', '(', 'of'];
+
+describe('filterFromInImports(word, index,  words)', () => {
+  it('should not filter the word, if the word is not "from"', () => {
+    expect(filterFromInImports(words, 0)).toEqual(false);
+  });
+
+  it('should not filter the word, if the word "from" is not positioned between } and \' signs', () => {
+    expect(filterFromInImports(words, 2)).toEqual(false);
+  });
+
+  it('should filter "from" when "from" is positioned between } and \' signs', () => {
+    expect(filterFromInImports(words, 4)).toEqual(true);
+  });
+
+  it('should not filter "from" when "from" is after } but not before \'', () => {
+    expect(filterFromInImports(words2, 1)).toEqual(false);
+  });
+});

--- a/docs_app/tools/transforms/angular-base-package/services/filterFromInImports.ts
+++ b/docs_app/tools/transforms/angular-base-package/services/filterFromInImports.ts
@@ -1,0 +1,21 @@
+/**
+ * This filter is filtering word 'from' in ES6 import statements.
+ * For example, next line:
+ *
+ * ```
+ * import { interval, from } from 'rxjs';
+ * ```
+ *
+ * will filter the second occurrence of the word 'from' leaving
+ * it without the link, but the first occurrence will remain
+ * unfiltered, thus it will get the link to
+ * /api/index/function/from
+ */
+module.exports = function filterFromInImports(): (words: string[], index: number) => boolean {
+  return (words: string[], index: number) => {
+    const previousWord = words[index - 1];
+    const nextWord = words[index + 1];
+
+    return words[index] === 'from' && /}/.test(previousWord) && /'/.test(nextWord);
+  };
+};


### PR DESCRIPTION
**Description:**
This PR adds a filter to [`autoLinkCode`](https://github.com/ReactiveX/rxjs/blob/4ba8f9a5845bfa76154f7dcebc73d688b3416afb/docs_app/tools/transforms/angular-base-package/post-processors/auto-link-code.js#L23) which is responsible for auto-detection of words inside code examples that have valid links. This filter can be used for multiple reasons. The first reason is to filter adding a link where not needed. For example, for this piece of code:

```
import { interval, from } from 'rxjs';
```

`autoLinkCode` will add links to both occurrences of the word "from". But, the second occurrence is not valid and should be skipped as this is the keyword. The newly added `filterFromInImports` filters such occurrences.

This is how it looked like before this fix:

![from included](https://user-images.githubusercontent.com/28087049/154027964-6443d22c-4531-455c-a74e-fcee6a310c63.gif)

This is how this looks like with this fix:

![from excluded](https://user-images.githubusercontent.com/28087049/154028059-cff51a3e-ee16-4874-8dd0-6408b6c7adaf.gif)

**Related issue (if exists):**
None