### PR TITLE
Fix `every` re-entrancy and signature.

### DIFF
--- a/packages/rxjs/spec/operators/every-spec.ts
+++ b/packages/rxjs/spec/operators/every-spec.ts
@@ -33,19 +33,6 @@ describe('every', () => {
     });
   });
 
-  it('should accept thisArg with scalar observables', () => {
-    const thisArg = {};
-
-    of(1)
-      .pipe(
-        every(function (this: any, value: number, index: number) {
-          expect(this).to.deep.equal(thisArg);
-          return true;
-        }, thisArg)
-      )
-      .subscribe();
-  });
-
   it('should increment index on each call to the predicate', () => {
     const indices: number[] = [];
     of(1, 2, 3, 4)
@@ -58,36 +45,6 @@ describe('every', () => {
       .subscribe();
 
     expect(indices).to.deep.equal([0, 1, 2, 3]);
-  });
-
-  it('should accept thisArg with array observable', () => {
-    const thisArg = {};
-
-    of(1, 2, 3, 4)
-      .pipe(
-        every(function (this: any, value: number, index: number) {
-          expect(this).to.deep.equal(thisArg);
-          return true;
-        }, thisArg)
-      )
-      .subscribe();
-  });
-
-  it('should accept thisArg with ordinary observable', () => {
-    const thisArg = {};
-
-    const source = new Observable((observer: Observer<number>) => {
-      observer.next(1);
-      observer.complete();
-    });
-    source
-      .pipe(
-        every(function (this: any, value: number, index: number) {
-          expect(this).to.deep.equal(thisArg);
-          return true;
-        }, thisArg)
-      )
-      .subscribe();
   });
 
   it('should emit true if source is empty', () => {

--- a/packages/rxjs/src/internal/operators/every.ts
+++ b/packages/rxjs/src/internal/operators/every.ts
@@ -2,16 +2,6 @@ import { Observable, operate } from '../Observable.js';
 import type { Falsy, OperatorFunction } from '../types.js';
 
 export function every<T>(predicate: BooleanConstructor): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
-/** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
-export function every<T>(
-  predicate: BooleanConstructor,
-  thisArg: any
-): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
-/** @deprecated Use a closure instead of a `thisArg`. Signatures accepting a `thisArg` will be removed in v8. */
-export function every<T, A>(
-  predicate: (this: A, value: T, index: number, source: Observable<T>) => boolean,
-  thisArg: A
-): OperatorFunction<T, boolean>;
 export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, boolean>;
 
 /**
@@ -39,10 +29,7 @@ export function every<T>(predicate: (value: T, index: number, source: Observable
  * @return A function that returns an Observable of booleans that determines if
  * all items of the source Observable meet the condition specified.
  */
-export function every<T>(
-  predicate: (value: T, index: number, source: Observable<T>) => boolean,
-  thisArg?: any
-): OperatorFunction<T, boolean> {
+export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, boolean> {
   return (source) =>
     new Observable((destination) => {
       let index = 0;
@@ -50,7 +37,7 @@ export function every<T>(
         operate({
           destination,
           next: (value) => {
-            if (!predicate.call(thisArg, value, index++, source)) {
+            if (!predicate(value, index++, source)) {
               destination.next(false);
               destination.complete();
             }

--- a/packages/rxjs/src/internal/operators/every.ts
+++ b/packages/rxjs/src/internal/operators/every.ts
@@ -2,7 +2,7 @@ import { Observable, operate } from '../Observable.js';
 import type { Falsy, OperatorFunction } from '../types.js';
 
 export function every<T>(predicate: BooleanConstructor): OperatorFunction<T, Exclude<T, Falsy> extends never ? false : boolean>;
-export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, boolean>;
+export function every<T>(predicate: (value: T, index: number) => boolean): OperatorFunction<T, boolean>;
 
 /**
  * Returns an Observable that emits whether or not every item of the source satisfies the condition specified.
@@ -29,7 +29,7 @@ export function every<T>(predicate: (value: T, index: number, source: Observable
  * @return A function that returns an Observable of booleans that determines if
  * all items of the source Observable meet the condition specified.
  */
-export function every<T>(predicate: (value: T, index: number, source: Observable<T>) => boolean): OperatorFunction<T, boolean> {
+export function every<T>(predicate: (value: T, index: number) => boolean): OperatorFunction<T, boolean> {
   return (source) =>
     new Observable((destination) => {
       let index = 0;
@@ -37,7 +37,7 @@ export function every<T>(predicate: (value: T, index: number, source: Observable
         operate({
           destination,
           next: (value) => {
-            if (!predicate(value, index++, source)) {
+            if (!predicate(value, index++)) {
               destination.next(false);
               destination.complete();
             }


### PR DESCRIPTION
- Removes `thisArg`.
- Removes `source` parameter in predicate (for consistency reasons)
- Fixes re-entrancy issue from #7425