### PR TITLE
chore(race): convert race specs to run mode

### DIFF
--- a/spec/observables/race-spec.ts
+++ b/spec/observables/race-spec.ts
@@ -1,215 +1,256 @@
-import { hot, cold, expectObservable, expectSubscriptions } from '../helpers/marble-testing';
+/** @prettier */
 import { race, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { expect } from 'chai';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {race} */
-describe('static race', () => {
+describe('race', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should race a single observable', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const expected = '---a-----b-----c----|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|');
+      const e1subs = '  ^-------------------!';
+      const expected = '---a-----b-----c----|';
 
-    const result = race(e1);
+      const result = race(e1);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should race cold and cold', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race with array of observable', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = race([e1, e2]);
+      const result = race([e1, e2]);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race hot and hot', () => {
-    const e1 =   hot('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = hot('  ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race hot and cold', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^                   !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b-----c----|';
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|   ');
+      const e1subs = '  ^-------------------!   ';
+      const e2 = hot('  ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race 2nd and 1st', () => {
-    const e1 =  cold('------x-----y-----z----|');
-    const e1subs =   '^  !';
-    const e2 =  cold('---a-----b-----c----|');
-    const e2subs =   '^                   !';
-    const expected = '---a-----b-----c----|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ------x-----y-----z----|');
+      const e1subs = '  ^--!                    ';
+      const e2 = cold(' ---a-----b-----c----|   ');
+      const e2subs = '  ^-------------------!   ';
+      const expected = '---a-----b-----c----|   ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should race emit and complete', () => {
-    const e1 =  cold('-----|');
-    const e1subs =   '^    !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^    !';
-    const expected = '-----|';
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -----|                  ');
+      const e1subs = '  ^----!                  ';
+      const e2 = hot('  ------x-----y-----z----|');
+      const e2subs = '  ^----!                  ';
+      const expected = '-----|                  ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should allow unsubscribing early and explicitly', () => {
-    const e1 =  cold('---a-----b-----c----|');
-    const e1subs =   '^           !';
-    const e2 =   hot('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----b---';
-    const unsub =    '            !';
+    rxTestScheduler.run(({ hot, cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----b-----c----|   ');
+      const e1subs = '  ^-----------!           ';
+      const e2 = hot('  ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----b---           ';
+      const unsub = '   ------------!           ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should not break unsubscription chains when unsubscribed explicitly', () => {
-    const e1 =   hot('--a--^--b--c---d-| ');
-    const e1subs =        '^        !    ';
-    const e2 =   hot('---e-^---f--g---h-|');
-    const e2subs =        '^  !    ';
-    const expected =      '---b--c---    ';
-    const unsub =         '         !    ';
+    rxTestScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--^--b--c---d-| ');
+      const e1subs = '       ^--------!    ';
+      const e2 = hot('  ---e-^---f--g---h-|');
+      const e2subs = '       ^--!          ';
+      const expected = '     ---b--c---    ';
+      const unsub = '        ---------!    ';
 
-    const result = race(
-        e1.pipe(mergeMap((x: string) => of(x))),
-        e2.pipe(mergeMap((x: string) => of(x)))
-    ).pipe(mergeMap((x: any) => of(x)));
+      const result = race(e1.pipe(mergeMap((x: string) => of(x))), e2.pipe(mergeMap((x: string) => of(x)))).pipe(
+        mergeMap((x: any) => of(x))
+      );
 
-    expectObservable(result, unsub).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result, unsub).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should never emit when given non emitting sources', () => {
-    const e1 =  cold('---|');
-    const e2 =  cold('---|');
-    const e1subs =   '^  !';
-    const expected = '---|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---|');
+      const e2 = cold(' ---|');
+      const e1subs = '  ^--!';
+      const expected = '---|';
 
-    const source = race(e1, e2);
+      const source = race(e1, e2);
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should throw when error occurs mid stream', () => {
-    const e1 =  cold('---a-----#');
-    const e1subs =   '^        !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---a-----#';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---a-----#              ');
+      const e1subs = '  ^--------!              ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---a-----#              ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('should throw when error occurs before a winner is found', () => {
-    const e1 =  cold('---#');
-    const e1subs =   '^  !';
-    const e2 =  cold('------x-----y-----z----|');
-    const e2subs =   '^  !';
-    const expected = '---#';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' ---#                    ');
+      const e1subs = '  ^--!                    ';
+      const e2 = cold(' ------x-----y-----z----|');
+      const e2subs = '  ^--!                    ';
+      const expected = '---#                    ';
 
-    const result = race(e1, e2);
+      const result = race(e1, e2);
 
-    expectObservable(result).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    expectSubscriptions(e2.subscriptions).toBe(e2subs);
+      expectObservable(result).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectSubscriptions(e2.subscriptions).toBe(e2subs);
+    });
   });
 
   it('handle empty', () => {
-    const e1 =  cold('|');
-    const e1subs =   '(^!)';
-    const expected = '|';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' |   ');
+      const e1subs = '  (^!)';
+      const expected = '|   ';
 
-    const source = race(e1);
+      const source = race(e1);
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('handle never', () => {
-    const e1 =  cold('-');
-    const e1subs =   '^';
-    const expected = '-';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' -');
+      const e1subs = '  ^';
+      const expected = '-';
 
-    const source = race(e1);
+      const source = race(e1);
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('handle throw', () => {
-    const e1 =  cold('#');
-    const e1subs =   '(^!)';
-    const expected = '#';
+    rxTestScheduler.run(({ cold, expectObservable, expectSubscriptions }) => {
+      const e1 = cold(' #   ');
+      const e1subs = '  (^!)';
+      const expected = '#   ';
 
-    const source = race(e1);
+      const source = race(e1);
 
-    expectObservable(source).toBe(expected);
-    expectSubscriptions(e1.subscriptions).toBe(e1subs);
+      expectObservable(source).toBe(expected);
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
   });
 
   it('should support a single ObservableInput argument', (done) => {
     const source = race(Promise.resolve(42));
-    source.subscribe({ next: value => {
-      expect(value).to.equal(42);
-    }, error: done, complete: done });
+    source.subscribe({
+      next: (value) => {
+        expect(value).to.equal(42);
+      },
+      error: done,
+      complete: done,
+    });
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `race` unit tests to run mode.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
