### PR TITLE
feat: removed deprecated call pattern in `find` & `findIndex`

### DIFF
--- a/spec-dtslint/operators/find-spec.ts
+++ b/spec-dtslint/operators/find-spec.ts
@@ -33,18 +33,3 @@ it('should support Boolean properly', () => {
   // Intentionally weird looking: Because `Observable<boolean>` is `Observable<true | false>` and `true` is the truthy bit.
   const o4 = of(false, false, false, false).pipe(find(Boolean)); // $ExpectType Observable<true>
 });
-
-it('should support this', () => {
-  const thisArg = { wanted: 5 };
-  const a = of(1, 2, 3).pipe(find(function (val) {
-    const wanted = this.wanted; // $ExpectType number
-    return val < wanted;
-  }, thisArg));
-});
-
-it('should deprecate thisArg usage', () => {
-  const a = of(1, 2, 3).pipe(find(Boolean)); // $ExpectNoDeprecation
-  const b = of(1, 2, 3).pipe(find(Boolean, {})); // $ExpectDeprecation
-  const c = of(1, 2, 3).pipe(find((value) => Boolean(value))); // $ExpectNoDeprecation
-  const d = of(1, 2, 3).pipe(find((value) => Boolean(value), {})); // $ExpectDeprecation
-});

--- a/spec-dtslint/operators/findIndex-spec.ts
+++ b/spec-dtslint/operators/findIndex-spec.ts
@@ -13,10 +13,6 @@ it('should support a predicate that takes a source ', () => {
   const o = of('foo', 'bar', 'baz').pipe(findIndex((p, index, source) => p === 'foo')); // $ExpectType Observable<number>
 });
 
-it('should support an argument ', () => {
-  const o = of('foo', 'bar', 'baz').pipe(findIndex(p => p === 'foo', 123)); // $ExpectType Observable<number>
-});
-
 it('should enforce types', () => {
   const o = of('foo', 'bar', 'baz').pipe(findIndex()); // $ExpectError
 });
@@ -41,19 +37,4 @@ it('should support inference from a predicate that returns any', () => {
     return !!value;
   }
   const a = of(1).pipe(findIndex(isTruthy)); // $ExpectType Observable<number>
-});
-
-it('should support this', () => {
-  const thisArg = { wanted: 5 };
-  const a = of(1, 2, 3).pipe(findIndex(function (val) {
-    const wanted = this.wanted; // $ExpectType number
-    return val < wanted;
-  }, thisArg));
-});
-
-it('should deprecate thisArg usage', () => {
-  const a = of(1, 2, 3).pipe(findIndex(Boolean)); // $ExpectNoDeprecation
-  const b = of(1, 2, 3).pipe(findIndex(Boolean, {})); // $ExpectDeprecation
-  const c = of(1, 2, 3).pipe(findIndex((value) => Boolean(value))); // $ExpectNoDeprecation
-  const d = of(1, 2, 3).pipe(findIndex((value) => Boolean(value), {})); // $ExpectDeprecation
 });

--- a/spec/operators/find-spec.ts
+++ b/spec/operators/find-spec.ts
@@ -86,24 +86,6 @@ describe('find', () => {
     });
   });
 
-  it('should work with a custom thisArg', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  --a--b---c-|');
-      const e1subs = '  ^----!      ';
-      const expected = '-----(b|)   ';
-
-      const finder = {
-        target: 'b',
-      };
-      const predicate = function (this: typeof finder, value: string) {
-        return value === this.target;
-      };
-
-      expectObservable(e1.pipe(find(predicate, finder))).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
   it('should return undefined if element does not match with predicate', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--b--c--|   ');

--- a/spec/operators/findIndex-spec.ts
+++ b/spec/operators/findIndex-spec.ts
@@ -86,23 +86,6 @@ describe('findIndex', () => {
     });
   });
 
