### PR TITLE
chore(test): use fakeTimers with setTimeout in buffer, skipUntil and window

### DIFF
--- a/packages/rxjs/spec/operators/buffer-spec.ts
+++ b/packages/rxjs/spec/operators/buffer-spec.ts
@@ -3,6 +3,7 @@ import { EMPTY, NEVER, throwError, of, Subject, interval } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 
 /** @test {buffer} */
 describe('Observable.prototype.buffer', () => {
@@ -325,6 +326,8 @@ describe('Observable.prototype.buffer', () => {
   });
 
   it('should buffer when Promise resolves', (done) => {
+    const sandbox = sinon.createSandbox();
+    const fakeTimers = sandbox.useFakeTimers();
     const e1 = interval(3).pipe(take(5));
     const expected = [
       [0, 1],
@@ -338,9 +341,12 @@ describe('Observable.prototype.buffer', () => {
       error: () => done(new Error('should not be called')),
       complete: () => {
         expect(expected.length).to.equal(0);
+        sandbox.restore();
         done();
       },
     });
+
+    fakeTimers.tickAsync(15);
   });
 
   it('should raise error when Promise rejects', (done) => {

--- a/packages/rxjs/spec/operators/skipUntil-spec.ts
+++ b/packages/rxjs/spec/operators/skipUntil-spec.ts
@@ -4,6 +4,7 @@ import { skipUntil, mergeMap, take } from 'rxjs/operators';
 import { asInteropObservable } from '../helpers/interop-helper';
 import { TestScheduler } from 'rxjs/testing';
 import { observableMatcher } from '../helpers/observableMatcher';
+import * as sinon from 'sinon';
 
 /** @test {skipUntil} */
 describe('skipUntil', () => {
@@ -369,6 +370,8 @@ describe('skipUntil', () => {
   });
 
   it('should skip until Promise resolves', (done) => {
+    const sandbox = sinon.createSandbox();
+    const fakeTimers = sandbox.useFakeTimers();
     const e1 = interval(3).pipe(take(5));
     const expected = [2, 3, 4];
 
@@ -379,9 +382,12 @@ describe('skipUntil', () => {
       error: () => done(new Error('should not be called')),
       complete: () => {
         expect(expected.length).to.equal(0);
+        sandbox.restore();
         done();
       },
     });
+
+    fakeTimers.tickAsync(15);
   });
 
   it('should raise error when Promise rejects', (done) => {

--- a/packages/rxjs/spec/operators/window-spec.ts
+++ b/packages/rxjs/spec/operators/window-spec.ts
@@ -4,6 +4,7 @@ import type { Observable} from 'rxjs';
 import { EMPTY, of, interval } from 'rxjs';
 import { observableMatcher } from '../helpers/observableMatcher';
 import { expect } from 'chai';
+import * as sinon from 'sinon';
 
 /** @test {window} */
 describe('window', () => {
@@ -284,6 +285,8 @@ describe('window', () => {
   });
 
   it('should window when Promise resolves', (done) => {
+    const sandbox = sinon.createSandbox();
+    const fakeTimers = sandbox.useFakeTimers();
     const e1 = interval(3).pipe(take(5));
     let pos = 0;
     const result: number[][] = [[], []];
@@ -302,9 +305,11 @@ describe('window', () => {
       error: () => done(new Error('should not be called')),
       complete: () => {
         expect(result).to.deep.equal(expected);
+        sandbox.restore();
         done();
       },
     });
+    fakeTimers.tickAsync(15);
   });
 
   it('should raise error when Promise rejects', (done) => {


### PR DESCRIPTION
**Description:**

After checking out the rxjs repo and running the unit tests, I noticed these 3 tests were always failing. (I'm running Windows 10 with Node 20)

The issue is probably that setTimeout does not necessarily execute at the specified delay.
I tried to reproduce the test in [StackBlitz](https://stackblitz.com/edit/rxjs-qa2f7v?file=index.ts) and I had the exact same issue when using timeouts so close to each other.

The PR updates these tests to use fake timers to make sure the tests work as expected.


