### PR TITLE
fix: animationFrameScheduler and asapScheduler no longer executing actions

### DIFF
--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -27,10 +27,10 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
-    // If the scheduler queue has no remaining actions with the same async id,
+    // If the scheduler queue has no remaining actions for the next schedule,
     // cancel the requested animation frame and set the scheduled flag to
     // undefined so the next AnimationFrameAction will request its own.
-    if (!scheduler.actions.some((action) => action.id === id)) {
+    if (scheduler._scheduled === id && !scheduler.actions.some((action) => action.id === id)) {
       animationFrameProvider.cancelAnimationFrame(id);
       scheduler._scheduled = undefined;
     }

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -27,10 +27,10 @@ export class AsapAction<T> extends AsyncAction<T> {
     if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
-    // If the scheduler queue has no remaining actions with the same async id,
+    // If the scheduler queue has no remaining actions for the next schedule,
     // cancel the requested microtask and set the scheduled flag to undefined
     // so the next AsapAction will request its own.
-    if (!scheduler.actions.some((action) => action.id === id)) {
+    if (scheduler._scheduled === id && !scheduler.actions.some((action) => action.id === id)) {
       immediateProvider.clearImmediate(id);
       scheduler._scheduled = undefined;
     }


### PR DESCRIPTION
**Description:**

`AnimationFrameAction` and `AsapAction`'s `recycleAsyncId` should only reset `scheduler_scheduled` if it's the same `id` we are currently recycling. This fixes the issue described in #6854 where actions scheduled from another action have already set `scheduler._scheduled`, which is then cleared when the currently executing action is done.
This works because there are at most 2 schedules for these schedulers: the currently executing one and the next schedule. This also means we no longer `cancelAnimationFrame`/`clearImmediate` the current schedule after its last action is done (which does nothing for correctness, but avoid unnecessary work).

**Related issue (if exists):**
Fixes #6854
