### PR TITLE
Evade override mistake

### DIFF
--- a/src/internal/util/createErrorClass.ts
+++ b/src/internal/util/createErrorClass.ts
@@ -14,7 +14,13 @@ export function createErrorClass<T>(createImpl: (_super: any) => any): T {
   };
 
   const ctorFunc = createImpl(_super);
-  ctorFunc.prototype = Object.create(Error.prototype);
-  ctorFunc.prototype.constructor = ctorFunc;
+    ctorFunc.prototype = Object.create(Error.prototype, {
+        constructor: {
+            value: ctorFunc,
+            writable: true,
+            enumerable: false,
+            configurable: true,
+        }
+    });
   return ctorFunc;
 }


### PR DESCRIPTION
See https://github.com/Agoric/agoric-sdk/blob/master/patches/inquirer%2B%2Brxjs%2B7.5.5.patch

The original code used assignment to override the `constructor` property inherited from `Error.prototype`. However, if `Error.prototype` is frozen, as it is under Hardened JS (aka SES) or under the Node frozen intrinsics flag, then this assignment fails due to the JavaScript "override mistake".

`enumerable: true` would accurately preserve the behavior of the original assignment, but I'm guessing that was not intentional. For an actual error subclass, this property would not be enumerable, so my PR currently proposes that. But either would work, so let me know if you'd like me to change it.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
https://github.com/endojs/endo/issues/576
https://github.com/Agoric/agoric-sdk/pull/5569