### PR TITLE
Add stricter argument types to timeout and interval providers

### DIFF
--- a/src/internal/scheduler/intervalProvider.ts
+++ b/src/internal/scheduler/intervalProvider.ts
@@ -15,9 +15,12 @@ interface IntervalProvider {
 export const intervalProvider: IntervalProvider = {
   // When accessing the delegate, use the variable rather than `this` so that
   // the functions can be called without being bound to the provider.
-  setInterval(...args) {
-    const { delegate } = intervalProvider;
-    return (delegate?.setInterval || setInterval)(...args);
+  setInterval(handler: () => void, timeout?: number, ...args) {
+    const {delegate} = intervalProvider;
+    if (delegate?.setInterval) {
+      return delegate.setInterval(handler, timeout, ...args);
+    }
+    return setInterval(handler, timeout, ...args);
   },
   clearInterval(handle) {
     const { delegate } = intervalProvider;

--- a/src/internal/scheduler/timeoutProvider.ts
+++ b/src/internal/scheduler/timeoutProvider.ts
@@ -15,9 +15,12 @@ interface TimeoutProvider {
 export const timeoutProvider: TimeoutProvider = {
   // When accessing the delegate, use the variable rather than `this` so that
   // the functions can be called without being bound to the provider.
-  setTimeout(...args) {
-    const { delegate } = timeoutProvider;
-    return (delegate?.setTimeout || setTimeout)(...args);
+  setTimeout(handler: () => void, timeout?: number, ...args) {
+    const {delegate} = timeoutProvider;
+    if (delegate?.setTimeout) {
+      return delegate.setTimeout(handler, timeout, ...args);
+    }
+    return setTimeout(handler, timeout, ...args);
   },
   clearTimeout(handle) {
     const { delegate } = timeoutProvider;


### PR DESCRIPTION
**Description:**

As discussed this makes these two changes that allow the providers to conform with Google's stricter conformance rules. Just typing changes. 

