### PR TITLE
Updating img url for README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# <img src="apps/rxjs.dev/src/assets/images/logos/Rx_Logo_S.png" alt="RxJS Logo" width="86" height="86"> RxJS: Reactive Extensions For JavaScript
+# <img src="https://github.com/ReactiveX/rxjs/blob/master/apps/rxjs.dev/src/assets/images/logos/Rx_Logo_S.png" alt="RxJS Logo" width="86" height="86"> RxJS: Reactive Extensions For JavaScript
 
 ![CI](https://github.com/reactivex/rxjs/workflows/CI/badge.svg)
 [![npm version](https://badge.fury.io/js/rxjs.svg)](http://badge.fury.io/js/rxjs)


### PR DESCRIPTION
The url of the `img` element on line 1 in the README.md file has been changed from:

apps/rxjs.dev/src/assets/images/logos/Rx_Logo_S.png

 to: 

https://raw.githubusercontent.com/ReactiveX/rxjs/master/apps/rxjs.dev/src/assets/images/logos/Rx_Logo_S.png

Thus, the logo will be visible on npmjs.com.
