### PR TITLE
Async dispatched config handlers

### DIFF
--- a/packages/rxjs/src/internal/Subscriber.ts
+++ b/packages/rxjs/src/internal/Subscriber.ts
@@ -4,7 +4,6 @@ import { Subscription } from './Subscription';
 import { config } from './config';
 import { reportUnhandledError } from './util/reportUnhandledError';
 import { nextNotification, errorNotification, COMPLETE_NOTIFICATION } from './NotificationFactories';
-import { timeoutProvider } from './scheduler/timeoutProvider';
 
 export interface SubscriberOverrides<T> {
   /**
@@ -267,7 +266,7 @@ function createSafeObserver<T>(observerOrNext?: Partial<Observer<T>> | ((value: 
  */
 function handleStoppedNotification(notification: ObservableNotification<any>, subscriber: Subscriber<any>) {
   const { onStoppedNotification } = config;
-  onStoppedNotification && timeoutProvider.setTimeout(() => onStoppedNotification(notification, subscriber));
+  onStoppedNotification && setTimeout(() => onStoppedNotification(notification, subscriber));
 }
 
 function hasAddAndUnsubscribe(value: any): value is Subscription {

--- a/packages/rxjs/src/internal/util/reportUnhandledError.ts
+++ b/packages/rxjs/src/internal/util/reportUnhandledError.ts
@@ -1,5 +1,4 @@
 import { config } from '../config';
-import { timeoutProvider } from '../scheduler/timeoutProvider';
 
 /**
  * Handles an error on another job either with the user-configured {@link onUnhandledError},
@@ -11,7 +10,7 @@ import { timeoutProvider } from '../scheduler/timeoutProvider';
  * @param err the error to report
  */
 export function reportUnhandledError(err: any) {
-  timeoutProvider.setTimeout(() => {
+  setTimeout(() => {
     const { onUnhandledError } = config;
     if (onUnhandledError) {
       // Execute the user-configured error handler.


### PR DESCRIPTION
This is removing dependency on `timeoutProvider` in `Observable` because observable depends on `Subscriber`, and `Subscriber` users `timeoutProvider` for both `onUnhandledError` and `onStoppedNotification`, when it doesn't really need to. That's not particularly what `timeoutProvider` is for.

This also preps us to publish `@rxjs/observable` by limiting the dependencies that `Observable` has.

Resolves #7343 
