### PR TITLE
docs(shareReplay): remove marble diagram

### DIFF
--- a/src/internal/operators/shareReplay.ts
+++ b/src/internal/operators/shareReplay.ts
@@ -17,19 +17,19 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
  *
  * This operator is a specialization of `replay` that connects to a source observable
  * and multicasts through a `ReplaySubject` constructed with the specified arguments.
- * A successfully completed source will stay cached in the `shareReplayed observable` forever,
+ * A successfully completed source will stay cached in the `shareReplay`ed observable forever,
  * but an errored source can be retried.
  *
- * ## Why use shareReplay?
+ * ## Why use `shareReplay`?
+ *
  * You generally want to use `shareReplay` when you have side-effects or taxing computations
  * that you do not wish to be executed amongst multiple subscribers.
  * It may also be valuable in situations where you know you will have late subscribers to
  * a stream that need access to previously emitted values.
  * This ability to replay values on subscription is what differentiates {@link share} and `shareReplay`.
  *
- * ![](shareReplay.png)
- *
  * ## Reference counting
+ *
  * By default `shareReplay` will use `refCount` of false, meaning that it will _not_ unsubscribe the
  * source when the reference counter drops to zero, i.e. the inner `ReplaySubject` will _not_ be unsubscribed
  * (and potentially run for ever).
@@ -143,9 +143,10 @@ export function shareReplay<T>(bufferSize?: number, windowTime?: number, schedul
  * @see {@link share}
  * @see {@link publishReplay}
  *
- * @param {Number} [bufferSize=Infinity] Maximum element count of the replay buffer.
- * @param {Number} [windowTime=Infinity] Maximum time length of the replay buffer in milliseconds.
- * @param {Scheduler} [scheduler] Scheduler where connected observers within the selector function
+ * @param configOrBufferSize Maximum element count of the replay buffer or {@link ShareReplayConfig configuration}
+ * object.
+ * @param windowTime Maximum time length of the replay buffer in milliseconds.
+ * @param scheduler Scheduler where connected observers within the selector function
  * will be invoked on.
  * @return A function that returns an Observable sequence that contains the
  * elements of a sequence produced by multicasting the source sequence within a


### PR DESCRIPTION
**Description:**
Since we never had marble diagram image for `shareReplay`, it can be removed from the docs.

**Related issue (if exists):**
Closes #6989