### PR TITLE
chore(bindCallback): convert bindCallback specs to run mode

### DIFF
--- a/spec/observables/bindCallback-spec.ts
+++ b/spec/observables/bindCallback-spec.ts
@@ -1,9 +1,9 @@
+/** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { bindCallback } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {bindCallback} */
 describe('bindCallback', () => {
@@ -13,14 +13,16 @@ describe('bindCallback', () => {
         cb();
       }
       const boundCallback = bindCallback(callback);
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback()
-        .subscribe({ next: (x: any) => {
+      boundCallback().subscribe({
+        next: (x: any) => {
           results.push(typeof x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal(['undefined', 'done']);
     });
@@ -30,18 +32,18 @@ describe('bindCallback', () => {
         cb(datum);
       }
 
-      const boundCallback = bindCallback(
-        callback,
-        (datum: any) => datum + 1,
-      );
+      const boundCallback = bindCallback(callback, (datum: any) => datum + 1);
 
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback(42)
-        .subscribe({
-          next(value) { results.push(value); },
-          complete() { results.push('done'); },
-        });
+      boundCallback(42).subscribe({
+        next(value) {
+          results.push(value);
+        },
+        complete() {
+          results.push('done');
+        },
+      });
 
       expect(results).to.deep.equal([43, 'done']);
     });
@@ -51,18 +53,18 @@ describe('bindCallback', () => {
         cb(datum);
       }
 
-      const boundCallback = bindCallback(
-        callback,
-        void 0,
-      );
+      const boundCallback = bindCallback(callback, void 0);
 
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback(42)
-        .subscribe({
-          next(value: any) { results.push(value); },
-          complete() { results.push('done'); },
-        });
+      boundCallback(42).subscribe({
+        next(value: any) {
+          results.push(value);
+        },
+        complete() {
+          results.push('done');
+        },
+      });
 
       expect(results).to.deep.equal([42, 'done']);
     });
@@ -72,14 +74,16 @@ describe('bindCallback', () => {
         cb(datum);
       }
       const boundCallback = bindCallback(callback);
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal([42, 'done']);
     });
@@ -90,12 +94,9 @@ describe('bindCallback', () => {
       }
 
       const boundCallback = bindCallback(callback);
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback.apply({datum: 5})
-        .subscribe(
-          { next: (x: number) => results.push(x), complete: () => results.push('done') }
-        );
+      boundCallback.apply({ datum: 5 }).subscribe({ next: (x: number) => results.push(x), complete: () => results.push('done') });
 
       expect(results).to.deep.equal([5, 'done']);
     });
@@ -111,8 +112,7 @@ describe('bindCallback', () => {
           cb(datum);
         }, 0);
       }
-      const subscription = bindCallback(callback)(42)
-        .subscribe({ next: nextSpy, error: throwSpy, complete: completeSpy });
+      const subscription = bindCallback(callback)(42).subscribe({ next: nextSpy, error: throwSpy, complete: completeSpy });
       subscription.unsubscribe();
 
       setTimeout(() => {
@@ -130,39 +130,51 @@ describe('bindCallback', () => {
         cb(datum);
       }
       const boundCallback = bindCallback(callback);
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
-      boundCallback(54)
-        .subscribe({ next: x => {
+        },
+      });
+      boundCallback(54).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal([42, 'done', 54, 'done']);
     });
   });
 
   describe('when scheduled', () => {
+    let rxTestScheduler: TestScheduler;
+
+    beforeEach(() => {
+      rxTestScheduler = new TestScheduler(observableMatcher);
+    });
+
     it('should emit undefined from a callback without arguments', () => {
       function callback(cb: Function) {
         cb();
       }
       const boundCallback = bindCallback(callback, rxTestScheduler);
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback()
-        .subscribe({ next: x => {
+      boundCallback().subscribe({
+        next: (x) => {
           results.push(typeof x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       rxTestScheduler.flush();
 
@@ -174,14 +186,16 @@ describe('bindCallback', () => {
         cb(datum);
       }
       const boundCallback = bindCallback(callback, rxTestScheduler);
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       rxTestScheduler.flush();
 
@@ -194,12 +208,9 @@ describe('bindCallback', () => {
       }
 
       const boundCallback = bindCallback(callback, rxTestScheduler);
-      const results: Array<string|number> = [];
+      const results: Array<string | number> = [];
 
-      boundCallback.apply({ datum: 5 })
-        .subscribe(
-          { next: (x: number) => results.push(x), complete: () => results.push('done') }
-        );
+      boundCallback.apply({ datum: 5 }).subscribe({ next: (x: number) => results.push(x), complete: () => results.push('done') });
 
       rxTestScheduler.flush();
 
@@ -213,92 +224,106 @@ describe('bindCallback', () => {
       }
       const boundCallback = bindCallback(callback, rxTestScheduler);
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           throw new Error('should not next');
-        }, error: (err: any) => {
+        },
+        error: (err: any) => {
           expect(err).to.equal(expected);
-        }, complete: () => {
+        },
+        complete: () => {
           throw new Error('should not complete');
-        } });
+        },
+      });
 
       rxTestScheduler.flush();
     });
 
-  it('should pass multiple inner arguments as an array', () => {
-    function callback(datum: number, cb: (a: number, b: number, c: number, d: number) => void) {
-      cb(datum, 1, 2, 3);
-    }
-    const boundCallback = bindCallback(callback, rxTestScheduler);
-    const results: Array<string|number[]> = [];
+    it('should pass multiple inner arguments as an array', () => {
+      function callback(datum: number, cb: (a: number, b: number, c: number, d: number) => void) {
+        cb(datum, 1, 2, 3);
+      }
+      const boundCallback = bindCallback(callback, rxTestScheduler);
+      const results: Array<string | number[]> = [];
 
-    boundCallback(42)
-      .subscribe({ next: x => {
-        results.push(x);
-      }, complete: () => {
-        results.push('done');
-      } });
+      boundCallback(42).subscribe({
+        next: (x) => {
+          results.push(x);
+        },
+        complete: () => {
+          results.push('done');
+        },
+      });
 
-    rxTestScheduler.flush();
+      rxTestScheduler.flush();
 
-    expect(results).to.deep.equal([[42, 1, 2, 3], 'done']);
+      expect(results).to.deep.equal([[42, 1, 2, 3], 'done']);
+    });
+
+    it('should cache value for next subscription and not call callbackFunc again', () => {
+      let calls = 0;
+      function callback(datum: number, cb: (x: number) => void) {
+        calls++;
+        cb(datum);
+      }
+      const boundCallback = bindCallback(callback, rxTestScheduler);
+      const results1: Array<number | string> = [];
+      const results2: Array<number | string> = [];
+
+      const source = boundCallback(42);
+
+      source.subscribe({
+        next: (x) => {
+          results1.push(x);
+        },
+        complete: () => {
+          results1.push('done');
+        },
+      });
+
+      source.subscribe({
+        next: (x) => {
+          results2.push(x);
+        },
+        complete: () => {
+          results2.push('done');
+        },
+      });
+
+      rxTestScheduler.flush();
+
+      expect(calls).to.equal(1);
+      expect(results1).to.deep.equal([42, 'done']);
+      expect(results2).to.deep.equal([42, 'done']);
+    });
+
+    it('should not even call the callbackFn if scheduled and immediately unsubscribed', () => {
+      let calls = 0;
+      function callback(datum: number, cb: Function) {
+        calls++;
+        cb(datum);
+      }
+      const boundCallback = bindCallback(callback, rxTestScheduler);
+      const results1: Array<number | string> = [];
+
+      const source = boundCallback(42);
+
+      const subscription = source.subscribe({
+        next: (x: any) => {
+          results1.push(x);
+        },
+        complete: () => {
+          results1.push('done');
+        },
+      });
+
+      subscription.unsubscribe();
+
+      rxTestScheduler.flush();
+
+      expect(calls).to.equal(0);
+    });
   });
-
-  it('should cache value for next subscription and not call callbackFunc again', () => {
-    let calls = 0;
-    function callback(datum: number, cb: (x: number) => void) {
-      calls++;
-      cb(datum);
-    }
-    const boundCallback = bindCallback(callback, rxTestScheduler);
-    const results1: Array<number|string> = [];
-    const results2: Array<number|string> = [];
-
-    const source = boundCallback(42);
-
-    source.subscribe({ next: x => {
-      results1.push(x);
-    }, complete: () => {
-      results1.push('done');
-    } });
-
-    source.subscribe({ next: x => {
-      results2.push(x);
-    }, complete: () => {
-      results2.push('done');
-    } });
-
-    rxTestScheduler.flush();
-
-    expect(calls).to.equal(1);
-    expect(results1).to.deep.equal([42, 'done']);
-    expect(results2).to.deep.equal([42, 'done']);
-  });
-
-  it('should not even call the callbackFn if scheduled and immediately unsubscribed', () => {
-    let calls = 0;
-    function callback(datum: number, cb: Function) {
-      calls++;
-      cb(datum);
-    }
-    const boundCallback = bindCallback(callback, rxTestScheduler);
-    const results1: Array<number|string> = [];
-
-    const source = boundCallback(42);
-
-    const subscription = source.subscribe({ next: (x: any) => {
-      results1.push(x);
-    }, complete: () => {
-      results1.push('done');
-    } });
-
-    subscription.unsubscribe();
-
-    rxTestScheduler.flush();
-
-    expect(calls).to.equal(0);
-  });
-});
 
   it('should emit post-callback errors', () => {
     function badFunction(callback: (answer: number) => void): void {
@@ -308,7 +333,7 @@ describe('bindCallback', () => {
     let receivedError: any;
 
     bindCallback(badFunction)().subscribe({
-      error: err => receivedError = err
+      error: (err) => (receivedError = err),
     });
 
     expect(receivedError).to.equal('kaboom');


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `bindCallback` unit tests to run mode.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->


**Related issue (if exists):**
None