### PR TITLE
feat(share): ShareConfig factory properties should support ObservableInput

### DIFF
--- a/spec-dtslint/operators/share-spec.ts
+++ b/spec-dtslint/operators/share-spec.ts
@@ -8,3 +8,8 @@ it('should infer correctly', () => {
 it('should enforce types', () => {
   const o = of('foo', 'bar', 'baz').pipe(share('abc')); // $ExpectError
 });
+
+it('should support Promises', () => {
+  const factory = () => Promise.resolve();
+  of(1, 2, 3).pipe(share({ resetOnError: factory, resetOnComplete: factory, resetOnRefCountZero: factory })); // $ExpectType Observable<number>
+});


### PR DESCRIPTION
**Description:**
This PR adds support for `ShareConfig`'s `resetOnError`, `resetOnComplete` and `resetOnRefCountZero` properties to accept `ObservableInput` when used as factory functions.

Please note: it's bound to happen that this PR will create conflicts with #7050 if that one gets merged before.

**Related issue (if exists):**
#6972  