### PR TITLE
fix(share): Prevent setup/reset race condition in share with refCount

### DIFF
--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { shareReplay, mergeMapTo, retry, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { Observable, Operator, Observer, of, from, defer, pipe } from 'rxjs';
+import { Observable, Operator, Observer, of, from, defer, pipe, combineLatest, firstValueFrom, BehaviorSubject } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {shareReplay} */
@@ -271,6 +271,20 @@ describe('shareReplay', () => {
     }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
     source.subscribe();
     source.subscribe();
+    expect(subscriptions).to.equal(1);
+  });
+
+  it('should only subscribe once each with multiple synchronous subscriptions and unsubscriptions ', async () => {
+    // This may seem very specific, but it's a regression test for https://github.com/ReactiveX/rxjs/issues/6760
+
+    let subscriptions = 0;
+    const source = defer(() => {
+      ++subscriptions;
+      // Needs to be an observable that doesn't complete
+      return new BehaviorSubject(1);
+    }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
+
+    firstValueFrom(combineLatest([source, source]));
     expect(subscriptions).to.equal(1);
   });
 

--- a/spec/operators/shareReplay-spec.ts
+++ b/spec/operators/shareReplay-spec.ts
@@ -284,7 +284,7 @@ describe('shareReplay', () => {
       return new BehaviorSubject(1);
     }).pipe(shareReplay({ bufferSize: 1, refCount: true }));
 
-    firstValueFrom(combineLatest([source, source]));
+    await firstValueFrom(combineLatest([source, source]));
     expect(subscriptions).to.equal(1);
   });
 

--- a/src/internal/operators/share.ts
+++ b/src/internal/operators/share.ts
@@ -211,7 +211,13 @@ export function share<T>(options: ShareConfig<T> = {}): MonoTypeOperatorFunction
       // Basically, `subscriber === dest.subscribe(subscriber)` is `true`.
       dest.subscribe(subscriber);
 
-      if (!connection) {
+      if (
+        !connection &&
+        // Check this shareReplay is still activate - it can be reset to 0
+        // and be "unsubscribed" _before_ it actually subscribes.
+        // If we were to subscribe then, it'd leak and get stuck.
+        refCount > 0
+      ) {
         // We need to create a subscriber here - rather than pass an observer and
         // assign the returned subscription to connection - because it's possible
         // for reentrant subscriptions to the shared observable to occur and in


### PR DESCRIPTION
**Description:** Fixes the bug described in #6760, which seems to be a race condition.

The conditions are as such:
- Have an observable that emits immediately, but does not complete (eg. a `BehaviorSubject`, or something with `startWith`)
- Share it with `shareReplay` (or any `share` with `refCount: true`)
- Subscribe multiple times simultaneously, then unsubscribe immediately (can happen with `firstValueFrom`)
- The shared observable then gets into a bad state where it stays subscribed to the source observable but doesn't emit new values when next subscribed to.

The reason this happens is because `share` adds the reset subscription before subscribing to the source. As a result, if we subscribe and unsubscribe simultaneously, the reset block can actually run before subscribing to the source. When it gets reset, the `connection` state gets reset as well, and it subscribes to the source again even though it's already been reset.

In the PR, I've fixed it via adding an extra check before subscribing to make sure we actually need to subscribe to the source. I feel like this is only patches over the issue and some other edge case may still be broken, but there are some comments in the code saying that the reset subscription needs to be before the source subscription, so I didn't want to move anything else around.

I added a test as well, though it tests a symptom (an excess subscription) rather than the real impact (doesn't emit again later). Couldn't get the latter working.

**BREAKING CHANGE:** No

**Related issue (if exists):** #6760 