### PR TITLE
Fixes a broken link to /api/operators/switchMapTo

### DIFF
--- a/apps/rxjs.dev/content/deprecations/resultSelector.md
+++ b/apps/rxjs.dev/content/deprecations/resultSelector.md
@@ -22,7 +22,7 @@ There were two reasons for actually deprecating those parameters:
 - [mergeMap](/api/operators/mergeMap)
 - [mergeMapTo](/api/operators/mergeMapTo)
 - [switchMap](/api/operators/switchMap)
-- [swithMapTo](/api/operators/switchMapTo)
+- [switchMapTo](/api/operators/switchMapTo)
 
 ## How to Refactor
 

--- a/apps/rxjs.dev/content/deprecations/resultSelector.md
+++ b/apps/rxjs.dev/content/deprecations/resultSelector.md
@@ -22,7 +22,7 @@ There were two reasons for actually deprecating those parameters:
 - [mergeMap](/api/operators/mergeMap)
 - [mergeMapTo](/api/operators/mergeMapTo)
 - [switchMap](/api/operators/switchMap)
-- [swithMapTo](/api/operators/swithMapTo)
+- [swithMapTo](/api/operators/switchMapTo)
 
 ## How to Refactor
 


### PR DESCRIPTION
**Description:**

In the current version, the link does not resolve, but with this change, it navigates users properly.