### PR TITLE
refactor: isolate reliance on SchedulerAction `this` context

### DIFF
--- a/packages/rxjs/src/internal/operators/timeout.ts
+++ b/packages/rxjs/src/internal/operators/timeout.ts
@@ -311,7 +311,7 @@ export function timeout<T, O extends ObservableInput<any>, M>(
       let originalSourceSubscription: Subscription;
       // The subscription for our timeout timer. This changes
       // every time we get a new value.
-      let timerSubscription: Subscription;
+      let timerSubscription: Subscription | void;
       // A bit of state we pass to our with and error factories to
       // tell what the last value we saw was.
       let lastValue: T | null = null;
@@ -353,9 +353,7 @@ export function timeout<T, O extends ObservableInput<any>, M>(
             each! > 0 && startTimer(each!);
           },
           finalize: () => {
-            if (!timerSubscription?.closed) {
-              timerSubscription?.unsubscribe();
-            }
+            timerSubscription?.unsubscribe();
             // Be sure not to hold the last value in memory after unsubscription
             // it could be quite large.
             lastValue = null;

--- a/packages/rxjs/src/internal/scheduled/scheduleArray.ts
+++ b/packages/rxjs/src/internal/scheduled/scheduleArray.ts
@@ -1,27 +1,24 @@
 import { Observable } from '../Observable.js';
 import type { SchedulerLike } from '../types.js';
+import { executeSchedule } from '../util/executeSchedule.js';
 
 export function scheduleArray<T>(input: ArrayLike<T>, scheduler: SchedulerLike) {
   return new Observable<T>((subscriber) => {
     // The current array index.
     let i = 0;
-    // Start iterating over the array like on a schedule.
-    return scheduler.schedule(function () {
+    const emit = () => {
+      // If we have hit the end of the array, complete.
       if (i === input.length) {
-        // If we have hit the end of the array like in the
-        // previous job, we can complete.
         subscriber.complete();
       } else {
-        // Otherwise let's next the value at the current index,
+        // Otherwise, next the value at the current index,
         // then increment our index.
         subscriber.next(input[i++]);
-        // If the last emission didn't cause us to close the subscriber
-        // (via take or some side effect), reschedule the job and we'll
-        // make another pass.
-        if (!subscriber.closed) {
-          this.schedule();
-        }
+        executeSchedule(subscriber, scheduler, emit);
       }
-    });
+    };
+
+    // Start iterating over the array like on a schedule.
+    return executeSchedule(subscriber, scheduler, emit);
   });
 }

--- a/packages/rxjs/src/internal/util/executeSchedule.ts
+++ b/packages/rxjs/src/internal/util/executeSchedule.ts
@@ -5,40 +5,27 @@ export function executeSchedule(
   parentSubscription: Subscription,
   scheduler: SchedulerLike,
   work: () => void,
-  delay: number,
-  repeat: true
-): void;
-export function executeSchedule(
-  parentSubscription: Subscription,
-  scheduler: SchedulerLike,
-  work: () => void,
-  delay?: number,
-  repeat?: false
-): Subscription;
-
-export function executeSchedule(
-  parentSubscription: Subscription,
-  scheduler: SchedulerLike,
-  work: () => void,
   delay = 0,
   repeat = false
 ): Subscription | void {
-  const scheduleSubscription = scheduler.schedule(function (this: SchedulerAction<any>) {
-    work();
-    if (repeat) {
-      parentSubscription.add(this.schedule(null, delay));
-    } else {
-      this.unsubscribe();
+  if (!parentSubscription.closed) {
+    const scheduleSubscription = scheduler.schedule(function (this: SchedulerAction<any>) {
+      work();
+      if (repeat) {
+        parentSubscription.add(this.schedule(null, delay));
+      } else {
+        this.unsubscribe();
+      }
+    }, delay);
+
+    parentSubscription.add(scheduleSubscription);
+
+    if (!repeat) {
+      // Because user-land scheduler implementations are unlikely to properly reuse
+      // Actions for repeat scheduling, we can't trust that the returned subscription
+      // will control repeat subscription scenarios. So we're trying to avoid using them
+      // incorrectly within this library.
+      return scheduleSubscription;
     }
-  }, delay);
-
-  parentSubscription.add(scheduleSubscription);
-
-  if (!repeat) {
-    // Because user-land scheduler implementations are unlikely to properly reuse
-    // Actions for repeat scheduling, we can't trust that the returned subscription
-    // will control repeat subscription scenarios. So we're trying to avoid using them
-    // incorrectly within this library.
-    return scheduleSubscription;
   }
 }


### PR DESCRIPTION
This goes through and moves all of the reliance on the `this` context for scheduling to a single point, `executeSchedule`. It also moves common complexities to that helper function. All of this is done in preparation for creating newer, simplified schedulers
