### PR TITLE
type: fix `ignoreElements` generic type

### DIFF
--- a/src/internal/operators/ignoreElements.ts
+++ b/src/internal/operators/ignoreElements.ts
@@ -38,7 +38,7 @@ import { noop } from '../util/noop';
  * `complete` or `error`, based on which one is called by the source
  * Observable.
  */
-export function ignoreElements(): OperatorFunction<unknown, never> {
+export function ignoreElements<T>(): OperatorFunction<T, never> {
   return (source) =>
     new Observable((destination) => {
       source.subscribe(operate({ destination, next: noop }));


### PR DESCRIPTION
**Description:**
If `ignoreElements` follows `tap` immediately, the type of the `tap` parameter will be incorrectly inferred to be `unknown`.
```ts
import { ignoreElements, of, tap } from 'rxjs';

function test() {
  const data = { value: 1 }
  of(data).pipe(
    tap(data => console.log(data.value)),
    // ---------------------^~~~ ['data' is of type 'unknown'.ts(18046)]
    ignoreElements(),
  )
}
```
