### PR TITLE
chore: remove src from published package

### DIFF
--- a/packages/rxjs/package.json
+++ b/packages/rxjs/package.json
@@ -180,7 +180,6 @@
     "operators",
     "testing",
     "webSocket",
-    "src",
     "CHANGELOG.md",
     "CODE_OF_CONDUCT.md",
     "LICENSE.txt",


### PR DESCRIPTION
This removes `src/` from the published npm package.

Does anyone have any good reason we can't do this? seems it'd save us a fair amount of package size.

extracted from the published `@next` package, `src` seems to be 1.2M locally 🤔 

bundlephobia doesn't show it since it isn't an export afaik