### PR TITLE
chore(publish): convert publish specs to run mode

### DIFF
--- a/spec/operators/publish-spec.ts
+++ b/spec/operators/publish-spec.ts
@@ -1,230 +1,258 @@
+/** @prettier */
 import { expect } from 'chai';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { publish, zip, mergeMapTo, mergeMap, tap, refCount, retry, repeat } from 'rxjs/operators';
 import { ConnectableObservable, of, Subscription, Observable, pipe } from 'rxjs';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {publish} */
 describe('publish operator', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should mirror a simple source Observable', () => {
-    const source = cold('--1-2---3-4--5-|');
-    const sourceSubs =  '^              !';
-    const published = source.pipe(publish()) as ConnectableObservable<any>;
-    const expected =    '--1-2---3-4--5-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2---3-4--5-|');
+      const sourceSubs = ' ^--------------!';
+      const published = source.pipe(publish()) as ConnectableObservable<any>;
+      const expected = '   --1-2---3-4--5-|';
 
-    expectObservable(published).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(published).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    published.connect();
+      published.connect();
+    });
   });
 
   it('should return a ConnectableObservable-ish', () => {
     const source = of(1).pipe(publish()) as ConnectableObservable<number>;
-    expect(typeof (<any> source)._subscribe === 'function').to.be.true;
-    expect(typeof (<any> source).getSubject === 'function').to.be.true;
+    expect(typeof (<any>source)._subscribe === 'function').to.be.true;
+    expect(typeof (<any>source).getSubject === 'function').to.be.true;
     expect(typeof source.connect === 'function').to.be.true;
     expect(typeof source.refCount === 'function').to.be.true;
   });
 
   it('should do nothing if connect is not called, despite subscriptions', () => {
-    const source = cold('--1-2---3-4--5-|');
-    const sourceSubs: string[] = [];
-    const published = source.pipe(publish());
-    const expected =    '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('--1-2---3-4--5-|');
+      const sourceSubs: string[] = [];
+      const published = source.pipe(publish());
+      const expected = '   -               ';
 
-    expectObservable(published).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(published).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should multicast the same values to multiple observers', () => {
-    const source =     cold('-1-2-3----4-|');
-    const sourceSubs =      '^           !';
-    const published = source.pipe(publish()) as ConnectableObservable<string>;
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
-    const expected1   =     '-1-2-3----4-|';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
-    const expected2   =     '    -3----4-|';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
-    const expected3   =     '        --4-|';
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const source = cold('   -1-2-3----4-|');
+      const sourceSubs = '    ^-----------!';
+      const published = source.pipe(publish()) as ConnectableObservable<string>;
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
+      const expected1 = '      -1-2-3----4-|';
+      const subscriber2 = hot('----b|       ').pipe(mergeMapTo(published));
+      const expected2 = '      -----3----4-|';
+      const subscriber3 = hot('--------c|   ').pipe(mergeMapTo(published));
+      const expected3 = '      ----------4-|';
 
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    published.connect();
+      published.connect();
+    });
   });
 
   it('should accept selectors', () => {
-    const source =     hot('-1-2-3----4-|');
-    const sourceSubs =     ['^           !',
-                            '    ^       !',
-                            '        ^   !'];
-    const published = source.pipe(publish(x => x.pipe(zip(x, (a, b) => (parseInt(a) + parseInt(b)).toString()))));
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
-    const expected1   =     '-2-4-6----8-|';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
-    const expected2   =     '    -6----8-|';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
-    const expected3   =     '        --8-|';
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('     -1-2-3----4-|');
+      const sourceSubs = [
+        '                      ^-----------!',
+        '                      ----^-------!',
+        '                      --------^---!',
+      ];
+      const published = source.pipe(publish((x) => x.pipe(zip(x, (a, b) => (parseInt(a) + parseInt(b)).toString()))));
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
+      const expected1 = '      -2-4-6----8-|';
+      const subscriber2 = hot('----b|       ').pipe(mergeMapTo(published));
+      const expected2 = '      -----6----8-|';
+      const subscriber3 = hot('--------c|   ').pipe(mergeMapTo(published));
+      const expected3 = '      ----------8-|';
 
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+    });
   });
 
   it('should multicast an error from the source to multiple observers', () => {
-    const source =     cold('-1-2-3----4-#');
-    const sourceSubs =      '^           !';
-    const published = source.pipe(publish()) as ConnectableObservable<string>;
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
-    const expected1   =     '-1-2-3----4-#';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
-    const expected2   =     '    -3----4-#';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
-    const expected3   =     '        --4-#';
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const source = cold('    -1-2-3----4-#');
+      const sourceSubs = '     ^-----------!';
+      const published = source.pipe(publish()) as ConnectableObservable<string>;
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
+      const expected1 = '      -1-2-3----4-#';
+      const subscriber2 = hot('----b|       ').pipe(mergeMapTo(published));
+      const expected2 = '      -----3----4-#';
+      const subscriber3 = hot('--------c|   ').pipe(mergeMapTo(published));
+      const expected3 = '      ----------4-#';
 
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    published.connect();
+      published.connect();
+    });
   });
 
