### PR TITLE
feat(operator): add `delayEach` operator

### DIFF
--- a/docs_app/content/guide/operators.md
+++ b/docs_app/content/guide/operators.md
@@ -227,6 +227,7 @@ Also see the [Join Creation Operators](#join-creation-operators) section above.
 - [`tap`](/api/operators/tap)
 - [`delay`](/api/operators/delay)
 - [`delayWhen`](/api/operators/delayWhen)
+- [`delayEach`](/api/operators/delayEach)
 - [`dematerialize`](/api/operators/dematerialize)
 - [`materialize`](/api/operators/materialize)
 - [`observeOn`](/api/operators/observeOn)

--- a/spec/operators/index-spec.ts
+++ b/spec/operators/index-spec.ts
@@ -21,6 +21,7 @@ describe('operators/index', () => {
     expect(index.defaultIfEmpty).to.exist;
     expect(index.delay).to.exist;
     expect(index.delayWhen).to.exist;
+    expect(index.delayEach).to.exist;
     expect(index.dematerialize).to.exist;
     expect(index.distinct).to.exist;
     expect(index.distinctUntilChanged).to.exist;

--- a/src/internal/operators/delayEach.ts
+++ b/src/internal/operators/delayEach.ts
@@ -1,0 +1,42 @@
+import { MonoTypeOperatorFunction, ObservableInput } from '../types';
+import { concatMap } from '../operators/concatMap';
+import { delay } from '../operators/delay';
+import { of } from '../observable/of';
+
+/**
+ * Delays the emission of each item from the source Observable by a given time duration.
+ *
+ * <span class="informal">It's similar to {@link delay}, but delays each item individually by a fixed time duration.</span>
+ *
+ * ![](delayEach.png)
+ *
+ * `delayEach` operator shifts the emission of each value from the source Observable by a fixed time duration.
+ * The source value is emitted on the output Observable after the specified time duration has passed.
+ *
+ * This operator internally leverages the {@link concatMap} and {@link delay} operators to achieve the desired behavior.
+ *
+ * ## Example
+ *
+ * Delay each click by 3 seconds
+ *
+ * ```ts
+ * import { fromEvent } from 'rxjs';
+ * import { delayEach } from './your-custom-operators';
+ *
+ * const clicks = fromEvent(document, 'click');
+ * const delayedClicks = clicks.pipe(
+ *   delayEach(3000)
+ * );
+ * delayedClicks.subscribe(x => console.log(x));
+ * ```
+ *
+ * @see {@link delay}
+ * @see {@link delayWhen}
+ * @see {@link concatMap}
+ *
+ * @param duration The time duration in milliseconds by which each item's emission should be delayed.
+ * @return A function that returns an Observable that delays the emissions of the source Observable by the specified duration for each item.
+ */
+export function delayEach<T>(duration: number): MonoTypeOperatorFunction<T> {
+  return concatMap((value) => of(value).pipe(delay(duration)));
+}

--- a/src/operators/index.ts
+++ b/src/operators/index.ts
@@ -19,6 +19,7 @@ export { debounce } from '../internal/operators/debounce';
 export { debounceTime } from '../internal/operators/debounceTime';
 export { defaultIfEmpty } from '../internal/operators/defaultIfEmpty';
 export { delay } from '../internal/operators/delay';
+export { delayEach } from '../internal/operators/delayEach';
 export { delayWhen } from '../internal/operators/delayWhen';
 export { dematerialize } from '../internal/operators/dematerialize';
 export { distinct } from '../internal/operators/distinct';


### PR DESCRIPTION
This commit introduces a new operator, delayEach, that delays the emission of each item from the source Observable by a given time duration. The operator is similar to the existing delay operator but applies the delay individually to each item.

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [x] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [x] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [x] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR introduces a new operator, `delayEach`, that delays the emission of each item from the source Observable by a given time duration. It is similar to the existing `delay` operator, but instead of delaying the entire sequence, it delays each item individually.

##### Motivation
`delayEach` can be helpful in various scenarios where it's necessary to introduce a consistent delay between each item emitted by an Observable. This operator provides a simple and concise way to achieve this without having to create a custom implementation each time.

##### Use Cases
1. Animating elements in a UI sequentially, where each element should appear with a fixed time delay between them.
2. Rate-limiting requests made to an API, ensuring that there is a consistent delay between each request to avoid hitting rate limits.
3. Introducing a delay in a stream of events, such as logs or messages, to simulate real-time behavior during testing or development.

##### Example
```ts
import { fromEvent } from 'rxjs';
import { delayEach } from './your-custom-operators';

const clicks = fromEvent(document, 'click');
const delayedClicks = clicks.pipe(
  delayEach(3000)
);
delayedClicks.subscribe(x => console.log(x));
```

Before finalizing this PR, I would like to hear your opinions on the usefulness of this operator and whether it would be a valuable addition to the library. If you agree, I will proceed with creating the necessary tests to ensure its functionality and reliability.

Looking forward to your feedback!


