### PR TITLE
feat: remove deprecated observable symbol export (#4466)

### DIFF
--- a/packages/rxjs/spec/helpers/interop-helper-spec.ts
+++ b/packages/rxjs/spec/helpers/interop-helper-spec.ts
@@ -1,13 +1,12 @@
 import { expect } from 'chai';
 import { Observable, of, Subscriber } from 'rxjs';
-import { observable as symbolObservable } from 'rxjs/internal/symbol/observable';
 import { asInteropObservable, asInteropSubscriber } from './interop-helper';
 
 describe('interop helper', () => {
   it('should simulate interop observables', () => {
     const observable: any = asInteropObservable(of(42));
     expect(observable).to.not.be.instanceOf(Observable);
-    expect(observable[symbolObservable]).to.be.a('function');
+    expect(observable[Symbol.observable ?? '@@observable']).to.be.a('function');
   });
 
   it('should simulate interop subscribers', () => {

--- a/packages/rxjs/spec/helpers/test-helper.ts
+++ b/packages/rxjs/spec/helpers/test-helper.ts
@@ -1,5 +1,4 @@
 import { of, asyncScheduler, Observable, scheduled, ObservableInput } from 'rxjs';
-import { observable } from 'rxjs/internal/symbol/observable';
 import { iterator } from 'rxjs/internal/symbol/iterator';
 
 if (process && process.on) {
@@ -9,7 +8,7 @@ if (process && process.on) {
    * it handles the rejected promise where it does not notice
    * that the test failed.
    */
-  process.on('unhandledRejection', err => {
+  process.on('unhandledRejection', (err) => {
     console.error(err);
     process.exit(1);
   });
@@ -18,43 +17,43 @@ if (process && process.on) {
 export function lowerCaseO<T>(...args: Array<any>): Observable<T> {
   const o: any = {
     subscribe(observer: any) {
-      args.forEach(v => observer.next(v));
+      args.forEach((v) => observer.next(v));
       observer.complete();
       return {
-        unsubscribe() { /* do nothing */ }
+        unsubscribe() {
+          /* do nothing */
+        },
       };
-    }
+    },
   };
 
-  o[observable] = function (this: any) {
+  o[Symbol.observable ?? '@@observable'] = function (this: any) {
     return this;
   };
 
   return <any>o;
 }
 
-export const createObservableInputs = <T>(value: T) => of(
-  of(value),
-  scheduled([value], asyncScheduler),
-  [value],
-  Promise.resolve(value),
-  {
-    [iterator]: () => {
-      const iteratorResults = [
-        { value, done: false },
-        { done: true }
-      ];
-      return {
-        next: () => {
-          return iteratorResults.shift();
-        }
-      };
-    }
-  } as any as Iterable<T>,
-  {
-    [observable]: () => of(value)
-  } as any
-) as Observable<ObservableInput<T>>;
+export const createObservableInputs = <T>(value: T) =>
+  of(
+    of(value),
+    scheduled([value], asyncScheduler),
+    [value],
+    Promise.resolve(value),
+    {
+      [iterator]: () => {
+        const iteratorResults = [{ value, done: false }, { done: true }];
+        return {
+          next: () => {
+            return iteratorResults.shift();
+          },
+        };
+      },
+    } as any as Iterable<T>,
+    {
+      [Symbol.observable ?? '@@observable']: () => of(value),
+    } as any
+  ) as Observable<ObservableInput<T>>;
 
 /**
  * Used to signify no subscriptions took place to `expectSubscriptions` assertions.

--- a/packages/rxjs/spec/observables/from-spec.ts
+++ b/packages/rxjs/spec/observables/from-spec.ts
@@ -1,7 +1,7 @@
 /** @prettier */
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
-import { asyncScheduler, of, from, Observer, observable, Subject, noop, Subscription } from 'rxjs';
+import { of, from, Observer, Subject, noop, Subscription } from 'rxjs';
 import { first, concatMap, delay, take, tap } from 'rxjs/operators';
 import { ReadableStream } from 'web-streams-polyfill';
 import { observableMatcher } from '../helpers/observableMatcher';
@@ -166,7 +166,7 @@ describe('from', () => {
   });
 
   const fakervable = <T>(...values: T[]) => ({
-    [observable]: () => ({
+    [Symbol.observable ?? '@@observable']: () => ({
       subscribe: (observer: Observer<T>) => {
         for (const value of values) {
           observer.next(value);
@@ -178,7 +178,7 @@ describe('from', () => {
 
   const fakeArrayObservable = <T>(...values: T[]) => {
     let arr: any = ['bad array!'];
-    arr[observable] = () => {
+    arr[Symbol.observable ?? '@@observable'] = () => {
       return {
         subscribe: (observer: Observer<T>) => {
           for (const value of values) {
@@ -277,7 +277,7 @@ describe('from', () => {
     it(`should accept a function that implements [Symbol.observable]`, (done) => {
       const subject = new Subject<any>();
       const handler: any = (arg: any) => subject.next(arg);
-      handler[observable] = () => subject;
+      handler[Symbol.observable ?? '@@observable'] = () => subject;
       let nextInvoked = false;
 
       from(handler as any)

--- a/packages/rxjs/src/index.ts
+++ b/packages/rxjs/src/index.ts
@@ -16,7 +16,6 @@
 export { Observable } from './internal/Observable.js';
 export { GroupedObservable } from './internal/operators/groupBy.js';
 export { Operator } from './internal/Operator.js';
-export { observable } from './internal/symbol/observable.js';
 export { animationFrames } from './internal/observable/dom/animationFrames.js';
 
 /* Subjects */

--- a/packages/rxjs/src/internal/Observable.ts
+++ b/packages/rxjs/src/internal/Observable.ts
@@ -1,7 +1,6 @@
 import { Subscriber } from './Subscriber.js';
 import { Subscription } from './Subscription.js';
 import { TeardownLogic, UnaryFunction, Subscribable, Observer, OperatorFunction } from './types.js';
-import { observable as Symbol_observable } from './symbol/observable.js';
 import { pipeFromArray } from './util/pipe.js';
 /**
  * A representation of any set of values over any amount of time. This is the most basic building block
@@ -240,7 +239,7 @@ export class Observable<T> implements Subscribable<T> {
    * An interop point defined by the es7-observable spec https://github.com/zenparsing/es-observable
    * @return This instance of the observable.
    */
-  [Symbol_observable]() {
+  [Symbol.observable ?? '@@observable']() {
     return this;
   }
 

--- a/packages/rxjs/src/internal/observable/from.ts
+++ b/packages/rxjs/src/internal/observable/from.ts
@@ -10,7 +10,6 @@ import { isReadableStreamLike, readableStreamLikeToAsyncGenerator } from '../uti
 import { Subscriber } from '../Subscriber.js';
 import { isFunction } from '../util/isFunction.js';
 import { reportUnhandledError } from '../util/reportUnhandledError.js';
-import { observable as Symbol_observable } from '../symbol/observable.js';
 
 /**
  * Creates an Observable from an Array, an array-like object, a Promise, an iterable object, or an Observable-like object.
@@ -117,7 +116,7 @@ export function from<T>(input: ObservableInput<T>): Observable<T> {
  */
 function fromInteropObservable<T>(obj: any) {
   return new Observable((subscriber: Subscriber<T>) => {
-    const obs = obj[Symbol_observable]();
+    const obs = obj[Symbol.observable ?? '@@observable']();
     if (isFunction(obs.subscribe)) {
       return obs.subscribe(subscriber);
     }

--- a/packages/rxjs/src/internal/symbol/observable.ts
+++ b/packages/rxjs/src/internal/symbol/observable.ts
@@ -1,7 +1,0 @@
-/**
- * Symbol.observable or a string "@@observable". Used for interop
- *
- * @deprecated We will no longer be exporting this symbol in upcoming versions of RxJS.
- * Instead polyfill and use Symbol.observable directly *or* use https://www.npmjs.com/package/symbol-observable
- */
-export const observable: string | symbol = (() => (typeof Symbol === 'function' && Symbol.observable) || '@@observable')();

--- a/packages/rxjs/src/internal/util/isInteropObservable.ts
+++ b/packages/rxjs/src/internal/util/isInteropObservable.ts
@@ -1,8 +1,7 @@
 import { InteropObservable } from '../types.js';
-import { observable as Symbol_observable } from '../symbol/observable.js';
 import { isFunction } from './isFunction.js';
 
 /** Identifies an input as being Observable (but not necessary an Rx Observable) */
 export function isInteropObservable(input: any): input is InteropObservable<any> {
-  return isFunction(input[Symbol_observable]);
+  return isFunction(input[Symbol.observable ?? '@@observable']);
 }


### PR DESCRIPTION
BREAKING CHANGE: `observable` (the `Symbol.observable` symbol instance) is no longer exported. Use a polyfill like `symbol-observable`, or use `Symbol.observable ?? '@@observable'` as a workaround.