-  it('should multicast the same values to multiple observers, ' +
-  'but is unsubscribed explicitly and early', () => {
-    const source =     cold('-1-2-3----4-|');
-    const sourceSubs =      '^        !   ';
-    const published = source.pipe(publish()) as ConnectableObservable<string>;
-    const unsub =           '         u   ';
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
-    const expected1   =     '-1-2-3----   ';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
-    const expected2   =     '    -3----   ';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
-    const expected3   =     '        --   ';
+  it('should multicast the same values to multiple observers, but is unsubscribed explicitly and early', () => {
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const source = cold('    -1-2-3----4-|');
+      const sourceSubs = '     ^--------!   ';
+      const published = source.pipe(publish()) as ConnectableObservable<string>;
+      const unsub = '          ---------u   ';
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
+      const expected1 = '      -1-2-3----   ';
+      const subscriber2 = hot('----b|       ').pipe(mergeMapTo(published));
+      const expected2 = '      -----3----   ';
+      const subscriber3 = hot('--------c|   ').pipe(mergeMapTo(published));
+      const expected3 = '      ----------   ';
 
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    // Set up unsubscription action
-    let connection: Subscription;
-    expectObservable(hot(unsub).pipe(tap(() => {
-      connection.unsubscribe();
-    }))).toBe(unsub);
+      // Set up unsubscription action
+      let connection: Subscription;
+      expectObservable(
+        hot(unsub).pipe(
+          tap(() => {
+            connection.unsubscribe();
+          })
+        )
+      ).toBe(unsub);
 
-    connection = published.connect();
+      connection = published.connect();
+    });
   });
 
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
-    const source =     cold('-1-2-3----4-|');
-    const sourceSubs =      '^        !   ';
-    const published = source.pipe(
-      mergeMap((x) => of(x)),
-      publish()
-    ) as ConnectableObservable<any>;
-    const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
-    const expected1   =     '-1-2-3----   ';
-    const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
-    const expected2   =     '    -3----   ';
-    const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
-    const expected3   =     '        --   ';
-    const unsub =           '         u   ';
+    testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+      const source = cold('    -1-2-3----4-|');
+      const sourceSubs = '     ^--------!   ';
+      const published = source.pipe(
+        mergeMap((x) => of(x)),
+        publish()
+      ) as ConnectableObservable<any>;
+      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
+      const expected1 = '      -1-2-3----   ';
+      const subscriber2 = hot('----b|       ').pipe(mergeMapTo(published));
+      const expected2 = '      -----3----   ';
+      const subscriber3 = hot('--------c|   ').pipe(mergeMapTo(published));
+      const expected3 = '      ----------   ';
+      const unsub = '          ---------u   ';
 
