### PR TITLE
chore: format scheduler test files using prettier

### DIFF
--- a/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { animationFrameScheduler, Subscription, merge } from 'rxjs';
@@ -30,10 +31,7 @@ describe('Scheduler.animationFrame', () => {
       const tb = time(' --------|    ');
       const expected = '----a---b----';
 
-      const result = merge(
-        a.pipe(delay(ta, animationFrame)),
-        b.pipe(delay(tb, animationFrame))
-      );
+      const result = merge(a.pipe(delay(ta, animationFrame)), b.pipe(delay(tb, animationFrame)));
       expectObservable(result).toBe(expected);
     });
   });
@@ -50,9 +48,7 @@ describe('Scheduler.animationFrame', () => {
       const subs = '    ^-!          ';
       const expected = '-------------';
 
-      const result = merge(
-        a.pipe(delay(ta, animationFrame))
-      );
+      const result = merge(a.pipe(delay(ta, animationFrame)));
       expectObservable(result, subs).toBe(expected);
 
       flush();
@@ -79,30 +75,42 @@ describe('Scheduler.animationFrame', () => {
   it('should execute recursively scheduled actions in separate asynchronous contexts', (done) => {
     let syncExec1 = true;
     let syncExec2 = true;
-    animationFrame.schedule(function (index) {
-      if (index === 0) {
-        this.schedule(1);
-        animationFrame.schedule(() => { syncExec1 = false; });
-      } else if (index === 1) {
-        this.schedule(2);
-        animationFrame.schedule(() => { syncExec2 = false; });
-      } else if (index === 2) {
-        this.schedule(3);
-      } else if (index === 3) {
-        if (!syncExec1 && !syncExec2) {
-          done();
-        } else {
-          done(new Error('Execution happened synchronously.'));
+    animationFrame.schedule(
+      function (index) {
+        if (index === 0) {
+          this.schedule(1);
+          animationFrame.schedule(() => {
+            syncExec1 = false;
+          });
+        } else if (index === 1) {
+          this.schedule(2);
+          animationFrame.schedule(() => {
+            syncExec2 = false;
+          });
+        } else if (index === 2) {
+          this.schedule(3);
+        } else if (index === 3) {
+          if (!syncExec1 && !syncExec2) {
+            done();
+          } else {
+            done(new Error('Execution happened synchronously.'));
+          }
         }
-      }
-    }, 0, 0);
+      },
+      0,
+      0
+    );
   });
 
   it('should cancel the animation frame if all scheduled actions unsubscribe before it executes', (done) => {
     let animationFrameExec1 = false;
     let animationFrameExec2 = false;
-    const action1 = animationFrame.schedule(() => { animationFrameExec1 = true; });
-    const action2 = animationFrame.schedule(() => { animationFrameExec2 = true; });
+    const action1 = animationFrame.schedule(() => {
+      animationFrameExec1 = true;
+    });
+    const action2 = animationFrame.schedule(() => {
+      animationFrameExec2 = true;
+    });
     expect(animationFrame._scheduled).to.exist;
     expect(animationFrame.actions.length).to.equal(2);
     action1.unsubscribe();
@@ -143,9 +151,9 @@ describe('Scheduler.animationFrame', () => {
 
   it('should not execute rescheduled actions when flushing', (done) => {
     let flushCount = 0;
-    let scheduledIndices: number[] = [];
+    const scheduledIndices: number[] = [];
 
-    let originalFlush = animationFrame.flush;
+    const originalFlush = animationFrame.flush;
     animationFrame.flush = (...args) => {
       ++flushCount;
       originalFlush.apply(animationFrame, args);
@@ -160,18 +168,22 @@ describe('Scheduler.animationFrame', () => {
       }
     };
 
-    animationFrame.schedule(function (index) {
-      if (flushCount < 2) {
-        this.schedule(index! + 1);
-        scheduledIndices.push(index! + 1);
-      }
-    }, 0, 0);
+    animationFrame.schedule(
+      function (index) {
+        if (flushCount < 2) {
+          this.schedule(index! + 1);
+          scheduledIndices.push(index! + 1);
+        }
+      },
+      0,
+      0
+    );
     scheduledIndices.push(0);
   });
 
   it('should execute actions scheduled when flushing in a subsequent flush', (done) => {
     const sandbox = sinon.createSandbox();
-    const stubFlush = (sandbox.stub(animationFrameScheduler, 'flush')).callThrough();
+    const stubFlush = sandbox.stub(animationFrameScheduler, 'flush').callThrough();
 
     let a: Subscription;
     let b: Subscription;
@@ -192,7 +204,7 @@ describe('Scheduler.animationFrame', () => {
 
   it('should execute actions scheduled when flushing in a subsequent flush when some actions are unsubscribed', (done) => {
     const sandbox = sinon.createSandbox();
-    const stubFlush = (sandbox.stub(animationFrameScheduler, 'flush')).callThrough();
+    const stubFlush = sandbox.stub(animationFrameScheduler, 'flush').callThrough();
 
     let a: Subscription;
     let b: Subscription;

--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -1,3 +1,4 @@
+/** @prettier  */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { asapScheduler, Subscription, SchedulerAction, merge } from 'rxjs';
@@ -29,10 +30,7 @@ describe('Scheduler.asap', () => {
       const tb = time(' --------|    ');
       const expected = '----a---b----';
 
-      const result = merge(
-        a.pipe(delay(ta, asap)),
-        b.pipe(delay(tb, asap))
-      );
+      const result = merge(a.pipe(delay(ta, asap)), b.pipe(delay(tb, asap)));
       expectObservable(result).toBe(expected);
     });
   });
@@ -49,9 +47,7 @@ describe('Scheduler.asap', () => {
       const subs = '    ^-!          ';
       const expected = '-------------';
 
-      const result = merge(
-        a.pipe(delay(ta, asap))
-      );
+      const result = merge(a.pipe(delay(ta, asap)));
       expectObservable(result, subs).toBe(expected);
 
       flush();
@@ -66,7 +62,7 @@ describe('Scheduler.asap', () => {
     const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sandbox.stub(global, 'setInterval')).callThrough();
+    const stubSetInterval = (<any>sandbox.stub(global, 'setInterval')).callThrough();
     const period = 50;
     const state = { index: 0, period };
     type State = typeof state;
@@ -92,7 +88,7 @@ describe('Scheduler.asap', () => {
     const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sandbox.stub(global, 'setInterval')).callThrough();
+    const stubSetInterval = (<any>sandbox.stub(global, 'setInterval')).callThrough();
     const period = 50;
     const state = { index: 0, period };
     type State = typeof state;
@@ -129,30 +125,42 @@ describe('Scheduler.asap', () => {
   it('should execute recursively scheduled actions in separate asynchronous contexts', (done) => {
     let syncExec1 = true;
     let syncExec2 = true;
-    asap.schedule(function (index) {
-      if (index === 0) {
-        this.schedule(1);
-        asap.schedule(() => { syncExec1 = false; });
-      } else if (index === 1) {
-        this.schedule(2);
-        asap.schedule(() => { syncExec2 = false; });
-      } else if (index === 2) {
-        this.schedule(3);
-      } else if (index === 3) {
-        if (!syncExec1 && !syncExec2) {
-          done();
-        } else {
-          done(new Error('Execution happened synchronously.'));
+    asap.schedule(
+      function (index) {
+        if (index === 0) {
+          this.schedule(1);
+          asap.schedule(() => {
+            syncExec1 = false;
+          });
+        } else if (index === 1) {
+          this.schedule(2);
+          asap.schedule(() => {
+            syncExec2 = false;
+          });
+        } else if (index === 2) {
+          this.schedule(3);
+        } else if (index === 3) {
+          if (!syncExec1 && !syncExec2) {
+            done();
+          } else {
+            done(new Error('Execution happened synchronously.'));
+          }
         }
-      }
-    }, 0, 0);
+      },
+      0,
+      0
+    );
   });
 
   it('should cancel the setImmediate if all scheduled actions unsubscribe before it executes', (done) => {
     let asapExec1 = false;
     let asapExec2 = false;
-    const action1 = asap.schedule(() => { asapExec1 = true; });
-    const action2 = asap.schedule(() => { asapExec2 = true; });
+    const action1 = asap.schedule(() => {
+      asapExec1 = true;
+    });
+    const action2 = asap.schedule(() => {
+      asapExec2 = true;
+    });
     expect(asap._scheduled).to.exist;
     expect(asap.actions.length).to.equal(2);
     action1.unsubscribe();
@@ -193,9 +201,9 @@ describe('Scheduler.asap', () => {
 
   it('should not execute rescheduled actions when flushing', (done) => {
     let flushCount = 0;
-    let scheduledIndices: number[] = [];
+    const scheduledIndices: number[] = [];
 
-    let originalFlush = asap.flush;
+    const originalFlush = asap.flush;
     asap.flush = (...args) => {
       ++flushCount;
       originalFlush.apply(asap, args);
@@ -210,18 +218,22 @@ describe('Scheduler.asap', () => {
       }
     };
 
-    asap.schedule(function (index) {
-      if (flushCount < 2) {
-        this.schedule(index! + 1);
-        scheduledIndices.push(index! + 1);
-      }
-    }, 0, 0);
+    asap.schedule(
+      function (index) {
+        if (flushCount < 2) {
+          this.schedule(index! + 1);
+          scheduledIndices.push(index! + 1);
+        }
+      },
+      0,
+      0
+    );
     scheduledIndices.push(0);
   });
 
   it('should execute actions scheduled when flushing in a subsequent flush', (done) => {
     const sandbox = sinon.createSandbox();
-    const stubFlush = (sandbox.stub(asapScheduler, 'flush')).callThrough();
+    const stubFlush = sandbox.stub(asapScheduler, 'flush').callThrough();
 
     let a: Subscription;
     let b: Subscription;
@@ -242,7 +254,7 @@ describe('Scheduler.asap', () => {
 
   it('should execute actions scheduled when flushing in a subsequent flush when some actions are unsubscribed', (done) => {
     const sandbox = sinon.createSandbox();
-    const stubFlush = (sandbox.stub(asapScheduler, 'flush')).callThrough();
+    const stubFlush = sandbox.stub(asapScheduler, 'flush').callThrough();
 
     let a: Subscription;
     let b: Subscription;
@@ -293,10 +305,10 @@ describe('Scheduler.asap', () => {
     const results: any[] = [];
 
     let resolve: () => void;
-    let promise = new Promise<void>((r) => resolve = r);
+    const promise = new Promise<void>((r) => (resolve = r));
 
     asapScheduler.schedule(() => {
-      results.push(1)
+      results.push(1);
       asapScheduler.schedule(() => {
         results.push(2);
       });

--- a/spec/schedulers/QueueScheduler-spec.ts
+++ b/spec/schedulers/QueueScheduler-spec.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { queueScheduler, Subscription, merge } from 'rxjs';
@@ -23,10 +24,7 @@ describe('Scheduler.queue', () => {
       const tb = time(' --------|    ');
       const expected = '----a---b----';
 
-      const result = merge(
-        a.pipe(delay(ta, queue)),
-        b.pipe(delay(tb, queue))
-      );
+      const result = merge(a.pipe(delay(ta, queue)), b.pipe(delay(tb, queue)));
       expectObservable(result).toBe(expected);
     });
   });
@@ -36,17 +34,21 @@ describe('Scheduler.queue', () => {
     const fakeTimer = sandbox.useFakeTimers();
 
     let asyncExec = false;
-    let state: Array<number> = [];
+    const state: Array<number> = [];
 
-    queue.schedule(function (index) {
-      state.push(index!);
-      if (index === 0) {
-        this.schedule(1, 100);
-      } else if (index === 1) {
-        asyncExec = true;
-        this.schedule(2, 0);
-      }
-    }, 0, 0);
+    queue.schedule(
+      function (index) {
+        state.push(index!);
+        if (index === 0) {
+          this.schedule(1, 100);
+        } else if (index === 1) {
+          asyncExec = true;
+          this.schedule(2, 0);
+        }
+      },
+      0,
+      0
+    );
 
     expect(asyncExec).to.be.false;
     expect(state).to.be.deep.equal([0]);
@@ -67,9 +69,15 @@ describe('Scheduler.queue', () => {
     try {
       queue.schedule(() => {
         actions.push(
-          queue.schedule(() => { throw new Error('oops'); }),
-          queue.schedule(() => { action2Exec = true; }),
-          queue.schedule(() => { action3Exec = true; })
+          queue.schedule(() => {
+            throw new Error('oops');
+          }),
+          queue.schedule(() => {
+            action2Exec = true;
+          }),
+          queue.schedule(() => {
+            action3Exec = true;
+          })
         );
       });
     } catch (e) {

--- a/spec/schedulers/VirtualTimeScheduler-spec.ts
+++ b/spec/schedulers/VirtualTimeScheduler-spec.ts
@@ -1,3 +1,4 @@
+/** @prettier */
 import { expect } from 'chai';
 import { SchedulerAction, VirtualAction, VirtualTimeScheduler } from 'rxjs';
 
@@ -66,14 +67,18 @@ describe('VirtualTimeScheduler', () => {
     let count = 0;
     const expected = [100, 200, 300];
 
-    v.schedule<string>(function (this: SchedulerAction<string>, state?: string) {
-      if (++count === 3) {
-        return;
-      }
-      const virtualAction = this as VirtualAction<string>;
-      expect(virtualAction.delay).to.equal(expected.shift());
-      this.schedule(state, virtualAction.delay);
-    }, 100, 'test');
+    v.schedule<string>(
+      function (this: SchedulerAction<string>, state?: string) {
+        if (++count === 3) {
+          return;
+        }
+        const virtualAction = this as VirtualAction<string>;
+        expect(virtualAction.delay).to.equal(expected.shift());
+        this.schedule(state, virtualAction.delay);
+      },
+      100,
+      'test'
+    );
 
     v.flush();
     expect(count).to.equal(3);
@@ -83,11 +88,7 @@ describe('VirtualTimeScheduler', () => {
     const v = new VirtualTimeScheduler();
     const messages: string[] = [];
 
-    const action: VirtualAction<string> = <VirtualAction<string>> v.schedule(
-      state => messages.push(state!),
-      10,
-      'first message'
-    );
+    const action: VirtualAction<string> = <VirtualAction<string>>v.schedule((state) => messages.push(state!), 10, 'first message');
 
     action.schedule('second message', 10);
     v.flush();
@@ -103,17 +104,13 @@ describe('VirtualTimeScheduler', () => {
     const actualMessages: string[] = [];
 
     messages.forEach((message, index) => {
-      v.schedule(
-        state => actualMessages.push(state!),
-        index * MAX_FRAMES,
-        message
-      );
+      v.schedule((state) => actualMessages.push(state!), index * MAX_FRAMES, message);
     });
 
     v.flush();
 
     expect(actualMessages).to.deep.equal(['first message', 'second message']);
-    expect(v.actions.map(a => a.state)).to.deep.equal(['third message']);
+    expect(v.actions.map((a) => a.state)).to.deep.equal(['third message']);
   });
 
   it('should pick up actions execution where it left off after reaching previous maxFrames limit', function () {
@@ -124,11 +121,7 @@ describe('VirtualTimeScheduler', () => {
     const actualMessages: string[] = [];
 
     messages.forEach((message, index) => {
-      v.schedule(
-        state => actualMessages.push(state!),
-        index * MAX_FRAMES,
-        message
-      );
+      v.schedule((state) => actualMessages.push(state!), index * MAX_FRAMES, message);
     });
 
     v.flush();


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR formats the scheduler spec files using prettier, with the exception of the test file for the `TestScheduler` for which a separate PR #7258 was opened.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
None
