### PR TITLE
fix(fromEvent): passing a generic parameter is no longer deprecated

### DIFF
--- a/packages/rxjs/src/internal/observable/fromEvent.ts
+++ b/packages/rxjs/src/internal/observable/fromEvent.ts
@@ -1,4 +1,4 @@
-import type { Subscriber} from '../Observable.js';
+import type { Subscriber } from '../Observable.js';
 import { Observable, isArrayLike, isFunction } from '../Observable.js';
 import { mapOneOrManyArgs } from '../util/mapOneOrManyArgs.js';
 
@@ -82,7 +82,6 @@ export function fromEvent(
   target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>,
   eventName: string | symbol
 ): Observable<unknown>;
-/** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */
 export function fromEvent<T>(target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>, eventName: string | symbol): Observable<T>;
 export function fromEvent<R>(
   target: NodeStyleEventEmitter | ArrayLike<NodeStyleEventEmitter>,
@@ -94,7 +93,6 @@ export function fromEvent(
   target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,
   eventName: string
 ): Observable<unknown>;
-/** @deprecated Do not specify explicit type parameters. Signatures with type parameters that cannot be inferred will be removed in v8. */
 export function fromEvent<T>(target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>, eventName: string): Observable<T>;
 export function fromEvent<R>(
   target: NodeCompatibleEventEmitter | ArrayLike<NodeCompatibleEventEmitter>,


### PR DESCRIPTION
This should never have been deprecated. There's not really a great way to infer these types because it's for both DOM and Node APIs. So `fromEvent<MouseEvent>(button, 'click')` is totally a thing.