### PR TITLE
fix(zip): handle when unsubscribe is called from within next

### DIFF
--- a/src/internal/observable/zip.ts
+++ b/src/internal/observable/zip.ts
@@ -90,7 +90,7 @@ export function zip(...args: unknown[]): Observable<unknown> {
                   // If any one of the sources is both complete and has an empty buffer
                   // then we complete the result. This is because we cannot possibly have
                   // any more values to zip together.
-                  if (buffers.some((buffer, i) => !buffer.length && completed[i])) {
+                  if (buffers?.some((buffer, i) => !buffer.length && completed[i])) {
                     destination.complete();
                   }
                 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->
This PR makes sure the error reported here (#6716) doesn't get thrown anymore.

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking --> There are no breaking changes.

**Related issue (if exists):** #6716

I've added a test case which covers the bug but I wasn't sure if there might be a better way to test this. Please let me know if I need to change anything.