### PR TITLE
docs(index): fix typo

### DIFF
--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -25,7 +25,7 @@ import { dateTimestampProvider } from './scheduler/dateTimestampProvider';
  *
  * ### Differences with BehaviorSubject
  *
- * `BehaviorSubject` is similar to `new ReplaySubject(1)`, with a couple fo exceptions:
+ * `BehaviorSubject` is similar to `new ReplaySubject(1)`, with a couple of exceptions:
  *
  * 1. `BehaviorSubject` comes "primed" with a single value upon construction.
  * 2. `ReplaySubject` will replay values, even after observing an error, where `BehaviorSubject` will not.


### PR DESCRIPTION
fix typo

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
