### PR TITLE
fix(buffer): subscribe to the closing notifier before the source

### DIFF
--- a/spec/operators/buffer-spec.ts
+++ b/spec/operators/buffer-spec.ts
@@ -317,11 +317,11 @@ describe('Observable.prototype.buffer', () => {
     });
 
     subject.next(1);
-    expect(results).to.deep.equal([[1]]);
+    expect(results).to.deep.equal([[]]);
     subject.next(2);
-    expect(results).to.deep.equal([[1], [2]]);
+    expect(results).to.deep.equal([[], [1]]);
     subject.complete();
-    expect(results).to.deep.equal([[1], [2], [], 'complete']);
+    expect(results).to.deep.equal([[], [1], [2], 'complete']);
   });
 
   it('should buffer when Promise resolves', (done) => {

--- a/src/internal/operators/buffer.ts
+++ b/src/internal/operators/buffer.ts
@@ -47,19 +47,7 @@ export function buffer<T>(closingNotifier: ObservableInput<any>): OperatorFuncti
     // The current buffered values.
     let currentBuffer: T[] = [];
 
-    // Subscribe to our source.
-    source.subscribe(
-      createOperatorSubscriber(
-        subscriber,
-        (value) => currentBuffer.push(value),
-        () => {
-          subscriber.next(currentBuffer);
-          subscriber.complete();
-        }
-      )
-    );
-
-    // Subscribe to the closing notifier.
+    // Subscribe to the closing notifier first.
     from(closingNotifier).subscribe(
       createOperatorSubscriber(
         subscriber,
@@ -70,6 +58,18 @@ export function buffer<T>(closingNotifier: ObservableInput<any>): OperatorFuncti
           subscriber.next(b);
         },
         noop
+      )
+    );
+
+    // Subscribe to our source.
+    source.subscribe(
+      createOperatorSubscriber(
+        subscriber,
+        (value) => currentBuffer.push(value),
+        () => {
+          subscriber.next(currentBuffer);
+          subscriber.complete();
+        }
       )
     );
 


### PR DESCRIPTION
**Description:**
Per [RxJS Core Semantics guide](https://rxjs.dev/guide/core-semantics):

> "Notifiers" provided directly to the operator MUST be subscribed to before the source is subscribed to.

This PR fixes this issue in `buffer` operator. Since there was a test related to this, I adjusted it so that it works with the new setup.

Also, one note: since we waited with similar bug for v8 in #7152, I think this should not be cherry picked to v7 branch.

**Related issue (if exists):**
None, only [this comment](https://github.com/ReactiveX/rxjs/pull/7073#discussion_r1000298398).