-  it('should work with a custom thisArg', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const sourceValues = { b: 7 };
-      const e1 = hot('  --a--b---c-|', sourceValues);
-      const e1subs = '  ^----!      ';
-      const expected = '-----(x|)   ';
-
-      const predicate = function (this: typeof sourceValues, value: number) {
-        return value === this.b;
-      };
-      const result = e1.pipe(findIndex(predicate, sourceValues));
-
-      expectObservable(result).toBe(expected, { x: 1 });
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
   it('should return negative index if element does not match with predicate', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--b--c--|   ');

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -51,14 +51,10 @@ export function find<T>(predicate: (value: T, index: number, source: Observable<
  * matches the condition.
  */
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, T | undefined> {
-  return operate(createFind(predicate, undefined, 'value'));
+  return operate(createFind(predicate, 'value'));
 }
 
-export function createFind<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg: any,
-  emit: 'value' | 'index'
-) {
+export function createFind<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean, emit: 'value' | 'index') {
   const findIndex = emit === 'index';
   return (source: Observable<T>, subscriber: Subscriber<any>) => {
     let index = 0;
@@ -67,7 +63,7 @@ export function createFind<T>(
         subscriber,
         (value) => {
           const i = index++;
-          if (predicate.call(thisArg, value, i, source)) {
+          if (predicate(value, i, source)) {
             subscriber.next(findIndex ? i : value);
             subscriber.complete();
           }

--- a/src/internal/operators/find.ts
+++ b/src/internal/operators/find.ts
@@ -5,19 +5,9 @@ import { operate } from '../util/lift';
 import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function find<T>(predicate: BooleanConstructor): OperatorFunction<T, TruthyTypesOf<T>>;
-/** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
-export function find<T, S extends T, A>(
-  predicate: (this: A, value: T, index: number, source: Observable<T>) => value is S,
-  thisArg: A
-): OperatorFunction<T, S | undefined>;
 export function find<T, S extends T>(
   predicate: (value: T, index: number, source: Observable<T>) => value is S
 ): OperatorFunction<T, S | undefined>;
-/** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
-export function find<T, A>(
-  predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean,
-  thisArg: A
-): OperatorFunction<T, T | undefined>;
 export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, T | undefined>;
 /**
  * Emits only the first value emitted by the source Observable that meets some
@@ -57,16 +47,11 @@ export function find<T>(predicate: (value: T, index: number, source: Observable<
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} predicate
  * A function called with each item to test for condition matching.
- * @param {any} [thisArg] An optional argument to determine the value of `this`
- * in the `predicate` function.
  * @return A function that returns an Observable that emits the first item that
  * matches the condition.
  */
-export function find<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
-): OperatorFunction<T, T | undefined> {
-  return operate(createFind(predicate, thisArg, 'value'));
+export function find<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, T | undefined> {
+  return operate(createFind(predicate, undefined, 'value'));
 }
 
 export function createFind<T>(

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -48,5 +48,5 @@ export function findIndex<T>(predicate: (value: T, index: number, source: Observ
  * first item that matches the condition.
  */
 export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number> {
-  return operate(createFind(predicate, undefined, 'index'));
+  return operate(createFind(predicate, 'index'));
 }

--- a/src/internal/operators/findIndex.ts
+++ b/src/internal/operators/findIndex.ts
@@ -4,13 +4,6 @@ import { operate } from '../util/lift';
 import { createFind } from './find';
 
 export function findIndex<T>(predicate: BooleanConstructor): OperatorFunction<T, T extends Falsy ? -1 : number>;
-/** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
-export function findIndex<T>(predicate: BooleanConstructor, thisArg: any): OperatorFunction<T, T extends Falsy ? -1 : number>;
-/** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
-export function findIndex<T, A>(
-  predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean,
-  thisArg: A
-): OperatorFunction<T, number>;
 export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number>;
 
 /**
@@ -51,14 +44,9 @@ export function findIndex<T>(predicate: (value: T, index: number, source: Observ
  *
  * @param {function(value: T, index: number, source: Observable<T>): boolean} predicate
  * A function called with each item to test for condition matching.
- * @param {any} [thisArg] An optional argument to determine the value of `this`
- * in the `predicate` function.
  * @return A function that returns an Observable that emits the index of the
  * first item that matches the condition.
  */
-export function findIndex<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
-): OperatorFunction<T, number> {
-  return operate(createFind(predicate, thisArg, 'index'));
+export function findIndex<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, number> {
+  return operate(createFind(predicate, undefined, 'index'));
 }


### PR DESCRIPTION
**BREAKING CHANGE:** `find(predicate, thisArg)` call pattern is no longer available. Use `find(predicate.bind(thisArg))`
**BREAKING CHANGE:** `findIndex(predicate, thisArg)` call pattern is no longer available. Use `findIndex(predicate.bind(thisArg))`
**Related issue (if exists):** #6367
