### PR TITLE
docs: remove duplicate deprecated note on retryWhen

### DIFF
--- a/packages/rxjs/src/internal/operators/retryWhen.ts
+++ b/packages/rxjs/src/internal/operators/retryWhen.ts
@@ -56,8 +56,7 @@ import type { MonoTypeOperatorFunction, ObservableInput } from '../types.js';
  * user can `complete` or `error`, aborting the retry.
  * @return A function that returns an Observable that mirrors the source
  * Observable with the exception of an `error`.
- * @deprecated Will be removed in v9 or v10, use {@link retry}'s `delay` option instead.
- * Will be removed in v9 or v10. Use {@link retry}'s {@link RetryConfig#delay delay} option instead.
+ * @deprecated Will be removed in v9 or v10. Use {@link retry}'s {@link RetryConfig#delay delay} option instead.
  * Instead of `retryWhen(() => notify$)`, use: `retry({ delay: () => notify$ })`.
  */
 export function retryWhen<T>(notifier: (errors: Observable<any>) => ObservableInput<any>): MonoTypeOperatorFunction<T> {


### PR DESCRIPTION
**Description:**

When I'm reading the documentation of [retryWhen](https://rxjs.dev/api/operators/retryWhen), I saw that the deprecation notice has two identical sentences.

> Will be removed in v9 or v10, use [retry](https://rxjs.dev/api/operators/retry)'s [delay](https://rxjs.dev/api/index/function/delay) option instead. Will be removed in v9 or v10. Use [retry](https://rxjs.dev/api/operators/retry)'s [delay](https://rxjs.dev/api/operators/RetryConfig#delay) option instead.

So, I merge them together, wdyt?

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
