### PR TITLE
chore(fromEvent): convert fromEvent specs to run mode

### DIFF
--- a/spec/observables/fromEvent-spec.ts
+++ b/spec/observables/fromEvent-spec.ts
@@ -21,7 +21,7 @@ describe('fromEvent', () => {
 
       const target = {
         addEventListener: (eventType: any, listener: any) => {
-          timer(delay1, delay2, rxTestScheduler).pipe(mapTo('ev'), take(2), concat(NEVER)).subscribe(listener);
+          timer(delay1, delay2).pipe(mapTo('ev'), take(2), concat(NEVER)).subscribe(listener);
         },
         removeEventListener: (): void => void 0,
         dispatchEvent: (): void => void 0,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `fromEvent` unit tests to run mode.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
