### PR TITLE
Replace polyfill.io with a Cloudflare equivalent

### DIFF
--- a/apps/rxjs.dev/src/index.html
+++ b/apps/rxjs.dev/src/index.html
@@ -84,7 +84,7 @@
   <script>
     if (!Object.assign) {
       // polyfill other non-evergreen browsers in a blocking way
-      var polyfillUrl = "https://cdn.polyfill.io/v2/polyfill.min.js?features=default,Array.prototype.find&flags=gated&unknown=polyfill";
+      var polyfillUrl = "https://cdnjs.cloudflare.com/polyfill/v2/polyfill.min.js?features=default,Array.prototype.find&flags=gated&unknown=polyfill";
 
       // send a blocking XHR to fetch the polyfill
       // then append it to the document so that its eval-ed synchronously


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR replaces the `polyfill.io` with a Cloudflare equivalent because `polyfill.io` can no longer be trusted.

> polyfill.io, a popular JavaScript library service, can no longer be trusted and should be removed from websites.

Source: [https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet](https://blog.cloudflare.com/automatically-replacing-polyfill-io-links-with-cloudflares-mirror-for-a-safer-internet)