### PR TITLE
fix(from): exclude from array-like objects not index-accessible

### DIFF
--- a/packages/observable/src/observable.ts
+++ b/packages/observable/src/observable.ts
@@ -1319,7 +1319,13 @@ function isIterable(input: any): input is Iterable<any> {
 }
 
 export function isArrayLike<T>(x: any): x is ArrayLike<T> {
-  return x && typeof x.length === 'number' && !isFunction(x);
+  return (
+    x &&
+    typeof x.length === 'number' &&
+    !isFunction(x) &&
+    x.length >= 0 &&
+    (x.length === 0 || (typeof x !== 'string' && 0 in x))
+  );
 }
 
 /**


### PR DESCRIPTION
iterable objects that also have length property are not considered array-like unless they also have index access (i.e. obj[0])

closes issue 7497

**Related issue:** [7497](https://github.com/ReactiveX/rxjs/issues/7497)
