### PR TITLE
Allow null | undefined as distinctUntilChanged parameter

### DIFF
--- a/packages/rxjs/src/internal/operators/distinctUntilChanged.ts
+++ b/packages/rxjs/src/internal/operators/distinctUntilChanged.ts
@@ -4,7 +4,7 @@ import { Observable, operate } from '@rxjs/observable';
 
 export function distinctUntilChanged<T>(comparator?: (previous: T, current: T) => boolean): MonoTypeOperatorFunction<T>;
 export function distinctUntilChanged<T, K>(
-  comparator: (previous: K, current: K) => boolean,
+  comparator: ((previous: K, current: K) => boolean) | null | undefined,
   keySelector: (value: T) => K
 ): MonoTypeOperatorFunction<T>;
 
@@ -136,7 +136,7 @@ export function distinctUntilChanged<T, K>(
  * source Observable with distinct values.
  */
 export function distinctUntilChanged<T, K>(
-  comparator?: (previous: K, current: K) => boolean,
+  comparator: ((previous: K, current: K) => boolean) | null | undefined,
   keySelector: (value: T) => K = identity as (value: T) => K
 ): MonoTypeOperatorFunction<T> {
   // We've been allowing `null` do be passed as the `compare`, so we can't do


### PR DESCRIPTION
**Description:**

The documentation mentions and the code allow for undefined parameter (and null), but the exported types didn't allow it.

Example mentioned in the existing JSDoc:
```
// We only want the events where it changed hands
const changedHands$ = accountUpdates$.pipe(
  distinctUntilChanged(undefined, update => update.updatedBy)
);
```

And the code includes a comment where it mentions null is also allowed:
```
// We've been allowing `null` do be passed as the `compare`, so we can't do
// a default value for the parameter, because that will only work
// for `undefined`.
comparator = comparator ?? defaultCompare;
```