### PR TITLE
Query Operator -- manage your asynchronous data query

### DIFF
--- a/apps/rxjs.dev/content/guide/operators.md
+++ b/apps/rxjs.dev/content/guide/operators.md
@@ -166,6 +166,7 @@ These are Observable creation operators that also have join functionality -- emi
 - [`mergeScan`](/api/operators/mergeScan)
 - [`pairwise`](/api/operators/pairwise)
 - [`partition`](/api/operators/partition)
+- [`query`](/api/operators/query)
 - [`scan`](/api/operators/scan)
 - [`switchScan`](/api/operators/switchScan)
 - [`switchMap`](/api/operators/switchMap)

--- a/packages/rxjs/spec-dtslint/operators/query-spec.ts
+++ b/packages/rxjs/spec-dtslint/operators/query-spec.ts
@@ -1,0 +1,13 @@
+import { of, throwError } from 'rxjs';
+import { query } from '../../src/internal/operators/query';
+import { QueryResult } from '../../src/internal/types';
+
+it('should infer QueryResult<T> when T is string', () => {
+  const result = of('hello').pipe(query());
+  // $ExpectType Observable<QueryResult<string>>
+});
+
+it('should handle error types correctly', () => {
+  const result = throwError(() => new Error()).pipe(query());
+  // $ExpectType Observable<QueryResult<unknown>>
+});

--- a/packages/rxjs/spec/operators/query-spec.ts
+++ b/packages/rxjs/spec/operators/query-spec.ts
@@ -1,0 +1,60 @@
+import { expect } from 'chai';
+import { TestScheduler } from 'rxjs/testing';
+import { query } from '../../src/internal/operators/query';
+import { QueryResult } from '../../src/internal/types';
+import { observableMatcher } from '../helpers/observableMatcher';
+
+/** @test {query} */
+describe('query operator', () => {
+  let testScheduler: TestScheduler;
+
+  beforeEach(() => {
+    testScheduler = new TestScheduler(observableMatcher);
+  });
+
+  it('should emit loading and then data', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source$ = cold('  --a|', { a: 'value' });
+      const expected = '      i-a|';
+
+      const expectedValues = {
+        i: { isLoading: true, data: null, error: null },
+        a: { isLoading: false, data: 'value', error: null },
+      };
+
+      const result$ = source$.pipe(query());
+
+      expectObservable(result$).toBe(expected, expectedValues);
+    });
+  });
+
+  it('should emit loading and then error', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source$ = cold('  --#', {}, 'BOOM');
+      const expected = '    i-(e|)';
+      const expectedValues: Record<string, QueryResult<any>> = {
+        i: { isLoading: true, data: null, error: null },
+        e: { isLoading: false, data: null, error: 'BOOM' },
+      };
+
+      const result$ = source$.pipe(query());
+
+      expectObservable(result$).toBe(expected, expectedValues);
+    });
+  });
+
+  it('should complete after emitting data', () => {
+    testScheduler.run(({ cold, expectObservable }) => {
+      const source$ = cold('  a---|', { a: 123 });
+      const expected = '    (ia)|';
+      const expectedValues = {
+        i: { isLoading: true, data: null, error: null },
+        a: { isLoading: false, data: 123, error: null },
+      };
+
+      const result$ = source$.pipe(query());
+
+      expectObservable(result$).toBe(expected, expectedValues);
+    });
+  });
+});

--- a/packages/rxjs/src/index.ts
+++ b/packages/rxjs/src/index.ts
@@ -140,6 +140,7 @@ export { min } from './internal/operators/min.js';
 export { observeOn } from './internal/operators/observeOn.js';
 export { onErrorResumeNextWith } from './internal/operators/onErrorResumeNextWith.js';
 export { pairwise } from './internal/operators/pairwise.js';
+export { query } from './internal/operators/query.js';
 export { raceWith } from './internal/operators/raceWith.js';
 export { reduce } from './internal/operators/reduce.js';
 export type { RepeatConfig } from './internal/operators/repeat.js';

