### PR TITLE
chore(of): convert of specs to run mode

### DIFF
--- a/spec/observables/of-spec.ts
+++ b/spec/observables/of-spec.ts
@@ -19,7 +19,7 @@ describe('of', () => {
 
       const e1 = of(1, 2, 3).pipe(
         // for the purpose of making a nice diagram, spread out the synchronous emissions
-        concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : delayValue, rxTestScheduler)))
+        concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : delayValue)))
       );
       const expected = 'x-y-(z|)';
       expectObservable(e1).toBe(expected, { x: 1, y: 2, z: 3 });
@@ -63,7 +63,7 @@ describe('of', () => {
 
   it('should handle an Observable as the only value', () => {
     rxTestScheduler.run(({ expectObservable }) => {
-      const source = of(of('a', 'b', 'c', rxTestScheduler), rxTestScheduler);
+      const source = of(of('a', 'b', 'c'));
       const result = source.pipe(concatAll());
       expectObservable(result).toBe('(abc|)');
     });
@@ -71,7 +71,7 @@ describe('of', () => {
 
   it('should handle many Observable as the given values', () => {
     rxTestScheduler.run(({ expectObservable }) => {
-      const source = of(of('a', 'b', 'c', rxTestScheduler), of('d', 'e', 'f', rxTestScheduler), rxTestScheduler);
+      const source = of(of('a', 'b', 'c'), of('d', 'e', 'f'));
 
       const result = source.pipe(concatAll());
       expectObservable(result).toBe('(abcdef|)');

--- a/spec/observables/of-spec.ts
+++ b/spec/observables/of-spec.ts
@@ -1,20 +1,29 @@
+/** @prettier */
 import { expect } from 'chai';
 import { of } from 'rxjs';
-import { expectObservable } from '../helpers/marble-testing';
 import { TestScheduler } from 'rxjs/testing';
 import { concatMap, delay, concatAll } from 'rxjs/operators';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {of} */
 describe('of', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should create a cold observable that emits 1, 2, 3', () => {
-    const e1 = of(1, 2, 3).pipe(
-      // for the purpose of making a nice diagram, spread out the synchronous emissions
-      concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : 20, rxTestScheduler)))
-    );
-    const expected = 'x-y-(z|)';
-    expectObservable(e1).toBe(expected, {x: 1, y: 2, z: 3});
+    rxTestScheduler.run(({ expectObservable, time }) => {
+      const delayValue = time('--|');
+
+      const e1 = of(1, 2, 3).pipe(
+        // for the purpose of making a nice diagram, spread out the synchronous emissions
+        concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : delayValue, rxTestScheduler)))
+      );
+      const expected = 'x-y-(z|)';
+      expectObservable(e1).toBe(expected, { x: 1, y: 2, z: 3 });
+    });
   });
 
   it('should create an observable from the provided values', (done) => {
@@ -22,46 +31,50 @@ describe('of', () => {
     const expected = [1, 'a', x];
     let i = 0;
 
-   of(1, 'a', x)
-      .subscribe({ next: (y: any) => {
+    of(1, 'a', x).subscribe({
+      next: (y: any) => {
         expect(y).to.equal(expected[i++]);
-      }, error: (x) => {
+      },
+      error: (x) => {
         done(new Error('should not be called'));
-      }, complete: () => {
+      },
+      complete: () => {
         done();
-      } });
+      },
+    });
   });
 
   it('should emit one value', (done) => {
     let calls = 0;
 
-    of(42).subscribe({ next: (x: number) => {
-      expect(++calls).to.equal(1);
-      expect(x).to.equal(42);
-  }, error: (err: any) => {
-      done(new Error('should not be called'));
-    }, complete: () => {
-      done();
-    } });
+    of(42).subscribe({
+      next: (x: number) => {
+        expect(++calls).to.equal(1);
+        expect(x).to.equal(42);
+      },
+      error: (err: any) => {
+        done(new Error('should not be called'));
+      },
+      complete: () => {
+        done();
+      },
+    });
   });
 
   it('should handle an Observable as the only value', () => {
-    const source = of(
-     of('a', 'b', 'c', rxTestScheduler),
-      rxTestScheduler
-    );
-    const result = source.pipe(concatAll());
-    expectObservable(result).toBe('(abc|)');
+    rxTestScheduler.run(({ expectObservable }) => {
+      const source = of(of('a', 'b', 'c', rxTestScheduler), rxTestScheduler);
+      const result = source.pipe(concatAll());
+      expectObservable(result).toBe('(abc|)');
+    });
   });
 
   it('should handle many Observable as the given values', () => {
-    const source = of(
-     of('a', 'b', 'c', rxTestScheduler),
-     of('d', 'e', 'f', rxTestScheduler),
-      rxTestScheduler
-    );
+    rxTestScheduler.run(({ expectObservable }) => {
+      const source = of(of('a', 'b', 'c', rxTestScheduler), of('d', 'e', 'f', rxTestScheduler), rxTestScheduler);
 
-    const result = source.pipe(concatAll());
-    expectObservable(result).toBe('(abcdef|)');
+      const result = source.pipe(concatAll());
+      expectObservable(result).toBe('(abcdef|)');
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `of` unit tests to run mode. The PR also removes the scheduler argument from the parameters of `of` in a second commit. If that is not desired just drop the commit before merging. 

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
