### PR TITLE
Deprecate retryWhen and repeatWhen

### DIFF
--- a/spec-dtslint/operators/repeatWhen-spec.ts
+++ b/spec-dtslint/operators/repeatWhen-spec.ts
@@ -1,0 +1,22 @@
+import { of } from 'rxjs';
+import { repeatWhen } from 'rxjs/operators';
+
+it('should infer correctly', () => {
+  const o = of(1, 2, 3).pipe(repeatWhen(errors => errors)); // $ExpectType Observable<number>
+});
+
+it('should infer correctly when the error observable has a different type', () => {
+  const o = of(1, 2, 3).pipe(repeatWhen(repeatWhen(errors => of('a', 'b', 'c')))); // $ExpectType Observable<number>
+});
+
+it('should enforce types', () => {
+  const o = of(1, 2, 3).pipe(repeatWhen()); // $ExpectError
+});
+
+it('should enforce types of the notifier', () => {
+  const o = of(1, 2, 3).pipe(repeatWhen(() => 8)); // $ExpectError
+});
+
+it('should be deprecated', () => {
+  const o = of(1, 2, 3).pipe(repeatWhen(() => of(true))); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/retryWhen-spec.ts
+++ b/spec-dtslint/operators/retryWhen-spec.ts
@@ -16,3 +16,7 @@ it('should enforce types', () => {
 it('should enforce types of the notifier', () => {
   const o = of(1, 2, 3).pipe(retryWhen(() => 8)); // $ExpectError
 });
+
+it('should be deprecated', () => {
+  const o = of(1, 2, 3).pipe(retryWhen(() => of(true))); // $ExpectDeprecation
+});

--- a/src/internal/operators/repeatWhen.ts
+++ b/src/internal/operators/repeatWhen.ts
@@ -37,6 +37,7 @@ import { createOperatorSubscriber } from './OperatorSubscriber';
  * which a user can `complete` or `error`, aborting the repetition.
  * @return A function that returns an Observable that that mirrors the source
  * Observable with the exception of a `complete`.
+ * @deprecated Will be removed in v9 or v10. Use {@link repeat}'s `delay` option instead.
  */
 export function repeatWhen<T>(notifier: (notifications: Observable<void>) => Observable<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {

--- a/src/internal/operators/retryWhen.ts
+++ b/src/internal/operators/retryWhen.ts
@@ -59,6 +59,7 @@ import { createOperatorSubscriber } from './OperatorSubscriber';
  * user can `complete` or `error`, aborting the retry.
  * @return A function that returns an Observable that mirrors the source
  * Observable with the exception of an `error`.
+ * @deprecated: Will be removed in v9 or v10, use {@link retry}'s `delay` option instead.
  */
 export function retryWhen<T>(notifier: (errors: Observable<any>) => Observable<any>): MonoTypeOperatorFunction<T> {
   return operate((source, subscriber) => {


### PR DESCRIPTION
Deprecates `retryWhen` and `repeatWhen`, as the same can be accomplished in a MUCH simpler way with the `delay` argument to both `retry` and `repeat`. Not to be removed until v9 or v10. (A long-long time away, still).

Related to #6367.