### PR TITLE
docs: mark deprecated items in module template

### DIFF
--- a/docs_app/src/styles/1-layouts/_api-page.scss
+++ b/docs_app/src/styles/1-layouts/_api-page.scss
@@ -1,88 +1,93 @@
 .api-section {
-    position: relative;
+  position: relative;
 
-    pre {
-        white-space: pre-wrap;
+  pre {
+    white-space: pre-wrap;
+  }
+
+  table.api-table {
+    min-width: 680px;
+
+    thead th {
+      color: white;
+      font-size: 16px;
+      background-color: $pink;
+      border-radius: 4px 4px 0 0;
+      text-transform: none;
+      padding: 8px 24px;
     }
 
-    table.api-table {
-        min-width: 680px;
+    tbody {
+      pre {
+        white-space: normal;
+        margin: 4px;
+        padding: 4px 16px;
+      }
 
-        thead th {
-            color: white;
-            font-size: 16px;
-            background-color: $pink;
-            border-radius: 4px 4px 0 0;
-            text-transform: none;
-            padding: 8px 24px;
-        }
+      td,
+      th {
+        padding: 0;
+      }
 
-        tbody {
-            pre {
-                white-space: normal;
-                margin: 4px;
-                padding: 4px 16px;
-            }
-
-            td, th {
-                padding: 0;
-            }
-
-            th {
-                max-width: 150px;
-            }
-        }
-
+      th {
+        max-width: 150px;
+      }
     }
+  }
 }
 
 .api-body {
+  max-width: 1200px;
 
-    max-width: 1200px;
-
-    table {
-
-        th {
-            text-transform: none;
-            font-size: 16px;
-            font-weight: bold;
-        }
-
-        tr {
-            border-bottom: 1px solid $lightgray;
-        }
-
-        td {
-            vertical-align: middle;
-        }
-
-        hr {
-            margin: 16px 0;
-        }
-
-        tr:last-child {
-            border-bottom: none;
-        }
-
-        &.item-table {
-            td {
-                padding: 32px;
-            }
-        }
-
-        &.list-table {
-            td {
-                padding: 16px 24px;
-            }
-        }
+  table {
+    th {
+      text-transform: none;
+      font-size: 16px;
+      font-weight: bold;
     }
 
-    /* used to target the short description */
-    > p:nth-child(2) {
-        border-left: 5px solid $pink;
-        font-size: 1rem;
-        line-height: 1.25;
-        padding-left: .5rem;
-
+    tr {
+      border-bottom: 1px solid $lightgray;
     }
+
+    td {
+      vertical-align: middle;
+    }
+
+    hr {
+      margin: 16px 0;
+    }
+
+    tr:last-child {
+      border-bottom: none;
+    }
+
+    &.item-table {
+      td {
+        padding: 32px;
+      }
+    }
+
+    &.list-table {
+      td {
+        padding: 16px 24px;
+      }
+    }
+  }
+
+  /* used to target the short description */
+  > p:nth-child(2) {
+    border-left: 5px solid $pink;
+    font-size: 1rem;
+    line-height: 1.25;
+    padding-left: 0.5rem;
+  }
+
+  .export-list {
+    a {
+      &.deprecated {
+        text-decoration: line-through;
+      }
+    }
+  }
 }

--- a/docs_app/tools/transforms/templates/api/module.template.html
+++ b/docs_app/tools/transforms/templates/api/module.template.html
@@ -9,7 +9,7 @@
   <ul>
     {% for export in doc.exports -%}
       {% if not export.duplicateOf %}
-        <li><a href="{$ export.path $}">{$ export.name $}</a></li>
+        <li><a{% if export.deprecated %} class="deprecated"{% endif %} href="{$ export.path $}">{$ export.name $}</a></li>
       {% endif %}
     {%- endfor %}
   </ul>


### PR DESCRIPTION
**Description:**
This PR improves modules template by marking deprecated items with a strikethrough.

For example, this is how [`/api/index`](https://rxjs.dev/api/index) page looks like now:

<img width="450" alt="image" src="https://user-images.githubusercontent.com/28087049/180616156-6275c090-a989-4ebe-bf1e-607a92803231.png">

With this PR, deprecated items are now marked with a strikethrough:

<img width="862" alt="image" src="https://user-images.githubusercontent.com/28087049/180616205-a46b649c-baeb-474e-9935-b08844de80a7.png">

**Related issue (if exists):**
None