### PR TITLE
fixed deprecated subscribe, used operate function instead of subscribe

### DIFF
--- a/packages/rxjs/src/internal/firstValueFrom.ts
+++ b/packages/rxjs/src/internal/firstValueFrom.ts
@@ -1,5 +1,4 @@
-import type { Observable} from '@rxjs/observable';
-import { Subscriber } from '@rxjs/observable';
+import { Observable, operate } from '@rxjs/observable';
 import { EmptyError } from './util/EmptyError.js';
 
 export interface FirstValueFromConfig<T> {
@@ -56,20 +55,23 @@ export function firstValueFrom<T>(source: Observable<T>): Promise<T>;
 export function firstValueFrom<T, D>(source: Observable<T>, config?: FirstValueFromConfig<D>): Promise<T | D> {
   const hasConfig = typeof config === 'object';
   return new Promise<T | D>((resolve, reject) => {
-    const subscriber = new Subscriber({
-      next: (value: T) => {
-        resolve(value);
-        subscriber.unsubscribe();
-      },
-      error: reject,
-      complete: () => {
-        if (hasConfig) {
-          resolve(config!.defaultValue);
-        } else {
-          reject(new EmptyError());
-        }
-      },
+    new Observable((destination) => {
+      const subscriber = operate({
+        destination,
+        next: (value: T) => {
+          resolve(value);
+          subscriber.unsubscribe();
+        },
+        error: reject,
+        complete: () => {
+          if (hasConfig) {
+            resolve(config!.defaultValue);
+          } else {
+            reject(new EmptyError());
+          }
+        },
+      });
+      source.subscribe(subscriber);
     });
-    source.subscribe(subscriber);
   });
 }


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
