### PR TITLE
Fix 6805: remove strange groupBy behavior

### DIFF
--- a/spec/Subject-spec.ts
+++ b/spec/Subject-spec.ts
@@ -4,7 +4,7 @@ import { AnonymousSubject } from 'rxjs/internal/Subject';
 import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from './helpers/observableMatcher';
-import { OperatorSubscriber } from 'rxjs/internal/operators/OperatorSubscriber';
+import { createOperatorSubscriber } from 'rxjs/internal/operators/OperatorSubscriber';
 
 /** @test {Subject} */
 describe('Subject', () => {
@@ -733,7 +733,7 @@ describe('Subject', () => {
     const subject = new Subject<number>();
     const destination = new Subscriber();
     const results: any[] = [];
-    const subscriber = new OperatorSubscriber(destination, (value) => {
+    const subscriber = createOperatorSubscriber(destination, (value) => {
       results.push(value);
     }, () => {
       results.push('complete');

--- a/src/internal/observable/onErrorResumeNext.ts
+++ b/src/internal/observable/onErrorResumeNext.ts
@@ -1,7 +1,7 @@
 import { Observable } from '../Observable';
 import { ObservableInputTuple } from '../types';
 import { argsOrArgArray } from '../util/argsOrArgArray';
-import { OperatorSubscriber } from '../operators/OperatorSubscriber';
+import { createOperatorSubscriber } from '../operators/OperatorSubscriber';
 import { noop } from '../util/noop';
 import { from } from './from';
 
@@ -89,7 +89,7 @@ export function onErrorResumeNext<A extends readonly unknown[]>(
           subscribeNext();
           return;
         }
-        const innerSubscriber = new OperatorSubscriber(subscriber, undefined, noop, noop);
+        const innerSubscriber = createOperatorSubscriber(subscriber, undefined, noop, noop);
         nextSource.subscribe(innerSubscriber);
         innerSubscriber.add(subscribeNext);
       } else {

--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -38,18 +38,13 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
    * this handler are sent to the `destination` error handler.
    * @param onFinalize Additional finalization logic here. This will only be called on finalization if the
    * subscriber itself is not already closed. This is called after all other finalization logic is executed.
-   * @param shouldUnsubscribe An optional check to see if an unsubscribe call should truly unsubscribe.
-   * NOTE: This currently **ONLY** exists to support the strange behavior of {@link groupBy}, where unsubscription
-   * to the resulting observable does not actually disconnect from the source if there are active subscriptions
-   * to any grouped observable. (DO NOT EXPOSE OR USE EXTERNALLY!!!)
    */
   constructor(
     destination: Subscriber<any>,
     onNext?: (value: T) => void,
     onComplete?: () => void,
     onError?: (err: any) => void,
-    private onFinalize?: () => void,
-    private shouldUnsubscribe?: () => boolean
+    private onFinalize?: () => void
   ) {
     // It's important - for performance reasons - that all of this class's
     // members are initialized and that they are always initialized in the same
@@ -102,11 +97,9 @@ export class OperatorSubscriber<T> extends Subscriber<T> {
   }
 
   unsubscribe() {
-    if (!this.shouldUnsubscribe || this.shouldUnsubscribe()) {
-      const { closed } = this;
-      super.unsubscribe();
-      // Execute additional teardown if we have any and we didn't already do so.
-      !closed && this.onFinalize?.();
-    }
+    const { closed } = this;
+    super.unsubscribe();
+    // Execute additional teardown if we have any and we didn't already do so.
+    !closed && this.onFinalize?.();
   }
 }

--- a/src/internal/operators/OperatorSubscriber.ts
+++ b/src/internal/operators/OperatorSubscriber.ts
@@ -26,7 +26,7 @@ export function createOperatorSubscriber<T>(
  * A generic helper for allowing operators to be created with a Subscriber and
  * use closures to capture necessary state from the operator function itself.
  */
-export class OperatorSubscriber<T> extends Subscriber<T> {
+class OperatorSubscriber<T> extends Subscriber<T> {
   /**
    * Creates an instance of an `OperatorSubscriber`.
    * @param destination The downstream subscriber.


### PR DESCRIPTION
fix(groupBy): will no longer leak inner subscriptions
    
`groupBy` no longer supports the behavior where inner subscriptions will cause the outer subscription to stay connected after consumer unsubscribes from result.
    
Resolves #6805
    
BREAKING CHANGE: `groupBy` no longer allows grouped observable subscriptions to stay connected after parent subscription unsubscribed. If you need this behavior, don't unsubscribe from the parent.
    
refactor: Remove direct instantiation of `OperatorSubscriber`
    
+ Stopped exporting `OperatorSubscriber` class from module
+ Updated `onErrorResumeNext` and a `Subject` test to use `createOperatorSubscriber`

Actual stream of the work is here, if that helps: https://youtu.be/rHgED1U6XDY

