### PR TITLE
fix: add missing deprecated JSDoc tag to pluck overload signatures

### DIFF
--- a/src/internal/operators/pluck.ts
+++ b/src/internal/operators/pluck.ts
@@ -2,19 +2,24 @@ import { map } from './map';
 import { OperatorFunction } from '../types';
 
 /* tslint:disable:max-line-length */
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<T, K1 extends keyof T>(k1: K1): OperatorFunction<T, T[K1]>;
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1]>(k1: K1, k2: K2): OperatorFunction<T, T[K1][K2]>;
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2]>(
   k1: K1,
   k2: K2,
   k3: K3
 ): OperatorFunction<T, T[K1][K2][K3]>;
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<T, K1 extends keyof T, K2 extends keyof T[K1], K3 extends keyof T[K1][K2], K4 extends keyof T[K1][K2][K3]>(
   k1: K1,
   k2: K2,
   k3: K3,
   k4: K4
 ): OperatorFunction<T, T[K1][K2][K3][K4]>;
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<
   T,
   K1 extends keyof T,
@@ -23,6 +28,7 @@ export function pluck<
   K4 extends keyof T[K1][K2][K3],
   K5 extends keyof T[K1][K2][K3][K4]
 >(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5): OperatorFunction<T, T[K1][K2][K3][K4][K5]>;
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<
   T,
   K1 extends keyof T,
@@ -32,6 +38,7 @@ export function pluck<
   K5 extends keyof T[K1][K2][K3][K4],
   K6 extends keyof T[K1][K2][K3][K4][K5]
 >(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6): OperatorFunction<T, T[K1][K2][K3][K4][K5][K6]>;
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<
   T,
   K1 extends keyof T,
@@ -41,6 +48,7 @@ export function pluck<
   K5 extends keyof T[K1][K2][K3][K4],
   K6 extends keyof T[K1][K2][K3][K4][K5]
 >(k1: K1, k2: K2, k3: K3, k4: K4, k5: K5, k6: K6, ...rest: string[]): OperatorFunction<T, unknown>;
+/** @deprecated Use {@link map} and optional chaining: `pluck('foo', 'bar')` is `map(x => x?.foo?.bar)`. Will be removed in v8. */
 export function pluck<T>(...properties: string[]): OperatorFunction<T, unknown>;
 /* tslint:enable:max-line-length */
 


### PR DESCRIPTION
**Description:**

Adds `@deprecated` to all overload signatures of `pluck` operator.
The implementation was already marked as deprecated, but that wasn't picked up by tooling, e.g. TypeScript, eslint-plugin-deprecation, IntelliJ, ...