### PR TITLE
chore(pairs): convert pairs specs to run mode

### DIFF
--- a/spec/observables/pairs-spec.ts
+++ b/spec/observables/pairs-spec.ts
@@ -1,43 +1,56 @@
+/** @prettier */
 import { expect } from 'chai';
-import { expectObservable } from '../helpers/marble-testing';
 import { TestScheduler } from 'rxjs/testing';
 import { pairs } from 'rxjs';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 describe('pairs', () => {
-  it('should create an observable emits key-value pair', () => {
-    const e1 = pairs({a: 1, b: 2}, rxTestScheduler);
-    const expected = '(ab|)';
-    const values = {
-      a: ['a', 1],
-      b: ['b', 2]
-    };
+  let rxTestScheduler: TestScheduler;
 
-    expectObservable(e1).toBe(expected, values);
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should create an observable emits key-value pair', () => {
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = pairs({ a: 1, b: 2 });
+      const expected = '(ab|)';
+      const values = {
+        a: ['a', 1],
+        b: ['b', 2],
+      };
+
+      expectObservable(e1).toBe(expected, values);
+    });
   });
 
   it('should create an observable without scheduler', (done) => {
     let expected = [
       ['a', 1],
       ['b', 2],
-      ['c', 3]
+      ['c', 3],
     ];
 
-    pairs({a: 1, b: 2, c: 3}).subscribe({ next: x => {
-      expect(x).to.deep.equal(expected.shift());
-    }, error: x => {
-      done(new Error('should not be called'));
-    }, complete: () => {
-      expect(expected).to.be.empty;
-      done();
-    } });
+    pairs({ a: 1, b: 2, c: 3 }).subscribe({
+      next: (x) => {
+        expect(x).to.deep.equal(expected.shift());
+      },
+      error: (x) => {
+        done(new Error('should not be called'));
+      },
+      complete: () => {
+        expect(expected).to.be.empty;
+        done();
+      },
+    });
   });
 
   it('should work with empty object', () => {
-    const e1 = pairs({}, rxTestScheduler);
-    const expected = '|';
+    rxTestScheduler.run(({ expectObservable }) => {
+      const e1 = pairs({});
+      const expected = '|';
 
-    expectObservable(e1).toBe(expected);
+      expectObservable(e1).toBe(expected);
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `pairs` unit tests to run mode.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
