### PR TITLE
chore(bindNodeCallback): convert bindNodeCallback specs to run mode

### DIFF
--- a/spec/observables/bindNodeCallback-spec.ts
+++ b/spec/observables/bindNodeCallback-spec.ts
@@ -1,12 +1,18 @@
+/** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { bindNodeCallback } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {bindNodeCallback} */
 describe('bindNodeCallback', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   describe('when not scheduled', () => {
     it('should emit undefined when callback is called without success arguments', () => {
       function callback(cb: Function) {
@@ -16,12 +22,14 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback);
       const results: Array<number | string> = [];
 
-      boundCallback()
-        .subscribe({ next: (x: any) => {
+      boundCallback().subscribe({
+        next: (x: any) => {
           results.push(typeof x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal(['undefined', 'done']);
     });
@@ -34,12 +42,14 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback, (x: number) => x + 1);
       const results: Array<number | string> = [];
 
-      boundCallback()
-        .subscribe({ next: x => {
+      boundCallback().subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal([43, 'done']);
     });
@@ -51,12 +61,14 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback);
       const results: Array<number | string> = [];
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal([42, 'done']);
     });
@@ -68,10 +80,7 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback);
       const results: Array<number | string> = [];
 
-      boundCallback.call({datum: 42})
-        .subscribe(
-          { next: (x: number) => results.push(x), complete: () => results.push('done') }
-        );
+      boundCallback.call({ datum: 42 }).subscribe({ next: (x: number) => results.push(x), complete: () => results.push('done') });
 
       expect(results).to.deep.equal([42, 'done']);
     });
@@ -86,14 +95,17 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback);
       const results: Array<number | string> = [];
 
-      boundCallback()
-        .subscribe({ next: () => {
+      boundCallback().subscribe({
+        next: () => {
           throw new Error('should not next');
-        }, error: (err: any) => {
+        },
+        error: (err: any) => {
           results.push(err);
-        }, complete: () => {
+        },
+        complete: () => {
           throw new Error('should not complete');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal([error]);
     });
@@ -109,8 +121,7 @@ describe('bindNodeCallback', () => {
           cb(null, datum);
         }, 0);
       }
-      const subscription = bindNodeCallback(callback)(42)
-        .subscribe({ next: nextSpy, error: throwSpy, complete: completeSpy });
+      const subscription = bindNodeCallback(callback)(42).subscribe({ next: nextSpy, error: throwSpy, complete: completeSpy });
       subscription.unsubscribe();
 
       setTimeout(() => {
@@ -130,18 +141,22 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback);
       const results: Array<number | string> = [];
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
-      boundCallback(54)
-        .subscribe({ next: x => {
+        },
+      });
+      boundCallback(54).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       expect(results).to.deep.equal([42, 'done', 54, 'done']);
     });
@@ -156,12 +171,14 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback, rxTestScheduler);
       const results: Array<number | string> = [];
 
-      boundCallback()
-        .subscribe({ next: (x: any) => {
+      boundCallback().subscribe({
+        next: (x: any) => {
           results.push(typeof x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       rxTestScheduler.flush();
 
@@ -175,12 +192,14 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback, rxTestScheduler);
       const results: Array<number | string> = [];
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           results.push(x);
-        }, complete: () => {
+        },
+        complete: () => {
           results.push('done');
-        } });
+        },
+      });
 
       rxTestScheduler.flush();
 
@@ -194,10 +213,7 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback, rxTestScheduler);
       const results: Array<number | string> = [];
 
-      boundCallback.call({datum: 42})
-        .subscribe(
-          { next: (x: number) => results.push(x), complete: () => results.push('done') }
-        );
+      boundCallback.call({ datum: 42 }).subscribe({ next: (x: number) => results.push(x), complete: () => results.push('done') });
 
       rxTestScheduler.flush();
 
@@ -211,14 +227,17 @@ describe('bindNodeCallback', () => {
       }
       const boundCallback = bindNodeCallback(callback, rxTestScheduler);
 
-      boundCallback(42)
-        .subscribe({ next: x => {
+      boundCallback(42).subscribe({
+        next: (x) => {
           throw new Error('should not next');
-        }, error: (err: any) => {
+        },
+        error: (err: any) => {
           expect(err).to.equal(expected);
-        }, complete: () => {
+        },
+        complete: () => {
           throw new Error('should not complete');
-        } });
+        },
+      });
 
       rxTestScheduler.flush();
     });
@@ -233,14 +252,17 @@ describe('bindNodeCallback', () => {
       const boundCallback = bindNodeCallback(callback, rxTestScheduler);
       const results: Array<number | string> = [];
 
-      boundCallback()
-        .subscribe({ next: () => {
+      boundCallback().subscribe({
+        next: () => {
           throw new Error('should not next');
-        }, error: (err: any) => {
+        },
+        error: (err: any) => {
           results.push(err);
-        }, complete: () => {
+        },
+        complete: () => {
           throw new Error('should not complete');
-        } });
+        },
+      });
 
       rxTestScheduler.flush();
 
@@ -255,12 +277,14 @@ describe('bindNodeCallback', () => {
     const boundCallback = bindNodeCallback(callback, rxTestScheduler);
     const results: Array<number[] | string> = [];
 
-    boundCallback(42)
-      .subscribe({ next: x => {
+    boundCallback(42).subscribe({
+      next: (x) => {
         results.push(x);
-      }, complete: () => {
+      },
+      complete: () => {
         results.push('done');
-      } });
+      },
+    });
 
     rxTestScheduler.flush();
 
@@ -279,17 +303,23 @@ describe('bindNodeCallback', () => {
 
     const source = boundCallback(42);
 
-    source.subscribe({ next: x => {
-      results1.push(x);
-    }, complete: () => {
-      results1.push('done');
-    } });
+    source.subscribe({
+      next: (x) => {
+        results1.push(x);
+      },
+      complete: () => {
+        results1.push('done');
+      },
+    });
 
-    source.subscribe({ next: x => {
-      results2.push(x);
-    }, complete: () => {
-      results2.push('done');
-    } });
+    source.subscribe({
+      next: (x) => {
+        results2.push(x);
+      },
+      complete: () => {
+        results2.push('done');
+      },
+    });
 
     rxTestScheduler.flush();
 
@@ -305,7 +335,7 @@ describe('bindNodeCallback', () => {
     }
     let receivedError: any;
     bindNodeCallback(badFunction)().subscribe({
-      error: err => receivedError = err
+      error: (err) => (receivedError = err),
     });
 
     expect(receivedError).to.equal('kaboom');
@@ -326,8 +356,8 @@ describe('bindNodeCallback', () => {
 
     let result1: any;
     let result2: any;
-    source$.subscribe(value => result1 = value);
-    source$.subscribe(value => result2 = value);
+    source$.subscribe((value) => (result1 = value));
+    source$.subscribe((value) => (result2 = value));
 
     expect(calls).to.equal(1);
     executeCallback(null, 'test');
@@ -343,15 +373,18 @@ describe('bindNodeCallback', () => {
       cb(null, datum);
     }
     const boundCallback = bindNodeCallback(callback, rxTestScheduler);
-    const results1: Array<number|string> = [];
+    const results1: Array<number | string> = [];
 
     const source = boundCallback(42);
 
-    const subscription = source.subscribe({ next: (x: any) => {
-      results1.push(x);
-    }, complete: () => {
-      results1.push('done');
-    } });
+    const subscription = source.subscribe({
+      next: (x: any) => {
+        results1.push(x);
+      },
+      complete: () => {
+        results1.push('done');
+      },
+    });
 
     subscription.unsubscribe();
 


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `bindNodeCallback` unit tests to run mode.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None