### PR TITLE
fix(docs): fix missing overloads in docs when overload count is less than 3

### DIFF
--- a/apps/rxjs.dev/tools/transforms/templates/api/function.template.html
+++ b/apps/rxjs.dev/tools/transforms/templates/api/function.template.html
@@ -3,7 +3,7 @@
 {% extends 'export-base.template.html' -%}
 
 {% block overview %}
-{% if doc.overloads.length > 0 and doc.overloads < 3 -%}
+{% if doc.overloads.length > 0 and doc.overloads.length < 3 -%}
   {% for overload in doc.overloads -%}
     {$ memberHelpers.renderOverloadInfo(overload, 'function-overload', doc) $}
     {% if not loop.last %}<hr class="hr-margin fullwidth">{% endif %}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR fixes an issue in the docs app, that does not display the overlays if the number of overloads is 2. The overload is printed at the top of the document.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):** #5281

See also AIO Commit: https://github.com/angular/angular/commit/e0c736066cfd3fb4d784c2a335e6214ed6d6ec21

