### PR TITLE
feat(fromEvent): complete the stream after the first value on one time events

### DIFF
--- a/packages/rxjs/src/internal/observable/fromEvent.ts
+++ b/packages/rxjs/src/internal/observable/fromEvent.ts
@@ -260,7 +260,12 @@ export function fromEvent<T>(
   }
 
   return new Observable<T>((subscriber) => {
-    const handler = (...args: any[]) => subscriber.next(1 < args.length ? args : args[0]);
+    const handler = (...args: any[]) => {
+      subscriber.next(1 < args.length ? args : args[0]);
+      if(!isFunction(options) && options?.once){
+        subscriber.complete();
+      }
+    };
     if (isValidTarget) {
       // Valid event targets, even if they have a `length` property
       // will be subscribed to as a single item.


### PR DESCRIPTION

<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
A small quality of life change to fromEvent when the once option is supplied, it makes sense to automatically close the stream after the first emission since the observable will only emit once. this will remove the need to manually unsubscribe every time you work with one time events.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
