### PR TITLE
Update skipWhile documentation to fix error

### DIFF
--- a/packages/rxjs/src/internal/operators/skipWhile.ts
+++ b/packages/rxjs/src/internal/operators/skipWhile.ts
@@ -12,7 +12,7 @@ export function skipWhile<T>(predicate: (value: T, index: number) => boolean): M
  * ![](skipWhile.png)
  *
  * Skips all the notifications with a truthy predicate. It will not skip the notifications when the predicate is falsy.
- * It can also be skipped using index. Once the predicate is true, it will not be called again.
+ * It can also be skipped using index. Once the predicate is false, it will not be called again, and all further notifications will be emitted.
  *
  * ## Example
  *

--- a/packages/rxjs/src/internal/operators/skipWhile.ts
+++ b/packages/rxjs/src/internal/operators/skipWhile.ts
@@ -11,8 +11,7 @@ export function skipWhile<T>(predicate: (value: T, index: number) => boolean): M
  *
  * ![](skipWhile.png)
  *
- * Skips all the notifications with a truthy predicate. It will not skip the notifications when the predicate is falsy.
- * It can also be skipped using index. Once the predicate is false, it will not be called again, and all further notifications will be emitted.
+ * Skips all the notifications where the given predicate returns a truthy value. Once the predicate is falsey, it will not be called again, and all further notifications will be emitted.
  *
  * ## Example
  *


### PR DESCRIPTION
**Description:** Fixes the documentation for skipWhile.

Previously, the docs for this operator suggested that its predicate would stop being called once truthy. This is the opposite of how the operator actually behaves. 

**Related issue (if exists):**

https://github.com/ReactiveX/rxjs/discussions/6661
