### PR TITLE
perf(operator): simplify the implementation of the `endWith` operator

### DIFF
--- a/src/internal/observable/innerFrom.ts
+++ b/src/internal/observable/innerFrom.ts
@@ -1,3 +1,4 @@
+import { subscribeToArray } from '../util/subscribeToArray';
 import { isArrayLike } from '../util/isArrayLike';
 import { isPromise } from '../util/isPromise';
 import { Observable } from '../Observable';
@@ -65,19 +66,7 @@ export function fromInteropObservable<T>(obj: any) {
  */
 export function fromArrayLike<T>(array: ArrayLike<T>) {
   return new Observable((subscriber: Subscriber<T>) => {
-    // Loop over the array and emit each value. Note two things here:
-    // 1. We're making sure that the subscriber is not closed on each loop.
-    //    This is so we don't continue looping over a very large array after
-    //    something like a `take`, `takeWhile`, or other synchronous unsubscription
-    //    has already unsubscribed.
-    // 2. In this form, reentrant code can alter that array we're looping over.
-    //    This is a known issue, but considered an edge case. The alternative would
-    //    be to copy the array before executing the loop, but this has
-    //    performance implications.
-    for (let i = 0; i < array.length && !subscriber.closed; i++) {
-      subscriber.next(array[i]);
-    }
-    subscriber.complete();
+    subscribeToArray(array, subscriber);
   });
 }
 

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -1,8 +1,8 @@
 /** prettier */
-import { fromArrayLike } from '../observable/innerFrom';
+import { subscribeToArray } from '../util/subscribeToArray';
 import { OperatorFunction, ValueFromArray } from '../types';
 import { operate } from '../util/lift';
-import { concatAll } from './concatAll';
+import { createOperatorSubscriber } from '../operators/OperatorSubscriber';
 
 /**
  * Returns an observable that will emit all values from the source, then synchronously emit
@@ -53,6 +53,10 @@ import { concatAll } from './concatAll';
  */
 export function endWith<T, A extends readonly unknown[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>> {
   return operate((source, subscriber) => {
-    concatAll()(fromArrayLike([source, fromArrayLike(values)])).subscribe(subscriber);
+    source.subscribe(
+      createOperatorSubscriber(subscriber, undefined, () => {
+        subscribeToArray(values as readonly ValueFromArray<A>[], subscriber);
+      })
+    );
   });
 }

--- a/src/internal/util/subscribeToArray.ts
+++ b/src/internal/util/subscribeToArray.ts
@@ -3,10 +3,20 @@ import { Subscriber } from '../Subscriber';
 /**
  * Subscribes to an ArrayLike with a subscriber
  * @param array The array or array-like to subscribe to
+ * @param subscriber
  */
-export const subscribeToArray = <T>(array: ArrayLike<T>) => (subscriber: Subscriber<T>) => {
-  for (let i = 0, len = array.length; i < len && !subscriber.closed; i++) {
+export function subscribeToArray<T>(array: ArrayLike<T>, subscriber: Subscriber<T>) {
+  // Loop over the array and emit each value. Note two things here:
+  // 1. We're making sure that the subscriber is not closed on each loop.
+  //    This is so we don't continue looping over a very large array after
+  //    something like a `take`, `takeWhile`, or other synchronous unsubscription
+  //    has already unsubscribed.
+  // 2. In this form, reentrant code can alter that array we're looping over.
+  //    This is a known issue, but considered an edge case. The alternative would
+  //    be to copy the array before executing the loop, but this has
+  //    performance implications.
+  for (let i = 0, { length } = array; i < length && !subscriber.closed; i++) {
     subscriber.next(array[i]);
   }
   subscriber.complete();
-};
+}

--- a/src/internal/util/subscribeToArray.ts
+++ b/src/internal/util/subscribeToArray.ts
@@ -15,7 +15,8 @@ export function subscribeToArray<T>(array: ArrayLike<T>, subscriber: Subscriber<
   //    This is a known issue, but considered an edge case. The alternative would
   //    be to copy the array before executing the loop, but this has
   //    performance implications.
-  for (let i = 0, { length } = array; i < length && !subscriber.closed; i++) {
+  const length = array.length;
+  for (let i = 0; i < length && !subscriber.closed; i++) {
     subscriber.next(array[i]);
   }
   subscriber.complete();


### PR DESCRIPTION
I would like to propose a simplification and optimization of the `endWith` operator.

Some operators may spend significantly more CPU and RAM than you expect from them. When trying to use the debugging tools, you can notice that often the problem lies in the fact that operators can consist of other operators. For example, in dealing with [`count`](https://github.com/ReactiveX/rxjs/blob/71a26ac155cb0f48c8054843282e7bbb5ed4e6fe/src/internal/operators/count.ts#L59-L61) you can see that the `reduce` operator is used in the implementation, but the code is quite simple and can hardly affect performance in any way. But if you take the operator from this PR ([`endWith`](https://github.com/ReactiveX/rxjs/blob/71a26ac155cb0f48c8054843282e7bbb5ed4e6fe/src/internal/operators/endWith.ts#L54-L58)), you can see that the relatively "heavy" operator `concatAll` is used in combination with the `fromArrayLike` functions.

I suggest trying to avoid using other operators in the implementation of operators if their implementation has a large amount of code that under no circumstances will be required (dead code) for the functionality of operators.

As an example, the difference in the number of created objects in this code:

```ts
new Observable<string>((subscriber) => {
  subscriber.next('a');
  subscriber.next('b');
  subscriber.next('c');
  subscriber.complete();
})
  .pipe(endWith('e', 'f', 'g'))
  .subscribe({
    next: (next) => {
      console.log('next', next);
    },
    complete: () => {
      console.log('complete');
    },
    error: (error) => {
      console.log('error', error);
    },
  });
```

|          | `Observable` | `Subscriber` | `Subscription` |
| -------- | -----------: | -----------: | -------------: |
| `master` |            5 |            4 |              5 |
| this PR  |            2 |            2 |              3 |

I would be very happy to hear reasoned criticism. 😄