### PR TITLE
feat(Subscription): Subscription now implements `Symbol.dispose`

### DIFF
--- a/spec/Subscription-spec.ts
+++ b/spec/Subscription-spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import { Observable, UnsubscriptionError, Subscription, merge } from 'rxjs';
+import sinon = require('sinon');
 
 /** @test {Subscription} */
 describe('Subscription', () => {
@@ -225,3 +226,22 @@ describe('Subscription', () => {
     });
   });
 });
+
+describe('Subscription[Symbol.dispose] implementation', () => {
+  it('should be the same as unsubscribe', () => {
+    const subscription = new Subscription();
+    expect(subscription[Symbol.dispose]).to.equal(subscription.unsubscribe);
+  });
+
+  it('should call a teardown when unsubscribed', () => {
+    // This is just a sanity check.
+    const callback = sinon.spy();
+    const subscription = new Subscription();
+    
+    subscription.add(callback);
+    subscription[Symbol.dispose]();
+    expect(callback).to.have.been.calledOnce;
+    expect(subscription.closed).to.be.true;
+  });
+});
+

--- a/spec/helpers/interop-helper.ts
+++ b/spec/helpers/interop-helper.ts
@@ -1,4 +1,4 @@
-import { Observable, Operator, Subject, Subscriber, Subscription } from 'rxjs';
+import { Observable, Subject, Subscriber, Subscription } from 'rxjs';
 
 /**
  * Returns an observable that will be deemed by this package's implementation

--- a/spec/helpers/setup.ts
+++ b/spec/helpers/setup.ts
@@ -53,5 +53,11 @@ if (!(Symbol as any).observable) {
   }
 }(global));
 
+// Polyfill Symbol.dispose for testing
+if (typeof Symbol.dispose !== 'symbol') {
+  (Symbol as any).dispose = Symbol('dispose polyfill');
+}
+
+
 //setup sinon-chai
 chai.use(sinonChai);

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -144,10 +144,28 @@ export class Subscription implements SubscriptionLike {
   }
 }
 
+// Even though Subscriptoin only conditionally implements `Symbol.dispose`
+// if it's available, we still need to declare it here so that TypeScript
+// knows that it exists on the prototype when it is available.
+export interface Subscription {
+  [Symbol.dispose](): void;
+}
+
+if (typeof Symbol.dispose === 'symbol') {
+  Subscription.prototype[Symbol.dispose] = Subscription.prototype.unsubscribe;
+}
+
 function execFinalizer(finalizer: Unsubscribable | (() => void)) {
   if (isFunction(finalizer)) {
     finalizer();
   } else {
     finalizer.unsubscribe();
+  }
+}
+
+// Ensure that `Symbol.dispose` is defined in TypeScript
+declare global {
+  interface SymbolConstructor {
+    readonly dispose: unique symbol;
   }
 }

--- a/src/internal/Subscription.ts
+++ b/src/internal/Subscription.ts
@@ -144,7 +144,7 @@ export class Subscription implements SubscriptionLike {
   }
 }
 
-// Even though Subscriptoin only conditionally implements `Symbol.dispose`
+// Even though Subscription only conditionally implements `Symbol.dispose`
 // if it's available, we still need to declare it here so that TypeScript
 // knows that it exists on the prototype when it is available.
 export interface Subscription {


### PR DESCRIPTION
Just an initial pass at implementing `Symbol.dispose`. Theoretical usage would be something like:

```ts
async function someLongRunningThing() {
  let valueFromObservable;

  // This is the usage.
  using someObservable$.subscribe(value => {
    valueFromObservable = value;
  })

  let n = 0;
  while (n++ < 10) {
    const userInput = await userInput();
    console.log(userInput + valueFromObservable);
  }

  // when this exits, the subscription will be "disposed".
}
```

cc @rbuckton

Related #7299 