### PR TITLE
Remove Subject.create, refactor WebSocketSubject

### DIFF
--- a/packages/rxjs/spec/Subject-spec.ts
+++ b/packages/rxjs/spec/Subject-spec.ts
@@ -1,6 +1,5 @@
 import { expect } from 'chai';
 import { Subject, Observable, AsyncSubject, Observer, of, config, Subscription, Subscriber, noop, operate } from 'rxjs';
-import { AnonymousSubject } from 'rxjs/internal/Subject';
 import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from './helpers/observableMatcher';
@@ -448,104 +447,6 @@ describe('Subject', () => {
     expect(subject.observed).to.equal(false);
   });
 
-  it('should have a static create function that works', () => {
-    expect(Subject.create).to.be.a('function');
-    const source = of(1, 2, 3, 4, 5);
-    const nexts: number[] = [];
-    const output: any[] = [];
-
-    let error: any;
-    let complete = false;
-    let outputComplete = false;
-
-    const destination = {
-      closed: false,
-      next: function (x: number) {
-        nexts.push(x);
-      },
-      error: function (err: any) {
-        error = err;
-        this.closed = true;
-      },
-      complete: function () {
-        complete = true;
-        this.closed = true;
-      },
-    };
-
-    const sub: Subject<any> = Subject.create(destination, source);
-
-    sub.subscribe({
-      next: function (x: number) {
-        output.push(x);
-      },
-      complete: () => {
-        outputComplete = true;
-      },
-    });
-
-    sub.next('a');
-    sub.next('b');
-    sub.next('c');
-    sub.complete();
-
-    expect(nexts).to.deep.equal(['a', 'b', 'c']);
-    expect(complete).to.be.true;
-    expect(error).to.be.a('undefined');
-
-    expect(output).to.deep.equal([1, 2, 3, 4, 5]);
-    expect(outputComplete).to.be.true;
-  });
-
-  it('should have a static create function that works also to raise errors', () => {
-    expect(Subject.create).to.be.a('function');
-    const source = of(1, 2, 3, 4, 5);
-    const nexts: number[] = [];
-    const output: number[] = [];
-
-    let error: any;
-    let complete = false;
-    let outputComplete = false;
-
-    const destination = {
-      closed: false,
-      next: function (x: number) {
-        nexts.push(x);
-      },
-      error: function (err: any) {
-        error = err;
-        this.closed = true;
-      },
-      complete: function () {
-        complete = true;
-        this.closed = true;
-      },
-    };
-
-    const sub: Subject<any> = Subject.create(destination, source);
-
-    sub.subscribe({
-      next: function (x: number) {
-        output.push(x);
-      },
-      complete: () => {
-        outputComplete = true;
-      },
-    });
-
-    sub.next('a');
-    sub.next('b');
-    sub.next('c');
-    sub.error('boom');
-
-    expect(nexts).to.deep.equal(['a', 'b', 'c']);
-    expect(complete).to.be.false;
-    expect(error).to.equal('boom');
-
-    expect(output).to.deep.equal([1, 2, 3, 4, 5]);
-    expect(outputComplete).to.be.true;
-  });
-
   it('should be an Observer which can be given to Observable.subscribe', (done) => {
     const source = of(1, 2, 3, 4, 5);
     const subject = new Subject<number>();
@@ -779,32 +680,5 @@ describe('Subject', () => {
     subject.complete();
 
     expect(results).to.deep.equal([1, 1, 2, 2, 'complete']);
-  });
-});
-
-describe('AnonymousSubject', () => {
-  it('should be exposed', () => {
-    expect(AnonymousSubject).to.be.a('function');
-  });
-
-  it('should not be eager', () => {
-    let subscribed = false;
-
-    const subject = Subject.create(
-      null,
-      new Observable((observer: Observer<any>) => {
-        subscribed = true;
-        const subscription = of('x').subscribe(observer);
-        return () => {
-          subscription.unsubscribe();
-        };
-      })
-    );
-
-    const observable = subject.asObservable();
-    expect(subscribed).to.be.false;
-
-    observable.subscribe();
-    expect(subscribed).to.be.true;
   });
 });

