### PR TITLE
Fixed defaultIfEmpty incorrect type with strictNullChecks off

### DIFF
--- a/src/internal/operators/defaultIfEmpty.ts
+++ b/src/internal/operators/defaultIfEmpty.ts
@@ -37,6 +37,19 @@ import { operate } from '../Subscriber';
  * specified `defaultValue` if the source Observable emits no items, or the
  * values emitted by the source Observable.
  */
+
+
+// To make things easier for (naughty) devs who use the
+// `strictNullChecks: false` TypeScript compiler option, these
+// overloads with explicit null and undefined values are included.
+
+export function defaultIfEmpty<T, R extends null>(
+  defaultValue: R
+): (source: Observable<T>) => Observable<T | null>;
+export function defaultIfEmpty<T, R extends undefined>(
+  defaultValue: R
+): (source: Observable<T>) => Observable<T | undefined>;
+
 export function defaultIfEmpty<T, R>(defaultValue: R): OperatorFunction<T, T | R> {
   return (source) =>
     new Observable((destination) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `docs_app/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

`defaultIfEmpty(null)` or `defaultIfEmpty(undefined)` always returns the observable of type `Observable<any>`

### Expected behavior

When strictNullChecks is off null type is ignored so it should just return the type of the source observable as it is.

Expected behaviour in `strictNullChecks: false`

`const test$ = of(1).pipe(defaultIfEmpty(null)); // Observable<number>`

Instead we get

`const test$ = of(1).pipe(defaultIfEmpty(null)); // Observable<any>`

This PR fixes the issue by adding explicit overloads for null and undefined

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):** #7280
