### PR TITLE
Refactor: no internal pipe method use

### DIFF
--- a/packages/rxjs/src/internal/observable/dom/fetch.ts
+++ b/packages/rxjs/src/internal/observable/dom/fetch.ts
@@ -107,7 +107,7 @@ export function fromFetch<T>(
     // This flag exists to make sure we don't `abort()` the fetch upon tearing down
     // this observable after emitting a Response. Aborting in such circumstances
     // would also abort subsequent methods - like `json()` - that could be called
-    // on the Response. Consider: `fromFetch().pipe(take(1), mergeMap(res => res.json()))`
+    // on the Response. Consider: `rx(fromFetch(), take(1), mergeMap(res => res.json()))`
     let abortable = true;
 
     // If the user provided an init configuration object,

--- a/packages/rxjs/src/internal/observable/forkJoin.ts
+++ b/packages/rxjs/src/internal/observable/forkJoin.ts
@@ -180,5 +180,5 @@ export function forkJoin(...args: any[]): Observable<any> {
       );
     }
   });
-  return resultSelector ? result.pipe(mapOneOrManyArgs(resultSelector)) : result;
+  return resultSelector ? mapOneOrManyArgs(resultSelector)(result) : result;
 }

--- a/packages/rxjs/src/internal/observable/fromEvent.ts
+++ b/packages/rxjs/src/internal/observable/fromEvent.ts
@@ -1,4 +1,4 @@
-import type { Subscriber} from '../Observable.js';
+import type { Subscriber } from '../Observable.js';
 import { Observable, isArrayLike, isFunction } from '../Observable.js';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs.js';
 
@@ -252,7 +252,7 @@ export function fromEvent<T>(
   }
 
   if (resultSelector) {
-    return fromEvent<T>(target, eventName as string, options as EventListenerOptions).pipe(mapOneOrManyArgs(resultSelector));
+    return mapOneOrManyArgs(resultSelector)(fromEvent<T>(target, eventName as string, options as EventListenerOptions));
   }
 
   const isValidTarget = isNodeStyleEventEmitter(target) || isJQueryStyleEventEmitter(target) || isEventTarget(target);

--- a/packages/rxjs/src/internal/observable/fromEventPattern.ts
+++ b/packages/rxjs/src/internal/observable/fromEventPattern.ts
@@ -138,7 +138,7 @@ export function fromEventPattern<T>(
   resultSelector?: (...args: any[]) => T
 ): Observable<T | T[]> {
   if (resultSelector) {
-    return fromEventPattern<T>(addHandler, removeHandler).pipe(mapOneOrManyArgs(resultSelector));
+    return mapOneOrManyArgs(resultSelector)(fromEventPattern<T>(addHandler, removeHandler));
   }
 
   return new Observable<T | T[]>((subscriber) => {

--- a/packages/rxjs/src/internal/operators/groupBy.ts
+++ b/packages/rxjs/src/internal/operators/groupBy.ts
@@ -169,7 +169,7 @@ export function groupBy<T, K, R>(
       // out-of-band with our `subscriber` which is the downstream subscriber, or destination,
       // in cases where a user unsubscribes from the main resulting subscription, but
       // still has groups from this subscription subscribed and would expect values from it
-      // Consider:  `source.pipe(groupBy(fn), take(2))`.
+      // Consider:  `rx(source, groupBy(fn), take(2))`.
       const groupBySourceSubscriber = operate({
         destination,
         next: (value: T) => {


### PR DESCRIPTION
Removes internal usage of the `pipe` method, so that in the future, other observables that do not implement `pipe` will work with our operators.

This PR doesn't have the explicit goal of ensuring operators work with "observable shaped things", but it's a step in that direction.
