### PR TITLE
feat(startWith): remove deprecated scheduler signature.

### DIFF
--- a/spec-dtslint/operators/startWith-spec.ts
+++ b/spec-dtslint/operators/startWith-spec.ts
@@ -1,5 +1,4 @@
-import { of, asyncScheduler  } from 'rxjs';
-import { startWith } from 'rxjs/operators';
+import { of, startWith  } from 'rxjs';
 import { A, B, a, b, c, d, e, f, g, h } from '../helpers';
 
 it('should infer correctly with N values', () => {
@@ -11,16 +10,6 @@ it('should infer correctly with N values', () => {
   const r5 = of(a).pipe(startWith(b, c, d, e, f)); // $ExpectType Observable<A | B | C | D | E | F>
   const r6 = of(a).pipe(startWith(b, c, d, e, f, g)); // $ExpectType Observable<A | B | C | D | E | F | G>
   const r7 = of(a).pipe(startWith(b, c, d, e, f, g, h)); // $ExpectType Observable<A | B | C | D | E | F | G | H>
-});
-
-it('should infer correctly with a scheduler', () => {
-  const r = of(a).pipe(startWith(asyncScheduler)); // $ExpectType Observable<A>
-  const r1 = of(a).pipe(startWith(b, asyncScheduler)); // $ExpectType Observable<A | B>
-  const r2 = of(a).pipe(startWith(b, c, asyncScheduler)); // $ExpectType Observable<A | B | C>
-  const r3 = of(a).pipe(startWith(b, c, d, asyncScheduler)); // $ExpectType Observable<A | B | C | D>
-  const r4 = of(a).pipe(startWith(b, c, d, e, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E>
-  const r5 = of(a).pipe(startWith(b, c, d, e, f, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E | F>
-  const r6 = of(a).pipe(startWith(b, c, d, e, f, g, asyncScheduler)); // $ExpectType Observable<A | B | C | D | E | F | G>
 });
 
 it('should infer correctly with a single specified type', () => {

--- a/spec/operators/startWith-spec.ts
+++ b/spec/operators/startWith-spec.ts
@@ -1,7 +1,6 @@
 import { expect } from 'chai';
-import { startWith, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { of, Observable } from 'rxjs';
+import { of, Observable, startWith, mergeMap, take } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 
 /** @test {startWith} */
@@ -143,21 +142,6 @@ describe('startWith', () => {
     });
   });
 
-  it('should allow unsubscribing explicitly and early', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  ---a--b----c--d--|');
-      const unsub = '   ---------!        ';
-      const e1subs = '  ^--------!        ';
-      const expected = 's--a--b---        ';
-      const values = { s: 's', a: 'a', b: 'b' };
-
-      const result = e1.pipe(startWith('s', testScheduler));
-
-      expectObservable(result, unsub).toBe(expected, values);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
   it('should not break unsubscription chains when result is unsubscribed explicitly', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  ---a--b----c--d--|');
@@ -168,50 +152,11 @@ describe('startWith', () => {
 
       const result = e1.pipe(
         mergeMap((x: string) => of(x)),
-        startWith('s', testScheduler),
+        startWith('s'),
         mergeMap((x: string) => of(x))
       );
 
       expectObservable(result, unsub).toBe(expected, values);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
-  it('should start with empty if given value is not specified', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  -a-|');
-      const e1subs = '  ^--!';
-      const expected = '-a-|';
-
-      const result = e1.pipe(startWith(testScheduler));
-
-      expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
-  it('should accept scheduler as last argument with single value', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  --a--|');
-      const e1subs = '  ^----!';
-      const expected = 'x-a--|';
-
-      const result = e1.pipe(startWith(defaultStartValue, testScheduler));
-
-      expectObservable(result).toBe(expected);
-      expectSubscriptions(e1.subscriptions).toBe(e1subs);
-    });
-  });
-
-  it('should accept scheduler as last argument with multiple value', () => {
-    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
-      const e1 = hot('  -----a--|');
-      const e1subs = '  ^-------!';
-      const expected = '(yz)-a--|';
-
-      const result = e1.pipe(startWith('y', 'z', testScheduler));
-
-      expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
     });
   });

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -133,7 +133,7 @@ function fromInteropObservable<T>(obj: any) {
  * `from` conditionals because we *know* they're dealing with an array.
  * @param array The array to emit values from
  */
-function fromArrayLike<T>(array: ArrayLike<T>) {
+export function fromArrayLike<T>(array: ArrayLike<T>) {
   return new Observable((subscriber: Subscriber<T>) => {
     subscribeToArray(array, subscriber);
   });

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -139,7 +139,7 @@ export function fromArrayLike<T>(array: ArrayLike<T>) {
   });
 }
 
-function fromPromise<T>(promise: PromiseLike<T>) {
+export function fromPromise<T>(promise: PromiseLike<T>) {
   return new Observable((subscriber: Subscriber<T>) => {
     promise
       .then(
@@ -205,7 +205,10 @@ export function subscribeToArray<T>(array: ArrayLike<T>, subscriber: Subscriber<
   //    be to copy the array before executing the loop, but this has
   //    performance implications.
   const length = array.length;
-  for (let i = 0; i < length && !subscriber.closed; i++) {
+  for (let i = 0; i < length; i++) {
+    if (subscriber.closed) {
+      return;
+    }
     subscriber.next(array[i]);
   }
   subscriber.complete();

--- a/src/internal/observable/from.ts
+++ b/src/internal/observable/from.ts
@@ -133,7 +133,7 @@ function fromInteropObservable<T>(obj: any) {
  * `from` conditionals because we *know* they're dealing with an array.
  * @param array The array to emit values from
  */
-export function fromArrayLike<T>(array: ArrayLike<T>) {
+function fromArrayLike<T>(array: ArrayLike<T>) {
   return new Observable((subscriber: Subscriber<T>) => {
     subscribeToArray(array, subscriber);
   });

--- a/src/internal/operators/endWith.ts
+++ b/src/internal/operators/endWith.ts
@@ -1,8 +1,8 @@
 /** prettier */
-import { subscribeToArray } from '../observable/from';
-import { OperatorFunction, ValueFromArray } from '../types';
 import { Observable } from '../Observable';
+import { OperatorFunction, ValueFromArray } from '../types';
 import { operate } from '../Subscriber';
+import { subscribeToArray } from '../observable/from';
 
 /**
  * Returns an observable that will emit all values from the source, then synchronously emit

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -2,11 +2,6 @@ import { OperatorFunction, ValueFromArray } from '../types';
 import { operate } from '../util/lift';
 import { createOperatorSubscriber } from './OperatorSubscriber';
 
-// Devs are more likely to pass null or undefined than they are a scheduler
-// without accompanying values. To make things easier for (naughty) devs who
-// use the `strictNullChecks: false` TypeScript compiler option, these
-// overloads with explicit null and undefined values are included.
-
 export function startWith<T>(value: null): OperatorFunction<T, T | null>;
 export function startWith<T>(value: undefined): OperatorFunction<T, T | undefined>;
 export function startWith<T, A extends readonly unknown[] = T[]>(...values: A): OperatorFunction<T, T | ValueFromArray<A>>;
@@ -52,8 +47,6 @@ export function startWith<T, A extends readonly unknown[] = T[]>(...values: A): 
  */
 export function startWith<T, D>(...values: D[]): OperatorFunction<T, T | D> {
   return operate((source, subscriber) => {
-    // Because this will run synchronously, we don't need to do any fancy chaining here.
-    // Just run it and check to see if we're closed before we move on.
     subscribeToArray(
       values,
       createOperatorSubscriber(subscriber, undefined, () => source.subscribe(subscriber))

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -1,6 +1,7 @@
+import { Observable } from '../Observable';
+import { subscribeToArray } from '../observable/from';
+import { operate } from '../Subscriber';
 import { OperatorFunction, ValueFromArray } from '../types';
-import { operate } from '../util/lift';
-import { createOperatorSubscriber } from './OperatorSubscriber';
 
 export function startWith<T>(value: null): OperatorFunction<T, T | null>;
 export function startWith<T>(value: undefined): OperatorFunction<T, T | undefined>;
@@ -46,10 +47,8 @@ export function startWith<T, A extends readonly unknown[] = T[]>(...values: A): 
  * @see {@link concat}
  */
 export function startWith<T, D>(...values: D[]): OperatorFunction<T, T | D> {
-  return operate((source, subscriber) => {
-    subscribeToArray(
-      values,
-      createOperatorSubscriber(subscriber, undefined, () => source.subscribe(subscriber))
-    );
-  });
+  return (source) =>
+    new Observable((destination) => {
+      subscribeToArray(values, operate({ destination, complete: () => source.subscribe(destination) }));
+    });
 }

--- a/src/internal/operators/startWith.ts
+++ b/src/internal/operators/startWith.ts
@@ -1,7 +1,5 @@
 import { OperatorFunction, ValueFromArray } from '../types';
-import { popScheduler } from '../util/args';
 import { Observable } from '../Observable';
-import { subscribeToArray } from '../observable/from';
 
 // Devs are more likely to pass null or undefined than they are a scheduler
 // without accompanying values. To make things easier for (naughty) devs who
@@ -54,11 +52,15 @@ export function startWith<T, A extends readonly unknown[] = T[]>(...values: A): 
 export function startWith<T, D>(...values: D[]): OperatorFunction<T, T | D> {
   return (source) =>
     new Observable((subscriber) => {
-      // Because this will run synchronously, we don't need to do any fancy chaining here.
-      // Just run it and check to see if we're closed before we move on.
-      subscribeToArray(values, subscriber);
-      if (!subscriber.closed) {
-        source.subscribe(subscriber);
+      for (let i = 0; i < values.length; i++) {
+        if (subscriber.closed) {
+          return;
+        }
+        subscriber.next(values[i]);
       }
+      if (subscriber.closed) {
+        return;
+      }
+      return source.subscribe(subscriber);
     });
 }


### PR DESCRIPTION
+ Removes deprecated scheduler signature
+ Improves performance slightly
+ Moves `subscribeToArray` closer to usage.