### PR TITLE
fix(forkJoin): the first empty source will now cause an EmptyError

### DIFF
--- a/src/internal/observable/forkJoin.ts
+++ b/src/internal/observable/forkJoin.ts
@@ -7,6 +7,7 @@ import { operate } from '../Subscriber';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs';
 import { createObject } from '../util/createObject';
 import { AnyCatcher } from '../AnyCatcher';
+import { EmptyError } from '../util/EmptyError';
 
 // forkJoin(any)
 // We put this first because we need to catch cases where the user has supplied
@@ -169,10 +170,12 @@ export function forkJoin(...args: any[]): Observable<any> {
           complete: () => remainingCompletions--,
           finalize: () => {
             if (!remainingCompletions || !hasValue) {
-              if (!remainingEmissions) {
+              if (remainingEmissions === 0) {
                 destination.next(keys ? createObject(keys, values) : values);
+                destination.complete();
+              } else {
+                destination.error(new EmptyError());
               }
-              destination.complete();
             }
           },
         })


### PR DESCRIPTION
BREAKING CHANGE: `forkJoin` will no longer just complete if a source completes without a value. Instead you will get an error of `EmptyError`. If you want to complete in this case, add `catchError(() => EMPTY)` to the forkJoin... however, if you just want to default the sources of your `forkJoin` to some other value if they're empty, apply the `defaultIfEmpty` operator. for example, `forkJoin(sources.map(defaultIfEmpty(null)))`.

resolves #5561
