### PR TITLE
Fix typo in docstring in connect.ts

### DIFF
--- a/packages/rxjs/src/internal/operators/connect.ts
+++ b/packages/rxjs/src/internal/operators/connect.ts
@@ -89,7 +89,7 @@ const DEFAULT_CONFIG: ConnectConfig<unknown> = {
  *
  * @param selector A function used to set up the multicast. Gives you a multicast observable
  * that is not yet connected. With that, you're expected to create and return
- * and Observable, that when subscribed to, will utilize the multicast observable.
+ * an Observable, that when subscribed to, will utilize the multicast observable.
  * After this function is executed -- and its return value subscribed to -- the
  * operator will subscribe to the source, and the connection will be made.
  * @param config The configuration object for `connect`.


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**
Fix a small typo in the docstring: `and Observable` -> `an Observable`.
<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
