### PR TITLE
docs: provide URL for the V8 docs app

### DIFF
--- a/docs_app/content/navigation.json
+++ b/docs_app/content/navigation.json
@@ -121,6 +121,10 @@
   ],
   "docVersions": [
     {
+      "title": "next",
+      "url": "https://next.rxjs.dev/"
+    },
+    {
       "title": "stable",
       "url": "https://rxjs.dev/"
     },


### PR DESCRIPTION
**Description:**
Now that V8 is actively being developed and published, we need to provide URL for the V8 docs app ([next.rxjs.dev](https://next.rxjs.dev)).

**Related issue (if exists):**
None