### PR TITLE
chore(onErrorResumeNext): convert onErrorResumeNext specs to run mode

### DIFF
--- a/spec/observables/onErrorResumeNext-spec.ts
+++ b/spec/observables/onErrorResumeNext-spec.ts
@@ -1,98 +1,92 @@
-
+/** @prettier */
 import { onErrorResumeNext, of } from 'rxjs';
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
 import { finalize } from 'rxjs/operators';
 import { expect } from 'chai';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 describe('onErrorResumeNext', () => {
-  it('should continue with observables', () => {
-    const s1 =   hot('--a--b--#');
-    const s2  =  cold(       '--c--d--#');
-    const s3  =  cold(               '--e--#');
-    const s4  =  cold(                    '--f--g--|');
-    const subs1 =    '^       !';
-    const subs2 =    '        ^       !';
-    const subs3 =    '                ^    !';
-    const subs4 =    '                     ^       !';
-    const expected = '--a--b----c--d----e----f--g--|';
+  let rxTestScheduler: TestScheduler;
 
-    expectObservable(onErrorResumeNext(s1, s2, s3, s4)).toBe(expected);
-    expectSubscriptions(s1.subscriptions).toBe(subs1);
-    expectSubscriptions(s2.subscriptions).toBe(subs2);
-    expectSubscriptions(s3.subscriptions).toBe(subs3);
-    expectSubscriptions(s4.subscriptions).toBe(subs4);
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should continue with observables', () => {
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('  --a--b--#                     ');
+      const s2 = cold('         --c--d--#             ');
+      const s3 = cold('                 --e--#        ');
+      const s4 = cold('                      --f--g--|');
+      const subs1 = '   ^-------!                     ';
+      const subs2 = '   --------^-------!             ';
+      const subs3 = '   ----------------^----!        ';
+      const subs4 = '   ---------------------^-------!';
+      const expected = '--a--b----c--d----e----f--g--|';
+
+      expectObservable(onErrorResumeNext(s1, s2, s3, s4)).toBe(expected);
+      expectSubscriptions(s1.subscriptions).toBe(subs1);
+      expectSubscriptions(s2.subscriptions).toBe(subs2);
+      expectSubscriptions(s3.subscriptions).toBe(subs3);
+      expectSubscriptions(s4.subscriptions).toBe(subs4);
+    });
   });
 
   it('should continue array of observables', () => {
-    const s1 =   hot('--a--b--#');
-    const s2  =  cold(       '--c--d--#');
-    const s3  =  cold(               '--e--#');
-    const s4  =  cold(                    '--f--g--|');
-    const subs1 =    '^       !';
-    const subs2 =    '        ^       !';
-    const subs3 =    '                ^    !';
-    const subs4 =    '                     ^       !';
-    const expected = '--a--b----c--d----e----f--g--|';
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const s1 = hot('  --a--b--#                     ');
+      const s2 = cold('         --c--d--#             ');
+      const s3 = cold('                 --e--#        ');
+      const s4 = cold('                      --f--g--|');
+      const subs1 = '   ^-------!                     ';
+      const subs2 = '   --------^-------!             ';
+      const subs3 = '   ----------------^----!        ';
+      const subs4 = '   ---------------------^-------!';
+      const expected = '--a--b----c--d----e----f--g--|';
 
-    expectObservable(onErrorResumeNext([s1, s2, s3, s4])).toBe(expected);
-    expectSubscriptions(s1.subscriptions).toBe(subs1);
-    expectSubscriptions(s2.subscriptions).toBe(subs2);
-    expectSubscriptions(s3.subscriptions).toBe(subs3);
-    expectSubscriptions(s4.subscriptions).toBe(subs4);
+      expectObservable(onErrorResumeNext([s1, s2, s3, s4])).toBe(expected);
+      expectSubscriptions(s1.subscriptions).toBe(subs1);
+      expectSubscriptions(s2.subscriptions).toBe(subs2);
+      expectSubscriptions(s3.subscriptions).toBe(subs3);
+      expectSubscriptions(s4.subscriptions).toBe(subs4);
+    });
   });
 
   it('should complete single observable throws', () => {
-    const source =   hot('#');
-    const subs =         '(^!)';
-    const expected =     '|';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const source = hot('#   ');
+      const subs = '      (^!)';
+      const expected = '  |   ';
 
-    expectObservable(onErrorResumeNext(source)).toBe(expected);
-    expectSubscriptions(source.subscriptions).toBe(subs);
+      expectObservable(onErrorResumeNext(source)).toBe(expected);
+      expectSubscriptions(source.subscriptions).toBe(subs);
+    });
   });
 
-  
   it('should skip invalid sources and move on', () => {
     const results: any[] = [];
 
-    onErrorResumeNext(
-      of(1),
-      [2, 3, 4],
-      { notValid: 'LOL' } as any,
-      of(5, 6),
-    )
-    .subscribe({
-      next: value => results.push(value),
-      complete: () => results.push('complete')
+    onErrorResumeNext(of(1), [2, 3, 4], { notValid: 'LOL' } as any, of(5, 6)).subscribe({
+      next: (value) => results.push(value),
+      complete: () => results.push('complete'),
     });
 
     expect(results).to.deep.equal([1, 2, 3, 4, 5, 6, 'complete']);
   });
 
   it('should call finalize after each sync observable', () => {
-    let results: any[] = []
-    
+    let results: any[] = [];
+
     onErrorResumeNext(
-      of(1).pipe(
-        finalize(() => results.push('finalize 1'))
-      ),
-      of(2).pipe(
-        finalize(() => results.push('finalize 2'))
-      ), of(3).pipe(
-        finalize(() => results.push('finalize 3'))
-      ), of(4).pipe(
-        finalize(() => results.push('finalize 4'))
-      )
+      of(1).pipe(finalize(() => results.push('finalize 1'))),
+      of(2).pipe(finalize(() => results.push('finalize 2'))),
+      of(3).pipe(finalize(() => results.push('finalize 3'))),
+      of(4).pipe(finalize(() => results.push('finalize 4')))
     ).subscribe({
-      next: value => results.push(value),
-      complete: () => results.push('complete')
+      next: (value) => results.push(value),
+      complete: () => results.push('complete'),
     });
 
-    expect(results).to.deep.equal([
-      1, 'finalize 1',
-      2, 'finalize 2',
-      3, 'finalize 3',
-      4, 'finalize 4',
-      'complete'
-    ]);
+    expect(results).to.deep.equal([1, 'finalize 1', 2, 'finalize 2', 3, 'finalize 3', 4, 'finalize 4', 'complete']);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `onErrorResumeNext` unit tests to run mode. 

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
