### PR TITLE
fix(docs): fix missing overloads in docs when overload count is less than 3

### DIFF
--- a/docs_app/tools/transforms/templates/api/function.template.html
+++ b/docs_app/tools/transforms/templates/api/function.template.html
@@ -3,7 +3,7 @@
 {% extends 'export-base.template.html' -%}
 
 {% block overview %}
-{% if doc.overloads.length > 0 and doc.overloads < 3 -%}
+{% if doc.overloads.length > 0 and doc.overloads.length < 3 -%}
   {% for overload in doc.overloads -%}
     {$ memberHelpers.renderOverloadInfo(overload, 'function-overload', doc) $}
     {% if not loop.last %}<hr class="hr-margin fullwidth">{% endif %}


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
This PR fixes the display of overloads in the docs application if there are less than 3 overloads. 

Backport of: #7367

**Related issue (if exists):** #5281
