### PR TITLE
chore(iif): convert iif specs to run mode

### DIFF
--- a/spec/observables/if-spec.ts
+++ b/spec/observables/if-spec.ts
@@ -1,94 +1,150 @@
+/** @prettier */
 import { expect } from 'chai';
 import { iif, of } from 'rxjs';
-import { expectObservable } from '../helpers/marble-testing';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 describe('iif', () => {
-  it('should subscribe to thenSource when the conditional returns true', () => {
-    const e1 = iif(() => true, of('a'), of());
-    const expected = '(a|)';
+  let rxTestScheduler: TestScheduler;
 
-    expectObservable(e1).toBe(expected);
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should subscribe to thenSource when the conditional returns true', () => {
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = iif(() => true, of('a'), of());
+      const expected = '(a|)';
+
+      expectObservable(e1).toBe(expected);
+    });
   });
 
   it('should subscribe to elseSource when the conditional returns false', () => {
-    const e1 = iif(() => false, of('a'), of('b'));
-    const expected = '(b|)';
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = iif(() => false, of('a'), of('b'));
+      const expected = '(b|)';
 
-    expectObservable(e1).toBe(expected);
+      expectObservable(e1).toBe(expected);
+    });
   });
 
   it('should complete without an elseSource when the conditional returns false', () => {
-    const e1 = iif(() => false, of('a'), of());
-    const expected = '|';
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = iif(() => false, of('a'), of());
+      const expected = '|';
 
-    expectObservable(e1).toBe(expected);
+      expectObservable(e1).toBe(expected);
+    });
   });
 
   it('should raise error when conditional throws', () => {
-    const e1 = iif(((): boolean => {
-      throw 'error';
-    }), of('a'), of());
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = iif(
+        (): boolean => {
+          throw 'error';
+        },
+        of('a'),
+        of()
+      );
 
-    const expected = '#';
+      const expected = '#';
 
-    expectObservable(e1).toBe(expected);
+      expectObservable(e1).toBe(expected);
+    });
   });
 
   it('should accept resolved promise as thenSource', (done) => {
     const expected = 42;
-    const e1 = iif(() => true, new Promise((resolve: any) => { resolve(expected); }), of());
+    const e1 = iif(
+      () => true,
+      new Promise((resolve: any) => {
+        resolve(expected);
+      }),
+      of()
+    );
 
-    e1.subscribe({ next: x => {
-      expect(x).to.equal(expected);
-    }, error: (x) => {
-      done(new Error('should not be called'));
-    }, complete: () => {
-      done();
-    } });
+    e1.subscribe({
+      next: (x) => {
+        expect(x).to.equal(expected);
+      },
+      error: (x) => {
+        done(new Error('should not be called'));
+      },
+      complete: () => {
+        done();
+      },
+    });
   });
 
   it('should accept resolved promise as elseSource', (done) => {
     const expected = 42;
-    const e1 = iif(() => false,
+    const e1 = iif(
+      () => false,
       of('a'),
-      new Promise((resolve: any) => { resolve(expected); }));
+      new Promise((resolve: any) => {
+        resolve(expected);
+      })
+    );
 
-    e1.subscribe({ next: x => {
-      expect(x).to.equal(expected);
-    }, error: (x) => {
-      done(new Error('should not be called'));
-    }, complete: () => {
-      done();
-    } });
+    e1.subscribe({
+      next: (x) => {
+        expect(x).to.equal(expected);
+      },
+      error: (x) => {
+        done(new Error('should not be called'));
+      },
+      complete: () => {
+        done();
+      },
+    });
   });
 
   it('should accept rejected promise as elseSource', (done) => {
     const expected = 42;
-    const e1 = iif(() => false,
+    const e1 = iif(
+      () => false,
       of('a'),
-      new Promise((resolve: any, reject: any) => { reject(expected); }));
+      new Promise((resolve: any, reject: any) => {
+        reject(expected);
+      })
+    );
 
-    e1.subscribe({ next: x => {
-      done(new Error('should not be called'));
-    }, error: (x) => {
-      expect(x).to.equal(expected);
-      done();
-    }, complete: () => {
-      done(new Error('should not be called'));
-    } });
+    e1.subscribe({
+      next: (x) => {
+        done(new Error('should not be called'));
+      },
+      error: (x) => {
+        expect(x).to.equal(expected);
+        done();
+      },
+      complete: () => {
+        done(new Error('should not be called'));
+      },
+    });
   });
 
   it('should accept rejected promise as thenSource', (done) => {
     const expected = 42;
-    const e1 = iif(() => true, new Promise((resolve: any, reject: any) => { reject(expected); }), of());
+    const e1 = iif(
+      () => true,
+      new Promise((resolve: any, reject: any) => {
+        reject(expected);
+      }),
+      of()
+    );
 
-    e1.subscribe({ next: x => {
-      done(new Error('should not be called'));
-    }, error: (x) => {
-      expect(x).to.equal(expected);
-      done();
-    }, complete: () => {
-      done(new Error('should not be called'));
-    } });
+    e1.subscribe({
+      next: (x) => {
+        done(new Error('should not be called'));
+      },
+      error: (x) => {
+        expect(x).to.equal(expected);
+        done();
+      },
+      complete: () => {
+        done(new Error('should not be called'));
+      },
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `iif` unit tests to run mode.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
