### PR TITLE
feat(map): removed deprecated `map(project, thisArg)` call pattern

### DIFF
--- a/spec-dtslint/operators/map-spec.ts
+++ b/spec-dtslint/operators/map-spec.ts
@@ -13,10 +13,6 @@ it('should support an index parameter', () => {
   const o = of('a', 'b', 'c').pipe(map((value, index) => index)); // $ExpectType Observable<number>
 });
 
-it('should support an extra parameter', () => {
-  const o = of(1, 2, 3).pipe(map(value => value, 'something')); // $ExpectType Observable<number>
-});
-
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(map()); // $ExpectError
 });
@@ -24,17 +20,4 @@ it('should enforce types', () => {
 it('should enforce the projector types', () => {
   const o = of(1, 2, 3).pipe(map((value: string) => value)); // $ExpectError
   const p = of(1, 2, 3).pipe(map((value, index: string) => value)); // $ExpectError
-});
-
-it('should support this', () => {
-  const thisArg = { limit: 2 };
-  const o = of(1, 2, 3).pipe(map(function (val) {
-    const limit = this.limit; // $ExpectType number
-    return val < limit ? val : limit;
-  }, thisArg));
-});
-
-it('should deprecate thisArg usage', () => {
-  const a = of(1, 2, 3).pipe(map((value) => value)); // $ExpectNoDeprecation
-  const b = of(1, 2, 3).pipe(map((value) => value, {})); // $ExpectDeprecation
 });

--- a/spec/operators/map-spec.ts
+++ b/spec/operators/map-spec.ts
@@ -213,28 +213,6 @@ describe('map', () => {
     });
   });
 
-  it('should map using a custom thisArg', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('-5-^-4--3---2----1--|');
-      const e1subs = '   ^----------------!';
-      const expected = ' --a--b---c----d--|';
-      const values = { a: 46, b: 55, c: 64, d: 73 };
-
-      const foo = {
-        value: 42,
-      };
-      const result = e1.pipe(
-        map(function (this: typeof foo, x: string, index: number) {
-          expect(this).to.equal(foo);
-          return parseInt(x) + foo.value + index * 10;
-        }, foo)
-      );
-
-      expectObservable(result).toBe(expected, values);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
   it('should map twice', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('-0----1-^-2---3--4-5--6--7-8-|');
@@ -259,36 +237,6 @@ describe('map', () => {
             expect(invoked2).to.equal(7);
           },
         })
-      );
-
-      expectObservable(result).toBe(expected, values);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
-  it('should do multiple maps using a custom thisArg', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  --1--2--3--4--|');
-      const e1subs = '  ^-------------!';
-      const expected = '--a--b--c--d--|';
-      const values = { a: 11, b: 14, c: 17, d: 20 };
-
-      class Filterer {
-        selector1 = (x: string) => parseInt(x) + 2;
-        selector2 = (x: string) => parseInt(x) * 3;
-      }
-      const filterer = new Filterer();
-
-      const result = e1.pipe(
-        map(function (this: any, x) {
-          return this.selector1(x);
-        }, filterer),
-        map(function (this: any, x) {
-          return this.selector2(x);
-        }, filterer),
-        map(function (this: any, x) {
-          return this.selector1(x);
-        }, filterer)
       );
 
       expectObservable(result).toBe(expected, values);

--- a/src/internal/operators/map.ts
+++ b/src/internal/operators/map.ts
@@ -2,10 +2,6 @@ import { OperatorFunction } from '../types';
 import { operate } from '../util/lift';
 import { createOperatorSubscriber } from './OperatorSubscriber';
 
-export function map<T, R>(project: (value: T, index: number) => R): OperatorFunction<T, R>;
-/** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
-export function map<T, R, A>(project: (this: A, value: T, index: number) => R, thisArg: A): OperatorFunction<T, R>;
-
 /**
  * Applies a given `project` function to each value emitted by the source
  * Observable, and emits the resulting values as an Observable.
@@ -40,12 +36,10 @@ export function map<T, R, A>(project: (this: A, value: T, index: number) => R, t
  * to each `value` emitted by the source Observable. The `index` parameter is
  * the number `i` for the i-th emission that has happened since the
  * subscription, starting from the number `0`.
- * @param {any} [thisArg] An optional argument to define what `this` is in the
- * `project` function.
  * @return A function that returns an Observable that emits the values from the
  * source Observable transformed by the given `project` function.
  */
-export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any): OperatorFunction<T, R> {
+export function map<T, R>(project: (value: T, index: number) => R): OperatorFunction<T, R> {
   return operate((source, subscriber) => {
     // The index of the value from the source. Used with projection.
     let index = 0;
@@ -55,7 +49,7 @@ export function map<T, R>(project: (value: T, index: number) => R, thisArg?: any
       createOperatorSubscriber(subscriber, (value: T) => {
         // Call the projection function with the appropriate this context,
         // and send the resulting value to the consumer.
-        subscriber.next(project.call(thisArg, value, index++));
+        subscriber.next(project(value, index++));
       })
     );
   });


### PR DESCRIPTION
BREAKING CHANGE: `map(project, thisArg)` call pattern is no longer available. Use Function#bind method: `map(project.bind(thisArg))`
**Related issue (if exists):** #6367