### PR TITLE
docs(deprecations): fix some typos in Scheduler Argument

### DIFF
--- a/docs_app/content/deprecations/scheduler-argument.md
+++ b/docs_app/content/deprecations/scheduler-argument.md
@@ -24,7 +24,7 @@ To support this transition the [scheduled creation function](/api/index/function
 
 ## How to Refactor
 
-If you use any operator from the list above and also use the `scheduler` argument, you have three potential refactoring options.
+If you use any operator from the above list and you're passing the `scheduler` argument, you have three potential refactoring options.
 
 ### Refactoring of `of` and `from`
 

--- a/docs_app/content/deprecations/scheduler-argument.md
+++ b/docs_app/content/deprecations/scheduler-argument.md
@@ -24,13 +24,13 @@ To support this transition the [scheduled creation function](/api/index/function
 
 ## How to Refactor
 
-If you use any other operator from the list above and using the `scheduler` argument, you have to three potential refactoring options.
+If you use any operator from the list above and also use the `scheduler` argument, you have three potential refactoring options.
 
 ### Refactoring of `of` and `from`
 
 `scheduled` is kinda copying the behavior of `from`. Therefore if you used `from` with a `scheduler` argument, you can just replace them.
 
-For the `of` creation function you need to this Observable with `scheduled` and instead of passing the `scheduler` argument to `of` pass it to `scheduled`.
+For the `of` creation function you need to replace this Observable with `scheduled` and instead of passing the `scheduler` argument to `of` pass it to `scheduled`.
 Following code example demonstrate this process.
 
 ```ts


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->
This PR is to fix a couple of typos found in "Scheduler Argument" page within "Deprecations & breaking changes" section.
