### PR TITLE
chore(interval): convert interval specs to run mode

### DIFF
--- a/spec/observables/interval-spec.ts
+++ b/spec/observables/interval-spec.ts
@@ -14,35 +14,6 @@ describe('interval', () => {
     rxTestScheduler = new TestScheduler(observableMatcher);
   });
 
-  it('should create an observable emitting periodically', () => {
-    rxTestScheduler.run(({ expectObservable, time }) => {
-      const values = {
-        a: 0,
-        b: 1,
-        c: 2,
-        d: 3,
-        e: 4,
-        f: 5,
-      };
-
-      const period = time('--|           ');
-      //                     --|
-      //                       --|
-      //                         --|
-      //                           --|
-      //                             --|
-      //                               --|
-      const expected = '   --a-b-c-d-e-f-';
-
-      const e1 = interval(period).pipe(
-        take(6), // make it actually finite, so it can be rendered
-        concat(NEVER) // but pretend it's infinite by not completing
-      );
-
-      expectObservable(e1).toBe(expected, values);
-    });
-  });
-
   it('should set up an interval', () => {
     rxTestScheduler.run(({ expectObservable, time }) => {
       const period = time('----------|                                                                 ');

--- a/spec/observables/interval-spec.ts
+++ b/spec/observables/interval-spec.ts
@@ -1,64 +1,101 @@
+/** @prettier */
 import { expect } from 'chai';
-import { expectObservable } from '../helpers/marble-testing';
 import { NEVER, interval, asapScheduler, animationFrameScheduler, queueScheduler } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { take, concat } from 'rxjs/operators';
 import * as sinon from 'sinon';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {interval} */
 describe('interval', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should create an observable emitting periodically', () => {
-    const e1 = interval(20, rxTestScheduler).pipe(
-      take(6), // make it actually finite, so it can be rendered
-      concat(NEVER) // but pretend it's infinite by not completing
-    );
-    const expected = '--a-b-c-d-e-f-';
-    const values = {
-      a: 0,
-      b: 1,
-      c: 2,
-      d: 3,
-      e: 4,
-      f: 5,
-    };
-    expectObservable(e1).toBe(expected, values);
+    rxTestScheduler.run(({ expectObservable, time }) => {
+      const values = {
+        a: 0,
+        b: 1,
+        c: 2,
+        d: 3,
+        e: 4,
+        f: 5,
+      };
+
+      const period = time('--|           ');
+      //                     --|
+      //                       --|
+      //                         --|
+      //                           --|
+      //                             --|
+      //                               --|
+      const expected = '   --a-b-c-d-e-f-';
+
+      const e1 = interval(period).pipe(
+        take(6), // make it actually finite, so it can be rendered
+        concat(NEVER) // but pretend it's infinite by not completing
+      );
+
+      expectObservable(e1).toBe(expected, values);
+    });
   });
 
   it('should set up an interval', () => {
-    const expected = '----------0---------1---------2---------3---------4---------5---------6-----';
-    expectObservable(interval(100, rxTestScheduler)).toBe(expected, [0, 1, 2, 3, 4, 5, 6]);
+    rxTestScheduler.run(({ expectObservable, time }) => {
+      const period = time('----------|                                                                 ');
+      //                             ----------|
+      //                                       ----------|
+      //                                                 ----------|
+      //                                                           ----------|
+      //                                                                     ----------|
+      //                                                                               ----------|
+      const unsubs = '     ---------------------------------------------------------------------------!';
+      const expected = '   ----------0---------1---------2---------3---------4---------5---------6-----';
+      expectObservable(interval(period), unsubs).toBe(expected, [0, 1, 2, 3, 4, 5, 6]);
+    });
   });
 
   it('should emit when relative interval set to zero', () => {
-    const e1 = interval(0, rxTestScheduler).pipe(take(7));
-    const expected = '(0123456|)';
-    expectObservable(e1).toBe(expected, [0, 1, 2, 3, 4, 5, 6]);
+    rxTestScheduler.run(({ expectObservable, time }) => {
+      const period = time('|         ');
+      const expected = '   (0123456|)';
+
+      const e1 = interval(period).pipe(take(7));
+      expectObservable(e1).toBe(expected, [0, 1, 2, 3, 4, 5, 6]);
+    });
   });
 
   it('should consider negative interval as zero', () => {
-    const e1 = interval(-1, rxTestScheduler).pipe(take(7));
-    const expected = '(0123456|)';
-    expectObservable(e1).toBe(expected, [0, 1, 2, 3, 4, 5, 6]);
+    rxTestScheduler.run(({ expectObservable }) => {
+      const expected = '(0123456|)';
+      const e1 = interval(-1).pipe(take(7));
+      expectObservable(e1).toBe(expected, [0, 1, 2, 3, 4, 5, 6]);
+    });
   });
 
   it('should emit values until unsubscribed', (done) => {
     const values: number[] = [];
     const expected = [0, 1, 2, 3, 4, 5, 6];
     const e1 = interval(5);
-    const subscription = e1.subscribe({ next: (x: number) => {
-      values.push(x);
-      if (x === 6) {
-        subscription.unsubscribe();
-        expect(values).to.deep.equal(expected);
-        done();
-      }
-    }, error: (err: any) => {
-      done(new Error('should not be called'));
-    }, complete: () => {
-      done(new Error('should not be called'));
-    } });
+    const subscription = e1.subscribe({
+      next: (x: number) => {
+        values.push(x);
+        if (x === 6) {
+          subscription.unsubscribe();
+          expect(values).to.deep.equal(expected);
+          done();
+        }
+      },
+      error: (err: any) => {
+        done(new Error('should not be called'));
+      },
+      complete: () => {
+        done(new Error('should not be called'));
+      },
+    });
   });
 
   it('should create an observable emitting periodically with the AsapScheduler', (done) => {
@@ -80,9 +117,10 @@ describe('interval', () => {
         expect(asapScheduler._scheduled).to.equal(undefined);
         sandbox.restore();
         done();
-      }
+      },
     });
-    let i = -1, n = events.length;
+    let i = -1,
+      n = events.length;
     while (++i < n) {
       fakeTimer.tick(period);
     }
@@ -107,9 +145,10 @@ describe('interval', () => {
         expect(queueScheduler._scheduled).to.equal(undefined);
         sandbox.restore();
         done();
-      }
+      },
     });
-    let i = -1, n = events.length;
+    let i = -1,
+      n = events.length;
     while (++i < n) {
       fakeTimer.tick(period);
     }
@@ -134,9 +173,10 @@ describe('interval', () => {
         expect(animationFrameScheduler._scheduled).to.equal(undefined);
         sandbox.restore();
         done();
-      }
+      },
     });
-    let i = -1, n = events.length;
+    let i = -1,
+      n = events.length;
     while (++i < n) {
       fakeTimer.tick(period);
     }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `interval` unit tests to run mode.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
