### PR TITLE
Improve type inference with `zen-observable`

### DIFF
--- a/spec-dtslint/helpers.ts
+++ b/spec-dtslint/helpers.ts
@@ -32,3 +32,35 @@ export const g$ = of(new G());
 export const h$ = of(new H());
 export const i$ = of(new I());
 export const j$ = of(new J());
+
+interface Subscription {
+  closed: boolean;
+  unsubscribe(): void;
+}
+interface SubscriptionObserver<T> {
+  closed: boolean;
+  next(value: T): void;
+  error(errorValue: any): void;
+  complete(): void;
+}
+type Subscriber<T> = (observer: SubscriptionObserver<T>) => void | (() => void) | Subscription;
+
+interface Observer<T> {
+  start?(subscription: Subscription): any;
+  next?(value: T): void;
+  error?(errorValue: any): void;
+  complete?(): void;
+}
+
+export declare class CompatObservable<T> {
+  constructor(subscriber: Subscriber<T>);
+
+  subscribe(observer: Observer<T>): Subscription;
+  subscribe(
+      onNext: (value: T) => void,
+      onError?: (error: any) => void,
+      onComplete?: () => void,
+  ): Subscription;
+
+  [Symbol.observable](): CompatObservable<T>;
+}

--- a/spec-dtslint/types-spec.ts
+++ b/spec-dtslint/types-spec.ts
@@ -7,7 +7,7 @@ import {
   Head,
   Tail
 } from 'rxjs';
-import { A, B, C } from './helpers';
+import { A, B, C, CompatObservable } from './helpers';
 
 describe('ObservedValueOf', () => {
   it('should infer from an observable', () => {
@@ -23,6 +23,11 @@ describe('ObservedValueOf', () => {
   it('should infer from a promise', () => {
     let explicit: ObservedValueOf<Promise<A>>;
     let inferred = explicit!; // $ExpectType A
+  });
+
+  it('should infer from an compatible observable', () => {
+    let explicit: ObservedValueOf<CompatObservable<A>>;
+    const inferred = explicit!; // $ExpectType A
   });
 });
 

--- a/src/internal/types.ts
+++ b/src/internal/types.ts
@@ -97,6 +97,11 @@ export interface Subscribable<T> {
   subscribe(observer: Partial<Observer<T>>): Unsubscribable;
 }
 
+export interface InteropSubscribable<T> {
+  subscribe(observer: Partial<Observer<T>>): Unsubscribable;
+  subscribe(onNext?: (value: T) => void, onError?: (error: any) => void, onComplete?: () => void): Subscription;
+}
+
 /**
  * Valid types that can be converted to observables.
  */
@@ -118,7 +123,7 @@ export type ObservableLike<T> = InteropObservable<T>;
  * An object that implements the `Symbol.observable` interface.
  */
 export interface InteropObservable<T> {
-  [Symbol.observable]: () => Subscribable<T>;
+  [Symbol.observable]: () => Subscribable<T> | InteropSubscribable<T>;
 }
 
 /* NOTIFICATIONS */


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

While trying to consume a `zen-observable` into rxjs via `from`, the types weren't being inferred. I added a facscimille of the zen-observable types as `CompatObservable` to the tests to figure out how it was failing, and discovered the solution of adding a `InteropSubscribable` with an overload, which allowed the types to infer properly. This might be a shortcoming of typescript itself, but, in the meantime, this seems to work well.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**Related issue (if exists):**
