### PR TITLE
docs: remove a link from keyword 'never' in code examples

### DIFF
--- a/docs_app/tools/transforms/angular-base-package/index.js
+++ b/docs_app/tools/transforms/angular-base-package/index.js
@@ -47,6 +47,7 @@ module.exports = new Package('angular-base', [
   .factory(require('./services/filterPipes'))
   .factory(require('./services/filterAmbiguousDirectiveAliases'))
   .factory(require('./services/filterFromInImports'))
+  .factory(require('./services/filterNeverAsGeneric'))
   .factory(require('./services/getImageDimensions'))
 
   .factory(require('./post-processors/add-image-dimensions'))
@@ -132,10 +133,10 @@ module.exports = new Package('angular-base', [
     computePathsProcessor.pathTemplates = [{ docTypes: ['example-region'], getOutputPath: function () {} }];
   })
 
-  .config(function (postProcessHtml, addImageDimensions, autoLinkCode, filterPipes, filterAmbiguousDirectiveAliases, filterFromInImports) {
+  .config(function (postProcessHtml, addImageDimensions, autoLinkCode, filterPipes, filterAmbiguousDirectiveAliases, filterFromInImports, filterNeverAsGeneric) {
     addImageDimensions.basePath = path.resolve(AIO_PATH, 'src');
     autoLinkCode.customFilters = [filterPipes, filterAmbiguousDirectiveAliases];
-    autoLinkCode.wordFilters = [filterFromInImports];
+    autoLinkCode.wordFilters = [filterFromInImports, filterNeverAsGeneric];
     postProcessHtml.plugins = [
       require('./post-processors/autolink-headings'),
       addImageDimensions,

--- a/docs_app/tools/transforms/angular-base-package/services/filterFromInImports.spec.js
+++ b/docs_app/tools/transforms/angular-base-package/services/filterFromInImports.spec.js
@@ -3,7 +3,7 @@ const filterFromInImports = require('./filterFromInImports')();
 const words = ['import', ' { ', 'from', ' } ', 'from', ' \'', 'rxjs', '\';'];
 const words2 = [' } ', 'from', '(', 'of'];
 
-describe('filterFromInImports(word, index,  words)', () => {
+describe('filterFromInImports(words, index)', () => {
   it('should not filter the word, if the word is not "from"', () => {
     expect(filterFromInImports(words, 0)).toEqual(false);
   });

--- a/docs_app/tools/transforms/angular-base-package/services/filterNeverAsGeneric.spec.js
+++ b/docs_app/tools/transforms/angular-base-package/services/filterNeverAsGeneric.spec.js
@@ -1,0 +1,17 @@
+const filterNeverAsGeneric = require('./filterNeverAsGeneric')();
+
+const words = ['const', ' ', 'never', ': ', 'Observable', '<', 'never', '>;'];
+
+describe('filterNeverAsGeneric(words, index)', () => {
+  it('should not filter the word, if the word is not "never"', () => {
+    expect(filterNeverAsGeneric(words, 0)).toEqual(false);
+  });
+
+  it('should not filter the word, if the word "never" is not positioned between < and > signs', () => {
+    expect(filterNeverAsGeneric(words, 2)).toEqual(false);
+  });
+
+  it('should filter "never" when "never" is positioned between < and > signs', () => {
+    expect(filterNeverAsGeneric(words, 6)).toEqual(true);
+  });
+});

--- a/docs_app/tools/transforms/angular-base-package/services/filterNeverAsGeneric.ts
+++ b/docs_app/tools/transforms/angular-base-package/services/filterNeverAsGeneric.ts
@@ -1,0 +1,22 @@
+/**
+ * This filter is filtering word 'never' when 'never' appears as
+ * generic type. For example, next line:
+ *
+ * ```
+ * const NEVER: Observable<never>;
+ * ```
+ *
+ * will filter 'never' in generic declaration of Observable type.
+ *
+ * This filter is not perfect at all and does not include many
+ * cases, such as multiple generic parameter (e.g. <string, never>),
+ * but it should be enough to cover the most use cases.
+ */
+module.exports = function filterNeverAsGeneric(): (words: string[], index: number) => boolean {
+  return (words: string[], index: number) => {
+    const previousWord = words[index - 1];
+    const nextWord = words[index + 1];
+
+    return words[index] === 'never' && /</.test(previousWord) && />/.test(nextWord);
+  };
+};


### PR DESCRIPTION
**Description:**
This PR adds a new filter that removes link from generic type `<never>`.

This is how this looks like before this fix:

![never included](https://user-images.githubusercontent.com/28087049/155232316-1c169e34-d4e9-4cce-8a35-5fa11cfc319b.gif)

And this is how this looks like after:

![never excluded](https://user-images.githubusercontent.com/28087049/155232349-d5f5c293-c8fd-4185-b77b-87a322da3d6b.gif)

**Related issue (if exists):**
None