### PR TITLE
race synchronous emissions now stop subsequent observable subscriptions

### DIFF
--- a/docs_app/content/6-to-7-change-summary.md
+++ b/docs_app/content/6-to-7-change-summary.md
@@ -107,7 +107,7 @@ This document contains a detailed list of changes between RxJS 6.x and RxJS 7.x,
 #### race
 
 - Generic signatures have changed. Do not explicitly pass generics.
-- `race` will no longer subscribe to subsequent observables if a provided source synchronously errors or completes. This means side effects that might have occurred during subscription in those rare cases will no longer occur.
+- `race` will no longer subscribe to subsequent observables if a provided source synchronously emits, errors, or completes. This means side effects that might have occurred during subscription in those rare cases will no longer occur.
 
 #### ReplaySubject
 


### PR DESCRIPTION
Looking at the code, if an observable synchronously emits, subsequent observables will not be subscribed to. Synchronous errors and completions were noted as a breaking change, so adding emits to the list.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
