### PR TITLE
fix(ReplaySubject): correct typo

### DIFF
--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -25,7 +25,7 @@ import { dateTimestampProvider } from './scheduler/dateTimestampProvider';
  *
  * ### Differences with BehaviorSubject
  *
- * `BehaviorSubject` is similar to `new ReplaySubject(1)`, with a couple fo exceptions:
+ * `BehaviorSubject` is similar to `new ReplaySubject(1)`, with a couple of exceptions:
  *
  * 1. `BehaviorSubject` comes "primed" with a single value upon construction.
  * 2. `ReplaySubject` will replay values, even after observing an error, where `BehaviorSubject` will not.


### PR DESCRIPTION
Fix a typo in the [ReplaySubject reference page](https://rxjs.dev/api/index/class/ReplaySubject).

![image](https://user-images.githubusercontent.com/33580481/191780494-21ba0d54-e712-4215-a68e-fd05f9a63b01.png)
