### PR TITLE
fix(asapScheduler): No longer stops after scheduling twice during flush

### DIFF
--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -288,4 +288,28 @@ describe('Scheduler.asap', () => {
       done();
     });
   });
+
+  it('scheduling inside of an executing action more than once should work', (done) => {
+    const results: any[] = [];
+
+    let resolve: () => void;
+    let promise = new Promise<void>((r) => resolve = r);
+
+    asapScheduler.schedule(() => {
+      results.push(1)
+      asapScheduler.schedule(() => {
+        results.push(2);
+      });
+      asapScheduler.schedule(() => {
+        results.push(3);
+        resolve();
+      });
+    });
+
+    promise.then(() => {
+      // This should always fire after two recursively scheduled microtasks.
+      expect(results).to.deep.equal([1, 2, 3]);
+      done();
+    });
+  });
 });

--- a/src/internal/scheduler/AsapAction.ts
+++ b/src/internal/scheduler/AsapAction.ts
@@ -35,7 +35,9 @@ export class AsapAction<T> extends AsyncAction<T> {
     const { actions } = scheduler;
     if (id != null && actions[actions.length - 1]?.id !== id) {
       immediateProvider.clearImmediate(id);
-      scheduler._scheduled = undefined;
+      if (scheduler._scheduled === id) {
+        scheduler._scheduled = undefined;
+      }
     }
     // Return undefined so the action knows to request a new async id if it's rescheduled.
     return undefined;


### PR DESCRIPTION
Fixes an issue where trying to share a microtask cause the scheduler to trip over itself.

resolves ReactiveX#7196

A non-breaking alternative fix to PR https://github.com/ReactiveX/rxjs/pull/7197