### PR TITLE
feat(tap): add assertion function overload

### DIFF
--- a/spec-dtslint/operators/tap-spec.ts
+++ b/spec-dtslint/operators/tap-spec.ts
@@ -11,8 +11,20 @@ it('should accept partial observer', () => {
   const c = of(1, 2, 3).pipe(tap({ complete: () => { } })); // $ExpectType Observable<number>
 });
 
+it('should support a user-defined assertion function', () => {
+  const o = of(1, 2, 3).pipe(tap((value: number): asserts value is 1 => { /* assertion code */ })); // $ExpectType Observable<1>
+});
+
+it('should support a partial observer with user-defined assertion function', () => {
+  const o = of(1, 2, 3).pipe(tap({ next: (value: number): asserts value is 1 => { /* assertion code */ }})); // $ExpectType Observable<1>
+});
+
 it('should enforce type for next observer function', () => {
   const a = of(1, 2, 3).pipe(tap({ next: (x: string) => { } })); // $ExpectError
+});
+
+it('should enforce type for next observer assertion function', () => {
+  const o = of(1, 2, 3).pipe(tap({ next: (value: string): asserts value is 1 => { /* assertion code */ }})); // $ExpectError
 });
 
 it('should deprecate the multi-argument usage', () => {

--- a/src/internal/operators/tap.ts
+++ b/src/internal/operators/tap.ts
@@ -1,4 +1,4 @@
-import { MonoTypeOperatorFunction, Observer } from '../types';
+import { MonoTypeOperatorFunction, Observer, OperatorFunction } from '../types';
 import { isFunction } from '../util/isFunction';
 import { Observable } from '../Observable';
 import { operate } from '../Subscriber';
@@ -71,6 +71,13 @@ export interface TapObserver<T> extends Observer<T> {
    */
   finalize: () => void;
 }
+
+export interface TapObserverWithAsserts<T, S extends T> extends Omit<TapObserver<T>, 'next'> {
+  next: (value: T) => asserts value is S;
+}
+
+export function tap<T, S extends T>(observerOrNext?: Partial<TapObserverWithAsserts<T, S>> | ((value: T) => asserts value is S)): OperatorFunction<T, S>;
+export function tap<T>(observerOrNext?: Partial<TapObserver<T>> | ((value: T) => void) | null): MonoTypeOperatorFunction<T>;
 
 /**
  * Used to perform side-effects for notifications from the source observable


### PR DESCRIPTION
**Description:**

I think no breaking changes in this PR.

Specifying an assertion function to `tap()` will ensure the type that follows.
This is similar to specifying a type guard function to `filter()`.

```ts
const stringOrNumberObservable: Observable<string | number> = of(1, 'aaa', 3, 'bb');

// Keep type-inference before PR
stringOrNumberObservable
  .pipe(tap((x) => {
    if (typeof x !== 'string') {
      throw new Error('not a String');
    }
  }))
  .subscribe((x) => x); // x is still {string | number}

// New type-inference in this PR
stringOrNumberObservable
  .pipe(tap((x: string | number): asserts x is string => {
    if (typeof x !== 'string') {
      throw new Error('not a String');
    }
  }))
  .subscribe((s) => s.length); // s is {string}
```

**Related issue (if exists):**
Nothing.