### PR TITLE
fix(ignoreElements): change the return type from unknown to Generic Type

### DIFF
--- a/spec-dtslint/operators/ignoreElements-spec.ts
+++ b/spec-dtslint/operators/ignoreElements-spec.ts
@@ -17,3 +17,18 @@ it('should not break the inference of type', () => {
     ignoreElements(),
   );
 });
+
+it('should not break the inference of types when piped in a larger chain', () => {
+  const o$ = of('a string').pipe(
+    tap((o) => {
+      const t = o; // $ExpectType string
+    }),
+    tap((o) => {
+      const t = o; // $ExpectType string
+    }),
+    ignoreElements(),
+    tap((o) => {
+      const t = o; // $ExpectType never
+    }),
+  );
+});

--- a/spec-dtslint/operators/ignoreElements-spec.ts
+++ b/spec-dtslint/operators/ignoreElements-spec.ts
@@ -1,5 +1,5 @@
 import { of } from 'rxjs';
-import { ignoreElements } from 'rxjs/operators';
+import { ignoreElements, tap } from 'rxjs/operators';
 
 it('should infer correctly', () => {
   const o = of(1, 2, 3).pipe(ignoreElements()); // $ExpectType Observable<never>
@@ -7,4 +7,13 @@ it('should infer correctly', () => {
 
 it('should enforce types', () => {
   const o = of(1, 2, 3).pipe(ignoreElements('nope')); // $ExpectError
+});
+
+it('should not break the inference of type', () => {
+  const o$ = of(1, 2, 3).pipe(
+    tap((o) => {
+      const t = o; // $ExpectType number
+    }),
+    ignoreElements(),
+  );
 });


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The old signature of the function forced the previous types to unknown.

Taking into account @cartant `s comment https://github.com/ReactiveX/rxjs/issues/5236#issuecomment-575399386, losing the typing for the previous operators forces to duplicate the typing information when it is not necessary.
Losing the explicit typing and as a side effect duplicating the type information is also a bad practice.

### Before [[stackblitz]](https://stackblitz.com/edit/typescript-zpw3s7?file=index.ts)

```typescript
of('a string').pipe(
  tap((value) => {
    /** string **/
  }),
  tap((value) => {
    /** unknow **/
  }),
  ignoreElements(),
  tap((value) => {
    /** never **/
  })
);
```
### Now

```typescript
of('a string').pipe(
  tap((value) => {
    /** string **/
  }),
  tap((value) => {
    /** string **/
  }),
  ignoreElements(),
  tap((value) => {
    /** never **/
  })
);

```

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue :**
https://github.com/ReactiveX/rxjs/issues/6765
https://github.com/ReactiveX/rxjs/issues/6899
https://github.com/ReactiveX/rxjs/issues/5236
https://github.com/ReactiveX/rxjs/issues/5460