### PR TITLE
[Idea] Make it possible for BehaviorSubject to emit an initial "summary" value to late subscribers

### DIFF
--- a/src/internal/BehaviorSubject.ts
+++ b/src/internal/BehaviorSubject.ts
@@ -31,6 +31,7 @@ export class BehaviorSubject<T> extends Subject<T> {
   }
 
   next(value: T): void {
-    super.next((this._value = this._valueFold(this._value, value)));
+    this._value = this._valueFold(this._value, value);
+    super.next(value);
   }
 }

--- a/src/internal/BehaviorSubject.ts
+++ b/src/internal/BehaviorSubject.ts
@@ -7,7 +7,7 @@ import { Subscription } from './Subscription';
  * value whenever it is subscribed to.
  */
 export class BehaviorSubject<T> extends Subject<T> {
-  constructor(private _value: T) {
+  constructor(private _value: T, private readonly _valueFold: (currentValue: T, newValue: T) => T = (_, v) => v) {
     super();
   }
 
@@ -31,6 +31,6 @@ export class BehaviorSubject<T> extends Subject<T> {
   }
 
   next(value: T): void {
-    super.next((this._value = value));
+    super.next((this._value = this._valueFold(this._value, value)));
   }
 }


### PR DESCRIPTION
**Description:**

**Note: this PR is intended to open a discussion on whether this change is considered broadly useful**

BehaviorSubject currently allows emitting the initial or latest value when it's subscribed to. However there is a use case that it non-trivial to model with it.

Imagine a BehaviorSubject is used to stream log events and consumers can subscribe and render them. However the logs subscribers will receive depends on when they subscribe, late subscribers won't see log events that happened before they subscribed.

This change proposes to make it possible for late subscribers to receive a "summary" value upon initial subscription, e.g.

```typescript
interface LogEvent {
  readonly log: string;
}

const events = new BehaviorSubject<LogEvent>(
    {log: "start"},
    (prev, next) => {log: `${prev.log}\n${next.log}`.slice(-2000)});
```

With this code, late subscribers will receive up to 2000 characters of previously emitted logs and then keep receiving new log lines as long as they are subscribed.
While this example it contrived, the proposed change is general enough to allow for more interesting folds to generate a meaningful "summary" value.

Thoughts?

**BREAKING CHANGE:** NA