--- a/packages/rxjs/src/internal/Subject.ts
+++ b/packages/rxjs/src/internal/Subject.ts
@@ -40,15 +40,6 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
   /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
   thrownError: any = null;
 
-  /**
-   * Creates a "subject" by basically gluing an observer to an observable.
-   *
-   * @deprecated Recommended you do not use. Will be removed at some point in the future. Plans for replacement still under discussion.
-   */
-  static create: (...args: any[]) => any = <T>(destination: Observer<T>, source: Observable<T>): AnonymousSubject<T> => {
-    return new AnonymousSubject<T>(destination, source);
-  };
-
   constructor() {
     // NOTE: This must be here to obscure Observable's constructor.
     super();
@@ -144,33 +135,5 @@ export class Subject<T> extends Observable<T> implements SubscriptionLike {
    */
   asObservable(): Observable<T> {
     return new Observable((subscriber) => this.subscribe(subscriber));
-  }
-}
-
-export class AnonymousSubject<T> extends Subject<T> {
-  constructor(
-    /** @deprecated Internal implementation detail, do not use directly. Will be made internal in v8. */
-    public destination?: Observer<T>,
-    /** @internal */
-    protected _source?: Observable<T>
-  ) {
-    super();
-  }
-
-  next(value: T) {
-    this.destination?.next?.(value);
-  }
-
-  error(err: any) {
-    this.destination?.error?.(err);
-  }
-
-  complete() {
-    this.destination?.complete?.();
-  }
-
-  /** @internal */
-  protected _subscribe(subscriber: Subscriber<T>): Subscription {
-    return this._source?.subscribe(subscriber) ?? Subscription.EMPTY;
   }
 }

--- a/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
+++ b/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
@@ -150,7 +150,7 @@ const WEBSOCKETSUBJECT_INVALID_ERROR_OBJECT =
 
 export type WebSocketMessage = string | ArrayBuffer | Blob | ArrayBufferView;
 
-export class WebSocketSubject<T> extends Subject<T> {
+export class WebSocketSubject<T> extends Observable<T> {
   private _config!: WebSocketSubjectConfig<T>;
 
   private _output: Subject<T>;
@@ -365,6 +365,5 @@ export class WebSocketSubject<T> extends Subject<T> {
       _socket.close();
     }
     this._resetState();
-    super.unsubscribe();
   }
 }

--- a/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
+++ b/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
@@ -1,4 +1,4 @@
-import { Subject, AnonymousSubject } from '../../Subject.js';
+import { Subject } from '../../Subject.js';
 import { Subscriber, Observable, Subscription, operate } from '../../Observable.js';
 import { ReplaySubject } from '../../ReplaySubject.js';
 import { Observer, NextObserver } from '../../types.js';
@@ -151,13 +151,17 @@ const WEBSOCKETSUBJECT_INVALID_ERROR_OBJECT =
 
 export type WebSocketMessage = string | ArrayBuffer | Blob | ArrayBufferView;
 
-export class WebSocketSubject<T> extends AnonymousSubject<T> {
+export class WebSocketSubject<T> extends Subject<T> {
   private _config!: WebSocketSubjectConfig<T>;
 
   /** @internal */
   _output!: Subject<T>;
 
   private _socket: WebSocket | null = null;
+
+  private destination: Observer<T> | undefined = undefined;
+
+  private _source: Observable<T> | undefined = undefined;
 
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>) {
     super();
@@ -332,6 +336,18 @@ export class WebSocketSubject<T> extends AnonymousSubject<T> {
         observer.error(err);
       }
     };
+  }
+
+  next(value: T) {
+    this.destination?.next?.(value);
+  }
+
+  error(err: any) {
+    this.destination?.error?.(err);
+  }
+
+  complete() {
+    this.destination?.complete?.();
   }
 
   /** @internal */

--- a/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
+++ b/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
@@ -154,38 +154,32 @@ export type WebSocketMessage = string | ArrayBuffer | Blob | ArrayBufferView;
 export class WebSocketSubject<T> extends Subject<T> {
   private _config!: WebSocketSubjectConfig<T>;
 
-  /** @internal */
-  _output!: Subject<T>;
+  private _output: Subject<T>;
 
   private _socket: WebSocket | null = null;
 
-  private destination: Observer<T> | undefined = undefined;
+  private destination: Observer<T>;
 
   private _source: Observable<T> | undefined = undefined;
 
-  constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T> | Observable<T>, destination?: Observer<T>) {
+  constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T>) {
     super();
-    if (urlConfigOrSource instanceof Observable) {
-      this.destination = destination;
-      this._source = urlConfigOrSource as Observable<T>;
-    } else {
-      const userConfig = typeof urlConfigOrSource === 'string' ? { url: urlConfigOrSource } : urlConfigOrSource;
-      this._config = {
-        ...DEFAULT_WEBSOCKET_CONFIG,
-        // Setting this here because a previous version of this allowed
-        // WebSocket to be polyfilled later than DEFAULT_WEBSOCKET_CONFIG
-        // was defined.
-        WebSocketCtor: WebSocket,
-        ...userConfig,
-      };
+    const userConfig = typeof urlConfigOrSource === 'string' ? { url: urlConfigOrSource } : urlConfigOrSource;
+    this._config = {
+      ...DEFAULT_WEBSOCKET_CONFIG,
+      // Setting this here because a previous version of this allowed
+      // WebSocket to be polyfilled later than DEFAULT_WEBSOCKET_CONFIG
+      // was defined.
+      WebSocketCtor: WebSocket,
+      ...userConfig,
+    };
 
-      if (!this._config.WebSocketCtor) {
-        throw new Error('no WebSocket constructor can be found');
-      }
-
-      this._output = new Subject<T>();
-      this.destination = new ReplaySubject();
+    if (!this._config.WebSocketCtor) {
+      throw new Error('no WebSocket constructor can be found');
     }
+
+    this._output = new Subject<T>();
+    this.destination = new ReplaySubject();
   }
 
   private _resetState() {
@@ -339,15 +333,15 @@ export class WebSocketSubject<T> extends Subject<T> {
   }
 
   next(value: T) {
-    this.destination?.next?.(value);
+    this.destination.next(value);
   }
 
   error(err: any) {
-    this.destination?.error?.(err);
+    this.destination.error(err);
   }
 
   complete() {
-    this.destination?.complete?.();
+    this.destination.complete();
   }
 
   /** @internal */

--- a/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
+++ b/packages/rxjs/src/internal/observable/dom/WebSocketSubject.ts
@@ -160,8 +160,6 @@ export class WebSocketSubject<T> extends Subject<T> {
 
   private _input: Observer<T>;
 
-  private _source: Observable<T> | undefined = undefined;
-
   constructor(urlConfigOrSource: string | WebSocketSubjectConfig<T>) {
     super();
     const userConfig = typeof urlConfigOrSource === 'string' ? { url: urlConfigOrSource } : urlConfigOrSource;
@@ -184,9 +182,7 @@ export class WebSocketSubject<T> extends Subject<T> {
 
   private _resetState() {
     this._socket = null;
-    if (!this._source) {
-      this._input = new ReplaySubject();
-    }
+    this._input = new ReplaySubject();
     this._output = new Subject<T>();
   }
 
@@ -345,10 +341,6 @@ export class WebSocketSubject<T> extends Subject<T> {
 
   /** @internal */
   protected _subscribe(subscriber: Subscriber<T>): Subscription {
-    const { _source } = this;
-    if (_source) {
-      return _source.subscribe(subscriber);
-    }
     if (!this._socket) {
       this._connectSocket();
     }


### PR DESCRIPTION
An incremental refactor of `WebSocketSubject` to clean it up quite a bit.

Includes the following **BREAKING CHANGES**:

1. `WebSocketSubject` is no longer `instanceof Subject`. It really didn't make any sense to do this, it didn't leverage anything from `Subject` to begin with.
2. `Subject.create`, a long-deprecated API has been removed. If you recall, `Subject.create(observer, observable)` basically "glued" the observer to the observable.

This removes `AnonymousSubject`, which was never exported, and was overall weird.