### PR TITLE
fix(pipe): Infer type for any number of functions

### DIFF
--- a/src/internal/operators/joinAllInternals.ts
+++ b/src/internal/operators/joinAllInternals.ts
@@ -20,9 +20,9 @@ export function joinAllInternals<T, R>(joinFn: (sources: ObservableInput<T>[]) =
   return pipe(
     // Collect all inner sources into an array, and emit them when the
     // source completes.
-    toArray() as OperatorFunction<ObservableInput<T>, ObservableInput<T>[]>,
+    toArray<ObservableInput<T>>(),
     // Run the join function on the collected array of inner sources.
-    mergeMap((sources) => joinFn(sources)),
+    mergeMap<ObservableInput<T>[], Observable<T>>((sources) => joinFn(sources)),
     // If a projection function was supplied, apply it to each result.
     project ? mapOneOrManyArgs(project) : (identity as any)
   );

--- a/src/internal/operators/joinAllInternals.ts
+++ b/src/internal/operators/joinAllInternals.ts
@@ -1,5 +1,5 @@
 import { Observable } from '../Observable';
-import { ObservableInput, OperatorFunction } from '../types';
+import { ObservableInput } from '../types';
 import { identity } from '../util/identity';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { pipe } from '../util/pipe';

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -3,10 +3,10 @@ import { UnaryFunction } from '../types';
 
 type PipeParameters<T extends any[], U extends any[] = []> = T extends [
   UnaryFunction<any, infer FR> | infer F,
-  UnaryFunction<infer SA, infer SR> | infer S,
+  UnaryFunction<any, infer SR>,
   ...infer R
 ]
-  ? PipeParameters<[[FR] extends [SA] ? S : UnaryFunction<FR, SR>, ...R], [...U, F]>
+  ? PipeParameters<[UnaryFunction<FR, SR>, ...R], [...U, F]>
   : T extends [any]
   ? [...U, ...T]
   : [];

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -1,24 +1,20 @@
 import { identity } from './identity';
 import { UnaryFunction } from '../types';
 
-type PipeParameters<T extends any[], U extends any[] = []> = T extends [infer F, infer S, ...infer R]
-  ? F extends UnaryFunction<any, infer FR>
-    ? S extends UnaryFunction<infer SA, infer SR>
-      ? [FR] extends [SA]
-        ? PipeParameters<[S, ...R], [...U, F]>
-        : PipeParameters<[UnaryFunction<FR, SR>, ...R], [...U, F]>
-      : never
-    : never
+type PipeParameters<T extends any[], U extends any[] = []> = T extends [
+  UnaryFunction<any, infer FR> | infer F,
+  UnaryFunction<infer SA, infer SR> | infer S,
+  ...infer R
+]
+  ? PipeParameters<[[FR] extends [SA] ? S : UnaryFunction<FR, SR>, ...R], [...U, F]>
   : T extends [any]
   ? [...U, ...T]
   : [];
 
-type PipeReturnType<T extends Array<UnaryFunction<any, any>>> = T extends [infer F, ...any[]] | [...any[], infer L]
-  ? F extends UnaryFunction<infer FA, any>
-    ? L extends UnaryFunction<any, infer LR>
-      ? UnaryFunction<FA, LR>
-      : never
-    : never
+type PipeReturnType<T extends Array<UnaryFunction<any, any>>> = T extends
+  | [UnaryFunction<infer FA, any>, ...any[]]
+  | [...any[], UnaryFunction<any, infer LR>]
+  ? UnaryFunction<FA, LR>
   : never;
 
 export function pipe(): typeof identity;

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -1,79 +1,34 @@
 import { identity } from './identity';
 import { UnaryFunction } from '../types';
 
+type PipeParameters<T extends any[], U extends any[] = []> = T extends [infer F, infer S, ...infer R]
+  ? F extends UnaryFunction<any, infer FR>
+    ? S extends UnaryFunction<infer SA, infer SR>
+      ? [FR] extends [SA]
+        ? PipeParameters<[S, ...R], [...U, F]>
+        : PipeParameters<[UnaryFunction<FR, SR>, ...R], [...U, F]>
+      : [...U, ...T]
+    : [...U, ...T]
+  : T extends [any]
+  ? [...U, ...T]
+  : [];
+
+type PipeReturnType<T extends Array<UnaryFunction<any, any>>> = T extends [infer F, ...any[]] | [...any[], infer L]
+  ? F extends UnaryFunction<infer FA, any>
+    ? L extends UnaryFunction<any, infer LR>
+      ? UnaryFunction<FA, LR>
+      : never
+    : never
+  : never;
+
 export function pipe(): typeof identity;
-export function pipe<T, A>(fn1: UnaryFunction<T, A>): UnaryFunction<T, A>;
-export function pipe<T, A, B>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>): UnaryFunction<T, B>;
-export function pipe<T, A, B, C>(fn1: UnaryFunction<T, A>, fn2: UnaryFunction<A, B>, fn3: UnaryFunction<B, C>): UnaryFunction<T, C>;
-export function pipe<T, A, B, C, D>(
-  fn1: UnaryFunction<T, A>,
-  fn2: UnaryFunction<A, B>,
-  fn3: UnaryFunction<B, C>,
-  fn4: UnaryFunction<C, D>
-): UnaryFunction<T, D>;
-export function pipe<T, A, B, C, D, E>(
-  fn1: UnaryFunction<T, A>,
-  fn2: UnaryFunction<A, B>,
-  fn3: UnaryFunction<B, C>,
-  fn4: UnaryFunction<C, D>,
-  fn5: UnaryFunction<D, E>
-): UnaryFunction<T, E>;
-export function pipe<T, A, B, C, D, E, F>(
-  fn1: UnaryFunction<T, A>,
-  fn2: UnaryFunction<A, B>,
-  fn3: UnaryFunction<B, C>,
-  fn4: UnaryFunction<C, D>,
-  fn5: UnaryFunction<D, E>,
-  fn6: UnaryFunction<E, F>
-): UnaryFunction<T, F>;
-export function pipe<T, A, B, C, D, E, F, G>(
-  fn1: UnaryFunction<T, A>,
-  fn2: UnaryFunction<A, B>,
-  fn3: UnaryFunction<B, C>,
-  fn4: UnaryFunction<C, D>,
-  fn5: UnaryFunction<D, E>,
-  fn6: UnaryFunction<E, F>,
-  fn7: UnaryFunction<F, G>
-): UnaryFunction<T, G>;
-export function pipe<T, A, B, C, D, E, F, G, H>(
-  fn1: UnaryFunction<T, A>,
-  fn2: UnaryFunction<A, B>,
-  fn3: UnaryFunction<B, C>,
-  fn4: UnaryFunction<C, D>,
-  fn5: UnaryFunction<D, E>,
-  fn6: UnaryFunction<E, F>,
-  fn7: UnaryFunction<F, G>,
-  fn8: UnaryFunction<G, H>
-): UnaryFunction<T, H>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(
-  fn1: UnaryFunction<T, A>,
-  fn2: UnaryFunction<A, B>,
-  fn3: UnaryFunction<B, C>,
-  fn4: UnaryFunction<C, D>,
-  fn5: UnaryFunction<D, E>,
-  fn6: UnaryFunction<E, F>,
-  fn7: UnaryFunction<F, G>,
-  fn8: UnaryFunction<G, H>,
-  fn9: UnaryFunction<H, I>
-): UnaryFunction<T, I>;
-export function pipe<T, A, B, C, D, E, F, G, H, I>(
-  fn1: UnaryFunction<T, A>,
-  fn2: UnaryFunction<A, B>,
-  fn3: UnaryFunction<B, C>,
-  fn4: UnaryFunction<C, D>,
-  fn5: UnaryFunction<D, E>,
-  fn6: UnaryFunction<E, F>,
-  fn7: UnaryFunction<F, G>,
-  fn8: UnaryFunction<G, H>,
-  fn9: UnaryFunction<H, I>,
-  ...fns: UnaryFunction<any, any>[]
-): UnaryFunction<T, unknown>;
+export function pipe<T extends Array<UnaryFunction<any, any>>>(...fns: PipeParameters<T>): PipeReturnType<T>;
 
 /**
  * pipe() can be called on one or more functions, each of which can take one argument ("UnaryFunction")
  * and uses it to return a value.
  * It returns a function that takes one argument, passes it to the first UnaryFunction, and then
- * passes the result to the next one, passes that result to the next one, and so on.  
+ * passes the result to the next one, passes that result to the next one, and so on.
  */
 export function pipe(...fns: Array<UnaryFunction<any, any>>): UnaryFunction<any, any> {
   return pipeFromArray(fns);

--- a/src/internal/util/pipe.ts
+++ b/src/internal/util/pipe.ts
@@ -7,8 +7,8 @@ type PipeParameters<T extends any[], U extends any[] = []> = T extends [infer F,
       ? [FR] extends [SA]
         ? PipeParameters<[S, ...R], [...U, F]>
         : PipeParameters<[UnaryFunction<FR, SR>, ...R], [...U, F]>
-      : [...U, ...T]
-    : [...U, ...T]
+      : never
+    : never
   : T extends [any]
   ? [...U, ...T]
   : [];


### PR DESCRIPTION
Now we can pass any number of functions:

```
pipe(
    (arg: number) => String(arg),
    (arg: string) => !!arg,
    (arg: boolean) => Number(arg),
    (arg: number) => String(arg),
    (arg: string) => !!arg,
    (arg: boolean) => Number(arg),
    (arg: number) => String(arg),
    (arg: string) => !!arg,
    (arg: boolean) => Number(arg),
    (arg: number) => String(arg),
    (arg: string) => !!arg,
    (arg: boolean) => Number(arg),
    (arg: object) => String(arg) // ts throw an error
    (arg: string) => !!arg,
    (arg: boolean) => Number(arg)
);
```

No need to keep a lot of overloads.

[You can test it here](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgVQHYEMoE8BiBXVAYxmAlTgF84AzKCEOAcigA8ArAZ0YG4AoXmFjABTOAAVgIsZnQhhMYVA4AeACpxhLBagAmHOOlRYA2gF0ANCg1bhu-YZOm4AXjhmAfC7jrN2vW944IJQMbHwiEjJlB0tgVGpFOBwAJU8AHzg4hKgk80DgtExcAmJSVGijWPjEgGVUvOC4ADoWrMTk3lN8oIB+cUlhaShZeUUVY0KwksjylMs690sWpuSLN2XkSxxTd264AC5vaz99Ywcuxr7jDaWW1Qvgw7M+ASFRCRFk+TwoVFU3tTHWz+ACCUGGWGUk2KETKFSwlgc7mRXh8NjsewyE1CMNKUTaORwIMRRkWzRaDjMDyCWOWlLW0PCePKMUy1RyABlUtS4H1GdM4UTLFzdo1DqhhAA3RQvQhkDjwMADLyA3zA-T82FRVlIjwACmW1FQHEOH0GMjkCiUancAEoXJ4EHsoN9fkxqBAIIwDPoCABrVAQADu5HQ+jNXxgPz+ANU7j4FBeOmEhAANphRHLjfAjSaQkUmTN4SSsO4zPwlSIDS1c7aKwM9Xs9ZgAObivAgABGintzk8NRgUDiLebUBbtoawVHbbgCqHqHHDrgAEJl63J0Fp4dO57U8JDL3PAA5DvdqDTidN1vtrs9pcD+cj1uXxpb2eD4eHldrscbuBvncID3A8lxPW9z2fP831QU87z7OAH2HC8oOvd9Hy-Vd1yvMdt13fdUC-MCz2Q7CZxg8Cv0QhcSNfVC50-JdMN-UjcKA-DCNgiCxxfKdUIgTs2BTGBKI-ajIJYtCGPgpiWxQnC4EA4CCNAziL14W0XkrYRG1o+TyLPETHxo3j5PohcMJ-WSJP4wTiA48C1I0+sqwk-S4P7USn24uSyM4izW3UvggA)