### PR TITLE
feat(combineLatest): remove spread params deprecated signature.

### DIFF
--- a/spec-dtslint/observables/combineLatest-spec.ts
+++ b/spec-dtslint/observables/combineLatest-spec.ts
@@ -1,69 +1,6 @@
 import { combineLatest } from 'rxjs';
 import { a$,  b$,  c$,  d$,  e$,  f$,  g$, A, B, C, D, E, F } from '../helpers';
 
-
-it('should accept 1 param', () => {
-  const o = combineLatest(a$); // $ExpectType Observable<[A]>
-});
-
-it('should accept 2 params', () => {
-  const o = combineLatest(a$, b$); // $ExpectType Observable<[A, B]>
-});
-
-it('should accept 3 params', () => {
-  const o = combineLatest(a$, b$, c$); // $ExpectType Observable<[A, B, C]>
-});
-
-it('should accept 4 params', () => {
-  const o = combineLatest(a$, b$, c$, d$); // $ExpectType Observable<[A, B, C, D]>
-});
-
-it('should accept 5 params', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$); // $ExpectType Observable<[A, B, C, D, E]>
-});
-
-it('should accept 6 params', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, f$); // $ExpectType Observable<[A, B, C, D, E, F]>
-});
-
-it('should result in Observable<unknown> for 7 or more params', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, f$, g$); // $ExpectType Observable<[A, B, C, D, E, F, G]>
-});
-
-it('should accept union types', () => {
-  const u1: typeof a$ | typeof b$ = Math.random() > 0.5 ? a$ : b$;
-  const u2: typeof c$ | typeof d$ = Math.random() > 0.5 ? c$ : d$;
-  const o = combineLatest(u1, u2); // $ExpectType Observable<[A | B, C | D]>
-});
-
-it('should accept 1 param and a result selector', () => {
-  const o = combineLatest(a$, (...values) => new A()); // $ExpectType Observable<A>
-});
-
-it('should accept 2 params and a result selector', () => {
-  const o = combineLatest(a$, b$, (...values) => new A()); // $ExpectType Observable<A>
-});
-
-it('should accept 3 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, (...values) => new A()); // $ExpectType Observable<A>
-});
-
-it('should accept 4 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, (...values) => new A()); // $ExpectType Observable<A>
-});
-
-it('should accept 5 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, (...values) => new A()); // $ExpectType Observable<A>
-});
-
-it('should accept 6 params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, f$, (...values) => new A()); // $ExpectType Observable<A>
-});
-
-it('should accept 7 or more params and a result selector', () => {
-  const o = combineLatest(a$, b$, c$, d$, e$, f$, g$, g$, g$, (...values) => new A()); // $ExpectType Observable<A>
-});
-
 it('should accept 1 param', () => {
   const o = combineLatest([a$]); // $ExpectType Observable<[A]>
 });

--- a/spec/observables/combineLatest-spec.ts
+++ b/spec/observables/combineLatest-spec.ts
@@ -1,10 +1,9 @@
 import { expect } from 'chai';
