### PR TITLE
fix: fix typing of distinctUntilChanged to allow comparator to be undefined

### DIFF
--- a/packages/rxjs/spec/operators/distinctUntilChanged-spec.ts
+++ b/packages/rxjs/spec/operators/distinctUntilChanged-spec.ts
@@ -263,6 +263,18 @@ describe('distinctUntilChanged', () => {
     });
   });
 
+  it('should allow passing undefined as comparator', () => {
+    testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
+      const e1 = hot('  --a--b--|', { a: 2, b: 4 });
+      const e1subs = '  ^-------!';
+      const expected = '--a-----|';
+      const keySelector = (x: number) => x % 2;
+
+      expectObservable(e1.pipe(distinctUntilChanged(undefined, keySelector))).toBe(expected, { a: 2 });
+      expectSubscriptions(e1.subscriptions).toBe(e1subs);
+    });
+  });
+
   it('should raise error when keySelector throws', () => {
     testScheduler.run(({ hot, expectObservable, expectSubscriptions }) => {
       const e1 = hot('  --a--b--c--d--e--f--|');

--- a/packages/rxjs/src/internal/operators/distinctUntilChanged.ts
+++ b/packages/rxjs/src/internal/operators/distinctUntilChanged.ts
@@ -4,7 +4,7 @@ import { Observable, operate } from '@rxjs/observable';
 
 export function distinctUntilChanged<T>(comparator?: (previous: T, current: T) => boolean): MonoTypeOperatorFunction<T>;
 export function distinctUntilChanged<T, K>(
-  comparator: (previous: K, current: K) => boolean,
+  comparator: ((previous: K, current: K) => boolean) | undefined,
   keySelector: (value: T) => K
 ): MonoTypeOperatorFunction<T>;
 


### PR DESCRIPTION
According to the docs you can omit the comparator in `distinctUntilChanged`. The typings however forbid this.

According to code comments passing null was previously supported. Not sure if that should be part of the public API or not. If yes I can add a `| null` in there as well...