### PR TITLE
chore: 7.x remove global npm install and ignore latest TS

### DIFF
--- a/.github/workflows/ci_main.yml
+++ b/.github/workflows/ci_main.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: install
         run: |
-          npm install -g npm@latest
+          npm --version
           npm ci
       - name: lint
         run: npm run lint

--- a/.github/workflows/ci_ts_latest.yml
+++ b/.github/workflows/ci_ts_latest.yml
@@ -3,6 +3,8 @@ name: CI (ts@latest)
 on:
   pull_request:
     types: ['opened', 'reopened', 'synchronize']
+    # Legacy v7 is incompatible with latest TS
+    branches-ignore: ['7.x']
 
 permissions:
   contents: read

--- a/.github/workflows/ci_ts_latest.yml
+++ b/.github/workflows/ci_ts_latest.yml
@@ -23,7 +23,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: build
         run: |
-          npm install -g npm@latest
+          npm --version
           npm ci
           npm install --legacy-peer-deps --no-save typescript@latest tslib@latest @types/node@latest
           npm run compile

--- a/.github/workflows/ci_ts_latest.yml
+++ b/.github/workflows/ci_ts_latest.yml
@@ -25,7 +25,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - name: build
         run: |
-          npm --version
+          npm install -g npm@latest
           npm ci
           npm install --legacy-peer-deps --no-save typescript@latest tslib@latest @types/node@latest
           npm run compile


### PR DESCRIPTION
All current issues on the 7.x branch relate to the same problem - the code has stayed the same, but it is trying to be run with tooling which has since evolved. Therefore this PR:

- Removes the `@latest` usage of npm
- Disables TS latest workflow