-import { queueScheduler as rxQueueScheduler, combineLatest, of } from 'rxjs';
+import { combineLatest, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 
-const queueScheduler = rxQueueScheduler;
 
 /** @test {combineLatest} */
 describe('static combineLatest', () => {
@@ -42,18 +41,6 @@ describe('static combineLatest', () => {
     expect(results).to.deep.equal(['done']);
   });
 
-  it('should combineLatest the provided observables', () => {
-    rxTestScheduler.run(({ hot, expectObservable }) => {
-      const firstSource = hot(' ----a----b----c----|');
-      const secondSource = hot('--d--e--f--g--|');
-      const expected = '        ----uv--wx-y--z----|';
-
-      const combined = combineLatest(firstSource, secondSource, (a, b) => '' + a + b);
-
-      expectObservable(combined).toBe(expected, { u: 'ad', v: 'ae', w: 'af', x: 'bf', y: 'bg', z: 'cg' });
-    });
-  });
-
   it('should accept array of observables', () => {
     rxTestScheduler.run(({ hot, expectObservable }) => {
       const firstSource = hot(' ----a----b----c----|');
@@ -88,7 +75,7 @@ describe('static combineLatest', () => {
       const e2subs = '  ^';
       const expected = '-';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -104,7 +91,7 @@ describe('static combineLatest', () => {
       const e2subs = '  (^!)';
       const expected = '-';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -120,7 +107,7 @@ describe('static combineLatest', () => {
       const e2subs = '  ^';
       const expected = '-';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -136,7 +123,7 @@ describe('static combineLatest', () => {
       const e2subs = '  (^!)';
       const expected = '|';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -158,7 +145,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^---!';
       const expected = ' ----|';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -179,7 +166,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^---!';
       const expected = ' ----|';
 
-      const result = combineLatest(e2, e1, (x, y) => x + y);
+      const result = combineLatest([e2, e1], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -198,7 +185,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^  ';
       const expected = ' -'; //never
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -218,7 +205,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^---!';
       const expected = ' -----'; //never
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -234,7 +221,7 @@ describe('static combineLatest', () => {
       const e2subs = '     ^---------!';
       const expected = '   ----x-yz--|';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, { x: 'bf', y: 'cf', z: 'cg' });
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -250,7 +237,7 @@ describe('static combineLatest', () => {
       const e2subs = '  ^-----!';
       const expected = '------#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'shazbot!');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -266,7 +253,7 @@ describe('static combineLatest', () => {
       const e2subs = '  ^---!';
       const expected = '----#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'too bad, honk');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -282,7 +269,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^-!';
       const expected = ' --#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'bazinga');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -298,7 +285,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^-!';
       const expected = ' --#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'bazinga');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -314,7 +301,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^-!';
       const expected = ' --#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'bazinga');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -330,7 +317,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^-!';
       const expected = ' --#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'flurp');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -346,7 +333,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^-!';
       const expected = ' --#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'flurp');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -362,7 +349,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^-----!';
       const expected = ' ------#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'wokka wokka');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -378,7 +365,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^----!';
       const expected = ' -----#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'wokka wokka');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -394,7 +381,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^--!';
       const expected = ' ---#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, { a: 1, b: 2 }, 'wokka wokka');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -410,7 +397,7 @@ describe('static combineLatest', () => {
       const e2subs = '   ^--!';
       const expected = ' ---#';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, { a: 1, b: 2 }, 'wokka wokka');
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -426,7 +413,7 @@ describe('static combineLatest', () => {
       const rightSubs = '     ^--------!';
       const expected = '      ---------#';
 
-      const result = combineLatest(left, right, (x, y) => x + y);
+      const result = combineLatest([left, right], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'bad things');
       expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -442,7 +429,7 @@ describe('static combineLatest', () => {
       const rightSubs = '     ^------!';
       const expected = '      ---------#';
 
-      const result = combineLatest(left, right, (x, y) => x + y);
+      const result = combineLatest([left, right], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'bad things');
       expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -458,7 +445,7 @@ describe('static combineLatest', () => {
       const e2subs = '    ^-----------!';
       const expected = '  -----x-y-z--|';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, { x: 'be', y: 'ce', z: 'cf' });
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -474,7 +461,7 @@ describe('static combineLatest', () => {
       const e2subs = '     ^-------------------!';
       const expected = '   -----------x--y--z--|';
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' });
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -490,7 +477,7 @@ describe('static combineLatest', () => {
       const rightSubs = '     ^--------!';
       const expected = '      ---------#';
 
-      const result = combineLatest(left, right, (x, y) => x + y);
+      const result = combineLatest([left, right], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, null, 'jenga');
       expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -506,7 +493,7 @@ describe('static combineLatest', () => {
       const rightSubs = '     ^-------------------!';
       const expected = '      -----------x--y--z--#';
 
-      const result = combineLatest(left, right, (x, y) => x + y);
+      const result = combineLatest([left, right], (x, y) => x + y);
 
       expectObservable(result).toBe(expected, { x: 'cd', y: 'ce', z: 'cf' }, 'dun dun dun');
       expectSubscriptions(left.subscriptions).toBe(leftSubs);
@@ -522,7 +509,7 @@ describe('static combineLatest', () => {
       const e2subs = '     ^--!';
       const expected = '   ---#';
 
-      const result = combineLatest(e1, e2, (x, y) => {
+      const result = combineLatest([e1, e2], (x, y) => {
         throw 'ha ha ' + x + ', ' + y;
       });
 
@@ -542,7 +529,7 @@ describe('static combineLatest', () => {
       const unsub = '      ---------!    ';
       const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-      const result = combineLatest(e1, e2, (x, y) => x + y);
+      const result = combineLatest([e1, e2], (x, y) => x + y);
 
       expectObservable(result, unsub).toBe(expected, values);
       expectSubscriptions(e1.subscriptions).toBe(e1subs);
@@ -560,7 +547,10 @@ describe('static combineLatest', () => {
       const unsub = '      ---------!    ';
       const values = { x: 'bf', y: 'cf', z: 'cg' };
 
-      const result = combineLatest(e1.pipe(mergeMap((x) => of(x))), e2.pipe(mergeMap((x) => of(x))), (x, y) => x + y).pipe(
+      const result = combineLatest([
+        e1.pipe(mergeMap((x) => of(x))), 
+        e2.pipe(mergeMap((x) => of(x)))
+      ], (x, y) => x + y).pipe(
         mergeMap((x) => of(x))
       );
 

--- a/src/internal/util/argsArgArrayOrObject.ts
+++ b/src/internal/util/argsArgArrayOrObject.ts
@@ -10,19 +10,27 @@ const { getPrototypeOf, prototype: objectProto, keys: getKeys } = Object;
 export function argsArgArrayOrObject<T, O extends Record<string, T>>(args: T[] | [O] | [T[]]): { args: T[]; keys: string[] | null } {
   if (args.length === 1) {
     const first = args[0];
-    if (isArray(first)) {
-      return { args: first, keys: null };
-    }
-    if (isPOJO(first)) {
-      const keys = getKeys(first);
-      return {
-        args: keys.map((key) => first[key]),
-        keys,
-      };
+    const result = arrayOrObject(first);
+    if (result) {
+      return result;
     }
   }
 
   return { args: args as T[], keys: null };
+}
+
+export function arrayOrObject<T, O extends Record<string, T>>(first: T | T[] | O) {
+  if (isArray(first)) {
+    return { args: first, keys: null };
+  }
+  if (isPOJO(first)) {
+    const keys = getKeys(first);
+    return {
+      args: keys.map((key) => first[key]),
+      keys,
+    };
+  }
+  return null;
 }
 
 function isPOJO(obj: any): obj is object {


### PR DESCRIPTION
+ Removes the `combineLatest(a$, b$, c$)` signature, so we can standardize on `combineLatest([a$, b$, c$])` and `combineLatest({ a: a$, b: b$ })`.

NOTE: It appears we forgot to deprecate the `resultSelector` signature. Which isn't even supported for the newer object argument syntax (and never was).