### PR TITLE
docs: fix mergeMap/switchMap copy/paste error

### DIFF
--- a/src/internal/operators/switchMapTo.ts
+++ b/src/internal/operators/switchMapTo.ts
@@ -2,7 +2,7 @@ import { switchMap } from './switchMap';
 import { ObservableInput, OperatorFunction, ObservedValueOf } from '../types';
 import { isFunction } from '../util/isFunction';
 
-/** @deprecated Will be removed in v9. Use {@link mergeMap} instead: `mergeMap(() => result)` */
+/** @deprecated Will be removed in v9. Use {@link switchMap} instead: `switchMap(() => result)` */
 export function switchMapTo<O extends ObservableInput<unknown>>(observable: O): OperatorFunction<unknown, ObservedValueOf<O>>;
 /** @deprecated The `resultSelector` parameter will be removed in v8. Use an inner `map` instead. Details: https://rxjs.dev/deprecations/resultSelector */
 export function switchMapTo<O extends ObservableInput<unknown>>(
@@ -54,7 +54,7 @@ export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
  * `resultSelector`) every time a value is emitted on the source Observable,
  * and taking only the values from the most recently projected inner
  * Observable.
- * @deprecated Will be removed in v9. Use {@link mergeMap} instead: `mergeMap(() => result)`
+ * @deprecated Will be removed in v9. Use {@link switchMap} instead: `switchMap(() => result)`
  */
 export function switchMapTo<T, R, O extends ObservableInput<unknown>>(
   innerObservable: O,


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

Fixes a copy/paste error in the `switchMapTo` TSDoc - the replacement should be `switchMap` and not `mergeMap` - that was mentioned [here](https://github.com/ReactiveX/rxjs/pull/6860#pullrequestreview-914312284) and [here](https://github.com/ReactiveX/rxjs/pull/6860#pullrequestreview-919493278).

**Related issue (if exists):** Nope