### PR TITLE
docs: fix "the the" -> "the"

### DIFF
--- a/docs_app/README.md
+++ b/docs_app/README.md
@@ -80,7 +80,7 @@ You also want to see those changes displayed properly in the doc viewer
 with a quick, edit/view cycle time.
 
 For this purpose, use the `npm run docs-watch` task, which watches for changes to source files and only
-re-processes the the files necessary to generate the docs that are related to the file that has changed.
+re-processes the files necessary to generate the docs that are related to the file that has changed.
 Since this task takes shortcuts, it is much faster (often less than 1 second) but it won't produce full
 fidelity content. For example, links to other docs and code examples may not render correctly. This is
 most particularly noticed in links to other docs and in the embedded examples, which may not always render

--- a/docs_app/src/app/custom-elements/elements-loader.spec.ts
+++ b/docs_app/src/app/custom-elements/elements-loader.spec.ts
@@ -194,7 +194,7 @@ describe('ElementsLoader', () => {
       expect(definedSpy).not.toHaveBeenCalled();
     }));
 
-    it('should fail if defining the the custom element fails', fakeAsync(() => {
+    it('should fail if defining the custom element fails', fakeAsync(() => {
       let state = 'pending';
       elementsLoader.loadCustomElement('element-b-selector').catch(e => state = `rejected: ${e}`);
       flushMicrotasks();

--- a/docs_app/src/app/shared/select/select.component.spec.ts
+++ b/docs_app/src/app/shared/select/select.component.spec.ts
@@ -73,7 +73,7 @@ describe('SelectComponent', () => {
     beforeEach(() => {
       host.options = options;
       host.showSymbol = true;
-      getButton().click(); // ensure the the options are visible
+      getButton().click(); // ensure the options are visible
       fixture.detectChanges();
     });
 

--- a/spec/operators/timeout-spec.ts
+++ b/spec/operators/timeout-spec.ts
@@ -444,7 +444,7 @@ describe('timeout operator', () => {
         const innerSubs = '    ----------^----------!';
         const expected = '     ------------x--y--z--|';
 
-        // The the current frame is zero.
+        // The current frame is zero.
         const result = source.pipe(
           timeout({
             first: new Date(t),

--- a/src/internal/scheduler/VirtualTimeScheduler.ts
+++ b/src/internal/scheduler/VirtualTimeScheduler.ts
@@ -8,7 +8,7 @@ export class VirtualTimeScheduler extends AsyncScheduler {
   static frameTimeFactor = 10;
 
   /**
-   * The current frame for the state of the virtual scheduler instance. The the difference
+   * The current frame for the state of the virtual scheduler instance. The difference
    * between two "frames" is synonymous with the passage of "virtual time units". So if
    * you record `scheduler.frame` to be `1`, then later, observe `scheduler.frame` to be at `11`,
    * that means `10` virtual time units have passed.


### PR DESCRIPTION
**Description:**

Replace typos "the the" with "the".