### PR TITLE
Update inaccurate example to 'of' replacement.

### DIFF
--- a/docs_app/content/deprecations/scheduler-argument.md
+++ b/docs_app/content/deprecations/scheduler-argument.md
@@ -37,7 +37,7 @@ Following code example demonstrate this process.
 import { of, asyncScheduler, scheduled } from 'rxjs';
 
 // Deprecated approach
-of([1, 2, 3], asyncScheduler).subscribe((x) => console.log(x));
+of(1, 2, 3, asyncScheduler).subscribe((x) => console.log(x));
 // suggested approach
 scheduled([1, 2, 3], asyncScheduler).subscribe((x) => console.log(x));
 ```


### PR DESCRIPTION
The arguments to 'of' should not be an array. When running the stackblitz, the output is:
[1, 2, 3]
1
2
3

That is the 'of' emitting the array, and the scheduled emitting each item in the array separately; not the same thing.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
