### PR TITLE
feat(sequenceEqual): compareTo should support ObservableInput

### DIFF
--- a/spec-dtslint/operators/sequenceEqual-spec.ts
+++ b/spec-dtslint/operators/sequenceEqual-spec.ts
@@ -16,3 +16,9 @@ it('should enforce compareTo to be the same type of Observable', () => {
 it('should infer correctly given comparator parameter', () => {
   const a = of(1, 2, 3).pipe(sequenceEqual(of(1), (val1, val2) => val1 === val2)); // $ExpectType Observable<boolean>
 });
+
+it('should support Promises', () => {
+  of(1, 2, 3).pipe(sequenceEqual(Promise.resolve(1))); // $ExpectType Observable<boolean>
+  // Enforce the same types produced by Promise and source observable
+  of(1, 2, 3).pipe(sequenceEqual(Promise.resolve('foo'))); // $ExpectError
+});


### PR DESCRIPTION
Description:
This PR adds support for `sequenceEqual`'s `compareTo` to accept `ObservableInput`.

Related issue (if exists):
#6972