### PR TITLE
fix(WebSocketSubject): Closes socket when closing socket observer

### DIFF
--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -359,7 +359,12 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
         const { deserializer } = this._config;
         observer.next(deserializer!(e));
       } catch (err) {
+        this._resetState();
         observer.error(err);
+        if (socket && (socket.readyState === 1 || socket.readyState === 0)) {
+          // close the socket after the observer so additional WebSocket events do not race to end the observer
+          socket.close();
+        }
       }
     };
   }


### PR DESCRIPTION
**Description:**

When the output observer is closed because of de-serialization errors, ensure the WebSocketSubject is reset and the WebSocket is closed.

**Related issue (if exists):** (#5312)
