### PR TITLE
add .js to imports in tests

### DIFF
--- a/packages/rxjs/spec/Observable-spec.ts
+++ b/packages/rxjs/spec/Observable-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { Observable, config, Subscription, Subject, of, throwError, EMPTY } from 'rxjs';
 import { map, tap, catchError } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from './helpers/observableMatcher';
+import { observableMatcher } from './helpers/observableMatcher.js';
 
 // function expectFullObserver(val: any) {
 //   expect(val).to.be.a('object');

--- a/packages/rxjs/spec/Subject-spec.ts
+++ b/packages/rxjs/spec/Subject-spec.ts
@@ -3,7 +3,7 @@ import type { Subscription} from 'rxjs';
 import { Subject, Observable, AsyncSubject, of, config, Subscriber, noop, operate } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from './helpers/observableMatcher';
+import { observableMatcher } from './helpers/observableMatcher.js';
 
 /** @test {Subject} */
 describe('Subject', () => {

--- a/packages/rxjs/spec/Subscriber-spec.ts
+++ b/packages/rxjs/spec/Subscriber-spec.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import type { Observer} from 'rxjs';
 import { Subscriber, Observable, of, config, operate } from 'rxjs';
 import * as sinon from 'sinon';
-import { asInteropSubscriber } from './helpers/interop-helper';
-import { getRegisteredFinalizers } from './helpers/subscription';
+import { asInteropSubscriber } from './helpers/interop-helper.js';
+import { getRegisteredFinalizers } from './helpers/subscription.js';
 
 /** @test {Subscriber} */
 describe('Subscriber', () => {

--- a/packages/rxjs/spec/helpers/interop-helper-spec.ts
+++ b/packages/rxjs/spec/helpers/interop-helper-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { Observable, of, Subscriber } from 'rxjs';
-import { asInteropObservable, asInteropSubscriber } from './interop-helper';
+import { asInteropObservable, asInteropSubscriber } from './interop-helper.js';
 
 describe('interop helper', () => {
   it('should simulate interop observables', () => {

--- a/packages/rxjs/spec/helpers/marble-testing.ts
+++ b/packages/rxjs/spec/helpers/marble-testing.ts
@@ -1,8 +1,8 @@
 import type { Observable } from 'rxjs';
-import type { SubscriptionLog } from '../../src/internal/testing/subscription-logging';
-import type { ColdObservable } from '../../src/internal/testing/ColdObservable';
-import type { HotObservable } from '../../src/internal/testing/HotObservable';
-import type { observableToBeFn, subscriptionLogsToBeFn } from '../../src/internal/testing/TestScheduler';
+import type { SubscriptionLog } from '../../src/internal/testing/subscription-logging.js';
+import type { ColdObservable } from '../../src/internal/testing/ColdObservable.js';
+import type { HotObservable } from '../../src/internal/testing/HotObservable.js';
+import type { observableToBeFn, subscriptionLogsToBeFn } from '../../src/internal/testing/TestScheduler.js';
 
 declare const global: any;
 

--- a/packages/rxjs/spec/observables/bindCallback-spec.ts
+++ b/packages/rxjs/spec/observables/bindCallback-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { bindCallback } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {bindCallback} */
 describe('bindCallback', () => {

--- a/packages/rxjs/spec/observables/bindNodeCallback-spec.ts
+++ b/packages/rxjs/spec/observables/bindNodeCallback-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { bindNodeCallback } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {bindNodeCallback} */
 describe('bindNodeCallback', () => {

--- a/packages/rxjs/spec/observables/combineLatest-spec.ts
+++ b/packages/rxjs/spec/observables/combineLatest-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { combineLatest, of } from 'rxjs';
 import { map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {combineLatest} */
 describe('static combineLatest', () => {

--- a/packages/rxjs/spec/observables/concat-spec.ts
+++ b/packages/rxjs/spec/observables/concat-spec.ts
@@ -1,10 +1,10 @@
 /** @prettier */
 import { expect } from 'chai';
-import { lowerCaseO } from '../helpers/test-helper';
+import { lowerCaseO } from '../helpers/test-helper.js';
 import { asyncScheduler, queueScheduler, concat, of, scheduled, defer, Observable } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {concat} */
 describe('static concat', () => {

--- a/packages/rxjs/spec/observables/connectable-spec.ts
+++ b/packages/rxjs/spec/observables/connectable-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { connectable, of, ReplaySubject } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 describe('connectable', () => {
   let testScheduler: TestScheduler;

--- a/packages/rxjs/spec/observables/defer-spec.ts
+++ b/packages/rxjs/spec/observables/defer-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { defer, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {defer} */
 describe('defer', () => {

--- a/packages/rxjs/spec/observables/dom/animationFrames-spec.ts
+++ b/packages/rxjs/spec/observables/dom/animationFrames-spec.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import { animationFrames } from 'rxjs';
 import { mergeMapTo, take, takeUntil } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../../helpers/observableMatcher';
+import { observableMatcher } from '../../helpers/observableMatcher.js';
 import { animationFrameProvider } from 'rxjs/internal/scheduler/animationFrameProvider';
 
 describe('animationFrames', () => {

--- a/packages/rxjs/spec/observables/empty-spec.ts
+++ b/packages/rxjs/spec/observables/empty-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { EMPTY } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {empty} */
 describe('empty', () => {

--- a/packages/rxjs/spec/observables/forkJoin-spec.ts
+++ b/packages/rxjs/spec/observables/forkJoin-spec.ts
@@ -1,9 +1,9 @@
 /** @prettier */
 import { expect } from 'chai';
 import { EmptyError, finalize, forkJoin, map, of, timer } from 'rxjs';
-import { lowerCaseO } from '../helpers/test-helper';
+import { lowerCaseO } from '../helpers/test-helper.js';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {forkJoin} */
 describe('forkJoin', () => {

--- a/packages/rxjs/spec/observables/from-spec.ts
+++ b/packages/rxjs/spec/observables/from-spec.ts
@@ -5,7 +5,7 @@ import type { Observer, Subscription } from 'rxjs';
 import { of, from, Subject, noop } from 'rxjs';
 import { first, concatMap, delay, take, tap } from 'rxjs/operators';
 import { ReadableStream } from 'web-streams-polyfill';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 function getArguments<T>(...args: T[]) {
   return args;

--- a/packages/rxjs/spec/observables/fromEvent-spec.ts
+++ b/packages/rxjs/spec/observables/fromEvent-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { fromEvent, NEVER, timer } from 'rxjs';
 import { mapTo, take, concatWith } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {fromEvent} */
 describe('fromEvent', () => {

--- a/packages/rxjs/spec/observables/fromEventPattern-spec.ts
+++ b/packages/rxjs/spec/observables/fromEventPattern-spec.ts
@@ -5,7 +5,7 @@ import * as sinon from 'sinon';
 import { fromEventPattern, noop, NEVER, timer } from 'rxjs';
 import { mapTo, take, concatWith } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {fromEventPattern} */
 describe('fromEventPattern', () => {

--- a/packages/rxjs/spec/observables/generate-spec.ts
+++ b/packages/rxjs/spec/observables/generate-spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { generate } from 'rxjs';
 import { take } from 'rxjs/operators';
 import { Subscriber } from '@rxjs/observable';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 function err(): any {
   throw 'error';

--- a/packages/rxjs/spec/observables/if-spec.ts
+++ b/packages/rxjs/spec/observables/if-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { iif, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 describe('iif', () => {
   let rxTestScheduler: TestScheduler;

--- a/packages/rxjs/spec/observables/interval-spec.ts
+++ b/packages/rxjs/spec/observables/interval-spec.ts
@@ -4,7 +4,7 @@ import { NEVER, interval, asapScheduler, animationFrameScheduler, queueScheduler
 import { TestScheduler } from 'rxjs/testing';
 import { take } from 'rxjs/operators';
 import * as sinon from 'sinon';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {interval} */
 describe('interval', () => {

--- a/packages/rxjs/spec/observables/merge-spec.ts
+++ b/packages/rxjs/spec/observables/merge-spec.ts
@@ -1,10 +1,10 @@
 /** @prettier */
 import { expect } from 'chai';
-import { lowerCaseO } from '../helpers/test-helper';
+import { lowerCaseO } from '../helpers/test-helper.js';
 import { TestScheduler } from 'rxjs/testing';
 import { merge, of, Observable, defer, asyncScheduler } from 'rxjs';
 import { delay } from 'rxjs/operators';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {merge} */
 describe('static merge(...observables)', () => {

--- a/packages/rxjs/spec/observables/never-spec.ts
+++ b/packages/rxjs/spec/observables/never-spec.ts
@@ -2,7 +2,7 @@
 import { NEVER } from 'rxjs';
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {NEVER} */
 describe('NEVER', () => {

--- a/packages/rxjs/spec/observables/of-spec.ts
+++ b/packages/rxjs/spec/observables/of-spec.ts
@@ -3,7 +3,7 @@ import { expect } from 'chai';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { concatMap, delay, concatAll } from 'rxjs/operators';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {of} */
 describe('of', () => {

--- a/packages/rxjs/spec/observables/onErrorResumeNext-spec.ts
+++ b/packages/rxjs/spec/observables/onErrorResumeNext-spec.ts
@@ -3,7 +3,7 @@ import { onErrorResumeNext, of } from 'rxjs';
 import { finalize } from 'rxjs/operators';
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 describe('onErrorResumeNext', () => {
   let rxTestScheduler: TestScheduler;

--- a/packages/rxjs/spec/observables/partition-spec.ts
+++ b/packages/rxjs/spec/observables/partition-spec.ts
@@ -4,7 +4,7 @@ import type { Observable} from 'rxjs';
 import { partition, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {partition} */
 describe('partition', () => {

--- a/packages/rxjs/spec/observables/race-spec.ts
+++ b/packages/rxjs/spec/observables/race-spec.ts
@@ -3,7 +3,7 @@ import { race, of } from 'rxjs';
 import { mergeMap } from 'rxjs/operators';
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {race} */
 describe('race', () => {

--- a/packages/rxjs/spec/observables/range-spec.ts
+++ b/packages/rxjs/spec/observables/range-spec.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 import { asapScheduler as asap, range, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { concatMap, delay } from 'rxjs/operators';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {range} */
 describe('range', () => {

--- a/packages/rxjs/spec/observables/throwError-spec.ts
+++ b/packages/rxjs/spec/observables/throwError-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
 import { throwError } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {throwError} */
 describe('throwError', () => {

--- a/packages/rxjs/spec/observables/timer-spec.ts
+++ b/packages/rxjs/spec/observables/timer-spec.ts
@@ -1,7 +1,7 @@
 import { timer, NEVER, merge } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
 import { mergeMap, take, concatWith } from 'rxjs/operators';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {timer} */
 describe('timer', () => {

--- a/packages/rxjs/spec/observables/zip-spec.ts
+++ b/packages/rxjs/spec/observables/zip-spec.ts
@@ -2,7 +2,7 @@
 import { expect } from 'chai';
 import { queueScheduler as rxQueueScheduler, zip, from, scheduled } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 const queueScheduler = rxQueueScheduler;
 

--- a/packages/rxjs/spec/operators/audit-spec.ts
+++ b/packages/rxjs/spec/operators/audit-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
 import { of, interval, EMPTY, Observable } from 'rxjs';
 import { audit, take, mergeMap } from 'rxjs/operators';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {audit} */
 describe('audit operator', () => {

--- a/packages/rxjs/spec/operators/auditTime-spec.ts
+++ b/packages/rxjs/spec/operators/auditTime-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of } from 'rxjs';
 import { auditTime, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {auditTime} */
 describe('auditTime', () => {

--- a/packages/rxjs/spec/operators/buffer-spec.ts
+++ b/packages/rxjs/spec/operators/buffer-spec.ts
@@ -1,7 +1,7 @@
 import { buffer, mergeMap, take, window, toArray } from 'rxjs/operators';
 import { EMPTY, NEVER, throwError, of, Subject, interval } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { expect } from 'chai';
 
 /** @test {buffer} */

--- a/packages/rxjs/spec/operators/bufferCount-spec.ts
+++ b/packages/rxjs/spec/operators/bufferCount-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Subject, of, Observable } from 'rxjs';
 import { bufferCount, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {bufferCount} */
 describe('bufferCount operator', () => {

--- a/packages/rxjs/spec/operators/bufferTime-spec.ts
+++ b/packages/rxjs/spec/operators/bufferTime-spec.ts
@@ -1,7 +1,7 @@
 import { of, throwError, interval, scheduled, asapScheduler, Subject } from 'rxjs';
 import { bufferTime, mergeMap, take, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { expect } from 'chai';
 
 /** @test {bufferTime} */

--- a/packages/rxjs/spec/operators/bufferToggle-spec.ts
+++ b/packages/rxjs/spec/operators/bufferToggle-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of, concat, timer, EMPTY } from 'rxjs';
 import { bufferToggle, mergeMap, mapTo } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {bufferToggle} */
 describe('bufferToggle operator', () => {

--- a/packages/rxjs/spec/operators/bufferWhen-spec.ts
+++ b/packages/rxjs/spec/operators/bufferWhen-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of } from 'rxjs';
 import { bufferWhen, mergeMap, takeWhile } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {bufferWhen} */
 describe('bufferWhen operator', () => {

--- a/packages/rxjs/spec/operators/catchError-spec.ts
+++ b/packages/rxjs/spec/operators/catchError-spec.ts
@@ -2,10 +2,10 @@ import { expect } from 'chai';
 import { concat, defer, Observable, of, throwError, EMPTY, from } from 'rxjs';
 import { catchError, map, mergeMap, takeWhile, delay, take } from 'rxjs/operators';
 import * as sinon from 'sinon';
-import { createObservableInputs } from '../helpers/test-helper';
+import { createObservableInputs } from '../helpers/test-helper.js';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
-import { asInteropObservable } from '../helpers/interop-helper';
+import { observableMatcher } from '../helpers/observableMatcher.js';
+import { asInteropObservable } from '../helpers/interop-helper.js';
 
 /** @test {catch} */
 describe('catchError operator', () => {

--- a/packages/rxjs/spec/operators/combineLatestAll-spec.ts
+++ b/packages/rxjs/spec/operators/combineLatestAll-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { queueScheduler, of, scheduled } from 'rxjs';
 import { combineLatestAll, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {combineLatestAll} */
 describe('combineLatestAll operator', () => {

--- a/packages/rxjs/spec/operators/combineLatestWith-spec.ts
+++ b/packages/rxjs/spec/operators/combineLatestWith-spec.ts
@@ -1,7 +1,7 @@
 import { of } from 'rxjs';
 import { combineLatestWith, mergeMap, distinct, count, map } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {combineLatestWith} */
 describe('combineLatestWith', () => {

--- a/packages/rxjs/spec/operators/concatAll-spec.ts
+++ b/packages/rxjs/spec/operators/concatAll-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { from, throwError, of, scheduled, Observable, defer } from 'rxjs';
 import { concatAll, take, mergeMap, finalize, delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {concatAll} */
 describe('concatAll operator', () => {

--- a/packages/rxjs/spec/operators/concatMap-spec.ts
+++ b/packages/rxjs/spec/operators/concatMap-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of, from, Observable, defer } from 'rxjs';
 import { concatMap, mergeMap, map, take, finalize, delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {concatMap} */
 describe('Observable.prototype.concatMap', () => {

--- a/packages/rxjs/spec/operators/concatMapTo-spec.ts
+++ b/packages/rxjs/spec/operators/concatMapTo-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of, from, Observable } from 'rxjs';
 import { concatMapTo, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {concatMapTo} */
 describe('concatMapTo', () => {

--- a/packages/rxjs/spec/operators/concatWith-spec.ts
+++ b/packages/rxjs/spec/operators/concatWith-spec.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { of, Observable } from 'rxjs';
 import { concatWith, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { NO_SUBS } from '../helpers/test-helper';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { NO_SUBS } from '../helpers/test-helper.js';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {concat} */
 describe('concat operator', () => {

--- a/packages/rxjs/spec/operators/connect-spec.ts
+++ b/packages/rxjs/spec/operators/connect-spec.ts
@@ -1,7 +1,7 @@
 import { BehaviorSubject, merge } from 'rxjs';
 import { connect, delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 describe('connect', () => {
   let rxTest: TestScheduler;

--- a/packages/rxjs/spec/operators/count-spec.ts
+++ b/packages/rxjs/spec/operators/count-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of, range } from 'rxjs';
 import { count, skip, take, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {count} */
 describe('count', () => {

--- a/packages/rxjs/spec/operators/debounce-spec.ts
+++ b/packages/rxjs/spec/operators/debounce-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { NEVER, timer, of, EMPTY, concat, Subject, Observable } from 'rxjs';
 import { debounce, mergeMap, mapTo, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {debounce} */
 describe('debounce', () => {

--- a/packages/rxjs/spec/operators/debounceTime-spec.ts
+++ b/packages/rxjs/spec/operators/debounceTime-spec.ts
@@ -5,7 +5,7 @@ import { AnimationFrameScheduler } from 'rxjs/internal/scheduler/AnimationFrameS
 import { debounceTime, mergeMap, startWith } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { VirtualTimeScheduler } from 'rxjs/internal/scheduler/VirtualTimeScheduler';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {debounceTime} */
 describe('debounceTime', () => {

--- a/packages/rxjs/spec/operators/defaultIfEmpty-spec.ts
+++ b/packages/rxjs/spec/operators/defaultIfEmpty-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { of, Observable } from 'rxjs';
 import { defaultIfEmpty, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';

--- a/packages/rxjs/spec/operators/delay-spec.ts
+++ b/packages/rxjs/spec/operators/delay-spec.ts
@@ -3,7 +3,7 @@ import { delay, repeatWhen, skip, take, tap, mergeMap, ignoreElements } from 'rx
 import { TestScheduler } from 'rxjs/testing';
 import * as sinon from 'sinon';
 import { expect } from 'chai';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {delay} */
 describe('delay', () => {

--- a/packages/rxjs/spec/operators/delayWhen-spec.ts
+++ b/packages/rxjs/spec/operators/delayWhen-spec.ts
@@ -1,7 +1,7 @@
 import { of, EMPTY, interval, take } from 'rxjs';
 import { delayWhen, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { expect } from 'chai';
 
 /** @test {delayWhen} */

--- a/packages/rxjs/spec/operators/dematerialize-spec.ts
+++ b/packages/rxjs/spec/operators/dematerialize-spec.ts
@@ -4,7 +4,7 @@ import { of, Observable } from 'rxjs';
 import { COMPLETE_NOTIFICATION, errorNotification, nextNotification } from '@rxjs/observable';
 import { dematerialize, map, mergeMap, materialize, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {dematerialize} */
 describe('dematerialize', () => {

--- a/packages/rxjs/spec/operators/distinct-spec.ts
+++ b/packages/rxjs/spec/operators/distinct-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { distinct, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {distinct} */
 describe('distinct', () => {

--- a/packages/rxjs/spec/operators/distinctUntilChanged-spec.ts
+++ b/packages/rxjs/spec/operators/distinctUntilChanged-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { distinctUntilChanged, mergeMap, take } from 'rxjs/operators';
 import { of, Observable, Subject } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {distinctUntilChanged} */
 describe('distinctUntilChanged', () => {

--- a/packages/rxjs/spec/operators/distinctUntilKeyChanged-spec.ts
+++ b/packages/rxjs/spec/operators/distinctUntilKeyChanged-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { distinctUntilKeyChanged, mergeMap, map, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {distinctUntilKeyChanged} */
 describe('distinctUntilKeyChanged', () => {

--- a/packages/rxjs/spec/operators/elementAt-spec.ts
+++ b/packages/rxjs/spec/operators/elementAt-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { elementAt, mergeMap, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { ArgumentOutOfRangeError, of, range, Observable, Subject, merge } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {elementAt} */
 describe('elementAt', () => {

--- a/packages/rxjs/spec/operators/endWith-spec.ts
+++ b/packages/rxjs/spec/operators/endWith-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { of, Observable } from 'rxjs';
 import { endWith, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {endWith} */
 describe('endWith', () => {

--- a/packages/rxjs/spec/operators/every-spec.ts
+++ b/packages/rxjs/spec/operators/every-spec.ts
@@ -3,7 +3,7 @@ import { every, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import type { Observer } from 'rxjs';
 import { of, Observable, Subject } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {every} */
 describe('every', () => {

--- a/packages/rxjs/spec/operators/exhaustAll-spec.ts
+++ b/packages/rxjs/spec/operators/exhaustAll-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { exhaustAll, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {exhaustAll} */
 describe('exhaustAll', () => {

--- a/packages/rxjs/spec/operators/exhaustMap-spec.ts
+++ b/packages/rxjs/spec/operators/exhaustMap-spec.ts
@@ -2,8 +2,8 @@ import { TestScheduler } from 'rxjs/testing';
 import { concat, defer, Observable, of, BehaviorSubject } from 'rxjs';
 import { exhaustMap, mergeMap, takeWhile, map, take } from 'rxjs/operators';
 import { expect } from 'chai';
-import { asInteropObservable } from '../helpers/interop-helper';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { asInteropObservable } from '../helpers/interop-helper.js';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {exhaustMap} */
 describe('exhaustMap', () => {

--- a/packages/rxjs/spec/operators/expand-spec.ts
+++ b/packages/rxjs/spec/operators/expand-spec.ts
@@ -3,7 +3,7 @@ import { expand, mergeMap, map, take, toArray } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import type { Observer, InteropObservable } from 'rxjs';
 import { EMPTY, Observable, of, asapScheduler, asyncScheduler } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {expand} */
 describe('expand', () => {

--- a/packages/rxjs/spec/operators/filter-spec.ts
+++ b/packages/rxjs/spec/operators/filter-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { filter, tap, map, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable, from } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {filter} */
 describe('filter', () => {

--- a/packages/rxjs/spec/operators/finalize-spec.ts
+++ b/packages/rxjs/spec/operators/finalize-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { finalize, map, share, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { of, timer, interval, NEVER, Observable, noop } from 'rxjs';
-import { asInteropObservable } from '../helpers/interop-helper';
+import { asInteropObservable } from '../helpers/interop-helper.js';
 
 /** @test {finalize} */
 describe('finalize', () => {

--- a/packages/rxjs/spec/operators/find-spec.ts
+++ b/packages/rxjs/spec/operators/find-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { find, mergeMap, delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { of, Observable, from } from 'rxjs';
 
 /** @test {find} */

--- a/packages/rxjs/spec/operators/findIndex-spec.ts
+++ b/packages/rxjs/spec/operators/findIndex-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { findIndex, mergeMap, delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { of, Observable } from 'rxjs';
 
 /** @test {findIndex} */

--- a/packages/rxjs/spec/operators/first-spec.ts
+++ b/packages/rxjs/spec/operators/first-spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { first, mergeMap, delay, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, from, Observable, Subject, EmptyError, merge } from 'rxjs';

--- a/packages/rxjs/spec/operators/groupBy-spec.ts
+++ b/packages/rxjs/spec/operators/groupBy-spec.ts
@@ -4,7 +4,7 @@ import { TestScheduler } from 'rxjs/testing';
 import type { NextNotification, ErrorNotification } from 'rxjs';
 import { ReplaySubject, of, Observable, Subject } from 'rxjs';
 import { createNotification } from '@rxjs/observable';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {groupBy} */
 describe('groupBy operator', () => {

--- a/packages/rxjs/spec/operators/ignoreElements-spec.ts
+++ b/packages/rxjs/spec/operators/ignoreElements-spec.ts
@@ -1,7 +1,7 @@
 import { ignoreElements, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {ignoreElements} */
 describe('ignoreElements', () => {

--- a/packages/rxjs/spec/operators/isEmpty-spec.ts
+++ b/packages/rxjs/spec/operators/isEmpty-spec.ts
@@ -1,7 +1,7 @@
 import { isEmpty, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {isEmpty} */
 describe('isEmpty', () => {

--- a/packages/rxjs/spec/operators/last-spec.ts
+++ b/packages/rxjs/spec/operators/last-spec.ts
@@ -2,7 +2,7 @@ import { TestScheduler } from 'rxjs/testing';
 import { last, mergeMap } from 'rxjs/operators';
 import type { Observable } from 'rxjs';
 import { EmptyError, of, from } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {last} */
 describe('last', () => {

--- a/packages/rxjs/spec/operators/map-spec.ts
+++ b/packages/rxjs/spec/operators/map-spec.ts
@@ -3,7 +3,7 @@ import { map, tap, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import type { Observer } from 'rxjs';
 import { of, Observable, identity } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 // function shortcuts
 const addDrama = (x: number | string) => x + '!';

--- a/packages/rxjs/spec/operators/mapTo-spec.ts
+++ b/packages/rxjs/spec/operators/mapTo-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { mapTo, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {mapTo} */
 describe('mapTo', () => {

--- a/packages/rxjs/spec/operators/materialize-spec.ts
+++ b/packages/rxjs/spec/operators/materialize-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { materialize, map, mergeMap, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { COMPLETE_NOTIFICATION, errorNotification, nextNotification } from '@rxjs/observable';
 
 /** @test {materialize} */

--- a/packages/rxjs/spec/operators/max-spec.ts
+++ b/packages/rxjs/spec/operators/max-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { max, mergeMap, skip, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, range } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {max} */
 describe('max', () => {

--- a/packages/rxjs/spec/operators/mergeAll-spec.ts
+++ b/packages/rxjs/spec/operators/mergeAll-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { mergeAll, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { throwError, from, of, scheduled, queueScheduler, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {mergeAll} */
 describe('mergeAll', () => {

--- a/packages/rxjs/spec/operators/mergeMap-spec.ts
+++ b/packages/rxjs/spec/operators/mergeMap-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { mergeMap, map, delay, take } from 'rxjs/operators';
 import { asapScheduler, defer, Observable, from, of, scheduled, timer } from 'rxjs';
-import { asInteropObservable } from '../helpers/interop-helper';
+import { asInteropObservable } from '../helpers/interop-helper.js';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {mergeMap} */
 describe('mergeMap', () => {

--- a/packages/rxjs/spec/operators/mergeMapTo-spec.ts
+++ b/packages/rxjs/spec/operators/mergeMapTo-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
 import { mergeMapTo, map, take } from 'rxjs/operators';
 import { from, of, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {mergeMapTo} */
 describe('mergeMapTo', () => {

--- a/packages/rxjs/spec/operators/mergeScan-spec.ts
+++ b/packages/rxjs/spec/operators/mergeScan-spec.ts
@@ -2,7 +2,7 @@ import { TestScheduler } from 'rxjs/testing';
 import { of, defer, EMPTY, NEVER, concat, throwError, Observable } from 'rxjs';
 import { mergeScan, delay, mergeMap, takeWhile, startWith, take } from 'rxjs/operators';
 import { expect } from 'chai';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {mergeScan} */
 describe('mergeScan', () => {

--- a/packages/rxjs/spec/operators/mergeWith-spec.ts
+++ b/packages/rxjs/spec/operators/mergeWith-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { mergeWith, map, mergeAll, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { queueScheduler, of, scheduled, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {merge} */
 describe('merge operator', () => {

--- a/packages/rxjs/spec/operators/min-spec.ts
+++ b/packages/rxjs/spec/operators/min-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { min, skip, take, mergeMap } from 'rxjs/operators';
 import { range, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {min} */
 describe('min', () => {

--- a/packages/rxjs/spec/operators/observeOn-spec.ts
+++ b/packages/rxjs/spec/operators/observeOn-spec.ts
@@ -2,7 +2,7 @@ import { observeOn, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { expect } from 'chai';
 import { of, Observable, queueScheduler } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {observeOn} */
 describe('observeOn', () => {

--- a/packages/rxjs/spec/operators/onErrorResumeNext-spec.ts
+++ b/packages/rxjs/spec/operators/onErrorResumeNext-spec.ts
@@ -2,8 +2,8 @@ import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
 import { onErrorResumeNextWith, take, finalize, tap } from 'rxjs/operators';
 import { concat, throwError, of, Observable } from 'rxjs';
-import { asInteropObservable } from '../helpers/interop-helper';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { asInteropObservable } from '../helpers/interop-helper.js';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 describe('onErrorResumeNextWith', () => {
   let testScheduler: TestScheduler;

--- a/packages/rxjs/spec/operators/pairwise-spec.ts
+++ b/packages/rxjs/spec/operators/pairwise-spec.ts
@@ -2,7 +2,7 @@ import { TestScheduler } from 'rxjs/testing';
 import { pairwise, take } from 'rxjs/operators';
 import { Subject, Observable } from 'rxjs';
 import { expect } from 'chai';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {pairwise} */
 describe('pairwise operator', () => {

--- a/packages/rxjs/spec/operators/raceWith-spec.ts
+++ b/packages/rxjs/spec/operators/raceWith-spec.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 import { EMPTY, NEVER, of, timer, defer, Observable, throwError } from 'rxjs';
 import { raceWith, mergeMap, map, finalize, startWith, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {raceWith} */
 describe('raceWith operator', () => {

--- a/packages/rxjs/spec/operators/reduce-spec.ts
+++ b/packages/rxjs/spec/operators/reduce-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
 import { reduce, mergeMap } from 'rxjs/operators';
 import { range, of } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {reduce} */
 describe('reduce', () => {

--- a/packages/rxjs/spec/operators/repeat-spec.ts
+++ b/packages/rxjs/spec/operators/repeat-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { repeat, mergeMap, map, share, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Subject, Observable, timer } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {repeat} */
 describe('repeat operator', () => {

--- a/packages/rxjs/spec/operators/repeatWhen-spec.ts
+++ b/packages/rxjs/spec/operators/repeatWhen-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { repeatWhen, map, mergeMap, takeUntil, takeWhile, take } from 'rxjs/operators';
 import { of, EMPTY, Observable, Subscriber } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {repeatWhen} */
 describe('repeatWhen operator', () => {

--- a/packages/rxjs/spec/operators/retry-spec.ts
+++ b/packages/rxjs/spec/operators/retry-spec.ts
@@ -3,7 +3,7 @@ import { retry, map, take, mergeMap, concatWith, share } from 'rxjs/operators';
 import type { Observer} from 'rxjs';
 import { Observable, defer, range, of, throwError, Subject, timer, EMPTY } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {retry} */
 describe('retry', () => {

--- a/packages/rxjs/spec/operators/retryWhen-spec.ts
+++ b/packages/rxjs/spec/operators/retryWhen-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { retryWhen, map, mergeMap, takeUntil, take } from 'rxjs/operators';
 import { of, EMPTY, Observable, throwError } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {retryWhen} */
 describe('retryWhen', () => {

--- a/packages/rxjs/spec/operators/sample-spec.ts
+++ b/packages/rxjs/spec/operators/sample-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { sample, mergeMap } from 'rxjs/operators';
 import { Subject, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {sample} */
 describe('sample', () => {

--- a/packages/rxjs/spec/operators/sampleTime-spec.ts
+++ b/packages/rxjs/spec/operators/sampleTime-spec.ts
@@ -1,7 +1,7 @@
 import { sampleTime, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {sampleTime} */
 describe('sampleTime', () => {

--- a/packages/rxjs/spec/operators/scan-spec.ts
+++ b/packages/rxjs/spec/operators/scan-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { scan, mergeMap, finalize, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {scan} */
 describe('scan', () => {

--- a/packages/rxjs/spec/operators/sequenceEqual-spec.ts
+++ b/packages/rxjs/spec/operators/sequenceEqual-spec.ts
@@ -1,6 +1,6 @@
 import { sequenceEqual } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 const booleans = { T: true, F: false };
 

--- a/packages/rxjs/spec/operators/share-spec.ts
+++ b/packages/rxjs/spec/operators/share-spec.ts
@@ -17,7 +17,7 @@ import {
   withLatestFrom,
 } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { spy } from 'sinon';
 
 const syncNotify = of(1);

--- a/packages/rxjs/spec/operators/shareReplay-spec.ts
+++ b/packages/rxjs/spec/operators/shareReplay-spec.ts
@@ -3,7 +3,7 @@ import * as sinon from 'sinon';
 import { shareReplay, mergeMapTo, retry, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { Observable, Operator, Observer, of, from, defer, pipe, combineLatest, firstValueFrom, BehaviorSubject } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {shareReplay} */
 describe('shareReplay', () => {

--- a/packages/rxjs/spec/operators/single-spec.ts
+++ b/packages/rxjs/spec/operators/single-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { single, mergeMap, tap } from 'rxjs/operators';
 import { of, EmptyError, SequenceError, NotFoundError, Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {single} */
 describe('single operator', () => {

--- a/packages/rxjs/spec/operators/skip-spec.ts
+++ b/packages/rxjs/spec/operators/skip-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { skip, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { of, Observable } from 'rxjs';
 
 /** @test {skip} */

--- a/packages/rxjs/spec/operators/skipLast-spec.ts
+++ b/packages/rxjs/spec/operators/skipLast-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { skipLast, mergeMap, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {skipLast} */
 describe('skipLast operator', () => {

--- a/packages/rxjs/spec/operators/skipUntil-spec.ts
+++ b/packages/rxjs/spec/operators/skipUntil-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { concat, defer, of, Subject, Observable, interval } from 'rxjs';
 import { skipUntil, mergeMap, take } from 'rxjs/operators';
-import { asInteropObservable } from '../helpers/interop-helper';
+import { asInteropObservable } from '../helpers/interop-helper.js';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {skipUntil} */
 describe('skipUntil', () => {

--- a/packages/rxjs/spec/operators/skipWhile-spec.ts
+++ b/packages/rxjs/spec/operators/skipWhile-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { skipWhile, mergeMap, tap, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {skipWhile} */
 describe('skipWhile', () => {

--- a/packages/rxjs/spec/operators/startWith-spec.ts
+++ b/packages/rxjs/spec/operators/startWith-spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable, startWith, mergeMap, take } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {startWith} */
 describe('startWith', () => {

--- a/packages/rxjs/spec/operators/subscribeOn-spec.ts
+++ b/packages/rxjs/spec/operators/subscribeOn-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { subscribeOn, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable, queueScheduler } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {subscribeOn} */
 describe('subscribeOn', () => {

--- a/packages/rxjs/spec/operators/switchAll-spec.ts
+++ b/packages/rxjs/spec/operators/switchAll-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Observable, of, NEVER, queueScheduler, Subject, scheduled } from 'rxjs';
 import { map, switchAll, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {switch} */
 describe('switchAll', () => {

--- a/packages/rxjs/spec/operators/switchMap-spec.ts
+++ b/packages/rxjs/spec/operators/switchMap-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { switchMap, mergeMap, map, takeWhile, take } from 'rxjs/operators';
 import { concat, defer, of, Observable, BehaviorSubject } from 'rxjs';
-import { asInteropObservable } from '../helpers/interop-helper';
+import { asInteropObservable } from '../helpers/interop-helper.js';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {switchMap} */
 describe('switchMap', () => {

--- a/packages/rxjs/spec/operators/switchMapTo-spec.ts
+++ b/packages/rxjs/spec/operators/switchMapTo-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { Observable, of } from 'rxjs';
 import { switchMapTo, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {switchMapTo} */
 describe('switchMapTo', () => {

--- a/packages/rxjs/spec/operators/switchScan-spec.ts
+++ b/packages/rxjs/spec/operators/switchScan-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { concat, defer, Observable, of } from 'rxjs';
 import { switchScan, map, mergeMap, takeWhile } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {switchScan} */
 describe('switchScan', () => {

--- a/packages/rxjs/spec/operators/take-spec.ts
+++ b/packages/rxjs/spec/operators/take-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { config, merge, Observable, of, Subject } from 'rxjs';
 import { finalize, mergeMap, take, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {take} */
 describe('take', () => {

--- a/packages/rxjs/spec/operators/takeLast-spec.ts
+++ b/packages/rxjs/spec/operators/takeLast-spec.ts
@@ -1,7 +1,7 @@
 import { takeLast, mergeMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {takeLast} */
 describe('takeLast operator', () => {

--- a/packages/rxjs/spec/operators/takeUntil-spec.ts
+++ b/packages/rxjs/spec/operators/takeUntil-spec.ts
@@ -2,7 +2,7 @@
 import { takeUntil, mergeMap, tap } from 'rxjs/operators';
 import { of, EMPTY, Subject, merge } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {takeUntil} */
 describe('takeUntil operator', () => {

--- a/packages/rxjs/spec/operators/takeWhile-spec.ts
+++ b/packages/rxjs/spec/operators/takeWhile-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { takeWhile, tap, mergeMap } from 'rxjs/operators';
 import { of, Observable, from, Subject, merge } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {takeWhile} */
 describe('takeWhile', () => {

--- a/packages/rxjs/spec/operators/tap-spec.ts
+++ b/packages/rxjs/spec/operators/tap-spec.ts
@@ -3,7 +3,7 @@ import { tap, mergeMap, take } from 'rxjs/operators';
 import type { Observer} from 'rxjs';
 import { Subject, of, throwError, EMPTY, Observable, noop } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {tap} */
 describe('tap', () => {

--- a/packages/rxjs/spec/operators/throttle-spec.ts
+++ b/packages/rxjs/spec/operators/throttle-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 import { TestScheduler } from 'rxjs/internal/testing/TestScheduler';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { throttle, mergeMap, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 

--- a/packages/rxjs/spec/operators/throttleTime-spec.ts
+++ b/packages/rxjs/spec/operators/throttleTime-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { throttleTime, take, map, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, concat, timer } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {throttleTime} */
 describe('throttleTime operator', () => {

--- a/packages/rxjs/spec/operators/throwIfEmpty-spec.ts
+++ b/packages/rxjs/spec/operators/throwIfEmpty-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { EMPTY, of, EmptyError, defer, throwError, Observable } from 'rxjs';
 import { throwIfEmpty, mergeMap, retry, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {throwIfEmpty} */
 describe('throwIfEmpty', () => {

--- a/packages/rxjs/spec/operators/timeInterval-spec.ts
+++ b/packages/rxjs/spec/operators/timeInterval-spec.ts
@@ -3,7 +3,7 @@ import { timeInterval, map, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
 import { TimeInterval } from 'rxjs/internal/operators/timeInterval';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {timeInterval} */
 describe('timeInterval', () => {

--- a/packages/rxjs/spec/operators/timeout-spec.ts
+++ b/packages/rxjs/spec/operators/timeout-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { timeout, mergeMap, take, concatWith } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { TimeoutError, of, Observable, NEVER } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {timeout} */
 describe('timeout operator', () => {

--- a/packages/rxjs/spec/operators/timeoutWith-spec.ts
+++ b/packages/rxjs/spec/operators/timeoutWith-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { timeoutWith, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable, EMPTY } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {timeoutWith} */
 describe('timeoutWith operator', () => {

--- a/packages/rxjs/spec/operators/timestamp-spec.ts
+++ b/packages/rxjs/spec/operators/timestamp-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { timestamp, map, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import { of, Observable } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {timestamp} */
 describe('timestamp', () => {

--- a/packages/rxjs/spec/operators/toArray-spec.ts
+++ b/packages/rxjs/spec/operators/toArray-spec.ts
@@ -1,7 +1,7 @@
 import { toArray, mergeMap } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {toArray} */
 describe('toArray', () => {

--- a/packages/rxjs/spec/operators/window-spec.ts
+++ b/packages/rxjs/spec/operators/window-spec.ts
@@ -2,7 +2,7 @@ import { window, mergeMap, take } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import type { Observable} from 'rxjs';
 import { EMPTY, of, interval } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { expect } from 'chai';
 
 /** @test {window} */

--- a/packages/rxjs/spec/operators/windowCount-spec.ts
+++ b/packages/rxjs/spec/operators/windowCount-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { windowCount, mergeMap, mergeAll, take } from 'rxjs/operators';
 import { of, Observable } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {windowCount} */
 describe('windowCount', () => {

--- a/packages/rxjs/spec/operators/windowTime-spec.ts
+++ b/packages/rxjs/spec/operators/windowTime-spec.ts
@@ -2,7 +2,7 @@ import { windowTime, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
 import type { Observable } from 'rxjs';
 import { of } from 'rxjs';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {windowTime} */
 describe('windowTime', () => {

--- a/packages/rxjs/spec/operators/windowToggle-spec.ts
+++ b/packages/rxjs/spec/operators/windowToggle-spec.ts
@@ -3,7 +3,7 @@ import type { Observable} from 'rxjs';
 import { NEVER, of, EMPTY } from 'rxjs';
 import { windowToggle, tap, mergeMap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {windowToggle} */
 describe('windowToggle', () => {

--- a/packages/rxjs/spec/operators/windowWhen-spec.ts
+++ b/packages/rxjs/spec/operators/windowWhen-spec.ts
@@ -2,7 +2,7 @@ import { windowWhen, mergeMap } from 'rxjs/operators';
 import type { Observable} from 'rxjs';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {windowWhen} */
 describe('windowWhen', () => {

--- a/packages/rxjs/spec/operators/withLatestFrom-spec.ts
+++ b/packages/rxjs/spec/operators/withLatestFrom-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
-import { lowerCaseO } from '../helpers/test-helper';
+import { lowerCaseO } from '../helpers/test-helper.js';
 import { withLatestFrom, mergeMap, delay } from 'rxjs/operators';
 import { of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {withLatestFrom} */
 describe('withLatestFrom', () => {

--- a/packages/rxjs/spec/operators/zipAll-spec.ts
+++ b/packages/rxjs/spec/operators/zipAll-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { zipAll, mergeMap } from 'rxjs/operators';
 import { queueScheduler, of, zip, scheduled } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {zipAll} */
 describe('zipAll operator', () => {

--- a/packages/rxjs/spec/operators/zipWith-spec.ts
+++ b/packages/rxjs/spec/operators/zipWith-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { zipWith, mergeMap } from 'rxjs/operators';
 import { queueScheduler, of, scheduled } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {zipWith} */
 describe('zipWith', () => {

--- a/packages/rxjs/spec/scheduled/scheduled-spec.ts
+++ b/packages/rxjs/spec/scheduled/scheduled-spec.ts
@@ -1,7 +1,7 @@
 import { scheduled, of } from 'rxjs';
 import { TestScheduler } from 'rxjs/testing';
-import { lowerCaseO } from '../helpers/test-helper';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { lowerCaseO } from '../helpers/test-helper.js';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { expect } from 'chai';
 
 describe('scheduled', () => {

--- a/packages/rxjs/spec/schedulers/AnimationFrameScheduler-spec.ts
+++ b/packages/rxjs/spec/schedulers/AnimationFrameScheduler-spec.ts
@@ -5,7 +5,7 @@ import type { Subscription} from 'rxjs';
 import { animationFrameScheduler, merge } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { animationFrameProvider } from 'rxjs/internal/scheduler/animationFrameProvider';
 import { intervalProvider } from 'rxjs/internal/scheduler/intervalProvider';
 

--- a/packages/rxjs/spec/schedulers/AsapScheduler-spec.ts
+++ b/packages/rxjs/spec/schedulers/AsapScheduler-spec.ts
@@ -5,7 +5,7 @@ import type { Subscription, SchedulerAction} from 'rxjs';
 import { asapScheduler, merge } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 import { immediateProvider } from 'rxjs/internal/scheduler/immediateProvider';
 import { intervalProvider } from 'rxjs/internal/scheduler/intervalProvider';
 

--- a/packages/rxjs/spec/schedulers/QueueScheduler-spec.ts
+++ b/packages/rxjs/spec/schedulers/QueueScheduler-spec.ts
@@ -5,7 +5,7 @@ import type { Subscription} from 'rxjs';
 import { queueScheduler, merge } from 'rxjs';
 import { delay } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 const queue = queueScheduler;
 

--- a/packages/rxjs/spec/schedulers/TestScheduler-spec.ts
+++ b/packages/rxjs/spec/schedulers/TestScheduler-spec.ts
@@ -8,7 +8,7 @@ import { animationFrameProvider } from 'rxjs/internal/scheduler/animationFramePr
 import { immediateProvider } from 'rxjs/internal/scheduler/immediateProvider';
 import { intervalProvider } from 'rxjs/internal/scheduler/intervalProvider';
 import { timeoutProvider } from 'rxjs/internal/scheduler/timeoutProvider';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {TestScheduler} */
 describe('TestScheduler', () => {

--- a/packages/rxjs/spec/subjects/BehaviorSubject-spec.ts
+++ b/packages/rxjs/spec/subjects/BehaviorSubject-spec.ts
@@ -1,9 +1,9 @@
 import { expect } from 'chai';
 import { BehaviorSubject, Subject, of } from 'rxjs';
 import { tap, mergeMapTo } from 'rxjs/operators';
-import { asInteropSubject } from '../helpers/interop-helper';
+import { asInteropSubject } from '../helpers/interop-helper.js';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {BehaviorSubject} */
 describe('BehaviorSubject', () => {

--- a/packages/rxjs/spec/subjects/ReplaySubject-spec.ts
+++ b/packages/rxjs/spec/subjects/ReplaySubject-spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { ReplaySubject, Subject, of } from 'rxjs';
 import { mergeMapTo, tap } from 'rxjs/operators';
 import { TestScheduler } from 'rxjs/testing';
-import { observableMatcher } from '../helpers/observableMatcher';
+import { observableMatcher } from '../helpers/observableMatcher.js';
 
 /** @test {ReplaySubject} */
 describe('ReplaySubject', () => {

--- a/packages/rxjs/spec/util/Immediate-spec.ts
+++ b/packages/rxjs/spec/util/Immediate-spec.ts
@@ -1,6 +1,6 @@
 import { expect } from 'chai';
 // TODO: import was changed due to the fact that at startup the test referred to rxjs from node_modules
-import { Immediate, TestTools } from '../../src/internal/util/Immediate';
+import { Immediate, TestTools } from '../../src/internal/util/Immediate.js';
 
 describe('Immediate', () => {
   it('should schedule on the next microtask', (done) => {


### PR DESCRIPTION
<!--
Thank you very much for your pull request!

If your PR is the addition of a new operator, please make sure all these boxes are ticked with an x:

- [ ] Add the operator to Rx
- [ ] It must have a `-spec.ts` tests file covering the canonical corner cases, with marble diagram tests
- [ ] The spec file should have a type definition test at the end of the spec to verify type definition for various use cases
- [ ] The operator must be documented in JSDoc style in the implementation file, including also the PNG marble diagram image
- [ ] The operator should be listed in `apps/rxjs.dev/content/guide/operators.md` in a category of operators
- [ ] The operator should also be documented. See [Documentation Guidelines](../CONTRIBUTING.md).
- [ ] You may need to update `MIGRATION.md` if the operator differs from the corresponding one in RxJS v4
-->

**Description:**

This does #7365 but for the spec/ files.

<!--
If this PR introduces a breaking change, it must contain a notice for it to be included in the CHANGELOG.
-->

**BREAKING CHANGE:** <!-- add description or remove entirely if not breaking -->

**Related issue (if exists):**
