### PR TITLE
fix(subject): Faster subscriptions management in Subject

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -71,7 +71,7 @@ describe('Subject', () => {
       }, complete: done }
     );
 
-    expect(subject.observers.length).to.equal(2);
+    expect(subject.observers.size).to.equal(2);
     subject.next('foo');
     subject.next('bar');
     subject.complete();
@@ -385,11 +385,11 @@ describe('Subject', () => {
       //noop
     });
 
-    expect(subject.observers.length).to.equal(2);
+    expect(subject.observers.size).to.equal(2);
     sub1.unsubscribe();
-    expect(subject.observers.length).to.equal(1);
+    expect(subject.observers.size).to.equal(1);
     sub2.unsubscribe();
-    expect(subject.observers.length).to.equal(0);
+    expect(subject.observers.size).to.equal(0);
     done();
   });
 

--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -684,6 +684,21 @@ describe('Subject', () => {
     });
   });
 
+  it('should handle re-entrant subscribers the same after the move to Maps', () => {
+    const subject = new Subject<number>();
+    const results: any[] = [];
+
+    subject.subscribe(one => results.push({ one }))
+    subject.subscribe(two => {
+      results.push({ two })
+      subject.subscribe(three => results.push({ three }))
+    })
+
+    subject.next(42);
+
+    expect(results).to.deep.equal([{ one: 42 }, { two: 42 }])
+  })
+
   describe('many subscribers', () => {
     it('should be able to subscribe and unsubscribe huge amounts of subscribers', () => {
       let numResultsReceived = 0;

--- a/spec/subjects/BehaviorSubject-spec.ts
+++ b/spec/subjects/BehaviorSubject-spec.ts
@@ -97,7 +97,7 @@ describe('BehaviorSubject', () => {
       complete: done,
     });
 
-    expect(subject.observers.length).to.equal(2);
+    expect(subject.observers.size).to.equal(2);
     subject.next('foo');
     subject.next('bar');
     subject.complete();
@@ -133,11 +133,11 @@ describe('BehaviorSubject', () => {
       expect(x).to.equal('init');
     });
 
-    expect(subject.observers.length).to.equal(2);
+    expect(subject.observers.size).to.equal(2);
     sub1.unsubscribe();
-    expect(subject.observers.length).to.equal(1);
+    expect(subject.observers.size).to.equal(1);
     sub2.unsubscribe();
-    expect(subject.observers.length).to.equal(0);
+    expect(subject.observers.size).to.equal(0);
     done();
   });
 

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -75,10 +75,8 @@ SubscriptionLike {
     if (!this.isStopped) {
       this.hasError = this.isStopped = true;
       this.thrownError = err;
-      const { currentObservers } = this
-      const len = currentObservers.length
-      for (let i = 0; i < len; i++) {
-        currentObservers[i].error(err);
+      for (const observer of this.observers.values()) {
+        observer.error(err)
       }
     }
   }
@@ -87,10 +85,8 @@ SubscriptionLike {
     this._throwIfClosed();
     if (!this.isStopped) {
       this.isStopped = true;
-      const { currentObservers } = this
-      const len = currentObservers.length
-      for (let i = 0; i < len; i++) {
-        currentObservers[i].complete();
+      for (const observer of this.observers.values()) {
+        observer.complete()
       }
     }
   }

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -3,7 +3,6 @@ import { Subscriber } from './Subscriber';
 import { Subscription } from './Subscription';
 import { Observer, SubscriptionLike, TeardownLogic } from './types';
 import { ObjectUnsubscribedError } from './util/ObjectUnsubscribedError';
-import { arrRemove } from './util/arrRemove';
 
 /**
  * A Subject is a special type of Observable that allows values to be
@@ -15,10 +14,12 @@ import { arrRemove } from './util/arrRemove';
 export class Subject<T> extends Observable<T> implements SubscriptionLike {
   closed = false;
 
-  private currentObservers: Observer<T>[] | null = null;
+  private currentObservers = new Map<Subscription, Observer<T>>();
 
   /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
-  observers: Observer<T>[] = [];
+  get observers(): Observer<T>[] {
+    return Array.from(this.currentObservers.values());
+  }
   /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   isStopped = false;
   /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
@@ -51,10 +52,7 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
   next(value: T) {
     this._throwIfClosed();
     if (!this.isStopped) {
-      if (!this.currentObservers) {
-        this.currentObservers = Array.from(this.observers);
-      }
-      for (const observer of this.currentObservers) {
+      for (const observer of this.currentObservers.values()) {
         observer.next(value);
       }
     }
@@ -65,10 +63,11 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     if (!this.isStopped) {
       this.hasError = this.isStopped = true;
       this.thrownError = err;
-      const { observers } = this;
-      while (observers.length) {
-        observers.shift()!.error(err);
+      const { currentObservers } = this;
+      for (const observer of currentObservers.values()) {
+        observer.error(err);
       }
+      currentObservers.clear();
     }
   }
 
@@ -76,20 +75,20 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
     this._throwIfClosed();
     if (!this.isStopped) {
       this.isStopped = true;
-      const { observers } = this;
-      while (observers.length) {
-        observers.shift()!.complete();
+      const { currentObservers } = this;
+      for (const observer of currentObservers.values()) {
+        observer.complete();
       }
+      currentObservers.clear();
     }
   }
 
   unsubscribe() {
     this.isStopped = this.closed = true;
-    this.observers = this.currentObservers = null!;
   }
 
   get observed() {
-    return this.observers?.length > 0;
+    return this.currentObservers.size > 0;
   }
 
   /** @internal */
@@ -107,16 +106,15 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
 
   /** @internal */
   protected _innerSubscribe(subscriber: Subscriber<any>) {
-    const { hasError, isStopped, observers } = this;
+    const { hasError, isStopped, currentObservers } = this;
     if (hasError || isStopped) {
       return Subscription.EMPTY;
     }
-    this.currentObservers = null;
-    observers.push(subscriber);
-    return new Subscription(() => {
-      this.currentObservers = null;
-      arrRemove(observers, subscriber);
+    const subscription = new Subscription(() => {
+      currentObservers.delete(subscription);
     });
+    currentObservers.set(subscription, subscriber);
+    return subscription;
   }
 
   /** @internal */

--- a/src/internal/Subject.ts
+++ b/src/internal/Subject.ts
@@ -25,7 +25,7 @@ SubscriptionLike {
   private currentObservers: Observer<T>[] | null = null;
 
   /** @internal */
-  observers = new Map<Subscription, Observer>()
+  observers = new Map<Subscription, Observer<T>>()
 
   /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   isStopped = false;

--- a/src/internal/observable/dom/WebSocketSubject.ts
+++ b/src/internal/observable/dom/WebSocketSubject.ts
@@ -367,7 +367,7 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
     this._output.subscribe(subscriber);
     subscriber.add(() => {
       const { _socket } = this;
-      if (this._output.observers.length === 0) {
+      if (this._output.observers.size === 0) {
         if (_socket && (_socket.readyState === 1 || _socket.readyState === 0)) {
           _socket.close();
         }


### PR DESCRIPTION


<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The current implementation of the Subject was backing itself on an array of observers. When one observer unsubscribed itself, it was performing a linear scan on the array of observers and dropping the item from the array of observers. The algorithm complexity of this operation was O(n) with n being the number of observers connected to the Subject.

It caused code like:

```js
const allSubscriptions = [];
const source = new Subject();
for (let index = 0 ; index !== 1_000_000 ; ++index) {
  allSubscriptions.push(source.subscribe()); // rather quick
}
for (const subscription of allSubscriptions) {
  subscription.unsubscribe(); // taking very long
}
```

The proposed approach consists into changing our backing collection (an array) into a Map. But we lose somehow the set capability on subject.observers (might possibly be patched in some way).

The command `cross-env TS_NODE_PROJECT=tsconfig.mocha.json mocha --config spec/support/.mocharc.js "spec/**/Subje*-spec.ts"` with the new test added:

- Now: 452ms
- Before: 10s

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

Subject.observers has been impacted. If needed we can probably make it backward compatible in some ways. Here is what changed:

- Now a getter property, was previously a basic property
- The value change from one call to another -we recompute it anytime we access it)
- There is no setter anymore
- The value is never null

**Related issue (if exists):**
