### PR TITLE
build(package): ensure NodeJS considers ESM .js files as ESM

### DIFF
--- a/tools/prepare-package.js
+++ b/tools/prepare-package.js
@@ -27,10 +27,14 @@ klawSync(ESM5_ROOT, {
 })
   .map((item) => item.path.slice(`${__dirname}/${ESM5_ROOT}`.length))
   .map((fileName) => {
-    if (!bo) {return fileName;}
+    if (!bo) {
+      return fileName;
+    }
     const fullPath = path.resolve(__dirname, ESM5_ROOT, fileName);
     // The file won't exist when running build_test as we don't create the ESM5 sources
-    if (!fs.existsSync(fullPath)) {return fileName;}
+    if (!fs.existsSync(fullPath)) {
+      return fileName;
+    }
     const content = fs.readFileSync(fullPath).toString();
     const transformed = bo.transformJavascript({
       content: content,
@@ -76,3 +80,9 @@ fs.removeSync(ESM5_ROOT + '/internal/umd.js.map');
 fs.removeSync(ESM_ROOT + '/internal/umd.js');
 fs.removeSync(ESM_ROOT + '/internal/umd.js.map');
 fs.removeSync(TYPE_ROOT + '/internal/umd.d.ts');
+
+// Create `package.json` files for the ESM5 and ESM2015 roots that
+// instruct NodeJS to treat `.js` files inside as ESM.
+const esmPkgJson = JSON.stringify({ type: 'module', sideEffects: false });
+fs.writeFileSync(path.join(ESM5_ROOT, 'package.json'), esmPkgJson);
+fs.writeFileSync(path.join(ESM_ROOT, 'package.json'), esmPkgJson);

--- a/tools/prepare-package.js
+++ b/tools/prepare-package.js
@@ -8,33 +8,33 @@ const { cleanSourceMapRoot } = require('../.make-helpers');
 const ROOT = 'dist/';
 const CJS_ROOT = ROOT + 'cjs/';
 const ESM5_ROOT = ROOT + 'esm5/';
-const ESM2015_ROOT = ROOT + 'esm2015/';
+const ESM_ROOT = ROOT + 'esm/';
 const UMD_ROOT = ROOT + 'global/';
 const ESM5_FOR_ROLLUP_ROOT = ROOT + 'esm5_for_rollup/';
 const TYPE_ROOT = ROOT + 'types/';
 const UMD_PKG = ROOT + 'bundles/';
 
 // License info for minified files
-let licenseUrl = 'https://github.com/ReactiveX/RxJS/blob/master/LICENSE.txt';
-let license = 'Apache License 2.0 ' + licenseUrl;
+const licenseUrl = 'https://github.com/ReactiveX/RxJS/blob/master/LICENSE.txt';
+const license = 'Apache License 2.0 ' + licenseUrl;
 
 // Execute build optimizer transforms on ESM5 files
 klawSync(ESM5_ROOT, {
   nodir: true,
   filter: function (item) {
     return item.path.endsWith('.js');
-  }
+  },
 })
-  .map(item => item.path.slice((`${__dirname}/${ESM5_ROOT}`).length))
-  .map(fileName => {
-    if (!bo) return fileName;
-    let fullPath = path.resolve(__dirname, ESM5_ROOT, fileName);
+  .map((item) => item.path.slice(`${__dirname}/${ESM5_ROOT}`.length))
+  .map((fileName) => {
+    if (!bo) {return fileName;}
+    const fullPath = path.resolve(__dirname, ESM5_ROOT, fileName);
     // The file won't exist when running build_test as we don't create the ESM5 sources
-    if (!fs.existsSync(fullPath)) return fileName;
-    let content = fs.readFileSync(fullPath).toString();
-    let transformed = bo.transformJavascript({
+    if (!fs.existsSync(fullPath)) {return fileName;}
+    const content = fs.readFileSync(fullPath).toString();
+    const transformed = bo.transformJavascript({
       content: content,
-      getTransforms: [bo.getPrefixClassesTransformer, bo.getPrefixFunctionsTransformer, bo.getFoldFileTransformer]
+      getTransforms: [bo.getPrefixClassesTransformer, bo.getPrefixFunctionsTransformer, bo.getFoldFileTransformer],
     });
     fs.writeFileSync(fullPath, transformed.content);
     return fileName;
@@ -44,10 +44,10 @@ if (fs.existsSync(UMD_ROOT)) {
   fs.copySync(UMD_ROOT, UMD_PKG);
   // Clean up source map paths so they can be re-mapped
   klawSync(UMD_PKG, { filter: (item) => item.path.endsWith('.js.map') })
-    .map(f => f.path)
-    .forEach(fName => {
+    .map((f) => f.path)
+    .forEach((fName) => {
       const sourceMap = fs.readJsonSync(fName);
-      sourceMap.sources = sourceMap.sources.map(s => {
+      sourceMap.sources = sourceMap.sources.map((s) => {
         const nm = 'node_modules/';
         const rr = path.resolve(ESM5_FOR_ROLLUP_ROOT);
         if (s.includes(nm)) {
@@ -73,6 +73,6 @@ fs.removeSync(CJS_ROOT + '/internal/umd.js');
 fs.removeSync(CJS_ROOT + '/internal/umd.js.map');
 fs.removeSync(ESM5_ROOT + '/internal/umd.js');
 fs.removeSync(ESM5_ROOT + '/internal/umd.js.map');
-fs.removeSync(ESM2015_ROOT + '/internal/umd.js');
-fs.removeSync(ESM2015_ROOT + '/internal/umd.js.map');
+fs.removeSync(ESM_ROOT + '/internal/umd.js');
+fs.removeSync(ESM_ROOT + '/internal/umd.js.map');
 fs.removeSync(TYPE_ROOT + '/internal/umd.d.ts');


### PR DESCRIPTION
**Concrete issue**

When you import `rxjs` from NodeJS from an ESM file, the loading
of the RxJS files fails with syntax errors because NodeJS treats
them as CommonJS.

**Background:**

NodeJS treats JavaScript files as ESM when one of the following is true:

 * The file is explicitly named `.mjs`
 * The file is part of a directory where the closest `package.json` has
   `type: module`.

Both things are not applying for the ESM output in `dist/esm` and
`dist/esm5` so these ESM artifacts cannot be used directly in NodeJS
because NodeJS will attempt loading them as CommonJS.

Note that this was not noticeable with e.g. bundlers like Webpack
as those do not rely on the NodeJS semantics for "detecting" ESM.



**Related issue (if exists):**

#6321 
