### PR TITLE
docs: add MonoTypeOperatorFunction documentation

### DIFF
--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -34,7 +34,7 @@ export type FactoryOrValue<T> = T | (() => T);
 /**
  * A function type interface that describes a function that accepts and returns a parameter of the same type.
  *
- * It only works with a single type of data. Input and output value must be of the same type.
+ * Used to describe {@link OperatorFunction} with the only one type: `OperatorFunction<T, T>`.
  *
  */
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -31,6 +31,12 @@ export interface OperatorFunction<T, R> extends UnaryFunction<Observable<T>, Obs
 
 export type FactoryOrValue<T> = T | (() => T);
 
+/**
+ * A function type interface that describes a function that accepts and returns a parameter of the same type.
+ *
+ * It only works with a single type of data. Input and output value must be of the same type.
+ *
+ */
 export interface MonoTypeOperatorFunction<T> extends OperatorFunction<T, T> {}
 
 /**


### PR DESCRIPTION
**Description:**
This PR adds [MonoTypeOperatorFunction](https://rxjs.dev/api/index/interface/MonoTypeOperatorFunction) docs.

**Related issue (if exists):**
None
