### PR TITLE
docs: Fix example for bindCallback

### DIFF
--- a/src/internal/observable/bindCallback.ts
+++ b/src/internal/observable/bindCallback.ts
@@ -86,13 +86,13 @@ export function bindCallback<A extends readonly unknown[], R extends readonly un
  * ```ts
  * import { bindCallback } from 'rxjs';
  *
- * const someFunction = (cb) => {
- *   cb(5, 'some string', {someProperty: 'someValue'})
+ * const someFunction = (n, s, cb) => {
+ *   cb(n, s, { someProperty: 'someValue' });
  * };
  *
  * const boundSomeFunction = bindCallback(someFunction);
- * boundSomeFunction(12, 10).subscribe(values => {
- *   console.log(values); // [22, 2]
+ * boundSomeFunction(5, 'some string').subscribe((values) => {
+ *   console.log(values); // [5, 'some string', {someProperty: 'someValue'}]
  * });
  * ```
  *


### PR DESCRIPTION
docs: Fix the example for bindCallback.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The example, as it was, crashes with `Error: cb is not a function` on line 5. The new example demonstrates how arguments are forwarded or added.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
