### PR TITLE
fix(subscriber): strict type signature for next method

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rxjs",
-  "version": "7.6.0",
+  "version": "7.8.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "rxjs",
-      "version": "7.6.0",
+      "version": "7.8.0",
       "license": "Apache-2.0",
       "dependencies": {
         "tslib": "^2.1.0"

--- a/spec/Subscriber-spec.ts
+++ b/spec/Subscriber-spec.ts
@@ -9,7 +9,7 @@ describe('SafeSubscriber', () => {
   it('should ignore next messages after unsubscription', () => {
     let times = 0;
 
-    const sub = new SafeSubscriber({
+    const sub = new SafeSubscriber<void>({
       next() { times += 1; }
     });
 
@@ -25,7 +25,7 @@ describe('SafeSubscriber', () => {
     let times = 0;
     let errorCalled = false;
 
-    const sub = new SafeSubscriber({
+    const sub = new SafeSubscriber<void>({
       next() { times += 1; },
       error() { errorCalled = true; }
     });
@@ -44,7 +44,7 @@ describe('SafeSubscriber', () => {
     let times = 0;
     let completeCalled = false;
 
-    const sub = new SafeSubscriber({
+    const sub = new SafeSubscriber<void>({
       next() { times += 1; },
       complete() { completeCalled = true; }
     });

--- a/src/internal/Subscriber.ts
+++ b/src/internal/Subscriber.ts
@@ -68,7 +68,7 @@ export class Subscriber<T> extends Subscription implements Observer<T> {
    * @param {T} [value] The `next` value.
    * @return {void}
    */
-  next(value?: T): void {
+  next(value: T): void {
     if (this.isStopped) {
       handleStoppedNotification(nextNotification(value), this);
     } else {
@@ -203,7 +203,7 @@ export class SafeSubscriber<T> extends Subscriber<T> {
       // The first argument is a function, not an observer. The next
       // two arguments *could* be observers, or they could be empty.
       partialObserver = {
-        next: (observerOrNext ?? undefined) as (((value: T) => void) | undefined),
+        next: (observerOrNext ?? undefined) as ((value: T) => void) | undefined,
         error: error ?? undefined,
         complete: complete ?? undefined,
       };


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->
This PR fixes type signature of `Subscriber.prototype.next` method that was previously taking optional argument which was violating generic constraint `T`.

**BREAKING CHANGE:** `Subscriber.prototype.next` now takes strict argument.
```typescript
new Observable(subscriber => {
  subscriber.next() // throws in compile time (expected, caused by this PR)
})

new Observable<string>(subscriber => {
  subscriber.next() // throws in compile time (expected, caused by this PR)
})

new Observable<void>(subscriber => {
  subscriber.next() // ok
})
```

**Related issue (if exists):** https://github.com/ReactiveX/rxjs/issues/2852

**Additional changes:**
- update package version in lockfile to `7.8.0` (running `npm i`)
