### PR TITLE
fix(timeout): do not timeout if source emits synchronously when subscribed

### DIFF
--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { timeout, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { TimeoutError, of, Observable } from 'rxjs';
+import { TimeoutError, of, Observable, BehaviorSubject } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {timeout} */
@@ -689,6 +689,15 @@ describe('timeout operator', () => {
         expectObservable(result).toBe(expected);
         expectSubscriptions(source.subscriptions).toBe(sourceSubs);
         expectSubscriptions(inner.subscriptions).toBe([]);
+      });
+    });
+
+    it('should not timeout if source emits synchronously when subscribed', () => {
+      rxTestScheduler.run(({ expectObservable, time }) => {
+        const source = new BehaviorSubject('a');
+        const t = time('  ---|');
+        const expected = 'a---';
+        expectObservable(source.pipe(timeout({ first: new Date(t) }))).toBe(expected);
       });
     });
   });

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -694,7 +694,7 @@ describe('timeout operator', () => {
 
     it('should not timeout if source emits synchronously when subscribed', () => {
       rxTestScheduler.run(({ expectObservable, time }) => {
-        const source = new BehaviorSubject('a');
+        const source = of('a');
         const t = time('  ---|');
         const expected = 'a---';
         expectObservable(source.pipe(timeout({ first: new Date(t) }))).toBe(expected);

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { timeout, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { TimeoutError, of, Observable, BehaviorSubject } from 'rxjs';
+import { TimeoutError, of, Observable } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {timeout} */

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -1,8 +1,8 @@
 /** @prettier */
 import { expect } from 'chai';
-import { timeout, mergeMap, take } from 'rxjs/operators';
+import { timeout, mergeMap, take, concatWith } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { TimeoutError, of, Observable } from 'rxjs';
+import { TimeoutError, of, Observable, NEVER } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {timeout} */
@@ -694,7 +694,7 @@ describe('timeout operator', () => {
 
     it('should not timeout if source emits synchronously when subscribed', () => {
       rxTestScheduler.run(({ expectObservable, time }) => {
-        const source = of('a');
+        const source = of('a').pipe(concatWith(NEVER));
         const t = time('  ---|');
         const expected = 'a---';
         expectObservable(source.pipe(timeout({ first: new Date(t) }))).toBe(expected);

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -386,6 +386,8 @@ export function timeout<T, O extends ObservableInput<any>, M>(
     );
 
     // Intentionally terse code.
+    // If we've `seen` a value, that means the "first" clause was met already, if it existed.
+    //   it also means that a timer was already started for "each" (in the next handler above).
     // If `first` was provided, and it's a number, then use it.
     // If `first` was provided and it's not a number, it's a Date, and we get the difference between it and "now".
     // If `first` was not provided at all, then our first timer will be the value from `each`.

--- a/src/internal/operators/timeout.ts
+++ b/src/internal/operators/timeout.ts
@@ -389,7 +389,7 @@ export function timeout<T, O extends ObservableInput<any>, M>(
     // If `first` was provided, and it's a number, then use it.
     // If `first` was provided and it's not a number, it's a Date, and we get the difference between it and "now".
     // If `first` was not provided at all, then our first timer will be the value from `each`.
-    startTimer(first != null ? (typeof first === 'number' ? first : +first - scheduler!.now()) : each!);
+    !seen && startTimer(first != null ? (typeof first === 'number' ? first : +first - scheduler!.now()) : each!);
   });
 }
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The `timeout` operator should not timeout if the source emits synchronously when subscribed.


<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue:** #6862
