### PR TITLE
docs: remove redundant deprecated section

### DIFF
--- a/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
+++ b/docs_app/tools/transforms/templates/api/lib/memberHelpers.html
@@ -45,11 +45,6 @@
 <div class="short-description">
   {$ overload.shortDescription | marked $}
 </div>{% endif %}
-{% if overload.deprecated !== undefined %}
-<div class="deprecated">
-  <h4>Deprecation Notes</h4>
-  {$ overload.deprecated | marked $}
-</div>{% endif %}
 
 <h4 class="no-anchor">Parameters</h4>
 {$ params.renderParameters(overload.parameterDocs, cssClass + '-parameters', cssClass + '-parameter', true) $}


### PR DESCRIPTION
**Description:**
This PR removes redundant section related to the deprecated stuff. This was added in #6379, but since this section existed before that PR, I will remove it as duplicated content.

<img width="818" alt="image" src="https://user-images.githubusercontent.com/28087049/158190171-f59e645b-0ad6-4b26-a339-907ce5d0d548.png">

With this part removed, it looks like this:

![image](https://user-images.githubusercontent.com/28087049/158190382-9535ccbb-bb06-4a46-bd1e-c9af77f6cb22.png)


**Related issue (if exists):**
None