### PR TITLE
docs(Observer): add documentation to Observer interface

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -193,7 +193,6 @@ export interface Observer<T> {
    * the consumer has unsubscribed.
    *
    * For more info, please refer to {@link guide/glossary-and-semantics#error this guide}.
-   * @param err
    */
   error: (err: any) => void;
   /**

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -169,9 +169,42 @@ export interface CompletionObserver<T> {
 
 export type PartialObserver<T> = NextObserver<T> | ErrorObserver<T> | CompletionObserver<T>;
 
+/**
+ * An object interface that defines a set of callback functions a user can use to get
+ * notified of any set of {@link Observable}
+ * {@link guide/glossary-and-semantics#notification notification} events.
+ *
+ * For more info, please refer to {@link guide/observer this guide}.
+ */
 export interface Observer<T> {
+  /**
+   * A callback function that gets called by the producer during the subscription when
+   * the producer "has" the `value`. It won't be called if `error` or `complete` callback
+   * functions have been called, nor after the consumer has unsubscribed.
+   *
+   * For more info, please refer to {@link guide/glossary-and-semantics#next this guide}.
+   */
   next: (value: T) => void;
+  /**
+   * A callback function that gets called by the producer if and when it encountered a
+   * problem of any kind. The errored value will be provided through the `err` parameter.
+   * This callback can't be called more than one time, it can't be called if the
+   * `complete` callback function have been called previously, nor it can't be called if
+   * the consumer has unsubscribed.
+   *
+   * For more info, please refer to {@link guide/glossary-and-semantics#error this guide}.
+   * @param err
+   */
   error: (err: any) => void;
+  /**
+   * A callback function that gets called by the producer if and when it has no more
+   * values to provide (by calling `next` callback function). This means that no error
+   * has happened. This callback can't be called more than one time, it can't be called
+   * if the `error` callback function have been called previously, nor it can't be called
+   * if the consumer has unsubscribed.
+   *
+   * For more info, please refer to {@link guide/glossary-and-semantics#complete this guide}.
+   */
   complete: () => void;
 }
 


### PR DESCRIPTION
**Description:**
Since I proposed a `TapObserver` documentation page PR (#6944), I thought that we should document the Observer interface [page](https://rxjs.dev/api/index/interface/Observer) as well. Although there are [a guide](https://rxjs.dev/guide/observer) and [a glossary](https://rxjs.dev/guide/glossary-and-semantics) pages that explain most of what I wrote in this PR (which I also mentioned in this PR), I wanted to still add the basic documentation to the [Observer interface page](https://rxjs.dev/api/index/interface/Observer) which users can encounter while roaming the docs app (which is empty for now).

This is how these changes look like:

![image](https://user-images.githubusercontent.com/28087049/165390236-eec81db4-b3b7-4714-958e-1d5d1d034c18.png)

**Related issue (if exists):**
None