### PR TITLE
docs(operators): fixed typo

### DIFF
--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -81,7 +81,7 @@ export interface TapObserver<T> extends Observer<T> {
  *
  * Tap is designed to allow the developer a designated place to perform side effects. While you _could_ perform side-effects
  * inside of a `map` or a `mergeMap`, that would make their mapping functions impure, which isn't always a big deal, but will
- * make it so you can't do things like memoize those functions. The `tap` operator is designed solely for such side-effects to
+ * make it so you can't do things like memorize those functions. The `tap` operator is designed solely for such side-effects to
  * help you remove side-effects from other operations.
  *
  * For any notification, next, error, or complete, `tap` will call the appropriate callback you have provided to it, via a function


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
