### PR TITLE
package.json - Correct types path

### DIFF
--- a/packages/rxjs/package.json
+++ b/packages/rxjs/package.json
@@ -4,7 +4,7 @@
   "description": "Reactive Extensions for modern JavaScript",
   "main": "./dist/cjs/index.js",
   "module": "./dist/esm/index.js",
-  "types": "index.d.ts",
+  "types": "./dist/types/index.d.ts",
   "typesVersions": {
     ">=4.2": {
       "*": [


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:
NVT
- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
The package.json path to the typings is wrong.

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
- Closes #7389