### PR TITLE
feat(cjs): output ES2022

### DIFF
--- a/src/tsconfig.cjs.json
+++ b/src/tsconfig.cjs.json
@@ -2,7 +2,7 @@
   "extends": "./tsconfig.base.json",
   "compilerOptions": {
     "module": "commonjs",
-    "target": "es5",
+    "target": "ES2022",
     "downlevelIteration": true,
     "outDir": "../dist/cjs"
   }


### PR DESCRIPTION
Makes sure we're publishing newer JavaScript for CJS files as well.