### PR TITLE
chore(never): convert never specs to run mode

### DIFF
--- a/spec/observables/never-spec.ts
+++ b/spec/observables/never-spec.ts
@@ -1,13 +1,23 @@
+/** @prettier */
 import { NEVER } from 'rxjs';
 import { expect } from 'chai';
-import { expectObservable } from '../helpers/marble-testing';
+import { TestScheduler } from 'rxjs/testing';
+import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {NEVER} */
 describe('NEVER', () => {
+  let rxTestScheduler: TestScheduler;
+
+  beforeEach(() => {
+    rxTestScheduler = new TestScheduler(observableMatcher);
+  });
+
   it('should create a cold observable that never emits', () => {
-    const expected = '-';
-    const e1 = NEVER;
-    expectObservable(e1).toBe(expected);
+    rxTestScheduler.run(({ expectObservable }) => {
+      const expected = '-';
+      const e1 = NEVER;
+      expectObservable(e1).toBe(expected);
+    });
   });
 
   it('should return the same instance every time', () => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR converts `never` unit tests to run mode.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None