### PR TITLE
chore(race): convert race specs to run mode

### DIFF
--- a/spec/operators/race-legacy-spec.ts
+++ b/spec/operators/race-legacy-spec.ts
@@ -1,176 +1,210 @@
+/** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { EMPTY, NEVER, of, timer, defer, Observable, throwError } from 'rxjs';
 import { race, mergeMap, map, finalize, startWith } from 'rxjs/operators';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {race} */
 describe('race operator', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should race cold and cold', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race cold and cold and accept an Array of Observable argument', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = e1.pipe(race([e2]));
+      const result = e1.pipe(race([e2]));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race hot and hot', () => {
-    const e1 =   hot('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = hot('  ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race hot and cold', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = hot('  ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race 2nd and 1st', () => {
-    const e1 =  cold('------x-----y-----z----|');
-    const e1subs =   '^  !';
-    const e2 =  cold('---a-----b-----c----|');
-    const e2subs =   '^                   !';
-    const expected = '---a-----b-----c----|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ------x-----y-----z----|');
+      const e1subs = '  ^--!                    ';
+      const e2 = cold(' ---a-----b-----c----|   ');
+      const e2subs = '  ^-------------------!   ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race emit and complete', () => {
-    const e1 =  cold('-----|');
-    const e1subs =   '^    !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^    !';
-    const expected = '-----|';
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -----|                  ');
+      const e1subs = '  ^----!                  ';
+      const e2 = hot('  ------x-----y-----z----|');
+      const e2subs = '  ^----!                  ';
+      const expected = '-----|                  ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should allow unsubscribing early and explicitly', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^           !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b---';
-    const unsub =    '            !';
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const e1 = cold('---a-----b-----c----|   ');
+      const e1subs = ' ^-----------!           ';
+      const e2 = hot(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                   ';
+      const expected = '---a-----b---          ';
+      const unsub = '   ------------!          ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not break unsubscription chains when unsubscribed explicitly', () => {
-    const e1 =   hot('--a--^--b--c---d-| ');
-    const e1subs =        '^        !    ';
-    const e2 =   hot('---e-^---f--g---h-|');
-    const e2subs =        '^  !    ';
-    const expected =      '---b--c---    ';
-    const unsub =         '         !    ';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--^--b--c---d-| ');
+      const e1subs = '       ^--------!    ';
+      const e2 = hot('  ---e-^---f--g---h-|');
+      const e2subs = '       ^--!    ';
+      const expected = '     ---b--c---    ';
+      const unsub = '        ---------!    ';
 
-    const result = e1.pipe(
-      mergeMap((x: string) => of(x)),
-      race(e2),
-      mergeMap((x: string) => of(x))
-    );
+      const result = e1.pipe(
+        mergeMap((x: string) => of(x)),
+        race(e2),
+        mergeMap((x: string) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should never emit when given non emitting sources', () => {
-    const e1 =  cold('---|');
-    const e2 =  cold('---|');
-    const e1subs =   '^  !';
-    const expected = '---|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---|');
+      const e2 = cold(' ---|');
+      const e1subs = '  ^--!';
+      const expected = '---|';
 
-    const source = e1.pipe(race(e2));
+      const source = e1.pipe(race(e2));
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should throw when error occurs mid stream', () => {
-    const e1 =  cold('---a-----#');
-    const e1subs =   '^        !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----#              ');
+      const e1subs = '  ^--------!              ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----#              ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should throw when error occurs before a winner is found', () => {
-    const e1 =  cold('---#');
-    const e1subs =   '^  !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---#                    ');
+      const e1subs = '  ^--!                    ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---#                    ';
 
-    const result = e1.pipe(race(e2));
+      const result = e1.pipe(race(e2));
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should allow observable emits immediately', (done) => {
     const e1 = of(true);
-    const e2 = timer(200).pipe(map(_ => false));
+    const e2 = timer(200).pipe(map((_) => false));
 
-    e1.pipe(race(e2)).subscribe({ next: x => {
-      expect(x).to.be.true;
-    }, error: done, complete: done });
+    e1.pipe(race(e2)).subscribe({
+      next: (x) => {
+        expect(x).to.be.true;
+      },
+      error: done,
+      complete: done,
+    });
   });
 
   it('should ignore latter observables if a former one emits immediately', () => {
@@ -198,7 +232,7 @@ describe('race operator', () => {
   it('should ignore latter observables if a former one errors immediately', () => {
     const onError = sinon.spy();
     const onSubscribe = sinon.spy() as any;
-    const e1 = throwError(() => ('kaboom')); // Wins the race
+    const e1 = throwError(() => 'kaboom'); // Wins the race
     const e2 = defer(onSubscribe); // Should be ignored
 
     e1.pipe(race(e2)).subscribe({ error: onError });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `race` operator tests to run mode.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None