-    expectObservable(subscriber1).toBe(expected1);
-    expectObservable(subscriber2).toBe(expected2);
-    expectObservable(subscriber3).toBe(expected3);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(subscriber1).toBe(expected1);
+      expectObservable(subscriber2).toBe(expected2);
+      expectObservable(subscriber3).toBe(expected3);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    // Set up unsubscription action
-    let connection: Subscription;
-    expectObservable(hot(unsub).pipe(tap(() => {
-      connection.unsubscribe();
-    }))).toBe(unsub);
+      // Set up unsubscription action
+      let connection: Subscription;
+      expectObservable(
+        hot(unsub).pipe(
+          tap(() => {
+            connection.unsubscribe();
+          })
+        )
+      ).toBe(unsub);
 
-    connection = published.connect();
+      connection = published.connect();
+    });
   });
 
   describe('with refCount()', () => {
     it('should connect when first subscriber subscribes', () => {
-      const source =     cold(   '-1-2-3----4-|');
-      const sourceSubs =      '   ^           !';
-      const replayed = source.pipe(
-        publish(),
-        refCount()
-      );
-      const subscriber1 = hot('   a|           ').pipe(mergeMapTo(replayed));
-      const expected1   =     '   -1-2-3----4-|';
-      const subscriber2 = hot('       b|       ').pipe(mergeMapTo(replayed));
-      const expected2   =     '       -3----4-|';
-      const subscriber3 = hot('           c|   ').pipe(mergeMapTo(replayed));
-      const expected3   =     '           --4-|';
+      testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+        const source = cold('       -1-2-3----4-|');
+        const sourceSubs = '     ---^-----------!';
+        const replayed = source.pipe(publish(), refCount());
+        const subscriber1 = hot('---a|           ').pipe(mergeMapTo(replayed));
+        const expected1 = '      ----1-2-3----4-|';
+        const subscriber2 = hot('-------b|       ').pipe(mergeMapTo(replayed));
+        const expected2 = '      --------3----4-|';
+        const subscriber3 = hot('-----------c|   ').pipe(mergeMapTo(replayed));
+        const expected3 = '      -------------4-|';
 
-      expectObservable(subscriber1).toBe(expected1);
-      expectObservable(subscriber2).toBe(expected2);
-      expectObservable(subscriber3).toBe(expected3);
-      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+        expectObservable(subscriber1).toBe(expected1);
+        expectObservable(subscriber2).toBe(expected2);
+        expectObservable(subscriber3).toBe(expected3);
+        expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      });
     });
 
     it('should disconnect when last subscriber unsubscribes', () => {
-      const source =     cold(   '-1-2-3----4-|');
-      const sourceSubs =      '   ^        !   ';
-      const replayed = source.pipe(publish(), refCount());
-      const subscriber1 = hot('   a|           ').pipe(mergeMapTo(replayed));
-      const unsub1 =          '          !     ';
-      const expected1   =     '   -1-2-3--     ';
-      const subscriber2 = hot('       b|       ').pipe(mergeMapTo(replayed));
-      const unsub2 =          '            !   ';
-      const expected2   =     '       -3----   ';
+      testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+        const source = cold('       -1-2-3----4-|');
+        const sourceSubs = '     ---^--------!   ';
+        const replayed = source.pipe(publish(), refCount());
+        const subscriber1 = hot('---a|           ').pipe(mergeMapTo(replayed));
+        const unsub1 = '         ----------!     ';
+        const expected1 = '      ----1-2-3--     ';
+        const subscriber2 = hot('-------b|       ').pipe(mergeMapTo(replayed));
+        const unsub2 = '         ------------!   ';
+        const expected2 = '      --------3----   ';
 
-      expectObservable(subscriber1, unsub1).toBe(expected1);
-      expectObservable(subscriber2, unsub2).toBe(expected2);
-      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+        expectObservable(subscriber1, unsub1).toBe(expected1);
+        expectObservable(subscriber2, unsub2).toBe(expected2);
+        expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      });
     });
 
     it('should NOT be retryable', () => {
-      const source =     cold('-1-2-3----4-#');
-      const sourceSubs =      '^           !';
-      const published = source.pipe(
-        publish(),
-        refCount(),
-        retry(3)
-      );
-      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
-      const expected1   =     '-1-2-3----4-#';
-      const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
-      const expected2   =     '    -3----4-#';
-      const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
-      const expected3   =     '        --4-#';
+      testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+        const source = cold('   -1-2-3----4-#');
+        const sourceSubs = '    ^-----------!';
+        const published = source.pipe(publish(), refCount(), retry(3));
+        const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
+        const expected1 = '      -1-2-3----4-#';
+        const subscriber2 = hot('----b|       ').pipe(mergeMapTo(published));
+        const expected2 = '      -----3----4-#';
+        const subscriber3 = hot('--------c|   ').pipe(mergeMapTo(published));
+        const expected3 = '      ----------4-#';
 
-      expectObservable(subscriber1).toBe(expected1);
-      expectObservable(subscriber2).toBe(expected2);
-      expectObservable(subscriber3).toBe(expected3);
-      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+        expectObservable(subscriber1).toBe(expected1);
+        expectObservable(subscriber2).toBe(expected2);
+        expectObservable(subscriber3).toBe(expected3);
+        expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      });
     });
 
     it('should NOT be repeatable', () => {
-      const source =     cold('-1-2-3----4-|');
-      const sourceSubs =      '^           !';
-      const published = source.pipe(
-        publish(),
-        refCount(),
-        repeat(3)
-      );
-      const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
-      const expected1   =     '-1-2-3----4-|';
-      const subscriber2 = hot('    b|       ').pipe(mergeMapTo(published));
-      const expected2   =     '    -3----4-|';
-      const subscriber3 = hot('        c|   ').pipe(mergeMapTo(published));
-      const expected3   =     '        --4-|';
+      testScheduler.run(({ cold, hot, expectObservable, expectSubscriptions }) => {
+        const source = cold('    -1-2-3----4-|');
+        const sourceSubs = '     ^-----------!';
+        const published = source.pipe(publish(), refCount(), repeat(3));
+        const subscriber1 = hot('a|           ').pipe(mergeMapTo(published));
+        const expected1 = '      -1-2-3----4-|';
+        const subscriber2 = hot('----b|       ').pipe(mergeMapTo(published));
+        const expected2 = '      -----3----4-|';
+        const subscriber3 = hot('--------c|   ').pipe(mergeMapTo(published));
+        const expected3 = '      ----------4-|';
 
-      expectObservable(subscriber1).toBe(expected1);
-      expectObservable(subscriber2).toBe(expected2);
-      expectObservable(subscriber3).toBe(expected3);
-      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+        expectObservable(subscriber1).toBe(expected1);
+        expectObservable(subscriber2).toBe(expected2);
+        expectObservable(subscriber3).toBe(expected3);
+        expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      });
     });
   });
 
