### PR TITLE
docs: add info when complete and error notifications occur

### DIFF
--- a/src/internal/operators/concatAll.ts
+++ b/src/internal/operators/concatAll.ts
@@ -13,7 +13,10 @@ import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
  * Joins every Observable emitted by the source (a higher-order Observable), in
  * a serial fashion. It subscribes to each inner Observable only after the
  * previous inner Observable has completed, and merges all of their values into
- * the returned observable.
+ * the returned Observable. The output Observable will only complete if the source
+ * Observable completes, *and* once all inner Observables have completed. Any error
+ * delivered by the inner Observable will be immediately emitted on the output
+ * Observable.
  *
  * __Warning:__ If the source Observable emits Observables quickly and
  * endlessly, and the inner Observables it emits generally complete slower than

--- a/src/internal/operators/exhaustAll.ts
+++ b/src/internal/operators/exhaustAll.ts
@@ -17,7 +17,10 @@ import { identity } from '../util/identity';
  * inner Observable. So far, it behaves like {@link mergeAll}. However,
  * `exhaustAll` ignores every new inner Observable if the previous Observable has
  * not yet completed. Once that one completes, it will accept and flatten the
- * next inner Observable and repeat this process.
+ * next inner Observable and repeat this process. The output Observable will only
+ * complete if the source Observable completes, *and* once the inner Observable have
+ * completed, if there were any. Any error delivered by the inner Observable will be
+ * immediately emitted on the output Observable.
  *
  * ## Example
  *

--- a/src/internal/operators/mergeAll.ts
+++ b/src/internal/operators/mergeAll.ts
@@ -13,9 +13,10 @@ import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
  * `mergeAll` subscribes to an Observable that emits Observables, also known as
  * a higher-order Observable. Each time it observes one of these emitted inner
  * Observables, it subscribes to that and delivers all the values from the
- * inner Observable on the output Observable. The output Observable only
- * completes once all inner Observables have completed. Any error delivered by
- * a inner Observable will be immediately emitted on the output Observable.
+ * inner Observable on the output Observable. The output Observable will only
+ * complete if the source Observable completes, *and* once all inner Observables
+ * have completed. Any error delivered by the inner Observable will be
+ * immediately emitted on the output Observable.
  *
  * ## Examples
  *
@@ -56,8 +57,7 @@ import { OperatorFunction, ObservableInput, ObservedValueOf } from '../types';
  * @see {@link switchMap}
  * @see {@link zipAll}
  *
- * @param {number} [concurrent=Infinity] Maximum number of inner
- * Observables being subscribed to concurrently.
+ * @param concurrent Maximum number of inner Observables being subscribed to concurrently.
  * @return A function that returns an Observable that emits values coming from
  * all the inner Observables emitted by the source Observable.
  */

--- a/src/internal/operators/switchAll.ts
+++ b/src/internal/operators/switchAll.ts
@@ -4,23 +4,25 @@ import { identity } from '../util/identity';
 
 /**
  * Converts a higher-order Observable into a first-order Observable
- * producing values only from the most recent observable sequence
+ * producing values only from the most recent Observable sequence.
  *
- * <span class="informal">Flattens an Observable-of-Observables.</span>
+ * <span class="informal">Flattens an Observable-of-Observables by subscribing to the next inner
+ * Observables and potentially unsubscribing from the current inner Observable.</span>
  *
  * ![](switchAll.png)
  *
- * `switchAll` subscribes to a source that is an observable of observables, also known as a
- * "higher-order observable" (or `Observable<Observable<T>>`). It subscribes to the most recently
- * provided "inner observable" emitted by the source, unsubscribing from any previously subscribed
- * to inner observable, such that only the most recent inner observable may be subscribed to at
- * any point in time. The resulting observable returned by `switchAll` will only complete if the
- * source observable completes, *and* any currently subscribed to inner observable also has completed,
- * if there are any.
+ * `switchAll` subscribes to a source that is an Observable of Observables, also known as a
+ * "higher-order Observable" (or `Observable<Observable<T>>`). It subscribes to the most recently
+ * provided "inner Observable" emitted by the source, unsubscribing from any previously subscribed
+ * to inner Observable, such that only the most recent inner Observable may be subscribed to at
+ * any point in time. The resulting Observable returned by `switchAll` will only complete if the
+ * source Observable completes, *and* any currently subscribed to inner Observable also has completed,
+ * if there are any. Any error delivered by the inner Observable will be immediately emitted on the
+ * output Observable.
  *
  * ## Examples
  *
- * Spawn a new interval observable for each click event, but for every new
+ * Spawn a new interval Observable for each click event, but for every new
  * click, cancel the previous interval and subscribe to the new one
  *
  * ```ts


### PR DESCRIPTION
Add more documentation to the `concatAll`, `exhaustAll`, `mergeAll` and `switchAll` operators about when the destination Observable gets complete and error notifications.

**Related issue (if exists):**
#6908