### PR TITLE
fix: make `observerOrNext` in `Observable#subscribe` nullable

### DIFF
--- a/src/internal/Observable.ts
+++ b/src/internal/Observable.ts
@@ -64,7 +64,7 @@ export class Observable<T> implements Subscribable<T> {
     return observable;
   }
 
-  subscribe(observerOrNext?: Partial<Observer<T>> | ((value: T) => void)): Subscription;
+  subscribe(observerOrNext?: Partial<Observer<T>> | ((value: T) => void) | null): Subscription;
   /** @deprecated Instead of passing separate callback arguments, use an observer argument. Signatures taking separate callback arguments will be removed in v8. Details: https://rxjs.dev/deprecations/subscribe-arguments */
   subscribe(next?: ((value: T) => void) | null, error?: ((error: any) => void) | null, complete?: (() => void) | null): Subscription;
   /**


### PR DESCRIPTION
**Description:**
This PR makes the `observerOrNext` param in ``Observable#subscribe`. No logic change is required, as `subscribe` is already overloaded with `null`, so the logic to check for this is already in place. This is also aligned with what's in the V8 branch.

**Related issue (if exists):**

- mobx-utils: https://github.com/mobxjs/mobx-utils/issues/324
