### PR TITLE
feat(delayWhen): `delayWhen`'s `delayDurationSelector` should support `ObservableInput`

### DIFF
--- a/spec-dtslint/operators/delayWhen-spec.ts
+++ b/spec-dtslint/operators/delayWhen-spec.ts
@@ -10,7 +10,7 @@ it('should support an empty notifier', () => {
   const o = of(1, 2, 3).pipe(delayWhen(() => NEVER)); // $ExpectType Observable<number>
 });
 
-it('should support a subscriptiondelayWhen parameter', () => {
+it('should support a subscriptionDelay parameter', () => {
   const o = of(1, 2, 3).pipe(delayWhen(() => of('a', 'b', 'c'), of(new Date()))); // $ExpectType Observable<number>
 });
 
@@ -18,12 +18,16 @@ it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(delayWhen()); // $ExpectError
 });
 
-it('should enforce types of delayWhenDurationSelector', () => {
+it('should enforce types of delayDurationSelector', () => {
   const o = of(1, 2, 3).pipe(delayWhen(of('a', 'b', 'c'))); // $ExpectError
   const p = of(1, 2, 3).pipe(delayWhen((value: string, index) => of('a', 'b', 'c'))); // $ExpectError
   const q = of(1, 2, 3).pipe(delayWhen((value, index: string) => of('a', 'b', 'c'))); // $ExpectError
 });
 
-it('should enforce types of subscriptiondelayWhen', () => {
+it('should enforce types of subscriptionDelay', () => {
   const o = of(1, 2, 3).pipe(delayWhen(() => of('a', 'b', 'c'), 'a')); // $ExpectError
+});
+
+it('should support Promises', () => {
+  const o = of(1, 2, 3).pipe(delayWhen(() => Promise.resolve('a'))); // $ExpectType Observable<number>
 });

--- a/spec/operators/audit-spec.ts
+++ b/spec/operators/audit-spec.ts
@@ -395,7 +395,7 @@ describe('audit operator', () => {
   });
 
   it('should audit by promise resolves', (done) => {
-    const e1 = interval(10).pipe(take(5));
+    const e1 = interval(1).pipe(take(5));
     const expected = [0, 1, 2, 3, 4];
 
     e1.pipe(audit(() => Promise.resolve(42))).subscribe({
@@ -413,7 +413,7 @@ describe('audit operator', () => {
   });
 
   it('should raise error when promise rejects', (done) => {
-    const e1 = interval(10).pipe(take(10));
+    const e1 = interval(1).pipe(take(10));
     const expected = [0, 1, 2];
     const error = new Error('error');
 

--- a/spec/operators/delayWhen-spec.ts
+++ b/spec/operators/delayWhen-spec.ts
@@ -340,7 +340,7 @@ describe('delayWhen', () => {
   });
 
   it('should delayWhen Promise resolves', (done) => {
-    const e1 = interval(10).pipe(take(5));
+    const e1 = interval(1).pipe(take(5));
     const expected = [0, 1, 2, 3, 4];
 
     e1.pipe(delayWhen(() => Promise.resolve(42))).subscribe({
@@ -358,7 +358,7 @@ describe('delayWhen', () => {
   });
 
   it('should raise error when Promise rejects', (done) => {
-    const e1 = interval(10).pipe(take(10));
+    const e1 = interval(1).pipe(take(10));
     const expected = [0, 1, 2];
     const error = new Error('err');
 


### PR DESCRIPTION
**Description:**
This PR adds support for `delayWhen`'s `delayDurationSelector` to accept `ObservableInput` as a return type.

Since `subscriptionDelay` is deprecated, I didn't add support for `ObservableInput` for that parameter.


**Related issue (if exists):**
Closes #7046 