### PR TITLE
chore(range): convert range specs to run mode

### DIFF
--- a/spec/observables/range-spec.ts
+++ b/spec/observables/range-spec.ts
@@ -1,47 +1,71 @@
+/** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
-import { asapScheduler as asap, range, of} from 'rxjs';
+import { asapScheduler as asap, range, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { expectObservable } from '../helpers/marble-testing';
 import { concatMap, delay } from 'rxjs/operators';
-
-declare const rxTestScheduler: TestScheduler;
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {range} */
 describe('range', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should create an observable with numbers 1 to 10', () => {
-    const e1 = range(1, 10)
-      // for the purpose of making a nice diagram, spread out the synchronous emissions
-      .pipe(concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : 20, rxTestScheduler))));
-    const expected = 'a-b-c-d-e-f-g-h-i-(j|)';
-    const values = {
-      a: 1,
-      b: 2,
-      c: 3,
-      d: 4,
-      e: 5,
-      f: 6,
-      g: 7,
-      h: 8,
-      i: 9,
-      j: 10,
-    };
-    expectObservable(e1).toBe(expected, values);
+    rxTestScheduler.run(({ expectObservable, time }) => {
+      const delayAmount = time('--|');
+      //                          --|
+      //                            --|
+      //                              --|
+      //                                --|
+      //                                  --|
+      //                                    --|
+      //                                      --|
+      //                                        --|
+      const expected = '        a-b-c-d-e-f-g-h-i-(j|)';
+
+      const e1 = range(1, 10)
+        // for the purpose of making a nice diagram, spread out the synchronous emissions
+        .pipe(concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : delayAmount))));
+      const values = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: 5,
+        f: 6,
+        g: 7,
+        h: 8,
+        i: 9,
+        j: 10,
+      };
+      expectObservable(e1).toBe(expected, values);
+    });
   });
 
   it('should work for two subscribers', () => {
-    const e1 = range(1, 5)
-      .pipe(concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : 20, rxTestScheduler))));
-    const expected = 'a-b-c-d-(e|)';
-    const values = {
-      a: 1,
-      b: 2,
-      c: 3,
-      d: 4,
-      e: 5
-    };
-    expectObservable(e1).toBe(expected, values);
-    expectObservable(e1).toBe(expected, values);
+    rxTestScheduler.run(({ expectObservable, time }) => {
+      const delayAmount = time('--|');
+      //                          --|
+      //                            --|
+      //                              --|
+      const expected = '        a-b-c-d-(e|)';
+
+      const e1 = range(1, 5).pipe(concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : delayAmount))));
+
+      const values = {
+        a: 1,
+        b: 2,
+        c: 3,
+        d: 4,
+        e: 5,
+      };
+      expectObservable(e1).toBe(expected, values);
+      expectObservable(e1).toBe(expected, values);
+    });
   });
 
   it('should synchronously create a range of values by default', () => {
@@ -58,49 +82,58 @@ describe('range', () => {
 
     const source = range(12, 4, asap);
 
-    source.subscribe({ next: function (x) {
-      expect(asap.schedule).have.been.called;
-      const exp = expected.shift();
-      expect(x).to.equal(exp);
-    }, error: function (x) {
-      done(new Error('should not be called'));
-    }, complete: () => {
-      (<any>asap.schedule).restore();
-      done();
-    } });
-
+    source.subscribe({
+      next: function (x) {
+        expect(asap.schedule).have.been.called;
+        const exp = expected.shift();
+        expect(x).to.equal(exp);
+      },
+      error: function (x) {
+        done(new Error('should not be called'));
+      },
+      complete: () => {
+        (<any>asap.schedule).restore();
+        done();
+      },
+    });
   });
 
   it('should accept only one argument where count is argument and start is zero', () => {
-    const e1 = range(5)
-      .pipe(concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : 20, rxTestScheduler))));
-    const expected = 'a-b-c-d-(e|)';
-    const values = {
-      a: 0,
-      b: 1,
-      c: 2,
-      d: 3,
-      e: 4
-    };
-    expectObservable(e1).toBe(expected, values);
-    expectObservable(e1).toBe(expected, values);
+    rxTestScheduler.run(({ expectObservable, time }) => {
+      const delayAmount = time('--|');
+      //                          --|
+      //                            --|
+      //                              --|
+      const expected = '        a-b-c-d-(e|)';
+
+      const e1 = range(5).pipe(concatMap((x, i) => of(x).pipe(delay(i === 0 ? 0 : delayAmount))));
+      const values = {
+        a: 0,
+        b: 1,
+        c: 2,
+        d: 3,
+        e: 4,
+      };
+      expectObservable(e1).toBe(expected, values);
+      expectObservable(e1).toBe(expected, values);
+    });
   });
 
   it('should return empty for range(0)', () => {
     const results: any[] = [];
     range(0).subscribe({
-      next: value => results.push(value),
-      complete: () => results.push('done')
-    })
-    expect(results).to.deep.equal(['done'])
+      next: (value) => results.push(value),
+      complete: () => results.push('done'),
+    });
+    expect(results).to.deep.equal(['done']);
   });
 
   it('should return empty for range with a negative count', () => {
     const results: any[] = [];
     range(5, -5).subscribe({
-      next: value => results.push(value),
-      complete: () => results.push('done')
-    })
-    expect(results).to.deep.equal(['done'])
+      next: (value) => results.push(value),
+      complete: () => results.push('done'),
+    });
+    expect(results).to.deep.equal(['done']);
   });
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `range` unit tests to run mode.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None