### PR TITLE
docs(operators): fixing a typo

### DIFF
--- a/src/internal/operators/scan.ts
+++ b/src/internal/operators/scan.ts
@@ -44,7 +44,7 @@ export function scan<V, A, S>(accumulator: (acc: A | S, value: V, index: number)
  *     // Get the sum of the numbers coming in.
  *     scan((total, n) => total + n),
  *     // Get the average by dividing the sum by the total number
- *     // received so var (which is 1 more than the zero-based index).
+ *     // received so far (which is 1 more than the zero-based index).
  *     map((sum, index) => sum / (index + 1))
  *   )
  *   .subscribe(console.log);


### PR DESCRIPTION
**Description:**
There seems to be a typo in this doc,
... received so ~var~ -> ... received so _far_

_My PR is only fixing a typo, not adding or changing behavior of existing or new operators._ 