### PR TITLE
fix(subject): Faster subscriptions management in Subject

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { Subject, ObjectUnsubscribedError, Observable, AsyncSubject, Observer, of, config, throwError, concat } from 'rxjs';
+import { Subject, ObjectUnsubscribedError, Observable, AsyncSubject, Observer, of, config, throwError, concat, Subscription } from 'rxjs';
 import { AnonymousSubject } from 'rxjs/internal/Subject';
 import { catchError, delay, map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
@@ -681,6 +681,47 @@ describe('Subject', () => {
         expect(true).to.be.false;
       }
       expect(true).to.be.true;
+    });
+  });
+
+  describe('many subscribers', () => {
+    it('should be able to subscribe and unsubscribe huge amounts of subscribers', () => {
+      let numResultsReceived = 0;
+      const allSubscriptions: Subscription[] = [];
+      const source = new Subject<number>();
+      const numSubscribers = 100000;
+      for (let index = 0 ; index !== numSubscribers ; ++index) {
+        allSubscriptions.push(source.subscribe(() => {
+          ++numResultsReceived;
+        }));
+      }
+      expect(numResultsReceived).to.eq(0);
+      expect(source.observed).to.be.true;
+      source.next(42);
+      expect(numResultsReceived).to.eq(numSubscribers);
+      expect(source.observed).to.be.true;
+      for (const subscription of allSubscriptions) {
+        subscription.unsubscribe();
+      }
+      expect(numResultsReceived).to.eq(numSubscribers);
+      expect(source.observed).to.be.false;
+    });
+  });
+
+  describe('re-rentrant subscribers', () => {
+    it('should handle re-entrant subscribers', () => {
+      const seenValues: number[] = [];
+      const source = new Subject<number>();
+      source.subscribe((value) => {
+        seenValues.push(value);
+        source.subscribe(nestedValue => {
+          seenValues.push(nestedValue);
+        });
+      });
+      source.next(1);
+      source.next(2);
+      source.next(3);
+      expect(seenValues).to.deep.eq([1, 2, 2, 3, 3, 3]);
     });
   });
 });


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

The current implementation of the Subject was backing itself on an array of observers. When one observer unsubscribed itself, it was performing a linear scan on the array of observers and dropping the item from the array of observers. The algorithm complexity of this operation was O(n) with n being the number of observers connected to the Subject.

It caused code like:

```js
const allSubscriptions = [];
const source = new Subject();
for (let index = 0 ; index !== 1_000_000 ; ++index) {
  allSubscriptions.push(source.subscribe()); // rather quick
}
for (const subscription of allSubscriptions) {
  subscription.unsubscribe(); // taking very long
}
```

The proposed approach consists into changing our backing collection (an array) into a Map. But we lose somehow the set capability on subject.observers (might possibly be patched in some way).

The command `cross-env TS_NODE_PROJECT=tsconfig.mocha.json mocha --config spec/support/.mocharc.js "spec/**/Subje*-spec.ts"` with the new test added:

- Now: 497ms
- Before: 10s

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

Subject.observers has been impacted. If needed we can probably make it backward compatible in some ways. Here is what changed:

- Now a getter property, was previously a basic property
- The value change from one call to another -we recompute it anytime we access it)
- There is no setter anymore
- The value is never null

**Related issue (if exists):**
