### PR TITLE
fix(schedulers): use return type of `setTimeout`

### DIFF
--- a/src/internal/scheduler/timerHandle.ts
+++ b/src/internal/scheduler/timerHandle.ts
@@ -1,1 +1,1 @@
-export type TimerHandle = number | NodeJS.Timeout;
+export type TimerHandle = number | ReturnType<typeof setTimeout>;


### PR DESCRIPTION
**Description:**

The `TimerHandle` type references a type from `@types/node` but that package might not be available, using the return type of `setTimeout` achieves the same result but doesn't require `@types/node` to be installed.

**Related issue (if exists):**
https://github.com/angular/angular-cli/issues/16980#issuecomment-1321839101