### PR TITLE
feat(buffer): closingNotifier should support ObservableInput

### DIFF
--- a/spec-dtslint/operators/buffer-spec.ts
+++ b/spec-dtslint/operators/buffer-spec.ts
@@ -9,3 +9,8 @@ it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(buffer()); // $ExpectError
   const p = of(1, 2, 3).pipe(buffer(6)); // $ExpectError
 });
+
+it('should support Promises', () => {
+  const o = of(1, 2, 3).pipe(buffer(Promise.resolve('foo'))); // $ExpectType Observable<number[]>
+  const p = of(1, 2, 3).pipe(buffer(async () => {})); // $ExpectType Observable<number[]>
+});

--- a/spec-dtslint/operators/buffer-spec.ts
+++ b/spec-dtslint/operators/buffer-spec.ts
@@ -12,5 +12,4 @@ it('should enforce types', () => {
 
 it('should support Promises', () => {
   const o = of(1, 2, 3).pipe(buffer(Promise.resolve('foo'))); // $ExpectType Observable<number[]>
-  const p = of(1, 2, 3).pipe(buffer(async () => {})); // $ExpectType Observable<number[]>
 });

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -1,8 +1,8 @@
-import { Observable } from '../Observable';
-import { OperatorFunction } from '../types';
+import { OperatorFunction, ObservableInput } from '../types';
 import { operate } from '../util/lift';
 import { noop } from '../util/noop';
 import { createOperatorSubscriber } from './OperatorSubscriber';
+import { innerFrom } from '../observable/innerFrom';
 
 /**
  * Buffers the source Observable values until `closingNotifier` emits.
@@ -13,7 +13,8 @@ import { createOperatorSubscriber } from './OperatorSubscriber';
  * ![](buffer.png)
  *
  * Buffers the incoming Observable values until the given `closingNotifier`
- * Observable emits a value, at which point it emits the buffer on the output
+ * `ObservableInput` (that internally gets converted to an Observable)
+ * emits a value, at which point it emits the buffer on the output
  * Observable and starts a new buffer internally, awaiting the next time
  * `closingNotifier` emits.
  *
@@ -36,12 +37,12 @@ import { createOperatorSubscriber } from './OperatorSubscriber';
  * @see {@link bufferWhen}
  * @see {@link window}
  *
- * @param {Observable<any>} closingNotifier An Observable that signals the
+ * @param closingNotifier An `ObservableInput` that signals the
  * buffer to be emitted on the output Observable.
  * @return A function that returns an Observable of buffers, which are arrays
  * of values.
  */
-export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T, T[]> {
+export function buffer<T>(closingNotifier: ObservableInput<any>): OperatorFunction<T, T[]> {
   return operate((source, subscriber) => {
     // The current buffered values.
     let currentBuffer: T[] = [];
@@ -59,7 +60,7 @@ export function buffer<T>(closingNotifier: Observable<any>): OperatorFunction<T,
     );
 
     // Subscribe to the closing notifier.
-    closingNotifier.subscribe(
+    innerFrom(closingNotifier).subscribe(
       createOperatorSubscriber(
         subscriber,
         () => {


### PR DESCRIPTION
**Description:**
This PR adds support for `buffer`'s `closingNotifier` to accept `ObservableInput`.

**Related issue (if exists):**
#6972