### PR TITLE
fix(animationFrameScheduler): some tasks are never flushed and sometimes it breaks completely

### DIFF
--- a/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -165,11 +165,15 @@ describe('Scheduler.animationFrame', () => {
     let runDelayed = false;
     let runFirst = false;
     animationFrame.schedule(() => {
-      animationFrame.schedule(() => { runFirst = true; });
       animationFrame.schedule(() => {
         if (!runDelayed) {
           done(new Error('Delayed action did not run'));
-        } else if (!runFirst) {
+          return;
+        }
+        runFirst = true;
+      });
+      animationFrame.schedule(() => {
+        if (!runFirst) {
           done(new Error('First action did not run'));
         } else {
           done();
@@ -177,7 +181,9 @@ describe('Scheduler.animationFrame', () => {
       });
 
       // This action will execute before the next frame because the delay is less than the one of the frame
-      animationFrame.schedule(() => { runDelayed = true; }, 1);
+      animationFrame.schedule(() => {
+        runDelayed = true;
+      }, 1);
     });
   });
 

--- a/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -141,6 +141,46 @@ describe('Scheduler.animationFrame', () => {
     }
   });
 
+  it('should schedule next frame actions from a delayed one', (done) => {
+    animationFrame.schedule(() => {
+      animationFrame.schedule(() => { done(); });
+    }, 1);
+  });
+
+  it('should schedule 2 actions for a subsequent frame', (done) => {
+    let runFirst = false;
+    animationFrame.schedule(() => {
+      animationFrame.schedule(() => { runFirst = true; });
+      animationFrame.schedule(() => {
+        if (runFirst) {
+          done();
+        } else {
+          done(new Error('First action did not run'));
+        }
+      });
+    });
+  });
+
+  it('should handle delayed action without affecting next frame actions', (done) => {
+    let runDelayed = false;
+    let runFirst = false;
+    animationFrame.schedule(() => {
+      animationFrame.schedule(() => { runFirst = true; });
+      animationFrame.schedule(() => {
+        if (!runDelayed) {
+          done(new Error('Delayed action did not run'));
+        } else if (!runFirst) {
+          done(new Error('First action did not run'));
+        } else {
+          done();
+        }
+      });
+
+      // This action will execute before the next frame because the delay is less than the one of the frame
+      animationFrame.schedule(() => { runDelayed = true; }, 1);
+    });
+  });
+
   it('should not execute rescheduled actions when flushing', (done) => {
     let flushCount = 0;
     let scheduledIndices: number[] = [];

--- a/spec/schedulers/AsapScheduler-spec.ts
+++ b/spec/schedulers/AsapScheduler-spec.ts
@@ -66,7 +66,7 @@ describe('Scheduler.asap', () => {
     const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sandbox.stub(global, 'setInterval')).callThrough();
+    const stubSetInterval = (<any> sandbox.stub(fakeTimer, 'setInterval')).callThrough();
     const period = 50;
     const state = { index: 0, period };
     type State = typeof state;
@@ -92,7 +92,7 @@ describe('Scheduler.asap', () => {
     const sandbox = sinon.createSandbox();
     const fakeTimer = sandbox.useFakeTimers();
     // callThrough is missing from the declarations installed by the typings tool in stable
-    const stubSetInterval = (<any> sandbox.stub(global, 'setInterval')).callThrough();
+    const stubSetInterval = (<any> sandbox.stub(fakeTimer, 'setInterval')).callThrough();
     const period = 50;
     const state = { index: 0, period };
     type State = typeof state;
@@ -146,6 +146,12 @@ describe('Scheduler.asap', () => {
         }
       }
     }, 0, 0);
+  });
+
+  it('should schedule asap actions from a delayed one', (done) => {
+    asap.schedule(() => {
+      asap.schedule(() => { done(); });
+    }, 1);
   });
 
   it('should cancel the setImmediate if all scheduled actions unsubscribe before it executes', (done) => {

--- a/src/internal/scheduler/AnimationFrameAction.ts
+++ b/src/internal/scheduler/AnimationFrameAction.ts
@@ -33,7 +33,7 @@ export class AnimationFrameAction<T> extends AsyncAction<T> {
     // cancel the requested animation frame and set the scheduled flag to
     // undefined so the next AnimationFrameAction will request its own.
     const { actions } = scheduler;
-    if (id != null && actions[actions.length - 1]?.id !== id) {
+    if (id != null && id === scheduler._scheduled && actions[actions.length - 1]?.id !== id) {
       animationFrameProvider.cancelAnimationFrame(id as number);
       scheduler._scheduled = undefined;
     }

--- a/src/internal/scheduler/AnimationFrameScheduler.ts
+++ b/src/internal/scheduler/AnimationFrameScheduler.ts
@@ -13,8 +13,13 @@ export class AnimationFrameScheduler extends AsyncScheduler {
     // are removed from the actions array and that can shift actions that are
     // scheduled to be executed in a subsequent flush into positions at which
     // they are executed within the current flush.
-    const flushId = this._scheduled;
-    this._scheduled = undefined;
+    let flushId;
+    if (action?.id) {
+      flushId = action?.id;
+    } else {
+      flushId = this._scheduled;
+      this._scheduled = undefined;
+    }
 
     const { actions } = this;
     let error: any;

--- a/src/internal/scheduler/AnimationFrameScheduler.ts
+++ b/src/internal/scheduler/AnimationFrameScheduler.ts
@@ -14,8 +14,8 @@ export class AnimationFrameScheduler extends AsyncScheduler {
     // scheduled to be executed in a subsequent flush into positions at which
     // they are executed within the current flush.
     let flushId;
-    if (action?.id) {
-      flushId = action?.id;
+    if (action) {
+      flushId = action.id;
     } else {
       flushId = this._scheduled;
       this._scheduled = undefined;


### PR DESCRIPTION
`animationFrameScheduler` has a few issues that makes it miss tasks and even start accumulating tasks that never get flushed.

 - It's clearing the _scheduled in every flush, but some of the flushes are not for the next scheduled frame, they're regular async timeouts.
 - because it might be picking the incorrect flushId it may flush tasks before the next frame
 - after flushing and recycling the id it's clearing the `_scheduled` even though current id might be a different one.

**Related issues:**
 - #7018
 - #6891
 - #7196
   already fixed but similar cause

Failing tests are included in a independent commit and then fixed.

Note:
The changes could also be ported to AsapScheduler for consistency (also I think it's more clear).
However, I couldn't reproduce the issues there because:
 - AsapScheduler already contains one of the fixes
 - In AsapScheduler I couldn't schedule a task to happen before the `_scheduled` one.
