### PR TITLE
Feat/to model operator

### DIFF
--- a/packages/rxjs/spec/operators/toModel-spec.ts
+++ b/packages/rxjs/spec/operators/toModel-spec.ts
@@ -1,0 +1,91 @@
+import { Observable, of } from 'rxjs';
+import { toModel } from 'rxjs/operators';
+
+// Mock class to be used for the test
+class Person {
+  firstName: string;
+  constructor(data: Person) {
+    this.firstName = data.firstName ?? 'Unknown';
+  }
+}
+
+describe('toModel operator', () => {
+  it('should map emitted values to instances of the specified model class', (done) => {
+    // Create an observable that emits raw data
+    const source$ = of({ firstName: 'Alice' }, { firstName: 'Bob' }) as any;
+
+    // Apply the toModel operator to transform the emitted data to instances of Person
+    const result$ = source$.pipe(toModel(Person));
+
+    // Subscribe and test that the emitted values are instances of Person
+    const expectedValues = [
+      new Person({ firstName: 'Alice' }),
+      new Person({ firstName: 'Bob' }),
+    ];
+
+    let index = 0;
+
+    result$.subscribe({
+      next: (value: any) => {
+        // Check that each emitted value is an instance of Person
+        expect(value).toBeInstanceOf(Person);
+        // Check that the value inside the model matches the expected data
+        expect(value).toEqual(expectedValues[index]);
+        index++;
+      },
+      error: (err: string | Error | undefined) => {
+        done.fail(err); // Fail the test if any error is thrown
+      },
+      complete: () => {
+        console.log(index)
+        expect(index).toBe(2); // Ensure two values were emitted
+        done(); // Test is complete
+      },
+    });
+  });
+
+  it('should propagate errors from the source observable', (done) => {
+    // Create an observable that emits an error
+    const source$ = new Observable<any>((subscriber) => {
+      subscriber.error('Test Error');
+    });
+
+    // Apply the toModel operator
+    const result$ = source$.pipe(toModel(Person));
+
+    // Subscribe and verify the error is propagated
+    result$.subscribe({
+      next: () => {
+        done.fail('Expected an error, but got a value');
+      },
+      error: (err) => {
+        expect(err).toBe('Test Error'); // Ensure the correct error is received
+        done(); // Test is complete
+      },
+      complete: () => {
+        done.fail('Expected an error, but got a complete signal');
+      },
+    });
+  });
+
+  it('should complete when the source observable completes', (done) => {
+    // Create an observable that completes without errors
+    const source$ = of();
+
+    // Apply the toModel operator
+    const result$ = source$.pipe(toModel(Person));
+
+    // Subscribe and verify completion
+    result$.subscribe({
+      next: () => {
+        done.fail('Expected no values, but got one');
+      },
+      error: () => {
+        done.fail('Expected no errors');
+      },
+      complete: () => {
+        done(); // Test is complete
+      },
+    });
+  });
+});

--- a/packages/rxjs/src/internal/ToModel.ts
+++ b/packages/rxjs/src/internal/ToModel.ts
@@ -1,0 +1,33 @@
+import type { MonoTypeOperatorFunction, Subscriber } from 'rxjs';
+import { Observable } from 'rxjs';
+
+export type Constructor<T> = { new (...args: any[]): T };
+
+/**
+ * Transforms an observable stream by mapping emitted values to instances of a specified model.
+ * This function takes a constructor as a parameter and returns a MonoTypeOperatorFunction,
+ * which can be used to convert emitted values into instances of the specified class.
+ *
+ * @param {Constructor<T>} Constructor - The constructor function used to create model instances from emitted values.
+ * @returns {MonoTypeOperatorFunction<T>} A function that takes an observable and transforms its emitted values.
+ */
+export function toModel<T>(Constructor: Constructor<T>): MonoTypeOperatorFunction<T> {
+  return (source: Observable<T>) =>
+    new Observable<T>((subscriber: Subscriber<T>) => {
+      // Subscribe to the source observable
+      source.subscribe({
+        // On receiving new data, instantiate the constructor with the data and emit it
+        next(data: T): void {
+          subscriber.next(new Constructor(data));
+        },
+        // Propagate errors to the subscriber
+        error(err): void {
+          subscriber.error(err);
+        },
+        // Signal completion to the subscriber
+        complete(): void {
+          subscriber.complete();
+        },
+      });
+    });
+}

--- a/packages/rxjs/src/internal/operators/toModel.ts
+++ b/packages/rxjs/src/internal/operators/toModel.ts
@@ -10,6 +10,9 @@ export type Constructor<T> = { new (...args: any[]): T };
  *
  * @param {Constructor<T>} Constructor - The constructor function used to create model instances from emitted values.
  * @returns {MonoTypeOperatorFunction<T>} A function that takes an observable and transforms its emitted values.
+ *
+ * @author Yusuf Alamu Musa
+ * @version 1.0
  */
 export function toModel<T>(Constructor: Constructor<T>): MonoTypeOperatorFunction<T> {
   return (source: Observable<T>) =>

--- a/packages/rxjs/src/operators/index.ts
+++ b/packages/rxjs/src/operators/index.ts
@@ -106,3 +106,4 @@ export { windowWhen } from '../internal/operators/windowWhen.js';
 export { withLatestFrom } from '../internal/operators/withLatestFrom.js';
 export { zipAll } from '../internal/operators/zipAll.js';
 export { zipWith } from '../internal/operators/zipWith.js';
+export { toModel } from '../internal/operators/toModel.js';


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [x] Add the operator to Rx
- [x] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [x] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [x] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This PR introduces a new `toModel` operator that transforms an observable stream by mapping emitted values to instances of a specified model class. 

The operator simplifies the process of converting raw data (e.g., from API responses) into model instances, improving type safety and reducing boilerplate code. 

It follows the existing RxJS operator patterns and is fully tested.

**Usage**:

```typescript
apiService.getData()
  .pipe(toModel(Person))
  .subscribe(userInstance => {
    // userInstance is now a Person object
  });

```

**Related issue (if exists):** <!-- Add the issue number if applicable, otherwise leave blank or remove -->
