### PR TITLE
fix: animationFrameScheduler prematurely executing actions without delay

### DIFF
--- a/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -261,4 +261,26 @@ describe('Scheduler.animationFrame', () => {
     animationFrameScheduler.schedule(work);
     expect(result).to.deep.equal([]);
   });
+
+  it('should execute actions with delay separate from all other actions', () => {
+    const sandbox = sinon.createSandbox();
+    const timers = sandbox.useFakeTimers();
+    let rafCallback!: () => void;
+    const stub = sinon.stub(animationFrameProvider, 'requestAnimationFrame').callsFake((cb) => rafCallback = cb);
+
+    let asyncExecuted = false;
+    let animationFrameExecuted = false
+    animationFrameScheduler.schedule(() => asyncExecuted = true, 1);
+    animationFrameScheduler.schedule(() => animationFrameExecuted = true);
+
+    timers.tick(1);
+    expect(asyncExecuted).to.equal(true);
+    expect(animationFrameExecuted).to.equal(false);
+
+    rafCallback();
+    expect(animationFrameExecuted).to.equal(true);
+
+    stub.restore();
+    sandbox.restore();
+  });
 });

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -27,10 +27,10 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
-    // If the scheduler queue has no remaining actions with the same async id,
+    // If the scheduler queue has no remaining actions for the next schedule,
     // cancel the requested animation frame and set the scheduled flag to
     // undefined so the next AnimationFrameAction will request its own.
-    if (!scheduler.actions.some((action) => action.id === id)) {
+    if (scheduler._scheduled === id && !scheduler.actions.some((action) => action.id === id)) {
       animationFrameProvider.cancelAnimationFrame(id);
       scheduler._scheduled = undefined;
     }

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -27,10 +27,10 @@ export class AsapAction<T> extends AsyncAction<T> {
     if ((delay != null && delay > 0) || (delay == null && this.delay > 0)) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
-    // If the scheduler queue has no remaining actions with the same async id,
+    // If the scheduler queue has no remaining actions for the next schedule,
     // cancel the requested microtask and set the scheduled flag to undefined
     // so the next AsapAction will request its own.
-    if (!scheduler.actions.some((action) => action.id === id)) {
+    if (scheduler._scheduled === id && !scheduler.actions.some((action) => action.id === id)) {
       immediateProvider.clearImmediate(id);
       scheduler._scheduled = undefined;
     }


### PR DESCRIPTION
**Description:**

If `AnimationFrameScheduler#flush` is called with an `action` as parameter, it's an action with `delay > 0`. Only execute this action and don't touch `scheduler._scheduled` and `scheduler.actions` because the action it not affected by any of them.

This branch is based on #6889 to avoid merge conflicts in the spec file.

**Related issue (if exists):**

Fixes: #6891 
