### PR TITLE
docs: fix checkOperator processor not to mark interfaces as operators

### DIFF
--- a/docs_app/tools/transforms/angular-base-package/processors/checkOperator.js
+++ b/docs_app/tools/transforms/angular-base-package/processors/checkOperator.js
@@ -4,7 +4,7 @@ module.exports = function checkOperator() {
     $runBefore: ['renderDocsProcessor'],
     $process(docs) {
       docs.forEach((doc) => {
-        doc.isOperator = !!(doc.originalModule && doc.originalModule.startsWith('internal/operators'));
+        doc.isOperator = !!(doc.originalModule?.startsWith('internal/operators') && doc.docType === 'function');
       });
     },
   };


### PR DESCRIPTION
**Description:**
Interfaces exported from the `internal/operators` module get marked as operators. Fix this issue by checking the doc type - only docs that originate as functions are operators.

**Related issue (if exists):**
None, but please take a look at the image from #6944