### PR TITLE
docs(ReplaySubject): fix typo in constructor jsdoc

### DIFF
--- a/src/internal/ReplaySubject.ts
+++ b/src/internal/ReplaySubject.ts
@@ -40,7 +40,7 @@ export class ReplaySubject<T> extends Subject<T> {
 
   /**
    * @param bufferSize The size of the buffer to replay on subscription
-   * @param windowTime The amount of time the buffered items will say buffered
+   * @param windowTime The amount of time the buffered items will stay buffered
    * @param timestampProvider An object with a `now()` method that provides the current timestamp. This is used to
    * calculate the amount of time something has been buffered.
    */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR fixes a minor typo in the constructor annotation for the _windowTime_ parameter.
"[...] will ~~say~~ buffered" --> "[...] will __stay__ buffered"

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->