### PR TITLE
docs: fix parameter generics rendering

### DIFF
--- a/docs_app/tools/transforms/templates/api/lib/paramList.html
+++ b/docs_app/tools/transforms/templates/api/lib/paramList.html
@@ -21,13 +21,13 @@
         <a id="{$ parameter.anchor or parameter.name $}"></a>
         <code>{$ parameter.name $}</code>
       </td>
-      {% if showType %}<td class="param-type"><code>{$ parameter.type $}</code></td>{% endif %}
+      {% if showType %}<td class="param-type"><code>{$ parameter.type | escape $}</code></td>{% endif %}
       <td class="param-description">
       {% marked %}
         {% if parameter.isOptional or parameter.defaultValue !== undefined %}Optional. Default is `{$ parameter.defaultValue === undefined and 'undefined' or parameter.defaultValue $}`.{% endif %}
 
         {% if parameter.description | trim %}{$ parameter.description $}
-        {% elseif not showType and parameter.type %}<p>Type: <code>{$ parameter.type $}</code>.</p>
+        {% elseif not showType and parameter.type %}<p>Type: <code>{$ parameter.type | escape $}</code>.</p>
         {% endif %}
       {% endmarked %}
       </td>


### PR DESCRIPTION
**Description:**
This PR fixes issues with rendering generics in the parameter list. In the following example:

<img width="1390" alt="image" src="https://user-images.githubusercontent.com/28087049/156924324-27f6e362-bdcf-4dec-8fe8-a21b02a79c5d.png">

Generic type `O` doesn't get rendered in the _Parameters_ table, but instead gets converted to tag `<o>`.

This PR fixes these issues so that it looks like this:

<img width="1175" alt="image" src="https://user-images.githubusercontent.com/28087049/156924417-c3f8f25f-e6af-458c-b8d2-ed750c7bcb88.png">

**Related issue (if exists):**
None. Similar to #6655