### PR TITLE
fix(expand): operator function signature

### DIFF
--- a/spec-dtslint/operators/expand-spec.ts
+++ b/spec-dtslint/operators/expand-spec.ts
@@ -7,12 +7,6 @@ it('should infer correctly', () => {
   const q = of(1, 2, 3).pipe(expand(value => Promise.resolve(value))); // $ExpectType Observable<number>
 });
 
-it('should infer correctly with a different type as the source', () => {
-  const o = of(1, 2, 3).pipe(expand(value => of('foo'))); // $ExpectType Observable<string>
-  const p = of(1, 2, 3).pipe(expand(value => ['foo'])); // $ExpectType Observable<string>
-  const q = of(1, 2, 3).pipe(expand(value => Promise.resolve('foo'))); // $ExpectType Observable<string>
-});
-
 it('should support a project function with index', () => {
   const o = of(1, 2, 3).pipe(expand((value, index) => of(index))); // $ExpectType Observable<number>
 });
@@ -47,5 +41,5 @@ it('should enforce scheduler type', () => {
 });
 
 it('should support union types', () => {
-  const o = of(1).pipe(expand(x => typeof x === 'string' ? of(123) : of('test'))); // $ExpectType Observable<string | number>
+  const o = of(1).pipe(expand<string | number>(x => typeof x === 'string' ? of(123) : of('test'))); // $ExpectType Observable<string | number>
 });

--- a/spec-dtslint/operators/expand-spec.ts
+++ b/spec-dtslint/operators/expand-spec.ts
@@ -7,8 +7,24 @@ it('should infer correctly', () => {
   const q = of(1, 2, 3).pipe(expand(value => Promise.resolve(value))); // $ExpectType Observable<number>
 });
 
