### PR TITLE
docs(rxjs.dev): fix decision tree file url in README

### DIFF
--- a/apps/rxjs.dev/src/app/custom-elements/operator-decision-tree/README.md
+++ b/apps/rxjs.dev/src/app/custom-elements/operator-decision-tree/README.md
@@ -1,6 +1,6 @@
 The `operator-decision-tree` module requires `decision-tree-data.json`, which is hosted at `/generated/app`.
 
-The JSON is generated via the `apps/rxjs.dev/tools/decision-tree-generator`.
+The JSON is generated via `apps/rxjs.dev/content/operator-decision-tree.yml`.
 
 # TODO
 


### PR DESCRIPTION
Updating the docs to match the new pathof the decision tree.