@@ -257,50 +285,60 @@ describe('publish operator', () => {
     expect(results2).to.deep.equal([]);
     expect(subscriptions).to.equal(1);
 
-    connectable.subscribe({ next: (x) => {
-      results2.push(x);
-    }, error: (x) => {
-      done(new Error('should not be called'));
-    }, complete: () => {
-      expect(results2).to.deep.equal([]);
-      done();
-    } });
+    connectable.subscribe({
+      next: (x) => {
+        results2.push(x);
+      },
+      error: (x) => {
+        done(new Error('should not be called'));
+      },
+      complete: () => {
+        expect(results2).to.deep.equal([]);
+        done();
+      },
+    });
   });
 
   it('should multicast an empty source', () => {
-    const source = cold('|');
-    const sourceSubs =  '(^!)';
-    const published = source.pipe(publish()) as ConnectableObservable<string>;
-    const expected =    '|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('|   ');
+      const sourceSubs = ' (^!)';
+      const published = source.pipe(publish()) as ConnectableObservable<string>;
+      const expected = '   |   ';
 
-    expectObservable(published).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(published).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    published.connect();
+      published.connect();
+    });
   });
 
   it('should multicast a never source', () => {
-    const source = cold('-');
-    const sourceSubs =  '^';
-    const published = source.pipe(publish()) as ConnectableObservable<string>;
-    const expected =    '-';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('-');
+      const sourceSubs = ' ^';
+      const published = source.pipe(publish()) as ConnectableObservable<string>;
+      const expected = '   -';
 
-    expectObservable(published).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(published).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    published.connect();
+      published.connect();
+    });
   });
 
   it('should multicast a throw source', () => {
-    const source = cold('#');
-    const sourceSubs =  '(^!)';
-    const published = source.pipe(publish()) as ConnectableObservable<string>;
-    const expected =    '#';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source = cold('#   ');
+      const sourceSubs = ' (^!)';
+      const published = source.pipe(publish()) as ConnectableObservable<string>;
+      const expected = '   #   ';
 
-    expectObservable(published).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(sourceSubs);
+      expectObservable(published).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(sourceSubs);
 
-    published.connect();
+      published.connect();
+    });
   });
 
   it('should multicast one observable to multiple observers', (done) => {
@@ -339,29 +377,29 @@ describe('publish operator', () => {
   });
 
   it('should be referentially-transparent', () => {
-    const source1 = cold('-1-2-3-4-5-|');
-    const source1Subs =  '^          !';
-    const expected1 =    '-1-2-3-4-5-|';
-    const source2 = cold('-6-7-8-9-0-|');
-    const source2Subs =  '^          !';
-    const expected2 =    '-6-7-8-9-0-|';
+    testScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const source1 = cold('-1-2-3-4-5-|');
+      const source1Subs = ' ^----------!';
+      const expected1 = '   -1-2-3-4-5-|';
+      const source2 = cold('-6-7-8-9-0-|');
+      const source2Subs = ' ^----------!';
+      const expected2 = '   -6-7-8-9-0-|';
 
-    // Calls to the _operator_ must be referentially-transparent.
-    const partialPipeLine = pipe(
-      publish()
-    );
+      // Calls to the _operator_ must be referentially-transparent.
+      const partialPipeLine = pipe(publish());
 
-    // The non-referentially-transparent publishing occurs within the _operator function_
-    // returned by the _operator_ and that happens when the complete pipeline is composed.
-    const published1 = source1.pipe(partialPipeLine) as ConnectableObservable<any>;
-    const published2 = source2.pipe(partialPipeLine) as ConnectableObservable<any>;
+      // The non-referentially-transparent publishing occurs within the _operator function_
+      // returned by the _operator_ and that happens when the complete pipeline is composed.
+      const published1 = source1.pipe(partialPipeLine) as ConnectableObservable<any>;
+      const published2 = source2.pipe(partialPipeLine) as ConnectableObservable<any>;
 
-    expectObservable(published1).toBe(expected1);
-    expectSubscriptions(source1.subscriptions).toBe(source1Subs);
-    expectObservable(published2).toBe(expected2);
-    expectSubscriptions(source2.subscriptions).toBe(source2Subs);
+      expectObservable(published1).toBe(expected1);
+      expectSubscriptions(source1.subscriptions).toBe(source1Subs);
+      expectObservable(published2).toBe(expected2);
+      expectSubscriptions(source2.subscriptions).toBe(source2Subs);
 
-    published1.connect();
-    published2.connect();
+      published1.connect();
+      published2.connect();
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `publish` operator tests to run mode.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None