### PR TITLE
chore: deprecate MapTo variants

### DIFF
--- a/spec-dtslint/operators/concatMapTo-spec.ts
+++ b/spec-dtslint/operators/concatMapTo-spec.ts
@@ -63,3 +63,7 @@ it('should enforce the return type', () => {
 it('should produce `Observable<never>` when mapping to an `ObservableInput<never>`', () => {
   const o = of(1, 2, 3).pipe(concatMapTo(Promise.reject())); // $ExpectType Observable<never>
 });
+
+it('should be deprecated', () => {
+  const o = of(1, 2, 3).pipe(concatMapTo(of(true))); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/mapTo-spec.ts
+++ b/spec-dtslint/operators/mapTo-spec.ts
@@ -12,3 +12,7 @@ it('should infer correctly when returning a different type', () => {
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(mapTo()); // $ExpectError
 });
+
+it('should be deprecated', () => {
+  const o = of(1, 2, 3).pipe(mapTo(true)); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/mergeMapTo-spec.ts
+++ b/spec-dtslint/operators/mergeMapTo-spec.ts
@@ -75,3 +75,7 @@ it('should enforce types of the concurrent parameter with a resultSelector', () 
 it('should produce `Observable<never>` when mapping to an `ObservableInput<never>`', () => {
   const o = of(1, 2, 3).pipe(mergeMapTo(Promise.reject())); // $ExpectType Observable<never>
 });
+
+it('should be deprecated', () => {
+  const o = of(1, 2, 3).pipe(mergeMapTo(of(true))); // $ExpectDeprecation
+});

--- a/spec-dtslint/operators/switchMapTo-spec.ts
+++ b/spec-dtslint/operators/switchMapTo-spec.ts
@@ -58,3 +58,7 @@ it('should enforce the return type', () => {
 it('should produce `Observable<never>` when mapping to an `ObservableInput<never>`', () => {
   const o = of(1, 2, 3).pipe(switchMapTo(Promise.reject())); // $ExpectType Observable<never>
 });
+
+it('should be deprecated', () => {
+  const o = of(1, 2, 3).pipe(switchMapTo(of(true))); // $ExpectDeprecation
+});

--- a/src/internal/operators/concatMapTo.ts
+++ b/src/internal/operators/concatMapTo.ts
@@ -2,7 +2,7 @@ import { concatMap } from './concatMap';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { isFunction } from '../util/isFunction';
 
-/* tslint:disable:max-line-length */
+/** @deprecated Will be removed in v9. Use {@link concatMap} instead: `concatMap(() => result)` */
 export function concatMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<unknown, ObservedValueOf<O>>;
 /** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function concatMapTo<O extends ObservableInput<unknown>>(
@@ -14,7 +14,6 @@ export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to the same Observable which is merged multiple
@@ -70,6 +69,7 @@ export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
  * @return A function that returns an Observable of values merged together by
  * joining the passed Observable with itself, one after the other, for each
  * value emitted from the source.
+ * @deprecated Will be removed in v9. Use {@link concatMap} instead: `concatMap(() => result)`
  */
 export function concatMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -1,8 +1,13 @@
 import { OperatorFunction } from '../types';
 import { map } from './map';
 
+/** @deprecated To be removed in v9. Use {@link map} instead: `map(() => value)`. */
 export function mapTo<R>(value: R): OperatorFunction<unknown, R>;
-/** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */
+/**
+ * @deprecated Do not specify explicit type parameters. Signatures with type parameters
+ * that cannot be inferred will be removed in v8. `mapTo` itself will be removed in v9,
+ * use {@link map} instead: `map(() => value)`.
+ * */
 export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
 
 /**

--- a/src/internal/operators/mapTo.ts
+++ b/src/internal/operators/mapTo.ts
@@ -36,6 +36,7 @@ export function mapTo<T, R>(value: R): OperatorFunction<T, R>;
  * @param value The value to map each source value to.
  * @return A function that returns an Observable that emits the given `value`
  * every time the source Observable emits.
+ * @deprecated To be removed in v9. Use {@link map} instead: `map(() => value)`.
  */
 export function mapTo<R>(value: R): OperatorFunction<unknown, R> {
   return map(() => value);

--- a/src/internal/operators/mergeMapTo.ts
+++ b/src/internal/operators/mergeMapTo.ts
@@ -2,12 +2,15 @@ import { OperatorFunction, ObservedValueOf, ObservableInput } from '../types';
 import { mergeMap } from './mergeMap';
 import { isFunction } from '../util/isFunction';
 
-/* tslint:disable:max-line-length */
+/** @deprecated Will be removed in v9. Use {@link mergeMap} instead: `mergeMap(() => result)` */
 export function mergeMapTo<O extends ObservableInput<unknown>>(
   innerObservable: O,
   concurrent?: number
 ): OperatorFunction<unknown, ObservedValueOf<O>>;
-/** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
+/**
+ * @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead.
+ * Details: https://rxjs.dev/deprecations/resultSelector
+ */
 export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R,
@@ -54,6 +57,7 @@ export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
  * Observables being subscribed to concurrently.
  * @return A function that returns an Observable that emits items from the
  * given `innerObservable`.
+ * @deprecated Will be removed in v9. Use {@link mergeMap} instead: `mergeMap(() => result)`
  */
 export function mergeMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,

--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -2,7 +2,7 @@ import { switchMap } from './switchMap';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { isFunction } from '../util/isFunction';
 
-/* tslint:disable:max-line-length */
+/** @deprecated Will be removed in v9. Use {@link mergeMap} instead: `mergeMap(() => result)` */
 export function switchMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<unknown, ObservedValueOf<O>>;
 /** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<O extends ObservableInput<unknown>>(
@@ -14,7 +14,6 @@ export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
   observable: O,
   resultSelector: (outerValue: T, innerValue: ObservedValueOf<O>, outerIndex: number, innerIndex: number) => R
 ): OperatorFunction<T, R>;
-/* tslint:enable:max-line-length */
 
 /**
  * Projects each source value to the same Observable which is flattened multiple
@@ -55,6 +54,7 @@ export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
  * `resultSelector`) every time a value is emitted on the source Observable,
  * and taking only the values from the most recently projected inner
  * Observable.
+ * @deprecated Will be removed in v9. Use {@link mergeMap} instead: `mergeMap(() => result)`
  */
 export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,


### PR DESCRIPTION
Deprecating MapTo variants, as they were only wrappers around the Map variants, and added unnecessary API surface area.

related #6367
