### PR TITLE
docs: mention sample and withLatestFrom in each other's docs

### DIFF
--- a/packages/rxjs/src/internal/operators/sample.ts
+++ b/packages/rxjs/src/internal/operators/sample.ts
@@ -35,6 +35,7 @@ import { noop } from '../util/noop.js';
  * @see {@link debounce}
  * @see {@link sampleTime}
  * @see {@link throttle}
+ * @see {@link withLatestFrom}
  *
  * @param notifier The `ObservableInput` to use for sampling the
  * source Observable.

--- a/packages/rxjs/src/internal/operators/withLatestFrom.ts
+++ b/packages/rxjs/src/internal/operators/withLatestFrom.ts
@@ -41,6 +41,7 @@ export function withLatestFrom<T, O extends unknown[], R>(
  * ```
  *
  * @see {@link combineLatest}
+ * @see {@link sample}
  *
  * @param inputs An input Observable to combine with the source Observable. More
  * than one input Observables may be given as argument. If the last parameter is


### PR DESCRIPTION
withLatestFrom and sample are pretty similar: the latter just skips emitting when the sampled observable hasn't emitted anything new. I recently found myself using sample when I should've been using withLatestFrom, and would've benefited from it being linked in the docs.