### PR TITLE
docs: Fix table of contents extra headings

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -121,7 +121,7 @@ export class Observable<T> implements Subscribable<T> {
    * by default emits all its values synchronously. Always check documentation for how given Observable
    * will behave when subscribed and if its default behavior can be modified with a `scheduler`.
    *
-   * ## Examples
+   * #### Examples
    *
    * Subscribe with an {@link guide/observer Observer}
    *
@@ -261,7 +261,7 @@ export class Observable<T> implements Subscribable<T> {
    * this situation, look into adding something like {@link timeout}, {@link take},
    * {@link takeWhile}, or {@link takeUntil} amongst others.
    *
-   * ## Example
+   * #### Example
    *
    * ```ts
    * import { interval, take } from 'rxjs';


### PR DESCRIPTION
Fix docs table of contents issue where headings inside of a method's description are included. In the example below, it looks like `Observable` only has two methods.


Before:
<img width="244" alt="image" src="https://user-images.githubusercontent.com/5565418/163436865-47171e28-5696-4f3c-a147-c3fb396324c2.png">

After:
<img width="182" alt="image" src="https://user-images.githubusercontent.com/5565418/163437141-1150f1f8-6bc7-4194-b479-8741dca98c12.png">

