### PR TITLE
chore: set primary node version and yarn v1 package manager

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -35,10 +35,8 @@ jobs:
       - name: rxjs dtslint
         run: yarn workspace rxjs dtslint
       - name: rxjs test:import
-        if: ${{ matrix.node == '18' || matrix.node == '20' }}
         run: yarn workspace rxjs test:import
       - name: rxjs test:esm
-        if: ${{ matrix.node == '18' || matrix.node == '20' }}
         run: yarn workspace rxjs test:esm
       - name: rxjs.dev build
         run: yarn workspace rxjs.dev build --prod

--- a/package.json
+++ b/package.json
@@ -14,11 +14,10 @@
     ]
   },
   "license": "Apache-2.0",
-  "packageManager": "yarn@1.22.21",
-  "volta": {
-    "node": "20.9.0",
-    "yarn": "1.22.21"
+  "engines": {
+    "node": "^18.13.0 || ^20.9.0"
   },
+  "packageManager": "yarn@1.22.21",
   "dependencies": {},
   "devDependencies": {
     "lerna": "^7.3.0"

--- a/package.json
+++ b/package.json
@@ -14,6 +14,11 @@
     ]
   },
   "license": "Apache-2.0",
+  "packageManager": "yarn@1.22.21",
+  "volta": {
+    "node": "20.9.0",
+    "yarn": "1.22.21"
+  },
   "dependencies": {},
   "devDependencies": {
     "lerna": "^7.3.0"


### PR DESCRIPTION
**Description:**

In getting started with the repo, my global yarn installation of latest v4 tried to upgrade the repo.

This PR adds a volta config so that those that use it to manager their node toolchain can benefit from automatic resolution of node and yarn, and also adds a `packageManager` definition for corepack users.

This should make it easier for first time contributors to get up and running faster.