### PR TITLE
chore(fromEventPattern): convert fromEventPattern specs to run mode

### DIFF
--- a/spec/observables/fromEventPattern-spec.ts
+++ b/spec/observables/fromEventPattern-spec.ts
@@ -1,26 +1,33 @@
+/** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { expectObservable } from '../helpers/marble-testing';
 
 import { fromEventPattern, noop, NEVER, timer } from 'rxjs';
 import { mapTo, take, concat } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {fromEventPattern} */
 describe('fromEventPattern', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should create an observable from the handler API', () => {
-    function addHandler(h: any) {
-      timer(50, 20, rxTestScheduler).pipe(
-        mapTo('ev'),
-        take(2),
-        concat(NEVER)
-      ).subscribe(h);
-    }
-    const e1 = fromEventPattern(addHandler);
-    const expected = '-----x-x---';
-    expectObservable(e1).toBe(expected, {x: 'ev'});
+    rxTestScheduler.run(({ time, expectObservable }) => {
+      const time1 = time('-----|     ');
+      const time2 = time('     --|   ');
+      const expected = '  -----x-x---';
+
+      function addHandler(h: any) {
+        timer(time1, time2, rxTestScheduler).pipe(mapTo('ev'), take(2), concat(NEVER)).subscribe(h);
+      }
+      const e1 = fromEventPattern(addHandler);
+
+      expectObservable(e1).toBe(expected, { x: 'ev' });
+    });
   });
 
   it('should call addHandler on subscription', () => {
@@ -50,7 +57,7 @@ describe('fromEventPattern', () => {
   });
 
   it('should deliver return value of addHandler to removeHandler as signal', () => {
-    const expected = { signal: true};
+    const expected = { signal: true };
     const addHandler = () => expected;
     const removeHandler = sinon.spy();
     fromEventPattern(addHandler, removeHandler).subscribe(noop).unsubscribe();
@@ -62,11 +69,14 @@ describe('fromEventPattern', () => {
   it('should send errors in addHandler down the error path', (done) => {
     fromEventPattern((h: any) => {
       throw 'bad';
-    }, noop).subscribe(
-      { next: () => done(new Error('should not be called')), error: (err: any) => {
+    }, noop).subscribe({
+      next: () => done(new Error('should not be called')),
+      error: (err: any) => {
         expect(err).to.equal('bad');
         done();
-      }, complete: () => done(new Error('should not be called')) });
+      },
+      complete: () => done(new Error('should not be called')),
+    });
   });
 
   it('should accept a selector that maps outgoing values', (done) => {
@@ -87,14 +97,19 @@ describe('fromEventPattern', () => {
       return a + b + '!';
     };
 
-    fromEventPattern(addHandler, removeHandler, selector).pipe(take(1))
-      .subscribe({ next: (x: any) => {
-        expect(x).to.equal('testme!');
-      }, error: (err: any) => {
-        done(new Error('should not be called'));
-      }, complete: () => {
-        done();
-      } });
+    fromEventPattern(addHandler, removeHandler, selector)
+      .pipe(take(1))
+      .subscribe({
+        next: (x: any) => {
+          expect(x).to.equal('testme!');
+        },
+        error: (err: any) => {
+          done(new Error('should not be called'));
+        },
+        complete: () => {
+          done();
+        },
+      });
 
     trigger('test', 'me');
   });
@@ -117,15 +132,18 @@ describe('fromEventPattern', () => {
       throw 'bad';
     };
 
-    fromEventPattern(addHandler, removeHandler, selector)
-      .subscribe({ next: (x: any) => {
+    fromEventPattern(addHandler, removeHandler, selector).subscribe({
+      next: (x: any) => {
         done(new Error('should not be called'));
-      }, error: (err: any) => {
+      },
+      error: (err: any) => {
         expect(err).to.equal('bad');
         done();
-      }, complete: () => {
+      },
+      complete: () => {
         done(new Error('should not be called'));
-      } });
+      },
+    });
 
     trigger('test');
   });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `fromEventPattern` unit tests to run mode.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None