### PR TITLE
feat(endWith): removed deprecated `endWith(value, scheduler)` call pattern

### DIFF
--- a/spec-dtslint/operators/endWith-spec.ts
+++ b/spec-dtslint/operators/endWith-spec.ts
@@ -1,10 +1,6 @@
-import { of, asyncScheduler } from 'rxjs';
+import { of } from 'rxjs';
 import { endWith } from 'rxjs/operators';
 import { A, B, a, b, c, d, e, f, g, h } from '../helpers';
-
-it('should support a scheduler', () => {
-  const r = of(a).pipe(endWith(asyncScheduler)); // $ExpectType Observable<A>
-});
 
 it('should infer type for N values', () => {
   const r0 = of(a).pipe(endWith()); // $ExpectType Observable<A>

--- a/spec/operators/endWith-spec.ts
+++ b/spec/operators/endWith-spec.ts
@@ -178,28 +178,6 @@ describe('endWith', () => {
     });
   });
 
-  it('should accept scheduler as last argument with single value', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  --a--|   ');
-      const e1subs = '  ^----!   ';
-      const expected = '--a--(x|)';
-
-      expectObservable(e1.pipe(endWith(defaultEndValue, testScheduler))).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
-  it('should accept scheduler as last argument with multiple value', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  -----a--|    ');
-      const e1subs = '  ^-------!    ';
-      const expected = '-----a--(yz|)';
-
-      expectObservable(e1.pipe(endWith('y', 'z', testScheduler))).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
   it('should stop listening to a synchronous observable when unsubscribed', () => {
     const sideEffects: number[] = [];
     const synchronousObservable = new Observable<number>((subscriber) => {

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -1,24 +1,11 @@
 /** prettier */
-import { Observable } from '../Observable';
 import { concat } from '../observable/concat';
-import { of } from '../observable/of';
-import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction, ValueFromArray } from '../types';
-
-/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `concatAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function endWith<T>(scheduler: SchedulerLike): MonoTypeOperatorFunction<T>;
-/** @deprecated The `scheduler` parameter will be removed in v8. Use `scheduled` and `concatAll`. Details: https://rxjs.dev/deprecations/scheduler-argument */
-export function endWith<T, A extends unknown[] = T[]>(
-  ...valuesAndScheduler: [...A, SchedulerLike]
-): OperatorFunction<T, T | ValueFromArray<A>>;
-
-export function endWith<T, A extends unknown[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>>;
+import { fromArrayLike } from '../observable/innerFrom';
+import { OperatorFunction, ValueFromArray } from '../types';
 
 /**
  * Returns an observable that will emit all values from the source, then synchronously emit
  * the provided value(s) immediately after the source completes.
- *
- * NOTE: Passing a last argument of a Scheduler is _deprecated_, and may result in incorrect
- * types in TypeScript.
  *
  * This is useful for knowing when an observable ends. Particularly when paired with an
  * operator like {@link takeUntil}
@@ -63,6 +50,6 @@ export function endWith<T, A extends unknown[] = T[]>(...values: A): OperatorFun
  * source, then synchronously emits the provided value(s) immediately after the
  * source completes.
  */
-export function endWith<T>(...values: Array<T | SchedulerLike>): MonoTypeOperatorFunction<T> {
-  return (source: Observable<T>) => concat(source, of(...values)) as Observable<T>;
+export function endWith<T, A extends readonly unknown[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>> {
+  return (source) => concat(source, fromArrayLike(values as readonly ValueFromArray<A>[]));
 }

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -1,6 +1,6 @@
 /** prettier */
 import { fromArrayLike } from '../observable/innerFrom';
-import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction, ValueFromArray } from '../types';
+import { OperatorFunction, ValueFromArray } from '../types';
 import { operate } from '../util/lift';
 import { concatAll } from './concatAll';
 

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -1,7 +1,8 @@
 /** prettier */
 import { concat } from '../observable/concat';
 import { fromArrayLike } from '../observable/innerFrom';
-import { OperatorFunction, ValueFromArray } from '../types';
+import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction, ValueFromArray } from '../types';
+import { concatAll } from './concatAll';
 
 /**
  * Returns an observable that will emit all values from the source, then synchronously emit
@@ -51,5 +52,5 @@ import { OperatorFunction, ValueFromArray } from '../types';
  * source completes.
  */
 export function endWith<T, A extends readonly unknown[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>> {
-  return (source) => concat(source, fromArrayLike(values as readonly ValueFromArray<A>[]));
+  return (source) => concatAll()(fromArrayLike([source, ...values] as any));
 }

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -1,7 +1,7 @@
 /** prettier */
-import { concat } from '../observable/concat';
 import { fromArrayLike } from '../observable/innerFrom';
 import { MonoTypeOperatorFunction, SchedulerLike, OperatorFunction, ValueFromArray } from '../types';
+import { operate } from '../util/lift';
 import { concatAll } from './concatAll';
 
 /**
@@ -52,5 +52,7 @@ import { concatAll } from './concatAll';
  * source completes.
  */
 export function endWith<T, A extends readonly unknown[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>> {
-  return (source) => concatAll()(fromArrayLike([source, ...values] as any));
+  return operate((source, subscriber) => {
+    concatAll()(fromArrayLike([source, fromArrayLike(values)])).subscribe(subscriber);
+  });
 }


### PR DESCRIPTION
**BREAKING CHANGE:** `endWith(value, scheduler)` call pattern is no longer available. [Read more](https://rxjs.dev/deprecations/scheduler-argument).

**Related issue (if exists):** #6367
