### PR TITLE
fix: Add SEO Page Title for 2 pages

### DIFF
--- a/docs_app/content/marketing/contributors.json
+++ b/docs_app/content/marketing/contributors.json
@@ -110,7 +110,7 @@
     "github": "https://github.com/mattpodwysocki",
     "picture": "https://avatars0.githubusercontent.com/u/49051",
     "twitter": "https://twitter.com/mattpodwysocki",
-    "group": "Alumn"
+    "group": "Alumni"
   },
   "andre": {
     "name": "André Staltz",
@@ -119,7 +119,7 @@
     "picture": "https://avatars0.githubusercontent.com/u/90512",
     "twitter": "https://twitter.com/andrestaltz",
     "website": "http://staltz.com",
-    "group": "Alumn"
+    "group": "Alumni"
   },
   "jay": {
     "name": "Jay Phelps",
@@ -128,7 +128,7 @@
     "picture": "https://avatars0.githubusercontent.com/u/762949",
     "twitter": "https://twitter.com/_jayphelps",
     "website": "http://jayphelps.com",
-    "group": "Alumn"
+    "group": "Alumni"
   },
   "nat": {
     "name": "Natalie Smith",

--- a/docs_app/content/marketing/operator-decision-tree.html
+++ b/docs_app/content/marketing/operator-decision-tree.html
@@ -1,1 +1,2 @@
+<h1 class="no-toc">Operator Decision Tree</h1>
 <aio-operator-decision-tree></aio-operator-decision-tree>

--- a/docs_app/content/marketing/team.html
+++ b/docs_app/content/marketing/team.html
@@ -1,1 +1,2 @@
+<h1 class="no-toc">Team</h1>
 <aio-contributor-list></aio-contributor-list>

--- a/docs_app/src/app/custom-elements/contributor/contributor.service.ts
+++ b/docs_app/src/app/custom-elements/contributor/contributor.service.ts
@@ -10,7 +10,7 @@ import { Contributor, ContributorGroup } from './contributors.model';
 import { CONTENT_URL_PREFIX } from 'app/documents/document.service';
 
 const contributorsPath = CONTENT_URL_PREFIX + 'contributors.json';
-const knownGroups = ['Core Team', 'Learning Team', 'Alumn', 'Contributors'];
+const knownGroups = ['Core Team', 'Learning Team', 'Alumni', 'Contributors'];
 
 @Injectable()
 export class ContributorService {

--- a/docs_app/src/app/custom-elements/operator-decision-tree/operator-decision-tree.component.ts
+++ b/docs_app/src/app/custom-elements/operator-decision-tree/operator-decision-tree.component.ts
@@ -8,7 +8,6 @@ import { OperatorDecisionTreeService } from './operator-decision-tree.service';
 @Component({
   selector: 'aio-operator-decision-tree',
   template: `
-    <h1 class="mat-heading" tabindex="0">Operator Decision Tree</h1>
     <ng-container *ngIf="!(hasError$ | async); else hasErrorTemplate">
       <h2 class="mat-subheading-2" tabindex="0">
         {{ currentSentence$ | async }}


### PR DESCRIPTION
**Description:**
- The page title is taken from the `h1` tag of a page in [this component](https://github.com/ReactiveX/rxjs/blob/master/docs_app/src/app/layout/doc-viewer/doc-viewer.component.ts#L96).
  - For "Operator Decision Tree", the `h1` tag was placed within the component for the page and not in the HTML file itself. Moved it into the correct file now.
  - For "Team", there was no `h1` tag. Added this now.
- Typo: "Alumn" should be "Alumni". Unrelated to the above, but I noticed it and included it here. I can remove it from here and submit it separately if anyone has strong opinions about that.

**Related issue (if exists):**
None

Screenshot of fix:

| Case | Before | After |
|------|--------|-------|
| Page title of "Operator Decision Tree" & inline `#` link | ![image](https://github.com/ReactiveX/rxjs/assets/19947758/848e8bee-61e2-4d91-b7ab-6cfb2d0b0916) | ![image](https://github.com/ReactiveX/rxjs/assets/19947758/5833f01f-6bb1-4ac2-b689-c4c879f9811d) |
| Page title of "Team" | ![image](https://github.com/ReactiveX/rxjs/assets/19947758/31623ae7-205a-40ab-bc65-bf9cae1b47c8) | ![image](https://github.com/ReactiveX/rxjs/assets/19947758/a0b6f79f-9833-41fe-8848-8f23eef9c811) |
| Typo in "Team" > "Alumni" | ![image](https://github.com/ReactiveX/rxjs/assets/19947758/31623ae7-205a-40ab-bc65-bf9cae1b47c8) | ![image](https://github.com/ReactiveX/rxjs/assets/19947758/a0b6f79f-9833-41fe-8848-8f23eef9c811) |

~~I suggest squash-committing this since I edited the commit messages via GitHub UI and will not pass commit-lint.~~ Fixed commit messages.