### PR TITLE
docs: remove links from heritage docs

### DIFF
--- a/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
@@ -2,10 +2,10 @@
 
 {%- macro renderHeritage(exportDoc) -%}
   {%- if exportDoc.extendsClauses.length %} extends {% for clause in exportDoc.extendsClauses -%}
-  {% if clause.doc.path %}<a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% else %}{$ clause.text | escape $}{% endif %}{% if not loop.last %}, {% endif -%}
+  {$ clause.text | escape $}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
   {%- if exportDoc.implementsClauses.length %} implements {% for clause in exportDoc.implementsClauses -%}
-  <a class="code-anchor" href="{$ clause.doc.path $}">{$ clause.text | escape $}</a>{% if not loop.last %}, {% endif -%}
+  {$ clause.text | escape $}{% if not loop.last %}, {% endif -%}
   {% endfor %}{% endif %}
 {%- endmacro -%}
 


### PR DESCRIPTION
**Description:**
This PR removes links from the docs that render heritage. This step will be replaced with [`autoLinkCode`](https://github.com/ReactiveX/rxjs/blob/8e0f8cc532accddd8333d78f89377fe6ca8bd7ae/docs_app/tools/transforms/angular-base-package/post-processors/auto-link-code.js#L23) processor that inserts links automatically while [it can't work](https://github.com/ReactiveX/rxjs/blob/8e0f8cc532accddd8333d78f89377fe6ca8bd7ae/docs_app/tools/transforms/angular-base-package/post-processors/auto-link-code.js#L41-L44) if the document is already a link. Adding links through `autoLinkCode` processor will fix multiple issues with links mostly related to rendering generic parameters.

For example, in this image the link tag also included generic parameters (which could've been links themselves):

![image](https://user-images.githubusercontent.com/28087049/156994955-ccac48f0-f571-4d97-8ab6-5e4aea50b2b9.png)

With link removed, `autoLinkCode` will add link to the every generic parameter for which it can find a valid document:

![image](https://user-images.githubusercontent.com/28087049/156996261-75c49651-0c97-4b70-bc1a-8a86793197f1.png)

**Related issue (if exists):**
None