### PR TITLE
chore: Use setup-node action to cache dependencies

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -15,9 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - name: install
         run: |
           npm install -g npm@latest

--- a/.github/workflows/ci_ts_latest.yml
+++ b/.github/workflows/ci_ts_latest.yml
@@ -15,9 +15,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - uses: actions/setup-node@v1
+      - uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node }}
+          cache: npm
       - name: build
         run: |
           npm install -g npm@latest


### PR DESCRIPTION
Signed-off-by: jongwooo <jongwooo.han@gmail.com>

## Description

Updated workflows to cache dependencies using [actions/setup-node](https://github.com/actions/setup-node#caching-global-packages-data). `setup-node@v3` or newer has caching **built-in**.

### AS-IS

```yaml
- uses: actions/setup-node@v1
  with:
    node-version: ${{ matrix.node }}
```

### TO-BE

```yml
- uses: actions/setup-node@v3
  with:
    node-version: ${{ matrix.node }}
    cache: npm
```

> It’s literally a one line change to pass the `cache: npm` input parameter.

## References

- [https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows](https://docs.github.com/en/actions/using-workflows/caching-dependencies-to-speed-up-workflows)
- [https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/](https://thearchivelog.dev/article/caching-dependencies-to-speed-up-workflows/)