### PR TITLE
docs: ensure deprecated styling is not overridden

### DIFF
--- a/docs_app/src/styles/2-modules/_api-list.scss
+++ b/docs_app/src/styles/2-modules/_api-list.scss
@@ -289,7 +289,6 @@ p {
 
 .code-anchor {
   cursor: pointer;
-  text-decoration: none;
 
   &:hover {
     text-decoration: underline;


### PR DESCRIPTION
**Description:**
Fix styling of the deprecated items. With this fix, it looks like this:

<img width="1084" alt="image" src="https://user-images.githubusercontent.com/28087049/157975312-ceb62518-d702-4e40-9df1-9fc6bca9c2a8.png">

vs previously:

<img width="1093" alt="image" src="https://user-images.githubusercontent.com/28087049/157975292-abf9778c-f951-43da-8ac2-755511922e7e.png">


**Related issue (if exists):**
None