-it('should infer correctly with output type extending input type', () => {
+it('should infer correctly specifying value argument type', () => {
   const o = of(1).pipe(expand((value: number | string) => of(value.toString()))); // $ExpectType Observable<string | number>
+});
+
+it('should infer correctly with specifying different input/output types', () => {
+  const o = of(1).pipe(expand<number, string>((value) => of(value.toString()))); // $ExpectType Observable<string | number>
+});
+
+it('should enforce project output type to be assignable with its generic', () => {
+  const o = of(1).pipe(expand<number, string>((value) => of(value))); // $ExpectError
+});
+
+it('should enforce project input type to be assignable with upstream', () => {
+  const o = of(1).pipe(expand((value: string) => of(value))); // $ExpectError
+});
+
+it('should enforce project input/output types compatibility by default', () => {
+  const o = of(1).pipe(expand((value) => of(value.toString()))); // $ExpectError
 });
 
 it('should support a project function with index', () => {

--- a/spec-dtslint/operators/expand-spec.ts
+++ b/spec-dtslint/operators/expand-spec.ts
@@ -7,6 +7,10 @@ it('should infer correctly', () => {
   const q = of(1, 2, 3).pipe(expand(value => Promise.resolve(value))); // $ExpectType Observable<number>
 });
 
+it('should infer correctly with output type extending input type', () => {
+  const o = of(1).pipe(expand((value: number | string) => of(value.toString()))); // $ExpectType Observable<string | number>
+});
+
 it('should support a project function with index', () => {
   const o = of(1, 2, 3).pipe(expand((value, index) => of(index))); // $ExpectType Observable<number>
 });

--- a/spec/operators/expand-spec.ts
+++ b/spec/operators/expand-spec.ts
@@ -511,7 +511,7 @@ describe('expand', () => {
 
     synchronousObservable
       .pipe(
-        expand(() => EMPTY),
+        expand((_) => EMPTY),
         take(3)
       )
       .subscribe(() => {

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -3,21 +3,21 @@ import { Observable } from '../Observable';
 import { mergeInternals } from './mergeInternals';
 
 /* tslint:disable:max-line-length */
-export function expand<T, O extends ObservableInput<unknown>>(
-  project: (value: T, index: number) => O,
+export function expand<T, O>(
+  project: (value: T | O, index: number) => ObservableInput<O>,
   concurrent?: number,
   scheduler?: SchedulerLike
-): OperatorFunction<T, ObservedValueOf<O>>;
+): OperatorFunction<T, O>;
 /**
  * @deprecated The `scheduler` parameter will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
  * Details: Details: https://rxjs.dev/deprecations/scheduler-argument
  */
-export function expand<T, O extends ObservableInput<unknown>>(
-  project: (value: T, index: number) => O,
+export function expand<T, O>(
+  project: (value: T | O, index: number) => ObservableInput<O>,
   concurrent: number | undefined,
   scheduler: SchedulerLike
-): OperatorFunction<T, ObservedValueOf<O>>;
+): OperatorFunction<T, O>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -70,11 +70,11 @@ export function expand<T, O extends ObservableInput<unknown>>(
  * the output Observable and merging the results of the Observables obtained
  * from this transformation.
  */
-export function expand<T, O extends ObservableInput<unknown>>(
-  project: (value: T, index: number) => O,
+export function expand<T, O>(
+  project: (value: T | O, index: number) => ObservableInput<O>,
   concurrent = Infinity,
   scheduler?: SchedulerLike
-): OperatorFunction<T, ObservedValueOf<O>> {
+): OperatorFunction<T, O> {
   concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
   return (source) =>
     new Observable((subscriber) =>
@@ -83,8 +83,7 @@ export function expand<T, O extends ObservableInput<unknown>>(
         source,
         subscriber,
 
-        // HACK: Cast because TypeScript seems to get confused here.
-        project as (value: T, index: number) => ObservableInput<ObservedValueOf<O>>,
+        project,
         concurrent,
 
         // onBeforeNext

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -2,20 +2,22 @@ import { OperatorFunction, ObservableInput, SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { mergeInternals } from './mergeInternals';
 
-export type ExpandProject<T, O> = (value: T | (unknown extends O ? never : O), index: number) => ObservableInput<O>;
-
 /* tslint:disable:max-line-length */
-export function expand<T, O>(project: ExpandProject<T, O>, concurrent?: number, scheduler?: SchedulerLike): OperatorFunction<T, O>;
+export function expand<T>(
+  project: (value: T, index: number) => ObservableInput<T>,
+  concurrent?: number,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T>;
 /**
  * @deprecated The `scheduler` parameter will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
  * Details: Details: https://rxjs.dev/deprecations/scheduler-argument
  */
-export function expand<T, O>(
-  project: ExpandProject<T, O>,
+export function expand<T>(
+  project: (value: T, index: number) => ObservableInput<T>,
   concurrent: number | undefined,
   scheduler: SchedulerLike
-): OperatorFunction<T, O>;
+): OperatorFunction<T, T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -68,7 +70,11 @@ export function expand<T, O>(
  * the output Observable and merging the results of the Observables obtained
  * from this transformation.
  */
-export function expand<T, O>(project: ExpandProject<T, O>, concurrent = Infinity, scheduler?: SchedulerLike): OperatorFunction<T, O> {
+export function expand<T>(
+  project: (value: T, index: number) => ObservableInput<T>,
+  concurrent = Infinity,
+  scheduler?: SchedulerLike
+): OperatorFunction<T, T> {
   concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
   return (source) =>
     new Observable((subscriber) =>

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,23 +1,23 @@
-import { ObservableInput, SchedulerLike, MonoTypeOperatorFunction } from '../types';
+import { ObservableInput, SchedulerLike, OperatorFunction } from '../types';
 import { Observable } from '../Observable';
 import { mergeInternals } from './mergeInternals';
 
 /* tslint:disable:max-line-length */
-export function expand<T>(
-  project: (value: T, index: number) => ObservableInput<T>,
+export function expand<I, O extends I = I>(
+  project: (value: I | O, index: number) => ObservableInput<O>,
   concurrent?: number,
   scheduler?: SchedulerLike
-): MonoTypeOperatorFunction<T>;
+): OperatorFunction<I, I | O>;
 /**
  * @deprecated The `scheduler` parameter will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
  * Details: Details: https://rxjs.dev/deprecations/scheduler-argument
  */
-export function expand<T>(
-  project: (value: T, index: number) => ObservableInput<T>,
+export function expand<I, O extends I = I>(
+  project: (value: I | O, index: number) => ObservableInput<O>,
   concurrent: number | undefined,
   scheduler: SchedulerLike
-): MonoTypeOperatorFunction<T>;
+): OperatorFunction<I, I | O>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -70,11 +70,11 @@ export function expand<T>(
  * the output Observable and merging the results of the Observables obtained
  * from this transformation.
  */
-export function expand<T>(
-  project: (value: T, index: number) => ObservableInput<T>,
+export function expand<I, O extends I = I>(
+  project: (value: I | O, index: number) => ObservableInput<O>,
   concurrent = Infinity,
   scheduler?: SchedulerLike
-): MonoTypeOperatorFunction<T> {
+): OperatorFunction<I, I | O> {
   concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
   return (source) =>
     new Observable((subscriber) =>

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -3,7 +3,7 @@ import { Observable } from '../Observable';
 import { mergeInternals } from './mergeInternals';
 
 /* tslint:disable:max-line-length */
-export function expand<I, O extends I = I>(
+export function expand<I, O = I>(
   project: (value: I | O, index: number) => ObservableInput<O>,
   concurrent?: number,
   scheduler?: SchedulerLike
@@ -13,7 +13,7 @@ export function expand<I, O extends I = I>(
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
  * Details: Details: https://rxjs.dev/deprecations/scheduler-argument
  */
-export function expand<I, O extends I = I>(
+export function expand<I, O = I>(
   project: (value: I | O, index: number) => ObservableInput<O>,
   concurrent: number | undefined,
   scheduler: SchedulerLike
@@ -70,7 +70,7 @@ export function expand<I, O extends I = I>(
  * the output Observable and merging the results of the Observables obtained
  * from this transformation.
  */
-export function expand<I, O extends I = I>(
+export function expand<I, O = I>(
   project: (value: I | O, index: number) => ObservableInput<O>,
   concurrent = Infinity,
   scheduler?: SchedulerLike

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -2,19 +2,17 @@ import { OperatorFunction, ObservableInput, SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { mergeInternals } from './mergeInternals';
 
+export type ExpandProject<T, O> = (value: T | (unknown extends O ? never : O), index: number) => ObservableInput<O>;
+
 /* tslint:disable:max-line-length */
-export function expand<T, O>(
-  project: (value: T | O, index: number) => ObservableInput<O>,
-  concurrent?: number,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, O>;
+export function expand<T, O>(project: ExpandProject<T, O>, concurrent?: number, scheduler?: SchedulerLike): OperatorFunction<T, O>;
 /**
  * @deprecated The `scheduler` parameter will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
  * Details: Details: https://rxjs.dev/deprecations/scheduler-argument
  */
 export function expand<T, O>(
-  project: (value: T | O, index: number) => ObservableInput<O>,
+  project: ExpandProject<T, O>,
   concurrent: number | undefined,
   scheduler: SchedulerLike
 ): OperatorFunction<T, O>;
@@ -70,11 +68,7 @@ export function expand<T, O>(
  * the output Observable and merging the results of the Observables obtained
  * from this transformation.
  */
-export function expand<T, O>(
-  project: (value: T | O, index: number) => ObservableInput<O>,
-  concurrent = Infinity,
-  scheduler?: SchedulerLike
-): OperatorFunction<T, O> {
+export function expand<T, O>(project: ExpandProject<T, O>, concurrent = Infinity, scheduler?: SchedulerLike): OperatorFunction<T, O> {
   concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
   return (source) =>
     new Observable((subscriber) =>

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,4 +1,4 @@
-import { OperatorFunction, ObservableInput, SchedulerLike } from '../types';
+import { ObservableInput, SchedulerLike, MonoTypeOperatorFunction } from '../types';
 import { Observable } from '../Observable';
 import { mergeInternals } from './mergeInternals';
 
@@ -7,7 +7,7 @@ export function expand<T>(
   project: (value: T, index: number) => ObservableInput<T>,
   concurrent?: number,
   scheduler?: SchedulerLike
-): MonotypeOperatorFunction<T>;
+): MonoTypeOperatorFunction<T>;
 /**
  * @deprecated The `scheduler` parameter will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.
@@ -17,7 +17,7 @@ export function expand<T>(
   project: (value: T, index: number) => ObservableInput<T>,
   concurrent: number | undefined,
   scheduler: SchedulerLike
-): OperatorFunction<T, T>;
+): MonoTypeOperatorFunction<T>;
 /* tslint:enable:max-line-length */
 
 /**
@@ -74,7 +74,7 @@ export function expand<T>(
   project: (value: T, index: number) => ObservableInput<T>,
   concurrent = Infinity,
   scheduler?: SchedulerLike
-): OperatorFunction<T, T> {
+): MonoTypeOperatorFunction<T> {
   concurrent = (concurrent || 0) < 1 ? Infinity : concurrent;
   return (source) =>
     new Observable((subscriber) =>

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -7,7 +7,7 @@ export function expand<T>(
   project: (value: T, index: number) => ObservableInput<T>,
   concurrent?: number,
   scheduler?: SchedulerLike
-): OperatorFunction<T, T>;
+): MonotypeOperatorFunction<T>;
 /**
  * @deprecated The `scheduler` parameter will be removed in v8. If you need to schedule the inner subscription,
  * use `subscribeOn` within the projection function: `expand((value) => fn(value).pipe(subscribeOn(scheduler)))`.

--- a/src/internal/operators/expand.ts
+++ b/src/internal/operators/expand.ts
@@ -1,4 +1,4 @@
-import { OperatorFunction, ObservableInput, ObservedValueOf, SchedulerLike } from '../types';
+import { OperatorFunction, ObservableInput, SchedulerLike } from '../types';
 import { Observable } from '../Observable';
 import { mergeInternals } from './mergeInternals';
 


### PR DESCRIPTION
Currently, `expand` operator have incorrect signature. From the description `it applies the projection function to every source value as well as every output value`, that means the `project` function can receive both – upstream observable output and it's own output. But based on typings it only receive upstream observable output, which is dramatically incorrect!
And it's the reason why current `expand` function body contains `as` type-casting.

This pull request addresses this issue. The changes made include:

- Corrected the function signature for the expand operator
- Removed hacky type-casting within the function body by fixing the high-level signature

These changes improve type safety and prevent potential issues related to incorrect type-casting in the expand operator implementation.

**Related issue:**

#7131 