### PR TITLE
feat(throwError): removed deprecated call patterns

### DIFF
--- a/spec-dtslint/observables/throwError-spec.ts
+++ b/spec-dtslint/observables/throwError-spec.ts
@@ -1,4 +1,4 @@
-import { throwError, animationFrameScheduler } from 'rxjs';
+import { throwError } from 'rxjs';
 
 it('should error for incorrect errorFactory', () => {
   const a = throwError(1); // $ExpectError
@@ -11,8 +11,4 @@ it('should accept any type and return never observable with support of factory',
   const b = throwError(() => ('a')); // $ExpectType Observable<never>
   const c = throwError(() => ({ a: 1 })); // $ExpectType Observable<never>
   const d = throwError(() => ({ a: 2 })); // $ExpectType Observable<never>
-});
-
-it('should support a factory and a scheduler', () => {
-  const a = throwError(() => 1, animationFrameScheduler); // $ExpectType Observable<never>
 });

--- a/spec-dtslint/observables/throwError-spec.ts
+++ b/spec-dtslint/observables/throwError-spec.ts
@@ -1,14 +1,9 @@
 import { throwError, animationFrameScheduler } from 'rxjs';
 
-it('should accept any type and return never observable', () => {
-  const a = throwError(1); // $ExpectType Observable<never>
-  const b = throwError('a'); // $ExpectType Observable<never>
-  const c = throwError({ a: 1 }); // $ExpectType Observable<never>
-  const d = throwError(() => ({ a: 2 })); // $ExpectType Observable<never>
-});
-
-it('should support an error value and a scheduler', () => {
-  const a = throwError(1, animationFrameScheduler); // $ExpectType Observable<never>
+it('should error for incorrect errorFactory', () => {
+  const a = throwError(1); // $ExpectError
+  const b = throwError('a'); // $ExpectError
+  const c = throwError({ a: 1 }); // $ExpectError
 });
 
 it('should accept any type and return never observable with support of factory', () => {

--- a/spec/observables/throwError-spec.ts
+++ b/spec/observables/throwError-spec.ts
@@ -34,14 +34,6 @@ describe('throwError', () => {
     });
   });
 
-  it('should accept scheduler', () => {
-    rxTest.run(({ expectObservable }) => {
-      const e = throwError(() => 'error', rxTest);
-
-      expectObservable(e).toBe('#');
-    });
-  });
-
   it('should accept a factory function', () => {
     let calls = 0;
     let errors: any[] = [];

--- a/spec/observables/throwError-spec.ts
+++ b/spec/observables/throwError-spec.ts
@@ -36,7 +36,7 @@ describe('throwError', () => {
 
   it('should accept scheduler', () => {
     rxTest.run(({ expectObservable }) => {
-      const e = throwError('error', rxTest);
+      const e = throwError(() => 'error', rxTest);
 
       expectObservable(e).toBe('#');
     });

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -1,6 +1,4 @@
 import { Observable } from '../Observable';
-import { Subscriber } from '../Subscriber';
-import { SchedulerLike } from '../types';
 
 /**
  * Creates an observable that will create an error instance and push it to the consumer as an error
@@ -94,20 +92,8 @@ import { SchedulerLike } from '../types';
  *
  * @param errorFactory A factory function that will create the error instance that is pushed.
  */
-export function throwError(errorFactory: () => any): Observable<never>;
-
-/**
- * Notifies the consumer of an error using a given scheduler by scheduling it at delay `0` upon subscription.
- *
- * @param errorFactory An error instance or error factory
- * @param scheduler A scheduler to use to schedule the error notification
- * @deprecated The `scheduler` parameter will be removed in v8.
- * Use `throwError` in combination with {@link observeOn}: `throwError(() => new Error('test')).pipe(observeOn(scheduler));`.
- * Details: https://rxjs.dev/deprecations/scheduler-argument
- */
-export function throwError(errorFactory: () => any, scheduler: SchedulerLike): Observable<never>;
-
-export function throwError(errorFactory: () => any, scheduler?: SchedulerLike): Observable<never> {
-  const init = (subscriber: Subscriber<never>) => subscriber.error(errorFactory());
-  return new Observable(scheduler ? (subscriber) => scheduler.schedule(init as any, 0, subscriber) : init);
+export function throwError(errorFactory: () => any): Observable<never> {
+  return new Observable((subscriber) => {
+    subscriber.error(errorFactory());
+  });
 }

--- a/src/internal/observable/throwError.ts
+++ b/src/internal/observable/throwError.ts
@@ -1,7 +1,6 @@
 import { Observable } from '../Observable';
 import { Subscriber } from '../Subscriber';
 import { SchedulerLike } from '../types';
-import { isFunction } from '../util/isFunction';
 
 /**
  * Creates an observable that will create an error instance and push it to the consumer as an error
@@ -98,28 +97,17 @@ import { isFunction } from '../util/isFunction';
 export function throwError(errorFactory: () => any): Observable<never>;
 
 /**
- * Returns an observable that will error with the specified error immediately upon subscription.
- *
- * @param error The error instance to emit
- * @deprecated Support for passing an error value will be removed in v8. Instead, pass a factory function to `throwError(() => new Error('test'))`. This is
- * because it will create the error at the moment it should be created and capture a more appropriate stack trace. If
- * for some reason you need to create the error ahead of time, you can still do that: `const err = new Error('test'); throwError(() => err);`.
- */
-export function throwError(error: any): Observable<never>;
-
-/**
  * Notifies the consumer of an error using a given scheduler by scheduling it at delay `0` upon subscription.
  *
- * @param errorOrErrorFactory An error instance or error factory
+ * @param errorFactory An error instance or error factory
  * @param scheduler A scheduler to use to schedule the error notification
  * @deprecated The `scheduler` parameter will be removed in v8.
  * Use `throwError` in combination with {@link observeOn}: `throwError(() => new Error('test')).pipe(observeOn(scheduler));`.
  * Details: https://rxjs.dev/deprecations/scheduler-argument
  */
-export function throwError(errorOrErrorFactory: any, scheduler: SchedulerLike): Observable<never>;
+export function throwError(errorFactory: () => any, scheduler: SchedulerLike): Observable<never>;
 
-export function throwError(errorOrErrorFactory: any, scheduler?: SchedulerLike): Observable<never> {
-  const errorFactory = isFunction(errorOrErrorFactory) ? errorOrErrorFactory : () => errorOrErrorFactory;
+export function throwError(errorFactory: () => any, scheduler?: SchedulerLike): Observable<never> {
   const init = (subscriber: Subscriber<never>) => subscriber.error(errorFactory());
   return new Observable(scheduler ? (subscriber) => scheduler.schedule(init as any, 0, subscriber) : init);
 }


### PR DESCRIPTION
**BREAKING CHANGE:** `throwError(error)` call pattern is no longer available. Use `throwError(() => error)`.  
**BREAKING CHANGE:** `throwError(errorFactory, scheduler)` call pattern is no longer available. [Read more](https://rxjs.dev/deprecations/scheduler-argument).
**Related issue (if exists):** #6367