### PR TITLE
fix(asapScheduler): No longer stops after being scheduled twice during flush

### DIFF
--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -16,9 +16,6 @@ export class AsapAction<T> extends AsyncAction<T> {
     }
     // Push the action to the end of the scheduler queue.
     scheduler.actions.push(this);
-    // If a microtask has already been scheduled, don't schedule another
-    // one. If a microtask hasn't been scheduled yet, schedule one now. Return
-    // the current scheduled microtask id.
     return immediateProvider.setImmediate(scheduler.flush.bind(scheduler, undefined));
   }
 
@@ -29,9 +26,7 @@ export class AsapAction<T> extends AsyncAction<T> {
     if (delay != null ? delay > 0 : this.delay > 0) {
       return super.recycleAsyncId(scheduler, id, delay);
     }
-    // If the scheduler queue has no remaining actions with the same async id,
-    // cancel the requested microtask and set the scheduled flag to undefined
-    // so the next AsapAction will request its own.
+
     if (id != null) {
       immediateProvider.clearImmediate(id);
     }

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -19,7 +19,7 @@ export class AsapAction<T> extends AsyncAction<T> {
     // If a microtask has already been scheduled, don't schedule another
     // one. If a microtask hasn't been scheduled yet, schedule one now. Return
     // the current scheduled microtask id.
-    return scheduler._scheduled || (scheduler._scheduled = immediateProvider.setImmediate(scheduler.flush.bind(scheduler, undefined)));
+    return immediateProvider.setImmediate(scheduler.flush.bind(scheduler, undefined));
   }
 
   protected recycleAsyncId(scheduler: AsapScheduler, id?: TimerHandle, delay: number = 0): TimerHandle | undefined {
@@ -32,10 +32,8 @@ export class AsapAction<T> extends AsyncAction<T> {
     // If the scheduler queue has no remaining actions with the same async id,
     // cancel the requested microtask and set the scheduled flag to undefined
     // so the next AsapAction will request its own.
-    const { actions } = scheduler;
-    if (id != null && actions[actions.length - 1]?.id !== id) {
+    if (id != null) {
       immediateProvider.clearImmediate(id);
-      scheduler._scheduled = undefined;
     }
     // Return undefined so the action knows to request a new async id if it's rescheduled.
     return undefined;


### PR DESCRIPTION
Fixes an issue where trying to share a microtask cause the scheduler to trip over itself. Instead, each scheduled item will get its own microtask.

resolves #7196