--- a/packages/rxjs/src/internal/operators/query.ts
+++ b/packages/rxjs/src/internal/operators/query.ts
@@ -23,11 +23,9 @@ import { startWith, catchError, map } from 'rxjs/operators';
 export function query<T>() {
   return (source$: Observable<T>): Observable<QueryResult<T>> => {
     return source$.pipe(
-        map((data) => ({ isLoading: false, data, error: null })),
-        catchError((error) =>
-          of({ isLoading: false, data: null, error })
-        ),
-        startWith({ isLoading: true, data: null, error: null })
-      )
-  }
+      map((data) => ({ isLoading: false, data, error: null })),
+      catchError((error) => of({ isLoading: false, data: null, error })),
+      startWith({ isLoading: true, data: null, error: null })
+    );
+  };
 }

--- a/packages/rxjs/src/internal/operators/query.ts
+++ b/packages/rxjs/src/internal/operators/query.ts
@@ -1,0 +1,33 @@
+import { Observable, of } from 'rxjs';
+import { QueryResult } from '../types';
+import { startWith, catchError, map } from 'rxjs/operators';
+
+/**
+ * Transforms an observable into a query result observable.
+ *
+ * The query result observable will emit one of the following states:
+ *
+ * - `isLoading: true, data: null, error: null` when the source observable is
+ *   executing.
+ * - `isLoading: false, data: T, error: null` when the source observable
+ *   completes successfully.
+ * - `isLoading: false, data: null, error: Error` when the source observable
+ *   throws an error.
+ *
+ * The first state is sent immediately using `startWith`, the others are sent
+ * when the source observable completes or throws an error.
+ *
+ * @param source$ The source observable to transform
+ * @returns An observable that emits the query result
+ */
+export function query<T>() {
+  return (source$: Observable<T>): Observable<QueryResult<T>> => {
+    return source$.pipe(
+        map((data) => ({ isLoading: false, data, error: null })),
+        catchError((error) =>
+          of({ isLoading: false, data: null, error })
+        ),
+        startWith({ isLoading: true, data: null, error: null })
+      )
+  }
+}

--- a/packages/rxjs/src/internal/types.ts
+++ b/packages/rxjs/src/internal/types.ts
@@ -72,6 +72,17 @@ export interface TimeInterval<T> {
   interval: number;
 }
 
+/**
+ * The result of a query.
+ * 
+ * @see {@link query}
+ */
+export interface QueryResult<T> {
+  isLoading: boolean;
+  data: T | null;
+  error: any;
+}
+
 /* SUBSCRIPTION INTERFACES */
 
 export interface Unsubscribable {


### PR DESCRIPTION
**Description:**
The _query_ operator is a custom RxJS operator designed to simplify managing asynchronous data query states in reactive applications. It transforms a source observable of data into an observable that emits a consistent state object representing the current status of the query: loading, success with data, or error.

**What it does:**
- Initially emits a loading state `({ isLoading: true, data: null, error: null })`.
- Emits the data wrapped in a success state `({ isLoading: false, data, error: null })` when the source emits.
- Emits an error state `({ isLoading: false, data: null, error })` if the source observable errors.

**Why it is useful:**
Managing loading, success, and error states for asynchronous data streams is a common pattern in frontend and reactive programming. The query operator encapsulates this pattern into a reusable operator, reducing boilerplate and enabling clear, declarative handling of query states in RxJS pipelines.

**How it integrates with RxJS:**
The operator composes existing RxJS operators (map, catchError, and startWith) into a higher-level abstraction that fits naturally into RxJS’s functional reactive programming model. It returns an observable stream that emits query states, allowing seamless integration into reactive data flows and UI state management.

**Future plans:**
I am planning to add a complementary _cache_ operator that will provide caching capabilities for query results, further optimizing data fetching workflows by avoiding unnecessary repeated requests.