### PR TITLE
docs(timeoutWith): fix rendering docs

### DIFF
--- a/src/internal/operators/timeoutWith.ts
+++ b/src/internal/operators/timeoutWith.ts
@@ -3,34 +3,33 @@ import { isValidDate } from '../util/isDate';
 import { ObservableInput, OperatorFunction, SchedulerLike } from '../types';
 import { timeout } from './timeout';
 
-/**
- * If the time of the Date object passed arrives before the first value arrives from the source, it will unsubscribe
- * from the source and switch the subscription to another observable.
- *
- * <span class="informal">Use to switch to a different observable if the first value doesn't arrive by a specific time</span>
- *
- * Can be used to set a timeout only for the first value, however it's recommended to use the {@link timeout} operator with
- * the `first` configuration to get that effect.
- *
- * @param dueBy The exact time, as a `Date`, at which the timeout will be triggered if the first value does not arrive.
- * @param switchTo The observable to switch to when timeout occurs.
- * @param scheduler The scheduler to use with time-related operations within this operator. Defaults to {@link asyncScheduler}
- * @deprecated Replaced with {@link timeout}. Instead of `timeoutWith(someDate, a$, scheduler)`, use the configuration object `timeout({ first: someDate, with: () => a$, scheduler })`. Will be removed in v8.
- */
+/** @deprecated Replaced with {@link timeout}. Instead of `timeoutWith(someDate, a$, scheduler)`, use the configuration object
+ * `timeout({ first: someDate, with: () => a$, scheduler })`. Will be removed in v8. */
 export function timeoutWith<T, R>(dueBy: Date, switchTo: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;
+/** @deprecated Replaced with {@link timeout}. Instead of `timeoutWith(100, a$, scheduler)`, use the configuration object
+ *  `timeout({ each: 100, with: () => a$, scheduler })`. Will be removed in v8. */
+export function timeoutWith<T, R>(waitFor: number, switchTo: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;
 
 /**
  * When the passed timespan elapses before the source emits any given value, it will unsubscribe from the source,
  * and switch the subscription to another observable.
  *
- * <span class="informal">Used to switch to a different observable if your source is being slow</span>
+ * <span class="informal">Used to switch to a different observable if your source is being slow.</span>
  *
  * Useful in cases where:
  *
- * - You want to switch to a different source that may be faster
- * - You want to notify a user that the data stream is slow
+ * - You want to switch to a different source that may be faster.
+ * - You want to notify a user that the data stream is slow.
  * - You want to emit a custom error rather than the {@link TimeoutError} emitted
  *   by the default usage of {@link timeout}.
+ *
+ * If the first parameter is passed as Date and the time of the Date arrives before the first value arrives from the source,
+ * it will unsubscribe from the source and switch the subscription to another observable.
+ *
+ * <span class="informal">Use Date object to switch to a different observable if the first value doesn't arrive by a specific time.</span>
+ *
+ * Can be used to set a timeout only for the first value, however it's recommended to use the {@link timeout} operator with
+ * the `first` configuration to get the same effect.
  *
  * ## Examples
  *
@@ -70,16 +69,17 @@ export function timeoutWith<T, R>(dueBy: Date, switchTo: ObservableInput<R>, sch
  *
  * @see {@link timeout}
  *
- * @param waitFor The time allowed between values from the source before timeout is triggered.
- * @param switchTo The observable to switch to when timeout occurs.
+ * @param due When passed a number, used as the time (in milliseconds) allowed between each value from the source before timeout
+ * is triggered. When passed a Date, used as the exact time at which the timeout will be triggered if the first value does not arrive.
+ * @param withObservable The observable to switch to when timeout occurs.
  * @param scheduler The scheduler to use with time-related operations within this operator. Defaults to {@link asyncScheduler}
  * @return A function that returns an Observable that mirrors behaviour of the
  * source Observable, unless timeout happens when it starts emitting values
- * from the Observable passed as a second parameter.
- * @deprecated Replaced with {@link timeout}. Instead of `timeoutWith(100, a$, scheduler)`, use the configuration object `timeout({ each: 100, with: () => a$, scheduler })`. Will be removed in v8.
+ * from the `ObservableInput` passed as a second parameter.
+ * @deprecated Replaced with {@link timeout}. Instead of `timeoutWith(100, a$, scheduler)`, use {@link timeout} with the configuration
+ * object: `timeout({ each: 100, with: () => a$, scheduler })`. Instead of `timeoutWith(someDate, a$, scheduler)`, use {@link timeout}
+ * with the configuration object: `timeout({ first: someDate, with: () => a$, scheduler })`. Will be removed in v8.
  */
-export function timeoutWith<T, R>(waitFor: number, switchTo: ObservableInput<R>, scheduler?: SchedulerLike): OperatorFunction<T, T | R>;
-
 export function timeoutWith<T, R>(
   due: number | Date,
   withObservable: ObservableInput<R>,


### PR DESCRIPTION
**Description:**
Please check the related issue for more info. This is how the page looks like with this fix (sorry for the large image):

![image](https://user-images.githubusercontent.com/28087049/156760242-72a9fd9f-fe1b-4eed-9a7a-23c14b0e410a.png)

**Related issue (if exists):**
#6660